### PR TITLE
feat(backend): add migration runner entrypoint + CI guard for backward-compat

### DIFF
--- a/.github/workflows/migration-compat.yml
+++ b/.github/workflows/migration-compat.yml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Backward-compat migration guard.
+#
+# Goal #11 DoD bullet 3 says ``helm rollback`` works without manual DB
+# intervention. The only way that holds at the schema layer is if every
+# migration is purely additive — adds tables / columns (nullable or with
+# default) / indexes; never DROPs, never RENAMEs, never adds NOT NULL to
+# existing columns without a documented nullable-phase-in shim.
+#
+# ``scripts/ci/check_migration_compat.py`` enforces that contract by
+# scanning ``backend/alembic/versions/`` for destructive patterns inside
+# ``upgrade()`` (downgrade() is intentionally exempt — see the script's
+# docstring). The workflow runs on every PR that touches the migrations
+# directory, so a PR that introduces a destructive pattern fails the
+# required check and cannot merge.
+#
+# Required status check in branch protection (added when this lands).
+# No ``continue-on-error`` — the gate is strict by design.
+
+name: migration-compat
+
+on:
+  pull_request:
+    paths:
+      - 'backend/alembic/versions/**'
+      - 'scripts/ci/check_migration_compat.py'
+      - '.github/workflows/migration-compat.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: migration-compat-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Backward-compat migration guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.12'
+
+      - name: Run migration-compat check
+        run: python scripts/ci/check_migration_compat.py

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -66,5 +66,30 @@ USER 1001:0
 
 EXPOSE 8000
 
+# Two execution modes share this image:
+#
+# 1. **Serve** (default) — uvicorn runs the FastAPI app on :8000. This
+#    is what the Deployment rolls; the CMD below is the unmodified
+#    invocation.
+#
+# 2. **Migrate** — the Helm pre-install / pre-upgrade Job (G2.5-T3)
+#    overrides the container command to run
+#    ``python -m meho_backplane.db.migrate`` before the Deployment
+#    rolls forward, so the schema is at ``alembic upgrade head`` by
+#    the time pods come up. No additional Dockerfile entrypoint is
+#    needed: ``/app/.venv/bin`` is on PATH (set above), the
+#    ``meho_backplane`` package is installed into the venv via the
+#    builder stage, and ``alembic.ini`` + the ``alembic/`` tree ship
+#    as wheel package data (force-included by ``pyproject.toml``) so
+#    ``meho_backplane.db.migrate`` resolves the config via
+#    ``importlib.resources`` without needing the source tree on disk.
+#
+#    The Helm Job spec passes:
+#        command: ["python"]
+#        args: ["-m", "meho_backplane.db.migrate"]
+#    plus ``env: [{name: DATABASE_URL, valueFrom: ...}]``. The runner
+#    exits 0 on success, 1 on failure; ``backoffLimit`` on the Job
+#    handles retries.
+#
 # Exec form forwards SIGTERM cleanly to uvicorn (k8s pod-shutdown contract).
 CMD ["uvicorn", "meho_backplane.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/src/meho_backplane/db/migrate.py
+++ b/backend/src/meho_backplane/db/migrate.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Helm pre-install / pre-upgrade Job entrypoint — ``alembic upgrade head``.
+
+The chart wired by Goal #11's G2.5-T3 runs this module as a Kubernetes
+Job before the Deployment rolls forward, so the schema is at ``head``
+by the time pods come up. The contract is intentionally minimal:
+
+* No CLI flags. Behaviour is governed entirely by ``DATABASE_URL`` and
+  ``ALEMBIC_CONFIG`` (both already honoured by
+  :mod:`meho_backplane.db.migrations`); operators can't accidentally
+  request a partial upgrade. Forward-only is enforced by *not*
+  exposing ``downgrade``.
+* Exit ``0`` on success, ``1`` on any failure. The Job's
+  ``backoffLimit`` retries on non-zero, but the Helm hook fails the
+  release out cleanly when retries exhaust.
+* Errors render to stderr as ``migration_failed: <ExcClass>: <msg>``.
+  The exception class (not the message) is the structured key
+  operators alert on; the message is for human triage and may carry
+  schema-shape detail but never bearer-token-shaped content (the
+  audit-side secret-leak sweep does not run inside this entrypoint;
+  Alembic itself is the only thing logging here).
+
+The runner shares :func:`meho_backplane.db.migrations.alembic_config`
+with the readiness probe so the migration that *applies* and the
+revision-comparison probe that *verifies* never disagree on which
+``alembic.ini`` they targeted (env-var override → wheel package data
+→ cwd → source tree).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from alembic import command
+
+from meho_backplane.db.migrations import alembic_config
+
+__all__ = ["main"]
+
+
+def main() -> int:
+    """Run ``alembic upgrade head`` and return a process exit code.
+
+    Returns ``0`` on success, ``1`` on any exception raised by
+    Alembic (including the underlying SQLAlchemy / asyncpg / network
+    errors propagated up from ``env.py``).
+    """
+    try:
+        cfg = alembic_config()
+        command.upgrade(cfg, "head")
+    except Exception as exc:
+        print(
+            f"migration_failed: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_migration_compat.py
+++ b/backend/tests/test_migration_compat.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``scripts/ci/check_migration_compat.py``.
+
+The CI guard is the gate that protects Goal #11's DoD bullet 3
+(``helm rollback`` works without manual DB intervention) at the
+schema layer. Weak coverage here lets a destructive migration slip
+through and breaks rollback for every future v0.1 deployment, so the
+matrix below is intentionally exhaustive: a positive test against
+the real first migration shipped in T28, and one negative test per
+banned pattern.
+
+Synthetic destructive migrations are written into ``tmp_path``-rooted
+fake versions directories and the CI script is invoked against that
+directory via its CLI argument. The fixtures never land under
+``backend/alembic/versions/`` and never trip the production guard's
+own scan path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+#: Repo root resolved relative to this test file. The script imports as
+#: a module rather than via ``subprocess`` so failure messages render
+#: as proper pytest tracebacks; the subprocess invocation is exercised
+#: separately by :func:`test_cli_invocation_returns_nonzero_on_violation`.
+_REPO_ROOT: pathlib.Path = pathlib.Path(__file__).resolve().parents[2]
+_SCRIPT_PATH: pathlib.Path = _REPO_ROOT / "scripts" / "ci" / "check_migration_compat.py"
+
+
+def _load_script_module() -> object:
+    """Import the CI guard script as a module without polluting
+    ``sys.path``. ``importlib.util.spec_from_file_location`` is the
+    canonical Python 3.12 idiom — see the
+    :mod:`importlib.util` docs.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_check_migration_compat_under_test",
+        _SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {_SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_module = _load_script_module()
+
+
+def _write_migration(path: pathlib.Path, body: str) -> None:
+    """Write *body* into *path* with a minimal Alembic file skeleton.
+
+    The skeleton matches the shape Alembic's own template renders:
+    a leading ``revision = "..."`` line plus the ``upgrade()`` /
+    ``downgrade()`` definitions. Tests pass the *interior* of
+    ``upgrade()`` (already 4-space-indented) via ``body``.
+    """
+    path.write_text(
+        textwrap.dedent(
+            '''\
+            """Synthetic test migration."""
+
+            from alembic import op
+            import sqlalchemy as sa
+
+            revision = "test"
+            down_revision = None
+
+
+            def upgrade():
+            {body}
+
+
+            def downgrade():
+                pass
+            '''
+        ).format(body=body)
+    )
+
+
+def _versions_dir(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Return a fresh fake versions directory under *tmp_path*."""
+    versions = tmp_path / "versions"
+    versions.mkdir()
+    return versions
+
+
+# ---------------------------------------------------------------------------
+# Positive cases
+# ---------------------------------------------------------------------------
+
+
+def test_real_first_migration_passes() -> None:
+    """The shipped ``0001_create_audit_log.py`` is purely additive in
+    upgrade(), so the guard returns 0 violations on it.
+
+    This is the canonical positive case: it locks in the contract
+    that the first migration on the schema must pass, which means
+    every subsequent CI run starts from a clean slate.
+    """
+    versions = _REPO_ROOT / "backend" / "alembic" / "versions"
+    violations = _module.check_versions_dir(versions)
+    assert violations == [], (
+        "expected zero violations on the real versions directory, got:\n" + "\n".join(violations)
+    )
+
+
+def test_purely_additive_migration_passes(tmp_path: pathlib.Path) -> None:
+    """A synthetic migration using only ``create_table`` /
+    ``add_column`` / ``create_index`` returns zero violations."""
+    versions = _versions_dir(tmp_path)
+    _write_migration(
+        versions / "0002_clean.py",
+        body=(
+            '    op.create_table("foo", sa.Column("id", sa.Integer(), primary_key=True))\n'
+            '    op.add_column("foo", sa.Column("name", sa.Text(), nullable=True))\n'
+            '    op.create_index("foo_name_idx", "foo", ["name"])'
+        ),
+    )
+    assert _module.check_versions_dir(versions) == []
+
+
+def test_alter_column_nullable_true_passes(tmp_path: pathlib.Path) -> None:
+    """Adding a column or relaxing NOT NULL is purely additive and
+    must not be flagged."""
+    versions = _versions_dir(tmp_path)
+    _write_migration(
+        versions / "0003_relax.py",
+        body='    op.alter_column("foo", "name", nullable=True)',
+    )
+    assert _module.check_versions_dir(versions) == []
+
+
+def test_destructive_pattern_in_downgrade_only_passes(tmp_path: pathlib.Path) -> None:
+    """``op.drop_table()`` inside ``downgrade()`` is allowed — the
+    guard only inspects ``upgrade()`` because production never
+    invokes ``alembic downgrade``.
+
+    Exercises the same shape as the real
+    ``0001_create_audit_log.py`` downgrade(), so a regression in
+    the upgrade-only restriction would surface here as well as on
+    :func:`test_real_first_migration_passes`.
+    """
+    versions = _versions_dir(tmp_path)
+    (versions / "0004_downgrade_only.py").write_text(
+        textwrap.dedent(
+            '''\
+            """Migration whose only destructive op is in downgrade()."""
+
+            from alembic import op
+            import sqlalchemy as sa
+
+            revision = "test"
+            down_revision = None
+
+
+            def upgrade():
+                op.create_table("foo", sa.Column("id", sa.Integer(), primary_key=True))
+
+
+            def downgrade():
+                op.drop_table("foo")
+                op.drop_column("foo", "name")
+                op.execute("DROP TABLE foo")
+            '''
+        )
+    )
+    assert _module.check_versions_dir(versions) == []
+
+
+def test_missing_versions_dir_passes() -> None:
+    """A nonexistent versions directory is treated as zero violations
+    rather than an error — the guard predates the first migration in
+    a fresh repo bootstrap."""
+    assert _module.check_versions_dir(pathlib.Path("/nonexistent/path/should/not/exist")) == []
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — one per banned pattern
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_substring"),
+    [
+        # Rule 1: op.drop_column
+        (
+            '    op.drop_column("audit_log", "request_id")',
+            "op.drop_column() is not allowed",
+        ),
+        # Rule 2: op.drop_table
+        (
+            '    op.drop_table("audit_log")',
+            "op.drop_table() is not allowed",
+        ),
+        # Rule 3: op.rename_table
+        (
+            '    op.rename_table("audit_log", "audit_events")',
+            "op.rename_table() is not allowed",
+        ),
+        # Rule 4: op.alter_column with new_column_name (rename)
+        (
+            '    op.alter_column("audit_log", "request_id", new_column_name="req_id")',
+            "new_column_name=...) is not allowed",
+        ),
+        # Rule 5: op.alter_column with nullable=False (NOT NULL)
+        (
+            '    op.alter_column("audit_log", "operator_sub", nullable=False)',
+            "nullable=False) requires a nullable-phase-in shim",
+        ),
+        # Rule 6a: op.execute with raw DROP COLUMN
+        (
+            '    op.execute("ALTER TABLE audit_log DROP COLUMN request_id")',
+            "DROP/RENAME/SET NOT NULL",
+        ),
+        # Rule 6b: op.execute with raw DROP TABLE
+        (
+            '    op.execute("DROP TABLE audit_log")',
+            "DROP/RENAME/SET NOT NULL",
+        ),
+        # Rule 6c: op.execute with RENAME TABLE
+        (
+            '    op.execute("ALTER TABLE audit_log RENAME TO audit_events")',
+            "raw SQL in upgrade() contains a banned destructive pattern",
+        ),
+        # Rule 6d: op.execute with SET NOT NULL
+        (
+            '    op.execute("ALTER TABLE audit_log ALTER COLUMN operator_sub SET NOT NULL")',
+            "SET NOT NULL",
+        ),
+    ],
+)
+def test_banned_pattern_in_upgrade_is_rejected(
+    tmp_path: pathlib.Path,
+    body: str,
+    expected_substring: str,
+) -> None:
+    """One synthetic migration per banned pattern. Each must produce
+    at least one violation whose message contains the documented
+    substring — that contract is what gives operators a clear,
+    pattern-named diagnostic on a failing PR."""
+    versions = _versions_dir(tmp_path)
+    _write_migration(versions / "0099_destructive.py", body=body)
+    violations = _module.check_versions_dir(versions)
+    assert violations, f"expected at least one violation for body={body!r}"
+    assert any(expected_substring in v for v in violations), (
+        f"expected violation containing {expected_substring!r}; got:\n" + "\n".join(violations)
+    )
+
+
+def test_raw_sql_in_fstring_is_caught_by_text_pass(tmp_path: pathlib.Path) -> None:
+    """The AST pass cannot resolve f-string payloads, but the regex
+    backstop must still catch destructive SQL embedded in them.
+
+    This is the load-bearing test for the AST/text dual-detector
+    design: removing the regex pass would silently let migrations
+    smuggle destructive ops past the guard via string formatting.
+    """
+    versions = _versions_dir(tmp_path)
+    _write_migration(
+        versions / "0098_fstring.py",
+        body=('    table = "audit_log"\n    op.execute(f"DROP TABLE {table}")'),
+    )
+    violations = _module.check_versions_dir(versions)
+    assert violations, "expected the regex backstop to catch the f-string raw SQL"
+    assert any("raw SQL in upgrade()" in v for v in violations)
+
+
+def test_destructive_pattern_in_helper_function_is_still_flagged(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Helpers called from ``upgrade()`` are walked by ``ast.walk`` —
+    a destructive op nested inside a helper *defined inside*
+    upgrade() must still be flagged.
+
+    The simpler shape "helper at module level, called from upgrade()"
+    is intentionally *not* in scope: it would require call-graph
+    analysis. Migrations should keep their op calls in the top-level
+    upgrade() body anyway, which is the alembic-template
+    convention.
+    """
+    versions = _versions_dir(tmp_path)
+    (versions / "0097_nested.py").write_text(
+        textwrap.dedent(
+            '''\
+            """Nested helper inside upgrade()."""
+
+            from alembic import op
+
+            revision = "test"
+            down_revision = None
+
+
+            def upgrade():
+                def _do_drop():
+                    op.drop_column("audit_log", "request_id")
+                _do_drop()
+
+
+            def downgrade():
+                pass
+            '''
+        )
+    )
+    violations = _module.check_versions_dir(versions)
+    assert violations
+    assert any("op.drop_column() is not allowed" in v for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_invocation_returns_zero_on_clean_dir(tmp_path: pathlib.Path) -> None:
+    """The script's ``main()`` returns 0 on a clean directory passed
+    via the CLI positional argument."""
+    versions = _versions_dir(tmp_path)
+    _write_migration(
+        versions / "0002_clean.py",
+        body='    op.create_table("foo", sa.Column("id", sa.Integer(), primary_key=True))',
+    )
+    rc = _module.main([str(versions)])
+    assert rc == 0
+
+
+def test_cli_invocation_returns_nonzero_on_violation(
+    tmp_path: pathlib.Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """``main()`` returns 1 *and* prints findings to stderr when a
+    destructive pattern is present.
+
+    Captured stderr is asserted to contain both the ``FAILED`` header
+    and the path of the violating file — the structured shape
+    operators reading the CI log rely on. The fixture is ``capfd``
+    (file-descriptor-level) rather than ``capsys`` because the
+    autouse secret-leak sweep in :mod:`tests.conftest` already
+    holds a ``capfd`` capture and pytest forbids the two from
+    overlapping.
+    """
+    versions = _versions_dir(tmp_path)
+    _write_migration(
+        versions / "0099_bad.py",
+        body='    op.drop_table("audit_log")',
+    )
+    rc = _module.main([str(versions)])
+    assert rc == 1
+    captured = capfd.readouterr()
+    assert "Migration compatibility check FAILED" in captured.err
+    assert "0099_bad.py" in captured.err
+
+
+def test_subprocess_invocation_against_real_versions_dir() -> None:
+    """End-to-end: the script runs as ``python scripts/ci/...`` from
+    the repo root and exits 0 against the shipped versions tree.
+
+    Mirrors what the GitHub Actions workflow runs on every PR
+    touching ``backend/alembic/versions/``. The subprocess shape
+    surfaces shebang / interpreter-discovery regressions that an
+    in-process import would mask.
+    """
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT_PATH)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"expected exit 0; got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -119,6 +119,33 @@ this stage it exposes:
   branching the column shape itself. The
   `meho_backplane.db.models.AuditLog` ORM model carries the same
   field set with `Mapped[...]` typed-mapped annotations.
+* Migration runner + CI guard (Task #29) — `backend/src/meho_backplane/db/migrate.py`
+  is the one-file CLI entrypoint the Helm pre-install / pre-upgrade Job
+  (G2.5-T3) runs before the Deployment rolls forward; it reuses
+  `alembic_config()` from `db/migrations.py` so the migration that
+  *applies* and the readiness probe that *verifies* never disagree on
+  which `alembic.ini` they targeted, then calls
+  `alembic.command.upgrade(cfg, "head")` and exits 0 on success or 1
+  on failure (with a `migration_failed: <ExcClass>: <msg>` line on
+  stderr). The Dockerfile keeps a single `CMD ["uvicorn", ...]` for
+  the serve mode; the migrate mode is reached by the Helm Job
+  overriding `command: ["python"]; args: ["-m", "meho_backplane.db.migrate"]`
+  — no second image, no second entrypoint script. The CI guard at
+  `scripts/ci/check_migration_compat.py` runs on every PR touching
+  `backend/alembic/versions/**` (`.github/workflows/migration-compat.yml`)
+  and rejects destructive patterns inside the `upgrade()` function:
+  `op.drop_column` / `op.drop_table` / `op.rename_table`,
+  `op.alter_column(..., new_column_name=...)`,
+  `op.alter_column(..., nullable=False)`, and any
+  `op.execute(...)` whose payload matches `DROP COLUMN` /
+  `DROP TABLE` / `RENAME TABLE` / `RENAME COLUMN` /
+  `ALTER ... SET NOT NULL`. Detection is a dual AST-plus-regex pass
+  so f-string and variable-arg payloads can't smuggle destructive
+  SQL past the AST. `downgrade()` is intentionally exempt because
+  production never invokes `alembic downgrade` (rollback is image-
+  revert + forward-compat schema discipline, per Goal #11 DoD bullet
+  3); the first migration's `downgrade()` legitimately drops the
+  table it just created and a flat scan would trip on it.
 * Audit middleware (Task #28) — `backend/src/meho_backplane/audit.py`
   defines the **pure-ASGI** `AuditMiddleware` that writes one row to
   `audit_log` per authenticated request **before** the response yields
@@ -187,6 +214,8 @@ PYTHONPATH-leak imports.
 | `Base` / `AuditLog` | `src/meho_backplane/db/models.py` | SQLAlchemy 2.x `DeclarativeBase` plus the v0.1 `AuditLog` model (Task #28). Columns use portable `Uuid` and `JSON().with_variant(JSONB(), "postgresql")` types so the model and migration run cleanly on both PG (production) and SQLite (dev/test). Indexes on `occurred_at` and `operator_sub` are declared in `__table_args__`. |
 | `AuditMiddleware` | `src/meho_backplane/audit.py` | Pure-ASGI middleware (Task #28). For every authenticated request (`operator_sub` present in contextvars) writes one `audit_log` row synchronously before yielding the response back to the send chain. Buffers `http.response.start`/`http.response.body` messages so the fail-closed path can replace them with a 500 `{"detail": "audit_write_failed"}` when the audit insert raises. Skips public surfaces and 401 paths by keying on the contextvar's presence rather than path-matching. |
 | `0001_create_audit_log` | `backend/alembic/versions/0001_create_audit_log.py` | First migration on the schema (Task #28). Creates the `audit_log` table plus `audit_log_occurred_at_idx` and `audit_log_operator_sub_idx`. PG gets `gen_random_uuid()` / `now()` / `'{}'::jsonb` server defaults; SQLite branches skip them and rely on the ORM Python-side defaults. Downgrade drops the table — the only revertible operation here because no production data exists yet; subsequent migrations land under the additive-only discipline enforced by Task #29's CI guard. |
+| `meho_backplane.db.migrate.main` | `backend/src/meho_backplane/db/migrate.py` | Helm pre-install / pre-upgrade Job entrypoint (Task #29). Calls `alembic.command.upgrade(cfg, "head")` against the `alembic_config()` resolved by `db/migrations.py`. Returns 0 on success / 1 on failure with `migration_failed: <ExcClass>: <msg>` on stderr. No CLI flags by design — schema target is always `head`, and forward-only is enforced by not exposing `downgrade`. |
+| `check_migration_compat` | `scripts/ci/check_migration_compat.py` | CI guard (Task #29). Scans every `backend/alembic/versions/*.py` migration's `upgrade()` function for destructive patterns via a dual AST + regex detector; exit 0 on a clean tree, 1 on any violation. Honours an optional positional argument (a versions directory) so the test suite can point the guard at synthetic fixtures without monkeypatching module state. Workflow trigger is path-filtered to `backend/alembic/versions/**` plus the script itself. |
 | `backend/alembic.ini` + `backend/alembic/env.py` + `backend/alembic/script.py.mako` | repo paths | Alembic configuration (Task #27). `env.py` follows the upstream async cookbook: `async_engine_from_config` + `connection.run_sync(do_run_migrations)`. URL is sourced from `DATABASE_URL` so the migration runner and the running backplane share one knob. `versions/` ships empty; first migration lands in T28. |
 | `Operator` | `src/meho_backplane/auth/operator.py` | Frozen pydantic v2 model carrying validated claims (`sub`, `name`, `email`, `raw_jwt`). Returned by `verify_jwt`; consumed by every authenticated route from G2.2-T3 onward. `raw_jwt` is preserved verbatim for G2.2-T2's Vault forward-auth. |
 | `verify_jwt` | `src/meho_backplane/auth/jwt.py` | FastAPI dependency: parses `Authorization: Bearer ...`, fetches/caches Keycloak's JWKS, validates signature + `iss` + `aud` + `exp` (with leeway), refreshes JWKS on a kid miss, and returns an `Operator`. Every failure mode collapses to a terse 401. |
@@ -341,6 +370,7 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - Task #25 — Federation-chain failure-mode test suite + always-on secret-leak sweep
 - Task #27 — PG connection pool + Alembic wiring + DB-migration-state readiness probe
 - Task #28 — Audit table schema + synchronous audit-write middleware
+- Task #29 — Migration runner entrypoint + CI guard rejecting destructive migration patterns
 - [SQLAlchemy 2.x async overview](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
 - [SQLAlchemy 2.x pool / pre-ping disconnect handling](https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic)
 - [Alembic async migrations cookbook](https://alembic.sqlalchemy.org/en/latest/cookbook.html#using-asyncio-with-alembic)

--- a/scripts/ci/check_migration_compat.py
+++ b/scripts/ci/check_migration_compat.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Reject Alembic migrations containing destructive patterns.
+
+Backward-compatibility discipline (Goal #11 DoD bullet 3 — ``helm
+rollback`` works without manual DB intervention) requires every
+migration to be **purely additive**: add tables, add columns
+(nullable or with default), create indexes; never DROP, never RENAME,
+never add NOT NULL to existing columns without a documented nullable
+phase-in. This script is the CI gate that enforces that rule.
+
+Detection runs over the ``upgrade()`` function only. The
+``downgrade()`` function is intentionally exempt because:
+
+* Production never invokes ``alembic downgrade`` — rollback in
+  Goal #11 is image-revert + forward-compat schema discipline.
+* The first migration's ``downgrade()`` legitimately drops the
+  table it just created (so the migration is reversible at
+  development time, on an empty schema), and that pattern would
+  trip a flat scan of the whole module.
+
+Forward-only scanning preserves the "no destructive operations on
+production data" contract while leaving development-time rollback
+symmetry intact in source.
+
+Banned patterns inside ``upgrade()``:
+
+1. ``op.drop_column(...)``
+2. ``op.drop_table(...)``
+3. ``op.rename_table(...)``
+4. ``op.alter_column(..., new_column_name=...)`` — column rename
+5. ``op.alter_column(..., nullable=False)`` — adds NOT NULL
+   without a documented nullable-phase-in shim
+6. ``op.execute(<str>)`` whose payload contains
+   ``DROP COLUMN``, ``DROP TABLE``, ``RENAME TABLE``,
+   ``RENAME COLUMN``, or ``ALTER TABLE ... ALTER COLUMN ...
+   SET NOT NULL`` (case-insensitive) — backstop for raw-SQL
+   smuggling around the Python op-API checks.
+
+The detector uses both an AST pass (rules 1-5 plus the
+op.execute-with-string-literal sub-case of rule 6) and a regex pass
+(rule 6's text-grep backstop covering f-strings / variable arg
+patterns the AST can't follow). Reading the source twice — once as
+text, once as AST — is intentional belt-and-braces.
+
+Exit codes
+----------
+
+* 0 — no violations
+* 1 — at least one violation (each printed to stderr with
+  ``<path>:<lineno>: <message>``)
+* 2 — internal error (file unreadable, syntax error, etc.)
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+import sys
+
+#: Path to the migrations directory, relative to the repo root.
+#: The script is invoked from the repo root by both the GitHub
+#: Actions workflow and the local pytest suite (which monkeypatches
+#: this constant to point at synthetic test fixtures).
+DEFAULT_VERSIONS_DIR: pathlib.Path = pathlib.Path("backend/alembic/versions")
+
+#: ``op.<name>`` calls banned outright inside ``upgrade()``.
+BANNED_OPS: frozenset[str] = frozenset(
+    {
+        "drop_column",
+        "drop_table",
+        "rename_table",
+    }
+)
+
+#: ``op.alter_column(..., <flag>=...)`` keyword arguments that signal
+#: a destructive change (column rename). Adding NOT NULL is handled
+#: separately because it is detected by the value, not the keyword
+#: name.
+ALTER_COLUMN_BANNED_KWARGS: frozenset[str] = frozenset({"new_column_name"})
+
+#: Regex matching destructive SQL inside ``op.execute(<str>)`` payloads
+#: and as a final text-grep backstop. The alternation covers:
+#:
+#: * ``DROP COLUMN`` / ``DROP TABLE``
+#: * ``RENAME TO`` / ``RENAME COLUMN`` — PostgreSQL canonical
+#:   ``ALTER TABLE <t> RENAME TO <new>`` and
+#:   ``ALTER TABLE <t> RENAME COLUMN <c> TO <new>`` shapes; also
+#:   matches the legacy ``RENAME TABLE`` / ``RENAME COLUMN`` direct
+#:   forms in case a future migration uses them.
+#: * ``ALTER TABLE <t> ALTER COLUMN <c> SET NOT NULL`` (PG syntax)
+#: * ``ALTER TABLE <t> MODIFY <c> ... NOT NULL`` (MySQL syntax — kept
+#:   even though ADR 0004 pins PG, in case a future driver lands)
+#:
+#: The pattern is intentionally permissive on whitespace
+#: (``\s+`` / ``\s*``) and case-insensitive (``re.IGNORECASE``).
+RAW_SQL_BANNED_RE: re.Pattern[str] = re.compile(
+    r"\b("
+    r"DROP\s+(COLUMN|TABLE)"
+    r"|RENAME\s+(TABLE|COLUMN|TO)\b"
+    r"|ALTER\s+TABLE\s+\S+\s+ALTER\s+COLUMN\s+\S+\s+SET\s+NOT\s+NULL"
+    r"|ALTER\s+TABLE\s+\S+\s+MODIFY\s+\S+[^,]*NOT\s+NULL"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _is_op_call(node: ast.Call) -> tuple[bool, str | None]:
+    """Return ``(is_op_call, attr_name)`` for ``op.<attr>(...)`` calls.
+
+    Returns ``(False, None)`` for any other call shape (including
+    chained attribute access like ``foo.op.drop_table()``, which we
+    intentionally do not match — Alembic's migration files always
+    write the bare ``op.`` prefix).
+    """
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return (False, None)
+    if not isinstance(func.value, ast.Name):
+        return (False, None)
+    if func.value.id != "op":
+        return (False, None)
+    return (True, func.attr)
+
+
+def _scan_upgrade_body(
+    path: pathlib.Path,
+    upgrade_node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[str]:
+    """Walk every ``op.<x>(...)`` call inside ``upgrade()`` and
+    collect violation strings."""
+    violations: list[str] = []
+    for node in ast.walk(upgrade_node):
+        if not isinstance(node, ast.Call):
+            continue
+        is_op, attr = _is_op_call(node)
+        if not is_op or attr is None:
+            continue
+        if attr in BANNED_OPS:
+            violations.append(
+                f"{path}:{node.lineno}: op.{attr}() is not allowed in upgrade() "
+                f"(destructive — violates backward-compat discipline)"
+            )
+            continue
+        if attr == "alter_column":
+            for kw in node.keywords:
+                if kw.arg in ALTER_COLUMN_BANNED_KWARGS:
+                    violations.append(
+                        f"{path}:{node.lineno}: op.alter_column(..., {kw.arg}=...) "
+                        f"is not allowed (column rename is destructive)"
+                    )
+                if (
+                    kw.arg == "nullable"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is False
+                ):
+                    violations.append(
+                        f"{path}:{node.lineno}: op.alter_column(..., nullable=False) "
+                        f"requires a nullable-phase-in shim "
+                        f"(see backend/docs nullable-phase-in pattern)"
+                    )
+            continue
+        if attr == "execute":
+            # Match string-literal payloads — f-strings / variable
+            # arguments are caught by the regex backstop below.
+            if (
+                node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+                and RAW_SQL_BANNED_RE.search(node.args[0].value)
+            ):
+                violations.append(
+                    f"{path}:{node.lineno}: op.execute(<str>) contains a banned "
+                    f"destructive pattern (DROP/RENAME/SET NOT NULL)"
+                )
+    return violations
+
+
+def _scan_text(path: pathlib.Path, src: str) -> list[str]:
+    """Regex backstop over the raw migration source.
+
+    Catches destructive SQL embedded in f-strings, variables, or any
+    construction the AST pass cannot statically resolve. Restricted
+    to the upgrade() block via a coarse text slice so the regex does
+    not flag downgrade()-only patterns.
+    """
+    upgrade_start = src.find("def upgrade(")
+    if upgrade_start == -1:
+        return []
+    # Stop at the next top-level ``def`` (matches ``def downgrade(`` and
+    # any later helper). ``\n\ndef`` is the conventional boundary
+    # rendered by ``black`` / ``ruff format`` and the alembic template.
+    after = src[upgrade_start:]
+    next_def = re.search(r"\n\ndef\s+\w+\(", after[len("def upgrade(") :])
+    upgrade_block = after if next_def is None else after[: len("def upgrade(") + next_def.start()]
+    violations: list[str] = []
+    for match in RAW_SQL_BANNED_RE.finditer(upgrade_block):
+        # Compute the line number relative to the original file by
+        # counting newlines up to and including the absolute match
+        # offset.
+        absolute_offset = upgrade_start + match.start()
+        lineno = src.count("\n", 0, absolute_offset) + 1
+        violations.append(
+            f"{path}:{lineno}: raw SQL in upgrade() contains a banned destructive "
+            f"pattern ({match.group(0).strip()!r})"
+        )
+    return violations
+
+
+def check_file(path: pathlib.Path) -> list[str]:
+    """Return all violations for a single migration file.
+
+    Combines the AST pass over the ``upgrade()`` body with the
+    text-grep backstop. Duplicate-line violations from the two
+    detectors are deduplicated to keep the operator-facing report
+    readable.
+    """
+    src = path.read_text()
+    try:
+        tree = ast.parse(src, filename=str(path))
+    except SyntaxError as exc:
+        return [f"{path}:{exc.lineno or 1}: syntax error: {exc.msg}"]
+    upgrade_node: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "upgrade":
+            upgrade_node = node
+            break
+    violations: list[str] = []
+    if upgrade_node is not None:
+        violations.extend(_scan_upgrade_body(path, upgrade_node))
+    violations.extend(_scan_text(path, src))
+    # Deduplicate while preserving order — the AST and regex passes
+    # often emit the same finding for the same line of raw SQL.
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for v in violations:
+        if v not in seen:
+            seen.add(v)
+            deduped.append(v)
+    return deduped
+
+
+def check_versions_dir(versions_dir: pathlib.Path) -> list[str]:
+    """Scan every ``*.py`` migration file in ``versions_dir``.
+
+    ``__init__.py`` and any non-Python file is skipped silently.
+    Files whose name starts with ``_`` (Alembic uses these for
+    helpers / templates) are also skipped — they are not migration
+    revisions.
+    """
+    if not versions_dir.exists():
+        return []
+    all_violations: list[str] = []
+    for path in sorted(versions_dir.glob("*.py")):
+        if path.name == "__init__.py" or path.name.startswith("_"):
+            continue
+        all_violations.extend(check_file(path))
+    return all_violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint.
+
+    Optional positional arg: path to a versions directory (defaults
+    to :data:`DEFAULT_VERSIONS_DIR`). The argument exists so the
+    pytest suite can point the guard at synthetic fixtures without
+    monkeypatching module state.
+    """
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) > 1:
+        print(
+            "usage: check_migration_compat.py [versions_dir]",
+            file=sys.stderr,
+        )
+        return 2
+    target = pathlib.Path(args[0]) if args else DEFAULT_VERSIONS_DIR
+    try:
+        violations = check_versions_dir(target)
+    except OSError as exc:
+        print(f"check_migration_compat: cannot read {target}: {exc}", file=sys.stderr)
+        return 2
+    if violations:
+        print("Migration compatibility check FAILED:", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Initiative #26 Task #29: ship the migration runner entrypoint + CI guard that protect Goal #11's DoD bullet 3 (`helm rollback` works without manual DB intervention) at the schema layer.
- Migration runner (`backend/src/meho_backplane/db/migrate.py`) is the one-file CLI the Helm pre-install / pre-upgrade Job (G2.5-T3) invokes. It reuses `alembic_config()` from `db/migrations.py` so the migration that *applies* and the readiness probe that *verifies* never disagree on which `alembic.ini` they targeted; calls `alembic.command.upgrade(cfg, "head")` and exits 0 / 1 with `migration_failed: <ExcClass>: <msg>` on stderr.
- CI guard (`scripts/ci/check_migration_compat.py` + `.github/workflows/migration-compat.yml`) does an AST-plus-regex scan over each migration's `upgrade()` body and rejects destructive patterns: `op.drop_column` / `op.drop_table` / `op.rename_table`, `op.alter_column(..., new_column_name=...)`, `op.alter_column(..., nullable=False)`, and `op.execute(...)` payloads matching `DROP COLUMN` / `DROP TABLE` / `RENAME TO` / `RENAME COLUMN` / `RENAME TABLE` / `ALTER ... SET NOT NULL`.

## Design notes

**Why scan `upgrade()` only.** Production never invokes `alembic downgrade` — Goal #11's rollback contract is image-revert + forward-compat schema discipline. The shipped first migration's `downgrade()` legitimately drops the table it just created (the only revertible operation on an empty schema); a flat scan would trip on it on day one. Restricting detection to `upgrade()` preserves the additive-only contract for production while leaving development-time rollback symmetry intact in source. This is the deliberate deviation from the task body's flat scan sketch — documented in the script's docstring and exercised by `test_destructive_pattern_in_downgrade_only_passes`.

**Why dual AST + regex.** The AST pass cannot follow f-strings or variables; the regex backstop catches destructive SQL embedded in `op.execute(f"DROP TABLE {table}")` shapes. Removing the regex pass would silently let migrations smuggle destructive ops past the guard via string formatting. Exercised by `test_raw_sql_in_fstring_is_caught_by_text_pass`.

**Why no separate migrate entrypoint in the Dockerfile.** `/app/.venv/bin` is on PATH (set by the existing runtime stage), the `meho_backplane` package is installed into the venv, and `alembic.ini` + `alembic/` ship as wheel package data. The Helm Job overrides `command: ["python"]; args: ["-m", "meho_backplane.db.migrate"]` and reaches the migrate mode with no second image. The Dockerfile change is comment-only — documenting the dual-mode contract so the chart author wiring G2.5-T3 doesn't have to spelunk.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (38 files)
- [x] `mypy --strict src/` — clean (21 source files)
- [x] `pytest tests/ -x -q` — 174 passed, 1 skipped (testcontainers PG; Docker absent in sandbox)
- [x] AC #1 — `python -m meho_backplane.db.migrate` applies 0001 cleanly against a fresh aiosqlite DB and exits 0; the failure path (bad DB URL) exits 1 with `migration_failed: OperationalError: ...` on stderr.
- [x] AC #2 — Dockerfile's documented dual-mode contract: serve via the unmodified `CMD`, migrate via Helm-Job-overridden `command` + `args`. Verified by inspection (the venv is on PATH, the package and `alembic.ini` are installed via the builder stage); end-to-end docker validation is out of scope for this Task and lands with the chart in G2.5-T3.
- [x] AC #3 — `python scripts/ci/check_migration_compat.py` against the real `backend/alembic/versions/` exits 0 (0001 is purely additive in `upgrade()`).
- [x] AC #4 — Negative tests in `backend/tests/test_migration_compat.py`: every banned pattern (drop_column / drop_table / rename_table / alter_column rename / alter_column NOT NULL / raw DROP COLUMN / raw DROP TABLE / raw RENAME TO / raw SET NOT NULL) triggers a violation when present in a synthetic migration. Plus the f-string regex-backstop test and the helper-function-inside-upgrade walking test.
- [x] AC #5 — `.github/workflows/migration-compat.yml` runs on PRs touching `backend/alembic/versions/**` (plus the script + workflow itself). Pinned-digest action SHAs (mirrors the existing workflows in `.github/workflows/`); `permissions: contents: read`.
- [x] `python3 .claude/hooks/code-quality.py --diff` — exits 0.

## Out of scope

- Helm pre-install / pre-upgrade Job manifest — G2.5-T3 (this Task ships the runner; the chart wires it).
- Forward-compat regression test (testcontainers, N image vs N+1 schema) — T30 (#30).
- Online schema change tools (`gh-ost`, `pt-osc`, `pgroll`) — v0.2+; the banned-pattern strategy is sufficient at zero-data scale.
- `squawk` migration linter (issue body's Phase 3 evaluation candidate) — out-of-scope decision recorded; the AST+regex approach covers v0.1's banned-pattern set, and `squawk` can be slotted in alongside the Python guard in v0.2 if PG-side analysis becomes valuable.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation in CI to ensure database migrations remain backward compatible by preventing destructive schema changes.
  * Added database migration runner entrypoint for deployment pipelines and Kubernetes Helm hooks.

* **Tests**
  * Added comprehensive test coverage for migration compatibility validation, including destructive pattern detection and CLI surface testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->