### PR TITLE
ci: add Dependabot + pre-commit-config; DCO bot install flagged as manual

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Dependabot configuration.
+#
+# Initial v0.1 scope: GitHub Actions only. Pip / npm / docker
+# ecosystems land when their manifests do (pyproject.toml,
+# package.json, Dockerfile). Adding them now would silently no-op
+# but invites confusion when manifests appear later — the schedule
+# would already be running.
+
+version: 2
+updates:
+  # Pin-bumps for third-party Actions used in .github/workflows/.
+  # Runs weekly; PRs land with `chore(deps):` prefix matching the
+  # repo's Conventional Commits convention.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # When language manifests land, add per-ecosystem blocks below.
+  # Reference (MEHO.X conventions):
+  #
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   labels: ["dependencies", "python"]
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #
+  # - package-ecosystem: "npm"
+  #   directory: "/<frontend-path>"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   labels: ["dependencies", "frontend"]
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #
+  # - package-ecosystem: "docker"
+  #   directory: "/<docker-context>"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   labels: ["dependencies", "docker"]
+  #   commit-message:
+  #     prefix: "chore(deps)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Pre-commit hooks.
+#
+# Install:  pre-commit install --install-hooks
+# Run:      pre-commit run --all-files
+#
+# Initial scope: stack-neutral hygiene (file-format, secret detection).
+# Language-specific hooks (ruff, mypy, eslint, vitest) land when the
+# language code lands.
+
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  # Standard hygiene hooks — universal across stacks.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending
+
+  # Secret scanning. CI also runs TruffleHog on full history
+  # (.github/workflows/secret-scan.yml); this hook is the local
+  # pre-commit version that catches secrets before they reach the
+  # remote.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  # Conventional Commits enforcement on commit messages.
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, chore, docs, refactor, test, ci, build, perf, revert]
+
+  # When Python lands, add ruff pinned to the same version pyproject.toml uses.
+  # When frontend lands, add eslint via npm-prefix or local hook.
+  # When mypy/typecheck thresholds matter, add as `local` hooks invoking
+  # the project's venv / node_modules so configuration matches CI.


### PR DESCRIPTION
## Summary

Two configs land in this PR; one manual follow-up flagged for after merge.

### `.github/dependabot.yml`

GitHub Actions ecosystem only for v0.1. Pip / npm / docker blocks are commented out as ready-to-uncomment templates for when those manifests land. Weekly cadence, Monday 09:00, PRs land with `chore(deps):` prefix matching Conventional Commits.

Why empty-now-not-broad: adding pip/npm/docker blocks empty would silently no-op until manifests appear, then start running on a schedule the team forgot about. The commented templates make the next step explicit.

### `.pre-commit-config.yaml`

Stack-neutral hygiene + Conventional Commits enforcement:

- `pre-commit-hooks` v5.0.0 — trailing-whitespace, end-of-file-fixer, check-yaml, check-json, check-added-large-files (500KB limit), check-merge-conflict, detect-private-key, mixed-line-ending
- `gitleaks` v8.21.2 — local secret scanning (CI also runs TruffleHog on full history; this is the pre-push line of defense)
- `conventional-pre-commit` v3.4.0 — Conventional Commits enforcement on commit messages

Language-specific hooks (ruff, mypy, eslint, vitest) **deferred** until language code lands. The MEHO.X pre-commit-config has many Python-specific hooks tied to `meho_app/` paths and pydantic-settings sync; those don't apply to the empty repo and would fail to find their target files.

### DCO bot install — manual follow-up (post-merge)

The DCO bot is a GitHub App at <https://github.com/apps/dco>. Install path:

1. Go to <https://github.com/apps/dco> → "Install"
2. Pick the `evoila` org → "Only select repositories" → check `evoila/meho`
3. After install, every PR shows a `DCO` status check that fails when any commit is missing `Signed-off-by:`
4. Add the `DCO` check to evoila/meho `main` branch protection (#709 left required-checks empty pending workflows landing; DCO is the first one to add)

I can't install GitHub Apps from a PR — that's a UI action on the org admin's side.

## Test plan

- [x] Dependabot validates (`yq` parses cleanly)
- [x] Pre-commit config validates (no syntax errors)
- [ ] First Dependabot run produces a PR within 1 week of merge (action-version bumps land automatically)
- [ ] Pre-commit hooks install cleanly via `pre-commit install --install-hooks` on a developer's clone
- [ ] DCO bot installed (manual; post-merge)
- [ ] DCO check added to branch protection (manual; post-DCO-bot)

Closes evoila-bosnia/MEHO.X#715

🤖 Generated with [Claude Code](https://claude.com/claude-code)