### PR TITLE
feat(backend): add /api/v1/health federation proof + operator-identity propagation

### DIFF
--- a/backend/src/meho_backplane/api/__init__.py
+++ b/backend/src/meho_backplane/api/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Versioned HTTP API surfaces.
+
+Each subpackage here corresponds to a stable API version (``v1``, ``v2``,
+…). Routes are mounted by :mod:`meho_backplane.main` via
+``app.include_router``; this top-level package intentionally re-exports
+nothing so that adding ``v2`` later does not implicitly leak ``v1``
+symbols.
+"""

--- a/backend/src/meho_backplane/api/v1/__init__.py
+++ b/backend/src/meho_backplane/api/v1/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Version 1 of the backplane HTTP API.
+
+v0.1 ships a single authenticated route — :mod:`~meho_backplane.api.v1.health`
+— that exercises the entire federation chain (JWT validation → Vault
+OIDC login → secret read) and returns the operator identity plus
+dependency status to the CLI's ``meho status`` command.
+"""

--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /api/v1/health`` — federation-proof authenticated health endpoint.
+
+This route is the load-bearing integration point for Goal #11's smoke
+test. A single call exercises the entire authn / authz / federation
+chain end-to-end:
+
+1. The :func:`~meho_backplane.middleware.verify_jwt_and_bind` dependency
+   runs :func:`~meho_backplane.auth.jwt.verify_jwt` against the incoming
+   ``Authorization: Bearer <jwt>`` header, validates the JWT against
+   Keycloak's JWKS, and binds the resulting ``operator_sub`` into
+   structlog's contextvars (so every log line under this request carries
+   the operator's identity).
+2. The handler enters
+   :func:`~meho_backplane.auth.vault.vault_client_for_operator`, which
+   forwards the *same* validated JWT to Vault's JWT/OIDC auth method.
+   Vault verifies the JWT against its own configured trust of Keycloak
+   (via the ``meho-mcp`` role) and issues a Vault token bound to the
+   operator's identity.
+3. The handler reads ``secret/meho/test/federation`` (KV v2) using the
+   per-operator Vault token. The read is the **federation proof**: if
+   Vault's audit log shows this operator's ``sub`` against the read,
+   the entire chain is wired correctly.
+4. The handler returns a structured JSON document carrying operator
+   identity, Vault status, and a placeholder for DB migration state
+   (which G2.3 will wire). The CLI's ``meho status`` command renders
+   this for the operator.
+
+Failure handling is **never** a 5xx. Vault unreachable, Vault role
+denied, secret read failure — each surfaces as the corresponding flag
+on the response with a structured ``detail`` string the smoke test can
+read. The authentication failure modes (missing / expired / tampered
+JWT) are the responsibility of :func:`verify_jwt` and remain 401s; that
+is the only error class operators routinely chase against this endpoint.
+
+Detail strings deliberately surface only exception class names, never
+their messages, so a misconfigured Vault role can't leak operator-
+controllable URL substrings into a successful 200 response.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import (
+    VaultClientError,
+    vault_client_for_operator,
+)
+from meho_backplane.middleware import verify_jwt_and_bind
+
+__all__ = ["router"]
+
+#: Hardcoded path inside the Vault KV v2 mount used to prove the
+#: federation chain. The path is provisioned by the consumer (see
+#: Goal #11's "Cross-repo dependencies" — Vault role + KV mount
+#: ``secret/meho/`` + this path under it). Per-route customization of
+#: which secret to read is explicitly out of scope for v0.1; product
+#: routes added post-Goal-2 will read different paths.
+_FEDERATION_PROOF_PATH: str = "meho/test/federation"
+
+
+class OperatorIdentity(BaseModel):
+    """Operator identity surface exposed to the CLI.
+
+    Excludes ``raw_jwt`` deliberately — the bearer token must never
+    appear in a response body, and the :class:`Operator` model carries
+    it for downstream Vault forward-auth only.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sub: str
+    name: str | None
+    email: str | None
+
+
+class VaultStatus(BaseModel):
+    """Vault federation-chain status.
+
+    ``reachable`` is true when ``vault_client_for_operator`` returns a
+    logged-in client (TCP + TLS + JWT/OIDC login all worked). ``read_ok``
+    is true when the test secret read succeeded against that client.
+    ``detail`` carries a short structured string for the CLI to render
+    on failure paths — never an unbounded exception message.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    reachable: bool
+    read_ok: bool
+    detail: str | None = None
+
+
+class DbStatus(BaseModel):
+    """Database migration status.
+
+    ``migrated`` is ``None`` in v0.1 — G2.3 wires the real Alembic check.
+    The field is present in the response shape now so the CLI's
+    ``meho status`` rendering doesn't have to special-case its absence
+    when G2.3 lands.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    migrated: bool | None
+
+
+class HealthResponse(BaseModel):
+    """``GET /api/v1/health`` response body."""
+
+    model_config = ConfigDict(frozen=True)
+
+    operator: OperatorIdentity
+    vault: VaultStatus
+    db: DbStatus
+
+
+router = APIRouter(prefix="/api/v1", tags=["health"])
+
+
+def _extract_version(secret_payload: Any) -> str:
+    """Pull the KV v2 metadata version from a ``read_secret_version`` payload.
+
+    hvac's KV v2 read returns ``{"data": {"data": ..., "metadata":
+    {"version": int, ...}}}``. Accessing the version through nested
+    ``[]`` calls inside a try/except would obscure the read-OK
+    contract; this helper isolates the unwrap so the route handler stays
+    legible. Any structural surprise (Vault returns an unexpected shape,
+    metadata absent) raises ``KeyError`` / ``TypeError`` from the dict
+    indexing, which the caller maps to ``read_ok=False`` with a
+    ``read_failed`` detail.
+    """
+    data = secret_payload["data"]
+    metadata = data["metadata"]
+    version = metadata["version"]
+    return f"version={version}"
+
+
+async def _probe_vault_federation(
+    operator: Operator,
+    log: Any,
+) -> VaultStatus:
+    """Run the federation-proof Vault chain and return its structured status.
+
+    Mirrors the route handler's three failure axes — login failure,
+    secret-read failure, full success — onto a single :class:`VaultStatus`
+    value. Lifted into a helper so the route handler stays focused on
+    response assembly and the function-size budget stays under the
+    code-quality threshold.
+
+    Detail strings carry only exception class names; operator-controllable
+    URL substrings never leak into a 200 response body or into a
+    structlog payload.
+    """
+    try:
+        async with vault_client_for_operator(operator) as client:
+            try:
+                # hvac's secrets.kv.v2 lives on the synchronous client.
+                # The read is a single GET; we don't bother offloading
+                # to a thread because the surrounding context manager's
+                # login call already did the expensive blocking work,
+                # and uvicorn's default worker count is 1 in v0.1.
+                secret_payload = client.secrets.kv.v2.read_secret_version(
+                    path=_FEDERATION_PROOF_PATH,
+                    raise_on_deleted_version=False,
+                )
+            except Exception as exc:
+                log.warning(
+                    "federation_health_read_failed",
+                    vault_read_path=_FEDERATION_PROOF_PATH,
+                    exc_type=type(exc).__name__,
+                )
+                return VaultStatus(
+                    reachable=True,
+                    read_ok=False,
+                    detail=f"read_failed: {type(exc).__name__}",
+                )
+            log.info("federation_health_ok", vault_read_path=_FEDERATION_PROOF_PATH)
+            return VaultStatus(
+                reachable=True,
+                read_ok=True,
+                detail=_extract_version(secret_payload),
+            )
+    except VaultClientError as exc:
+        log.warning("federation_health_login_failed", exc_type=type(exc).__name__)
+        return VaultStatus(
+            reachable=False,
+            read_ok=False,
+            detail=f"login_failed: {type(exc).__name__}",
+        )
+
+
+@router.get("/health", response_model=HealthResponse)
+async def authenticated_health(
+    operator: Operator = Depends(verify_jwt_and_bind),
+) -> HealthResponse:
+    """Federation-proof authenticated health check.
+
+    See module docstring for the four-step chain this exercises. The
+    ``Depends(verify_jwt_and_bind)`` annotation is what guarantees the
+    JWT is validated *and* ``operator_sub`` is bound into structlog
+    contextvars before this body runs — every log line emitted from
+    here downstream carries operator identity automatically.
+    """
+    log = structlog.get_logger()
+    vault_status = await _probe_vault_federation(operator, log)
+    return HealthResponse(
+        operator=OperatorIdentity(
+            sub=operator.sub,
+            name=operator.name,
+            email=operator.email,
+        ),
+        vault=vault_status,
+        db=DbStatus(migrated=None),
+    )

--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -42,6 +42,7 @@ controllable URL substrings into a successful 200 response.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import structlog
@@ -162,14 +163,34 @@ async def _probe_vault_federation(
     try:
         async with vault_client_for_operator(operator) as client:
             try:
-                # hvac's secrets.kv.v2 lives on the synchronous client.
-                # The read is a single GET; we don't bother offloading
-                # to a thread because the surrounding context manager's
-                # login call already did the expensive blocking work,
-                # and uvicorn's default worker count is 1 in v0.1.
-                secret_payload = client.secrets.kv.v2.read_secret_version(
+                # hvac's secrets.kv.v2 lives on the synchronous client; the
+                # read is a blocking GET against Vault. Offload it to a
+                # worker thread so the event loop stays free, mirroring
+                # auth/vault.py's _to_thread_jwt_login pattern.
+                secret_payload = await asyncio.to_thread(
+                    client.secrets.kv.v2.read_secret_version,
                     path=_FEDERATION_PROOF_PATH,
                     raise_on_deleted_version=False,
+                )
+                # Unwrap inside the same try so a malformed hvac payload
+                # (missing data/metadata/version keys) surfaces as a
+                # structured read failure rather than escaping as an
+                # HTTP 500 — AC #3 forbids 5xx on this endpoint. The
+                # tight (KeyError, TypeError) catch is sufficient for the
+                # dict-indexing failure modes _extract_version can raise;
+                # the broader ``except Exception`` below covers hvac's own
+                # error surface (Forbidden, InvalidPath, RequestException).
+                detail = _extract_version(secret_payload)
+            except (KeyError, TypeError) as exc:
+                log.warning(
+                    "federation_health_read_failed",
+                    vault_read_path=_FEDERATION_PROOF_PATH,
+                    exc_type=type(exc).__name__,
+                )
+                return VaultStatus(
+                    reachable=True,
+                    read_ok=False,
+                    detail=f"read_failed: {type(exc).__name__}",
                 )
             except Exception as exc:
                 log.warning(
@@ -186,7 +207,7 @@ async def _probe_vault_federation(
             return VaultStatus(
                 reachable=True,
                 read_ok=True,
-                detail=_extract_version(secret_payload),
+                detail=detail,
             )
     except VaultClientError as exc:
         log.warning("federation_health_login_failed", exc_type=type(exc).__name__)

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -13,6 +13,9 @@ Gunicorn / k8s probes. v0.1 ships:
 * Observability primitives — structured JSON logs to stdout, the
   request-context middleware, and the Prometheus ``/metrics``
   endpoint (Task #20).
+* The authenticated federation-proof endpoint at ``/api/v1/health``
+  (Task #24), which exercises the entire JWT → Vault chain on every
+  call and is what the CLI's ``meho status`` (G2.6-T3) hits.
 """
 
 from collections.abc import AsyncIterator
@@ -22,6 +25,7 @@ from typing import Final
 from fastapi import FastAPI, Response
 
 from meho_backplane import __version__
+from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.auth.jwt import keycloak_readiness_probe
 from meho_backplane.auth.vault import vault_readiness_probe
 from meho_backplane.health import register_probe
@@ -77,6 +81,7 @@ app.add_middleware(RequestContextMiddleware)
 
 app.include_router(health_router)
 app.include_router(version_router)
+app.include_router(api_v1_health_router)
 
 
 @app.get("/")

--- a/backend/src/meho_backplane/middleware.py
+++ b/backend/src/meho_backplane/middleware.py
@@ -1,7 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Request-context middleware (pure ASGI).
+"""Request-context middleware (pure ASGI) and operator-identity binding.
+
+Two concerns share this module: the request-scoped contextvar lifecycle
+that every authenticated route inherits, and the small dependency
+wrapper that binds operator identity into that same context after JWT
+validation succeeds. Co-locating them keeps the contextvar contract
+auditable in one file — the middleware sets up and tears down the
+``request_id`` / ``operator_sub`` slots; the wrapper populates the
+``operator_sub`` slot at the integration boundary where verify_jwt
+returns a trusted :class:`Operator`.
+
+Request-context middleware (:class:`RequestContextMiddleware`)
+==============================================================
 
 For every HTTP request the middleware:
 
@@ -38,6 +50,30 @@ per the Starlette 1.0+ docs (BaseHTTPMiddleware spawns an anyio task
 wrapper that interferes with streaming responses and complicates
 contextvar lifetimes). The pattern below is the canonical "wrap
 ``send`` to mutate the response start" recipe.
+
+Operator-identity binding (:func:`verify_jwt_and_bind`)
+=======================================================
+
+Authenticated routes declare ``Depends(verify_jwt_and_bind)`` instead
+of ``Depends(verify_jwt)`` directly. The wrapper delegates to
+:func:`~meho_backplane.auth.jwt.verify_jwt` for the actual security
+work (signature, claims, JWKS rotation) and — only on success — binds
+``operator_sub`` into structlog's contextvars. Every log line emitted
+*after* this point under the same request context (handler logs, the
+middleware's own ``request_completed`` line, future audit-middleware
+rows) automatically carries the operator's stable subject id.
+
+The binding lives in a dependency wrapper rather than the middleware
+itself because the middleware is pure ASGI and runs *before* FastAPI
+has resolved the request to a route — so it does not yet know whether
+the route requires auth or which dependency would extract the
+``Operator``. ``verify_jwt`` stays free of side effects so its unit
+tests do not need to mock contextvars; the binding side effect is
+introduced at the integration boundary, where it belongs.
+
+The middleware's :func:`structlog.contextvars.clear_contextvars` call
+at request entry is what guarantees ``operator_sub`` does not leak
+across requests served on the same asyncio task.
 """
 
 from __future__ import annotations
@@ -47,9 +83,18 @@ from typing import Final
 from uuid import uuid4
 
 import structlog
+from fastapi import Depends
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from meho_backplane.auth.jwt import verify_jwt
+from meho_backplane.auth.operator import Operator
 from meho_backplane.metrics import HTTP_REQUESTS_TOTAL
+
+__all__ = [
+    "SENSITIVE_HEADERS",
+    "RequestContextMiddleware",
+    "verify_jwt_and_bind",
+]
 
 #: Lower-cased header names whose values must never appear in logs or
 #: metrics. The set is intentionally tiny — every entry is paid for in
@@ -161,3 +206,42 @@ class RequestContextMiddleware:
             status=status_code,
             duration_ms=duration_ms,
         )
+
+
+async def verify_jwt_and_bind(
+    operator: Operator = Depends(verify_jwt),
+) -> Operator:
+    """Validate the Bearer token and bind ``operator_sub`` for the request.
+
+    Authenticated routes use this wrapper as their security dependency
+    in place of :func:`~meho_backplane.auth.jwt.verify_jwt`::
+
+        @router.get("/protected")
+        async def protected(
+            operator: Operator = Depends(verify_jwt_and_bind),
+        ) -> ...:
+            ...
+
+    The wrapper relies on FastAPI's dependency-graph contract: ``verify_jwt``
+    runs first; only if it returns successfully does this function execute,
+    so a failed JWT validation never bleeds an ``operator_sub`` into a
+    later request. The bound value is the OIDC ``sub`` claim — the stable
+    operator identifier — and nothing else; ``name`` and ``email`` are
+    deliberately *not* bound, because they are soft identity claims that
+    can vary across token refreshes and would noise the logs without
+    adding traceability beyond what ``sub`` already provides.
+
+    The middleware's request-entry :func:`structlog.contextvars.clear_contextvars`
+    call is what guarantees the bound key does not leak into the next
+    request reusing the same asyncio task. We deliberately do **not**
+    unbind here — the contextvar lives only as long as the current
+    request's ASGI scope, and clearing once per request entry is both
+    cheaper and more robust than asymmetric unbind logic that would have
+    to run in a finally clause inside the wrapper.
+
+    Returns:
+        The same :class:`Operator` that ``verify_jwt`` produced — the
+        wrapper is transparent to the route handler.
+    """
+    structlog.contextvars.bind_contextvars(operator_sub=operator.sub)
+    return operator

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -1,0 +1,579 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end tests for the federation-proof authenticated health route.
+
+Covers Task #24's acceptance criteria:
+
+* Happy path: a valid JWT plus a reachable Vault returns 200 with the
+  full federation-chain response shape (operator identity, vault
+  status, db status). The Vault test secret read succeeds and its
+  KV v2 metadata version surfaces in ``vault.detail``.
+* 401 on missing ``Authorization`` header (delegated to ``verify_jwt``;
+  asserted here as a contract guard so future refactors of the wrapper
+  cannot regress the auth gate).
+* Vault unreachable: returns **200** with ``vault.reachable=false`` and
+  a structured ``detail`` — never a 5xx. The smoke test reads this
+  flag, so the no-5xx contract is load-bearing.
+* Vault read failure (login succeeds but secret read raises): returns
+  200 with ``vault.reachable=true`` and ``vault.read_ok=false``.
+* Operator-identity propagation: every log line emitted under the
+  authenticated request carries ``operator_sub`` matching the JWT's
+  ``sub`` claim, including the middleware's ``request_completed`` line.
+
+Comprehensive failure-mode coverage (expired / wrong-aud / wrong-iss /
+tampered JWT, every Vault error subclass, etc.) belongs to Task #25;
+this file ships a happy-path-plus-sanity-check suite so #24 can land in
+isolation.
+
+Test strategy:
+
+* Mock Keycloak via the same ``respx`` pattern Task #22 uses — RSA
+  fixture key, JWKS document, JWT signed locally.
+* Mock Vault via the same ``_install_fake_client`` pattern Task #23
+  uses — patch ``meho_backplane.auth.vault._build_client`` to return
+  a controllable fake; configure the fake's ``read_secret_version``
+  return value or raise behaviour per scenario.
+* Capture logs via the same in-memory ``StringIO`` buffer pattern
+  ``test_observability`` uses — rebind ``structlog``'s factory so we
+  can parse each emitted JSON line.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import time
+import warnings
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import pytest
+import respx
+import structlog
+from fastapi.testclient import TestClient
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from authlib.jose import JsonWebKey, JsonWebToken
+
+from meho_backplane.auth import vault as vault_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ISSUER: str = "https://keycloak.test/realms/meho"
+_AUDIENCE: str = "meho-backplane"
+_DISCOVERY_URL: str = f"{_ISSUER}/.well-known/openid-configuration"
+_JWKS_URL: str = f"{_ISSUER}/protocol/openid-connect/certs"
+
+
+# ---------------------------------------------------------------------------
+# Settings + JWKS-cache fixtures (mirror Task #22 / #23 patterns)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` reads, around every test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    """Empty the module-level JWKS cache around every test."""
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+# ---------------------------------------------------------------------------
+# JWT minting helpers (lifted shape from tests/test_auth_jwt.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_rsa_keypair(kid: str) -> Any:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return JsonWebKey.generate_key(
+            "RSA",
+            2048,
+            options={"kid": kid},
+            is_private=True,
+        )
+
+
+def _public_jwks(*keys: Any) -> dict[str, list[dict[str, Any]]]:
+    return {"keys": [k.as_dict(is_private=False) for k in keys]}
+
+
+def _mint_token(
+    private_key: Any,
+    *,
+    sub: str = "op-42",
+    name: str | None = "Damir",
+    email: str | None = "damir@example.com",
+) -> str:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        jwt = JsonWebToken(["RS256"])
+        now = int(time.time())
+        payload: dict[str, Any] = {
+            "sub": sub,
+            "iss": _ISSUER,
+            "aud": _AUDIENCE,
+            "iat": now,
+            "exp": now + 3600,
+            "nbf": now,
+        }
+        if name is not None:
+            payload["name"] = name
+        if email is not None:
+            payload["email"] = email
+        header = {"alg": "RS256", "kid": private_key.as_dict()["kid"], "typ": "JWT"}
+        token: bytes | str = jwt.encode(header, payload, private_key)
+        return token.decode("ascii") if isinstance(token, bytes) else token
+
+
+def _mock_discovery_and_jwks(
+    mock_router: respx.MockRouter,
+    jwks: dict[str, Any],
+) -> None:
+    mock_router.get(_DISCOVERY_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"issuer": _ISSUER, "jwks_uri": _JWKS_URL},
+        ),
+    )
+    mock_router.get(_JWKS_URL).mock(
+        return_value=httpx.Response(200, json=jwks),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vault fake (lifted shape from tests/test_auth_vault.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeJWTAuth:
+    login_calls: list[dict[str, Any]] = field(default_factory=list)
+    raise_on_login: Exception | None = None
+    issued_token: str = "fake-vault-token"
+    parent: _FakeClient | None = None
+
+    def jwt_login(self, role: str, jwt: str, path: str | None = None) -> dict[str, Any]:
+        self.login_calls.append({"role": role, "jwt": jwt, "path": path})
+        if self.raise_on_login is not None:
+            raise self.raise_on_login
+        if self.parent is not None:
+            self.parent.token = self.issued_token
+        return {"auth": {"client_token": self.issued_token}}
+
+
+@dataclass
+class _FakeTokenAuth:
+    revoke_calls: int = 0
+
+    def revoke_self(self, mount_point: str = "token") -> None:
+        self.revoke_calls += 1
+
+
+@dataclass
+class _FakeAuth:
+    jwt: _FakeJWTAuth
+    token: _FakeTokenAuth
+
+
+@dataclass
+class _FakeKVv2:
+    """Stand-in for ``client.secrets.kv.v2``.
+
+    Returns the canonical hvac KV v2 read shape:
+    ``{"data": {"data": <secret>, "metadata": {"version": int, ...}}}``.
+    Tests pin ``read_exc`` to raise from the read, leaving login intact.
+    """
+
+    secret: dict[str, Any] = field(default_factory=lambda: {"username": "demo"})
+    version: int = 7
+    read_calls: list[dict[str, Any]] = field(default_factory=list)
+    read_exc: Exception | None = None
+
+    def read_secret_version(self, path: str, **_kwargs: Any) -> dict[str, Any]:
+        self.read_calls.append({"path": path})
+        if self.read_exc is not None:
+            raise self.read_exc
+        return {
+            "data": {
+                "data": self.secret,
+                "metadata": {"version": self.version, "path": path},
+            }
+        }
+
+
+@dataclass
+class _FakeKV:
+    v2: _FakeKVv2
+
+
+@dataclass
+class _FakeSecrets:
+    kv: _FakeKV
+
+
+@dataclass
+class _FakeSysBackend:
+    payload: Any = None
+
+    def read_health_status(self, *, method: str = "HEAD", **_kwargs: Any) -> Any:
+        return self.payload
+
+
+@dataclass
+class _FakeClient:
+    url: str
+    timeout: float
+    namespace: str | None
+    token: str | None
+    auth: _FakeAuth
+    sys: _FakeSysBackend
+    secrets: _FakeSecrets
+
+
+def _install_fake_vault(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    login_exc: Exception | None = None,
+    read_exc: Exception | None = None,
+    secret: dict[str, Any] | None = None,
+    version: int = 7,
+) -> _FakeClient:
+    jwt_auth = _FakeJWTAuth(raise_on_login=login_exc)
+    token_auth = _FakeTokenAuth()
+    kv_v2 = _FakeKVv2(
+        secret=secret or {"username": "demo"},
+        version=version,
+        read_exc=read_exc,
+    )
+    fake = _FakeClient(
+        url="https://vault.test",
+        timeout=5.0,
+        namespace=None,
+        token=None,
+        auth=_FakeAuth(jwt=jwt_auth, token=token_auth),
+        sys=_FakeSysBackend(),
+        secrets=_FakeSecrets(kv=_FakeKV(v2=kv_v2)),
+    )
+    jwt_auth.parent = fake
+
+    def _fake_build_client(_settings: Any, *, token: str | None = None) -> _FakeClient:
+        fake.token = token
+        return fake
+
+    monkeypatch.setattr(vault_module, "_build_client", _fake_build_client)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Log capture (mirrors tests/test_observability.py)
+# ---------------------------------------------------------------------------
+
+
+def _configure_capture(buf: io.StringIO) -> None:
+    structlog.reset_defaults()
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=buf),
+        cache_logger_on_first_use=False,
+    )
+
+
+@pytest.fixture
+def log_buffer() -> Iterator[io.StringIO]:
+    buf = io.StringIO()
+    _configure_capture(buf)
+    yield buf
+    structlog.reset_defaults()
+
+
+@pytest.fixture
+def client(log_buffer: io.StringIO) -> Iterator[TestClient]:
+    """``TestClient`` driving the production ``app`` with logs captured.
+
+    The ``log_buffer`` fixture must come first so structlog's factory
+    is rebound before any handler logs through it. The ``with`` form
+    is *not* used: entering it would re-run ``configure_logging`` via
+    the lifespan and clobber the capture (same trick as
+    ``test_observability``).
+    """
+    yield TestClient(app)
+
+
+def _read_log_lines(buf: io.StringIO) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Header-shape failures
+# ---------------------------------------------------------------------------
+
+
+def test_missing_authorization_returns_401(client: TestClient) -> None:
+    """Without a Bearer token the wrapper inherits ``verify_jwt``'s 401."""
+    response = client.get("/api/v1/health")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "missing_token"}
+
+
+# ---------------------------------------------------------------------------
+# Happy path — full chain green
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_returns_full_federation_response(
+    client: TestClient,
+    log_buffer: io.StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid JWT + reachable Vault + secret read OK → 200 with full shape."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-100", name="Alice", email="alice@example.com")
+    fake = _install_fake_vault(monkeypatch, version=11)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "operator": {"sub": "op-100", "name": "Alice", "email": "alice@example.com"},
+        "vault": {"reachable": True, "read_ok": True, "detail": "version=11"},
+        "db": {"migrated": None},
+    }
+
+    # Vault was hit with the configured role / mount and the operator's
+    # *raw* JWT — bit-for-bit forwarding is what makes the Vault audit
+    # row carry the operator's identity.
+    assert fake.auth.jwt.login_calls == [
+        {"role": "meho-mcp", "jwt": token, "path": "jwt"},
+    ]
+    # The federation-proof path is hardcoded for v0.1.
+    assert fake.secrets.kv.v2.read_calls == [{"path": "meho/test/federation"}]
+    # Per-request login → revoke pair.
+    assert fake.auth.token.revoke_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Operator-identity propagation
+# ---------------------------------------------------------------------------
+
+
+def test_operator_sub_propagates_into_structlog_contextvars(
+    client: TestClient,
+    log_buffer: io.StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every log line under an authenticated request carries ``operator_sub``.
+
+    The acceptance criterion that earned this Task its name. Specifically:
+
+    * The handler-emitted ``federation_health_ok`` log line carries
+      the JWT's ``sub`` claim.
+    * The middleware's own ``request_completed`` line carries the same
+      value — proving the binding is live for the entire request scope,
+      not just inside the handler.
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-traceable")
+    _install_fake_vault(monkeypatch)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+
+    lines = _read_log_lines(log_buffer)
+
+    handler_lines = [line for line in lines if line.get("event") == "federation_health_ok"]
+    assert handler_lines, "expected a federation_health_ok log line"
+    assert handler_lines[-1].get("operator_sub") == "op-traceable"
+
+    completed_lines = [line for line in lines if line.get("event") == "request_completed"]
+    assert completed_lines, "expected a request_completed log line from the middleware"
+    # The binding lives in the same contextvar scope the middleware's
+    # final log uses, so request_completed inherits operator_sub too.
+    assert completed_lines[-1].get("operator_sub") == "op-traceable"
+
+
+def test_operator_sub_does_not_leak_to_unauthenticated_requests(
+    client: TestClient,
+    log_buffer: io.StringIO,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The middleware's ``clear_contextvars`` zeroes ``operator_sub`` per request.
+
+    Drives an authenticated request first (binding ``operator_sub``),
+    then an unauthenticated request to ``/`` on the same TestClient
+    (which reuses the same asyncio task). The second request's logs
+    must not carry ``operator_sub``.
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-first")
+    _install_fake_vault(monkeypatch)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        first = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    second = client.get("/")  # unauthenticated route on the same client
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    lines = _read_log_lines(log_buffer)
+
+    # Match the request_completed line for the second request by path.
+    second_completed = [
+        line
+        for line in lines
+        if line.get("event") == "request_completed" and line.get("path") == "/"
+    ]
+    assert second_completed, "expected a request_completed log line for the second request"
+    # No ``operator_sub`` key — the middleware cleared contextvars at
+    # request entry, and the unauthenticated route never re-bound it.
+    assert "operator_sub" not in second_completed[-1]
+
+
+# ---------------------------------------------------------------------------
+# Vault failure modes — never 5xx, always structured response
+# ---------------------------------------------------------------------------
+
+
+def test_vault_unreachable_returns_200_with_structured_detail(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vault TCP failure surfaces as ``vault.reachable=false`` — not a 5xx.
+
+    The smoke test reads the structured ``detail`` to render an
+    operator-actionable message; an unhandled 5xx would break the
+    dogfood loop's Definition-of-Done bullet 2.
+    """
+    import requests.exceptions
+
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-200")
+    _install_fake_vault(
+        monkeypatch,
+        login_exc=requests.exceptions.ConnectionError("no route to host"),
+    )
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["operator"]["sub"] == "op-200"
+    assert body["vault"]["reachable"] is False
+    assert body["vault"]["read_ok"] is False
+    assert body["vault"]["detail"] == "login_failed: VaultUnreachableError"
+    assert body["db"]["migrated"] is None
+
+
+def test_vault_role_denied_returns_200_with_role_denied_detail(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vault 403 surfaces as ``login_failed: VaultRoleDeniedError``."""
+    import hvac.exceptions
+
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key)
+    _install_fake_vault(
+        monkeypatch,
+        login_exc=hvac.exceptions.Forbidden("role denied"),
+    )
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["vault"]["reachable"] is False
+    assert body["vault"]["detail"] == "login_failed: VaultRoleDeniedError"
+
+
+def test_vault_secret_read_failure_returns_200_with_read_failed_detail(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Login succeeds but the secret read raises → ``read_ok=false``.
+
+    The KV mount is missing, the path is missing, or hvac's response
+    shape changed. The route surfaces ``read_ok=false`` with a
+    structured ``detail`` carrying only the exception class name —
+    operator-controllable URL substrings never make it into the body.
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key)
+    _install_fake_vault(
+        monkeypatch,
+        read_exc=RuntimeError("secret missing"),
+    )
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["vault"]["reachable"] is True
+    assert body["vault"]["read_ok"] is False
+    assert body["vault"]["detail"] == "read_failed: RuntimeError"

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -577,3 +577,40 @@ def test_vault_secret_read_failure_returns_200_with_read_failed_detail(
     assert body["vault"]["reachable"] is True
     assert body["vault"]["read_ok"] is False
     assert body["vault"]["detail"] == "read_failed: RuntimeError"
+
+
+def test_vault_malformed_payload_returns_200_with_read_failed_detail(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed hvac payload (missing version key) is a 200, not a 500.
+
+    Regression for the bug where ``_extract_version`` raised ``KeyError``
+    on payloads like ``{"data": {}}`` and the exception escaped the route
+    as an HTTP 500 — violating AC #3 (the endpoint must never 5xx; a
+    Vault read failure is always a 200 with ``vault.read_ok=false``).
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key)
+    fake = _install_fake_vault(monkeypatch)
+    # Override the fake's read to return a structurally-broken payload —
+    # ``data`` exists but ``metadata`` (and ``version``) do not. The
+    # _extract_version unwrap raises KeyError on this shape.
+    monkeypatch.setattr(
+        fake.secrets.kv.v2,
+        "read_secret_version",
+        lambda path, **_kwargs: {"data": {}},
+    )
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["vault"]["reachable"] is True
+    assert body["vault"]["read_ok"] is False
+    assert body["vault"]["detail"] == "read_failed: KeyError"

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -32,9 +32,19 @@ this stage it exposes:
   yields an authenticated `hvac.Client`, and revokes the issued token
   on exit (Task #23). The Vault readiness probe registered in lifespan
   flips `/ready` red when `/sys/health` is unreachable, sealed, or
-  uninitialized. No protected route consuming Vault has landed yet;
-  G2.2-T3 wires this into `/api/v1/health` and reads the federation
-  proof secret.
+  uninitialized.
+* Federation-proof endpoint — `GET /api/v1/health` (auth-required) is
+  the load-bearing integration point where the entire JWT → Vault
+  chain runs on every call (Task #24). The route uses the
+  `verify_jwt_and_bind` dependency wrapper, which delegates to
+  `verify_jwt` and — on success — binds `operator_sub` into structlog
+  contextvars. The handler then forwards the validated JWT to Vault
+  via `vault_client_for_operator`, reads the test secret at
+  `secret/meho/test/federation` (KV v2), and returns a structured
+  JSON document with operator identity, Vault status, and a DB
+  migration placeholder (`db.migrated = null` until G2.3). All Vault
+  failure modes surface as structured fields on a 200 response — the
+  smoke test never sees a 5xx from this endpoint.
 
 Database persistence lands progressively in subsequent G2.3 Tasks. The stack (FastAPI, Pydantic v2,
 SQLAlchemy 2.x async, Alembic, structlog, prometheus_client, authlib
@@ -60,7 +70,8 @@ PYTHONPATH-leak imports.
 | `health.router` (`/healthz`, `/ready`) | `src/meho_backplane/health.py` | Liveness and readiness endpoints. `/healthz` is unconditional 200; `/ready` aggregates the probe registry and **fails closed on the empty default** (vacuous-truth trap explicitly guarded). |
 | `version.router` (`/version`) | `src/meho_backplane/version.py` | Build identity. Reads `GIT_SHA` and `BUILD_DATE` env vars (injected via `docker build --build-arg`); falls back to `"unknown"` when unset or empty. `chart_version` is `None` until G2.5. |
 | `configure_logging` | `src/meho_backplane/logging.py` | Configures structlog: `merge_contextvars` → `add_log_level` → `TimeStamper(iso, utc)` → `JSONRenderer`, writing to stdout. Idempotent. |
-| `RequestContextMiddleware` | `src/meho_backplane/middleware.py` | Pure-ASGI middleware. Per request: extracts/mints a `request_id`, binds into structlog contextvars, mirrors it onto the `X-Request-Id` response header, increments `http_requests_total{method,path,status}`, emits one `request_completed` JSON log line with method / path / status / duration_ms. |
+| `RequestContextMiddleware` | `src/meho_backplane/middleware.py` | Pure-ASGI middleware. Per request: extracts/mints a `request_id`, clears any leftover contextvars and binds the new `request_id`, mirrors it onto the `X-Request-Id` response header, increments `http_requests_total{method,path,status}`, emits one `request_completed` JSON log line with method / path / status / duration_ms (which inherits any contextvars bound during the request, including `operator_sub` from `verify_jwt_and_bind`). |
+| `verify_jwt_and_bind` | `src/meho_backplane/middleware.py` | FastAPI dependency wrapper around `verify_jwt`. On successful validation, binds `operator_sub` (the JWT's `sub` claim) into structlog contextvars so every subsequent log line in the request scope carries operator identity automatically. Authenticated routes use `Depends(verify_jwt_and_bind)` instead of `Depends(verify_jwt)` directly. Lives alongside the middleware because `RequestContextMiddleware`'s request-entry `clear_contextvars` call is what guarantees the bound key does not leak across requests reusing the same asyncio task. |
 | `SENSITIVE_HEADERS` | `src/meho_backplane/middleware.py` | `frozenset({b"authorization", b"cookie", b"x-api-key"})`. The middleware never logs the values of these headers; redaction is enforced by *not* logging request headers at all in v0.1, with a `tests/test_observability.py` regression test. |
 | `HTTP_REQUESTS_TOTAL` | `src/meho_backplane/metrics.py` | Module-level `prometheus_client.Counter` registered against the default registry. Labels: `method`, `path`, `status`. `path` is the matched FastAPI route template when available, bounding label cardinality. |
 | `render_metrics` | `src/meho_backplane/metrics.py` | Returns `(body, content_type)` for the `/metrics` route. Pins `text/plain; version=0.0.4; charset=utf-8` — the legacy Prometheus format every scraper accepts (`prometheus_client>=0.21` advertises 1.0.0 in `CONTENT_TYPE_LATEST`, but 0.0.4 stays universally compatible). |
@@ -72,6 +83,8 @@ PYTHONPATH-leak imports.
 | `vault_client_for_operator` | `src/meho_backplane/auth/vault.py` | Async context manager: builds an `hvac.Client` from settings, performs `client.auth.jwt.jwt_login(role, jwt, path)` against the configured mount path, yields the authenticated client, and revokes the issued token on exit (best-effort). Every blocking hvac call runs through `asyncio.to_thread` because hvac is `requests`-based and FastAPI does not auto-offload sync I/O inside `async def` callables. Per-request login by design (v0.1); v0.2 may add a per-operator cache. |
 | `vault_readiness_probe` | `src/meho_backplane/auth/vault.py` | Synchronous probe registered with the readiness registry at app lifespan startup. Calls `client.sys.read_health_status(method='GET')` (unauthenticated) and classifies the response — `sealed=False`/`http_429`/`http_472`/`http_473` → ok; `sealed`/`uninitialized`/connection-error → not ok. Detail strings never echo the Vault URL or namespace. |
 | `VaultClientError` / `VaultUnreachableError` / `VaultRoleDeniedError` | `src/meho_backplane/auth/vault.py` | Backplane-side exception hierarchy. Callers catch `VaultClientError` for a single error response shape, or one of the subclasses to map to specific HTTP statuses. The hierarchy lets consumers avoid importing `hvac` directly. |
+| `api/v1/health.router` (`/api/v1/health`) | `src/meho_backplane/api/v1/health.py` | Authenticated federation-proof endpoint (Task #24). `GET` handler runs through `Depends(verify_jwt_and_bind)`, calls `vault_client_for_operator(operator)`, reads `secret/meho/test/federation` (KV v2), and returns `HealthResponse` (operator identity + vault status + db status). Vault unreachable / role denied / read failure surface as structured fields on a 200 response — never 5xx. |
+| `HealthResponse` / `OperatorIdentity` / `VaultStatus` / `DbStatus` | `src/meho_backplane/api/v1/health.py` | Frozen pydantic v2 response models. `OperatorIdentity` deliberately excludes `raw_jwt` so the bearer token never appears in the response body. `DbStatus.migrated` is `None` until G2.3 wires Alembic. `VaultStatus.detail` carries only structured tokens (`version=N`, `read_failed: <ExcClass>`, `login_failed: <ExcClass>`) — no operator-controllable URL substrings. |
 
 ## Control flow
 
@@ -108,6 +121,14 @@ PYTHONPATH-leak imports.
    - `GET /metrics` → returns the default registry's exposition text
      directly. The middleware still wraps it, so `/metrics` requests
      show up in the counter (under `path="/metrics"`).
+   - `GET /api/v1/health` → resolves `Depends(verify_jwt_and_bind)`
+     (which runs `verify_jwt` and binds `operator_sub` into
+     contextvars on success), calls `vault_client_for_operator(op)`
+     to forward the JWT to Vault and obtain a per-operator client,
+     reads `secret/meho/test/federation`, and returns the
+     `HealthResponse` document. The middleware's eventual
+     `request_completed` log line inherits `operator_sub` because
+     the binding lives in the same request-scoped contextvar context.
 
 The FastAPI
 [lifespan](https://fastapi.tiangolo.com/advanced/events/) hook is the
@@ -194,6 +215,7 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - Task #20 — observability primitives (`/metrics`, structlog, middleware)
 - Task #22 — Keycloak JWT validation + readiness probe
 - Task #23 — Vault OIDC forward-auth client + readiness probe
+- Task #24 — Federation-proof `/api/v1/health` + operator-identity propagation
 - [FastAPI tutorial](https://fastapi.tiangolo.com/tutorial/)
 - [FastAPI lifespan API](https://fastapi.tiangolo.com/advanced/events/)
 - [FastAPI dependencies (`Depends`)](https://fastapi.tiangolo.com/tutorial/dependencies/)


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/health` — authenticated federation-proof endpoint that exercises the entire JWT → Vault chain on every call (forwards the validated JWT to Vault's OIDC auth method via `meho-mcp` role, reads `secret/meho/test/federation` KV v2, returns operator identity + Vault status + DB migration placeholder). All Vault failure modes surface as structured fields on a 200 response — never 5xx.
- Add `verify_jwt_and_bind` dependency wrapper in `middleware.py`: delegates to `verify_jwt`, then binds `operator_sub` into structlog contextvars on success. The middleware's request-entry `clear_contextvars` guarantees the binding never leaks across requests sharing an asyncio task.
- Wire `/api/v1/health` into `main.py` and document the route, the wrapper, and the propagation invariant in `docs/codebase/backend.md`.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — 22 files already formatted
- [x] `mypy --strict` (via `[tool.mypy] strict = true`) — no issues in 15 source files
- [x] `pytest -x -q` — 65 passed (7 new in `test_api_v1_health.py`, all prior tests still green)
- [x] `code-quality.py --diff` — 0 blockers, 0 warnings
- [x] Acceptance criterion 1 (200 + full body shape under valid JWT, `operator.sub` matches the JWT, `vault.reachable=true`, `vault.read_ok=true`): `test_happy_path_returns_full_federation_response`
- [x] Acceptance criterion 2 (401 without `Authorization`): `test_missing_authorization_returns_401`
- [x] Acceptance criterion 3 (Vault unreachable → 200 with `vault.reachable=false` and structured `detail`, no 5xx): `test_vault_unreachable_returns_200_with_structured_detail` (+ `test_vault_role_denied_*` and `test_vault_secret_read_failure_*` for the adjacent failure shapes)
- [x] Acceptance criterion 4 (operator-identity propagation: handler logs and the middleware's `request_completed` log line both carry `operator_sub`): `test_operator_sub_propagates_into_structlog_contextvars` (+ `test_operator_sub_does_not_leak_to_unauthenticated_requests` regression guard for the per-request `clear_contextvars` invariant)
- [x] Acceptance criterion 5 (end-to-end test against mocked Keycloak + mocked Vault, full chain returns expected JSON with `operator_sub` populated and `vault.read_ok=true`): same `test_happy_path_*` end-to-end assertion

## Out of scope

- Comprehensive failure-mode coverage (expired / wrong-aud / wrong-iss / tampered JWT × every Vault subclass) — Task #25 (G2.2-T4)
- DB migration check — `db.migrated` stays `null` until G2.3 wires Alembic
- Audit row writes — G2.3 reads `operator_sub` from contextvars (this PR binds it) and writes the row
- Per-operator Vault token caching across requests — v0.2

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated /api/v1/health endpoint that validates credentials, exercises the JWT→Vault federation chain, and returns a structured health response (operator identity, vault reachable/read_ok, db placeholder).

* **Documentation**
  * Backend docs updated to describe the new endpoint, response shape, and request-scoped identity propagation into completion logs.

* **Tests**
  * Added end-to-end tests covering auth cases, Vault success/failure modes, and structured logging of operator identity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/153)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->