### PR TITLE
ci: add secret-scan, security-scan, dependency-license-check workflows

### DIFF
--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Dependency license check.
+#
+# Verifies all Python and npm dependencies are compatible with the
+# project's outbound license: **Apache 2.0** (per evoila-bosnia/MEHO.X
+# decision #701 / #727). Apache 2.0 is permissive and combines cleanly
+# with most permissive and weak-copyleft licenses; the explicit forbid
+# list is AGPL (would force the combined work to AGPL), proprietary
+# EULAs, SSPL, BUSL, Elastic License v2, CC-BY-NC.
+#
+# Both jobs guard with hashFiles() so the workflow no-ops on the
+# placeholder repo (no pyproject.toml / package.json yet). When
+# manifests land, the checks fire automatically.
+#
+# When the dependency graph reveals license identifiers not in the
+# allow-list (e.g. `Apache Software License` vs `Apache-2.0` — pip
+# emits various forms), expand the allow-list specifically rather
+# than broadening it.
+
+name: Dependency License Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '.github/workflows/dependency-license-check.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '.github/workflows/dependency-license-check.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: dependency-license-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  python-licenses:
+    name: Python License Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: hashFiles('pyproject.toml') != ''
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+      - name: Install pip-licenses
+        run: pip install pip-licenses==5.0.0
+      - name: Install project deps
+        run: pip install -e .
+      - name: Verify license compatibility
+        # Apache 2.0 outbound: permissive + weak-copyleft inbound is fine.
+        # AGPL inbound is forbidden (would flip combined work to AGPL).
+        # Multiple identifier forms covered because pip-licenses falls back
+        # from PEP 639 License-Expression to Classifier to raw License field.
+        run: >
+          pip-licenses --format=plain --allow-only="
+          Apache Software License;
+          Apache-2.0;
+          Apache 2.0;
+          Apache License 2.0;
+          MIT License;
+          MIT;
+          BSD License;
+          BSD-2-Clause;
+          BSD-3-Clause;
+          3-Clause BSD License;
+          ISC License (ISCL);
+          ISC;
+          Python Software Foundation License;
+          PSF-2.0;
+          0BSD;
+          The Unlicense (Unlicense);
+          Unlicense;
+          Mozilla Public License 2.0 (MPL 2.0);
+          MPL-2.0;
+          CC0-1.0;
+          "
+
+  npm-licenses:
+    name: NPM License Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: hashFiles('**/package-lock.json') != ''
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "20"
+      - name: Install license-checker
+        run: npm install -g license-checker@25.0.1
+      - name: Verify license compatibility
+        run: >
+          license-checker --onlyAllow "Apache-2.0;MIT;BSD-2-Clause;BSD-3-Clause;ISC;CC0-1.0;0BSD;Unlicense;MPL-2.0"
+          --excludePrivatePackages

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# TruffleHog secret scanning.
+#
+# Runs on every push and PR. Scans full git history (fetch-depth: 0) for
+# leaked secrets — verified findings AND unknown/likely findings (the
+# `--results=verified,unknown` default that catches new patterns).
+#
+# Required status check in branch protection. continue-on-error is NOT
+# set: any finding fails the workflow and blocks merge. Fresh-repo policy:
+# the new project starts with a zero-finding baseline rather than
+# inheriting MEHO.X's continue-on-error tolerance.
+
+name: Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trufflehog:
+    name: TruffleHog Secret Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog Scan
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26  # v3.95.2
+        with:
+          extra_args: --results=verified,unknown

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Semgrep static analysis.
+#
+# Runs on every push and PR. Uses Semgrep's curated registry packs
+# (p/python, p/typescript, p/security-audit, p/owasp-top-ten) rather
+# than vendored rules. The registry-packs trade-off — registry-side
+# changes can silently move suppression behavior — does not bite yet
+# because the codebase has no suppressions to break. When suppressions
+# accumulate, vendor a curated rule set under .semgrep/rules/ and
+# switch the --config flag.
+#
+# SARIF is uploaded to GitHub Code Scanning (continue-on-error: true
+# on the upload step so a not-yet-enabled Code Scanning UI doesn't
+# block the workflow). The Semgrep step itself fails on ERROR-severity
+# findings (--error --severity ERROR).
+#
+# Per evoila-bosnia/MEHO.X#712: pip-audit and npm-audit jobs deferred
+# until pyproject.toml / package.json exist (their suppression lists
+# are deeply tied to MEHO.X's specific dependency graph; carrying
+# them over to an empty repo is signal decay).
+
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write  # required for SARIF upload to Code Scanning
+
+jobs:
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      # Bump cadence: monthly review or on advisory.
+      image: semgrep/semgrep:1.160.0
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Run Semgrep
+        run: >
+          semgrep scan
+          --config p/python
+          --config p/typescript
+          --config p/security-audit
+          --config p/owasp-top-ten
+          --sarif
+          -o semgrep-results.sarif
+          --error
+          --severity ERROR
+
+      - name: Upload SARIF as job artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        if: always()
+        with:
+          name: semgrep-sarif
+          path: semgrep-results.sarif
+          retention-days: 14
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+        if: always()
+        continue-on-error: true  # graceful fallback if Code Scanning not enabled
+        with:
+          sarif_file: semgrep-results.sarif


### PR DESCRIPTION
## Summary

Three scanning workflows in one PR; independent of each other, similar shape, share external-action SHAs. Closes three Initiative B tasks.

### #711 — `.github/workflows/secret-scan.yml`

TruffleHog on full git history (`fetch-depth: 0`). `continue-on-error` is **not** set — any finding blocks merge. Fresh-repo policy: the new project starts with a zero-finding baseline rather than inheriting MEHO.X's continue-on-error tolerance.

### #712 — `.github/workflows/security-scan.yml`

Semgrep SAST with **curated registry packs** (`p/python`, `p/typescript`, `p/security-audit`, `p/owasp-top-ten`) instead of vendoring MEHO.X's 30K-line `.semgrep/rules/`. The trade-off: registry-side rule changes can silently move suppression behavior, but the new codebase has zero suppressions to break. Switch to vendored rules when suppressions accumulate.

SARIF uploaded as artifact AND to GitHub Code Scanning (`continue-on-error` on the upload step so disabled Code Scanning doesn't block the workflow).

**Deferred until codebase needs them:**
- `pip-audit` job (no `pyproject.toml` yet)
- `npm-audit` job (no `package.json` yet)

Their MEHO.X suppression lists are deeply tied to MEHO.X's dependency graph; carrying them over to an empty repo would be signal decay.

### #713 — `.github/workflows/dependency-license-check.yml`

Both jobs guard with `hashFiles()` so they no-op on the placeholder repo. Allow-list configured for **Apache 2.0** outbound per decision #701/#727. AGPL/SSPL/BUSL/Elastic License inbound is forbidden.

Multiple identifier forms (e.g. `"Apache Software License"` + `"Apache-2.0"` + `"Apache 2.0"`) covered because pip-licenses falls back through PEP 639 / Classifier / raw License field formats. When the dep graph reveals a license identifier not in the allow-list, expand specifically rather than broadening.

## Test plan

- [x] All actions pinned by 40-char SHA
- [x] `permissions: contents: read` default; `security-events: write` only where SARIF upload needs it
- [x] Concurrency cancellation on every workflow
- [x] Per-job `timeout-minutes`
- [ ] Workflows trigger on this PR (verify post-merge or via PR-trigger)

Closes evoila-bosnia/MEHO.X#711
Closes evoila-bosnia/MEHO.X#712
Closes evoila-bosnia/MEHO.X#713

🤖 Generated with [Claude Code](https://claude.com/claude-code)