### PR TITLE
ci(image): cosign keyless signing of pushed images via GHA OIDC

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -27,11 +27,27 @@
 # is org-scoped and changing it from a workflow would require a PAT with
 # org admin scope. README.md documents the one-time step.
 #
-# Forward-compatibility note (G2.4-T3 + G2.4-T4):
-#   - id-token: write is granted now so the cosign keyless signing step
-#     (Task #34, ADR 0006) can be appended without re-touching permissions.
+# Cosign keyless signing (Task #34, ADR 0006):
+#   - id-token: write (granted in the permissions block) lets the runner mint
+#     a GitHub Actions OIDC token; cosign exchanges that token at Fulcio for
+#     a short-lived (~10-min) signing certificate, signs the manifest-list
+#     digest, and uploads the signature + certificate to the public Rekor
+#     transparency log. No private keys, no GitHub secrets.
+#   - The signature is bound to the digest (not the tag), so every tag alias
+#     of the same digest (:sha-<long>, :main, :v<x.y.z>) is covered by one
+#     `cosign sign` invocation.
+#   - The certificate identity an operator verifies against is the workflow
+#     file path + ref pattern:
+#       https://github.com/evoila/meho/.github/workflows/image.yml@<ref>
+#     where <ref> is `refs/heads/main` for main pushes or `refs/tags/v*` for
+#     tag pushes. Verification commands and the identity regex live in
+#     backend/README.md (operator copy-paste) and docs/codebase/backend.md
+#     (rationale).
+#
+# Forward-compatibility note (G2.4-T4):
 #   - provenance + sbom on build-push-action emit small inline OCI annotations
-#     into the manifest; the richer syft SBOM attestation lands in Task #35.
+#     into the manifest; the richer syft SBOM attestation + trivy scan land in
+#     Task #35 as additional steps on this same job, after the sign step below.
 
 name: image
 
@@ -142,6 +158,39 @@ jobs:
 
       - name: Echo pushed digest
         # Surfaces the immutable manifest-list digest in workflow logs.
-        # Task #34 (cosign keyless) signs by exactly this digest.
+        # The cosign sign step below signs by exactly this digest.
         if: github.event_name != 'pull_request'
         run: echo "Pushed digest=${{ steps.build.outputs.digest }}"
+
+      - name: Install cosign
+        # Pinned to cosign-installer v4.1.2 (ships cosign v3.0.6 by default;
+        # see action.yml). v4.x dropped pre-2.0 cosign support; v3.x of cosign
+        # has keyless-by-default semantics — no COSIGN_EXPERIMENTAL=1 needed.
+        # SHA pinned per repo policy (every third-party action pins to a SHA;
+        # the trailing comment carries the human-readable tag).
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Sign image with cosign (keyless OIDC)
+        # Keyless signing flow:
+        #   1. cosign requests an OIDC token from GitHub Actions (id-token: write).
+        #   2. Fulcio CA verifies the token's claims (repo + workflow + ref) and
+        #      mints a ~10-minute x509 certificate bound to that identity.
+        #   3. cosign signs the manifest-list digest with the cert's ephemeral key.
+        #   4. cosign uploads {signature, certificate} to the public Rekor
+        #      transparency log (tlog-upload defaults to true on keyless;
+        #      disabling it would make the post-expiry certificate unverifiable
+        #      and is forbidden by ADR 0006).
+        #
+        # --yes is the non-interactive confirmation (CI has no TTY); it replaces
+        # the deprecated COSIGN_EXPERIMENTAL=1 of the cosign-1.x era.
+        #
+        # We sign the manifest-list digest, not any tag. For multi-arch builds
+        # docker/build-push-action's `digest` output IS the manifest-list digest,
+        # so this one invocation covers every per-arch child manifest and every
+        # tag alias pointing at this digest (`:sha-<long>`, `:main`, `:v<x.y.z>`).
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "ghcr.io/evoila/meho@${DIGEST}"

--- a/backend/README.md
+++ b/backend/README.md
@@ -115,6 +115,57 @@ so wall-clock time is bounded by the slower job, not the sum.
 `docs/codebase/backend.md` records the cost detail and the refresh
 policy for `PYTHON_BASE_DIGEST`.
 
+## Verifying image signatures
+
+Every image published to `ghcr.io/evoila/meho` from `.github/workflows/image.yml`
+is signed with [cosign](https://github.com/sigstore/cosign) keyless OIDC. There
+are **no private keys** to distribute — verification works against the public
+Sigstore trust root (Fulcio CA + Rekor transparency log) plus the expected
+**certificate identity** (which workflow file + ref produced the signature).
+
+The signature is bound to the manifest-list digest, so the same signature
+verifies every tag alias (`:sha-<long>`, `:main`, `:v<x.y.z>`) and every
+per-architecture child manifest under that digest.
+
+Verify the `:main` rolling tag:
+
+```bash
+cosign verify ghcr.io/evoila/meho:main \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/image\.yml@refs/heads/main$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  | jq .
+```
+
+Verify a `v*` release tag:
+
+```bash
+cosign verify ghcr.io/evoila/meho:v0.1.0 \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/image\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  | jq .
+```
+
+Verify by immutable digest (most defensible — content-addressed, never moves):
+
+```bash
+DIGEST=$(docker buildx imagetools inspect ghcr.io/evoila/meho:main \
+  --format '{{json .Manifest}}' | jq -r '.digest')
+
+cosign verify ghcr.io/evoila/meho@${DIGEST} \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/image\.yml@.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  | jq .
+```
+
+A successful verification prints a JSON array of signature payload objects;
+exit status is `0`. Verification failure (wrong identity, unsigned image,
+tampered registry) exits non-zero with a structured error.
+
+These are the same identity-regex + issuer values
+[`claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)'s
+`install.sh` uses as a **gating** check before pulling the image (per Goal #11
+cross-repo coordination).
+
 ## What this skeleton intentionally omits
 
 | Surface          | Lands in       |
@@ -138,3 +189,6 @@ policy for `PYTHON_BASE_DIGEST`.
 - [FastAPI tutorial](https://fastapi.tiangolo.com/tutorial/)
 - [uv project guide](https://docs.astral.sh/uv/concepts/projects/)
 - [uv Docker pattern](https://docs.astral.sh/uv/guides/integration/docker/)
+- [Sigstore cosign keyless signing overview](https://docs.sigstore.dev/cosign/signing/overview/)
+- [Sigstore CI quickstart (GitHub Actions OIDC)](https://docs.sigstore.dev/quickstart/quickstart-ci/)
+- [`sigstore/cosign-installer`](https://github.com/sigstore/cosign-installer) action

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -430,6 +430,82 @@ The runtime stage stamps the published image with OCI annotations
 `revision` and `created` flow into `GET /version` via the same build
 args, so the registry view and the running app agree on identity.
 
+### Cosign keyless signing (Task #34, ADR 0006)
+
+Every image push from `.github/workflows/image.yml` is signed with
+[cosign](https://github.com/sigstore/cosign) keyless OIDC against the
+public Sigstore trust root (Fulcio CA + Rekor transparency log). There
+are no private signing keys to custody, rotate, or distribute — the
+trust anchor is the **certificate identity** baked into the Fulcio
+certificate at signing time:
+
+| Field | Value |
+| --- | --- |
+| OIDC issuer | `https://token.actions.githubusercontent.com` |
+| Identity (main pushes) | `https://github.com/evoila/meho/.github/workflows/image.yml@refs/heads/main` |
+| Identity (v* tag pushes) | `https://github.com/evoila/meho/.github/workflows/image.yml@refs/tags/v<x.y.z>` |
+| Transparency log | public Rekor (`rekor.sigstore.dev`) |
+| Cosign version | v3.0.6 (pinned via `sigstore/cosign-installer@v4.1.2`) |
+
+The flow on every non-PR build:
+
+1. The job's `id-token: write` permission (granted at the workflow level
+   in PR #164's forward-compat scaffold) lets the runner mint a short-
+   lived GitHub Actions OIDC token whose subject encodes the repo +
+   workflow file path + ref.
+2. `cosign sign --yes ghcr.io/evoila/meho@<digest>` hands the OIDC
+   token to Fulcio; Fulcio mints a ~10-minute x509 certificate binding
+   an ephemeral ECDSA-P256 keypair to the OIDC identity.
+3. cosign signs the manifest-list digest with the ephemeral key and
+   uploads `{signature, certificate}` to public Rekor. The Rekor
+   inclusion proof is what verifies the (now-expired) Fulcio
+   certificate was valid at signing time — disabling tlog upload would
+   make the signature unverifiable post-expiry and is forbidden by
+   ADR 0006.
+
+**Signing by digest, not by tag.** `docker/build-push-action@v7`'s
+`outputs.digest` is the manifest-list digest, not a per-arch child.
+Signing the manifest list covers every tag alias pointing at it
+(`:sha-<long>`, `:main`, `:v<x.y.z>`) and every per-arch child
+(linux/amd64 + linux/arm64) without separate invocations. Tags are
+mutable; digests are content-addressed — the signature binds to *what*
+was signed, not the human-readable name.
+
+**The `--yes` flag** is the non-interactive confirmation prompt cosign
+otherwise emits before contacting Fulcio. CI has no TTY. It is *not*
+related to the deprecated `COSIGN_EXPERIMENTAL=1` of the cosign-1.x
+era; cosign 2.x+ makes keyless the default for `cosign sign` and the
+experimental gate is gone.
+
+**Why a single workflow signs many tag aliases.** ADR 0006 anticipates
+a future `release.yml` that bundles image + Helm chart + CLI tarball
+signing under one identity. For now, the image workflow signs only
+the image; the chart and CLI workflows (G2.5, G2.6) will each carry
+their own cosign step under their own `<workflow>.yml@<ref>` identity.
+Operator verification policies pattern-match across them
+(`--certificate-identity-regexp '.../\.github/workflows/.*\.yml@.*'`)
+where appropriate.
+
+**Verification commands** live in `backend/README.md` under "Verifying
+image signatures" — same regex, same issuer, copy-pasteable into an
+operator runbook. The downstream
+[`claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)
+`install.sh` runs that exact `cosign verify` as a **gating** check
+before `docker pull`; a failed verification aborts the install with
+the expected-identity error message.
+
+**Action pin discipline.** `sigstore/cosign-installer` is pinned to a
+commit SHA (`6f9f17788090df1f26f669e9d70d6ae9567deba6`, tag `v4.1.2`)
+matching the rest of the workflow's third-party-action pinning policy.
+The action installs cosign `v3.0.6` (its default) — bumping the action
+major version (v3 → v4) is a deliberate Renovate / Dependabot review
+because v4 dropped cosign-1.x support.
+
+**Out of scope, lands later.** SBOM (syft) attestation and trivy
+vulnerability scanning are Task #35; they extend the same workflow
+with `cosign attest` (SPDX JSON predicate) and a report-only trivy
+SARIF upload after the sign step.
+
 ## Known issues
 
 `/ready` returns 503 until every registered probe passes. After Task
@@ -493,7 +569,12 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - Task #28 — Audit table schema + synchronous audit-write middleware
 - Task #29 — Migration runner entrypoint + CI guard rejecting destructive migration patterns
 - Task #32 — Multi-stage Dockerfile finalized + multi-arch buildx (linux/amd64 + linux/arm64); base image digest-pinned
+- Task #33 — GHCR image push workflow (`.github/workflows/image.yml`)
+- Task #34 — Cosign keyless signing of pushed images via GitHub Actions OIDC (per ADR 0006)
 - [OCI image-spec annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+- [Sigstore cosign keyless signing overview](https://docs.sigstore.dev/cosign/signing/overview/)
+- [Sigstore CI quickstart (GitHub Actions OIDC)](https://docs.sigstore.dev/quickstart/quickstart-ci/)
+- [`sigstore/cosign-installer`](https://github.com/sigstore/cosign-installer) action
 - [Docker buildx multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
 - [SQLAlchemy 2.x async overview](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
 - [SQLAlchemy 2.x pool / pre-ping disconnect handling](https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic)


### PR DESCRIPTION
## Summary

- Extend `.github/workflows/image.yml` with cosign keyless signing per ADR 0006: install `sigstore/cosign-installer@v4.1.2` (cosign v3.0.6) and `cosign sign --yes` the manifest-list digest emitted by `docker/build-push-action@v7`. No private keys, no GitHub secrets — Fulcio + public Rekor + the workflow's GitHub Actions OIDC identity.
- Sign **by digest** (not by tag) — the one `cosign sign` invocation covers every per-arch child manifest and every tag alias (`:sha-<long>`, `:main`, `:v<x.y.z>`).
- Document the operator-facing `cosign verify` invocations in `backend/README.md` (copy-paste for `:main`, `v*`, and by-digest), with the same identity regex + issuer values `claude-rdc-hetzner-dc/install.sh` uses as a gating check.
- Capture the flow + sign-by-digest rationale in `docs/codebase/backend.md` under a new "Cosign keyless signing (Task #34, ADR 0006)" subsection.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/image.yml'))"` — workflow YAML parses clean.
- [x] `pre-commit-config` static hooks (trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files, gitleaks, conventional-pre-commit) — all changes within hook constraints (no secrets, all files end in newline, no whitespace tails, commit subject is conventional `ci(image): ...`).
- [x] `id-token: write` permission verified intact at the workflow level (added forward-compat by PR #164 / Task #33).
- [x] Action pin verified — `sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6` is the v4.1.2 release commit; `action.yml` at that ref declares `default: 'v3.0.6'` for `cosign-release`.
- [ ] **Runtime (verified on first post-merge `main` push run):** workflow logs show successful Fulcio issuance + Rekor upload; `cosign verify ghcr.io/evoila/meho@<digest> --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/image\.yml@refs/heads/main$' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'` exits 0 against the just-pushed image. (Cannot be verified locally — the OIDC token is only issued inside a GitHub Actions runner.)
- [ ] **Runtime (verified on first `v*` tag push):** the same `cosign verify` against a `refs/tags/v*` identity regex passes.

## Out of scope

- SBOM (syft) generation + attachment as a cosign attestation, plus trivy vulnerability scan (report-only) — Task #35; both extend this same workflow with `cosign attest` + trivy steps after the `cosign sign` step landed here.
- Helm chart and CLI signing — separate workflows per ADR 0006 implications (G2.5-T5, G2.6-T5).
- Updating the legacy "What this skeleton intentionally omits" table in `backend/README.md` (the "Multi-arch image, GHCR, cosign | Initiative G2.4" row is now historically stale after Tasks #32/#33/#34, but the table documents the v0.1 chassis bootstrap state — out of scope for a signing PR).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container images published to GHCR are now cryptographically signed.

* **Documentation**
  * Added instructions for verifying published container image signatures.
  * Updated documentation with details about the image signing process and operational flow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/165)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->