### PR TITLE
ci: switch all workflows to self-hosted meho-runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   lint-python:
     name: Python lint (ruff)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, meho-runners]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -48,7 +48,7 @@ jobs:
 
   placeholder-tests:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, meho-runners]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   python-licenses:
     name: Python License Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, meho-runners]
     timeout-minutes: 10
     if: hashFiles('pyproject.toml') != ''
     steps:
@@ -91,7 +91,7 @@ jobs:
 
   npm-licenses:
     name: NPM License Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, meho-runners]
     timeout-minutes: 10
     if: hashFiles('**/package-lock.json') != ''
     steps:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   sonarcloud:
     name: SonarCloud Analysis
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, meho-runners]
     timeout-minutes: 20
     continue-on-error: true
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   trufflehog:
     name: TruffleHog Secret Scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, meho-runners]
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   semgrep:
     name: Semgrep SAST
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, meho-runners]
     timeout-minutes: 15
     container:
       # Bump cadence: monthly review or on advisory.


### PR DESCRIPTION
## Summary
- Replaces `runs-on: ubuntu-latest` with `[self-hosted, meho-runners]` across all 5 workflows (7 jobs total): CI, quality-gate, secret-scan, security-scan, dependency-license-check.
- Uses label-list form so jobs only land on runners explicitly tagged with both `self-hosted` and `meho-runners`.

## Runner prerequisites
Before merge, verify the self-hosted runners satisfy what the workflows assume `ubuntu-latest` provides:
- **Docker** installed and runner user in the `docker` group — required by [security-scan.yml](.github/workflows/security-scan.yml) (`container: semgrep/semgrep:1.160.0`) and the TruffleHog action in [secret-scan.yml](.github/workflows/secret-scan.yml).
- **Writable tool cache** for `actions/setup-python` and `actions/setup-node` (Python 3.13, Node 20).
- **Network egress** to GitHub, SonarCloud (quality-gate), and the Semgrep registry.

## Test plan
- [ ] Confirm runners are online and registered with the `meho-runners` label
- [ ] Open this PR and verify CI jobs are picked up by the self-hosted pool (not queued indefinitely)
- [ ] Verify Semgrep container job runs successfully (Docker prerequisite)
- [ ] Verify TruffleHog scan completes (Docker prerequisite)
- [ ] After merge to main, verify the SonarCloud quality-gate `workflow_run` trigger fires on the self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all GitHub Actions workflows to run on self-hosted infrastructure instead of GitHub-hosted runners, affecting continuous integration testing, dependency license verification, security scanning, and code quality analysis pipelines.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/160)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->