### PR TITLE
feat(backend): finalize multi-arch Dockerfile (linux/amd64 + linux/arm64)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -19,6 +19,28 @@ __pycache__/
 # Tests are not shipped in the runtime image.
 tests/
 
+# Repo-root entries when the build is invoked from above `backend/`. The
+# default context is `backend/` (so these are no-ops), but listing them
+# is defence in depth for the rare CI invocation that uses the repo root
+# as context. Leaking `.git/` into a build context exposes commit history
+# (and any historical secrets) to the image layers and to anyone who can
+# pull the published image.
+.git/
+.github/
+.gitignore
+.gitattributes
+
+# Documentation. README.md is required by hatchling at wheel-build time
+# (see note further down), so it is whitelisted back in below.
+*.md
+!README.md
+
+# Docker-related files (not needed inside the image).
+Dockerfile*
+.dockerignore
+docker-compose*.yml
+docker-compose*.yaml
+
 # Editor / OS noise.
 .idea/
 .vscode/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,16 +3,56 @@
 
 # syntax=docker/dockerfile:1.7
 
+# ---------- Base image (digest-pinned manifest list) ------------------------
+# Pin the base image by its OCI manifest-list digest, not by the floating
+# `:3.12-slim` tag. The manifest-list digest indirects into the per-arch
+# image (amd64, arm64, …) automatically when buildx builds for multiple
+# `--platform` targets — same line, correct arch, byte-identical input.
+#
+# Refresh policy: every digest bump lands in a dedicated PR titled
+# "chore(backend): bump python:3.12-slim base digest to <new>" so the
+# supply-chain audit trail records when and why the input moved. Run
+# `docker manifest inspect python:3.12-slim` (or the Docker Hub `tags`
+# API for the current digest) to verify before bumping.
+#
+# Pinned digest : sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe
+# Recorded on   : 2026-05-10
+# Source        : docker.io/library/python:3.12-slim (Debian bookworm,
+#                 Python 3.12.x, multi-arch manifest list)
+ARG PYTHON_BASE_DIGEST=sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe
+
 # ---------- Builder ----------------------------------------------------------
 # Resolves and installs locked dependencies into /app/.venv. The two-step
 # `uv sync` (deps first, then project) keeps the dependency layer cacheable
 # across source-only rebuilds — see
 # https://docs.astral.sh/uv/guides/integration/docker/.
-FROM python:3.12-slim AS builder
+#
+# Multi-arch invariant: buildx runs this whole Dockerfile once per target
+# `--platform` (e.g. linux/amd64 and linux/arm64). We do *not* split the
+# builder onto `--platform=$BUILDPLATFORM` because the backplane depends
+# on compiled-wheel packages (`asyncpg`, `cryptography`, `pydantic-core`)
+# that must be installed for the **target** arch — cross-compiling those
+# from a builder running on a different arch is fragile. Instead we
+# accept QEMU emulation cost for the non-native target (typically 3–5×
+# slower than native for arm64 on amd64 hosts; documented in
+# `docs/codebase/backend.md`). `BUILDPLATFORM` and `TARGETPLATFORM` are
+# auto-populated by BuildKit and surfaced in the build log so CI runs
+# show which arch each layer compiled on.
+FROM python@${PYTHON_BASE_DIGEST} AS builder
 
-# Pin uv at a digest in CI when reproducibility matters; the ":latest" tag
-# is acceptable for the chassis bootstrap.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "Builder running on BUILDPLATFORM=${BUILDPLATFORM} for TARGETPLATFORM=${TARGETPLATFORM}"
+
+# uv installer image — pinned to a specific version AND manifest-list digest
+# so the build is byte-identical across rebuilds and the supply-chain audit
+# names the exact uv binary. Refresh in the same dedicated PR that bumps
+# PYTHON_BASE_DIGEST when the surrounding toolchain moves.
+#
+# Pinned uv     : 0.11.12
+# Manifest-list : sha256:3a59a3cdd5f7c217faa36e32dbc7fddbb0412889c2a0a5229f6d790e5a019dd7
+# Verify        : crane digest ghcr.io/astral-sh/uv:0.11.12
+COPY --from=ghcr.io/astral-sh/uv:0.11.12@sha256:3a59a3cdd5f7c217faa36e32dbc7fddbb0412889c2a0a5229f6d790e5a019dd7 /uv /uvx /bin/
 
 ENV UV_PYTHON_DOWNLOADS=0 \
     UV_LINK_MODE=copy \
@@ -31,13 +71,19 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --no-install-project
 
 # Step 2: copy the project source and install the project itself, non-editable
-# so the wheel ends up in the venv rather than as a `.pth` reference.
+# so the wheel ends up in the venv rather than as a `.pth` reference. The
+# wheel build pulls in `alembic.ini` and `alembic/` via hatch's
+# `[tool.hatch.build.targets.wheel.force-include]` (see backend/pyproject.toml);
+# hatch errors out when a force-include source is missing, so both must
+# exist in the build context at the moment of `uv sync --no-editable`.
 COPY src ./src
+COPY alembic ./alembic
+COPY alembic.ini ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --no-editable
 
 # ---------- Runtime ----------------------------------------------------------
-FROM python:3.12-slim AS runtime
+FROM python@${PYTHON_BASE_DIGEST} AS runtime
 
 # Non-root user (uid 1001 — fixed for k8s SecurityContext alignment).
 RUN useradd --system --uid 1001 --gid 0 --no-create-home --shell /usr/sbin/nologin meho
@@ -45,10 +91,22 @@ RUN useradd --system --uid 1001 --gid 0 --no-create-home --shell /usr/sbin/nolog
 # Build-identity stamps surfaced via GET /version. CI passes these via
 # `docker build --build-arg GIT_SHA=$(git rev-parse HEAD) \
 #                --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)`
-# (G2.4 will pin that exact invocation). When unset, /version falls back
+# (G2.4-T2 wires the exact invocation). When unset, /version falls back
 # to "unknown" so locally-built images don't crash on startup.
 ARG GIT_SHA=unknown
 ARG BUILD_DATE=unknown
+
+# OCI image annotations — the published image is self-describing and the
+# registry can link back to the source repo, license, and revision without
+# a separate metadata store. Spec:
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.source="https://github.com/evoila/meho" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="meho-backplane" \
+      org.opencontainers.image.description="MEHO governance-layer backplane (HTTP server, observability, audit, federation)." \
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.vendor="evoila"
 
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/backend/README.md
+++ b/backend/README.md
@@ -58,8 +58,62 @@ docker rm -f meho-backplane
 The image runs as **uid 1001** in the root group (gid 0) so the
 runtime filesystem can stay read-only when the orchestrator sets
 `readOnlyRootFilesystem: true` (configured in the Helm chart in
-G2.5). The base image is `python:3.12-slim`; the runtime stage
-contains only the locked virtualenv, no build tools.
+G2.5). The base image is `python:3.12-slim` pinned by manifest-list
+digest (see `Dockerfile` — `ARG PYTHON_BASE_DIGEST`); the runtime
+stage contains only the locked virtualenv, no build tools.
+
+## Multi-arch build (linux/amd64 + linux/arm64)
+
+The image is published for both `linux/amd64` (Hetzner deploy target)
+and `linux/arm64` (Apple Silicon developer machines). Building the
+manifest list locally requires `docker buildx` with QEMU registered
+for the non-native architecture.
+
+```bash
+cd backend/
+
+# One-time: register QEMU for cross-arch emulation on an amd64 host
+# (and create a dedicated builder so the default builder stays
+# untouched).
+docker run --privileged --rm tonistiigi/binfmt --install all
+docker buildx create --use --name meho-builder
+
+# Build both architectures into a manifest list. `--load` only works
+# with a single platform — to inspect both archs locally, push to a
+# local registry or omit `--load` and use `buildx imagetools` after
+# pushing to a registry.
+docker buildx build \
+  --platform=linux/amd64,linux/arm64 \
+  --build-arg GIT_SHA=$(git rev-parse HEAD) \
+  --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -t meho-backplane:multiarch-test \
+  --output=type=image,push=false \
+  .
+
+# Inspect the manifest list (after pushing to a registry — buildx
+# does not write multi-arch manifests to the local docker daemon).
+docker buildx imagetools inspect meho-backplane:multiarch-test
+
+# Per-arch single-platform builds (loadable into the local daemon):
+docker buildx build --platform=linux/amd64 --load -t meho-backplane:amd64 .
+docker buildx build --platform=linux/arm64 --load -t meho-backplane:arm64 .
+
+# Smoke-test the resulting image — `platform.machine()` is the arch
+# Python sees, which matches the build platform.
+docker run --rm --platform=linux/amd64 meho-backplane:amd64 \
+  python -c "import platform; print(platform.machine())"     # → x86_64
+docker run --rm --platform=linux/arm64 meho-backplane:arm64 \
+  python -c "import platform; print(platform.machine())"     # → aarch64
+```
+
+**Expect arm64 builds on an amd64 host to take 3–5× longer than the
+native amd64 build** — QEMU user-mode emulation translates every
+guest instruction, and `uv`'s wheel-install step is heavy on
+compiled extensions (`asyncpg`, `cryptography`, `pydantic-core`).
+The CI pipeline (G2.4-T2) runs both architectures in parallel jobs
+so wall-clock time is bounded by the slower job, not the sum.
+`docs/codebase/backend.md` records the cost detail and the refresh
+policy for `PYTHON_BASE_DIGEST`.
 
 ## What this skeleton intentionally omits
 

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -334,6 +334,102 @@ Pinned-floor declarations; exact versions resolved into `uv.lock`.
 | (dev) `ruff` ≥ 0.5 | | Lint + format. |
 | (dev) `mypy` ≥ 1.10 | | Strict type checking. |
 
+## Container image (multi-arch build)
+
+The backplane ships as a multi-stage Docker image at `backend/Dockerfile`,
+built for `linux/amd64` (Hetzner deploy target) and `linux/arm64`
+(Apple Silicon developer machines, GitHub Actions arm64 runners).
+
+### Base image digest pin (Task #32)
+
+`ARG PYTHON_BASE_DIGEST` near the top of the Dockerfile pins the base
+image to a specific OCI manifest-list digest, not the floating
+`python:3.12-slim` tag. The digest references the manifest list, not a
+per-arch image — buildx resolves it to the correct `linux/amd64` or
+`linux/arm64` child at build time, so one pin covers both architectures.
+
+| Field | Value |
+| --- | --- |
+| Base | `docker.io/library/python:3.12-slim` |
+| Pinned digest | `sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe` |
+| Pinned on | 2026-05-10 |
+| Verify | `docker manifest inspect python:3.12-slim` or the [Docker Hub `tags` API](https://hub.docker.com/v2/repositories/library/python/tags/3.12-slim) |
+
+The uv installer image (`ghcr.io/astral-sh/uv`) is also digest-pinned
+at `0.11.12@sha256:3a59a3cdd5f7c217faa36e32dbc7fddbb0412889c2a0a5229f6d790e5a019dd7`
+in the same file. The two pins move together when the toolchain
+upgrades.
+
+**Refresh policy.** Every digest bump lands in a dedicated PR titled
+`chore(backend): bump python:3.12-slim base digest to <new>`. Open a
+new PR rather than batching the digest bump into an unrelated change
+— the supply-chain audit trail (G2.4-T3 cosign + G2.4-T4 SBOM) reads
+this PR as the provenance event for the upgrade. The same rule
+applies to the uv digest.
+
+### arm64 cross-compile cost (Task #32)
+
+The Dockerfile does *not* split the builder stage onto
+`--platform=$BUILDPLATFORM` (the cross-compile pattern from the Docker
+multi-platform guide). Buildx runs the full Dockerfile once per target
+platform; for the non-native architecture this means QEMU user-mode
+emulation translates every guest instruction.
+
+**Expect arm64 builds on an amd64 host to take 3–5× longer than the
+native amd64 build.** The dominant cost is `uv sync --no-editable`
+invoking the wheel installer for compiled extensions:
+
+- `asyncpg` — C extension, native build under QEMU
+- `cryptography` — Rust + C extensions, slowest single dep
+- `pydantic-core` — Rust extension
+- `greenlet` — C extension
+
+Cross-compile via `--platform=$BUILDPLATFORM` was considered and
+rejected: it works cleanly for pure-Python projects but breaks here
+because the builder would be installing wheels for the wrong arch
+(or recompiling Rust crates without a cross toolchain configured).
+The CI pipeline (G2.4-T2) runs amd64 and arm64 in parallel jobs so
+wall-clock time is bounded by the slower job, not the sum; the
+self-hosted `meho-runners` pool (introduced in PR #160) can provision
+arm64 nodes natively when the team is ready to skip QEMU entirely
+for the arm64 leg.
+
+### .dockerignore discipline
+
+`backend/.dockerignore` excludes:
+
+- `tests/`, `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`,
+  `.ruff_cache/` — never shipped in the runtime image
+- `.git/`, `.github/` — defence in depth against build contexts
+  rooted above `backend/`
+- `*.md` (whitelist-exempt: `README.md` for hatchling
+  `[project].readme`)
+- `Dockerfile*`, `.dockerignore`, `docker-compose*.yml` — never
+  needed inside the image
+- `.env*`, `*.pem`, `*.key`, `*.crt` — secret-shaped paths,
+  whitelist-exempt: `.env.example`
+
+`README.md` is intentionally **not** excluded — hatchling errors at
+wheel-build time with `OSError: Readme file does not exist:
+README.md` when `[project].readme` is set and the file is absent.
+
+### OCI image labels
+
+The runtime stage stamps the published image with OCI annotations
+(see [image-spec annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)):
+
+- `org.opencontainers.image.source=https://github.com/evoila/meho`
+- `org.opencontainers.image.licenses=Apache-2.0`
+- `org.opencontainers.image.title=meho-backplane`
+- `org.opencontainers.image.description=…`
+- `org.opencontainers.image.revision=${GIT_SHA}` (filled by CI via
+  `--build-arg GIT_SHA=$(git rev-parse HEAD)`)
+- `org.opencontainers.image.created=${BUILD_DATE}` (RFC 3339 UTC)
+- `org.opencontainers.image.vendor=evoila`
+
+`revision` and `created` flow into `GET /version` via the same build
+args, so the registry view and the running app agree on identity.
+
 ## Known issues
 
 `/ready` returns 503 until every registered probe passes. After Task
@@ -396,6 +492,9 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - Task #27 — PG connection pool + Alembic wiring + DB-migration-state readiness probe
 - Task #28 — Audit table schema + synchronous audit-write middleware
 - Task #29 — Migration runner entrypoint + CI guard rejecting destructive migration patterns
+- Task #32 — Multi-stage Dockerfile finalized + multi-arch buildx (linux/amd64 + linux/arm64); base image digest-pinned
+- [OCI image-spec annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+- [Docker buildx multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
 - [SQLAlchemy 2.x async overview](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
 - [SQLAlchemy 2.x pool / pre-ping disconnect handling](https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic)
 - [Alembic async migrations cookbook](https://alembic.sqlalchemy.org/en/latest/cookbook.html#using-asyncio-with-alembic)


### PR DESCRIPTION
## Summary

- Finalize `backend/Dockerfile` for multi-arch builds: pin `python:3.12-slim` and `ghcr.io/astral-sh/uv` to specific OCI manifest-list digests so the supply-chain pipeline (cosign in #34, SBOM/trivy in #35) operates on byte-identical inputs.
- Stamp `org.opencontainers.image.*` labels (source, licenses, title, description, revision, created, vendor) on the runtime stage, fed from the existing `GIT_SHA` / `BUILD_DATE` build args so the registry view and `GET /version` stay aligned.
- Restore `COPY alembic ./alembic` and `COPY alembic.ini ./` in the builder stage — hatchling's `[tool.hatch.build.targets.wheel.force-include]` (added with #155 / #159) errors out when these are absent from the build context, so the prior Dockerfile would have failed at `uv sync --no-editable` the moment anyone actually built it. Listed as in-scope because the AC requires the build to succeed.
- Surface `TARGETPLATFORM` / `BUILDPLATFORM` ARGs for CI-log visibility. Deliberately **not** splitting the builder onto `--platform=$BUILDPLATFORM` because the backplane depends on compiled wheels (`asyncpg`, `cryptography`, `pydantic-core`, `greenlet`) that cross-compile fragilely. Buildx runs the whole file once per `--platform` target with QEMU emulation for the non-native arch. arm64 cost honestly documented (3–5× slower than native).
- `backend/.dockerignore` extended (`.git/`, `.github/`, `*.md` with `README.md` whitelisted, `docker-compose*.yml`, `Dockerfile*`).
- `backend/README.md` gains the full `docker buildx build --platform=linux/amd64,linux/arm64 ...` recipe (QEMU registration via `tonistiigi/binfmt`, per-arch `--load` workflow for local smoke).
- `docs/codebase/backend.md` gains a new "Container image (multi-arch build)" section covering the digest pin policy, the arm64 cross-compile cost, `.dockerignore` discipline, and the OCI label schema.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 41 files already formatted
- [x] `uv run mypy --strict src/` — clean (21 source files)
- [x] `uv run pytest tests/` — 176 passed, 2 skipped (testcontainers PG + one Vault integration skip; both expected when the sandbox lacks the relevant socket)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exits 0
- [x] Dockerfile digest pins verified against current registry state at implementation time:
  - `python:3.12-slim` manifest-list `sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe` (Docker Hub `tags` API)
  - `ghcr.io/astral-sh/uv:0.11.12` manifest-list `sha256:3a59a3cdd5f7c217faa36e32dbc7fddbb0412889c2a0a5229f6d790e5a019dd7` (GHCR manifest API)
- [ ] Multi-arch buildx (`docker buildx build --platform=linux/amd64,linux/arm64 ...`) — deferred to CI. The Task body explicitly accepts CI-with-QEMU as the verification path, and the sandboxed agent host has no Docker daemon. G2.4-T2's `.github/workflows/image.yml` (next Task in the Initiative) will exercise the buildx invocation on the self-hosted `meho-runners` pool.

## Acceptance criteria

- [x] Dockerfile pins base image to a specific digest (not floating `python:3.12-slim`); digest + date documented in inline comment.
- [ ] `docker buildx build --platform=linux/amd64,linux/arm64 -t test:dev backend/` succeeds — **deferred to G2.4-T2 (#33) CI; no Docker in agent sandbox**.
- [x] OCI labels set (`org.opencontainers.image.source`, `licenses`, `title`, `revision`, `created`, plus `description` and `vendor` for completeness).
- [ ] amd64 / arm64 image runs correctly — **deferred to G2.4-T2 (#33) CI**.
- [x] `.dockerignore` excludes `tests/`, `.git/`, `*.md` (README.md whitelist-exempt), `docker-compose*.yml`, `.env*`.

## Out of scope

- `.github/workflows/image.yml` (multi-arch build CI workflow) — Task #33.
- Cosign signing — Task #34.
- SBOM + trivy — Task #35.
- Switching base to distroless / alpine — v0.2 supply-chain hardening.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded container documentation with multi-architecture build instructions for amd64 and arm64 platforms
  * Added comprehensive guidance on container runtime configuration, security constraints, and read-only filesystem support

* **Build & Infrastructure**
  * Enhanced container builds with pinned base images and multi-platform support for improved reliability and consistency

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->