### PR TITLE
fix: drop trailing slash from .claude/.planning/.cursor/.vscode patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
 # =============================================================================
-# Private companion repo content — must NEVER land in public history
+# Private companion repo content — must NEVER land in public history.
+# Patterns intentionally have NO trailing slash so they match both real
+# directories AND symlinks-to-directories. The meho-init script in
+# evoila-bosnia/meho-internal creates `.claude` as a symlink into the
+# private repo; with a trailing-slash pattern, gitignore wouldn't catch
+# the symlink and the symlinked content could leak into public history.
 # =============================================================================
-.claude/
-.planning/
-.cursor/
-.vscode/
+.claude
+.planning
+.cursor
+.vscode
 
 # =============================================================================
 # Secrets / env


### PR DESCRIPTION
## Summary

Discovered while exercising `meho-init` end-to-end against a fresh `evoila/meho` clone.

The current `.gitignore` patterns use `.claude/` / `.planning/` / `.cursor/` / `.vscode/` with **trailing slashes**, which only match real directories. After `meho-init` runs, `.claude` becomes a **symlink** into `evoila-bosnia/meho-internal/.claude/` — and gitignore's trailing-slash form does NOT match symlinks, even when they point at directories.

## Effect of the bug

With the symlink in place:

- `git status` in the public repo treats `.claude` as **untracked** (gitignore pattern doesn't match)
- `git check-ignore .claude/anything` errors with `fatal: pathspec '.claude/anything' is beyond a symbolic link`
- A future `git add -A` could pull symlinked content into the public history

Verified by running `meho-init` then `git check-ignore -v .claude` in the public repo: returns exit 1 (NOT ignored) before the fix, exit 0 (ignored) after.

## Fix

Drop the trailing slash from `.claude`, `.planning`, `.cursor`, `.vscode`. The no-slash pattern matches anything named that — file, directory, OR symlink. Other gitignore patterns (`.env`, `*.pem`, `secrets/`, etc.) keep their existing form because none of them are ever symlinked.

Inline comment block added so the next reader doesn't restore the trailing slashes thinking they're more idiomatic.

## Test plan

Post-merge, in the public repo with a `meho-init`-created `.claude` symlink:

```bash
cd ~/repos/evoila/meho
git pull
git check-ignore -v .claude  # expected: prints ".gitignore:N:.claude   .claude" + exit 0
```

Refs evoila-bosnia/MEHO.X#721

🤖 Generated with [Claude Code](https://claude.com/claude-code)