### PR TITLE
ci: switch migration-compat workflow to self-hosted meho-runners

### DIFF
--- a/.github/workflows/migration-compat.yml
+++ b/.github/workflows/migration-compat.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   check:
     name: Backward-compat migration guard
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, meho-runners]
     timeout-minutes: 5
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Follow-up to #160. The `migration-compat.yml` workflow was added in #159 in parallel with the bulk switch, so it slipped through still pointing at `ubuntu-latest`.
- Aligns it with every other workflow (`[self-hosted, meho-runners]`).

## Notes
- `runner-smoke.yml` already uses the self-hosted pool (bare `meho-runners` label) — intentionally left alone since it's already on the right runners.

## Test plan
- [ ] PR's own `check` job runs on the self-hosted pool (not queued indefinitely)
- [ ] `actions/setup-python` and `uv` install succeed on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration for enhanced build infrastructure management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/162)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->