### PR TITLE
ci: use bare meho-runners label for runs-on (gha-runner-scale-set)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   lint-python:
     name: Python lint (ruff)
-    runs-on: [self-hosted, meho-runners]
+    runs-on: meho-runners
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -48,7 +48,7 @@ jobs:
 
   placeholder-tests:
     name: Tests
-    runs-on: [self-hosted, meho-runners]
+    runs-on: meho-runners
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   python-licenses:
     name: Python License Check
-    runs-on: [self-hosted, meho-runners]
+    runs-on: meho-runners
     timeout-minutes: 10
     if: hashFiles('pyproject.toml') != ''
     steps:
@@ -91,7 +91,7 @@ jobs:
 
   npm-licenses:
     name: NPM License Check
-    runs-on: [self-hosted, meho-runners]
+    runs-on: meho-runners
     timeout-minutes: 10
     if: hashFiles('**/package-lock.json') != ''
     steps:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -90,7 +90,7 @@ jobs:
     # The OR short-circuits on push events, so the missing pull_request context
     # on push is irrelevant. Job-level (not step-level) so no step ever starts.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, meho-runners]
+    runs-on: meho-runners
     timeout-minutes: 45  # arm64 emulation under QEMU is 3-5x slower than native
     steps:
       - name: Checkout

--- a/.github/workflows/migration-compat.yml
+++ b/.github/workflows/migration-compat.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   check:
     name: Backward-compat migration guard
-    runs-on: ubuntu-latest
+    runs-on: meho-runners
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   sonarcloud:
     name: SonarCloud Analysis
-    runs-on: [self-hosted, meho-runners]
+    runs-on: meho-runners
     timeout-minutes: 20
     continue-on-error: true
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   trufflehog:
     name: TruffleHog Secret Scan
-    runs-on: [self-hosted, meho-runners]
+    runs-on: meho-runners
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   semgrep:
     name: Semgrep SAST
-    runs-on: [self-hosted, meho-runners]
+    runs-on: meho-runners
     timeout-minutes: 15
     container:
       # Bump cadence: monthly review or on advisory.


### PR DESCRIPTION
## Why CI is stuck

Every job is currently sitting in \`queued\` for tens of minutes. Root cause:

\`\`\`
GET /repos/evoila/meho/actions/runners
{"id":26,"name":"meho-runners-fqq29-runner-zgfhn","status":"online","busy":false,"labels":[]}
\`\`\`

The org's runner is deployed via **gha-runner-scale-set** (ARC v2 — note the \`fqq29\` scale-set hash in the runner name). In that mode runners are addressed by scale-set name, not by labels — runners report \`labels: []\` to GitHub by design. The \`[self-hosted, meho-runners]\` list form I introduced in #160 requires both labels to be present on the runner, which never happens, so jobs wait forever.

\`runner-smoke.yml\` was already using \`runs-on: meho-runners\` (bare scale-set name) and has been completing in 8-9s consistently — that's the working pattern.

## What this PR does

Switches every workflow to bare \`runs-on: meho-runners\`:

| File | Before | After |
|---|---|---|
| ci.yml (×2) | \`[self-hosted, meho-runners]\` | \`meho-runners\` |
| dependency-license-check.yml (×2) | same | same |
| image.yml | same | same |
| quality-gate.yml | same | same |
| secret-scan.yml | same | same |
| security-scan.yml | same | same |
| migration-compat.yml | \`ubuntu-latest\` | \`meho-runners\` |
| runner-smoke.yml | \`meho-runners\` (already correct) | unchanged |

10 jobs across 8 workflows, all consistent.

## Context

- #160 picked the wrong syntax (classic-runner list form) and was inherited as the project convention by [image.yml](.github/workflows/image.yml). Both are corrected here.
- #162 was opened with the same wrong syntax and is closed — superseded by this PR.

## Test plan
- [ ] PR's own \`CI\`, \`Secret Scan\`, \`Security Scan\` jobs leave \`queued\` within seconds (not minutes)
- [ ] After merge to main, confirm all currently-stuck queued runs on other PRs/branches start picking up
- [ ] \`image.yml\` build still works (the largest job; arm64 cross-build under QEMU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment pipeline runner configurations to optimize build and testing processes across workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/167)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->