### PR TITLE
test(backend): forward-compat regression test (testcontainers; N image vs N+1 schema)

### DIFF
--- a/backend/tests/fixtures/__init__.py
+++ b/backend/tests/fixtures/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Test-only fixtures kept outside ``backend/alembic/versions/``.
+
+Anything under this package is **never** part of the production
+migration sequence — the CI guard at
+``scripts/ci/check_migration_compat.py`` scopes itself to
+``backend/alembic/versions/**`` (see ``DEFAULT_VERSIONS_DIR`` in that
+script and the ``paths:`` filter in
+``.github/workflows/migration-compat.yml``), so synthetic destructive
+or schema-evolution-narrative migrations placed here cannot trip the
+guard or pollute the production revision graph.
+"""

--- a/backend/tests/fixtures/synthetic_n_plus_1.py
+++ b/backend/tests/fixtures/synthetic_n_plus_1.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Synthetic N+1 additive migration applied during the forward-compat test.
+
+Goal #11's DoD bullet 3 ("``helm rollback`` works without DB
+intervention") imposes two disciplines:
+
+* Migration-side — every ``upgrade()`` is purely additive; the CI
+  guard at ``scripts/ci/check_migration_compat.py`` enforces this.
+* Code-side — the running backplane image must tolerate a schema
+  that is *ahead* of it (the situation a rollback lands in: image
+  reverted to revision N, schema still at revision N+1).
+
+This module owns the second discipline's test fixture: a small
+helper that drops two additive columns onto ``audit_log`` via raw
+DDL, simulating an N+1 additive migration without going through
+Alembic. The helper is intentionally **not** a real Alembic
+migration file:
+
+* A real revision under ``backend/alembic/versions/`` would be picked
+  up by the script-directory walker on the next ``alembic upgrade
+  head``, polluting the production migration sequence in a way that
+  would be invisible from the test alone.
+* A real revision would also be scanned by the CI guard's path
+  filter (``backend/alembic/versions/**``) and would have to pass
+  the destructive-pattern check — which the synthetic *should* pass
+  (it is purely additive), but the contract-test value is in keeping
+  the synthetic clearly out-of-band from production migrations.
+
+The two columns added match the issue body verbatim:
+
+* ``future_field text NULL DEFAULT 'reserved_for_v0.2'`` — proves
+  the simple-text/string default path.
+* ``future_jsonb_field jsonb NULL DEFAULT '{}'::jsonb`` — proves the
+  PG-specific JSONB default path; this is the realistic shape future
+  v0.2 schema additions will take (the ``payload`` column on
+  ``audit_log`` already uses JSONB, so a sibling JSONB column is a
+  representative additive change).
+
+Both defaults are applied **server-side** by PostgreSQL itself when
+the revision-N backplane code inserts an ``audit_log`` row without
+mentioning the new columns. Asserting the defaults landed on the
+written row is the negative test for "revision-N code did not write
+the future columns" — the load-bearing forward-compat property.
+
+The DDL runs through an ``asyncpg``-backed :class:`AsyncEngine`
+because that is the only PostgreSQL driver installed in the
+backplane's environment (``pyproject.toml`` pins ``asyncpg>=0.29``;
+no ``psycopg`` / ``psycopg2`` is shipped — see ADR 0004). Calling
+this helper from a sync test wrapper means the helper itself owns
+the ``asyncio.run`` boundary so the caller does not need to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from typing import Final
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+__all__ = [
+    "FUTURE_JSONB_FIELD_DEFAULT",
+    "FUTURE_TEXT_FIELD_DEFAULT",
+    "SYNTHETIC_N_PLUS_1_COLUMNS",
+    "apply_synthetic_n_plus_1_migration",
+]
+
+#: Default value PostgreSQL applies to ``future_field`` rows whose
+#: INSERT does not mention the column. Pinned as a module constant so
+#: the test asserts on the same string the migration writes — drift in
+#: either direction surfaces as a failed test rather than a silent
+#: assertion miss.
+FUTURE_TEXT_FIELD_DEFAULT: Final[str] = "reserved_for_v0.2"
+
+#: Default value PostgreSQL applies to ``future_jsonb_field``. The
+#: column type is ``jsonb`` so the value round-trips as a Python
+#: ``dict`` through asyncpg / SQLAlchemy 2.x; the constant is kept as
+#: the dict (not the SQL literal) so test assertions compare apples
+#: to apples without re-parsing the JSON.
+FUTURE_JSONB_FIELD_DEFAULT: Final[dict[str, object]] = {}
+
+#: The columns this synthetic migration adds, in the order they are
+#: declared inside :func:`apply_synthetic_n_plus_1_migration`. Exposed
+#: as a tuple so a test can iterate over expected names without
+#: re-stating them inline. Kept out of the function body to keep the
+#: DDL strings as the only place column names appear in the SQL itself.
+SYNTHETIC_N_PLUS_1_COLUMNS: Final[Sequence[str]] = (
+    "future_field",
+    "future_jsonb_field",
+)
+
+
+async def _run_alters(async_url: str) -> None:
+    """Open an asyncpg engine and issue the two ``ALTER TABLE`` DDL stmts.
+
+    Two distinct statements rather than one combined ``ADD COLUMN
+    ..., ADD COLUMN ...`` so a failure localises to the offending
+    column instead of rolling both back as a unit. Both columns are
+    NULLABLE with server-side defaults; PostgreSQL applies the
+    default to existing rows lazily (since 11), so this is O(1)
+    regardless of ``audit_log`` row count.
+    """
+    engine = create_async_engine(async_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "ALTER TABLE audit_log "
+                    "ADD COLUMN future_field text NULL "
+                    f"DEFAULT '{FUTURE_TEXT_FIELD_DEFAULT}'"
+                ),
+            )
+            await conn.execute(
+                text(
+                    "ALTER TABLE audit_log "
+                    "ADD COLUMN future_jsonb_field jsonb NULL "
+                    "DEFAULT '{}'::jsonb"
+                ),
+            )
+    finally:
+        await engine.dispose()
+
+
+def apply_synthetic_n_plus_1_migration(async_url: str) -> None:
+    """Apply the N+1 additive migration to ``audit_log``.
+
+    *async_url* must be an async PostgreSQL URL
+    (``postgresql+asyncpg://...``) — the only driver shipped in the
+    backplane environment. The helper drives its own
+    :func:`asyncio.run` so the caller can stay synchronous; this
+    matches the pattern Alembic's ``command.upgrade`` uses internally
+    via the env.py async cookbook (see
+    ``backend/alembic/env.py``'s ``run_migrations_online``). Calling
+    this from inside a running event loop would crash with
+    ``RuntimeError: asyncio.run() cannot be called from a running
+    event loop`` — by design; the forward-compat test runs
+    synchronously precisely so this nesting is impossible.
+
+    Returns ``None``; callers that need to inspect the columns
+    afterwards re-issue their own ``information_schema`` /
+    ``inspect(engine)`` query.
+    """
+    asyncio.run(_run_alters(async_url))

--- a/backend/tests/test_migration_rollback.py
+++ b/backend/tests/test_migration_rollback.py
@@ -1,0 +1,553 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Forward-compat regression test (testcontainers).
+
+Goal #11's Definition-of-Done bullet 3 promises that ``helm rollback``
+works without DB intervention. That guarantee depends on **two**
+disciplines:
+
+* Migration-side — every ``upgrade()`` is purely additive (enforced
+  in source by ``scripts/ci/check_migration_compat.py``).
+* Code-side — the running backplane image must tolerate a schema
+  *ahead* of it (the situation a rollback lands in: image reverted to
+  revision N, schema still at revision N+1).
+
+This module owns the unit-test-level proof of the second discipline.
+The cluster-level proof — exercising real ``helm rollback`` against a
+running deployment — is Goal #11's G2.8-T3, intentionally out of
+scope here. Splitting the two layers means a regression in the code's
+forward-compat property fails fast in CI rather than waiting on the
+expensive end-to-end deploy gate.
+
+What the test exercises
+-----------------------
+
+#. Spin up ``postgres:16-alpine`` via ``testcontainers``.
+#. Run ``alembic upgrade head`` against it. The schema is now at
+   revision N (the audit-log table from
+   ``0001_create_audit_log.py``).
+#. Apply a synthetic *additive* migration that adds two columns to
+   ``audit_log`` — ``future_field text DEFAULT 'reserved_for_v0.2'``
+   and ``future_jsonb_field jsonb DEFAULT '{}'::jsonb``. The schema is
+   now at revision N+1.
+#. Make an authenticated ``GET /api/v1/health`` request through the
+   FastAPI ``TestClient`` driving the production
+   :data:`meho_backplane.main.app` (revision-N code). The audit
+   middleware writes one row to ``audit_log``.
+#. Read the row back. Assert (a) the response was 200, (b) the audit
+   row exists, (c) revision-N's ORM-mapped fields landed correctly,
+   and (d) — load-bearing — the synthetic N+1 columns hold their
+   PostgreSQL-side defaults, which proves the revision-N code did
+   *not* write them. The negative assertion is the load-bearing
+   forward-compat property; without it, the test would pass
+   vacuously even if the code reached for ``future_field``.
+
+The synthetic migration lives at
+``tests/fixtures/synthetic_n_plus_1.py`` rather than under
+``backend/alembic/versions/`` precisely so the production migration
+sequence and the CI guard's path filter
+(``backend/alembic/versions/**``) remain undisturbed.
+
+Skipping in sandbox
+-------------------
+
+testcontainers needs Docker. The ``_docker_socket_present()`` heuristic
+mirrors the one used in :class:`tests.test_db_engine.TestPostgresIntegration`
+and skips the test on agent sandboxes that have no Docker; CI provisions
+Docker via the runner pool, so the test runs there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import warnings
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from alembic import command
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from authlib.jose import JsonWebKey, JsonWebToken
+
+from meho_backplane.auth import vault as vault_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db import engine as engine_module
+from meho_backplane.db.engine import (
+    create_engine_for_url,
+    dispose_engine,
+    reset_engine_for_testing,
+)
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+from tests.fixtures.synthetic_n_plus_1 import (
+    FUTURE_JSONB_FIELD_DEFAULT,
+    FUTURE_TEXT_FIELD_DEFAULT,
+    SYNTHETIC_N_PLUS_1_COLUMNS,
+    apply_synthetic_n_plus_1_migration,
+)
+
+_ISSUER: str = "https://keycloak.test/realms/meho"
+_AUDIENCE: str = "meho-backplane"
+_DISCOVERY_URL: str = f"{_ISSUER}/.well-known/openid-configuration"
+_JWKS_URL: str = f"{_ISSUER}/protocol/openid-connect/certs"
+
+
+# ---------------------------------------------------------------------------
+# Docker-availability skip — same shape as test_db_engine.TestPostgresIntegration
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_present() -> bool:
+    """Heuristic: Docker is usable if the unix socket is present.
+
+    Lifted from :mod:`tests.test_db_engine` so the skip condition
+    stays consistent across the testcontainers-PG suites — agent
+    sandboxes (no Docker) skip; CI runners (Docker provisioned) run.
+    """
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_DOCKER_AVAILABLE: bool = _docker_socket_present()
+_SKIP_REASON: str = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+
+# ---------------------------------------------------------------------------
+# JWT / Vault helpers — mirror tests/test_audit_middleware.py
+# ---------------------------------------------------------------------------
+
+
+def _make_rsa_keypair(kid: str) -> Any:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return JsonWebKey.generate_key(
+            "RSA",
+            2048,
+            options={"kid": kid},
+            is_private=True,
+        )
+
+
+def _public_jwks(*keys: Any) -> dict[str, list[dict[str, Any]]]:
+    return {"keys": [k.as_dict(is_private=False) for k in keys]}
+
+
+def _mint_token(private_key: Any, *, sub: str = "op-rollback") -> str:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        jwt = JsonWebToken(["RS256"])
+        now = int(time.time())
+        payload: dict[str, Any] = {
+            "sub": sub,
+            "iss": _ISSUER,
+            "aud": _AUDIENCE,
+            "iat": now,
+            "exp": now + 3600,
+            "nbf": now,
+            "name": "Forward Compat",
+            "email": "fc@example.com",
+        }
+        header = {"alg": "RS256", "kid": private_key.as_dict()["kid"], "typ": "JWT"}
+        token: bytes | str = jwt.encode(header, payload, private_key)
+        return token.decode("ascii") if isinstance(token, bytes) else token
+
+
+def _mock_discovery_and_jwks(
+    mock_router: respx.MockRouter,
+    jwks: dict[str, Any],
+) -> None:
+    mock_router.get(_DISCOVERY_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"issuer": _ISSUER, "jwks_uri": _JWKS_URL},
+        ),
+    )
+    mock_router.get(_JWKS_URL).mock(
+        return_value=httpx.Response(200, json=jwks),
+    )
+
+
+class _FakeJWTAuth:
+    """Minimal hvac jwt-auth shim — replays
+    :class:`tests.test_audit_middleware._FakeJWTAuth` without the
+    dataclass machinery (the test only ever needs ``jwt_login``)."""
+
+    def __init__(self) -> None:
+        self.issued_token: str = "fake-vault-token"
+        self.parent: _FakeClient | None = None
+
+    def jwt_login(
+        self,
+        role: str,
+        jwt: str,
+        path: str | None = None,
+    ) -> dict[str, Any]:
+        if self.parent is not None:
+            self.parent.token = self.issued_token
+        return {"auth": {"client_token": self.issued_token}}
+
+
+class _FakeTokenAuth:
+    def revoke_self(self, mount_point: str = "token") -> None:
+        return None
+
+
+class _FakeAuth:
+    def __init__(self) -> None:
+        self.jwt = _FakeJWTAuth()
+        self.token = _FakeTokenAuth()
+
+
+class _FakeKVv2:
+    def __init__(self) -> None:
+        self.secret: dict[str, Any] = {"username": "demo"}
+        self.version: int = 11
+
+    def read_secret_version(self, path: str, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "data": {
+                "data": self.secret,
+                "metadata": {"version": self.version, "path": path},
+            }
+        }
+
+
+class _FakeKV:
+    def __init__(self) -> None:
+        self.v2 = _FakeKVv2()
+
+
+class _FakeSecrets:
+    def __init__(self) -> None:
+        self.kv = _FakeKV()
+
+
+class _FakeSysBackend:
+    def read_health_status(self, *, method: str = "HEAD", **_kwargs: Any) -> Any:
+        return None
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.url: str = "https://vault.test"
+        self.timeout: float = 5.0
+        self.namespace: str | None = None
+        self.token: str | None = None
+        self.auth = _FakeAuth()
+        self.sys = _FakeSysBackend()
+        self.secrets = _FakeSecrets()
+        self.auth.jwt.parent = self
+
+
+def _install_fake_vault(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
+    """Replace ``meho_backplane.auth.vault._build_client`` with a fake.
+
+    The forward-compat test does not exercise the Vault federation
+    chain — it only needs the ``/api/v1/health`` route to reach the
+    audit-write middleware with a valid operator binding. The fake
+    keeps the route's Vault-status branch on the success path so the
+    response is 200 rather than 502/500.
+    """
+    fake = _FakeClient()
+
+    def _fake_build_client(_settings: Any, *, token: str | None = None) -> _FakeClient:
+        fake.token = token
+        return fake
+
+    monkeypatch.setattr(vault_module, "_build_client", _fake_build_client)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+def _async_url_from(sync_url: str) -> str:
+    """Translate a testcontainers-issued sync URL to the asyncpg URL.
+
+    ``PostgresContainer.get_connection_url`` returns
+    ``postgresql+psycopg2://...`` by default. The backplane's engine
+    factory (and Alembic's env.py) target asyncpg; ADR 0004 pins the
+    driver. This helper handles both the default psycopg2 prefix and
+    the bare ``postgresql://`` shape that older testcontainers
+    versions emitted.
+    """
+    return sync_url.replace(
+        "postgresql+psycopg2://",
+        "postgresql+asyncpg://",
+    ).replace(
+        "postgresql://",
+        "postgresql+asyncpg://",
+    )
+
+
+@pytest.fixture
+def env_overrides(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env vars :class:`Settings` requires for module construction.
+
+    The autouse ``_default_database_url`` fixture in :mod:`tests.conftest`
+    points ``DATABASE_URL`` at a per-test SQLite tmp file *and* runs
+    ``alembic upgrade head`` against it. This fixture deliberately
+    overrides ``DATABASE_URL`` later (after the testcontainers PG
+    starts up) so the audit middleware sees the PG schema instead.
+    The conftest-time SQLite migration is harmless extra work — the
+    PG migration replaces it before any request fires.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+async def _fetch_audit_state(async_url: str) -> dict[str, Any]:
+    """Read back the single audit row plus the synthetic columns.
+
+    Issued through a dedicated short-lived :class:`AsyncEngine` so the
+    query is independent of the engine the audit middleware just
+    used (which the test must dispose-then-rebuild between phases).
+    Selecting the synthetic columns explicitly is what proves the
+    forward-compat property: if the revision-N code wrote anything
+    to ``future_field`` / ``future_jsonb_field``, the row would carry
+    those values; otherwise the columns hold their PostgreSQL-side
+    defaults. Either outcome is observable here.
+
+    Returns the row as a dict so the caller can assert on each
+    field by name; using positional indices into a tuple was the
+    earlier shape and made assertion failures harder to read.
+    """
+    engine = create_async_engine(async_url)
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT "
+                    "operator_sub, method, path, status_code, "
+                    "future_field, future_jsonb_field "
+                    "FROM audit_log "
+                    "ORDER BY occurred_at DESC "
+                    "LIMIT 1"
+                )
+            )
+            row = result.first()
+            row_count_result = await conn.execute(text("SELECT COUNT(*) FROM audit_log"))
+            count = row_count_result.scalar_one()
+    finally:
+        await engine.dispose()
+
+    if row is None:
+        return {"count": count, "row": None}
+    return {
+        "count": count,
+        "row": {
+            "operator_sub": row[0],
+            "method": row[1],
+            "path": row[2],
+            "status_code": row[3],
+            "future_field": row[4],
+            "future_jsonb_field": row[5],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# The forward-compat regression test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason=_SKIP_REASON)
+class TestForwardCompatRollback:
+    """Backplane image at revision N runs cleanly against schema at revision N+1.
+
+    The test class form mirrors :class:`tests.test_db_engine.TestPostgresIntegration`
+    so the skip annotation applies once at the class level and the
+    intent — "this class is the testcontainers-PG slice; skipped
+    when Docker is absent" — is visible on a single line.
+    """
+
+    def test_n_image_runs_cleanly_against_n_plus_1_schema(
+        self,
+        env_overrides: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Full forward-compat round-trip — see module docstring.
+
+        The test is **synchronous** for the same reason every other
+        ``alembic upgrade head`` driving test in this suite is sync:
+        ``alembic.command.upgrade`` invokes :func:`asyncio.run`
+        internally via the env.py async cookbook, and ``asyncio.run``
+        cannot be re-entered from a running loop. Decorating with
+        ``@pytest.mark.asyncio`` would crash. Async work that the
+        test needs to do directly (the audit-row read-back) is
+        wrapped in its own ``asyncio.run`` boundary, mirroring how
+        Alembic itself does it.
+        """
+        from testcontainers.postgres import PostgresContainer
+
+        operator_sub = "op-rollback"
+        key = _make_rsa_keypair("kid-rollback")
+        token = _mint_token(key, sub=operator_sub)
+        _install_fake_vault(monkeypatch)
+
+        with PostgresContainer("postgres:16-alpine") as pg:
+            sync_url = pg.get_connection_url()
+            async_url = _async_url_from(sync_url)
+
+            # Step 1 — migrate the PG schema to revision N (current head).
+            # ``DATABASE_URL`` must be set before ``command.upgrade`` so the
+            # alembic env.py picks up the test container's URL rather than
+            # the conftest-installed SQLite default.
+            monkeypatch.setenv("DATABASE_URL", async_url)
+            get_settings.cache_clear()
+            reset_engine_for_testing()
+
+            cfg = alembic_config()
+            cfg.set_main_option("sqlalchemy.url", async_url)
+            command.upgrade(cfg, "head")
+
+            # Step 2 — apply the synthetic N+1 additive migration.
+            # The helper drives its own ``asyncio.run`` so the outer
+            # test stays synchronous.
+            apply_synthetic_n_plus_1_migration(async_url)
+
+            # Step 3 — wire the production engine cache at the PG URL
+            # so the audit middleware writes through the test container,
+            # not through the conftest-installed SQLite engine that the
+            # autouse fixture cached. The cache reset *plus* explicit
+            # injection is what makes this safe to interleave with the
+            # autouse fixture's own engine teardown.
+            reset_engine_for_testing()
+            engine_module._engine = create_engine_for_url(async_url, pool_size=5, pool_timeout=10.0)
+
+            try:
+                # Step 4 — drive a real authenticated request through
+                # the production app. The audit middleware writes to
+                # ``audit_log`` against the N+1 schema; the revision-N
+                # code only knows the original column set.
+                client = TestClient(app)
+                with respx.mock as mock_router:
+                    _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+                    response = client.get(
+                        "/api/v1/health",
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
+
+                # Assertion (a) — backplane handled the request cleanly.
+                # No 5xx is the explicit forward-compat acceptance
+                # criterion; the schema being ahead must not poison
+                # the request hot path.
+                assert response.status_code == 200, (
+                    "revision-N image must serve a 200 against revision-N+1 schema; "
+                    f"got {response.status_code}: {response.text!r}"
+                )
+
+                # Assertion (b) + (c) — the audit row landed with the
+                # revision-N column set populated correctly.
+                state = asyncio.run(_fetch_audit_state(async_url))
+                assert state["count"] == 1, f"expected exactly one audit row, got {state['count']}"
+                row = state["row"]
+                assert row is not None
+                assert row["operator_sub"] == operator_sub
+                assert row["method"] == "GET"
+                assert row["path"] == "/api/v1/health"
+                assert row["status_code"] == 200
+
+                # Assertion (d) — the load-bearing negative test. The
+                # synthetic N+1 columns were added with PG-side
+                # defaults; if the revision-N code had written to
+                # them (e.g. via a ``SELECT *``-shaped reflection or
+                # an explicit column list that included future
+                # fields), the values would differ. Asserting the
+                # defaults landed verbatim proves the revision-N
+                # ORM never mentioned the new columns on insert.
+                assert row["future_field"] == FUTURE_TEXT_FIELD_DEFAULT, (
+                    "future_field on the audit row must hold the PG-side default; "
+                    "any other value would mean the revision-N code wrote to a "
+                    "column it should not know about, falsifying the forward-compat "
+                    f"property. Saw: {row['future_field']!r}"
+                )
+                assert row["future_jsonb_field"] == FUTURE_JSONB_FIELD_DEFAULT, (
+                    "future_jsonb_field must hold the PG-side jsonb default; "
+                    f"saw {row['future_jsonb_field']!r}"
+                )
+
+                # Sanity — the columns we asserted on cover every
+                # synthetic column the migration added. Drift between
+                # the migration's column list and the test's
+                # assertions would silently shrink coverage; the
+                # explicit subset check is the lock against that.
+                assert set(SYNTHETIC_N_PLUS_1_COLUMNS) == {
+                    "future_field",
+                    "future_jsonb_field",
+                }
+            finally:
+                # Tear down the engine cache before the container goes
+                # away — leaving an asyncpg pool pointing at a stopped
+                # container would leak warnings on event-loop shutdown.
+                asyncio.run(dispose_engine())
+                reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Always-on smoke — proves the synthetic-migration helper imports cleanly
+# even on no-Docker sandboxes, so a typo / syntax error surfaces fast in CI
+# without the full PG suite running.
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_migration_helper_exposes_documented_constants() -> None:
+    """Module-level smoke: the fixture's public surface stays stable.
+
+    The test itself is cheap — no Docker, no PG, no event loop. It
+    catches the failure mode "someone renamed a constant in
+    ``synthetic_n_plus_1.py`` and the testcontainers test fails to
+    import on the runner that *does* have Docker", which would
+    otherwise only surface in CI at the bottom of a 5-minute matrix.
+    """
+    assert FUTURE_TEXT_FIELD_DEFAULT == "reserved_for_v0.2"
+    assert FUTURE_JSONB_FIELD_DEFAULT == {}
+    assert tuple(SYNTHETIC_N_PLUS_1_COLUMNS) == (
+        "future_field",
+        "future_jsonb_field",
+    )
+    # Helper must be importable and callable; we don't invoke it (no
+    # PG to point at), but referencing the symbol catches a removed
+    # export.
+    assert callable(apply_synthetic_n_plus_1_migration)
+
+
+def test_docker_skip_reason_explains_ci_path() -> None:
+    """Soft contract: the skip message points at CI.
+
+    A future agent debugging "why is this test not running locally"
+    needs the breadcrumb. Asserting on the skip-reason text keeps
+    the breadcrumb readable.
+    """
+    assert "CI" in _SKIP_REASON
+    assert "Docker" in _SKIP_REASON

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -146,6 +146,31 @@ this stage it exposes:
   revert + forward-compat schema discipline, per Goal #11 DoD bullet
   3); the first migration's `downgrade()` legitimately drops the
   table it just created and a flat scan would trip on it.
+* Forward-compat regression test (Task #30) —
+  `backend/tests/test_migration_rollback.py` is the unit-test-level
+  proof of Goal #11 DoD bullet 3's *code-side* discipline: the
+  running backplane image must tolerate a schema *ahead* of it
+  (revision N+1 columns the revision-N image doesn't know about).
+  The test spins up `postgres:16-alpine` via testcontainers, runs
+  `alembic upgrade head` to revision N, applies a synthetic
+  additive migration from
+  `backend/tests/fixtures/synthetic_n_plus_1.py` (two columns —
+  `future_field text` and `future_jsonb_field jsonb`, both with
+  PostgreSQL-side defaults), then drives a real authenticated
+  `GET /api/v1/health` request through the production app. The
+  load-bearing assertion is **negative**: the synthetic columns
+  hold their PG-side defaults verbatim, proving the revision-N
+  ORM/middleware never wrote to columns it should not know about
+  (the property a `SELECT *`-shaped query or a future-aware column
+  list would falsify). The synthetic migration deliberately lives
+  outside `backend/alembic/versions/` so the production migration
+  graph and the CI guard's path filter stay undisturbed. The test
+  skips on agent sandboxes without Docker (same heuristic as
+  `tests.test_db_engine.TestPostgresIntegration`); CI runs it on
+  the runner pool that provisions Docker. The cluster-level proof
+  of the same property — exercising real `helm rollback` against a
+  running deployment — is Goal #11's G2.8-T3, intentionally out of
+  scope here.
 * Audit middleware (Task #28) — `backend/src/meho_backplane/audit.py`
   defines the **pure-ASGI** `AuditMiddleware` that writes one row to
   `audit_log` per authenticated request **before** the response yields


### PR DESCRIPTION
## Summary

- Adds `backend/tests/test_migration_rollback.py` — a testcontainers-based forward-compat regression test that proves the revision-N backplane image runs cleanly against a database whose schema is at revision N+1 (the situation `helm rollback` lands in).
- Adds `backend/tests/fixtures/synthetic_n_plus_1.py` — synthetic additive migration helper that drops two columns onto `audit_log` (`future_field text`, `future_jsonb_field jsonb`) via raw DDL through an asyncpg-backed `AsyncEngine`. The synthetic intentionally lives outside `backend/alembic/versions/` so the production migration graph and the CI guard's path filter (`migration-compat.yml`) stay undisturbed.
- Closes the unit-test-level half of Goal #11 DoD bullet 3 (`helm rollback` works without DB intervention). The cluster-level half — exercising real `helm rollback` against a running deployment — is G2.8-T3.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (21 source files, no issues)
- [x] `uv run pytest tests/test_migration_rollback.py -v` — 2 passed (always-on smoke), 1 skipped (testcontainers PG slice; Docker not available in this sandbox — runs in CI where the runner pool provisions Docker, expected ~5-10s including PG startup)
- [x] `uv run pytest -x -q` (full suite) — 176 passed, 2 skipped (the two testcontainers-PG slices), 0 regressions
- [x] `uv run pytest tests/test_migration_compat.py -v` — 19 passed (verifies the synthetic fixture under `tests/fixtures/` does not pollute the production migration sequence and the CI guard still passes against the real `versions/` tree)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0

### Acceptance-criteria evidence (per issue body)

- [x] Test file exists with SPDX header
- [x] `postgres:16-alpine` via testcontainers; `alembic upgrade head`; synthetic additive migration adds two columns (one text + default, one jsonb + default) ahead of code
- [x] Authenticated request through FastAPI test client; assertions on 200 + audit row written
- [x] Synthetic columns hold their PG-side defaults verbatim on the written row (load-bearing **negative** assertion: proves revision-N code never reached for columns it should not know about)
- [x] Runs in CI: skipped-in-sandbox locally, expected `1 passed in ~5-10s` on a Docker-provisioned runner

## Out of scope

- Real `helm rollback` deploy proof — Goal #11's G2.8-T3
- `alembic downgrade` testing — v0.1 doesn't support down-migrations; rollback is image-revert with schema-stays-ahead
- Multi-version compatibility matrix (N-2, N-3) — v0.1 supports N to N-1; deeper rollbacks are out-of-scope per the issue body
- Performance regression on schema with many additive columns — v0.2 concern

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added forward-compatibility regression test to verify the application operates correctly when the database schema is ahead of the running version, ensuring future columns are left unchanged.

* **Documentation**
  * Documented the new forward-compatibility testing approach in the backend codebase guide.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->