### PR TITLE
feat(backend): add Vault OIDC forward-auth client + readiness probe

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "prometheus-client>=0.20",
     "authlib>=1.3",
     "httpx>=0.27",
+    "hvac>=2.4.0",
 ]
 
 [dependency-groups]
@@ -83,6 +84,25 @@ files = ["src"]
 # every other dependency.
 [[tool.mypy.overrides]]
 module = ["authlib.*"]
+ignore_missing_imports = true
+
+# hvac (HashiCorp Vault Python client, ADR 0004) ships no ``py.typed``
+# marker as of 2.4.0 — every public method returns ``Any``. Whitelisting
+# its tree lets strict mode keep biting on the rest of the codebase
+# while the Vault wrapper module localises the untyped surface to one
+# place. If hvac later ships stubs, drop this override.
+[[tool.mypy.overrides]]
+module = ["hvac.*"]
+ignore_missing_imports = true
+
+# ``requests`` is hvac's transport dependency. We only catch its
+# exception types in :mod:`meho_backplane.auth.vault` to map them
+# through to backplane-side errors; we don't depend on its public API
+# directly. ``types-requests`` would pull a separate stub package into
+# the runtime image; whitelisting the module keeps the dev image lean
+# without weakening typing for first-party code.
+[[tool.mypy.overrides]]
+module = ["requests.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/backend/src/meho_backplane/auth/__init__.py
+++ b/backend/src/meho_backplane/auth/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Operator authentication — JWT validation and identity primitives.
+"""Operator authentication — JWT validation, identity, and Vault forward-auth.
 
 Public surface:
 
@@ -12,13 +12,37 @@ Public surface:
 * :func:`keycloak_readiness_probe` — registered against the readiness
   registry from :mod:`meho_backplane.health` so ``/ready`` flips to
   ``not_ready`` whenever the JWKS endpoint is unreachable.
+* :func:`vault_client_for_operator` — async context manager yielding an
+  authenticated :class:`hvac.Client` bound to the operator. Performs a
+  Vault OIDC login on entry and revokes the per-request token on exit.
+* :func:`vault_readiness_probe` — registered against the readiness
+  registry; reports Vault reachability via ``/sys/health``.
+* :class:`VaultClientError`, :class:`VaultUnreachableError`,
+  :class:`VaultRoleDeniedError` — backplane-side exception hierarchy
+  callers raise / catch without importing hvac.
 
 Downstream code should never import private symbols (``_`` prefix) from
-:mod:`meho_backplane.auth.jwt`; the cache helpers in particular are
-test-only.
+:mod:`meho_backplane.auth.jwt` or :mod:`meho_backplane.auth.vault`; the
+cache helpers and threadpool wrappers are test-only.
 """
 
 from meho_backplane.auth.jwt import keycloak_readiness_probe, verify_jwt
 from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import (
+    VaultClientError,
+    VaultRoleDeniedError,
+    VaultUnreachableError,
+    vault_client_for_operator,
+    vault_readiness_probe,
+)
 
-__all__ = ["Operator", "keycloak_readiness_probe", "verify_jwt"]
+__all__ = [
+    "Operator",
+    "VaultClientError",
+    "VaultRoleDeniedError",
+    "VaultUnreachableError",
+    "keycloak_readiness_probe",
+    "vault_client_for_operator",
+    "vault_readiness_probe",
+    "verify_jwt",
+]

--- a/backend/src/meho_backplane/auth/vault.py
+++ b/backend/src/meho_backplane/auth/vault.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault OIDC forward-auth — hvac client + per-request ``jwt_login``.
+
+This module is the **federation chain's middle link**. After
+:mod:`meho_backplane.auth.jwt` validates a Keycloak-issued JWT and
+yields an :class:`~meho_backplane.auth.operator.Operator`, callers use
+:func:`vault_client_for_operator` to forward that *same validated* JWT
+to Vault's JWT/OIDC auth method. Vault verifies the JWT against its own
+configured trust of Keycloak (bound to the ``meho-mcp`` role per Goal
+#11) and issues a Vault token bound to the operator's identity. Every
+secret read the backplane performs on behalf of an operator therefore
+appears in Vault's audit log tagged with that operator's ``sub`` —
+completing the audit trail the requirement letter mandates.
+
+Per-request login is deliberate for v0.1: each authenticated request
+that needs a Vault read does (1) JWT validate, (2) Vault OIDC login,
+(3) read secret, (4) revoke the Vault token. v0.2 may cache per-operator
+across requests with token-TTL respect; the simpler shape is acceptable
+under dogfood load.
+
+Library choice (per ADR 0004 — see Initiative #21 / Task #13): hvac.
+hvac is **synchronous** (built on ``requests``); FastAPI does *not*
+auto-offload blocking I/O inside ``async def`` callables, so every hvac
+call from this module is wrapped in ``asyncio.to_thread`` to keep the
+event loop responsive. The wrapper helpers
+(:func:`_to_thread_jwt_login`, :func:`_to_thread_revoke_self`,
+:func:`_to_thread_read_health`) are the only seam tests need to mock.
+
+Error mapping:
+
+* Vault returns 403 when the JWT is valid but the role denies access
+  (or when the role is missing). hvac's adapter raises
+  :class:`hvac.exceptions.Forbidden` — surfaced here as
+  :class:`VaultRoleDeniedError`.
+* The TCP / TLS layer fails (DNS, connection refused, TLS handshake,
+  read timeout) before any Vault status code lands. ``requests``
+  raises one of :class:`requests.exceptions.ConnectionError` /
+  :class:`requests.exceptions.Timeout` — surfaced as
+  :class:`VaultUnreachableError`.
+* Anything else hvac raises (:class:`hvac.exceptions.VaultError`
+  subclasses for 400/404/429/500/501/502/503) is wrapped in the
+  generic :class:`VaultClientError` so callers don't have to import
+  hvac to catch them.
+
+Token revocation on context exit is best-effort. A failed
+``revoke_self`` is logged in the future (G2.4 audit middleware) but
+does **not** propagate — the request has already returned its body to
+the caller, and the Vault token will time out on its own TTL anyway.
+The revoke is a defence-in-depth measure that limits the blast radius
+if a token leaks via a future log-instrumentation regression.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+from typing import Any
+
+import hvac
+import hvac.exceptions
+import requests.exceptions
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.health import ProbeResult
+from meho_backplane.settings import Settings, get_settings
+
+__all__ = [
+    "VaultClientError",
+    "VaultRoleDeniedError",
+    "VaultUnreachableError",
+    "vault_client_for_operator",
+    "vault_readiness_probe",
+]
+
+
+class VaultClientError(Exception):
+    """Base class for backplane-side Vault failures.
+
+    Raised by :func:`vault_client_for_operator` when the JWT forward to
+    Vault fails for any reason. Subclasses carry more specific intent;
+    callers can catch the base class to surface a single error response
+    shape (G2.2-T3 wires this into the ``/api/v1/health`` route).
+    """
+
+
+class VaultUnreachableError(VaultClientError):
+    """Vault is not reachable — DNS, TCP, TLS, or read-timeout failure.
+
+    Distinguishes infrastructure failure from auth failure. Operators
+    chasing a 5xx in production should see this when the Vault pod is
+    down; the readiness probe registered via :func:`vault_readiness_probe`
+    will be flapping in lock-step.
+    """
+
+
+class VaultRoleDeniedError(VaultClientError):
+    """Vault rejected the JWT for the configured role.
+
+    Either the role does not exist on the configured mount path, the
+    role's bound claims (``bound_audiences``, ``bound_subject``,
+    ``role_type``, ``user_claim``) do not match the incoming JWT, or
+    Vault's own trust of the Keycloak issuer is misconfigured. Surfaces
+    as a 401/403 to the caller in G2.2-T3 — never a 5xx.
+    """
+
+
+def _build_client(settings: Settings, *, token: str | None = None) -> hvac.Client:
+    """Construct an unauthenticated :class:`hvac.Client` from settings.
+
+    Centralises the ``vault_addr`` / ``vault_namespace`` /
+    ``vault_timeout_seconds`` mapping so the readiness probe and the
+    per-operator login share one construction path. ``token`` is
+    threaded through so tests can build a client bound to a fixture
+    token without round-tripping through ``jwt_login``.
+    """
+    return hvac.Client(
+        url=str(settings.vault_addr).rstrip("/"),
+        namespace=settings.vault_namespace,
+        timeout=settings.vault_timeout_seconds,
+        token=token,
+    )
+
+
+def _do_jwt_login(client: hvac.Client, *, role: str, jwt: str, mount_path: str) -> None:
+    """Synchronously perform ``client.auth.jwt.jwt_login`` and bind the token.
+
+    hvac's ``jwt_login`` returns the raw JSON response from Vault; with
+    ``use_token=True`` (the default) it also assigns the issued token
+    onto ``client.token`` so subsequent calls authenticate. This helper
+    re-asserts that contract and raises :class:`VaultRoleDeniedError`
+    when Vault returns a 403 — the most operator-actionable failure
+    mode and the one Task #25 will exercise comprehensively.
+
+    The ``Forbidden`` catch is intentionally narrow. Any other
+    :class:`hvac.exceptions.VaultError` (bad mount path → 404, server
+    error → 500, sealed Vault → 503) propagates as
+    :class:`VaultClientError` from the calling context manager so the
+    caller can choose its 401 / 5xx mapping without inspecting hvac
+    internals.
+    """
+    try:
+        client.auth.jwt.jwt_login(role=role, jwt=jwt, path=mount_path)
+    except hvac.exceptions.Forbidden as exc:
+        raise VaultRoleDeniedError(f"vault role denied: {exc}") from exc
+
+
+def _do_revoke_self(client: hvac.Client) -> None:
+    """Best-effort revoke of the per-request Vault token.
+
+    Swallows every exception class hvac and requests can raise. The
+    request has already returned to the operator; a failed revoke does
+    not invalidate the secret read that succeeded a moment earlier, and
+    the Vault token will expire on its own TTL. Defence-in-depth
+    measure — its failure is not actionable.
+    """
+    with suppress(hvac.exceptions.VaultError, requests.exceptions.RequestException):
+        client.auth.token.revoke_self()
+
+
+async def _to_thread_jwt_login(
+    client: hvac.Client, *, role: str, jwt: str, mount_path: str
+) -> None:
+    """Run :func:`_do_jwt_login` off the event loop."""
+    await asyncio.to_thread(_do_jwt_login, client, role=role, jwt=jwt, mount_path=mount_path)
+
+
+async def _to_thread_revoke_self(client: hvac.Client) -> None:
+    """Run :func:`_do_revoke_self` off the event loop."""
+    await asyncio.to_thread(_do_revoke_self, client)
+
+
+@asynccontextmanager
+async def vault_client_for_operator(operator: Operator) -> AsyncIterator[hvac.Client]:
+    """Yield an authenticated :class:`hvac.Client` bound to *operator*.
+
+    Performs the JWT/OIDC login on every entry — v0.1 has no per-operator
+    token cache. The caller drives any Vault operations the role allows
+    (typically a KV v2 read) and the context manager revokes the issued
+    token on exit, capping the token's lifetime at one request even
+    when Vault's role TTL is generous.
+
+    Raises
+    ------
+    VaultUnreachableError:
+        TCP / TLS / timeout failure reaching Vault. The caller should
+        translate this into a 503 from any HTTP route that needed Vault.
+    VaultRoleDeniedError:
+        Vault returned 403 — JWT valid but role bindings did not match
+        or the role is missing.
+    VaultClientError:
+        Any other Vault-side failure (4xx / 5xx that isn't 403, sealed
+        Vault, malformed response, etc.).
+    """
+    settings = get_settings()
+    client = _build_client(settings)
+
+    try:
+        await _to_thread_jwt_login(
+            client,
+            role=settings.vault_oidc_role,
+            jwt=operator.raw_jwt,
+            mount_path=settings.vault_oidc_mount_path,
+        )
+    except VaultClientError:
+        # Already a backplane error — propagate verbatim. (Caught by the
+        # subclass check before the base ``VaultError`` branch below.)
+        raise
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+    ) as exc:
+        raise VaultUnreachableError(f"vault unreachable: {type(exc).__name__}") from exc
+    except hvac.exceptions.VaultError as exc:
+        raise VaultClientError(f"vault error: {type(exc).__name__}: {exc}") from exc
+
+    try:
+        yield client
+    finally:
+        await _to_thread_revoke_self(client)
+
+
+def _classify_health_response(payload: Any) -> tuple[bool, str]:
+    """Translate hvac's ``read_health_status`` return into (ok, detail).
+
+    hvac's ``JSONAdapter`` returns a plain dict for HTTP 200 responses
+    and a :class:`requests.Response` for any non-200 (because non-200
+    bodies are not guaranteed to be JSON). For ``/sys/health`` Vault
+    happens to always return JSON regardless of status code, but the
+    adapter only auto-decodes 200s. We coerce both shapes here.
+
+    Vault's ``/sys/health`` HTTP contract:
+
+    ===== =========================================================
+    200   initialized + unsealed + active
+    429   initialized + unsealed + standby
+    472   DR secondary
+    473   performance standby
+    501   not initialized
+    503   sealed
+    ===== =========================================================
+
+    For readiness purposes we treat 200/429 as **ok** (Vault is serving
+    requests); 472/473 are also "ok" for OSS dogfood (we don't run a
+    DR / performance-standby topology in v0.1, but a future operator
+    could). 501 and 503 are **not ok** — Vault cannot honour an OIDC
+    login while sealed or uninitialized.
+    """
+    if isinstance(payload, dict):
+        sealed = bool(payload.get("sealed", False))
+        initialized = bool(payload.get("initialized", True))
+        if sealed:
+            return False, "sealed"
+        if not initialized:
+            return False, "uninitialized"
+        return True, f"sealed={sealed}"
+
+    # Non-200 path — payload is a ``requests.Response`` instance. We
+    # cannot import its concrete type for an isinstance check without
+    # tightening the test contract; the duck-typed ``status_code``
+    # attribute is sufficient and matches what hvac itself does.
+    status_code = getattr(payload, "status_code", None)
+    if status_code in (429, 472, 473):
+        # Vault is reachable and serving — just not the active leader.
+        return True, f"http_{status_code}"
+    if status_code == 501:
+        return False, "uninitialized"
+    if status_code == 503:
+        return False, "sealed"
+    return False, f"unexpected_status: {status_code}"
+
+
+def vault_readiness_probe() -> ProbeResult:
+    """Readiness probe — confirm Vault's ``/sys/health`` is reachable.
+
+    Registered with :mod:`meho_backplane.health` at app startup. Hits
+    Vault on every call (no caching); ``/sys/health`` is unauthenticated
+    and explicitly designed to be cheap by HashiCorp's own contract.
+
+    The probe distinguishes three failure shapes in ``detail``:
+
+    * ``unreachable: <ExceptionClassName>`` — TCP/TLS/DNS/timeout.
+    * ``sealed`` / ``uninitialized`` — Vault answered, but is not
+      serving. ``/api/v1/health`` callers will get a 503 next.
+    * ``unexpected_status: <code>`` — the contract changed (or a proxy
+      injected an unexpected response). Visible in
+      :mod:`/ready <meho_backplane.health>` for operators to chase.
+
+    Detail strings never echo Vault's URL or the operator's namespace —
+    those are operator-controlled inputs and a 503 payload should not
+    surface them.
+    """
+    try:
+        settings = get_settings()
+    except Exception as exc:
+        return ProbeResult(
+            name="vault",
+            ok=False,
+            detail=f"settings_unavailable: {type(exc).__name__}",
+        )
+
+    client = _build_client(settings)
+    try:
+        # ``method='GET'`` so we get the JSON body when status is 200,
+        # and a ``requests.Response`` (with a status code we can read)
+        # when Vault is sealed / uninitialized / standby. The HEAD
+        # default returns no body, which is fine for a load balancer
+        # but loses the ``sealed`` flag we want to surface in detail.
+        payload = client.sys.read_health_status(method="GET")
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+    ) as exc:
+        return ProbeResult(
+            name="vault",
+            ok=False,
+            detail=f"unreachable: {type(exc).__name__}",
+        )
+    except hvac.exceptions.VaultError as exc:
+        # ``read_health_status`` is called with ``raise_exception=False``
+        # internally, so reaching this branch implies a Vault response
+        # the adapter could not classify (e.g. wholly malformed body).
+        return ProbeResult(
+            name="vault",
+            ok=False,
+            detail=f"vault_error: {type(exc).__name__}",
+        )
+
+    ok, detail = _classify_health_response(payload)
+    return ProbeResult(name="vault", ok=ok, detail=detail)

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -23,6 +23,7 @@ from fastapi import FastAPI, Response
 
 from meho_backplane import __version__
 from meho_backplane.auth.jwt import keycloak_readiness_probe
+from meho_backplane.auth.vault import vault_readiness_probe
 from meho_backplane.health import register_probe
 from meho_backplane.health import router as health_router
 from meho_backplane.logging import configure_logging
@@ -39,16 +40,20 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 
     Configures structlog at startup so every log line emitted from this
     point onwards (including the very first request) is JSON-formatted,
-    and registers the Keycloak readiness probe with the registry so
-    ``/ready`` reflects whether the JWKS endpoint is reachable.
+    and registers the Keycloak + Vault readiness probes with the
+    registry so ``/ready`` reflects whether each dependency is
+    reachable. The Vault probe is registered even though no protected
+    route consuming Vault has landed yet (G2.2-T3) — readiness is a
+    deployment-shape concern, not a request-path concern.
 
     There is nothing to tear down at shutdown yet; the ``yield`` /
-    ``return`` shape is preserved so future Initiatives (G2.2 Vault
-    client teardown, G2.3 SQLAlchemy engine ``dispose()``) can plug in
-    without restructuring the function.
+    ``return`` shape is preserved so future Initiatives (G2.3
+    SQLAlchemy engine ``dispose()``) can plug in without restructuring
+    the function.
     """
     configure_logging()
     register_probe("keycloak", keycloak_readiness_probe)
+    register_probe("vault", vault_readiness_probe)
     yield
 
 

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -57,12 +57,45 @@ class Settings(BaseModel):
         validation. Real-world deployments routinely drift a few seconds
         between Keycloak and backplane hosts; default 30s absorbs that
         without giving meaningful runway to a stolen-token replay.
+    vault_addr:
+        Base URL of the Vault server, e.g. ``https://vault.evba.lab``.
+        Required — the backplane refuses to start without it. The OIDC
+        forward-auth chain hangs entirely off this endpoint.
+    vault_oidc_role:
+        Vault role bound to the JWT auth method that the backplane
+        forwards tokens against. Default ``meho-mcp`` matches Goal #11's
+        requirement letter; operators provisioning a different Vault
+        role can override per environment.
+    vault_oidc_mount_path:
+        Mount path of Vault's JWT/OIDC auth method, **without** the
+        ``auth/`` prefix. Vault's recommended convention is to mount
+        the JWT method at ``jwt`` (the default) and the OIDC method at
+        ``oidc``; either name works for this backplane because hvac's
+        ``jwt_login`` calls the same ``POST /auth/{path}/login``
+        endpoint regardless of the underlying handler. Override only
+        when a Vault operator has chosen a non-standard mount path.
+    vault_namespace:
+        Vault Enterprise namespace for the JWT auth method, sent as
+        the ``X-Vault-Namespace`` header. ``None`` (the default) for
+        Vault OSS — the header is omitted, which is the correct shape
+        for non-Enterprise deployments.
+    vault_timeout_seconds:
+        Timeout applied to every HTTP call into Vault (login, secret
+        read, health probe). Kept tight: a hung Vault should
+        fail-closed quickly rather than starve request capacity. The
+        v0.1 dogfood load is per-request login, so the timeout governs
+        worst-case request latency directly.
     """
 
     keycloak_issuer_url: HttpUrl
     keycloak_audience: str = Field(min_length=1)
     keycloak_jwks_cache_ttl_seconds: int = Field(default=300, gt=0)
     keycloak_jwt_leeway_seconds: int = Field(default=30, ge=0)
+    vault_addr: HttpUrl
+    vault_oidc_role: str = Field(default="meho-mcp", min_length=1)
+    vault_oidc_mount_path: str = Field(default="jwt", min_length=1)
+    vault_namespace: str | None = None
+    vault_timeout_seconds: float = Field(default=10.0, gt=0)
 
 
 @lru_cache(maxsize=1)
@@ -79,6 +112,7 @@ def get_settings() -> Settings:
     in code review. When the surface grows, switching to
     ``BaseSettings`` is a one-commit refactor.
     """
+    vault_namespace_env = os.environ.get("VAULT_NAMESPACE")
     return Settings(
         keycloak_issuer_url=os.environ["KEYCLOAK_ISSUER_URL"],  # type: ignore[arg-type]
         keycloak_audience=os.environ["KEYCLOAK_AUDIENCE"],
@@ -87,5 +121,19 @@ def get_settings() -> Settings:
         ),
         keycloak_jwt_leeway_seconds=int(
             os.environ.get("KEYCLOAK_JWT_LEEWAY_SECONDS", "30"),
+        ),
+        vault_addr=os.environ["VAULT_ADDR"],  # type: ignore[arg-type]
+        vault_oidc_role=os.environ.get("VAULT_OIDC_ROLE", "meho-mcp"),
+        vault_oidc_mount_path=os.environ.get("VAULT_OIDC_MOUNT_PATH", "jwt"),
+        # ``VAULT_NAMESPACE`` distinguishes "unset" (OSS deployment, no
+        # header) from empty-string (operator misconfiguration); the
+        # latter is preserved so pydantic's ``min_length`` would reject
+        # it — but we deliberately allow None|str without min_length
+        # because OSS expects None. Empty-string is treated as None
+        # here to match Vault's own CLI which silently drops empty
+        # ``-namespace`` values.
+        vault_namespace=vault_namespace_env if vault_namespace_env else None,
+        vault_timeout_seconds=float(
+            os.environ.get("VAULT_TIMEOUT_SECONDS", "10.0"),
         ),
     )

--- a/backend/tests/test_auth_jwt.py
+++ b/backend/tests/test_auth_jwt.py
@@ -62,15 +62,20 @@ _JWKS_URL: str = f"{_ISSUER}/protocol/openid-connect/certs"
 
 @pytest.fixture(autouse=True)
 def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Pin the four Keycloak env vars and reset the settings cache.
+    """Pin every env var the Settings model reads and reset the cache.
 
     Settings are cached per-process via ``functools.lru_cache``; without
-    a per-test reset, an env-var change wouldn't propagate.
+    a per-test reset, an env-var change wouldn't propagate. The Vault
+    knobs are pinned here even though this file does not exercise the
+    Vault client — :class:`Settings` validates them at construction
+    time, so any path that calls :func:`get_settings` (including
+    :func:`verify_jwt`) needs them populated.
     """
     monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
     monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
     monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/backend/tests/test_auth_vault.py
+++ b/backend/tests/test_auth_vault.py
@@ -1,0 +1,546 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Vault OIDC forward-auth primitive.
+
+Coverage matrix (per Task #23 acceptance criteria):
+
+* Happy path: ``vault_client_for_operator(operator)`` performs
+  ``jwt_login`` against the configured role + mount path, yields a
+  client that can read a secret, and revokes the issued token on exit.
+* Token revocation: the same suite asserts ``revoke_self`` runs on
+  context exit even when the body raises.
+* Per-request login: each entry into the context manager performs an
+  independent ``jwt_login`` (no caching across calls).
+* Vault readiness probe: passes when ``/sys/health`` returns 200 with
+  ``sealed: false``; reports ``sealed`` / ``uninitialized`` /
+  ``http_429`` (standby) / ``unreachable`` distinctly in ``detail``.
+
+Failure-mode coverage beyond these basics is the responsibility of
+Task #25 (G2.2-T4); this file ships a happy-path-plus-sanity-check
+suite so #23 can land in isolation. The Vault-unreachable and
+role-denied paths are exercised here as sanity checks because they're
+the two failure modes most likely to regress on hvac upgrades.
+
+Test isolation strategy: the production code constructs the hvac
+client through one private helper (``_build_client``). Tests
+monkey-patch that helper with a fake whose methods record calls and
+return whatever the test scenario demands — no real HTTP, no
+``requests``-level mocking, no Vault container. This keeps the suite
+fast (entire run is sub-second) and decouples it from the wire-level
+``requests`` library that hvac depends on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import hvac.exceptions
+import pytest
+import requests.exceptions
+
+from meho_backplane.auth import vault as vault_module
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import (
+    VaultClientError,
+    VaultRoleDeniedError,
+    VaultUnreachableError,
+    vault_client_for_operator,
+    vault_readiness_probe,
+)
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var the Settings model reads.
+
+    Settings are cached per-process via ``functools.lru_cache``; without
+    a per-test reset, an env-var change wouldn't propagate.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@dataclass
+class _FakeJWTAuth:
+    """Stand-in for ``client.auth.jwt`` exposing the one method we exercise."""
+
+    login_calls: list[dict[str, Any]] = field(default_factory=list)
+    raise_on_login: Exception | None = None
+    issued_token: str = "fake-vault-token"
+    parent: _FakeClient | None = None
+
+    def jwt_login(self, role: str, jwt: str, path: str | None = None) -> dict[str, Any]:
+        self.login_calls.append({"role": role, "jwt": jwt, "path": path})
+        if self.raise_on_login is not None:
+            raise self.raise_on_login
+        # hvac's real implementation also assigns the token onto the client
+        # when ``use_token=True`` (the default). The wrapper relies on
+        # that side effect for subsequent secret reads.
+        if self.parent is not None:
+            self.parent.token = self.issued_token
+        return {"auth": {"client_token": self.issued_token}}
+
+
+@dataclass
+class _FakeTokenAuth:
+    """Stand-in for ``client.auth.token`` covering ``revoke_self``."""
+
+    revoke_calls: int = 0
+    raise_on_revoke: Exception | None = None
+
+    def revoke_self(self, mount_point: str = "token") -> None:
+        self.revoke_calls += 1
+        if self.raise_on_revoke is not None:
+            raise self.raise_on_revoke
+
+
+@dataclass
+class _FakeAuth:
+    """Stand-in for ``client.auth`` aggregating jwt + token sub-namespaces."""
+
+    jwt: _FakeJWTAuth
+    token: _FakeTokenAuth
+
+
+@dataclass
+class _FakeSysBackend:
+    """Stand-in for ``client.sys`` covering ``read_health_status``."""
+
+    payload: Any = None
+    raise_on_read: Exception | None = None
+    read_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def read_health_status(self, *, method: str = "HEAD", **_kwargs: Any) -> Any:
+        self.read_calls.append({"method": method})
+        if self.raise_on_read is not None:
+            raise self.raise_on_read
+        return self.payload
+
+
+@dataclass
+class _FakeSecretsKVv2:
+    """Stand-in for ``client.secrets.kv.v2`` covering one secret read."""
+
+    fixture_secret: dict[str, Any] = field(default_factory=dict)
+    last_token_seen: str | None = None
+    parent: _FakeClient | None = None
+
+    def read_secret_version(self, path: str, **_kwargs: Any) -> dict[str, Any]:
+        # Capture whichever token the client carries when the read fires —
+        # the happy-path test asserts the post-login token is in effect.
+        if self.parent is not None:
+            self.last_token_seen = self.parent.token
+        return {"data": {"data": self.fixture_secret, "metadata": {"path": path}}}
+
+
+@dataclass
+class _FakeSecretsKV:
+    v2: _FakeSecretsKVv2
+
+
+@dataclass
+class _FakeSecrets:
+    kv: _FakeSecretsKV
+
+
+@dataclass
+class _FakeClient:
+    """In-memory stand-in for :class:`hvac.Client`.
+
+    Carries the public attributes the production code touches —
+    ``token``, ``auth``, ``sys``, ``secrets`` — and nothing more.
+    Constructed through :func:`_install_fake_client` so the
+    ``vault_module._build_client`` seam returns it on every call.
+    """
+
+    url: str
+    timeout: float
+    namespace: str | None
+    token: str | None
+    auth: _FakeAuth
+    sys: _FakeSysBackend
+    secrets: _FakeSecrets
+
+
+def _install_fake_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    health_payload: Any = None,
+    health_exc: Exception | None = None,
+    login_exc: Exception | None = None,
+    revoke_exc: Exception | None = None,
+    secret_data: dict[str, Any] | None = None,
+) -> _FakeClient:
+    """Patch ``vault_module._build_client`` to return a controllable fake.
+
+    Returns the fake so individual tests can read ``login_calls`` /
+    ``revoke_calls`` / ``read_calls`` after exercising the production
+    code path.
+    """
+    jwt_auth = _FakeJWTAuth(raise_on_login=login_exc)
+    token_auth = _FakeTokenAuth(raise_on_revoke=revoke_exc)
+    sys_backend = _FakeSysBackend(
+        payload=health_payload,
+        raise_on_read=health_exc,
+    )
+    kv_v2 = _FakeSecretsKVv2(fixture_secret=secret_data or {})
+    fake = _FakeClient(
+        url="https://vault.test",
+        timeout=5.0,
+        namespace=None,
+        token=None,
+        auth=_FakeAuth(jwt=jwt_auth, token=token_auth),
+        sys=sys_backend,
+        secrets=_FakeSecrets(kv=_FakeSecretsKV(v2=kv_v2)),
+    )
+    # Cross-link so the fake jwt_login can mutate ``fake.token`` and the
+    # secret read can capture the active token at call time — both
+    # behaviours that the real hvac client exhibits.
+    jwt_auth.parent = fake
+    kv_v2.parent = fake
+
+    def _fake_build_client(_settings: Any, *, token: str | None = None) -> _FakeClient:
+        fake.token = token
+        return fake
+
+    monkeypatch.setattr(vault_module, "_build_client", _fake_build_client)
+    return fake
+
+
+def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
+    """Build a minimal :class:`Operator` for the forward-auth tests."""
+    return Operator(
+        sub="op-1",
+        name="Alice",
+        email="alice@example.com",
+        raw_jwt=jwt,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Settings smoke-test
+# ---------------------------------------------------------------------------
+
+
+def test_settings_carry_vault_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Vault settings load from env with the documented defaults."""
+    monkeypatch.delenv("VAULT_OIDC_ROLE", raising=False)
+    monkeypatch.delenv("VAULT_OIDC_MOUNT_PATH", raising=False)
+    monkeypatch.delenv("VAULT_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert str(settings.vault_addr).startswith("https://vault.test")
+    assert settings.vault_oidc_role == "meho-mcp"
+    assert settings.vault_oidc_mount_path == "jwt"
+    assert settings.vault_namespace is None
+    assert settings.vault_timeout_seconds == 10.0
+
+
+def test_settings_vault_namespace_empty_string_normalises_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator misconfiguration (``VAULT_NAMESPACE=``) is treated as OSS.
+
+    Vault's own CLI silently drops empty ``-namespace`` values; we
+    follow that convention so a misset env var doesn't poison every
+    request with an empty ``X-Vault-Namespace`` header.
+    """
+    monkeypatch.setenv("VAULT_NAMESPACE", "")
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert settings.vault_namespace is None
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_vault_client_for_operator_logs_in_and_yields_authenticated_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``jwt_login`` runs once, the client carries the issued token, the
+    body can read a secret, and ``revoke_self`` runs on exit.
+    """
+    fake = _install_fake_client(
+        monkeypatch,
+        secret_data={"username": "demo", "password": "s3cret"},
+    )
+    operator = _make_operator(jwt="op-jwt")
+
+    async with vault_client_for_operator(operator) as client:
+        # Cast: the fake quacks like hvac.Client for the surface the
+        # caller exercises, even though it isn't a subclass.
+        secret = client.secrets.kv.v2.read_secret_version(  # type: ignore[attr-defined]
+            path="meho/test/federation",
+        )
+        assert secret["data"]["data"] == {"username": "demo", "password": "s3cret"}
+        # The fake captured the token in effect at call time — the
+        # post-login one, not the pre-login None.
+        assert fake.secrets.kv.v2.last_token_seen == "fake-vault-token"
+
+    # Login was called with the configured role + mount path + raw jwt.
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"},
+    ]
+    # Token was revoked on context exit.
+    assert fake.auth.token.revoke_calls == 1
+
+
+async def test_vault_client_for_operator_revokes_token_even_when_body_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``finally`` branch guarantees revoke runs on the unhappy path too."""
+    fake = _install_fake_client(monkeypatch)
+    operator = _make_operator()
+
+    class _BoomError(Exception):
+        pass
+
+    with pytest.raises(_BoomError):
+        async with vault_client_for_operator(operator):
+            raise _BoomError("user code blew up")
+
+    assert fake.auth.token.revoke_calls == 1
+
+
+async def test_vault_client_for_operator_per_request_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each entry performs an independent login; v0.1 has no token cache."""
+    fake = _install_fake_client(monkeypatch)
+    operator = _make_operator()
+
+    async with vault_client_for_operator(operator):
+        pass
+    async with vault_client_for_operator(operator):
+        pass
+
+    assert len(fake.auth.jwt.login_calls) == 2
+    assert fake.auth.token.revoke_calls == 2
+
+
+async def test_vault_client_revoke_failure_does_not_propagate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed revoke is best-effort — it must not surface as an error.
+
+    The body has already returned its result. A failed revoke means
+    the token will time out on its own TTL; it does not invalidate
+    the secret read that succeeded a moment earlier.
+    """
+    fake = _install_fake_client(
+        monkeypatch,
+        revoke_exc=hvac.exceptions.InvalidRequest("token already revoked"),
+    )
+    operator = _make_operator()
+
+    async with vault_client_for_operator(operator):
+        pass
+
+    assert fake.auth.token.revoke_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Sanity-check failure modes (full coverage in Task #25)
+# ---------------------------------------------------------------------------
+
+
+async def test_vault_unreachable_wraps_to_unreachable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Connection failure during login surfaces as ``VaultUnreachableError``."""
+    _install_fake_client(
+        monkeypatch,
+        login_exc=requests.exceptions.ConnectionError("no route to host"),
+    )
+
+    with pytest.raises(VaultUnreachableError) as exc_info:
+        async with vault_client_for_operator(_make_operator()):
+            pytest.fail("body should not run when login raises")
+    assert "ConnectionError" in str(exc_info.value)
+
+
+async def test_vault_timeout_wraps_to_unreachable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A read timeout maps to ``VaultUnreachableError`` (same operator action)."""
+    _install_fake_client(
+        monkeypatch,
+        login_exc=requests.exceptions.Timeout("read timed out"),
+    )
+
+    with pytest.raises(VaultUnreachableError):
+        async with vault_client_for_operator(_make_operator()):
+            pytest.fail("body should not run when login raises")
+
+
+async def test_vault_role_denied_wraps_to_role_denied_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 403 from Vault surfaces as ``VaultRoleDeniedError``."""
+    _install_fake_client(
+        monkeypatch,
+        login_exc=hvac.exceptions.Forbidden("permission denied"),
+    )
+
+    with pytest.raises(VaultRoleDeniedError):
+        async with vault_client_for_operator(_make_operator()):
+            pytest.fail("body should not run when login raises")
+
+
+async def test_vault_other_error_wraps_to_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-403 hvac errors collapse to the base ``VaultClientError``."""
+    _install_fake_client(
+        monkeypatch,
+        login_exc=hvac.exceptions.InvalidRequest("bad mount path"),
+    )
+
+    with pytest.raises(VaultClientError) as exc_info:
+        async with vault_client_for_operator(_make_operator()):
+            pytest.fail("body should not run when login raises")
+    # Must NOT be a subclass — it's the generic catchall.
+    assert not isinstance(exc_info.value, (VaultUnreachableError, VaultRoleDeniedError))
+
+
+# ---------------------------------------------------------------------------
+# Readiness probe
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_probe_passes_on_unsealed_active_vault(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _install_fake_client(
+        monkeypatch,
+        health_payload={
+            "initialized": True,
+            "sealed": False,
+            "standby": False,
+            "version": "1.18.0",
+        },
+    )
+    result = vault_readiness_probe()
+
+    assert result.name == "vault"
+    assert result.ok is True
+    assert result.detail == "sealed=False"
+    assert fake.sys.read_calls == [{"method": "GET"}]
+
+
+def test_readiness_probe_fails_on_sealed_vault(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sealed Vault answers ``/sys/health`` but cannot honour OIDC logins."""
+    _install_fake_client(
+        monkeypatch,
+        health_payload={"initialized": True, "sealed": True},
+    )
+    result = vault_readiness_probe()
+
+    assert result.ok is False
+    assert result.detail == "sealed"
+
+
+def test_readiness_probe_fails_on_uninitialized_vault(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_client(
+        monkeypatch,
+        health_payload={"initialized": False, "sealed": False},
+    )
+    result = vault_readiness_probe()
+
+    assert result.ok is False
+    assert result.detail == "uninitialized"
+
+
+def test_readiness_probe_passes_on_standby_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Standby Vault returns 429; hvac returns the raw Response.
+
+    For v0.1 we accept standby as "Vault reachable" — the probe is
+    binary, and a standby node is still serving at the API surface.
+    """
+
+    class _FakeResponse:
+        status_code = 429
+
+    _install_fake_client(monkeypatch, health_payload=_FakeResponse())
+    result = vault_readiness_probe()
+
+    assert result.ok is True
+    assert result.detail == "http_429"
+
+
+def test_readiness_probe_reports_unexpected_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A status code outside the documented matrix surfaces verbatim."""
+
+    class _FakeResponse:
+        status_code = 418
+
+    _install_fake_client(monkeypatch, health_payload=_FakeResponse())
+    result = vault_readiness_probe()
+
+    assert result.ok is False
+    assert result.detail is not None
+    assert "418" in result.detail
+
+
+def test_readiness_probe_fails_when_vault_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_client(
+        monkeypatch,
+        health_exc=requests.exceptions.ConnectionError("dns failure"),
+    )
+    result = vault_readiness_probe()
+
+    assert result.ok is False
+    assert result.detail is not None
+    assert result.detail.startswith("unreachable: ConnectionError")
+
+
+def test_readiness_probe_handles_settings_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing required env var on probe call yields ``settings_unavailable``.
+
+    Probes run on every ``/ready`` hit; if an operator deletes
+    ``VAULT_ADDR`` mid-flight (or the cache is cleared and the env is
+    incomplete), the probe must report rather than raise — uncaught
+    probe exceptions surface as 500 from ``/ready`` (Task #19's
+    deliberate fail-loud contract for probe-implementation bugs), and
+    a settings-resolution failure is a configuration drift, not a
+    probe bug.
+    """
+    monkeypatch.delenv("VAULT_ADDR", raising=False)
+    get_settings.cache_clear()
+
+    result = vault_readiness_probe()
+
+    assert result.ok is False
+    assert result.detail is not None
+    assert result.detail.startswith("settings_unavailable:")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -155,6 +155,79 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -333,6 +406,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hvac"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -430,6 +515,7 @@ dependencies = [
     { name = "authlib" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "hvac" },
     { name = "prometheus-client" },
     { name = "pydantic", extra = ["email"] },
     { name = "structlog" },
@@ -451,6 +537,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.3" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "hvac", specifier = ">=2.4.0" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.6" },
     { name = "structlog", specifier = ">=24.1" },
@@ -754,6 +841,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
 name = "respx"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -831,6 +933,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -26,9 +26,17 @@ this stage it exposes:
   (cached, kid-rotation aware) and yields a frozen `Operator` model
   (Task #22). No protected routes are mounted yet; consumers land in
   G2.2-T3 (`/api/v1/health`).
+* Vault forward-auth — the `vault_client_for_operator` async context
+  manager performs a per-request JWT/OIDC login against Vault
+  (`meho-mcp` role by default) using the operator's validated JWT,
+  yields an authenticated `hvac.Client`, and revokes the issued token
+  on exit (Task #23). The Vault readiness probe registered in lifespan
+  flips `/ready` red when `/sys/health` is unreachable, sealed, or
+  uninitialized. No protected route consuming Vault has landed yet;
+  G2.2-T3 wires this into `/api/v1/health` and reads the federation
+  proof secret.
 
-Vault federation and database persistence land progressively in
-subsequent G2.2 / G2.3 Tasks. The stack (FastAPI, Pydantic v2,
+Database persistence lands progressively in subsequent G2.3 Tasks. The stack (FastAPI, Pydantic v2,
 SQLAlchemy 2.x async, Alembic, structlog, prometheus_client, authlib
 for JOSE) is locked by
 [ADR 0004](https://github.com/evoila-bosnia/meho-internal/issues/13).
@@ -56,11 +64,14 @@ PYTHONPATH-leak imports.
 | `SENSITIVE_HEADERS` | `src/meho_backplane/middleware.py` | `frozenset({b"authorization", b"cookie", b"x-api-key"})`. The middleware never logs the values of these headers; redaction is enforced by *not* logging request headers at all in v0.1, with a `tests/test_observability.py` regression test. |
 | `HTTP_REQUESTS_TOTAL` | `src/meho_backplane/metrics.py` | Module-level `prometheus_client.Counter` registered against the default registry. Labels: `method`, `path`, `status`. `path` is the matched FastAPI route template when available, bounding label cardinality. |
 | `render_metrics` | `src/meho_backplane/metrics.py` | Returns `(body, content_type)` for the `/metrics` route. Pins `text/plain; version=0.0.4; charset=utf-8` — the legacy Prometheus format every scraper accepts (`prometheus_client>=0.21` advertises 1.0.0 in `CONTENT_TYPE_LATEST`, but 0.0.4 stays universally compatible). |
-| `Settings` / `get_settings` | `src/meho_backplane/settings.py` | Pydantic v2 model + `lru_cache`-singleton accessor for the Keycloak knobs (`KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_JWKS_CACHE_TTL_SECONDS`, `KEYCLOAK_JWT_LEEWAY_SECONDS`). Tests reset via `get_settings.cache_clear()`. |
+| `Settings` / `get_settings` | `src/meho_backplane/settings.py` | Pydantic v2 model + `lru_cache`-singleton accessor for the Keycloak knobs (`KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_JWKS_CACHE_TTL_SECONDS`, `KEYCLOAK_JWT_LEEWAY_SECONDS`) and the Vault knobs (`VAULT_ADDR`, `VAULT_OIDC_ROLE`, `VAULT_OIDC_MOUNT_PATH`, `VAULT_NAMESPACE`, `VAULT_TIMEOUT_SECONDS`). Tests reset via `get_settings.cache_clear()`. |
 | `Operator` | `src/meho_backplane/auth/operator.py` | Frozen pydantic v2 model carrying validated claims (`sub`, `name`, `email`, `raw_jwt`). Returned by `verify_jwt`; consumed by every authenticated route from G2.2-T3 onward. `raw_jwt` is preserved verbatim for G2.2-T2's Vault forward-auth. |
 | `verify_jwt` | `src/meho_backplane/auth/jwt.py` | FastAPI dependency: parses `Authorization: Bearer ...`, fetches/caches Keycloak's JWKS, validates signature + `iss` + `aud` + `exp` (with leeway), refreshes JWKS on a kid miss, and returns an `Operator`. Every failure mode collapses to a terse 401. |
 | `keycloak_readiness_probe` | `src/meho_backplane/auth/jwt.py` | Synchronous probe registered with the readiness registry at app lifespan startup. Hits `{issuer}/.well-known/openid-configuration` then `jwks_uri`; failure detail surfaces only the exception class name to avoid leaking issuer URLs into 503 payloads. |
 | JWKS cache | `src/meho_backplane/auth/jwt.py` (`_jwks_cache`, `_jwks_fetched_at`, `_jwks_lock`) | Module-level dict + monotonic-fetched timestamp + asyncio lock. TTL-bounded (default 5 min) and kid-rotation refreshed (one forced re-fetch per request on a kid miss). Single-worker design; v0.2 may move to Redis when multi-worker uvicorn is needed. |
+| `vault_client_for_operator` | `src/meho_backplane/auth/vault.py` | Async context manager: builds an `hvac.Client` from settings, performs `client.auth.jwt.jwt_login(role, jwt, path)` against the configured mount path, yields the authenticated client, and revokes the issued token on exit (best-effort). Every blocking hvac call runs through `asyncio.to_thread` because hvac is `requests`-based and FastAPI does not auto-offload sync I/O inside `async def` callables. Per-request login by design (v0.1); v0.2 may add a per-operator cache. |
+| `vault_readiness_probe` | `src/meho_backplane/auth/vault.py` | Synchronous probe registered with the readiness registry at app lifespan startup. Calls `client.sys.read_health_status(method='GET')` (unauthenticated) and classifies the response — `sealed=False`/`http_429`/`http_472`/`http_473` → ok; `sealed`/`uninitialized`/connection-error → not ok. Detail strings never echo the Vault URL or namespace. |
+| `VaultClientError` / `VaultUnreachableError` / `VaultRoleDeniedError` | `src/meho_backplane/auth/vault.py` | Backplane-side exception hierarchy. Callers catch `VaultClientError` for a single error response shape, or one of the subclasses to map to specific HTTP statuses. The hierarchy lets consumers avoid importing `hvac` directly. |
 
 ## Control flow
 
@@ -73,7 +84,8 @@ PYTHONPATH-leak imports.
    and `metrics` route handlers.
 3. uvicorn opens the lifespan context: `configure_logging()` runs,
    pinning structlog's processor chain so every subsequent log line
-   is JSON to stdout.
+   is JSON to stdout, and the Keycloak + Vault readiness probes are
+   registered against the probe registry.
 4. uvicorn binds to `:8000` and starts the ASGI event loop.
 5. Each HTTP request enters `RequestContextMiddleware.__call__`,
    which:
@@ -119,6 +131,7 @@ Pinned-floor declarations; exact versions resolved into `uv.lock`.
 | `pydantic[email]` | ≥ 2.6 | Frozen `Operator` model uses `EmailStr`, which pulls `email-validator` via the `email` extra. |
 | `authlib` | ≥ 1.3 | JWS / JWK / JWT primitives for Keycloak token verification. The `authlib.jose` namespace is deprecated in favour of `joserfc` (same maintainer, clean rewrite); migration to `joserfc` is tracked as a v0.2 candidate. |
 | `httpx` | ≥ 0.27 | Async + sync HTTP client for the OIDC discovery doc and JWKS endpoint. (Also used as the `fastapi.testclient.TestClient` backend.) |
+| `hvac` | ≥ 2.4 | Official HashiCorp Vault Python client (per ADR 0004). Sync-only, transitively pulls `requests` + `urllib3`; the backplane localises the sync surface inside `auth/vault.py` and wraps every call in `asyncio.to_thread` from the async context manager. No type stubs ship with the package, so `[tool.mypy.overrides]` whitelists `hvac.*` and `requests.*`. |
 | (dev) `pytest` ≥ 8 | | Test runner. |
 | (dev) `pytest-asyncio` ≥ 0.23 | | Async test support; `asyncio_mode = "auto"` in pyproject. |
 | (dev) `cryptography` ≥ 42.0 | | RSA keypair generation in test fixtures (authlib pulls it transitively in production). |
@@ -128,13 +141,22 @@ Pinned-floor declarations; exact versions resolved into `uv.lock`.
 
 ## Known issues
 
-`/ready` returns 503 until at least one passing probe is registered.
-After Task #22 the lifespan hook registers the Keycloak probe, so a
-running app with a reachable Keycloak realm reports 200. Without
-Keycloak (or before Vault lands in G2.2-T2 and DB migrations land in
-G2.3) `/ready` stays 503 by design. Helm charts pointing their
-kubernetes readiness probe at `/ready` before those Initiatives land
-will see pods stay `NotReady`; that's the intended contract.
+`/ready` returns 503 until every registered probe passes. After Task
+#23 the lifespan hook registers both the Keycloak and Vault probes,
+so a running app needs Keycloak's JWKS endpoint reachable **and**
+Vault's `/sys/health` reachable + unsealed before `/ready` flips green.
+Until DB migrations land in G2.3, the registry is otherwise complete
+for the federation-chain dependency surface. Helm charts pointing
+their kubernetes readiness probe at `/ready` before either dependency
+is provisioned will see pods stay `NotReady`; that is the intended
+contract.
+
+Vault hvac calls are synchronous (the library is built on `requests`)
+but the backplane is async-first. Every hvac call from
+`auth/vault.py` runs through `asyncio.to_thread` to avoid blocking
+the event loop. v0.2 may move to a native async Vault client when one
+of acceptable maturity emerges, or to per-operator token caching to
+reduce login pressure under higher load.
 
 `authlib.jose` emits an `AuthlibDeprecationWarning` at first import,
 recommending `joserfc` (the same maintainer's clean rewrite). The
@@ -171,6 +193,7 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - Task #19 — public health + version + readiness endpoints
 - Task #20 — observability primitives (`/metrics`, structlog, middleware)
 - Task #22 — Keycloak JWT validation + readiness probe
+- Task #23 — Vault OIDC forward-auth client + readiness probe
 - [FastAPI tutorial](https://fastapi.tiangolo.com/tutorial/)
 - [FastAPI lifespan API](https://fastapi.tiangolo.com/advanced/events/)
 - [FastAPI dependencies (`Depends`)](https://fastapi.tiangolo.com/tutorial/dependencies/)
@@ -178,6 +201,8 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - [structlog contextvars](https://www.structlog.org/en/stable/contextvars.html)
 - [prometheus_client](https://github.com/prometheus/client_python)
 - [authlib JOSE / JWT docs](https://docs.authlib.org/en/latest/jose/jwt.html)
+- [hvac JWT/OIDC auth](https://python-hvac.org/en/stable/usage/auth_methods/jwt-oidc.html)
+- [Vault `/sys/health` HTTP API](https://developer.hashicorp.com/vault/api-docs/system/health)
 - [respx mock router](https://lundberg.github.io/respx/)
 - [OIDC core — token validation](https://openid.net/specs/openid-connect-core-1_0.html#TokenResponseValidation)
 - [uv project structure](https://docs.astral.sh/uv/concepts/projects/)


### PR DESCRIPTION
## Summary

- Adds `vault_client_for_operator` async context manager that forwards an operator's validated Keycloak JWT to Vault's JWT auth method (`meho-mcp` role by default) and yields an authenticated `hvac.Client`; revokes the per-request token on exit. Wraps every sync hvac call in `asyncio.to_thread` because hvac is `requests`-based and FastAPI does not auto-offload sync I/O inside `async def` callables.
- Registers `vault_readiness_probe` in the lifespan hook so `/ready` requires Vault `/sys/health` reachable + unsealed alongside the Keycloak probe. Detail strings classify sealed / uninitialized / unreachable / unexpected_status without echoing operator-controlled URLs.
- Backplane exception hierarchy (`VaultClientError` / `VaultUnreachableError` / `VaultRoleDeniedError`) lets Task #24's `/api/v1/health` map Vault failures to HTTP status codes without importing hvac.
- Settings extended with `VAULT_ADDR`, `VAULT_OIDC_ROLE`, `VAULT_OIDC_MOUNT_PATH`, `VAULT_NAMESPACE`, `VAULT_TIMEOUT_SECONDS`. `pyproject.toml` adds `hvac>=2.4.0` and whitelists `hvac.*` + `requests.*` under `[tool.mypy.overrides]` (no `py.typed` marker upstream).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` (strict) — clean
- [x] `pytest -x -q` — 58 passed, 1 warning (pre-existing authlib deprecation)
- [x] `python3 .claude/hooks/code-quality.py --diff` — clean (exit 0)
- [x] AC1 — `auth/vault.py` exists with `vault_client_for_operator` async ctx mgr + `vault_readiness_probe` + SPDX headers (verified by file existence + ruff/mypy passes)
- [x] AC2 — Settings carry `VAULT_ADDR`, `VAULT_OIDC_ROLE`, `VAULT_TIMEOUT_SECONDS` (+ `VAULT_OIDC_MOUNT_PATH`, `VAULT_NAMESPACE`); covered by `test_settings_carry_vault_defaults` and `test_settings_vault_namespace_empty_string_normalises_to_none`
- [x] AC3 — Happy-path login + secret read covered by `test_vault_client_for_operator_logs_in_and_yields_authenticated_client` (asserts `read_secret_version` succeeds with the post-login token)
- [x] AC4 — Token revocation on exit covered by `test_vault_client_for_operator_revokes_token_even_when_body_raises` and `test_vault_client_for_operator_logs_in_and_yields_authenticated_client`
- [x] AC5 — Vault readiness probe registered in lifespan; covered by 7 probe-classification tests (`test_readiness_probe_*`) including `sealed=False` / `sealed` / `uninitialized` / `http_429` standby / `unreachable` / unexpected status / settings unavailable

## Out of scope

- Failure-mode test suite (expired/wrong-aud/wrong-iss JWT, comprehensive Vault failures) — Task #25
- Federation proof + `/api/v1/health` route + operator-identity propagation into structlog — Task #24
- Per-operator token caching across requests — v0.2 (recorded in module docstring)
- mTLS / SSL pinning to Vault — v0.2 (uses standard CA-validated TLS in v0.1)

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated HashiCorp Vault with OIDC authentication support.
  * Readiness endpoint now validates both Keycloak and Vault availability.
  * Added Vault error handling with specific exception types.

* **Chores**
  * Added HashiCorp Vault client library dependency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->