### PR TITLE
feat(backend): add Keycloak JWT validation + verify_jwt dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,18 +8,21 @@ license = "Apache-2.0"
 dependencies = [
     "fastapi>=0.110",
     "uvicorn[standard]>=0.30",
-    "pydantic>=2.6",
+    "pydantic[email]>=2.6",
     "structlog>=24.1",
     "prometheus-client>=0.20",
+    "authlib>=1.3",
+    "httpx>=0.27",
 ]
 
 [dependency-groups]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
-    "httpx>=0.27",
     "ruff>=0.5",
     "mypy>=1.10",
+    "cryptography>=42.0",
+    "respx>=0.21",
 ]
 
 [build-system]
@@ -52,11 +55,44 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]  # asserts allowed in tests
 
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI's standard dependency-injection pattern relies on calling
+# Depends() / Header() / Query() / Path() / Body() / File() / Form() /
+# Security() in argument defaults. B008 would flag every one of those;
+# whitelisting them here keeps the rule strict for genuine
+# accidental-call defaults.
+extend-immutable-calls = [
+    "fastapi.Depends",
+    "fastapi.Header",
+    "fastapi.Query",
+    "fastapi.Path",
+    "fastapi.Body",
+    "fastapi.Form",
+    "fastapi.File",
+    "fastapi.Security",
+]
+
 [tool.mypy]
 strict = true
 python_version = "3.12"
 files = ["src"]
 
+# authlib publishes no type stubs (the maintainer migrated typing
+# attention to ``joserfc``). Whitelist its module tree rather than
+# disabling missing-imports globally — strict mode stays in effect for
+# every other dependency.
+[[tool.mypy.overrides]]
+module = ["authlib.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# Note: ``authlib.deprecate`` calls ``warnings.simplefilter("always",
+# AuthlibDeprecationWarning)`` at import time, so the
+# ``AuthlibDeprecationWarning("authlib.jose module is deprecated...")``
+# raised on first import shows in the pytest summary even when the
+# import is wrapped in ``warnings.catch_warnings()``. The single
+# warning is intentional — it's the only signal the test run carries
+# of the v0.2 ``joserfc`` migration backlog item, and silencing it
+# would risk obscuring future authlib deprecations.

--- a/backend/src/meho_backplane/auth/__init__.py
+++ b/backend/src/meho_backplane/auth/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Operator authentication — JWT validation and identity primitives.
+
+Public surface:
+
+* :class:`Operator` — frozen pydantic v2 model carrying validated claims.
+* :func:`verify_jwt` — FastAPI dependency that validates the
+  ``Authorization: Bearer <jwt>`` header and yields an
+  :class:`Operator` to the route handler.
+* :func:`keycloak_readiness_probe` — registered against the readiness
+  registry from :mod:`meho_backplane.health` so ``/ready`` flips to
+  ``not_ready`` whenever the JWKS endpoint is unreachable.
+
+Downstream code should never import private symbols (``_`` prefix) from
+:mod:`meho_backplane.auth.jwt`; the cache helpers in particular are
+test-only.
+"""
+
+from meho_backplane.auth.jwt import keycloak_readiness_probe, verify_jwt
+from meho_backplane.auth.operator import Operator
+
+__all__ = ["Operator", "keycloak_readiness_probe", "verify_jwt"]

--- a/backend/src/meho_backplane/auth/jwt.py
+++ b/backend/src/meho_backplane/auth/jwt.py
@@ -1,0 +1,416 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Keycloak JWT validation — JWKS fetch + cache + ``verify_jwt`` dependency.
+
+This module is the load-bearing security primitive for every protected
+route in the backplane. Every authenticated request flows through
+:func:`verify_jwt`, which:
+
+1. Reads the ``Authorization: Bearer <token>`` header.
+2. Resolves the JWKS for the configured Keycloak issuer (cached
+   in-memory; bounded by a TTL and refreshed on a kid-miss).
+3. Verifies the JWT's signature, ``exp`` / ``nbf`` (with leeway),
+   ``iss``, and ``aud`` against the configured values.
+4. Returns an :class:`~meho_backplane.auth.operator.Operator` model
+   carrying the validated claims plus the original token string (the
+   raw JWT is needed verbatim by G2.2-T2's Vault forward-auth).
+
+Library choice (per ADR 0004 — see Initiative #21 / Task #13):
+``authlib.jose``. The module emits a deprecation warning recommending
+``joserfc`` (authlib's own successor); we keep ``authlib.jose`` for v0.1
+because the published API is stable until authlib 2.0 and the issue
+body's reference sketch targets it. Migration to ``joserfc`` is tracked
+as a v0.2 candidate.
+
+JWKS-cache shape: a single module-level tuple of ``(jwks_dict,
+fetched_at_monotonic)``. v0.1 runs single-worker uvicorn so the in-process
+cache is fine; multi-worker deployments would need a Redis-backed shared
+cache to avoid N worker-local round trips against Keycloak. That upgrade
+is recorded in #21's "Out of scope" section.
+
+Concurrency: the module-level cache is guarded by an ``asyncio.Lock`` so
+the first wave of authenticated requests after startup doesn't fan out N
+concurrent JWKS fetches.
+
+Readiness probe: :func:`keycloak_readiness_probe` performs a *synchronous*
+fetch against the same JWKS endpoint to bridge the registry's
+``Callable[[], ProbeResult]`` contract (Task #19) to the network reality.
+It is deliberately independent of the async cache — readiness must report
+"is the dependency reachable right now?", not "did we last reach it
+during a JWT verify?".
+
+This module never logs token contents or claim values — the
+``request_id`` correlation in :mod:`meho_backplane.middleware` is the
+only crumb left on a 401, by design (no leaks of bearer secrets, no
+identity leaks before authentication completes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import warnings
+from typing import Any
+
+import httpx
+
+# ``authlib.jose`` emits an ``AuthlibDeprecationWarning`` at first
+# import, recommending ``joserfc`` (authlib's own successor). The
+# published API stays compatible until authlib 2.0, and the issue
+# body's reference sketch targets it; v0.1 commits to ``authlib.jose``
+# and tracks migration as a v0.2 candidate. We deliberately do *not*
+# suppress this import-time warning — ``authlib.deprecate`` calls
+# ``warnings.simplefilter("always", AuthlibDeprecationWarning)`` which
+# overrides any nested ``catch_warnings`` context. The single warning
+# in pytest output is intentional and serves as the migration breadcrumb.
+from authlib.jose import JsonWebKey, JsonWebToken
+from authlib.jose.errors import (
+    BadSignatureError,
+    DecodeError,
+    ExpiredTokenError,
+    InvalidClaimError,
+    InvalidTokenError,
+    JoseError,
+    MissingClaimError,
+)
+from fastapi import Header, HTTPException, status
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.health import ProbeResult
+from meho_backplane.settings import Settings, get_settings
+
+__all__ = [
+    "clear_jwks_cache",
+    "keycloak_readiness_probe",
+    "verify_jwt",
+]
+
+#: HTTP timeout for both the OIDC discovery hit and the JWKS hit. Keep
+#: tight: a hung Keycloak should fail-closed quickly rather than
+#: starving request capacity.
+_HTTP_TIMEOUT_SECONDS: float = 5.0
+
+#: Algorithms accepted on the JWS header. Pinning to ``RS256`` mitigates
+#: the algorithm-confusion class of attacks (CVE-2016-10555); Keycloak
+#: defaults to ``RS256`` for ID/access tokens. Add other RS/ES variants
+#: here only when a specific Keycloak realm requires them.
+_ACCEPTED_ALGORITHMS: tuple[str, ...] = ("RS256",)
+
+# Module-level JWKS cache. ``_jwks_cache`` is None until the first fetch
+# succeeds; ``_jwks_fetched_at`` is the monotonic clock value at the
+# successful fetch. monotonic time is used (not wall clock) so a system
+# clock jump never silently extends or invalidates the cache.
+_jwks_cache: dict[str, Any] | None = None
+_jwks_fetched_at: float = 0.0
+_jwks_lock: asyncio.Lock = asyncio.Lock()
+
+
+def clear_jwks_cache() -> None:
+    """Invalidate the JWKS cache. Test-only — never call from production."""
+    global _jwks_cache, _jwks_fetched_at
+    _jwks_cache = None
+    _jwks_fetched_at = 0.0
+
+
+async def _http_get_json(url: str) -> dict[str, Any]:
+    """Fetch *url* and return the parsed JSON body.
+
+    Wrapped in its own helper so tests can monkey-patch a single seam,
+    and so the timeout / error-mapping policy lives in one place.
+    Network failures are re-raised as :class:`httpx.HTTPError` for the
+    caller to translate into a probe failure or a 401.
+    """
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        data: Any = response.json()
+        if not isinstance(data, dict):
+            raise httpx.HTTPError(f"expected JSON object from {url}, got {type(data).__name__}")
+        return data
+
+
+async def _resolve_jwks_uri(settings: Settings) -> str:
+    """Fetch the OIDC discovery doc and return the ``jwks_uri`` field.
+
+    Keycloak guarantees the well-known endpoint at
+    ``{issuer}/.well-known/openid-configuration``. We deliberately
+    re-resolve discovery on every cache miss rather than caching the
+    URI long-term; the cost is one extra round trip per cache miss
+    (rare), and it lets operators rotate Keycloak realms (and the
+    associated ``jwks_uri``) without restarting the backplane.
+    """
+    issuer = str(settings.keycloak_issuer_url).rstrip("/")
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    discovery = await _http_get_json(discovery_url)
+    jwks_uri = discovery.get("jwks_uri")
+    if not isinstance(jwks_uri, str) or not jwks_uri:
+        raise httpx.HTTPError(f"discovery doc at {discovery_url} missing 'jwks_uri'")
+    return jwks_uri
+
+
+async def _fetch_jwks(*, force_refresh: bool = False) -> dict[str, Any]:
+    """Return a JWKS dict, fetching from Keycloak when the cache is stale.
+
+    Cache-hit conditions:
+
+    * ``_jwks_cache`` is populated, AND
+    * ``force_refresh`` is False, AND
+    * ``time.monotonic() - _jwks_fetched_at`` is below the configured TTL.
+
+    Otherwise the function fetches discovery → JWKS, repopulates the
+    cache atomically under ``_jwks_lock``, and returns the new dict.
+    The lock prevents a thundering herd on first request after startup
+    or after a TTL expiry.
+    """
+    global _jwks_cache, _jwks_fetched_at
+
+    settings = get_settings()
+    ttl = settings.keycloak_jwks_cache_ttl_seconds
+
+    if (
+        not force_refresh
+        and _jwks_cache is not None
+        and (time.monotonic() - _jwks_fetched_at) < ttl
+    ):
+        return _jwks_cache
+
+    async with _jwks_lock:
+        # Re-check inside the lock — a sibling coroutine may have
+        # populated the cache while we were waiting.
+        if (
+            not force_refresh
+            and _jwks_cache is not None
+            and (time.monotonic() - _jwks_fetched_at) < ttl
+        ):
+            return _jwks_cache
+
+        jwks_uri = await _resolve_jwks_uri(settings)
+        jwks = await _http_get_json(jwks_uri)
+        if not isinstance(jwks.get("keys"), list):
+            raise httpx.HTTPError(f"JWKS at {jwks_uri} missing 'keys' array")
+
+        _jwks_cache = jwks
+        _jwks_fetched_at = time.monotonic()
+        return jwks
+
+
+def _decode_with_jwks(token: str, jwks: dict[str, Any], settings: Settings) -> Any:
+    """Verify *token* against *jwks* and return the validated claims.
+
+    Wrapped behind the ``warnings.catch_warnings`` block to suppress the
+    authlib-jose deprecation noise on every request — the deprecation is
+    a v0.2 migration item, not a per-request signal.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        jwt = JsonWebToken(list(_ACCEPTED_ALGORITHMS))
+        key_set = JsonWebKey.import_key_set(jwks)
+        claims = jwt.decode(
+            token,
+            key_set,
+            claims_options={
+                "iss": {
+                    "essential": True,
+                    "value": str(settings.keycloak_issuer_url).rstrip("/"),
+                },
+                "aud": {
+                    "essential": True,
+                    "value": settings.keycloak_audience,
+                },
+            },
+        )
+        claims.validate(leeway=settings.keycloak_jwt_leeway_seconds)
+        return claims
+
+
+# Exception classes that authlib raises for any kind of token-content
+# failure (signature, claims, structure). Grouped so ``verify_jwt`` can
+# treat them uniformly as 401 ``invalid_token``. ``_DECODE_ERRORS_WITH_VALUEERROR``
+# adds ``ValueError`` for the post-refresh retry path where a residual
+# kid-miss must also be classified as ``invalid_token`` rather than
+# triggering another infinite refresh loop.
+_AUTHLIB_DECODE_ERRORS: tuple[type[Exception], ...] = (
+    BadSignatureError,
+    DecodeError,
+    ExpiredTokenError,
+    InvalidClaimError,
+    InvalidTokenError,
+    MissingClaimError,
+    JoseError,
+)
+_DECODE_ERRORS_WITH_VALUEERROR: tuple[type[Exception], ...] = (
+    ValueError,
+    *_AUTHLIB_DECODE_ERRORS,
+)
+
+
+def _http_401(detail: str) -> HTTPException:
+    """Build the 401 the dependency raises on any failure path.
+
+    Centralised so the contract is one-line-changeable and so detail
+    strings don't drift across call sites — the dispatch table tests
+    in Task #25 will assert on these tokens verbatim.
+    """
+    return HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail)
+
+
+def _extract_bearer_token(authorization: str | None) -> str:
+    """Return the bare token from ``Authorization: Bearer <token>``.
+
+    Raises 401 ``missing_token`` for any header shape that isn't a
+    well-formed Bearer credential, including the empty-token edge case
+    (``Bearer    `` with whitespace only).
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        raise _http_401("missing_token")
+    token = authorization.removeprefix("Bearer ").strip()
+    if not token:
+        raise _http_401("missing_token")
+    return token
+
+
+async def _decode_with_kid_rotation(token: str, settings: Settings) -> Any:
+    """Decode *token* against the cached JWKS, refreshing once on a kid miss.
+
+    The first ``_fetch_jwks`` call serves the cached keyset (or fetches
+    one if the cache is empty). On a ``ValueError("Key not found")`` —
+    the canonical kid-rotation signal from authlib — the function
+    force-refreshes the JWKS and retries exactly once. Any other
+    decoding error, or a second kid miss after refresh, is fatal.
+    """
+    try:
+        jwks = await _fetch_jwks()
+    except (httpx.HTTPError, KeyError):
+        # JWKS unreachable surfaces as a credentials failure (401),
+        # not 5xx; /ready will flap on the same root cause via the
+        # readiness probe.
+        raise _http_401("jwks_unavailable") from None
+
+    try:
+        return _decode_with_jwks(token, jwks, settings)
+    except ValueError as exc:
+        if "Key not found" not in str(exc):
+            raise _http_401("invalid_token") from exc
+    except _AUTHLIB_DECODE_ERRORS as exc:
+        raise _http_401("invalid_token") from exc
+
+    # Kid miss → refresh once and retry.
+    try:
+        jwks = await _fetch_jwks(force_refresh=True)
+    except (httpx.HTTPError, KeyError):
+        raise _http_401("jwks_unavailable") from None
+
+    try:
+        return _decode_with_jwks(token, jwks, settings)
+    except _DECODE_ERRORS_WITH_VALUEERROR as retry_exc:
+        raise _http_401("invalid_token") from retry_exc
+
+
+def _operator_from_claims(claims: Any, raw_jwt: str) -> Operator:
+    """Project the validated claims into the public :class:`Operator` shape."""
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub:
+        # ``sub`` is mandated by OIDC core §2; a token without it is
+        # malformed regardless of signature validity.
+        raise _http_401("invalid_token")
+    name = claims.get("name")
+    email = claims.get("email")
+    return Operator(
+        sub=sub,
+        name=name if isinstance(name, str) else None,
+        email=email if isinstance(email, str) else None,
+        raw_jwt=raw_jwt,
+    )
+
+
+async def verify_jwt(authorization: str | None = Header(default=None)) -> Operator:
+    """FastAPI dependency: validate the Bearer token and return an Operator.
+
+    Raises 401 on every failure mode — missing header, malformed
+    ``Authorization`` shape, JWKS unreachable, signature mismatch,
+    expired token, audience mismatch, issuer mismatch, malformed JWT.
+    The error body is intentionally terse (``{"detail": "<reason>"}``)
+    and never echoes claim values; that prevents an unauthenticated
+    caller from probing the backplane for token shape.
+
+    Kid-rotation handling lives in :func:`_decode_with_kid_rotation`:
+    on the canonical "Key not found" ValueError from authlib, the JWKS
+    cache is refreshed exactly once and the verify is retried. A
+    second miss is a hard 401 ``invalid_token``.
+    """
+    token = _extract_bearer_token(authorization)
+    settings = get_settings()
+    claims = await _decode_with_kid_rotation(token, settings)
+    return _operator_from_claims(claims, token)
+
+
+def _http_get_json_sync(url: str) -> dict[str, Any]:
+    """Synchronous twin of :func:`_http_get_json` for the readiness probe.
+
+    The probe registry from Task #19 expects a synchronous callable, so
+    a sync HTTP client lives here. We don't share the async cache —
+    readiness is "Keycloak reachable *now*", not "we last reached it
+    inside some request".
+    """
+    with httpx.Client(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        data: Any = response.json()
+        if not isinstance(data, dict):
+            raise httpx.HTTPError(f"expected JSON object from {url}, got {type(data).__name__}")
+        return data
+
+
+def keycloak_readiness_probe() -> ProbeResult:
+    """Readiness probe: confirm Keycloak's JWKS endpoint is fetchable.
+
+    Registered with :mod:`meho_backplane.health` at app startup.
+
+    The probe issues a fresh discovery + JWKS fetch on every call. That
+    is intentional: ``/ready`` should reflect *current* dependency
+    health, not a stale cache state. Probes are cheap by registry
+    contract (Task #19), and Keycloak's JWKS endpoint is a single
+    HTTP GET against a CDN-able JSON document — a few hundred
+    milliseconds in the worst case.
+
+    Failure detail surfaces the exception class name (not its
+    message) so the probe payload never leaks issuer URLs or other
+    operator-controllable strings into a 503 response.
+    """
+    try:
+        settings = get_settings()
+    except Exception as exc:
+        return ProbeResult(
+            name="keycloak",
+            ok=False,
+            detail=f"settings_unavailable: {type(exc).__name__}",
+        )
+
+    issuer = str(settings.keycloak_issuer_url).rstrip("/")
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    try:
+        discovery = _http_get_json_sync(discovery_url)
+        jwks_uri = discovery.get("jwks_uri")
+        if not isinstance(jwks_uri, str) or not jwks_uri:
+            return ProbeResult(
+                name="keycloak",
+                ok=False,
+                detail="jwks_uri_missing",
+            )
+        jwks = _http_get_json_sync(jwks_uri)
+        if not isinstance(jwks.get("keys"), list):
+            return ProbeResult(
+                name="keycloak",
+                ok=False,
+                detail="jwks_malformed",
+            )
+    except Exception as exc:
+        return ProbeResult(
+            name="keycloak",
+            ok=False,
+            detail=f"jwks_fetch_failed: {type(exc).__name__}",
+        )
+
+    return ProbeResult(name="keycloak", ok=True, detail="jwks_fetched")

--- a/backend/src/meho_backplane/auth/jwt.py
+++ b/backend/src/meho_backplane/auth/jwt.py
@@ -54,6 +54,7 @@ import warnings
 from typing import Any
 
 import httpx
+import pydantic
 
 # ``authlib.jose`` emits an ``AuthlibDeprecationWarning`` at first
 # import, recommending ``joserfc`` (authlib's own successor). The
@@ -274,10 +275,17 @@ async def _decode_with_kid_rotation(token: str, settings: Settings) -> Any:
     """Decode *token* against the cached JWKS, refreshing once on a kid miss.
 
     The first ``_fetch_jwks`` call serves the cached keyset (or fetches
-    one if the cache is empty). On a ``ValueError("Key not found")`` —
-    the canonical kid-rotation signal from authlib — the function
-    force-refreshes the JWKS and retries exactly once. Any other
-    decoding error, or a second kid miss after refresh, is fatal.
+    one if the cache is empty). authlib raises ``ValueError`` (currently
+    with the message ``"Key not found"``) when the JWT's ``kid`` is
+    absent from the keyset — but the message is an internal detail and
+    has changed across authlib releases. We deliberately do **not**
+    string-match on it: any ``ValueError`` from ``_decode_with_jwks``
+    triggers a single, bounded refresh-and-retry. Other decoding errors
+    (signature, claims, structure) fail fast as 401 ``invalid_token``.
+
+    The retry budget is exactly one — a second ``ValueError`` after the
+    forced JWKS refresh is treated as a hard 401, preventing an
+    infinite-refresh loop on a token whose ``kid`` truly does not exist.
     """
     try:
         jwks = await _fetch_jwks()
@@ -289,9 +297,11 @@ async def _decode_with_kid_rotation(token: str, settings: Settings) -> Any:
 
     try:
         return _decode_with_jwks(token, jwks, settings)
-    except ValueError as exc:
-        if "Key not found" not in str(exc):
-            raise _http_401("invalid_token") from exc
+    except ValueError:
+        # Treat *any* ValueError as a kid-miss signal — the message
+        # ("Key not found") is authlib-internal and not part of any
+        # stable contract. Fall through to refresh-and-retry.
+        pass
     except _AUTHLIB_DECODE_ERRORS as exc:
         raise _http_401("invalid_token") from exc
 
@@ -308,7 +318,16 @@ async def _decode_with_kid_rotation(token: str, settings: Settings) -> Any:
 
 
 def _operator_from_claims(claims: Any, raw_jwt: str) -> Operator:
-    """Project the validated claims into the public :class:`Operator` shape."""
+    """Project the validated claims into the public :class:`Operator` shape.
+
+    A signature-valid JWT can still carry malformed claim values — most
+    notably an ``email`` that fails the ``EmailStr`` validator on
+    :class:`Operator`. Pydantic raises ``ValidationError`` in that case;
+    the security contract is that *every* failure to materialise a
+    trusted operator from a token surfaces as 401 ``invalid_token``,
+    never an unhandled 500. The try/except converts the validation
+    failure into the same 401 the rest of the dependency emits.
+    """
     sub = claims.get("sub")
     if not isinstance(sub, str) or not sub:
         # ``sub`` is mandated by OIDC core §2; a token without it is
@@ -316,12 +335,15 @@ def _operator_from_claims(claims: Any, raw_jwt: str) -> Operator:
         raise _http_401("invalid_token")
     name = claims.get("name")
     email = claims.get("email")
-    return Operator(
-        sub=sub,
-        name=name if isinstance(name, str) else None,
-        email=email if isinstance(email, str) else None,
-        raw_jwt=raw_jwt,
-    )
+    try:
+        return Operator(
+            sub=sub,
+            name=name if isinstance(name, str) else None,
+            email=email if isinstance(email, str) else None,
+            raw_jwt=raw_jwt,
+        )
+    except pydantic.ValidationError as exc:
+        raise _http_401("invalid_token") from exc
 
 
 async def verify_jwt(authorization: str | None = Header(default=None)) -> Operator:

--- a/backend/src/meho_backplane/auth/operator.py
+++ b/backend/src/meho_backplane/auth/operator.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The :class:`Operator` model — validated identity passed to routes.
+
+An :class:`Operator` is what every authenticated route handler receives
+via ``Depends(verify_jwt)``. The model is **frozen** (pydantic v2
+``ConfigDict(frozen=True)``) so a route handler can stash the operator
+on request state, log it, and forward it to downstream services without
+fear of mutation creating a confused-deputy bug.
+
+Field choices reflect what G2.2 / G2.3 consumers actually need:
+
+* ``sub`` — the OIDC subject identifier; the stable operator id.
+  Required.
+* ``name`` / ``email`` — soft identity bound from the matching JWT
+  claims when present. Used by audit middleware (G2.3) for
+  human-readable rows and by the CLI for the ``meho status`` greeting.
+* ``raw_jwt`` — the original Bearer token string. Required because
+  G2.2-T2's Vault forward-auth passes the original JWT (not a re-issued
+  one) to Vault's OIDC auth method; the chain of custody must be
+  preserved bit-for-bit.
+
+Email validation uses pydantic's ``EmailStr`` (powered by
+``email-validator``); a malformed ``email`` claim from Keycloak is a
+configuration bug and surfaces as a 401 rather than silently propagating
+garbage downstream.
+"""
+
+from pydantic import BaseModel, ConfigDict, EmailStr
+
+__all__ = ["Operator"]
+
+
+class Operator(BaseModel):
+    """Validated operator identity extracted from a verified JWT."""
+
+    model_config = ConfigDict(frozen=True)
+
+    sub: str
+    name: str | None = None
+    email: EmailStr | None = None
+    raw_jwt: str

--- a/backend/src/meho_backplane/auth/operator.py
+++ b/backend/src/meho_backplane/auth/operator.py
@@ -27,17 +27,26 @@ configuration bug and surfaces as a 401 rather than silently propagating
 garbage downstream.
 """
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 __all__ = ["Operator"]
 
 
 class Operator(BaseModel):
-    """Validated operator identity extracted from a verified JWT."""
+    """Validated operator identity extracted from a verified JWT.
+
+    ``raw_jwt`` is excluded from :meth:`__repr__` (``Field(repr=False)``)
+    so that an :class:`Operator` accidentally bound into a structured
+    log record — e.g. via ``logger.bind(operator=op)`` under structlog,
+    whose JSON renderer calls ``repr()`` on non-primitive values — never
+    leaks the bearer token to stdout or any downstream log shipper.
+    The model field is still populated and accessible by name; only the
+    default string representation is sanitised.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     sub: str
     name: str | None = None
     email: EmailStr | None = None
-    raw_jwt: str
+    raw_jwt: str = Field(repr=False)

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -22,6 +22,8 @@ from typing import Final
 from fastapi import FastAPI, Response
 
 from meho_backplane import __version__
+from meho_backplane.auth.jwt import keycloak_readiness_probe
+from meho_backplane.health import register_probe
 from meho_backplane.health import router as health_router
 from meho_backplane.logging import configure_logging
 from meho_backplane.metrics import render_metrics
@@ -36,13 +38,17 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     """Application lifespan hook.
 
     Configures structlog at startup so every log line emitted from this
-    point onwards (including the very first request) is JSON-formatted.
+    point onwards (including the very first request) is JSON-formatted,
+    and registers the Keycloak readiness probe with the registry so
+    ``/ready`` reflects whether the JWKS endpoint is reachable.
+
     There is nothing to tear down at shutdown yet; the ``yield`` /
     ``return`` shape is preserved so future Initiatives (G2.2 Vault
     client teardown, G2.3 SQLAlchemy engine ``dispose()``) can plug in
     without restructuring the function.
     """
     configure_logging()
+    register_probe("keycloak", keycloak_readiness_probe)
     yield
 
 

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runtime configuration sourced from environment variables.
+
+The backplane is configured exclusively through env vars in v0.1 — there
+is no on-disk config file, no config server, and no live reload. Every
+field has a documented default where one is sensible; required fields
+(``keycloak_issuer_url``, ``keycloak_audience``) raise at startup if the
+operator forgot to set them, which is the correct fail-closed behaviour
+for a security-critical surface.
+
+Settings are accessed through :func:`get_settings`, which caches a single
+:class:`Settings` instance for the process lifetime. This keeps the
+constructor's env-var parsing cost to once-per-process and gives every
+module (including FastAPI dependencies) a stable singleton without
+shipping a global. Tests override config by monkey-patching env vars and
+clearing the cache via ``get_settings.cache_clear()``.
+
+Pydantic v2 is the model engine; the ``BaseModel`` validators run at
+construction time so a missing or malformed env var fails the import
+chain immediately rather than days later under load.
+"""
+
+import os
+from functools import lru_cache
+
+from pydantic import BaseModel, Field, HttpUrl
+
+__all__ = ["Settings", "get_settings"]
+
+
+class Settings(BaseModel):
+    """Process-wide configuration knobs.
+
+    Attributes
+    ----------
+    keycloak_issuer_url:
+        The Keycloak realm's issuer URL — typically
+        ``https://<host>/realms/<realm>``. Must match the ``iss`` claim
+        of every accepted JWT exactly. Required (no default); the
+        backplane refuses to start without it.
+    keycloak_audience:
+        The OIDC ``aud`` claim every accepted JWT must carry. The
+        backplane is registered as a Keycloak client (e.g.
+        ``meho-backplane``); only tokens whose ``aud`` matches that
+        client id are honoured. Required.
+    keycloak_jwks_cache_ttl_seconds:
+        Maximum age of a cached JWKS document before it must be
+        refetched. The cache also refreshes on a kid-miss (key
+        rotation), so this TTL is a *safety net* against silent rotation
+        of the same kid — a low-probability but high-impact attack
+        surface — rather than the primary refresh trigger. Default 300
+        (5 minutes) follows the OIDC ecosystem norm.
+    keycloak_jwt_leeway_seconds:
+        Clock-skew tolerance applied to ``exp`` and ``nbf`` claim
+        validation. Real-world deployments routinely drift a few seconds
+        between Keycloak and backplane hosts; default 30s absorbs that
+        without giving meaningful runway to a stolen-token replay.
+    """
+
+    keycloak_issuer_url: HttpUrl
+    keycloak_audience: str = Field(min_length=1)
+    keycloak_jwks_cache_ttl_seconds: int = Field(default=300, gt=0)
+    keycloak_jwt_leeway_seconds: int = Field(default=30, ge=0)
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return the process-wide :class:`Settings` singleton.
+
+    Reads env vars on first call; subsequent calls return the cached
+    instance. Tests that need to swap config call
+    ``get_settings.cache_clear()`` after mutating ``os.environ``.
+
+    The function deliberately does **not** use ``pydantic-settings`` —
+    the backplane has only four knobs in v0.1 and the explicit
+    ``os.environ.get`` mapping below makes the env-var contract obvious
+    in code review. When the surface grows, switching to
+    ``BaseSettings`` is a one-commit refactor.
+    """
+    return Settings(
+        keycloak_issuer_url=os.environ["KEYCLOAK_ISSUER_URL"],  # type: ignore[arg-type]
+        keycloak_audience=os.environ["KEYCLOAK_AUDIENCE"],
+        keycloak_jwks_cache_ttl_seconds=int(
+            os.environ.get("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300"),
+        ),
+        keycloak_jwt_leeway_seconds=int(
+            os.environ.get("KEYCLOAK_JWT_LEEWAY_SECONDS", "30"),
+        ),
+    )

--- a/backend/tests/test_auth_jwt.py
+++ b/backend/tests/test_auth_jwt.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the JWT validation primitive.
+
+Coverage matrix (per Task #22 acceptance criteria):
+
+* Happy path: a JWT signed by a fixture key is accepted; the resulting
+  :class:`Operator` carries the expected ``sub`` / ``name`` / ``email``
+  / ``raw_jwt`` fields.
+* JWKS cache hit: two consecutive verifies issue exactly one JWKS fetch.
+* JWKS cache miss + refresh: clearing the cache forces a refetch.
+* Kid rotation: when the first JWKS response lacks the JWT's ``kid``,
+  the dependency refetches JWKS once and succeeds on retry.
+* Audience mismatch → 401.
+* Issuer mismatch → 401.
+* Expired token → 401.
+* Tampered signature → 401.
+* Missing / malformed Authorization header → 401.
+
+Failure-mode coverage beyond these basics is the responsibility of
+Task #25 (G2.2-T4); this file ships a happy-path-plus-sanity-check
+suite so #22 can land in isolation.
+
+Test fixture strategy: the suite mints its own RSA key pair, builds a
+JWKS document around the public half, and uses ``respx`` to intercept
+both the OIDC discovery URL and the ``jwks_uri`` returned by it. That
+keeps the test self-contained — no network, no test-double Keycloak
+container, no fixture key files in the repo.
+"""
+
+from __future__ import annotations
+
+import time
+import warnings
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from authlib.jose import JsonWebKey, JsonWebToken
+
+from meho_backplane.auth.jwt import (
+    clear_jwks_cache,
+    keycloak_readiness_probe,
+    verify_jwt,
+)
+from meho_backplane.auth.operator import Operator
+from meho_backplane.settings import get_settings
+
+_ISSUER: str = "https://keycloak.test/realms/meho"
+_AUDIENCE: str = "meho-backplane"
+_DISCOVERY_URL: str = f"{_ISSUER}/.well-known/openid-configuration"
+_JWKS_URL: str = f"{_ISSUER}/protocol/openid-connect/certs"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the four Keycloak env vars and reset the settings cache.
+
+    Settings are cached per-process via ``functools.lru_cache``; without
+    a per-test reset, an env-var change wouldn't propagate.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    """Empty the module-level JWKS cache around every test."""
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+def _make_rsa_keypair(kid: str) -> Any:
+    """Generate a fresh RSA-2048 keypair with the requested ``kid``."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return JsonWebKey.generate_key(
+            "RSA",
+            2048,
+            options={"kid": kid},
+            is_private=True,
+        )
+
+
+def _public_jwks(*keys: Any) -> dict[str, list[dict[str, Any]]]:
+    """Build a JWKS document containing the public half of each key."""
+    return {"keys": [k.as_dict(is_private=False) for k in keys]}
+
+
+def _mint_token(
+    private_key: Any,
+    *,
+    sub: str = "op-42",
+    name: str | None = "Damir Topić",
+    email: str | None = "damir@example.com",
+    issuer: str = _ISSUER,
+    audience: str = _AUDIENCE,
+    expires_in: int = 3600,
+    not_before_offset: int = 0,
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    """Mint a JWT signed by *private_key*, returning the compact form."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        jwt = JsonWebToken(["RS256"])
+        now = int(time.time())
+        payload: dict[str, Any] = {
+            "sub": sub,
+            "iss": issuer,
+            "aud": audience,
+            "iat": now,
+            "exp": now + expires_in,
+            "nbf": now + not_before_offset,
+        }
+        if name is not None:
+            payload["name"] = name
+        if email is not None:
+            payload["email"] = email
+        if extra_claims:
+            payload.update(extra_claims)
+        header = {
+            "alg": "RS256",
+            "kid": private_key.as_dict()["kid"],
+            "typ": "JWT",
+        }
+        token: bytes | str = jwt.encode(header, payload, private_key)
+        return token.decode("ascii") if isinstance(token, bytes) else token
+
+
+def _mock_discovery_and_jwks(
+    mock_router: respx.MockRouter,
+    jwks: dict[str, Any],
+) -> tuple[respx.Route, respx.Route]:
+    """Stub the OIDC discovery endpoint and the JWKS endpoint."""
+    discovery_route = mock_router.get(_DISCOVERY_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "issuer": _ISSUER,
+                "jwks_uri": _JWKS_URL,
+            },
+        ),
+    )
+    jwks_route = mock_router.get(_JWKS_URL).mock(
+        return_value=httpx.Response(200, json=jwks),
+    )
+    return discovery_route, jwks_route
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app exposing one verify_jwt-protected route."""
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(operator: Operator = Depends(verify_jwt)) -> dict[str, Any]:
+        return {
+            "sub": operator.sub,
+            "name": operator.name,
+            "email": operator.email,
+            "raw_jwt": operator.raw_jwt,
+        }
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Header-shape failures (no token reaches verification)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_authorization_header_returns_401() -> None:
+    client = TestClient(_build_app())
+    response = client.get("/whoami")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "missing_token"}
+
+
+def test_non_bearer_authorization_returns_401() -> None:
+    client = TestClient(_build_app())
+    response = client.get("/whoami", headers={"Authorization": "Basic abc"})
+    assert response.status_code == 401
+    assert response.json() == {"detail": "missing_token"}
+
+
+def test_empty_bearer_token_returns_401() -> None:
+    client = TestClient(_build_app())
+    response = client.get("/whoami", headers={"Authorization": "Bearer    "})
+    assert response.status_code == 401
+    assert response.json() == {"detail": "missing_token"}
+
+
+def test_unparseable_bearer_token_returns_401() -> None:
+    client = TestClient(_build_app())
+    with respx.mock(assert_all_called=False) as mock_router:
+        # JWKS is technically reachable; the token itself is garbage.
+        _mock_discovery_and_jwks(mock_router, {"keys": []})
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": "Bearer not-a-real-jwt"},
+        )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid_token"}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_jwt_returns_operator_with_claims() -> None:
+    """A well-signed token yields an Operator carrying the verified claims."""
+    key = _make_rsa_keypair("kid-A")
+    jwks = _public_jwks(key)
+    token = _mint_token(key, sub="op-1", name="Alice", email="alice@example.com")
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, jwks)
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "sub": "op-1",
+        "name": "Alice",
+        "email": "alice@example.com",
+        "raw_jwt": token,
+    }
+
+
+def test_valid_jwt_without_optional_claims_yields_none_fields() -> None:
+    """``name`` / ``email`` are optional; absence yields explicit ``None``."""
+    key = _make_rsa_keypair("kid-A")
+    jwks = _public_jwks(key)
+    token = _mint_token(key, sub="op-7", name=None, email=None)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, jwks)
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sub"] == "op-7"
+    assert body["name"] is None
+    assert body["email"] is None
+
+
+# ---------------------------------------------------------------------------
+# JWKS cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_jwks_cache_hit_avoids_second_fetch() -> None:
+    """Two consecutive verifies share one JWKS fetch."""
+    key = _make_rsa_keypair("kid-A")
+    jwks = _public_jwks(key)
+    token = _mint_token(key)
+
+    with respx.mock as mock_router:
+        discovery_route, jwks_route = _mock_discovery_and_jwks(mock_router, jwks)
+        client = TestClient(_build_app())
+        first = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+        second = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert discovery_route.call_count == 1
+    assert jwks_route.call_count == 1
+
+
+def test_jwks_cache_miss_after_clear_triggers_refresh() -> None:
+    """Explicitly clearing the cache forces the next verify to refetch JWKS."""
+    key = _make_rsa_keypair("kid-A")
+    jwks = _public_jwks(key)
+    token = _mint_token(key)
+
+    with respx.mock as mock_router:
+        discovery_route, jwks_route = _mock_discovery_and_jwks(mock_router, jwks)
+        client = TestClient(_build_app())
+        first = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+        clear_jwks_cache()
+        second = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert discovery_route.call_count == 2
+    assert jwks_route.call_count == 2
+
+
+def test_kid_rotation_triggers_jwks_refresh_and_succeeds() -> None:
+    """A token signed by a kid that's missing from the cached JWKS forces a refetch.
+
+    First verify primes the cache with ``kid-A``. We then mint a token
+    against ``kid-B`` and swap the JWKS endpoint to return the
+    ``kid-B``-only key set. The dependency must observe the kid miss,
+    refresh the cache, and succeed on retry.
+    """
+    key_a = _make_rsa_keypair("kid-A")
+    key_b = _make_rsa_keypair("kid-B")
+    token_a = _mint_token(key_a)
+    token_b = _mint_token(key_b)
+
+    with respx.mock as mock_router:
+        discovery_route, jwks_route = _mock_discovery_and_jwks(
+            mock_router,
+            _public_jwks(key_a),
+        )
+        client = TestClient(_build_app())
+
+        # Prime the cache with the kid-A keyset.
+        first = client.get("/whoami", headers={"Authorization": f"Bearer {token_a}"})
+        assert first.status_code == 200
+
+        # Rotate the JWKS endpoint to return only the kid-B key.
+        jwks_route.mock(return_value=httpx.Response(200, json=_public_jwks(key_b)))
+
+        second = client.get("/whoami", headers={"Authorization": f"Bearer {token_b}"})
+
+    assert second.status_code == 200
+    # First verify: 1 discovery + 1 jwks. Second verify: cache hit, then
+    # kid miss, then forced refresh = 1 more discovery + 1 more jwks.
+    assert discovery_route.call_count == 2
+    assert jwks_route.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Validation failures (sanity check; full coverage in Task #25)
+# ---------------------------------------------------------------------------
+
+
+def test_audience_mismatch_returns_401() -> None:
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, audience="wrong-audience")
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid_token"}
+
+
+def test_issuer_mismatch_returns_401() -> None:
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, issuer="https://attacker.test/realms/meho")
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid_token"}
+
+
+def test_expired_token_returns_401() -> None:
+    key = _make_rsa_keypair("kid-A")
+    # expires_in negative → exp is in the past, beyond the leeway window
+    token = _mint_token(key, expires_in=-600)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid_token"}
+
+
+def test_tampered_signature_returns_401() -> None:
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key)
+    # Flip the last 10 chars of the signature segment.
+    head, _, tail = token.rpartition(".")
+    tampered = f"{head}.{'A' * len(tail)}"
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {tampered}"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid_token"}
+
+
+# ---------------------------------------------------------------------------
+# JWKS unreachable
+# ---------------------------------------------------------------------------
+
+
+def test_jwks_unreachable_returns_401() -> None:
+    """When discovery / JWKS fetch fails the dependency yields 401.
+
+    The token itself is well-formed; only the network is broken. We
+    distinguish ``jwks_unavailable`` from ``invalid_token`` so operators
+    chasing 401s can tell whether they're looking at a credential issue
+    or a dependency issue.
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key)
+
+    with respx.mock as mock_router:
+        mock_router.get(_DISCOVERY_URL).mock(return_value=httpx.Response(503))
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "jwks_unavailable"}
+
+
+# ---------------------------------------------------------------------------
+# Readiness probe
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_probe_passes_when_jwks_fetchable() -> None:
+    key = _make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        result = keycloak_readiness_probe()
+
+    assert result.name == "keycloak"
+    assert result.ok is True
+    assert result.detail == "jwks_fetched"
+
+
+def test_readiness_probe_fails_when_discovery_unreachable() -> None:
+    with respx.mock as mock_router:
+        mock_router.get(_DISCOVERY_URL).mock(return_value=httpx.Response(503))
+        result = keycloak_readiness_probe()
+
+    assert result.name == "keycloak"
+    assert result.ok is False
+    assert result.detail is not None
+    assert result.detail.startswith("jwks_fetch_failed:")
+
+
+def test_readiness_probe_fails_when_jwks_malformed() -> None:
+    with respx.mock as mock_router:
+        mock_router.get(_DISCOVERY_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"issuer": _ISSUER, "jwks_uri": _JWKS_URL},
+            ),
+        )
+        mock_router.get(_JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"unexpected": "shape"}),
+        )
+        result = keycloak_readiness_probe()
+
+    assert result.ok is False
+    assert result.detail == "jwks_malformed"

--- a/backend/tests/test_auth_jwt.py
+++ b/backend/tests/test_auth_jwt.py
@@ -486,3 +486,110 @@ def test_readiness_probe_fails_when_jwks_malformed() -> None:
 
     assert result.ok is False
     assert result.detail == "jwks_malformed"
+
+
+# ---------------------------------------------------------------------------
+# Regression: malformed claims, secret-leak, contract-coupling
+# (B1 / B2 / M1 from PR #151 review iter-1)
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_email_claim_returns_401() -> None:
+    """B1 regression: a signature-valid JWT carrying a malformed ``email``
+    claim must reject as 401 ``invalid_token`` — never as a 500.
+
+    The Operator model uses pydantic's ``EmailStr`` validator; if the
+    Keycloak realm is misconfigured and emits ``"not-an-email"``,
+    pydantic raises ``ValidationError`` during ``Operator(...)``
+    construction. The dependency must catch that and return 401, not
+    propagate the exception as an unhandled 500.
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-evil", email="not-an-email")
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid_token"}
+
+
+def test_operator_repr_does_not_leak_raw_jwt() -> None:
+    """B2 regression: ``repr(Operator(...))`` must not contain the bearer
+    token string, and must not even mention ``raw_jwt`` as a field name.
+
+    structlog (wired in Task #24) calls ``repr()`` on bound non-primitive
+    values when emitting JSON; an unrestricted default repr would dump
+    every operator's full bearer token to stdout / log shippers. The
+    field is excluded via ``Field(repr=False)``.
+    """
+    fake_token = "header.payload.signature-very-secret"
+    op = Operator(
+        sub="op-1",
+        name="Alice",
+        email="alice@example.com",
+        raw_jwt=fake_token,
+    )
+
+    text = repr(op)
+    assert fake_token not in text, f"raw_jwt value leaked into repr: {text!r}"
+    assert "raw_jwt" not in text, f"raw_jwt field name leaked into repr: {text!r}"
+    # The field is still populated and accessible by name — we only
+    # sanitised the default representation.
+    assert op.raw_jwt == fake_token
+
+
+def test_value_error_key_not_found_triggers_jwks_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M1 regression: any ``ValueError`` from the JWKS-decode helper
+    triggers a single refresh-and-retry — independent of the message
+    string.
+
+    The kid-rotation contract used to depend on string-matching
+    authlib's ``"Key not found"`` ValueError; an authlib version bump
+    could silently change that message and break rotation. The fix
+    drops the string match. To prove the new contract, we monkey-patch
+    ``_decode_with_jwks`` to raise a ``ValueError`` with an *unrelated*
+    message on the first call and to delegate to the real implementation
+    on the second — and assert (a) the JWKS endpoint was hit twice
+    (initial + forced refresh) and (b) the verify ultimately succeeds.
+    """
+    from meho_backplane.auth import jwt as jwt_module
+
+    key = _make_rsa_keypair("kid-A")
+    jwks = _public_jwks(key)
+    token = _mint_token(key)
+
+    real_decode = jwt_module._decode_with_jwks
+    call_count = {"n": 0}
+
+    def fake_decode(tok: str, ks: dict[str, Any], settings: Any) -> Any:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Message intentionally unrelated to "Key not found" — the
+            # fix must refresh on *any* ValueError.
+            raise ValueError("some opaque authlib internal message")
+        return real_decode(tok, ks, settings)
+
+    monkeypatch.setattr(jwt_module, "_decode_with_jwks", fake_decode)
+
+    with respx.mock as mock_router:
+        discovery_route, jwks_route = _mock_discovery_and_jwks(mock_router, jwks)
+        client = TestClient(_build_app())
+        response = client.get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    # Initial decode raised ValueError -> forced refresh -> retry succeeds.
+    assert call_count["n"] == 2
+    # The forced refresh re-hits both discovery and JWKS.
+    assert discovery_route.call_count == 2
+    assert jwks_route.call_count == 2

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -76,12 +76,82 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -103,6 +173,81 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -206,6 +351,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -270,37 +427,43 @@ name = "meho-backplane"
 version = "0.1.0.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "authlib" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "prometheus-client" },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
+    { name = "cryptography" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", specifier = ">=1.3" },
     { name = "fastapi", specifier = ">=0.110" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "prometheus-client", specifier = ">=0.20" },
-    { name = "pydantic", specifier = ">=2.6" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.6" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "cryptography", specifier = ">=42.0" },
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.5" },
 ]
 
@@ -394,6 +557,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -406,6 +578,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -574,6 +751,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -8,21 +8,29 @@
 `backend/` houses the MEHO governance-layer backplane — a FastAPI
 service that mediates every operation an AI agent runs against shared
 infrastructure (policy gating, audit, federation, observability). At
-this Goal-#11 chassis stage it exposes:
+this stage it exposes:
 
 * The identity route at `/`.
 * The public operator surfaces — `/healthz`, `/version`, `/ready` —
-  backed by a pluggable readiness-probe registry that is empty by
-  default and **fails closed on `/ready`** (Task #19).
+  backed by a pluggable readiness-probe registry. The chassis defaults
+  to an empty registry that **fails closed on `/ready`** (Task #19);
+  the lifespan hook now registers the Keycloak readiness probe
+  (Task #22) so `/ready` flips green only when Keycloak's JWKS is
+  reachable.
 * Observability primitives — Prometheus metrics on `/metrics`,
   structured JSON logs to stdout via structlog, and a `request_id`
   correlation identifier propagated across every HTTP request via the
   request-context middleware (Task #20).
+* Operator authentication — the `verify_jwt` FastAPI dependency
+  validates `Authorization: Bearer <jwt>` against Keycloak's JWKS
+  (cached, kid-rotation aware) and yields a frozen `Operator` model
+  (Task #22). No protected routes are mounted yet; consumers land in
+  G2.2-T3 (`/api/v1/health`).
 
-JWT validation, Vault federation, and database persistence land
-progressively in subsequent G2.2 / G2.3 Tasks. The stack (FastAPI,
-Pydantic v2, SQLAlchemy 2.x async, Alembic, structlog,
-prometheus_client) is locked by
+Vault federation and database persistence land progressively in
+subsequent G2.2 / G2.3 Tasks. The stack (FastAPI, Pydantic v2,
+SQLAlchemy 2.x async, Alembic, structlog, prometheus_client, authlib
+for JOSE) is locked by
 [ADR 0004](https://github.com/evoila-bosnia/meho-internal/issues/13).
 
 The project follows the modern src-layout
@@ -48,6 +56,11 @@ PYTHONPATH-leak imports.
 | `SENSITIVE_HEADERS` | `src/meho_backplane/middleware.py` | `frozenset({b"authorization", b"cookie", b"x-api-key"})`. The middleware never logs the values of these headers; redaction is enforced by *not* logging request headers at all in v0.1, with a `tests/test_observability.py` regression test. |
 | `HTTP_REQUESTS_TOTAL` | `src/meho_backplane/metrics.py` | Module-level `prometheus_client.Counter` registered against the default registry. Labels: `method`, `path`, `status`. `path` is the matched FastAPI route template when available, bounding label cardinality. |
 | `render_metrics` | `src/meho_backplane/metrics.py` | Returns `(body, content_type)` for the `/metrics` route. Pins `text/plain; version=0.0.4; charset=utf-8` — the legacy Prometheus format every scraper accepts (`prometheus_client>=0.21` advertises 1.0.0 in `CONTENT_TYPE_LATEST`, but 0.0.4 stays universally compatible). |
+| `Settings` / `get_settings` | `src/meho_backplane/settings.py` | Pydantic v2 model + `lru_cache`-singleton accessor for the Keycloak knobs (`KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_JWKS_CACHE_TTL_SECONDS`, `KEYCLOAK_JWT_LEEWAY_SECONDS`). Tests reset via `get_settings.cache_clear()`. |
+| `Operator` | `src/meho_backplane/auth/operator.py` | Frozen pydantic v2 model carrying validated claims (`sub`, `name`, `email`, `raw_jwt`). Returned by `verify_jwt`; consumed by every authenticated route from G2.2-T3 onward. `raw_jwt` is preserved verbatim for G2.2-T2's Vault forward-auth. |
+| `verify_jwt` | `src/meho_backplane/auth/jwt.py` | FastAPI dependency: parses `Authorization: Bearer ...`, fetches/caches Keycloak's JWKS, validates signature + `iss` + `aud` + `exp` (with leeway), refreshes JWKS on a kid miss, and returns an `Operator`. Every failure mode collapses to a terse 401. |
+| `keycloak_readiness_probe` | `src/meho_backplane/auth/jwt.py` | Synchronous probe registered with the readiness registry at app lifespan startup. Hits `{issuer}/.well-known/openid-configuration` then `jwks_uri`; failure detail surfaces only the exception class name to avoid leaking issuer URLs into 503 payloads. |
+| JWKS cache | `src/meho_backplane/auth/jwt.py` (`_jwks_cache`, `_jwks_fetched_at`, `_jwks_lock`) | Module-level dict + monotonic-fetched timestamp + asyncio lock. TTL-bounded (default 5 min) and kid-rotation refreshed (one forced re-fetch per request on a kid miss). Single-worker design; v0.2 may move to Redis when multi-worker uvicorn is needed. |
 
 ## Control flow
 
@@ -103,20 +116,35 @@ Pinned-floor declarations; exact versions resolved into `uv.lock`.
 | `pydantic` | ≥ 2.6 | Pulled transitively by FastAPI; pinned explicitly so v1 can't be substituted. |
 | `structlog` | ≥ 24.1 | JSON-to-stdout logging + `contextvars`-based `request_id` propagation. |
 | `prometheus-client` | ≥ 0.20 | Default process / GC collectors + the `http_requests_total` counter exposed on `/metrics`. |
+| `pydantic[email]` | ≥ 2.6 | Frozen `Operator` model uses `EmailStr`, which pulls `email-validator` via the `email` extra. |
+| `authlib` | ≥ 1.3 | JWS / JWK / JWT primitives for Keycloak token verification. The `authlib.jose` namespace is deprecated in favour of `joserfc` (same maintainer, clean rewrite); migration to `joserfc` is tracked as a v0.2 candidate. |
+| `httpx` | ≥ 0.27 | Async + sync HTTP client for the OIDC discovery doc and JWKS endpoint. (Also used as the `fastapi.testclient.TestClient` backend.) |
 | (dev) `pytest` ≥ 8 | | Test runner. |
 | (dev) `pytest-asyncio` ≥ 0.23 | | Async test support; `asyncio_mode = "auto"` in pyproject. |
-| (dev) `httpx` ≥ 0.27 | | Backend for `fastapi.testclient.TestClient`. |
+| (dev) `cryptography` ≥ 42.0 | | RSA keypair generation in test fixtures (authlib pulls it transitively in production). |
+| (dev) `respx` ≥ 0.21 | | httpx-native mock router used to stub Keycloak's discovery + JWKS endpoints in `tests/test_auth_jwt.py`. |
 | (dev) `ruff` ≥ 0.5 | | Lint + format. |
 | (dev) `mypy` ≥ 1.10 | | Strict type checking. |
 
 ## Known issues
 
-`/ready` returns 503 in the default chassis state because the probe
-registry is empty — this is **fail-closed by design**, not a bug. The
-chassis flips to readiness-ready only once G2.2 (Vault/Keycloak) and
-G2.3 (Alembic migrations) call `register_probe`. Helm charts pointing
-their kubernetes readiness probe at `/ready` before those Initiatives
-land will see pods stay `NotReady`; that's the intended contract.
+`/ready` returns 503 until at least one passing probe is registered.
+After Task #22 the lifespan hook registers the Keycloak probe, so a
+running app with a reachable Keycloak realm reports 200. Without
+Keycloak (or before Vault lands in G2.2-T2 and DB migrations land in
+G2.3) `/ready` stays 503 by design. Helm charts pointing their
+kubernetes readiness probe at `/ready` before those Initiatives land
+will see pods stay `NotReady`; that's the intended contract.
+
+`authlib.jose` emits an `AuthlibDeprecationWarning` at first import,
+recommending `joserfc` (the same maintainer's clean rewrite). The
+warning shows up once in every pytest run because authlib's own
+`authlib/deprecate.py` calls `warnings.simplefilter("always",
+AuthlibDeprecationWarning)` at import time, overriding any nested
+`warnings.catch_warnings()` context. We intentionally leave the
+warning visible — it's the migration breadcrumb for the v0.2
+`joserfc` switch — and the published API stays stable until
+authlib 2.0.
 
 The `Authorization` / `Cookie` / `X-API-Key` redaction guarantee in
 `RequestContextMiddleware` is enforced *by omission*: the middleware
@@ -142,10 +170,15 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - Task #18 — this chassis bootstrap
 - Task #19 — public health + version + readiness endpoints
 - Task #20 — observability primitives (`/metrics`, structlog, middleware)
+- Task #22 — Keycloak JWT validation + readiness probe
 - [FastAPI tutorial](https://fastapi.tiangolo.com/tutorial/)
 - [FastAPI lifespan API](https://fastapi.tiangolo.com/advanced/events/)
+- [FastAPI dependencies (`Depends`)](https://fastapi.tiangolo.com/tutorial/dependencies/)
 - [Starlette middleware (pure ASGI vs BaseHTTPMiddleware)](https://www.starlette.io/middleware/)
 - [structlog contextvars](https://www.structlog.org/en/stable/contextvars.html)
 - [prometheus_client](https://github.com/prometheus/client_python)
+- [authlib JOSE / JWT docs](https://docs.authlib.org/en/latest/jose/jwt.html)
+- [respx mock router](https://lundberg.github.io/respx/)
+- [OIDC core — token validation](https://openid.net/specs/openid-connect-core-1_0.html#TokenResponseValidation)
 - [uv project structure](https://docs.astral.sh/uv/concepts/projects/)
 - [uv production Docker pattern](https://docs.astral.sh/uv/guides/integration/docker/)


### PR DESCRIPTION
## Summary

- Adds the `verify_jwt` FastAPI dependency — every protected route from G2.2-T3 onward will declare `Depends(verify_jwt)` to receive a validated `Operator` model (sub / name / email / raw_jwt). The raw JWT is preserved verbatim because G2.2-T2's Vault forward-auth needs bit-for-bit chain of custody.
- Implements a JWKS cache with TTL bounding (default 5 min) plus kid-rotation refresh: on a `ValueError("Key not found")` from authlib the cache is force-refreshed exactly once and the verify retried. Single `asyncio.Lock` prevents thundering-herd JWKS fetches at startup.
- Registers a synchronous Keycloak readiness probe with the Task #19 registry from the FastAPI lifespan hook. `/ready` now reflects whether `{issuer}/.well-known/openid-configuration` and the resulting `jwks_uri` are reachable. Failure detail surfaces only the exception class name so issuer URLs never leak into 503 payloads.
- Adds `meho_backplane.settings` (pydantic v2 `BaseModel` + `lru_cache` accessor) for `KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_JWKS_CACHE_TTL_SECONDS` (default 300), `KEYCLOAK_JWT_LEEWAY_SECONDS` (default 30).

Library choice per ADR 0004: `authlib.jose` (issue body's reference). authlib emits an `AuthlibDeprecationWarning` recommending its successor `joserfc`; the API stays compatible until authlib 2.0 and migration is a v0.2 candidate.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean (strict mode, with one `[[overrides]]` block whitelisting `authlib.*` since the package ships no stubs)
- [x] `pytest -x -q` — 38 passed (17 new tests in `test_auth_jwt.py`, 21 pre-existing unchanged)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (one informational warning for the 417-line jwt.py file, well below the 600-line block limit)

Acceptance criteria — verified:
- [x] Module structure exists at `backend/src/meho_backplane/auth/{jwt,operator}.py`; SPDX headers on every authored file (per ADR 0003)
- [x] `verify_jwt` is a FastAPI dependency: a route declared as `Depends(verify_jwt)` returns 401 without `Authorization: Bearer ...` (`test_missing_authorization_header_returns_401`) and 401 with an unparseable token (`test_unparseable_bearer_token_returns_401`)
- [x] Happy-path test: JWT signed by a fixture key yields an `Operator` with `sub` / `name` / `email` / `raw_jwt` populated from claims (`test_valid_jwt_returns_operator_with_claims`)
- [x] Kid-rotation test: first JWKS response lacks the JWT's kid → dependency refetches JWKS once and succeeds on retry (`test_kid_rotation_triggers_jwks_refresh_and_succeeds`)
- [x] Keycloak readiness probe registered; `/ready` includes `{"name": "keycloak", "ok": true, "detail": "jwks_fetched"}` when JWKS is reachable (`test_readiness_probe_passes_when_jwks_fetchable`)

## Out of scope

- Failure-mode test sweep beyond happy-path + sanity (expired, wrong-aud, wrong-iss, tampered) — Task #25 (G2.2-T4) ships the comprehensive suite. This PR includes single-shot smoke versions of each so #22 lands self-verifiable.
- Routes that USE `verify_jwt` — Task #24 (G2.2-T3) mounts `/api/v1/health`.
- Vault forward-auth — Task #23 (G2.2-T2).
- Operator-identity propagation into structlog contextvars — Task #24.
- Per-instance JWKS cache shared across uvicorn workers (Redis-backed) — v0.2 candidate.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#22


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keycloak-based JWT auth for protected endpoints; readiness check reflects Keycloak JWKS availability
  * JWKS caching with automatic refresh on key rotation; token parsing preserves raw token without exposing it in representations

* **Bug Fixes**
  * Claim validation tightened (malformed claims return 401); single-refresh retry on transient JWKS decode errors

* **Chores**
  * Updated dependencies (pydantic[email], authlib, httpx) and added Keycloak environment config

* **Documentation**
  * Backend docs updated with auth/readiness behavior and related references

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/151)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->