### PR TITLE
chore(github): add issue + PR templates with DCO sign-off prompt

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+name: Bug Report
+description: Report a bug in MEHO
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill out the form below to help us investigate.
+
+        **Security vulnerabilities**: do NOT file a public bug. See [SECURITY.md](https://github.com/evoila/meho/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal reproduction steps.
+      placeholder: |
+        1. Run `...`
+        2. Observe `...`
+        3. Expected `...`, actual `...`
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: How is MEHO deployed and which versions are involved? (Versions only relevant once releases exist.)
+      placeholder: |
+        - MEHO commit / version: <git SHA or tag>
+        - Deployment: docker-compose / kubernetes / other
+        - OS: <distro + version>
+        - MCP client: Claude Code / Cursor / Cline / other
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output. Will be rendered as a code block.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/evoila/meho/discussions
+    about: Ask questions or discuss ideas
+  - name: Security Vulnerability
+    url: https://github.com/evoila/meho/blob/main/SECURITY.md
+    about: Report security vulnerabilities (do NOT use public issues)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+name: Feature Request
+description: Suggest a new feature or improvement for MEHO
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a feature. Please describe your idea below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature description
+      description: A clear and concise description of what you'd like.
+      placeholder: What should MEHO do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case / problem
+      description: What problem does this solve? Why is this feature needed?
+      placeholder: I want to do X but currently...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work?
+      placeholder: Describe your ideal implementation...
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+      placeholder: I've tried...
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 evoila Group -->
+
+## Description
+
+<!-- What and why -->
+
+## Related issue
+
+<!-- Closes #N -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+- [ ] CI / build / chore
+
+## Checklist
+
+- [ ] Conventional Commits format on every commit
+- [ ] Every commit has a `Signed-off-by:` line (DCO; `git commit -s`)
+- [ ] Tests added/updated where applicable
+- [ ] Documentation updated where applicable
+- [ ] CI green


### PR DESCRIPTION
## Summary

First PR on the post-pivot `evoila/meho`. Lands the GitHub-side contribution flow (issue templates, PR template) so subsequent contributions have a consistent shape.

- `.github/ISSUE_TEMPLATE/bug_report.yml` — drops the MEHO.X-specific "Component" dropdown (Agent/Investigation, 19-connectors, etc.) since none of that exists in the new product shape; keeps the description / repro / environment / logs structure.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — same simplification.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, points contributors to Discussions and SECURITY.md.
- `.github/PULL_REQUEST_TEMPLATE.md` — DCO sign-off explicitly checked, no CLA reference (per evoila-bosnia/MEHO.X#701 + #727 license decision).

Companion API-side configuration (description, topics, secret scanning + push protection, CodeQL default setup, main branch protection) was applied directly via `gh` CLI alongside this PR — see the originating issue for the verification matrix.

## Test plan

- [x] All four files render on github.com after merge
- [x] PR template auto-populates new PRs
- [x] Issue template chooser shows Bug / Feature with config redirecting blank → Discussions / Security
- [x] Repo description + topics set (10 topics)
- [x] Secret scanning + push protection enabled
- [x] CodeQL default setup configured
- [x] Branch protection on main: PR + 1 approval + linear history + no force-push + no deletions + conversation resolution required
- [ ] Required CI status check on branch protection — deferred until ci.yml lands in Initiative B (#710)

Closes evoila-bosnia/MEHO.X#709

🤖 Generated with [Claude Code](https://claude.com/claude-code)