### PR TITLE
ci: add SonarCloud quality-gate workflow + sonar-project.properties

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# SonarCloud quality gate.
+#
+# Triggers via workflow_run after CI succeeds. Downloads Python coverage
+# from CI's artifacts (when CI starts producing them), then runs the
+# SonarCloud scan. The "Clean as You Code" model applies the gate to
+# new code only — existing issues don't block PRs.
+#
+# After the orphan-commit reset, SonarCloud sees a fresh single-commit
+# history. The project (evoila_meho on org evoila) persists across the
+# reset — it's external state keyed by repo identifier — so the same
+# project picks up the new commits and resets the baseline naturally.
+#
+# Prerequisite: SONAR_TOKEN repo secret. Verified present pre-merge.
+#
+# IMPORTANT: Uses SonarSource/sonarqube-scan-action@v5 (NOT the
+# deprecated sonarcloud-github-action). All third-party actions are
+# pinned to commit SHAs.
+
+name: Quality Gate
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+concurrency:
+  group: quality-gate-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write  # required for PR decoration (Sonar comment with the gate result)
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0  # full history for accurate blame + new-code detection
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download Python coverage from CI workflow
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: python-coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true  # coverage artifact may not exist yet (no tests)
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703  # v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# SonarCloud project configuration. Project + organization persist across
+# the orphan-commit reset (external state keyed by repo identifier).
+# Coverage paths are added when language toolchains start producing them.
+
+sonar.projectKey=evoila_meho
+sonar.organization=evoila
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=.
+
+# Paths excluded from analysis. Add language-specific dirs (build/, dist/,
+# coverage/, etc.) when toolchains land.
+sonar.exclusions=.github/**,**/node_modules/**,**/dist/**,**/build/**
+
+# Language-specific blocks — ready to populate when code lands.
+# sonar.python.version=3.13
+# sonar.python.coverage.reportPaths=coverage.xml
+# sonar.javascript.lcov.reportPaths=meho_frontend/coverage/lcov.info


### PR DESCRIPTION
## Summary

Reconnects the existing SonarCloud project to the post-reset `evoila/meho` repo.

- **Project key**: `evoila_meho`
- **Organization**: `evoila`
- **`SONAR_TOKEN` secret**: verified present (last rotated 2026-03-31)

The SonarCloud project persists across the orphan-commit reset — it's external state keyed by repo identifier — so the same project picks up new commits and resets its **"Clean as You Code"** baseline naturally to the new single-commit history.

## What's in this PR

- `.github/workflows/quality-gate.yml` — triggers via `workflow_run` after CI succeeds, downloads coverage from CI's artifacts (when those exist), runs the SonarCloud scan via `SonarSource/sonarqube-scan-action@v5` (NOT the deprecated `sonarcloud-github-action`).
- `sonar-project.properties` — project key + organization + sources/exclusions. Language-specific coverage paths left commented for when toolchains land.

## Dropped from the MEHO.X reference (per evoila-bosnia/MEHO.X#714)

- Frontend coverage step (`npm ci` + `npm run test:coverage` in `meho_frontend/`) — defer until frontend code lands
- Frontend Node setup step — same reason

## Test plan

- [x] `SONAR_TOKEN` confirmed in repo secrets
- [x] All actions pinned by 40-char SHA
- [x] `permissions: contents: read` + `pull-requests: write` (the latter for PR decoration only)
- [ ] First post-merge CI run triggers a SonarCloud analysis successfully (visible at `https://sonarcloud.io/project/overview?id=evoila_meho`)
- [ ] PR decoration appears on a follow-up test PR (Sonar comment with the gate result)

## Out of scope

- "Clean as You Code" baseline reconfiguration (SonarCloud auto-resets when it sees the new history)
- Coverage upload from CI (CI doesn't produce coverage yet — `download-artifact` step `continue-on-error`s gracefully)
- Quality-gate threshold tuning (defaults match MEHO.X's "block PR with new ERROR-severity findings"; revisit when real code lands)

Closes evoila-bosnia/MEHO.X#714

🤖 Generated with [Claude Code](https://claude.com/claude-code)