### PR TITLE
feat(backend): add /healthz, /version, /ready + readiness-probe registry

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,9 +42,19 @@ FROM python:3.12-slim AS runtime
 # Non-root user (uid 1001 — fixed for k8s SecurityContext alignment).
 RUN useradd --system --uid 1001 --gid 0 --no-create-home --shell /usr/sbin/nologin meho
 
+# Build-identity stamps surfaced via GET /version. CI passes these via
+# `docker build --build-arg GIT_SHA=$(git rev-parse HEAD) \
+#                --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)`
+# (G2.4 will pin that exact invocation). When unset, /version falls back
+# to "unknown" so locally-built images don't crash on startup.
+ARG GIT_SHA=unknown
+ARG BUILD_DATE=unknown
+
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    GIT_SHA=${GIT_SHA} \
+    BUILD_DATE=${BUILD_DATE}
 
 WORKDIR /app
 

--- a/backend/src/meho_backplane/health.py
+++ b/backend/src/meho_backplane/health.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Liveness and readiness surfaces plus a pluggable readiness-probe registry.
+
+Two endpoints live here:
+
+* ``GET /healthz`` — process-up signal. Returns 200 unconditionally; never
+  consults the probe registry. This is the kubernetes *liveness* contract:
+  pod restart on failure.
+* ``GET /ready`` — readiness signal. Iterates every probe registered via
+  :func:`register_probe`, returning 200 only if every probe passes. With
+  an empty registry (the default at the chassis stage), ``/ready``
+  returns 503 by design — the backplane fails closed until downstream
+  initiatives wire concrete probes (Vault/Keycloak in G2.2, Alembic
+  migrations in G2.3).
+
+Probes are plain callables that return a :class:`ProbeResult`. They are
+expected to be cheap and synchronous; long-running checks should cache
+state out-of-band and have the probe return the cached verdict. v0.1
+deliberately ships no timeout / retry / circuit-breaker around probes —
+if a probe hangs, ``/ready`` hangs, and the kubelet's own readiness
+timeout takes the pod out of rotation.
+
+Usage::
+
+    from meho_backplane.health import register_probe, ProbeResult
+
+    def vault_probe() -> ProbeResult:
+        return ProbeResult(name="vault", ok=client.is_authenticated())
+
+    register_probe("vault", vault_probe)
+"""
+
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+__all__ = [
+    "ProbeResult",
+    "clear_probes",
+    "register_probe",
+    "router",
+    "run_probes",
+]
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Outcome of a single readiness probe.
+
+    Attributes
+    ----------
+    name:
+        Stable identifier surfaced in the ``/ready`` response. Must match
+        the ``name`` passed to :func:`register_probe`.
+    ok:
+        ``True`` if the underlying dependency is healthy from this
+        process's perspective.
+    detail:
+        Optional human-readable context (error message, version banner,
+        etc.). Operators read this when ``ok`` is ``False``.
+    """
+
+    name: str
+    ok: bool
+    detail: str | None = None
+
+
+_probes: list[tuple[str, Callable[[], ProbeResult]]] = []
+
+
+def register_probe(name: str, fn: Callable[[], ProbeResult]) -> None:
+    """Register *fn* under *name* in the readiness-probe registry.
+
+    Probes are evaluated in registration order on every ``/ready`` hit.
+    The same name may be registered more than once (callers are
+    responsible for uniqueness); duplicates simply run twice. This
+    permissive contract keeps the registry trivially testable — see
+    :func:`clear_probes`.
+    """
+    _probes.append((name, fn))
+
+
+def run_probes() -> list[ProbeResult]:
+    """Evaluate every registered probe and return the result list.
+
+    Pure pass-through: probe exceptions are *not* caught here. Probes
+    are expected to convert their own failures into a ``ProbeResult``
+    with ``ok=False``; an uncaught exception is a probe-implementation
+    bug and surfacing it as a 500 from ``/ready`` is the correct
+    behaviour.
+    """
+    return [fn() for _, fn in _probes]
+
+
+def clear_probes() -> None:
+    """Empty the registry. Test-only — never call from production code."""
+    _probes.clear()
+
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/healthz")
+async def healthz() -> dict[str, str]:
+    """Liveness probe. Always returns 200; never inspects the registry."""
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def ready() -> JSONResponse:
+    """Readiness probe.
+
+    Returns 200 with ``{"status": "ready", "checks": [...]}`` when at
+    least one probe is registered and every probe reports ``ok``.
+    Returns 503 with ``{"status": "not_ready", "checks": [...]}``
+    otherwise — including the fail-closed empty-registry case at the
+    chassis stage. The empty case is handled explicitly because
+    ``all([])`` is vacuously ``True`` in Python, which would otherwise
+    flip the chassis to "ready" with zero evidence.
+    """
+    results = run_probes()
+    ready_ok = bool(results) and all(r.ok for r in results)
+    payload = {
+        "status": "ready" if ready_ok else "not_ready",
+        "checks": [asdict(r) for r in results],
+    }
+    return JSONResponse(content=payload, status_code=200 if ready_ok else 503)

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -4,9 +4,9 @@
 """FastAPI application entrypoint.
 
 This module exposes the ``app`` callable consumed by uvicorn /
-Gunicorn / k8s probes. v0.1 ships only a root identity route — health
-endpoints (``/healthz``, ``/version``, ``/ready``), structured logs,
-and Prometheus metrics land in subsequent G2.1 Tasks (#19, #20).
+Gunicorn / k8s probes. v0.1 ships the identity route plus the public
+operator surfaces (``/healthz``, ``/version``, ``/ready``); structured
+logs and Prometheus ``/metrics`` land in Task #20.
 """
 
 from typing import Final
@@ -14,6 +14,8 @@ from typing import Final
 from fastapi import FastAPI
 
 from meho_backplane import __version__
+from meho_backplane.health import router as health_router
+from meho_backplane.version import router as version_router
 
 _APP_NAME: Final[str] = "meho-backplane"
 
@@ -23,13 +25,16 @@ app: FastAPI = FastAPI(
     description="MEHO governance-layer backplane (chassis-only in v0.1).",
 )
 
+app.include_router(health_router)
+app.include_router(version_router)
+
 
 @app.get("/")
 async def root() -> dict[str, str]:
     """Identity route.
 
-    Returns the running app's name and version. Acts as a smoke probe
-    for ``uvicorn`` / container startup until ``/healthz`` is wired in
-    Task #19.
+    Returns the running app's name and version. Kept alongside
+    ``/healthz`` because some legacy probes hit ``/`` instead of
+    ``/healthz`` and we want both paths to behave.
     """
     return {"name": _APP_NAME, "version": __version__}

--- a/backend/src/meho_backplane/version.py
+++ b/backend/src/meho_backplane/version.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Build-identity surface — ``GET /version``.
+
+Returns the immutable triple operators rely on to confirm *which* image
+is running in the cluster:
+
+* ``git_sha`` — full commit hash injected by CI at ``docker build`` time
+  via ``--build-arg GIT_SHA``.
+* ``build_date`` — ISO-8601 UTC timestamp injected the same way.
+* ``chart_version`` — populated in G2.5 once the helm chart owns the
+  release-version concept; intentionally ``null`` at the chassis stage.
+
+Reading the values from environment variables (rather than baking them
+into a generated ``_version.py``) keeps the runtime image generic and
+the build pipeline simple: the same wheel can be re-tagged with
+different ``GIT_SHA`` / ``BUILD_DATE`` values just by rebuilding the
+runtime layer. Missing env vars fall back to ``"unknown"`` so local
+``uvicorn`` runs don't crash before the operator sets the build
+arguments.
+"""
+
+import os
+
+from fastapi import APIRouter
+
+__all__ = ["router"]
+
+_UNKNOWN: str = "unknown"
+
+router = APIRouter(tags=["version"])
+
+
+@router.get("/version")
+async def version() -> dict[str, str | None]:
+    """Return the build-identity payload.
+
+    Each field falls back to ``"unknown"`` when its env var is unset or
+    empty, which keeps local development frictionless without ever
+    pretending an unknown build is a known one.
+    """
+    return {
+        "git_sha": os.environ.get("GIT_SHA") or _UNKNOWN,
+        "build_date": os.environ.get("BUILD_DATE") or _UNKNOWN,
+        "chart_version": None,
+    }

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``/healthz``, ``/version``, and ``/ready``.
+
+Coverage matrix (per Task #19 acceptance criteria):
+
+* ``/healthz`` always returns 200, even with a failing probe registered.
+* ``/version`` returns the env-injected triple (``GIT_SHA``,
+  ``BUILD_DATE``) and falls back to ``"unknown"`` when env vars are
+  absent. ``chart_version`` is always ``None`` at the chassis stage.
+* ``/ready`` returns 503 with an empty registry (default v0.1 state),
+  200 once a passing probe is registered, and 503 again with one
+  failing probe registered alongside a passing one (so the failure
+  detail is visible in the payload).
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.health import (
+    ProbeResult,
+    clear_probes,
+    register_probe,
+    run_probes,
+)
+from meho_backplane.main import app
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Iterator[None]:
+    """Reset the module-level probe registry around every test.
+
+    The registry is a module global; without this fixture, tests that
+    register probes leak state into siblings and run-order becomes
+    load-bearing. Clearing both before *and* after defends against
+    failures that abort mid-test.
+    """
+    clear_probes()
+    yield
+    clear_probes()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Registry API surface
+# ---------------------------------------------------------------------------
+
+
+def test_registry_symbols_importable() -> None:
+    """``register_probe`` and ``run_probes`` are part of the public API."""
+    # Imports at module top would already have failed; this assertion
+    # documents the contract for the acceptance-criteria reviewer.
+    assert callable(register_probe)
+    assert callable(run_probes)
+    assert run_probes() == []
+
+
+# ---------------------------------------------------------------------------
+# /healthz
+# ---------------------------------------------------------------------------
+
+
+def test_healthz_returns_ok(client: TestClient) -> None:
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_healthz_ignores_failing_probes(client: TestClient) -> None:
+    """``/healthz`` is liveness, not readiness — registry state is irrelevant."""
+    register_probe("always-fail", lambda: ProbeResult(name="always-fail", ok=False))
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# /version
+# ---------------------------------------------------------------------------
+
+
+def test_version_falls_back_to_unknown(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GIT_SHA", raising=False)
+    monkeypatch.delenv("BUILD_DATE", raising=False)
+
+    response = client.get("/version")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "git_sha": "unknown",
+        "build_date": "unknown",
+        "chart_version": None,
+    }
+
+
+def test_version_reads_env_vars(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GIT_SHA", "abc1234")
+    monkeypatch.setenv("BUILD_DATE", "2026-05-09T12:00:00Z")
+
+    response = client.get("/version")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "git_sha": "abc1234",
+        "build_date": "2026-05-09T12:00:00Z",
+        "chart_version": None,
+    }
+
+
+def test_version_treats_empty_env_as_unknown(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty strings are as uninformative as unset; coerce to ``"unknown"``."""
+    monkeypatch.setenv("GIT_SHA", "")
+    monkeypatch.setenv("BUILD_DATE", "")
+
+    response = client.get("/version")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "git_sha": "unknown",
+        "build_date": "unknown",
+        "chart_version": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# /ready
+# ---------------------------------------------------------------------------
+
+
+def test_ready_with_empty_registry_returns_503(client: TestClient) -> None:
+    """The chassis fails closed until a downstream Initiative wires probes."""
+    response = client.get("/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "not_ready", "checks": []}
+
+
+def test_ready_with_all_passing_probes_returns_200(client: TestClient) -> None:
+    register_probe(
+        "vault",
+        lambda: ProbeResult(name="vault", ok=True, detail="auth ok"),
+    )
+    register_probe("db", lambda: ProbeResult(name="db", ok=True))
+
+    response = client.get("/ready")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["checks"] == [
+        {"name": "vault", "ok": True, "detail": "auth ok"},
+        {"name": "db", "ok": True, "detail": None},
+    ]
+
+
+def test_ready_with_one_failing_probe_returns_503_with_detail(
+    client: TestClient,
+) -> None:
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True))
+    register_probe(
+        "db",
+        lambda: ProbeResult(name="db", ok=False, detail="migration pending"),
+    )
+
+    response = client.get("/ready")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "not_ready"
+    assert body["checks"] == [
+        {"name": "vault", "ok": True, "detail": None},
+        {"name": "db", "ok": False, "detail": "migration pending"},
+    ]

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -8,12 +8,14 @@
 `backend/` houses the MEHO governance-layer backplane — a FastAPI
 service that mediates every operation an AI agent runs against shared
 infrastructure (policy gating, audit, federation, observability). At
-this Goal-#11 chassis stage it serves only a single identity route on
-`/`; health, readiness, metrics, structured logging, JWT validation,
-Vault federation, and database persistence land progressively in
-subsequent G2.1 / G2.2 / G2.3 Tasks. The stack (FastAPI, Pydantic v2,
-SQLAlchemy 2.x async, Alembic, structlog, prometheus_client) is locked
-by [ADR 0004](https://github.com/evoila-bosnia/meho-internal/issues/13).
+this Goal-#11 chassis stage it exposes the public operator surface
+(`/`, `/healthz`, `/version`, `/ready`) and a pluggable readiness-probe
+registry (empty by default, fail-closed on `/ready`); metrics,
+structured logging, JWT validation, Vault federation, and database
+persistence land progressively in subsequent G2.1 / G2.2 / G2.3 Tasks.
+The stack (FastAPI, Pydantic v2, SQLAlchemy 2.x async, Alembic,
+structlog, prometheus_client) is locked by
+[ADR 0004](https://github.com/evoila-bosnia/meho-internal/issues/13).
 
 The project follows the modern src-layout
 (`backend/src/meho_backplane/...`) so tests resolve only the installed
@@ -26,21 +28,33 @@ PYTHONPATH-leak imports.
 | --- | --- | --- |
 | `app` (`fastapi.FastAPI`) | `src/meho_backplane/main.py` | ASGI application instance consumed by uvicorn / k8s probes. Title and `version` are populated from `__version__` so OpenAPI metadata stays in lock-step with the package. |
 | `__version__` (`str`) | `src/meho_backplane/__init__.py` | Single source of truth for the running app version. The pyproject `[project].version` field mirrors this constant; the `test_version_constant_matches_pyproject` test acts as a tripwire if the two drift. |
-| `root` (route) | `src/meho_backplane/main.py` | `GET /` returning `{"name": "meho-backplane", "version": "<x>"}`. Smoke-probe surface until `/healthz` is wired in Task #19. |
+| `root` (route) | `src/meho_backplane/main.py` | `GET /` returning `{"name": "meho-backplane", "version": "<x>"}`. Identity smoke-probe; coexists with `/healthz`. |
+| `ProbeResult` (`dataclass`) | `src/meho_backplane/health.py` | Frozen record `(name, ok, detail)` returned by every readiness probe. Surfaced verbatim in the `/ready` response body. |
+| `register_probe` / `run_probes` / `clear_probes` | `src/meho_backplane/health.py` | Public registry API. G2.2 (Vault, Keycloak) and G2.3 (DB migrations) call `register_probe` at startup; `clear_probes` is test-only. |
+| `health.router` (`/healthz`, `/ready`) | `src/meho_backplane/health.py` | Liveness and readiness endpoints. `/healthz` is unconditional 200; `/ready` aggregates the probe registry and **fails closed on the empty default** (vacuous-truth trap explicitly guarded). |
+| `version.router` (`/version`) | `src/meho_backplane/version.py` | Build identity. Reads `GIT_SHA` and `BUILD_DATE` env vars (injected via `docker build --build-arg`); falls back to `"unknown"` when unset or empty. `chart_version` is `None` until G2.5. |
 
 ## Control flow
 
 1. The container's `CMD` invokes
    `uvicorn meho_backplane.main:app --host 0.0.0.0 --port 8000`.
 2. uvicorn imports `meho_backplane.main`, which constructs the
-   `FastAPI` instance and registers the `root` coroutine.
+   `FastAPI` instance, mounts the `health` and `version` routers via
+   `include_router`, and registers the `root` coroutine.
 3. uvicorn binds to `:8000` and starts the ASGI event loop.
-4. Each `GET /` request is dispatched to `root()`, which returns a
-   plain `dict`; FastAPI serialises it to JSON.
+4. Each request is dispatched to its route handler:
+   - `GET /` → `root()` returns the identity dict.
+   - `GET /healthz` → `healthz()` returns `{"status": "ok"}` with 200.
+   - `GET /version` → reads `GIT_SHA` / `BUILD_DATE` env vars per
+     request (cheap; no caching needed).
+   - `GET /ready` → calls `run_probes()` and translates the aggregate
+     into a 200 / 503 `JSONResponse`.
 
 There is no startup or shutdown machinery yet — the FastAPI
 [lifespan](https://fastapi.tiangolo.com/advanced/events/) hook is
-introduced when DB/Vault wiring lands (G2.2 / G2.3).
+introduced when DB/Vault wiring lands (G2.2 / G2.3). Downstream
+probes will be registered from those lifespans:
+`register_probe("vault", check_vault)`.
 
 ## Dependencies
 
@@ -66,10 +80,12 @@ top of their own changes, which keeps the per-Task PR diffs focused.
 
 ## Known issues
 
-None at the chassis stage. `/ready` does not exist yet, so kubernetes
-readiness probes pointed at it during initial helm-chart development
-will 404 until Task #19 lands; that's by design and tracked in #19's
-acceptance criteria.
+`/ready` returns 503 in the default chassis state because the probe
+registry is empty — this is **fail-closed by design**, not a bug. The
+chassis flips to readiness-ready only once G2.2 (Vault/Keycloak) and
+G2.3 (Alembic migrations) call `register_probe`. Helm charts pointing
+their kubernetes readiness probe at `/ready` before those Initiatives
+land will see pods stay `NotReady`; that's the intended contract.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Adds the public, no-auth operator surface for the backplane chassis: `/healthz` (liveness, always 200), `/version` (build identity from `GIT_SHA` / `BUILD_DATE` env vars), `/ready` (aggregates a pluggable readiness-probe registry).
- Ships a small registry (`register_probe`, `run_probes`, `ProbeResult` dataclass) so G2.2 (Vault, Keycloak) and G2.3 (DB migrations) can wire concrete probes without touching this module.
- Empty registry is the **fail-closed default**: `/ready` returns 503 until a downstream Initiative registers a probe — `all([])` is vacuously true and is explicitly guarded.
- Dockerfile runtime stage now accepts `--build-arg GIT_SHA=… --build-arg BUILD_DATE=…` and forwards them to `ENV`, so `/version` surfaces the build identity that CI will pin in G2.4.

## Test plan

- [x] `ruff check backend/` — clean
- [x] `ruff format --check backend/` — clean
- [x] `mypy --strict backend/src/ backend/tests/` — clean
- [x] `pytest -x backend/` — 11 passed (2 pre-existing app-starts + 9 new health/version/ready)
- [x] `/healthz` returns 200 + `{"status": "ok"}` even with a failing probe registered
- [x] `/version` returns env-injected `git_sha` / `build_date`, falls back to `"unknown"` when env vars are unset or empty; `chart_version` is `None`
- [x] `/ready` returns 503 with empty registry; 200 with all-passing probes; 503 with one failing probe (detail surfaced in the payload)
- [x] `register_probe` / `run_probes` importable from `meho_backplane.health`

## Out of scope

- `/metrics`, structlog JSON logging, request-context middleware — Task #20 (parallel)
- `/api/v1/health` (auth-required operator-identity body) — G2.2
- Concrete Vault / Keycloak / DB probes — G2.2 / G2.3
- Probe timeout / retry / circuit-breaker — kept dumb in v0.1; kubelet's own readiness timeout takes pods out of rotation if a probe hangs

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/healthz` endpoint for basic health checks
  * Added `/version` endpoint exposing build metadata (git SHA and build date)
  * Added `/ready` endpoint for readiness status with pluggable probe registry system
  * Enabled custom readiness checks to be registered and evaluated

* **Chores**
  * Enhanced Docker image with build identity metadata

* **Documentation**
  * Updated backend documentation for new operational endpoints

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/149)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->