### PR TITLE
feat(backend): add SQLAlchemy async engine + Alembic + DB readiness probe

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Alembic configuration for the meho-backplane.
+#
+# The actual SQLAlchemy URL is *not* set here — env.py resolves it from
+# the same ``DATABASE_URL`` env var the running backplane reads, so the
+# migration runner and the request hot path can never drift on which
+# database they target. The empty ``sqlalchemy.url`` is preserved
+# because Alembic's config parser still expects the key to exist.
+
+[alembic]
+# Path to the migration scripts directory. Relative to this file.
+script_location = alembic
+
+# Naming template for new migration files. Includes the revision id +
+# slug so ``ls versions/`` is self-documenting at the file level.
+file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# Empty sentinel — env.py overrides this from os.environ["DATABASE_URL"].
+sqlalchemy.url =
+
+# Add the project's src/ to sys.path so `target_metadata` imports work
+# when alembic is invoked from the backend/ directory. Alembic 1.18+
+# requires the explicit path separator setting; ``os`` follows the
+# host's ``os.pathsep`` (``:`` on POSIX, ``;`` on Windows) which
+# matches the legacy behaviour without the deprecation warning.
+prepend_sys_path = src
+path_separator = os
+
+[post_write_hooks]
+# Hooks that run on every ``alembic revision`` invocation. Empty for
+# now; T29 may wire ``ruff format`` here once the first migration lands.
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Alembic environment script — async-aware (SQLAlchemy 2.x + asyncpg).
+
+The pattern follows the upstream `Alembic async cookbook
+<https://alembic.sqlalchemy.org/en/latest/cookbook.html#using-asyncio-with-alembic>`_:
+``run_migrations_online`` enters an :func:`asyncio.run` boundary,
+constructs an :class:`AsyncEngine` via
+:func:`sqlalchemy.ext.asyncio.async_engine_from_config`, opens an
+async connection, and delegates to a synchronous migration callable
+through :meth:`AsyncConnection.run_sync`.
+
+Two design decisions worth flagging:
+
+* **URL source.** ``sqlalchemy.url`` in ``alembic.ini`` is left blank;
+  the URL is resolved from the ``DATABASE_URL`` env var here so the
+  migration runner and the request hot path can never disagree on the
+  target database. Operators run ``DATABASE_URL=... alembic upgrade
+  head`` and the same env var the backplane already reads is honoured.
+* **Empty target_metadata.** v0.1 ships an empty ``versions/``
+  directory; the first model lands in T28. ``target_metadata = None``
+  means autogeneration is a no-op until then, but ``alembic upgrade
+  head`` still works (and creates the ``alembic_version`` table on
+  first run, which is what the readiness probe in T27 looks for).
+  When T28 adds the audit-log model, this file imports its
+  ``Base.metadata`` and assigns it here.
+
+Offline mode is preserved for completeness — operators rendering
+SQL without a live DB connection (``alembic upgrade head --sql``)
+still need it. The offline path uses the URL straight from the env
+var, no engine construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from logging.config import fileConfig
+from typing import Any
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+# this is the Alembic Config object, which provides access to values
+# within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging. Skipped when running
+# under tools that do not pass an ini file (some IDE integrations).
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Resolve the database URL from the env var the running backplane
+# reads. Mirrors the migration-runner contract documented in the
+# T29 issue and keeps env.py and the live engine in lock-step.
+_database_url = os.environ.get("DATABASE_URL")
+if _database_url:
+    config.set_main_option("sqlalchemy.url", _database_url)
+
+# v0.1 chassis: no models declared yet. T28's audit-log migration
+# imports ``meho_backplane.db.models.Base.metadata`` and assigns it
+# here. Until then ``--autogenerate`` is a no-op.
+target_metadata: Any = None
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    Renders SQL without binding to a live DB. Useful for review and
+    for CI dry-runs before ``upgrade head`` runs in production.
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    """Synchronous core of an online migration run.
+
+    Receives a sync :class:`Connection` (which the async wrapper
+    provides via ``run_sync``); configures Alembic against it and
+    invokes the migrations inside a transaction. Splitting the
+    function out is what lets ``async_engine_from_config`` /
+    ``run_sync`` work without re-entering an event loop from inside
+    the migration scripts.
+    """
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """Build an async engine and run migrations through ``run_sync``."""
+    section = config.get_section(config.config_ini_section) or {}
+    connectable = async_engine_from_config(
+        section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Entry point Alembic invokes for online migrations."""
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: str | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,19 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/meho_backplane"]
 
+# Ship ``alembic.ini`` + the ``alembic/`` migration tree as package
+# data adjacent to the ``meho_backplane`` package so installed wheels
+# can resolve them via :func:`importlib.resources.files`. The
+# in-repo source layout keeps both at ``backend/`` (matching the
+# Alembic CLI's cwd-relative discovery rule for local dev); the wheel
+# layout collapses them under ``meho_backplane/`` so a ``pip install
+# meho-backplane`` deployment doesn't need an external ``alembic.ini``
+# bind-mount. ``find_alembic_ini`` (db/migrations.py) walks both
+# layouts in order: env var → package data → cwd → source tree.
+[tool.hatch.build.targets.wheel.force-include]
+"alembic.ini" = "meho_backplane/alembic.ini"
+"alembic" = "meho_backplane/alembic"
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "authlib>=1.3",
     "httpx>=0.27",
     "hvac>=2.4.0",
+    "sqlalchemy[asyncio]>=2.0",
+    "asyncpg>=0.29",
+    "alembic>=1.13",
 ]
 
 [dependency-groups]
@@ -25,6 +28,8 @@ dev = [
     "cryptography>=42.0",
     "respx>=0.21",
     "pytest-cov>=5.0",
+    "aiosqlite>=0.19",
+    "testcontainers>=4.0",
 ]
 
 [build-system]

--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -54,6 +54,7 @@ from meho_backplane.auth.vault import (
     VaultClientError,
     vault_client_for_operator,
 )
+from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.middleware import verify_jwt_and_bind
 
 __all__ = ["router"]
@@ -102,10 +103,16 @@ class VaultStatus(BaseModel):
 class DbStatus(BaseModel):
     """Database migration status.
 
-    ``migrated`` is ``None`` in v0.1 — G2.3 wires the real Alembic check.
-    The field is present in the response shape now so the CLI's
-    ``meho status`` rendering doesn't have to special-case its absence
-    when G2.3 lands.
+    ``migrated`` is ``True`` when the DB-migration-state probe reports
+    healthy (current Alembic revision matches head), ``False`` when
+    the probe reports unhealthy for any reason (DB unreachable,
+    revision diverged, ``alembic_version`` table absent). v0.1 ships
+    no opinions on retry / repair — operators see the probe's
+    ``detail`` string on the ``/ready`` payload (and downstream tooling
+    in T29 enforces the migration-runner contract). The field stays
+    ``bool | None`` for forward compatibility with response decoders
+    that were generated against the chassis-stage shape, but the
+    handler now always populates it from the probe.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -232,6 +239,7 @@ async def authenticated_health(
     """
     log = structlog.get_logger()
     vault_status = await _probe_vault_federation(operator, log)
+    db_probe_result = await db_migration_probe()
     return HealthResponse(
         operator=OperatorIdentity(
             sub=operator.sub,
@@ -239,5 +247,5 @@ async def authenticated_health(
             email=operator.email,
         ),
         vault=vault_status,
-        db=DbStatus(migrated=None),
+        db=DbStatus(migrated=db_probe_result.ok),
     )

--- a/backend/src/meho_backplane/db/__init__.py
+++ b/backend/src/meho_backplane/db/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""PostgreSQL persistence layer for the backplane.
+
+This package owns the SQLAlchemy 2.x async engine, the per-request
+session factory, and the DB-migration-state readiness probe that
+compares the database's current Alembic revision to the head revision
+on disk. v0.1 ships an empty migration history (T28 lands the first
+migration); the probe still flips ``/ready`` red until ``alembic
+upgrade head`` has been applied — a deliberately fail-closed default
+that matches the chassis-level discipline established in T19.
+"""
+
+__all__: list[str] = []

--- a/backend/src/meho_backplane/db/engine.py
+++ b/backend/src/meho_backplane/db/engine.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""SQLAlchemy 2.x async engine + per-request session factory.
+
+The backplane uses **async** SQLAlchemy paired with the ``asyncpg``
+driver (per `ADR 0004
+<https://github.com/evoila-bosnia/meho-internal/issues/13>`_); every
+database I/O path off the request hot loop must be ``await``-able so
+the FastAPI event loop never blocks on PostgreSQL. This module owns
+three responsibilities:
+
+* **Engine creation** — :func:`get_engine` returns a process-wide
+  :class:`sqlalchemy.ext.asyncio.AsyncEngine`. The engine is built
+  lazily on first call so that test code can patch ``DATABASE_URL``
+  via env vars before the first DB-using request fires; it is cached
+  for the lifetime of the process so connection pooling actually
+  pools.
+* **Session factory** — :func:`get_sessionmaker` returns the
+  :func:`sqlalchemy.ext.asyncio.async_sessionmaker` bound to the
+  process engine. ``expire_on_commit=False`` matches the SQLAlchemy
+  2.x async-doc recommendation: with the default value, attribute
+  access on a committed ORM object lazily emits I/O, which inside an
+  async route is a footgun (the implicit reload would need its own
+  ``await``).
+* **Per-request dependency** — :func:`get_session` is the FastAPI
+  ``Depends`` used by every authenticated route that touches the
+  database (audit middleware in T28; product routes from G3 onward).
+  It opens a session, hands it to the route, commits on success, and
+  rolls back on any exception. The route never sees ``session.begin``
+  directly.
+
+Pool sizing is governed by ``DATABASE_POOL_SIZE`` and
+``DATABASE_POOL_TIMEOUT`` (see :mod:`meho_backplane.settings`); the
+defaults (10 / 30s) match SQLAlchemy 2.x's published guidance for a
+single-replica web service. ``pool_pre_ping=True`` is enabled
+unconditionally — the cost is one extra ``SELECT 1`` round-trip per
+checkout, the benefit is silent recovery from PG restarts and idle
+TCP timeouts which are common in cloud environments. The trade-off is
+documented at length in the SQLAlchemy 2.x async docs.
+
+References
+----------
+* https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html
+* https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "create_engine_for_url",
+    "dispose_engine",
+    "get_engine",
+    "get_session",
+    "get_sessionmaker",
+    "reset_engine_for_testing",
+]
+
+
+_engine: AsyncEngine | None = None
+_sessionmaker: async_sessionmaker[AsyncSession] | None = None
+
+
+def create_engine_for_url(url: str, *, pool_size: int, pool_timeout: float) -> AsyncEngine:
+    """Build a configured :class:`AsyncEngine` for *url*.
+
+    Factored out of :func:`get_engine` so tests (and Alembic's
+    ``env.py``) can construct one-off engines without hitting the
+    process-wide cache. ``pool_pre_ping=True`` is non-negotiable —
+    every checkout pays an extra ``SELECT 1`` round-trip in exchange
+    for transparent recovery from idle-TCP-timeouts and PG restarts.
+
+    SQLite (the v0.1 dev / test driver via aiosqlite) uses
+    :class:`sqlalchemy.pool.StaticPool` and rejects ``pool_size`` /
+    ``pool_timeout`` kwargs at engine-construction time. The kwargs
+    are pruned out for SQLite URLs so the same factory function works
+    for both the production Postgres pool and the local-dev SQLite
+    pool. The pruning is keyed on the SQLAlchemy dialect prefix, not
+    on a feature-flag, because the asyncpg vs aiosqlite split is
+    deterministic from the URL.
+    """
+    pool_kwargs: dict[str, int | float | bool] = {"pool_pre_ping": True}
+    if not url.startswith("sqlite"):
+        pool_kwargs["pool_size"] = pool_size
+        pool_kwargs["pool_timeout"] = pool_timeout
+    return create_async_engine(url, future=True, **pool_kwargs)
+
+
+def get_engine() -> AsyncEngine:
+    """Return the process-wide :class:`AsyncEngine`, creating on first call.
+
+    The engine is cached at module scope; subsequent callers in the
+    same process share the connection pool. Tests that need to drop
+    the cache (e.g. after monkeypatching ``DATABASE_URL``) should call
+    :func:`reset_engine_for_testing`.
+    """
+    global _engine
+    if _engine is None:
+        settings = get_settings()
+        _engine = create_engine_for_url(
+            settings.database_url,
+            pool_size=settings.database_pool_size,
+            pool_timeout=settings.database_pool_timeout,
+        )
+    return _engine
+
+
+def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
+    """Return the process-wide :class:`async_sessionmaker`.
+
+    ``expire_on_commit=False`` matches the SQLAlchemy 2.x async-doc
+    recommendation: with the default ``True``, post-commit attribute
+    access lazily emits I/O, which inside an ``async def`` route turns
+    into an implicit blocking reload — a footgun the async docs flag
+    explicitly.
+    """
+    global _sessionmaker
+    if _sessionmaker is None:
+        _sessionmaker = async_sessionmaker(get_engine(), expire_on_commit=False)
+    return _sessionmaker
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    """FastAPI dependency yielding a transactional :class:`AsyncSession`.
+
+    Wraps the route handler in an outer transaction: SQLAlchemy commits
+    when the ``async with session.begin()`` block exits cleanly, rolls
+    back on any exception. The session is closed by the
+    ``async_sessionmaker`` context manager regardless of outcome.
+
+    Routes consume this via::
+
+        from fastapi import Depends
+        from meho_backplane.db.engine import get_session
+
+        @router.get("/widgets")
+        async def list_widgets(session: AsyncSession = Depends(get_session)):
+            result = await session.execute(select(Widget))
+            return result.scalars().all()
+
+    The audit-write middleware (T28) reuses the same factory but does
+    its own session lifecycle management because it must commit *before*
+    the route handler returns — synchronous-audit semantics are part of
+    Goal #11's DoD.
+    """
+    async with get_sessionmaker()() as session, session.begin():
+        yield session
+
+
+async def dispose_engine() -> None:
+    """Tear down the process-wide engine and reset the cached factory.
+
+    Called from the FastAPI ``lifespan`` shutdown phase so the pool's
+    connections are closed cleanly when the worker exits. The
+    SQLAlchemy 2.x async docs are emphatic that ``AsyncEngine.dispose``
+    must be ``await``\\ ed in async contexts; calling the sync variant
+    leaves underlying asyncpg connections reachable only from a
+    different event loop, which the GC cannot reliably reach.
+    """
+    global _engine, _sessionmaker
+    if _engine is not None:
+        await _engine.dispose()
+    _engine = None
+    _sessionmaker = None
+
+
+def reset_engine_for_testing() -> None:
+    """Clear the cached engine + sessionmaker. Test-only.
+
+    Production code never calls this — :func:`dispose_engine` is the
+    correct shutdown path. The cache reset is needed in tests that
+    swap ``DATABASE_URL`` between cases (e.g. one case using
+    aiosqlite, another using a testcontainers PG); without it the
+    second case would silently reuse the first case's pool.
+    """
+    global _engine, _sessionmaker
+    _engine = None
+    _sessionmaker = None

--- a/backend/src/meho_backplane/db/migrations.py
+++ b/backend/src/meho_backplane/db/migrations.py
@@ -27,6 +27,8 @@ References
 from __future__ import annotations
 
 import logging
+import os
+from importlib import resources
 from pathlib import Path
 
 from alembic.config import Config
@@ -50,34 +52,72 @@ _log = logging.getLogger(__name__)
 #: so an ops-time relocation only requires one knob change.
 _ALEMBIC_INI_NAME: str = "alembic.ini"
 
+#: Env-var ops can set to point the probe / migration runner at an
+#: arbitrary ``alembic.ini`` — escape hatch for deployments where the
+#: file lives outside both the working directory and the installed
+#: package (e.g. mounted from a ConfigMap in Kubernetes).
+_ALEMBIC_CONFIG_ENV_VAR: str = "ALEMBIC_CONFIG"
+
 
 def find_alembic_ini() -> Path:
     """Resolve the on-disk path to ``alembic.ini``.
 
-    Looks two places in order:
+    Looks four places in order so the helper works in every deployment
+    shape — operator override, installed wheel, source-tree dev, and
+    arbitrary-cwd test runners:
 
-    1. The current working directory. This matches the ``alembic ...``
-       CLI's own resolution rule and is the path the migration runner
-       hits in containers (where ``WORKDIR`` is ``/app/backend``).
-    2. The package layout — walks up from ``meho_backplane.db`` to
-       find the ``backend/`` directory containing ``alembic.ini``.
-       This is what the readiness probe hits when running under
-       ``pytest`` from arbitrary cwds.
+    1. ``$ALEMBIC_CONFIG`` env var — explicit ops override; used as-is
+       (no existence check beyond the final :class:`FileNotFoundError`
+       message), which lets operators get an actionable error message
+       when they typo the path.
+    2. Package data — :func:`importlib.resources.files` against
+       :mod:`meho_backplane`. This is the path installed-wheel
+       deployments hit; ``alembic.ini`` is shipped as package data
+       via ``[tool.hatch.build.targets.wheel.force-include]`` in
+       ``pyproject.toml``.
+    3. The current working directory. Matches the ``alembic ...`` CLI's
+       own resolution rule and is the path the migration runner hits
+       in containers (where ``WORKDIR`` is ``/app/backend``).
+    4. The source-tree layout — walks up from
+       :mod:`meho_backplane.db` to find the ``backend/`` directory
+       containing ``alembic.ini``. This is what the readiness probe
+       hits when running under ``pytest`` from arbitrary cwds against
+       an editable install.
 
-    Raises :class:`FileNotFoundError` when neither location holds the
-    file; callers translate that to ``ok=False`` with a stable detail
-    string.
+    Raises :class:`FileNotFoundError` naming the env var and the
+    package lookup when no candidate resolves.
     """
+    env_override = os.environ.get(_ALEMBIC_CONFIG_ENV_VAR)
+    if env_override:
+        env_candidate = Path(env_override)
+        if env_candidate.is_file():
+            return env_candidate
+        raise FileNotFoundError(
+            f"alembic.ini not found at {env_candidate} (set via ${_ALEMBIC_CONFIG_ENV_VAR})",
+        )
+    # ``importlib.resources.files`` returns a ``Traversable``; for the
+    # editable / unpacked-wheel case it is a real :class:`Path`. We
+    # only honour it when it actually points at an existing file so
+    # editable installs (where the package data is *not* materialised
+    # adjacent to the package source) fall through to the cwd /
+    # source-tree probes below.
+    package_traversable = resources.files("meho_backplane").joinpath(_ALEMBIC_INI_NAME)
+    package_candidate = Path(str(package_traversable))
+    if package_candidate.is_file():
+        return package_candidate
     cwd_candidate = Path.cwd() / _ALEMBIC_INI_NAME
     if cwd_candidate.is_file():
         return cwd_candidate
     # ``__file__`` is .../backend/src/meho_backplane/db/migrations.py;
     # parents[3] resolves to .../backend, which is where alembic.ini lives.
-    package_candidate = Path(__file__).resolve().parents[3] / _ALEMBIC_INI_NAME
-    if package_candidate.is_file():
-        return package_candidate
+    source_tree_candidate = Path(__file__).resolve().parents[3] / _ALEMBIC_INI_NAME
+    if source_tree_candidate.is_file():
+        return source_tree_candidate
     raise FileNotFoundError(
-        f"alembic.ini not found at {cwd_candidate} or {package_candidate}",
+        f"alembic.ini not found via ${_ALEMBIC_CONFIG_ENV_VAR}, "
+        f"importlib.resources('meho_backplane') ({package_candidate}), "
+        f"cwd ({cwd_candidate}), "
+        f"or source tree ({source_tree_candidate})",
     )
 
 

--- a/backend/src/meho_backplane/db/migrations.py
+++ b/backend/src/meho_backplane/db/migrations.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""DB-migration-state readiness probe + Alembic configuration helpers.
+
+The probe answers a single operational question: *is the database
+schema at the revision this code expects?* Three failure modes — DB
+unreachable, ``alembic_version`` table missing, current revision
+diverges from the code's head — collapse into a single
+:class:`~meho_backplane.health.ProbeResult` with ``ok=False`` and a
+short structured detail string. The probe is registered against the
+shared readiness registry from :mod:`meho_backplane.main`'s lifespan
+hook so ``/ready`` returns 503 (and the kubelet keeps the pod out of
+service traffic) until the schema matches.
+
+The helper :func:`alembic_config` resolves and caches the on-disk
+``alembic.ini``; both the probe and the migration runner (T29) share
+a single :class:`alembic.config.Config` instance to avoid drift
+between what the runner *applied* and what the probe *expects*.
+
+References
+----------
+* https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.migration.MigrationContext
+* https://alembic.sqlalchemy.org/en/latest/api/script.html#alembic.script.ScriptDirectory
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy.engine import Connection
+
+from meho_backplane.db.engine import get_engine
+from meho_backplane.health import ProbeResult
+
+__all__ = [
+    "alembic_config",
+    "db_migration_probe",
+    "find_alembic_ini",
+]
+
+_log = logging.getLogger(__name__)
+
+#: Filename Alembic conventionally reads from. The probe and the
+#: migration runner both look this up via :func:`find_alembic_ini`,
+#: so an ops-time relocation only requires one knob change.
+_ALEMBIC_INI_NAME: str = "alembic.ini"
+
+
+def find_alembic_ini() -> Path:
+    """Resolve the on-disk path to ``alembic.ini``.
+
+    Looks two places in order:
+
+    1. The current working directory. This matches the ``alembic ...``
+       CLI's own resolution rule and is the path the migration runner
+       hits in containers (where ``WORKDIR`` is ``/app/backend``).
+    2. The package layout — walks up from ``meho_backplane.db`` to
+       find the ``backend/`` directory containing ``alembic.ini``.
+       This is what the readiness probe hits when running under
+       ``pytest`` from arbitrary cwds.
+
+    Raises :class:`FileNotFoundError` when neither location holds the
+    file; callers translate that to ``ok=False`` with a stable detail
+    string.
+    """
+    cwd_candidate = Path.cwd() / _ALEMBIC_INI_NAME
+    if cwd_candidate.is_file():
+        return cwd_candidate
+    # ``__file__`` is .../backend/src/meho_backplane/db/migrations.py;
+    # parents[3] resolves to .../backend, which is where alembic.ini lives.
+    package_candidate = Path(__file__).resolve().parents[3] / _ALEMBIC_INI_NAME
+    if package_candidate.is_file():
+        return package_candidate
+    raise FileNotFoundError(
+        f"alembic.ini not found at {cwd_candidate} or {package_candidate}",
+    )
+
+
+def alembic_config(ini_path: Path | None = None) -> Config:
+    """Return an :class:`alembic.config.Config` rooted at *ini_path*.
+
+    *ini_path* defaults to :func:`find_alembic_ini`. The returned
+    Config is **not** cached — it is cheap to construct and the
+    caller may want to override ``script_location`` for offline /
+    test scenarios.
+    """
+    resolved = ini_path or find_alembic_ini()
+    return Config(str(resolved))
+
+
+def _read_current_revision(connection: Connection) -> str | None:
+    """Return the database's currently-applied revision, or ``None``.
+
+    Wraps :class:`alembic.runtime.migration.MigrationContext` to read
+    the version. Returns ``None`` when the ``alembic_version`` table
+    is absent (fresh DB before ``upgrade head``) — the table is
+    created on the first migration run, so its absence is a
+    legitimate "not yet migrated" signal rather than a probe failure.
+    """
+    context = MigrationContext.configure(connection)
+    return context.get_current_revision()
+
+
+async def db_migration_probe() -> ProbeResult:
+    """Compare the DB's Alembic revision to the code's head.
+
+    Three observable outcomes:
+
+    * **healthy** — database reachable, ``alembic_version`` table
+      readable, current revision matches the head defined by the
+      ``versions/`` directory on disk. Detail carries
+      ``revision=<sha>``.
+    * **unhealthy (revision diverged)** — current and head both
+      resolved but they differ. Detail carries
+      ``current=<sha> head=<sha>``. Operators see this when a
+      forward-deploy missed an ``alembic upgrade head`` or when a
+      rollback returned the image but not the schema.
+    * **unhealthy (DB / config error)** — DB unreachable, table
+      missing, ini missing, etc. Detail carries
+      ``check_failed: <ExcClass>`` — the class name only, not the
+      message, mirroring the redaction discipline of the Vault
+      federation probe in T24 (operator-controllable substrings must
+      not leak into a ``/ready`` payload).
+
+    The function is ``async`` because the canonical SQLAlchemy 2.x
+    pattern reads the version through an ``AsyncEngine.connect()`` /
+    ``run_sync`` pair; it is registered as an async probe by
+    :mod:`meho_backplane.main`'s lifespan hook.
+    """
+    try:
+        cfg = alembic_config()
+        head = ScriptDirectory.from_config(cfg).get_current_head()
+        engine = get_engine()
+        async with engine.connect() as conn:
+            current = await conn.run_sync(_read_current_revision)
+    except Exception as exc:
+        _log.warning(
+            "db_migration_probe_failed",
+            extra={"exc_type": type(exc).__name__},
+        )
+        return ProbeResult(
+            name="db",
+            ok=False,
+            detail=f"check_failed: {type(exc).__name__}",
+        )
+    if head is None and current is None:
+        # No migrations on disk and none applied. Treat as not-ready
+        # rather than vacuously-ready: the chassis ships with an
+        # empty ``versions/`` so the smoke test still flips ``/ready``
+        # red until T28's first migration lands.
+        return ProbeResult(
+            name="db",
+            ok=False,
+            detail="no_migrations: head and current are both unset",
+        )
+    if current == head:
+        return ProbeResult(
+            name="db",
+            ok=True,
+            detail=f"revision={head}",
+        )
+    return ProbeResult(
+        name="db",
+        ok=False,
+        detail=f"current={current} head={head}",
+    )

--- a/backend/src/meho_backplane/health.py
+++ b/backend/src/meho_backplane/health.py
@@ -32,18 +32,21 @@ Usage::
     register_probe("vault", vault_probe)
 """
 
-from collections.abc import Callable
+import inspect
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 __all__ = [
+    "ProbeFn",
     "ProbeResult",
     "clear_probes",
     "register_probe",
     "router",
     "run_probes",
+    "run_probes_async",
 ]
 
 
@@ -69,23 +72,45 @@ class ProbeResult:
     detail: str | None = None
 
 
-_probes: list[tuple[str, Callable[[], ProbeResult]]] = []
+#: A probe is either a plain callable returning :class:`ProbeResult`
+#: synchronously (Keycloak / Vault probes — both use the ``hvac``
+#: + ``httpx`` sync clients wrapped where needed) or an ``async def``
+#: coroutine returning the same (the DB-migration-state probe — the
+#: SQLAlchemy 2.x async engine forces the I/O onto the event loop).
+#: The registry stores both shapes; the ``/ready`` handler awaits
+#: coroutine-returning probes and calls sync probes inline.
+ProbeFn = Callable[[], ProbeResult] | Callable[[], Awaitable[ProbeResult]]
 
 
-def register_probe(name: str, fn: Callable[[], ProbeResult]) -> None:
+_probes: list[tuple[str, ProbeFn]] = []
+
+
+def register_probe(name: str, fn: ProbeFn) -> None:
     """Register *fn* under *name* in the readiness-probe registry.
 
     Probes are evaluated in registration order on every ``/ready`` hit.
-    The same name may be registered more than once (callers are
-    responsible for uniqueness); duplicates simply run twice. This
-    permissive contract keeps the registry trivially testable — see
-    :func:`clear_probes`.
+    Both synchronous (``def``) and asynchronous (``async def``) probe
+    callables are accepted — the registry keeps them in a single list
+    and the ``/ready`` handler dispatches via
+    :func:`inspect.iscoroutinefunction`. The same name may be
+    registered more than once (callers are responsible for
+    uniqueness); duplicates simply run twice. This permissive contract
+    keeps the registry trivially testable — see :func:`clear_probes`.
     """
     _probes.append((name, fn))
 
 
 def run_probes() -> list[ProbeResult]:
-    """Evaluate every registered probe and return the result list.
+    """Evaluate every registered **synchronous** probe.
+
+    Async probes are skipped — calling them from a synchronous
+    context would either return an un-awaited coroutine (silently
+    discarding the I/O) or require spinning a new event loop (which
+    would deadlock when called from inside a running loop). The
+    ``/ready`` endpoint uses :func:`run_probes_async` instead;
+    this function is preserved for the Task #19 contract that
+    ``run_probes`` is part of the public registry API and for
+    callers that only register sync probes.
 
     Pure pass-through: probe exceptions are *not* caught here. Probes
     are expected to convert their own failures into a ``ProbeResult``
@@ -93,7 +118,46 @@ def run_probes() -> list[ProbeResult]:
     bug and surfacing it as a 500 from ``/ready`` is the correct
     behaviour.
     """
-    return [fn() for _, fn in _probes]
+    results: list[ProbeResult] = []
+    for _name, fn in _probes:
+        if inspect.iscoroutinefunction(fn):
+            continue
+        result = fn()
+        # An ``async def`` without the ``__wrapped__`` marker still
+        # returns a coroutine when called; defensively skip those.
+        if inspect.iscoroutine(result):  # pragma: no cover — defensive
+            continue
+        # Mypy can't see that ``iscoroutinefunction`` already excluded
+        # the awaitable branch of the ``ProbeFn`` union at this point,
+        # so we narrow explicitly via :func:`isinstance`.
+        if isinstance(result, ProbeResult):
+            results.append(result)
+    return results
+
+
+async def run_probes_async() -> list[ProbeResult]:
+    """Evaluate every registered probe — sync and async alike.
+
+    Async probes are awaited; sync probes are called inline. Probes
+    run sequentially in registration order (parallelising readiness
+    checks across dependencies is a v0.2 optimisation; v0.1 favours
+    deterministic ordering for readable ``/ready`` payloads and
+    audit logs).
+    """
+    results: list[ProbeResult] = []
+    for _name, fn in _probes:
+        if inspect.iscoroutinefunction(fn):
+            results.append(await fn())
+        else:
+            value = fn()
+            # Defensive: a sync-typed callable that returned an
+            # awaitable (mis-annotated probe) gets awaited rather
+            # than silently dropped on the floor.
+            if inspect.isawaitable(value):  # pragma: no cover — defensive
+                results.append(await value)
+            else:
+                results.append(value)
+    return results
 
 
 def clear_probes() -> None:
@@ -122,7 +186,7 @@ async def ready() -> JSONResponse:
     ``all([])`` is vacuously ``True`` in Python, which would otherwise
     flip the chassis to "ready" with zero evidence.
     """
-    results = run_probes()
+    results = await run_probes_async()
     ready_ok = bool(results) and all(r.ok for r in results)
     payload = {
         "status": "ready" if ready_ok else "not_ready",

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -28,6 +28,8 @@ from meho_backplane import __version__
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.auth.jwt import keycloak_readiness_probe
 from meho_backplane.auth.vault import vault_readiness_probe
+from meho_backplane.db.engine import dispose_engine
+from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.health import register_probe
 from meho_backplane.health import router as health_router
 from meho_backplane.logging import configure_logging
@@ -44,21 +46,27 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 
     Configures structlog at startup so every log line emitted from this
     point onwards (including the very first request) is JSON-formatted,
-    and registers the Keycloak + Vault readiness probes with the
-    registry so ``/ready`` reflects whether each dependency is
-    reachable. The Vault probe is registered even though no protected
-    route consuming Vault has landed yet (G2.2-T3) — readiness is a
-    deployment-shape concern, not a request-path concern.
+    and registers the Keycloak + Vault + DB-migration-state readiness
+    probes with the registry so ``/ready`` reflects whether each
+    dependency is reachable. Probes are registered even though no
+    request-path consumer of the dependency may have landed yet —
+    readiness is a deployment-shape concern, not a request-path
+    concern.
 
-    There is nothing to tear down at shutdown yet; the ``yield`` /
-    ``return`` shape is preserved so future Initiatives (G2.3
-    SQLAlchemy engine ``dispose()``) can plug in without restructuring
-    the function.
+    On shutdown the SQLAlchemy async engine is disposed so the asyncpg
+    connection pool releases its connections cleanly; without the
+    explicit ``await engine.dispose()`` the SQLAlchemy 2.x async docs
+    warn that the underlying connections may stay reachable only from
+    a different event loop, which the GC cannot reliably close.
     """
     configure_logging()
     register_probe("keycloak", keycloak_readiness_probe)
     register_probe("vault", vault_readiness_probe)
-    yield
+    register_probe("db", db_migration_probe)
+    try:
+        yield
+    finally:
+        await dispose_engine()
 
 
 app: FastAPI = FastAPI(

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -28,7 +28,7 @@ from meho_backplane import __version__
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.auth.jwt import keycloak_readiness_probe
 from meho_backplane.auth.vault import vault_readiness_probe
-from meho_backplane.db.engine import dispose_engine
+from meho_backplane.db.engine import dispose_engine, get_engine
 from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.health import register_probe
 from meho_backplane.health import router as health_router
@@ -53,6 +53,17 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     readiness is a deployment-shape concern, not a request-path
     concern.
 
+    The SQLAlchemy async engine is **eagerly** instantiated here (via
+    :func:`get_engine`) so that the pool is built and the
+    ``DATABASE_URL`` is validated at startup, not on the first
+    request. Without this pre-warm the very first ``/ready`` poll the
+    kubelet sends absorbs the engine-construction cost, which both
+    inflates first-request latency and risks a race where the readiness
+    probe is asked to query a database whose engine hasn't been
+    constructed yet. The engine factory itself stays lazy
+    (process-level cache); the lifespan call is what flips it from
+    "lazy on first request" to "eager at process boot".
+
     On shutdown the SQLAlchemy async engine is disposed so the asyncpg
     connection pool releases its connections cleanly; without the
     explicit ``await engine.dispose()`` the SQLAlchemy 2.x async docs
@@ -63,6 +74,8 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     register_probe("keycloak", keycloak_readiness_probe)
     register_probe("vault", vault_readiness_probe)
     register_probe("db", db_migration_probe)
+    # Eager engine construction — see lifespan docstring for why.
+    get_engine()
     try:
         yield
     finally:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -24,10 +24,22 @@ chain immediately rather than days later under load.
 
 import os
 from functools import lru_cache
+from typing import Final
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl, field_validator
 
 __all__ = ["Settings", "get_settings"]
+
+#: Driver schemes accepted on ``DATABASE_URL``. Both are async — the
+#: backplane refuses to construct a sync engine because every database
+#: I/O path off the request hot loop must be ``await``-able (ADR 0004).
+#: ``postgresql+asyncpg://`` is the production driver; ``sqlite+aiosqlite://``
+#: is the v0.1 dev/test driver. Adding a third scheme requires both an
+#: ADR amendment and a confirmed async driver shipping with that prefix.
+_SUPPORTED_DATABASE_URL_SCHEMES: Final[tuple[str, ...]] = (
+    "postgresql+asyncpg://",
+    "sqlite+aiosqlite://",
+)
 
 
 class Settings(BaseModel):
@@ -121,6 +133,29 @@ class Settings(BaseModel):
     database_url: str = Field(min_length=1)
     database_pool_size: int = Field(default=10, gt=0)
     database_pool_timeout: float = Field(default=30.0, gt=0)
+
+    @field_validator("database_url")
+    @classmethod
+    def _database_url_must_be_async(cls, value: str) -> str:
+        """Reject sync SQLAlchemy DSNs at construction time.
+
+        ADR 0004 mandates that every database I/O path off the request
+        hot loop is ``await``-able. A sync DSN
+        (``postgresql://`` / ``sqlite:///``) would silently work for
+        engine construction but would block the FastAPI event loop on
+        every checkout — the failure mode is a saturated worker that
+        looks healthy on ``/healthz`` but starves at ``/api/...``. Fail
+        fast at startup instead, with an actionable error message that
+        names the supported schemes so the operator can fix the
+        ``DATABASE_URL`` env var directly without grepping the codebase.
+        """
+        if not value.startswith(_SUPPORTED_DATABASE_URL_SCHEMES):
+            supported = ", ".join(_SUPPORTED_DATABASE_URL_SCHEMES)
+            raise ValueError(
+                f"DATABASE_URL must use an async driver scheme; "
+                f"supported: {supported}. Got: {value!r}",
+            )
+        return value
 
 
 @lru_cache(maxsize=1)

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -85,6 +85,28 @@ class Settings(BaseModel):
         fail-closed quickly rather than starve request capacity. The
         v0.1 dogfood load is per-request login, so the timeout governs
         worst-case request latency directly.
+    database_url:
+        SQLAlchemy URL for the PostgreSQL database, e.g.
+        ``postgresql+asyncpg://meho:<password>@<host>:5432/meho``.
+        Required — the backplane refuses to start without it. The
+        ``+asyncpg`` driver is mandatory (per ADR 0004); a sync URL
+        would silently work for the engine factory but the per-request
+        session dependency would block the FastAPI event loop on every
+        I/O call. Required also for Alembic — ``env.py`` reads this
+        value rather than the static ``[alembic]`` ini setting so the
+        migration runner's URL stays in lock-step with the running
+        backplane.
+    database_pool_size:
+        Maximum number of connections SQLAlchemy keeps idle in the
+        pool. Default 10 follows SQLAlchemy 2.x's published guidance
+        for a single-replica web service; raise it when sustained
+        request concurrency exceeds the default.
+    database_pool_timeout:
+        Seconds to wait for an available pool connection before
+        raising :class:`sqlalchemy.exc.TimeoutError`. Default 30s
+        gives a real PG outage time to recover before requests start
+        failing fast; tune downward for traffic shapes where
+        backpressure is preferred to long latency.
     """
 
     keycloak_issuer_url: HttpUrl
@@ -96,6 +118,9 @@ class Settings(BaseModel):
     vault_oidc_mount_path: str = Field(default="jwt", min_length=1)
     vault_namespace: str | None = None
     vault_timeout_seconds: float = Field(default=10.0, gt=0)
+    database_url: str = Field(min_length=1)
+    database_pool_size: int = Field(default=10, gt=0)
+    database_pool_timeout: float = Field(default=30.0, gt=0)
 
 
 @lru_cache(maxsize=1)
@@ -135,5 +160,10 @@ def get_settings() -> Settings:
         vault_namespace=vault_namespace_env if vault_namespace_env else None,
         vault_timeout_seconds=float(
             os.environ.get("VAULT_TIMEOUT_SECONDS", "10.0"),
+        ),
+        database_url=os.environ["DATABASE_URL"],
+        database_pool_size=int(os.environ.get("DATABASE_POOL_SIZE", "10")),
+        database_pool_timeout=float(
+            os.environ.get("DATABASE_POOL_TIMEOUT", "30.0"),
         ),
     )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -44,6 +44,8 @@ import httpx
 import pytest
 import respx
 
+from meho_backplane.settings import get_settings
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from authlib.jose import JsonWebKey, JsonWebToken
@@ -116,12 +118,22 @@ def _default_database_url(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     constructs an engine directly. Tests that exercise the
     DB-migration-state probe override this default with a testcontainers
     PG URL or a ``aiosqlite:///<tmp>`` file path.
+
+    The ``get_settings.cache_clear()`` brackets matter: ``Settings`` is
+    cached at module scope by :func:`functools.lru_cache`, and a stale
+    cache entry from an earlier test (constructed before this fixture
+    set the env var) would survive into the next test and silently
+    return the previous URL. Clearing the cache before *and* after the
+    yield guarantees every test in this suite sees a fresh
+    ``Settings`` constructed against this fixture's env-var pin.
     """
+    get_settings.cache_clear()
     monkeypatch.setenv(
         "DATABASE_URL",
         "sqlite+aiosqlite:///:memory:",
     )
     yield
+    get_settings.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -104,6 +104,27 @@ SECRET_LEAK_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
 
 
 @pytest.fixture(autouse=True)
+def _default_database_url(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Provide a default ``DATABASE_URL`` so :class:`Settings` constructs.
+
+    Every existing test file pins ``KEYCLOAK_ISSUER_URL`` / ``VAULT_ADDR``
+    in its own per-file fixture; ``DATABASE_URL`` is the third required
+    field added in T27. Pinning the default here (an aiosqlite URL,
+    intentionally not a real PG host) avoids a 7-file diff chasing every
+    settings-using fixture and keeps the failure shape obvious if a test
+    actually needs a live PG: the test resets ``DATABASE_URL`` itself or
+    constructs an engine directly. Tests that exercise the
+    DB-migration-state probe override this default with a testcontainers
+    PG URL or a ``aiosqlite:///<tmp>`` file path.
+    """
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "sqlite+aiosqlite:///:memory:",
+    )
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _no_secret_leak_sweep(
     caplog: pytest.LogCaptureFixture,
     capfd: pytest.CaptureFixture[str],

--- a/backend/tests/test_alembic_probe.py
+++ b/backend/tests/test_alembic_probe.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :func:`meho_backplane.db.migrations.db_migration_probe`.
+
+Coverage matrix (Task #27 acceptance criteria #3, #4):
+
+* Probe healthy when the database revision matches the on-disk head.
+* Probe unhealthy when the database revision diverges from head.
+* Probe unhealthy when the database is unreachable / driver fails.
+* Probe unhealthy with a stable detail string when the
+  ``alembic_version`` table is absent (fresh DB before ``upgrade head``).
+* ``/api/v1/health.db.migrated`` reflects the probe outcome — the
+  response field is no longer hardcoded ``None``.
+
+The aiosqlite tests stay always-on; they exercise the probe's
+revision comparison machinery without needing Docker. The probe's
+async-engine code path is the same one a PG deployment hits — the
+only DB-specific surface is the SQL the ``MigrationContext`` issues,
+and Alembic's own contract is that the SQL is portable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from meho_backplane.db.engine import (
+    create_engine_for_url,
+    dispose_engine,
+    reset_engine_for_testing,
+)
+from meho_backplane.db.migrations import db_migration_probe
+from meho_backplane.health import (
+    ProbeResult,
+    clear_probes,
+    register_probe,
+    run_probes_async,
+)
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def sqlite_engine(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> AsyncIterator[AsyncEngine]:
+    """Create a per-test aiosqlite engine and wire it as the process engine.
+
+    Resets the module-level cache before and after so the probe sees
+    *this* engine when it calls :func:`get_engine`. The DB file lives
+    under pytest's ``tmp_path`` so each test gets an isolated DB.
+    """
+    db_path = tmp_path / "probe.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    eng = create_engine_for_url(url, pool_size=5, pool_timeout=10.0)
+    # Inject as the cached engine so db_migration_probe's get_engine() returns it.
+    from meho_backplane.db import engine as engine_module
+
+    engine_module._engine = eng
+    try:
+        yield eng
+    finally:
+        await dispose_engine()
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Iterator[None]:
+    """Empty the readiness-probe registry around every test."""
+    clear_probes()
+    yield
+    clear_probes()
+
+
+async def _create_alembic_version_table(eng: AsyncEngine, revision: str | None) -> None:
+    """Create ``alembic_version`` and stamp it with *revision*.
+
+    Used to manufacture the "applied revision" half of the head/current
+    comparison. Mirrors what ``alembic stamp <rev>`` would do at the
+    SQL layer; we issue the DDL directly so the test does not depend
+    on the alembic CLI at runtime.
+    """
+    async with eng.begin() as conn:
+        await conn.execute(
+            text(
+                "CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL PRIMARY KEY)",
+            ),
+        )
+        if revision is not None:
+            await conn.execute(
+                text("INSERT INTO alembic_version (version_num) VALUES (:r)"),
+                {"r": revision},
+            )
+
+
+# ---------------------------------------------------------------------------
+# db_migration_probe outcomes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_unhealthy_when_no_migrations_and_no_table(
+    sqlite_engine: AsyncEngine,
+) -> None:
+    """Empty versions/ + fresh DB → not ready, with a stable detail string."""
+    result = await db_migration_probe()
+    assert result.name == "db"
+    assert result.ok is False
+    assert result.detail is not None
+    assert "no_migrations" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_probe_unhealthy_when_revisions_diverge(
+    sqlite_engine: AsyncEngine,
+) -> None:
+    """DB stamped with one revision, head reports another → unhealthy.
+
+    Patches :class:`ScriptDirectory` so head returns a synthetic
+    revision; manufactures the ``alembic_version`` row with a
+    different revision; asserts the probe returns ``ok=False`` with
+    the diverged detail string.
+    """
+    await _create_alembic_version_table(sqlite_engine, "deadbeef0000")
+
+    with patch(
+        "meho_backplane.db.migrations.ScriptDirectory.from_config",
+    ) as fake_from_config:
+        fake_from_config.return_value.get_current_head.return_value = "headcafe1111"
+        result = await db_migration_probe()
+
+    assert result.ok is False
+    assert result.detail == "current=deadbeef0000 head=headcafe1111"
+
+
+@pytest.mark.asyncio
+async def test_probe_healthy_when_revisions_match(
+    sqlite_engine: AsyncEngine,
+) -> None:
+    """DB stamped with head's revision → ok=True, detail carries revision."""
+    await _create_alembic_version_table(sqlite_engine, "headcafe1111")
+
+    with patch(
+        "meho_backplane.db.migrations.ScriptDirectory.from_config",
+    ) as fake_from_config:
+        fake_from_config.return_value.get_current_head.return_value = "headcafe1111"
+        result = await db_migration_probe()
+
+    assert result.ok is True
+    assert result.detail == "revision=headcafe1111"
+
+
+@pytest.mark.asyncio
+async def test_probe_unhealthy_when_db_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB connection failure → ok=False with redacted detail.
+
+    Resets the engine cache and points DATABASE_URL at an asyncpg URL
+    that cannot connect (port 1 on localhost). The probe must not
+    raise; AC #3 says it converts every failure to a structured
+    ``ProbeResult``.
+    """
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://nobody:nobody@127.0.0.1:1/none",
+    )
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    try:
+        result = await db_migration_probe()
+    finally:
+        await dispose_engine()
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+    assert result.name == "db"
+    assert result.ok is False
+    assert result.detail is not None
+    assert result.detail.startswith("check_failed: ")
+    # Detail must not echo operator-controllable substrings (URL, host,
+    # creds). The check_failed prefix carries only an exception class
+    # name — anything else is a leak.
+    assert "127.0.0.1" not in result.detail
+    assert "nobody" not in result.detail
+
+
+@pytest.mark.asyncio
+async def test_probe_registers_with_async_runner(
+    sqlite_engine: AsyncEngine,
+) -> None:
+    """``run_probes_async`` awaits :func:`db_migration_probe` correctly."""
+    register_probe("db", db_migration_probe)
+    results = await run_probes_async()
+    assert len(results) == 1
+    assert results[0].name == "db"
+    assert isinstance(results[0], ProbeResult)
+
+
+# ---------------------------------------------------------------------------
+# /ready integration
+# ---------------------------------------------------------------------------
+
+
+def test_ready_reflects_db_probe_state(
+    sqlite_engine: AsyncEngine,
+) -> None:
+    """``/ready`` payload includes the DB probe verdict.
+
+    Registers only the DB probe (clearing Keycloak/Vault from the
+    autouse fixture); asserts the response carries the structured
+    ``check_failed`` detail when the empty versions/ + fresh DB
+    flips the probe red.
+    """
+    register_probe("db", db_migration_probe)
+
+    client = TestClient(app)
+    response = client.get("/ready")
+
+    assert response.status_code == 503
+    body = response.json()
+    db_check = next(c for c in body["checks"] if c["name"] == "db")
+    assert db_check["ok"] is False
+    assert "no_migrations" in (db_check["detail"] or "")

--- a/backend/tests/test_api_health_failures.py
+++ b/backend/tests/test_api_health_failures.py
@@ -325,7 +325,10 @@ def test_valid_jwt_vault_unreachable_returns_200_with_structured_detail(
     assert body["vault"]["reachable"] is False
     assert body["vault"]["read_ok"] is False
     assert body["vault"]["detail"] == "login_failed: VaultUnreachableError"
-    assert body["db"]["migrated"] is None
+    # ``db.migrated`` reflects the T27 DB-migration-state probe verdict;
+    # the autouse default DATABASE_URL has no migrations applied so the
+    # probe returns False until T28 lands the first revision.
+    assert body["db"]["migrated"] is False
 
 
 def test_valid_jwt_vault_role_denied_returns_200_with_role_denied_detail(

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -374,10 +374,14 @@ def test_happy_path_returns_full_federation_response(
 
     assert response.status_code == 200
     body = response.json()
+    # ``db.migrated`` now reflects the DB-migration-state probe verdict
+    # (T27). Under the autouse default DATABASE_URL (in-memory aiosqlite,
+    # no alembic_version table) the probe reports unhealthy → migrated=False.
+    # T28's first migration flips this back to True end-to-end.
     assert body == {
         "operator": {"sub": "op-100", "name": "Alice", "email": "alice@example.com"},
         "vault": {"reachable": True, "read_ok": True, "detail": "version=11"},
-        "db": {"migrated": None},
+        "db": {"migrated": False},
     }
 
     # Vault was hit with the configured role / mount and the operator's
@@ -517,7 +521,9 @@ def test_vault_unreachable_returns_200_with_structured_detail(
     assert body["vault"]["reachable"] is False
     assert body["vault"]["read_ok"] is False
     assert body["vault"]["detail"] == "login_failed: VaultUnreachableError"
-    assert body["db"]["migrated"] is None
+    # ``db.migrated`` now reflects the T27 probe verdict; with no migrations
+    # applied it remains False until T28 lands the first revision.
+    assert body["db"]["migrated"] is False
 
 
 def test_vault_role_denied_returns_200_with_role_denied_detail(

--- a/backend/tests/test_db_engine.py
+++ b/backend/tests/test_db_engine.py
@@ -239,6 +239,45 @@ def test_find_alembic_ini_resolves_packaged_path() -> None:
     assert path.name == "alembic.ini"
 
 
+def test_find_alembic_ini_honours_env_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``$ALEMBIC_CONFIG`` wins over package / cwd / source-tree probes.
+
+    Ops can override the file location for non-standard deployments
+    (mounted ConfigMaps, k8s init-containers, etc.) by setting the env
+    var; the override must take precedence over every other resolution
+    rule and the resolver must return that path verbatim.
+    """
+    custom_ini = tmp_path / "custom-alembic.ini"
+    custom_ini.write_text("[alembic]\nscript_location = /nowhere\n")
+    monkeypatch.setenv("ALEMBIC_CONFIG", str(custom_ini))
+
+    resolved = find_alembic_ini()
+    assert resolved == custom_ini
+
+
+def test_find_alembic_ini_env_override_missing_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``$ALEMBIC_CONFIG`` pointing at a non-existent path raises clearly.
+
+    Falling back to the cwd / source-tree probes when the operator
+    explicitly set ``ALEMBIC_CONFIG`` would mask a typo and load the
+    *wrong* migration tree. Surface the error instead so the operator
+    sees the typo immediately.
+    """
+    missing = tmp_path / "does-not-exist.ini"
+    monkeypatch.setenv("ALEMBIC_CONFIG", str(missing))
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        find_alembic_ini()
+    assert "ALEMBIC_CONFIG" in str(exc_info.value)
+    assert str(missing) in str(exc_info.value)
+
+
 # ---------------------------------------------------------------------------
 # Optional testcontainers-PG suite
 # ---------------------------------------------------------------------------
@@ -273,8 +312,7 @@ class TestPostgresIntegration:
     why and points at the CI environment that does provision Docker.
     """
 
-    @pytest.mark.asyncio
-    async def test_alembic_upgrade_head_against_real_pg(
+    def test_alembic_upgrade_head_against_real_pg(
         self,
         isolated_engine_cache: None,
         monkeypatch: pytest.MonkeyPatch,
@@ -285,6 +323,14 @@ class TestPostgresIntegration:
         completes cleanly. With an empty ``versions/`` directory, no
         ``alembic_version`` row is created (Alembic skips the table
         when there is nothing to stamp), but the command must not raise.
+
+        The test is **synchronous** for the same reason the SQLite
+        sibling at lines 188-232 is synchronous: ``alembic.command.upgrade``
+        drives :func:`asyncio.run` itself (via the env.py
+        ``run_migrations_online`` entry point), and ``asyncio.run`` cannot
+        be re-entered from inside a running loop. Decorating this test
+        with ``@pytest.mark.asyncio`` would crash with a ``RuntimeError``
+        the moment Docker is available and the container starts.
         """
         from testcontainers.postgres import PostgresContainer
 

--- a/backend/tests/test_db_engine.py
+++ b/backend/tests/test_db_engine.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.db.engine`.
+
+Coverage matrix (Task #27 acceptance criteria #1, #2, #5):
+
+* :func:`get_engine` returns a configured :class:`AsyncEngine` with
+  the URL pulled from settings, and caches the instance across calls.
+* :func:`get_sessionmaker` reuses the shared engine and produces an
+  ``async_sessionmaker`` configured with ``expire_on_commit=False``
+  (the SQLAlchemy 2.x async-doc default for web services — see the
+  module docstring of ``db/engine.py``).
+* :func:`get_session` yields an :class:`AsyncSession`, executes a
+  trivial ``SELECT 1`` against it, and the session is closed when the
+  generator exits — proven by asserting on the session's ``is_active``
+  flag pre- and post-yield.
+* :func:`dispose_engine` is awaitable and resets the cache so the
+  next :func:`get_engine` call constructs a fresh engine.
+* End-to-end against a SQLite-async DB: an engine is created,
+  ``alembic upgrade head`` runs against it, the ``alembic_version``
+  table exists, the current revision matches the script-directory
+  head. Aiosqlite is the v0.1 dev DB used here so the test runs in
+  any sandbox; a parallel testcontainers-PG suite covers the real
+  driver path under :class:`TestPostgresIntegration`.
+
+The testcontainers PG suite gracefully skips when Docker is
+unavailable in the runner; the SQLite-async coverage above remains
+the always-on assertion.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from meho_backplane.db import engine as engine_module
+from meho_backplane.db.engine import (
+    create_engine_for_url,
+    dispose_engine,
+    get_engine,
+    get_session,
+    get_sessionmaker,
+    reset_engine_for_testing,
+)
+from meho_backplane.db.migrations import alembic_config, find_alembic_ini
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_engine_cache(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear the module-level engine cache + pin every required env var.
+
+    The :class:`Settings` model has three required fields
+    (``KEYCLOAK_ISSUER_URL`` / ``KEYCLOAK_AUDIENCE`` / ``VAULT_ADDR``)
+    plus ``DATABASE_URL`` (T27). The autouse ``_default_database_url``
+    fixture provides the latter; the rest are pinned here so every
+    test in this module that calls :func:`get_engine` (which
+    transitively constructs ``Settings``) succeeds without leaking
+    test-specific values across cases. Cache resets bracket the
+    yield so URL changes between cases actually take effect.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    reset_engine_for_testing()
+    get_settings.cache_clear()
+    yield
+    reset_engine_for_testing()
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Engine + sessionmaker basics
+# ---------------------------------------------------------------------------
+
+
+def test_create_engine_for_url_returns_async_engine() -> None:
+    """``create_engine_for_url`` produces an :class:`AsyncEngine`.
+
+    Built without going through the cache so the test is order-
+    independent and exercises the factory's pool kwargs explicitly.
+    """
+    eng = create_engine_for_url(
+        "sqlite+aiosqlite:///:memory:",
+        pool_size=5,
+        pool_timeout=15.0,
+    )
+    assert isinstance(eng, AsyncEngine)
+    # ``pool_size`` is meaningless for SQLite's StaticPool/SingletonThreadPool
+    # so we only assert the URL came through correctly.
+    assert str(eng.url).startswith("sqlite+aiosqlite")
+
+
+def test_get_engine_caches_across_calls(
+    isolated_engine_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The second :func:`get_engine` call returns the same instance."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    first = get_engine()
+    second = get_engine()
+    assert first is second
+
+
+def test_get_sessionmaker_returns_async_factory(
+    isolated_engine_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``get_sessionmaker`` returns an :func:`async_sessionmaker`."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    factory = get_sessionmaker()
+    assert isinstance(factory, async_sessionmaker)
+    assert factory is get_sessionmaker()
+
+
+# ---------------------------------------------------------------------------
+# get_session contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_session_yields_active_async_session(
+    isolated_engine_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``get_session`` yields an :class:`AsyncSession`, then closes it.
+
+    Drives the dependency by hand (without FastAPI) so the test asserts
+    on the lifecycle rather than the HTTP plumbing. The contract:
+
+    * The yielded value is an :class:`AsyncSession`.
+    * Inside the yield the session is in a transaction
+      (``async with session.begin()`` is the wrapping context).
+    * After the generator exhausts, the session is no longer in a
+      transaction (the outer ``async with`` released it).
+    """
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+    gen: AsyncIterator[AsyncSession] = get_session()
+    session = await gen.__anext__()
+    try:
+        assert isinstance(session, AsyncSession)
+        result = await session.execute(text("SELECT 1"))
+        assert result.scalar_one() == 1
+        assert session.in_transaction() is True
+    finally:
+        with pytest.raises(StopAsyncIteration):
+            await gen.__anext__()
+    # After the generator exits, both the inner ``session.begin()`` and
+    # the outer ``async_sessionmaker()`` contexts have closed; the
+    # session is no longer attached to a transaction.
+    assert session.in_transaction() is False
+
+
+@pytest.mark.asyncio
+async def test_dispose_engine_is_awaitable_and_resets_cache(
+    isolated_engine_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``await dispose_engine()`` clears the cached engine."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    eng_first = get_engine()
+    await dispose_engine()
+    assert engine_module._engine is None
+    eng_second = get_engine()
+    assert eng_first is not eng_second
+
+
+# ---------------------------------------------------------------------------
+# alembic upgrade head against an aiosqlite DB
+# ---------------------------------------------------------------------------
+
+
+def test_alembic_upgrade_head_against_sqlite_creates_version_table(
+    isolated_engine_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``alembic upgrade head`` against a fresh SQLite DB creates the version table.
+
+    Asserts AC #2 of Task #27: a ``DATABASE_URL`` plus the on-disk
+    Alembic config is enough to drive the async ``env.py`` end-to-end
+    and Alembic creates its bookkeeping table on the first contact.
+    The chassis ships with an empty ``versions/`` directory so the
+    head is ``None`` and no revision is stamped, but the
+    ``alembic_version`` table is still materialised (with no rows).
+    T28's first migration adds a row; T29's migration runner asserts
+    the row matches head before letting the backplane process traffic.
+
+    The test is **synchronous** because ``alembic.command.upgrade``
+    drives :func:`asyncio.run` itself (via the env.py
+    ``run_migrations_online`` entry point), and ``asyncio.run`` cannot
+    be re-entered from inside a running loop — wrapping this test in
+    ``@pytest.mark.asyncio`` would crash with a ``RuntimeError``.
+    """
+    db_path = tmp_path / "test.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    cfg = alembic_config()
+    # Override the URL so the inner async engine targets the test DB.
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.upgrade(cfg, "head")
+
+    head = ScriptDirectory.from_config(cfg).get_current_head()
+    assert head is None  # empty versions/ dir at the chassis stage.
+
+    # ``alembic_version`` is materialised on the first ``upgrade head``
+    # contact even when no revision is stamped. T28's first migration
+    # adds a row; this assertion documents the chassis-stage shape.
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            tables = sa_inspect(conn).get_table_names()
+            assert "alembic_version" in tables
+    finally:
+        sync_eng.dispose()
+
+
+def test_find_alembic_ini_resolves_packaged_path() -> None:
+    """``find_alembic_ini`` returns a real, existing ``alembic.ini`` path."""
+    path = find_alembic_ini()
+    assert path.is_file()
+    assert path.name == "alembic.ini"
+
+
+# ---------------------------------------------------------------------------
+# Optional testcontainers-PG suite
+# ---------------------------------------------------------------------------
+
+
+_DOCKER_AVAILABLE: bool
+
+
+def _docker_socket_present() -> bool:
+    """Heuristic: Docker is usable if the unix socket is present.
+
+    Avoids importing ``docker`` (which testcontainers would lazily
+    do anyway) just to discover availability. The negative path is
+    common in agent sandboxes; the positive path is what runs in CI.
+    """
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_DOCKER_AVAILABLE = _docker_socket_present()
+
+
+_SKIP_REASON = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason=_SKIP_REASON)
+class TestPostgresIntegration:
+    """End-to-end smoke against a real Postgres via testcontainers.
+
+    Not skipped silently — the class-level ``skipif`` reason calls out
+    why and points at the CI environment that does provision Docker.
+    """
+
+    @pytest.mark.asyncio
+    async def test_alembic_upgrade_head_against_real_pg(
+        self,
+        isolated_engine_cache: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Spin up ``postgres:16-alpine`` and run ``alembic upgrade head``.
+
+        AC #2 of Task #27: against a fresh PG, ``alembic upgrade head``
+        completes cleanly. With an empty ``versions/`` directory, no
+        ``alembic_version`` row is created (Alembic skips the table
+        when there is nothing to stamp), but the command must not raise.
+        """
+        from testcontainers.postgres import PostgresContainer
+
+        with PostgresContainer("postgres:16-alpine") as pg:
+            sync_url = pg.get_connection_url()  # postgresql+psycopg2://...
+            async_url = sync_url.replace(
+                "postgresql+psycopg2://",
+                "postgresql+asyncpg://",
+            ).replace(
+                "postgresql://",
+                "postgresql+asyncpg://",
+            )
+            monkeypatch.setenv("DATABASE_URL", async_url)
+
+            cfg = alembic_config()
+            cfg.set_main_option("sqlalchemy.url", async_url)
+            # Should complete without raising; empty versions/ means
+            # this is a no-op but exercises the env.py async pattern.
+            command.upgrade(cfg, "head")

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.settings`.
+
+The validator under test is the async-DSN guard on
+:attr:`Settings.database_url` (T27 review iteration 1, M2): ADR 0004
+mandates that every database I/O path off the request hot loop is
+``await``-able, so a sync DSN like ``postgresql://`` or ``sqlite:///``
+must fail at :class:`Settings` construction time rather than silently
+landing as the engine URL and blocking the FastAPI event loop on the
+first DB checkout.
+
+The tests below cover both halves of the contract:
+
+* Accepted async schemes (``postgresql+asyncpg://`` and
+  ``sqlite+aiosqlite://``) construct successfully.
+* Sync schemes raise :class:`ValueError` with the supported-schemes
+  message (so the operator can fix ``DATABASE_URL`` from the error
+  text alone).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from meho_backplane.settings import Settings
+
+
+def _settings_kwargs(database_url: str) -> dict[str, object]:
+    """Return the minimum kwargs needed to construct :class:`Settings`.
+
+    Only ``database_url`` varies across tests; the rest are fixed at
+    valid sentinels so the construction failure (when it happens) is
+    unambiguously the validator under test.
+    """
+    return {
+        "keycloak_issuer_url": "https://keycloak.test/realms/meho",
+        "keycloak_audience": "meho-backplane",
+        "vault_addr": "https://vault.test",
+        "database_url": database_url,
+    }
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "postgresql+asyncpg://meho:secret@db.test:5432/meho",
+        "sqlite+aiosqlite:///:memory:",
+        "sqlite+aiosqlite:///tmp/test.db",
+    ],
+)
+def test_database_url_accepts_async_drivers(url: str) -> None:
+    """Both supported async schemes construct without raising."""
+    settings = Settings(**_settings_kwargs(url))  # type: ignore[arg-type]
+    assert settings.database_url == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "postgresql://meho:secret@db.test:5432/meho",
+        "postgresql+psycopg2://meho:secret@db.test:5432/meho",
+        "postgres://meho:secret@db.test:5432/meho",
+        "sqlite:///:memory:",
+        "mysql://meho:secret@db.test/meho",
+    ],
+)
+def test_database_url_rejects_sync_or_unsupported_drivers(url: str) -> None:
+    """Sync DSNs and unsupported schemes raise with the supported-schemes message.
+
+    The error message must name the supported schemes so the operator
+    can fix ``DATABASE_URL`` from the error text alone — without
+    grepping the codebase or hunting for ADR 0004. The assertion below
+    pins both supported scheme prefixes literally.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(**_settings_kwargs(url))  # type: ignore[arg-type]
+    message = str(exc_info.value)
+    assert "postgresql+asyncpg://" in message
+    assert "sqlite+aiosqlite://" in message

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -7,6 +7,29 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -73,6 +96,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/95/74/f99c81193a2725911e1911ae567ed27c2f2419332c7f3537366f9d238cac/ast_serialize-0.3.0-cp39-abi3-win32.whl", hash = "sha256:2db3dd99de5e6a5a11d7dda73de8750eb6e5baaf25245adf7bdcfe64b6108ae2", size = 1067804, upload-time = "2026-04-30T23:24:43.091Z" },
     { url = "https://files.pythonhosted.org/packages/16/81/76af00c47daa151e89f98ae21fbbcb2840aaa9f5766579c4da76a3c57188/ast_serialize-0.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2cd125adccf7969470621905d302750cd25951f22ea430d9a25b7be031e5549", size = 1105561, upload-time = "2026-04-30T23:24:44.578Z" },
     { url = "https://files.pythonhosted.org/packages/bd/46/d3ec57ad500f598d1554bd14ce4df615960549ab2844961bc4e1f5fbd174/ast_serialize-0.3.0-cp39-abi3-win_arm64.whl", hash = "sha256:0dd00da29985f15f50dc35728b7e1e7c84507bccfea1d9914738530f1c72238a", size = 1077165, upload-time = "2026-04-30T23:24:46.377Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
 ]
 
 [[package]]
@@ -395,6 +458,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -421,6 +498,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -592,22 +716,101 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "meho-backplane"
 version = "0.1.0.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "alembic" },
+    { name = "asyncpg" },
     { name = "authlib" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "hvac" },
     { name = "prometheus-client" },
     { name = "pydantic", extra = ["email"] },
+    { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "cryptography" },
     { name = "mypy" },
     { name = "pytest" },
@@ -615,22 +818,27 @@ dev = [
     { name = "pytest-cov" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.13" },
+    { name = "asyncpg", specifier = ">=0.29" },
     { name = "authlib", specifier = ">=1.3" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "hvac", specifier = ">=2.4.0" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.6" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiosqlite", specifier = ">=0.19" },
     { name = "cryptography", specifier = ">=42.0" },
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8.0" },
@@ -638,6 +846,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.5" },
+    { name = "testcontainers", specifier = ">=4.0" },
 ]
 
 [[package]]
@@ -895,6 +1104,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -993,6 +1218,57 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1012,6 +1288,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]
@@ -1213,4 +1505,68 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -78,7 +78,12 @@ this stage it exposes:
   registered as **async** against the readiness registry, which now
   accepts both sync and async probes via `register_probe` and is
   evaluated by `run_probes_async()` from `/ready`. The lifespan
-  shutdown path now `await`s `dispose_engine()` so the asyncpg pool
+  hook also **eagerly** instantiates the SQLAlchemy async engine
+  (`get_engine()` is called before `yield`) so the pool is built and
+  `DATABASE_URL` is validated at process boot rather than on the
+  first incoming request — without the pre-warm the very first
+  `/ready` poll would absorb the engine-construction cost. The
+  shutdown path `await`s `dispose_engine()` so the asyncpg pool
   closes cleanly. `/api/v1/health.db.migrated` is no longer
   hardcoded `null`: it carries the probe's `ok` value (G2.2-T3's
   forward-looking placeholder is now wired through).
@@ -90,7 +95,17 @@ this stage it exposes:
   `DATABASE_URL` env var the running backplane reads, so the
   migration runner and the request hot path can never drift. The
   `versions/` directory ships empty in T27 — T28 lands the first
-  migration (the audit log table).
+  migration (the audit log table). `alembic.ini` and the `alembic/`
+  tree are also shipped as package data under `meho_backplane/` (via
+  the `[tool.hatch.build.targets.wheel.force-include]` table in
+  `backend/pyproject.toml`) so installed-wheel deployments resolve
+  them via `importlib.resources.files('meho_backplane')` rather than
+  needing the source tree on disk. The `find_alembic_ini` resolver
+  walks four locations in order: `$ALEMBIC_CONFIG` env-var override
+  (ops escape hatch), `importlib.resources` package data (wheel
+  layout), the current working directory (matches the `alembic` CLI's
+  rule), and the source-tree layout (`__file__.parents[3]` for the
+  editable-install dev case).
 
 Database persistence lands progressively in subsequent G2.3 Tasks. The stack (FastAPI, Pydantic v2,
 SQLAlchemy 2.x async, Alembic, structlog, prometheus_client, authlib
@@ -122,7 +137,7 @@ PYTHONPATH-leak imports.
 | `SENSITIVE_HEADERS` | `src/meho_backplane/middleware.py` | `frozenset({b"authorization", b"cookie", b"x-api-key"})`. The middleware never logs the values of these headers; redaction is enforced by *not* logging request headers at all in v0.1, with a `tests/test_observability.py` regression test. |
 | `HTTP_REQUESTS_TOTAL` | `src/meho_backplane/metrics.py` | Module-level `prometheus_client.Counter` registered against the default registry. Labels: `method`, `path`, `status`. `path` is the matched FastAPI route template when available, bounding label cardinality. |
 | `render_metrics` | `src/meho_backplane/metrics.py` | Returns `(body, content_type)` for the `/metrics` route. Pins `text/plain; version=0.0.4; charset=utf-8` — the legacy Prometheus format every scraper accepts (`prometheus_client>=0.21` advertises 1.0.0 in `CONTENT_TYPE_LATEST`, but 0.0.4 stays universally compatible). |
-| `Settings` / `get_settings` | `src/meho_backplane/settings.py` | Pydantic v2 model + `lru_cache`-singleton accessor for the Keycloak knobs (`KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_JWKS_CACHE_TTL_SECONDS`, `KEYCLOAK_JWT_LEEWAY_SECONDS`), the Vault knobs (`VAULT_ADDR`, `VAULT_OIDC_ROLE`, `VAULT_OIDC_MOUNT_PATH`, `VAULT_NAMESPACE`, `VAULT_TIMEOUT_SECONDS`), and the database knobs (`DATABASE_URL`, `DATABASE_POOL_SIZE`, `DATABASE_POOL_TIMEOUT`). `DATABASE_URL` is required; the others have sensible defaults. Tests reset via `get_settings.cache_clear()`. |
+| `Settings` / `get_settings` | `src/meho_backplane/settings.py` | Pydantic v2 model + `lru_cache`-singleton accessor for the Keycloak knobs (`KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_JWKS_CACHE_TTL_SECONDS`, `KEYCLOAK_JWT_LEEWAY_SECONDS`), the Vault knobs (`VAULT_ADDR`, `VAULT_OIDC_ROLE`, `VAULT_OIDC_MOUNT_PATH`, `VAULT_NAMESPACE`, `VAULT_TIMEOUT_SECONDS`), and the database knobs (`DATABASE_URL`, `DATABASE_POOL_SIZE`, `DATABASE_POOL_TIMEOUT`). `DATABASE_URL` is required and validated by a Pydantic `@field_validator` that rejects sync DSNs (`postgresql://`, `sqlite:///`, `postgresql+psycopg2://`) — only `postgresql+asyncpg://` and `sqlite+aiosqlite://` are accepted, matching ADR 0004's async-only mandate. Tests reset via `get_settings.cache_clear()`. |
 | `create_engine_for_url` / `get_engine` / `get_sessionmaker` / `get_session` / `dispose_engine` | `src/meho_backplane/db/engine.py` | SQLAlchemy 2.x async engine + per-request session factory (Task #27). `get_engine` is lazy + cached; `get_session` is the FastAPI `Depends` that yields a transaction-bracketed `AsyncSession`. SQLite URLs (dev / aiosqlite) prune the `pool_size` / `pool_timeout` kwargs because StaticPool rejects them; Postgres URLs (asyncpg) keep them. `dispose_engine` is awaited from the lifespan shutdown so asyncpg's pool releases its connections cleanly. |
 | `db_migration_probe` / `alembic_config` / `find_alembic_ini` | `src/meho_backplane/db/migrations.py` | Async readiness probe + Alembic config helpers (Task #27). The probe compares `MigrationContext.configure(conn).get_current_revision()` against `ScriptDirectory.from_config(cfg).get_current_head()` over an `AsyncEngine.connect()`/`run_sync` pair; every failure mode collapses onto `ProbeResult(ok=False)` with a redacted `detail` (no operator-controllable URL substrings). |
 | `backend/alembic.ini` + `backend/alembic/env.py` + `backend/alembic/script.py.mako` | repo paths | Alembic configuration (Task #27). `env.py` follows the upstream async cookbook: `async_engine_from_config` + `connection.run_sync(do_run_migrations)`. URL is sourced from `DATABASE_URL` so the migration runner and the running backplane share one knob. `versions/` ships empty; first migration lands in T28. |

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -64,6 +64,34 @@ this stage it exposes:
   `Authorization:\s*Bearer\s+\S+` regex pass over `capfd` + `caplog`
   on every test exit, fail-closed when any pattern matches.
 
+* Persistence layer (Task #27) — `src/meho_backplane/db/` houses the
+  SQLAlchemy 2.x async engine (`engine.py`), the per-request
+  session-factory dependency (`get_session`), and the
+  DB-migration-state readiness probe (`migrations.py`). The probe
+  compares the database's current Alembic revision (read from
+  `alembic_version` via `MigrationContext.configure(...).get_current_revision()`)
+  against the head defined by `ScriptDirectory.from_config(cfg).get_current_head()`;
+  three failure modes (DB unreachable, table missing, revision
+  diverged) collapse onto a single `ProbeResult` with `ok=False` and
+  a structured `detail` string (`check_failed: <ExcClass>` /
+  `current=<sha> head=<sha>` / `no_migrations: …`). The probe is
+  registered as **async** against the readiness registry, which now
+  accepts both sync and async probes via `register_probe` and is
+  evaluated by `run_probes_async()` from `/ready`. The lifespan
+  shutdown path now `await`s `dispose_engine()` so the asyncpg pool
+  closes cleanly. `/api/v1/health.db.migrated` is no longer
+  hardcoded `null`: it carries the probe's `ok` value (G2.2-T3's
+  forward-looking placeholder is now wired through).
+* Alembic configuration (Task #27) — `backend/alembic.ini` plus the
+  async-aware `backend/alembic/env.py` follow the upstream Alembic
+  cookbook's async pattern: `async_engine_from_config` + a sync
+  inner `do_run_migrations` invoked through `run_sync`. The URL is
+  not pinned in `alembic.ini`; `env.py` resolves it from the same
+  `DATABASE_URL` env var the running backplane reads, so the
+  migration runner and the request hot path can never drift. The
+  `versions/` directory ships empty in T27 — T28 lands the first
+  migration (the audit log table).
+
 Database persistence lands progressively in subsequent G2.3 Tasks. The stack (FastAPI, Pydantic v2,
 SQLAlchemy 2.x async, Alembic, structlog, prometheus_client, authlib
 for JOSE) is locked by
@@ -82,9 +110,10 @@ PYTHONPATH-leak imports.
 | `__version__` (`str`) | `src/meho_backplane/__init__.py` | Single source of truth for the running app version. The pyproject `[project].version` field mirrors this constant; the `test_version_constant_matches_pyproject` test acts as a tripwire if the two drift. |
 | `root` (route) | `src/meho_backplane/main.py` | `GET /` returning `{"name": "meho-backplane", "version": "<x>"}`. Identity smoke-probe; coexists with `/healthz`. |
 | `metrics` (route) | `src/meho_backplane/main.py` | `GET /metrics` returning the Prometheus exposition format from the default registry (process / GC collectors + the `http_requests_total` counter). |
-| `lifespan` | `src/meho_backplane/main.py` | FastAPI lifespan async context manager; calls `configure_logging()` once at startup. The yield/return shape leaves room for G2.2 / G2.3 teardown without restructuring. |
+| `lifespan` | `src/meho_backplane/main.py` | FastAPI lifespan async context manager. At startup: `configure_logging()` runs once and the Keycloak / Vault / DB readiness probes are registered. At shutdown: `await dispose_engine()` closes the SQLAlchemy async pool cleanly. |
+| `ProbeFn` (alias) | `src/meho_backplane/health.py` | `Callable[[], ProbeResult] \| Callable[[], Awaitable[ProbeResult]]`. The registry accepts both sync and async probes; the `/ready` handler dispatches via `inspect.iscoroutinefunction`. |
 | `ProbeResult` (`dataclass`) | `src/meho_backplane/health.py` | Frozen record `(name, ok, detail)` returned by every readiness probe. Surfaced verbatim in the `/ready` response body. |
-| `register_probe` / `run_probes` / `clear_probes` | `src/meho_backplane/health.py` | Public registry API. G2.2 (Vault, Keycloak) and G2.3 (DB migrations) call `register_probe` at startup; `clear_probes` is test-only. |
+| `register_probe` / `run_probes` / `run_probes_async` / `clear_probes` | `src/meho_backplane/health.py` | Public registry API. G2.2 (Vault, Keycloak) and G2.3 (DB migrations) call `register_probe` at startup. `run_probes()` returns the sync subset (test-friendly); `run_probes_async()` awaits async probes too and is what `/ready` calls. `clear_probes` is test-only. |
 | `health.router` (`/healthz`, `/ready`) | `src/meho_backplane/health.py` | Liveness and readiness endpoints. `/healthz` is unconditional 200; `/ready` aggregates the probe registry and **fails closed on the empty default** (vacuous-truth trap explicitly guarded). |
 | `version.router` (`/version`) | `src/meho_backplane/version.py` | Build identity. Reads `GIT_SHA` and `BUILD_DATE` env vars (injected via `docker build --build-arg`); falls back to `"unknown"` when unset or empty. `chart_version` is `None` until G2.5. |
 | `configure_logging` | `src/meho_backplane/logging.py` | Configures structlog: `merge_contextvars` → `add_log_level` → `TimeStamper(iso, utc)` → `JSONRenderer`, writing to stdout. Idempotent. |
@@ -93,7 +122,10 @@ PYTHONPATH-leak imports.
 | `SENSITIVE_HEADERS` | `src/meho_backplane/middleware.py` | `frozenset({b"authorization", b"cookie", b"x-api-key"})`. The middleware never logs the values of these headers; redaction is enforced by *not* logging request headers at all in v0.1, with a `tests/test_observability.py` regression test. |
 | `HTTP_REQUESTS_TOTAL` | `src/meho_backplane/metrics.py` | Module-level `prometheus_client.Counter` registered against the default registry. Labels: `method`, `path`, `status`. `path` is the matched FastAPI route template when available, bounding label cardinality. |
 | `render_metrics` | `src/meho_backplane/metrics.py` | Returns `(body, content_type)` for the `/metrics` route. Pins `text/plain; version=0.0.4; charset=utf-8` — the legacy Prometheus format every scraper accepts (`prometheus_client>=0.21` advertises 1.0.0 in `CONTENT_TYPE_LATEST`, but 0.0.4 stays universally compatible). |
-| `Settings` / `get_settings` | `src/meho_backplane/settings.py` | Pydantic v2 model + `lru_cache`-singleton accessor for the Keycloak knobs (`KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_JWKS_CACHE_TTL_SECONDS`, `KEYCLOAK_JWT_LEEWAY_SECONDS`) and the Vault knobs (`VAULT_ADDR`, `VAULT_OIDC_ROLE`, `VAULT_OIDC_MOUNT_PATH`, `VAULT_NAMESPACE`, `VAULT_TIMEOUT_SECONDS`). Tests reset via `get_settings.cache_clear()`. |
+| `Settings` / `get_settings` | `src/meho_backplane/settings.py` | Pydantic v2 model + `lru_cache`-singleton accessor for the Keycloak knobs (`KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_JWKS_CACHE_TTL_SECONDS`, `KEYCLOAK_JWT_LEEWAY_SECONDS`), the Vault knobs (`VAULT_ADDR`, `VAULT_OIDC_ROLE`, `VAULT_OIDC_MOUNT_PATH`, `VAULT_NAMESPACE`, `VAULT_TIMEOUT_SECONDS`), and the database knobs (`DATABASE_URL`, `DATABASE_POOL_SIZE`, `DATABASE_POOL_TIMEOUT`). `DATABASE_URL` is required; the others have sensible defaults. Tests reset via `get_settings.cache_clear()`. |
+| `create_engine_for_url` / `get_engine` / `get_sessionmaker` / `get_session` / `dispose_engine` | `src/meho_backplane/db/engine.py` | SQLAlchemy 2.x async engine + per-request session factory (Task #27). `get_engine` is lazy + cached; `get_session` is the FastAPI `Depends` that yields a transaction-bracketed `AsyncSession`. SQLite URLs (dev / aiosqlite) prune the `pool_size` / `pool_timeout` kwargs because StaticPool rejects them; Postgres URLs (asyncpg) keep them. `dispose_engine` is awaited from the lifespan shutdown so asyncpg's pool releases its connections cleanly. |
+| `db_migration_probe` / `alembic_config` / `find_alembic_ini` | `src/meho_backplane/db/migrations.py` | Async readiness probe + Alembic config helpers (Task #27). The probe compares `MigrationContext.configure(conn).get_current_revision()` against `ScriptDirectory.from_config(cfg).get_current_head()` over an `AsyncEngine.connect()`/`run_sync` pair; every failure mode collapses onto `ProbeResult(ok=False)` with a redacted `detail` (no operator-controllable URL substrings). |
+| `backend/alembic.ini` + `backend/alembic/env.py` + `backend/alembic/script.py.mako` | repo paths | Alembic configuration (Task #27). `env.py` follows the upstream async cookbook: `async_engine_from_config` + `connection.run_sync(do_run_migrations)`. URL is sourced from `DATABASE_URL` so the migration runner and the running backplane share one knob. `versions/` ships empty; first migration lands in T28. |
 | `Operator` | `src/meho_backplane/auth/operator.py` | Frozen pydantic v2 model carrying validated claims (`sub`, `name`, `email`, `raw_jwt`). Returned by `verify_jwt`; consumed by every authenticated route from G2.2-T3 onward. `raw_jwt` is preserved verbatim for G2.2-T2's Vault forward-auth. |
 | `verify_jwt` | `src/meho_backplane/auth/jwt.py` | FastAPI dependency: parses `Authorization: Bearer ...`, fetches/caches Keycloak's JWKS, validates signature + `iss` + `aud` + `exp` (with leeway), refreshes JWKS on a kid miss, and returns an `Operator`. Every failure mode collapses to a terse 401. |
 | `keycloak_readiness_probe` | `src/meho_backplane/auth/jwt.py` | Synchronous probe registered with the readiness registry at app lifespan startup. Hits `{issuer}/.well-known/openid-configuration` then `jwks_uri`; failure detail surfaces only the exception class name to avoid leaking issuer URLs into 503 payloads. |
@@ -101,8 +133,8 @@ PYTHONPATH-leak imports.
 | `vault_client_for_operator` | `src/meho_backplane/auth/vault.py` | Async context manager: builds an `hvac.Client` from settings, performs `client.auth.jwt.jwt_login(role, jwt, path)` against the configured mount path, yields the authenticated client, and revokes the issued token on exit (best-effort). Every blocking hvac call runs through `asyncio.to_thread` because hvac is `requests`-based and FastAPI does not auto-offload sync I/O inside `async def` callables. Per-request login by design (v0.1); v0.2 may add a per-operator cache. |
 | `vault_readiness_probe` | `src/meho_backplane/auth/vault.py` | Synchronous probe registered with the readiness registry at app lifespan startup. Calls `client.sys.read_health_status(method='GET')` (unauthenticated) and classifies the response — `sealed=False`/`http_429`/`http_472`/`http_473` → ok; `sealed`/`uninitialized`/connection-error → not ok. Detail strings never echo the Vault URL or namespace. |
 | `VaultClientError` / `VaultUnreachableError` / `VaultRoleDeniedError` | `src/meho_backplane/auth/vault.py` | Backplane-side exception hierarchy. Callers catch `VaultClientError` for a single error response shape, or one of the subclasses to map to specific HTTP statuses. The hierarchy lets consumers avoid importing `hvac` directly. |
-| `api/v1/health.router` (`/api/v1/health`) | `src/meho_backplane/api/v1/health.py` | Authenticated federation-proof endpoint (Task #24). `GET` handler runs through `Depends(verify_jwt_and_bind)`, calls `vault_client_for_operator(operator)`, reads `secret/meho/test/federation` (KV v2), and returns `HealthResponse` (operator identity + vault status + db status). Vault unreachable / role denied / read failure surface as structured fields on a 200 response — never 5xx. |
-| `HealthResponse` / `OperatorIdentity` / `VaultStatus` / `DbStatus` | `src/meho_backplane/api/v1/health.py` | Frozen pydantic v2 response models. `OperatorIdentity` deliberately excludes `raw_jwt` so the bearer token never appears in the response body. `DbStatus.migrated` is `None` until G2.3 wires Alembic. `VaultStatus.detail` carries only structured tokens (`version=N`, `read_failed: <ExcClass>`, `login_failed: <ExcClass>`) — no operator-controllable URL substrings. |
+| `api/v1/health.router` (`/api/v1/health`) | `src/meho_backplane/api/v1/health.py` | Authenticated federation-proof endpoint (Task #24, extended in Task #27). `GET` handler runs through `Depends(verify_jwt_and_bind)`, calls `vault_client_for_operator(operator)`, reads `secret/meho/test/federation` (KV v2), invokes `db_migration_probe()` to populate `db.migrated`, and returns `HealthResponse` (operator identity + vault status + db status). Vault unreachable / role denied / read failure / DB unreachable / revision diverged all surface as structured fields on a 200 response — never 5xx. |
+| `HealthResponse` / `OperatorIdentity` / `VaultStatus` / `DbStatus` | `src/meho_backplane/api/v1/health.py` | Frozen pydantic v2 response models. `OperatorIdentity` deliberately excludes `raw_jwt` so the bearer token never appears in the response body. `DbStatus.migrated` reflects the T27 DB-migration-state probe verdict (true when current matches Alembic head, false otherwise; `bool \| None` is preserved for forward compatibility with chassis-stage decoders). `VaultStatus.detail` carries only structured tokens (`version=N`, `read_failed: <ExcClass>`, `login_failed: <ExcClass>`) — no operator-controllable URL substrings. |
 | `_no_secret_leak_sweep` | `tests/conftest.py` (autouse) | Pytest fixture that runs after every test in `tests/`, scanning `capfd`-captured stdout/stderr and `caplog` records for credential-shaped substrings (`Bearer <long>`, `password=`, `secret=`, `token=`, `api_key=`, `Authorization: Bearer …`). First match → `pytest.fail` with a redacted preview. The patterns live in `SECRET_LEAK_PATTERNS` for contributor extension; the targeted leak tests in `tests/test_secret_leak_checks.py` complement the always-on sweep with explicit assertions on the structlog `StringIO` buffers used by route-level tests. |
 
 ## Control flow
@@ -135,8 +167,9 @@ PYTHONPATH-leak imports.
    - `GET /healthz` → `healthz()` returns `{"status": "ok"}` with 200.
    - `GET /version` → reads `GIT_SHA` / `BUILD_DATE` env vars per
      request (cheap; no caching needed).
-   - `GET /ready` → calls `run_probes()` and translates the aggregate
-     into a 200 / 503 `JSONResponse`.
+   - `GET /ready` → calls `run_probes_async()` (which awaits async
+     probes and calls sync probes inline) and translates the
+     aggregate into a 200 / 503 `JSONResponse`.
    - `GET /metrics` → returns the default registry's exposition text
      directly. The middleware still wraps it, so `/metrics` requests
      show up in the counter (under `path="/metrics"`).
@@ -172,6 +205,11 @@ Pinned-floor declarations; exact versions resolved into `uv.lock`.
 | `authlib` | ≥ 1.3 | JWS / JWK / JWT primitives for Keycloak token verification. The `authlib.jose` namespace is deprecated in favour of `joserfc` (same maintainer, clean rewrite); migration to `joserfc` is tracked as a v0.2 candidate. |
 | `httpx` | ≥ 0.27 | Async + sync HTTP client for the OIDC discovery doc and JWKS endpoint. (Also used as the `fastapi.testclient.TestClient` backend.) |
 | `hvac` | ≥ 2.4 | Official HashiCorp Vault Python client (per ADR 0004). Sync-only, transitively pulls `requests` + `urllib3`; the backplane localises the sync surface inside `auth/vault.py` and wraps every call in `asyncio.to_thread` from the async context manager. No type stubs ship with the package, so `[tool.mypy.overrides]` whitelists `hvac.*` and `requests.*`. |
+| `sqlalchemy[asyncio]` | ≥ 2.0 | Async ORM + Core (per ADR 0004). The `asyncio` extra pulls `greenlet`, which SQLAlchemy 2.x async needs to bridge sync ORM callsites onto the event loop. |
+| `asyncpg` | ≥ 0.29 | Async PostgreSQL driver (per ADR 0004). Faster than `psycopg`'s sync wrapper for the read/write patterns of an audit log + per-operator metadata, and the only async driver SQLAlchemy 2.x officially supports. |
+| `alembic` | ≥ 1.13 | Schema migrations. The async-aware `env.py` follows the upstream cookbook pattern (`async_engine_from_config` + `connection.run_sync(do_run_migrations)`); Alembic itself stays sync, but reaches into asyncpg via the engine. |
+| (dev) `aiosqlite` | ≥ 0.19 | Async SQLite driver used for local-dev / test DBs that do not need Docker. The probe + engine module both work against `sqlite+aiosqlite://` URLs because the driver-specific surface is encapsulated by SQLAlchemy. |
+| (dev) `testcontainers` | ≥ 4.0 | Spins up `postgres:16-alpine` for the end-to-end test in `tests/test_db_engine.py::TestPostgresIntegration`. Skipped gracefully when the Docker socket is absent — the SQLite-async coverage stays always-on. |
 | (dev) `pytest` ≥ 8 | | Test runner. |
 | (dev) `pytest-asyncio` ≥ 0.23 | | Async test support; `asyncio_mode = "auto"` in pyproject. |
 | (dev) `cryptography` ≥ 42.0 | | RSA keypair generation in test fixtures (authlib pulls it transitively in production). |
@@ -183,14 +221,15 @@ Pinned-floor declarations; exact versions resolved into `uv.lock`.
 ## Known issues
 
 `/ready` returns 503 until every registered probe passes. After Task
-#23 the lifespan hook registers both the Keycloak and Vault probes,
-so a running app needs Keycloak's JWKS endpoint reachable **and**
-Vault's `/sys/health` reachable + unsealed before `/ready` flips green.
-Until DB migrations land in G2.3, the registry is otherwise complete
-for the federation-chain dependency surface. Helm charts pointing
-their kubernetes readiness probe at `/ready` before either dependency
-is provisioned will see pods stay `NotReady`; that is the intended
-contract.
+#27 the lifespan hook registers three probes: Keycloak, Vault, and the
+DB-migration-state probe. A running app needs Keycloak's JWKS endpoint
+reachable, Vault's `/sys/health` reachable + unsealed, **and** the
+PostgreSQL database reachable with an `alembic_version` row matching
+the on-disk Alembic head. The empty `versions/` directory in T27 means
+the probe reports `ok=False` with `no_migrations: …` until T28's first
+migration lands; that is the intended fail-closed default. Helm charts
+pointing their kubernetes readiness probe at `/ready` before all three
+dependencies are provisioned will see pods stay `NotReady` — by design.
 
 Vault hvac calls are synchronous (the library is built on `requests`)
 but the backplane is async-first. Every hvac call from
@@ -237,6 +276,12 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - Task #23 — Vault OIDC forward-auth client + readiness probe
 - Task #24 — Federation-proof `/api/v1/health` + operator-identity propagation
 - Task #25 — Federation-chain failure-mode test suite + always-on secret-leak sweep
+- Task #27 — PG connection pool + Alembic wiring + DB-migration-state readiness probe
+- [SQLAlchemy 2.x async overview](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
+- [SQLAlchemy 2.x pool / pre-ping disconnect handling](https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic)
+- [Alembic async migrations cookbook](https://alembic.sqlalchemy.org/en/latest/cookbook.html#using-asyncio-with-alembic)
+- [asyncpg driver](https://magicstack.github.io/asyncpg/)
+- [testcontainers-python](https://testcontainers-python.readthedocs.io/)
 - [FastAPI tutorial](https://fastapi.tiangolo.com/tutorial/)
 - [FastAPI lifespan API](https://fastapi.tiangolo.com/advanced/events/)
 - [FastAPI dependencies (`Depends`)](https://fastapi.tiangolo.com/tutorial/dependencies/)


### PR DESCRIPTION
## Summary

- Adds SQLAlchemy 2.x async engine + per-request session factory + async-aware Alembic env.py.
- Registers a DB-migration-state readiness probe that compares the database's current Alembic revision to the on-disk head; surfaces the verdict on `/ready` and on `/api/v1/health.db.migrated` (no longer hardcoded `null`).
- Alembic ships with an empty `versions/`; T28 lands the first migration. URL is sourced from `DATABASE_URL` so the migration runner and the request hot path share one knob.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --strict` — clean (18 source files)
- [x] `pytest -x -q` — 138 passed, 1 skipped (testcontainers PG, Docker not provisioned in sandbox; runs in CI)
- [x] `DATABASE_URL=sqlite+aiosqlite:///$(mktemp -u --suffix=.db) uv run alembic upgrade head` — completes cleanly against a fresh DB
- [x] DB-migration-state probe healthy when revisions match (`tests/test_alembic_probe.py::test_probe_healthy_when_revisions_match`)
- [x] Probe unhealthy when revisions diverge (`test_probe_unhealthy_when_revisions_diverge`)
- [x] Probe unhealthy when DB unreachable (`test_probe_unhealthy_when_db_unreachable`)
- [x] `/ready` reflects DB probe state (`test_ready_reflects_db_probe_state`)
- [x] `/api/v1/health.db.migrated` reflects the probe's `ok` value (existing `test_api_v1_health.py` / `test_api_health_failures.py` updated)

## Out of scope (per Initiative #26 task split)

- `audit_log` schema + first migration — T28 (#28)
- Synchronous audit-write middleware — T28 (#28)
- Migration runner entrypoint + CI guard for backward-compat-only patterns — T29 (#29)
- Forward-compat regression test (N image vs N+1 schema) — T30 (#30)
- The 5 advisory CI failures — stay G2.7 scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#27

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-10)

Addressed review findings from `.claude/auto/review-results/pr-155-iter-1.json` (verdict `REQUEST_CHANGES`):

- **B1** `0e5e466` — Convert `TestPostgresIntegration::test_alembic_upgrade_head_against_real_pg` from `async def` (with `@pytest.mark.asyncio`) to `def`; mirrors the SQLite sibling at lines 188-232 and avoids `asyncio.run` reentrancy when Docker is available.
- **M1** `6d37666` — Make `find_alembic_ini` deployment-shape-agnostic: walks `$ALEMBIC_CONFIG` env override → `importlib.resources.files('meho_backplane')` package data → cwd → source-tree layout. Ships `alembic.ini` + the `alembic/` tree as wheel package data via `[tool.hatch.build.targets.wheel.force-include]`. Adds tests for the env-var override.
- **M2** `95fa81a` — Add `@field_validator('database_url')` rejecting sync DSNs; supported async schemes (`postgresql+asyncpg://`, `sqlite+aiosqlite://`) are pinned in `_SUPPORTED_DATABASE_URL_SCHEMES`. Error message names both schemes so the operator can fix `DATABASE_URL` from the log alone. New `tests/test_settings.py` covers the matrix.
- **M3** `b5cc82f` — Eagerly call `get_engine()` from the FastAPI `lifespan` hook before `yield` so the connection pool is built at startup rather than on the first request; the docstring is updated to match the (now-correct) behaviour.
- **m1** `ba1c8f6` — Add `get_settings.cache_clear()` brackets around the autouse `_default_database_url` fixture so future order-dependent tests cannot see a stale cached `Settings`.

Disputed: none.

Deferred: none.

Verification (in worktree):

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (33 files)
- [x] `mypy --strict src/` — clean (18 source files)
- [x] `pytest tests/ -x -q` — 148 passed, 1 skipped (testcontainers PG; Docker absent in sandbox)
- [x] `uv build --wheel` smoke — wheel ships `meho_backplane/alembic.ini` + `meho_backplane/alembic/{env.py,script.py.mako,versions/.gitkeep}` so `importlib.resources` resolves on installed deployments

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async DB engine/session wiring and async migration readiness probe; readiness now runs async probes and eagerly initializes DB pool at startup.

* **Bug Fixes**
  * Health endpoints now report actual DB migration status (db.migrated) from the migration probe.

* **Documentation**
  * Backend docs updated for async persistence, migration behavior, and readiness semantics.

* **Tests**
  * New comprehensive tests for DB engine, migrations, settings validation, and readiness probe behavior.

* **Chores**
  * Packaging updated to include migration config and async DB dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/155)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
