### PR TITLE
Add runner-smoke.yml to validate the meho-runners self-hosted pool

### DIFF
--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -1,0 +1,24 @@
+name: meho-runners smoke
+# Verifies the meho-runners self-hosted runner pool can pick up + run a job
+# end-to-end. Filed alongside the pool's first deploy (claude-rdc-hetzner-dc#262).
+# Triggered manually; no `push:` / `pull_request:` so it never runs accidentally
+# on regular CI traffic.
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: meho-runners
+    timeout-minutes: 5
+    steps:
+      - name: Identify the runner
+        run: |
+          echo "host: $(hostname)"
+          echo "uname: $(uname -a)"
+          echo "os:"
+          cat /etc/os-release | head -5
+          echo "---"
+          echo "GITHUB_ACTIONS=$GITHUB_ACTIONS"
+          echo "RUNNER_NAME=$RUNNER_NAME"
+          echo "RUNNER_OS=$RUNNER_OS"
+          echo "RUNNER_ARCH=$RUNNER_ARCH"


### PR DESCRIPTION
Adds a `workflow_dispatch`-only smoke workflow that exercises the new `meho-runners` self-hosted runner pool. Filed alongside the pool's first deploy ([`evoila-bosnia/claude-rdc-hetzner-dc#262`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/262)).

## What it does

The workflow has a single job pinned to `runs-on: meho-runners`. When triggered manually (Actions tab → "meho-runners smoke" → Run workflow, OR `gh workflow run runner-smoke.yml --repo evoila/meho`), it prints the runner's hostname, kernel, OS release, and the standard `RUNNER_*` envvars. Total runtime: a few seconds.

No `push:` or `pull_request:` triggers — it never runs on regular CI traffic; only when someone explicitly asks.

## Why merge

1. **Validates pool registration end-to-end.** The pool is up on `rke2-meho/arc-runners` and the runner has appeared at <https://github.com/evoila/meho/settings/actions/runners> as `online`/`idle`, but until a real workflow run picks the pool up, we haven't proven the listener → runner → job-execution path.
2. **GitHub's API requires `workflow_dispatch` files to exist on the default branch** to be triggerable; that's why this lands as a PR rather than a commit on a feature branch.
3. **Permanent on-demand smoke.** After merge the workflow stays as-is for future re-runs (e.g. after an ARC upgrade, after a pool-config change, or just to sanity-check the listener is alive). It costs nothing when not triggered.

## Pool context (FYI)

- Repo-scoped pool at `runs-on: meho-runners`, GitHub App auth, hosted on rke2-meho's existing ARC controller.
- Capacity: min=1, max=6.
- The pool is NOT yet wired into `evoila/meho`'s real CI (`ci.yml`, `quality-gate.yml`, etc.) — that workflow-side adoption + the fork-PR safety gating (`ci-trusted.yml` on `meho-runners`, `ci-fork.yml` on `ubuntu-latest`) is a separate task on the MEHO board (G2.7 / [#137](https://github.com/evoila/meho/issues/137)).

After merge I'll trigger the workflow once via `gh workflow run`, observe the run, and report back. The branch can stay or be deleted post-merge — your call.

Refs evoila-bosnia/claude-rdc-hetzner-dc#262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a smoke test workflow to verify self-hosted runner functionality and environment configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->