### PR TITLE
feat(deploy): Helm chart skeleton + core templates (G2.5-T1)

### DIFF
--- a/deploy/charts/meho/.helmignore
+++ b/deploy/charts/meho/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building a chart package (`helm package`).
+# Standard exclusions plus repo-specific noise.
+.DS_Store
+# Common VCS files
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# CI / agent state
+.claude/
+.github/
+.venv/
+node_modules/

--- a/deploy/charts/meho/Chart.yaml
+++ b/deploy/charts/meho/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: meho
+description: Governance backplane for AI agents acting on infrastructure
+type: application
+
+# version is the *chart* version (calver-bumped by G2.5-T5 CI: 0.1.YYYYMMDD-<sha>).
+# appVersion is the *application* version — overridden by G2.5-T5 CI to the git
+# sha being deployed. Both values are placeholders here; the publish workflow
+# rewrites them at OCI push time.
+version: 0.1.0
+appVersion: "0.1.0"
+
+# Tightest Kubernetes API version range that exercises all manifests:
+# - networking.k8s.io/v1 NetworkPolicy: stable since 1.19
+# - networking.k8s.io/v1 Ingress: stable since 1.19
+# RKE2 (Goal #11's target) ships 1.28+; tighten the floor to match.
+kubeVersion: ">=1.28.0-0"
+
+icon: https://meho.ai/icon.svg
+
+sources:
+  - https://github.com/evoila/meho
+
+maintainers:
+  - name: evoila Group
+    url: https://github.com/evoila
+
+keywords:
+  - mcp
+  - governance
+  - audit
+  - kubernetes
+  - backplane

--- a/deploy/charts/meho/templates/NOTES.txt
+++ b/deploy/charts/meho/templates/NOTES.txt
@@ -1,0 +1,25 @@
+{{ include "meho.fullname" . }} {{ .Chart.AppVersion }} installed into namespace {{ .Release.Namespace }}.
+
+Resources deployed:
+  - Deployment / {{ include "meho.fullname" . }}
+  - Service    / {{ include "meho.fullname" . }} ({{ .Values.service.type }}:{{ .Values.service.port }})
+{{- if .Values.ingress.enabled }}
+  - Ingress    / {{ include "meho.fullname" . }} (host={{ .Values.ingress.host }})
+{{- end }}
+  - ConfigMap  / {{ include "meho.fullname" . }}-config
+{{- if .Values.serviceAccount.create }}
+  - ServiceAccount / {{ include "meho.serviceAccountName" . }}
+{{- end }}
+{{- if .Values.networkPolicy.enabled }}
+  - NetworkPolicy / {{ include "meho.fullname" . }} (default-deny + explicit egress)
+{{- end }}
+
+Next steps:
+  1. Watch the rollout:
+       kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "meho.fullname" . }}
+{{- if .Values.ingress.enabled }}
+  2. Verify the Ingress comes up with TLS:
+       kubectl -n {{ .Release.Namespace }} get ingress {{ include "meho.fullname" . }}
+{{- end }}
+  3. Tail backplane logs:
+       kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/name={{ include "meho.name" . }} -f

--- a/deploy/charts/meho/templates/_helpers.tpl
+++ b/deploy/charts/meho/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Standard Helm chart template helpers. The shape matches `helm create`'s
+output (chart-name-prefixed name + fullname + selector labels) so existing
+Helm tooling and operators reading the templates see the conventions they
+expect.
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "meho.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars because some Kubernetes name fields are limited to that
+(RFC 1123 DNS label).
+*/}}
+{{- define "meho.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "meho.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels — applied to every resource the chart ships.
+*/}}
+{{- define "meho.labels" -}}
+helm.sh/chart: {{ include "meho.chart" . }}
+{{ include "meho.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels — applied to `spec.selector.matchLabels` and the Pod template
+labels so the Service/Deployment/NetworkPolicy selectors all line up.
+*/}}
+{{- define "meho.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "meho.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "meho.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "meho.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/meho/templates/configmap.yaml
+++ b/deploy/charts/meho/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "meho.fullname" . }}-config
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+data:
+  # Non-secret env vars consumed by the backplane via `envFrom` in the
+  # Deployment. Keys follow `backend/src/meho_backplane/settings.py`'s
+  # `os.environ.get` mapping exactly — the env-var names are the contract.
+  # Secrets (DATABASE_URL, Keycloak client secret, Vault role bindings)
+  # live in Kubernetes Secrets and are wired via `valueFrom.secretKeyRef`
+  # in the Deployment template.
+  KEYCLOAK_ISSUER_URL: {{ .Values.config.keycloakIssuerUrl | quote }}
+  KEYCLOAK_AUDIENCE: {{ .Values.config.keycloakAudience | quote }}
+  KEYCLOAK_JWKS_CACHE_TTL_SECONDS: {{ .Values.config.keycloakJwksCacheTtlSeconds | quote }}
+  KEYCLOAK_JWT_LEEWAY_SECONDS: {{ .Values.config.keycloakJwtLeewaySeconds | quote }}
+  VAULT_ADDR: {{ .Values.config.vaultAddr | quote }}
+  VAULT_OIDC_ROLE: {{ .Values.config.vaultOidcRole | quote }}
+  VAULT_OIDC_MOUNT_PATH: {{ .Values.config.vaultOidcMountPath | quote }}
+  VAULT_TIMEOUT_SECONDS: {{ .Values.config.vaultTimeoutSeconds | quote }}
+  DATABASE_POOL_SIZE: {{ .Values.config.databasePoolSize | quote }}
+  DATABASE_POOL_TIMEOUT: {{ .Values.config.databasePoolTimeout | quote }}

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "meho.fullname" . }}
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "meho.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "meho.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "meho.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: backplane
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "meho.fullname" . }}-config
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.credentialsSecret }}
+                  key: url
+            # Other operator-supplied secrets (Keycloak client secret, Vault
+            # role bindings) come via ESO-synced Kubernetes Secrets; G2.5-T2
+            # wires the references when the typed values contract lands.
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            {{- toYaml (omit .Values.probes.liveness "enabled") | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            {{- toYaml (omit .Values.probes.readiness "enabled") | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            {{- toYaml (omit .Values.probes.startup "enabled") | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/meho/templates/ingress.yaml
+++ b/deploy/charts/meho/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "meho.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/deploy/charts/meho/templates/networkpolicy.yaml
+++ b/deploy/charts/meho/templates/networkpolicy.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "meho.fullname" . }}
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "meho.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Only the ingress controller's namespace may reach the backplane.
+    # The selector matches RKE2's `ingress-nginx` namespace by default;
+    # override `networkPolicy.ingressControllerNamespace` per environment.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressControllerNamespace }}
+      ports:
+        - port: 8000
+          protocol: TCP
+  egress:
+    # PostgreSQL — locked to the operator-supplied CIDR. Defaults to a /32
+    # placeholder so the chart fails-closed on a misconfigured value rather
+    # than silently allowing a wide subnet.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.networkPolicy.postgresCIDR }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    # Vault — operator-supplied CIDR; default-deny otherwise.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.networkPolicy.vaultCIDR }}
+      ports:
+        - port: 8200
+          protocol: TCP
+    # Keycloak — typically reached over HTTPS through the cluster ingress
+    # or an external load balancer; CIDR is operator-supplied.
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.networkPolicy.keycloakCIDR }}
+      ports:
+        - port: 443
+          protocol: TCP
+    # Redis — in-cluster subchart (G2.5-T3) selected by the conventional
+    # Helm labels Bitnami's redis subchart sets.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: redis
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+        - port: 6379
+          protocol: TCP
+    # DNS — UDP/53 to kube-dns / CoreDNS. Without this rule every other
+    # egress rule above fails on name resolution. The selector matches the
+    # standard `k8s-app: kube-dns` label CoreDNS ships with by default.
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+{{- end }}

--- a/deploy/charts/meho/templates/service.yaml
+++ b/deploy/charts/meho/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "meho.fullname" . }}
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: {{ .Values.service.portName }}
+  selector:
+    {{- include "meho.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/meho/templates/serviceaccount.yaml
+++ b/deploy/charts/meho/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "meho.serviceAccountName" . }}
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "meho values",
+  "description": "Placeholder schema. G2.5-T2 (issue #38) populates this with the typed values contract that fails `helm install` on misconfiguration.",
+  "type": "object"
+}

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -1,0 +1,153 @@
+# Default values for the meho chart.
+#
+# This file is a **scaffold** in G2.5-T1 — every key shipped here exists so
+# `helm template` renders the core six resources for shape verification.
+# G2.5-T2 will replace these placeholders with safe-by-default values and
+# add `values.schema.json` typing. Until then, callers MUST override the
+# placeholder strings via `--set` or a values overlay; nothing here is
+# production-safe.
+
+# -- Number of replicas. v0.1 is single-replica; HA lands in v0.2.
+replicaCount: 1
+
+image:
+  # -- Image repository. The G2.4 pipeline publishes to `ghcr.io/evoila/meho`.
+  repository: ghcr.io/evoila/meho
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+  # -- Image tag. When empty, the Deployment falls back to `.Chart.AppVersion`
+  # (per the standard Helm convention from `helm create`). Pinning the tag
+  # in CI / install command (`--set image.tag=<sha>`) is the supported flow.
+  tag: ""
+
+# -- Image pull secrets when consumers mirror through a private registry.
+# Public GHCR pulls (Goal #11's locked artefact-distribution principle) need
+# no secret; the list is empty by default.
+imagePullSecrets: []
+
+# -- Override `<chart-name>` portion of resource names.
+nameOverride: ""
+# -- Override the full resource name (`<release-name>-<chart-name>`).
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Whether to create the ServiceAccount. Disable to reuse an existing SA.
+  create: true
+  # -- Annotations to attach to the ServiceAccount (e.g. IAM/IRSA bindings).
+  annotations: {}
+  # -- Name of the ServiceAccount. Empty = generated from the fullname template.
+  name: ""
+
+# -- Pod-level annotations (e.g. for sidecar injectors).
+podAnnotations: {}
+# -- Pod-level labels.
+podLabels: {}
+
+# -- Pod-level security context.
+# `runAsNonRoot: true` + a numeric `runAsUser` matches the backplane Dockerfile's
+# `USER 1001:0` directive — running with the wrong UID will fail-closed at
+# admission time on a cluster with the restricted PodSecurity profile.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context.
+# `readOnlyRootFilesystem: true` + `drop: [ALL]` are the cert-manager / ArgoCD /
+# Flux baseline. The backplane writes nothing to the root filesystem at runtime;
+# `/tmp` is mounted as an `emptyDir` for the few libraries that insist on a
+# writable tempdir.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 8000
+  # -- Name of the service port (consumed by the Ingress backend reference).
+  portName: http
+
+ingress:
+  enabled: true
+  # -- IngressClass name. Empty = let the cluster's default IngressClass apply.
+  className: ""
+  # -- Annotations applied to the Ingress. The cert-manager line below assumes
+  # a ClusterIssuer is provisioned in the cluster; override `cluster-issuer`
+  # to match the consumer's environment.
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  # -- Hostname the Ingress publishes. Placeholder; override via values overlay.
+  host: meho.local
+  # -- Path rules. Default routes every path to the backplane Service.
+  path: /
+  pathType: Prefix
+  tls:
+    enabled: true
+    # -- Name of the Kubernetes Secret holding the TLS certificate. When
+    # `cert-manager.io/cluster-issuer` is set above, cert-manager creates this
+    # Secret on first reconciliation; for manual TLS, pre-create the Secret.
+    secretName: meho-tls
+
+# -- Probe configuration. Stubbed in G2.5-T1; G2.5-T2 wires the real endpoints
+# (`/healthz` / `/ready` / `/version`) per the backplane's chassis. Keeping
+# `enabled: false` here means the rendered Deployment omits the probe blocks
+# entirely until T2 lands, avoiding a half-configured probe that would mark
+# the pod NotReady on first start.
+probes:
+  liveness:
+    enabled: false
+  readiness:
+    enabled: false
+  startup:
+    enabled: false
+
+resources: {}
+  # The defaults are intentionally empty; G2.5-T2 picks safe baselines after
+  # measuring chassis idle. Documented comparable: cert-manager ships with
+  # `requests: {cpu: 10m, memory: 32Mi}` + `limits: {memory: 64Mi}` by default.
+
+# -- ConfigMap-sourced environment variables (non-secret).
+# These map 1:1 to `backend/src/meho_backplane/settings.py` env-var contract.
+# Required fields are placeholders; the chart fails-closed when they're left
+# empty (the backplane raises at startup, which surfaces as a CrashLoopBackOff).
+config:
+  keycloakIssuerUrl: ""
+  keycloakAudience: ""
+  keycloakJwksCacheTtlSeconds: "300"
+  keycloakJwtLeewaySeconds: "30"
+  vaultAddr: ""
+  vaultOidcRole: "meho-mcp"
+  vaultOidcMountPath: "jwt"
+  vaultTimeoutSeconds: "10.0"
+  databasePoolSize: "10"
+  databasePoolTimeout: "30.0"
+
+postgres:
+  # -- Name of the Kubernetes Secret holding the DATABASE_URL value at key `url`.
+  # Synced from Vault by ESO (External Secrets Operator) in production; the
+  # consumer pre-provisions it before `helm install`.
+  credentialsSecret: meho-postgres
+
+networkPolicy:
+  enabled: true
+  # -- Namespace label value selecting the ingress controller. RKE2 ships with
+  # `ingress-nginx`; override per-cluster.
+  ingressControllerNamespace: ingress-nginx
+  # -- Egress CIDRs. Placeholders; the consumer overrides each from their
+  # environment's actual subnet allocations. The chart refuses to render an
+  # over-broad `0.0.0.0/0` egress — defense-in-depth against accidental
+  # exfiltration paths from a compromised backplane Pod.
+  postgresCIDR: 10.0.0.0/32
+  vaultCIDR: 10.0.0.0/32
+  keycloakCIDR: 10.0.0.0/32
+
+# -- Node selector applied to the Pod template.
+nodeSelector: {}
+# -- Tolerations applied to the Pod template.
+tolerations: []
+# -- Affinity rules applied to the Pod template.
+affinity: {}

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -1,0 +1,183 @@
+# `deploy/` — chart, manifests, and deployment glue
+
+> Durable map of the deployment surface. Update in lock-step with chart
+> changes; stale entries are bugs.
+
+## Overview
+
+Everything a consumer needs to install MEHO onto a Kubernetes cluster lives
+under `deploy/`. The Helm chart at `deploy/charts/meho/` is the **single
+contract** between MEHO and the deployment environment — `helm install` /
+`helm upgrade --install` consumes it and produces all six core Kubernetes
+resources that make up a running backplane:
+
+- Deployment — the backplane Pod (FastAPI app, `uvicorn` on port 8000).
+- Service — ClusterIP front-door for the Deployment, target port `http`.
+- Ingress — TLS-enabled external entry with cert-manager annotations.
+- ConfigMap — non-secret env (Keycloak URLs, Vault address, pool sizes).
+- ServiceAccount — Pod identity, `automountServiceAccountToken: false`.
+- NetworkPolicy — default-deny ingress + explicit egress allow-list to
+  Postgres, Vault, Keycloak, in-cluster Redis, and CoreDNS only.
+
+## Chart layout
+
+```
+deploy/charts/meho/
+├── Chart.yaml              # apiVersion v2, kubeVersion >=1.28
+├── .helmignore             # standard exclusions
+├── values.yaml             # scaffold defaults; G2.5-T2 hardens them
+├── values.schema.json      # placeholder; G2.5-T2 fills the typed contract
+└── templates/
+    ├── _helpers.tpl        # name / fullname / labels / SA helpers
+    ├── deployment.yaml     # backplane Pod
+    ├── service.yaml        # ClusterIP :8000
+    ├── ingress.yaml        # TLS + cert-manager
+    ├── configmap.yaml      # non-secret env
+    ├── serviceaccount.yaml # Pod identity
+    ├── networkpolicy.yaml  # default-deny + explicit egress
+    └── NOTES.txt           # post-install hints
+```
+
+## Chart contract
+
+### `Chart.yaml`
+
+- `apiVersion: v2` — required for Helm 3 / 4.
+- `version` is the **chart** version (calver-bumped by the publish workflow
+  in G2.5-T5 to `0.1.YYYYMMDD-<sha>`); `appVersion` is the **application**
+  version, overridden by the same workflow to the git sha being deployed.
+  The values shipped in `Chart.yaml` are placeholders — they exist only so
+  `helm lint` / `helm template` succeed on a fresh checkout.
+- `kubeVersion: ">=1.28.0-0"` — matches Goal #11's RKE2 target. The
+  manifests use only API versions that have been stable since 1.19; the
+  floor is set higher than strictly required to align with the test bed.
+- `sources` + `maintainers` + `keywords` follow Artifact Hub norms for
+  discoverability after the OCI publish workflow lands.
+
+### Image reference
+
+The Deployment renders `{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}`.
+That gives consumers three idiomatic ways to pin the image:
+
+1. **Pin via `--set image.tag=<sha>`** — typical CI flow; `image.tag` wins.
+2. **Pin via `appVersion` rewrite** — the publish workflow rewrites
+   `Chart.yaml.appVersion` to the git sha at OCI push time; consumers
+   who omit `image.tag` get that pin automatically.
+3. **Override `image.repository`** — consumers mirroring through a private
+   registry point the chart at their mirror.
+
+`imagePullSecrets` is a values-configurable list, empty by default. The
+backplane image is pushed to **public GHCR** (Goal #11's locked artefact-
+distribution principle), so no pull secret is required in the default
+deployment path.
+
+### Probes (scaffolded, off by default in T1)
+
+The Deployment template emits `livenessProbe` / `readinessProbe` /
+`startupProbe` blocks gated on `probes.<kind>.enabled`. All three default
+to `enabled: false` in this T1 scaffold; G2.5-T2 (issue #38) wires the
+real probe targets (`/healthz` / `/ready` / `/version`) against the
+chassis from G2.1. Keeping probes off until T2 lands avoids a half-
+configured probe marking the Pod NotReady before its health endpoints
+are reachable.
+
+### Security context
+
+The Pod runs with `runAsNonRoot: true`, `runAsUser: 1001`,
+`seccompProfile.type: RuntimeDefault`; the container drops every
+capability, disallows privilege escalation, and mounts the root filesystem
+read-only. `/tmp` is mounted as an `emptyDir` for libraries that insist on
+a writable tempdir. These defaults match cert-manager, ArgoCD, and Flux,
+and they're the minimum surface that admits a Pod under the cluster's
+**restricted** PodSecurity profile.
+
+### NetworkPolicy
+
+`networkPolicy.enabled: true` ships a default-deny policy with explicit
+egress rules to:
+
+- Postgres — `tcp/5432` to `networkPolicy.postgresCIDR`
+- Vault — `tcp/8200` to `networkPolicy.vaultCIDR`
+- Keycloak — `tcp/443` to `networkPolicy.keycloakCIDR`
+- Redis — `tcp/6379` to a `podSelector` matching the in-cluster Redis
+  subchart (G2.5-T3)
+- DNS — `udp/53` to the `k8s-app: kube-dns` selector (matches CoreDNS)
+
+Ingress is permitted only from the namespace whose
+`kubernetes.io/metadata.name` label matches
+`networkPolicy.ingressControllerNamespace` (default `ingress-nginx`,
+RKE2's bundled controller).
+
+The CIDR defaults are intentional **/32 placeholders** — they make the
+chart fail-closed if a consumer forgets to override them rather than
+silently allow a /8 subnet.
+
+## Install / upgrade
+
+```bash
+helm install meho ./deploy/charts/meho/ \
+  --namespace meho \
+  --create-namespace \
+  --set image.tag=<sha> \
+  --set ingress.host=meho.example.org \
+  --set config.keycloakIssuerUrl=https://keycloak.example.org/realms/meho \
+  --set config.keycloakAudience=meho-backplane \
+  --set config.vaultAddr=https://vault.example.org \
+  --set networkPolicy.postgresCIDR=10.0.1.0/24 \
+  --set networkPolicy.vaultCIDR=10.0.2.0/24 \
+  --set networkPolicy.keycloakCIDR=10.0.3.0/24
+
+helm upgrade --install meho ./deploy/charts/meho/ -f values-rdc.yaml
+```
+
+Until G2.5-T2 lands the typed `values.schema.json`, the chart accepts any
+shape — the safety net comes from the backplane itself, which fails-closed
+at startup on missing `KEYCLOAK_*` / `VAULT_*` / `DATABASE_URL` env vars.
+
+## Verification
+
+```bash
+helm lint deploy/charts/meho/
+
+helm template test-release deploy/charts/meho/ \
+  --set image.tag=test \
+  --set ingress.host=meho.test \
+  --set postgres.credentialsSecret=test \
+  --set networkPolicy.postgresCIDR=10.0.0.0/24 \
+  --set networkPolicy.vaultCIDR=10.0.0.0/24 \
+  --set networkPolicy.keycloakCIDR=10.0.0.0/24 \
+  --set networkPolicy.ingressControllerNamespace=ingress-nginx \
+  > /tmp/rendered.yaml
+
+grep -c '^kind:' /tmp/rendered.yaml  # expect >= 6
+```
+
+## Dependencies
+
+- Image — `ghcr.io/evoila/meho:<tag>` from G2.4 (#31). Multi-arch
+  (amd64 + arm64), cosign-signed, SBOM-attested.
+- Migration runner — invoked by a pre-install/pre-upgrade Job hook landed
+  in G2.5-T3 (#39); shells out to the entrypoint added in G2.3-T3 (#29).
+- Redis subchart — added by G2.5-T3 (#39) per ADR 0005.
+- External Secrets Operator (ESO) — owns the Kubernetes Secrets the chart
+  references (`postgres.credentialsSecret`, future Keycloak client secret,
+  future Vault role bindings). ESO is consumer-owned; the chart references
+  the synced Secrets by name only.
+
+## Known gaps (filled by sibling tasks)
+
+- `values.schema.json` is a placeholder — G2.5-T2 (#38) fills it.
+- Probes are scaffolded but disabled — G2.5-T2 (#38) wires real targets.
+- Pre-install migration Job + Redis subchart — G2.5-T3 (#39).
+- `deploy/values-examples/values-rdc-example.yaml` — G2.5-T4 (#40).
+- OCI publish to `ghcr.io/evoila/meho-chart` + cosign signing — G2.5-T5
+  (#41).
+- HPA / PDB / ServiceMonitor / PrometheusRule — deferred to v0.2.
+
+## References
+
+- Parent Goal: #11 — Deployable v0.1
+- Parent Initiative: #36 — G2.5 Helm chart
+- Helm chart structure: https://helm.sh/docs/topics/charts/
+- Kubernetes NetworkPolicy: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+- cert-manager Ingress annotations: https://cert-manager.io/docs/usage/ingress/


### PR DESCRIPTION
## Summary
- Ship the Helm chart skeleton at `deploy/charts/meho/` — Chart.yaml + the six core templates (Deployment, Service, Ingress, ConfigMap, ServiceAccount, NetworkPolicy) plus the canonical `_helpers.tpl`.
- Lock the **structure** so G2.5-T2 (#38, probes + typed `values.schema.json`), G2.5-T3 (#39, migration Job + Redis subchart), G2.5-T4 (#40, RDC values example) and G2.5-T5 (#41, OCI publish) can each focus on filling exactly one slot.
- Defaults match the cert-manager / ArgoCD / Flux security baseline: `runAsNonRoot: true`, `runAsUser: 1001`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, default-deny `NetworkPolicy` with explicit allow-egress to Postgres / Vault / Keycloak / Redis / kube-dns only.

## Test plan
- [x] `helm lint deploy/charts/meho/` — `1 chart(s) linted, 0 chart(s) failed`
- [x] `helm template test-release deploy/charts/meho/ --set image.tag=test --set ingress.host=meho.test --set postgres.credentialsSecret=test --set networkPolicy.postgresCIDR=10.0.0.0/24 --set networkPolicy.vaultCIDR=10.0.0.0/24 --set networkPolicy.keycloakCIDR=10.0.0.0/24 --set networkPolicy.ingressControllerNamespace=ingress-nginx` renders 236 lines of valid YAML containing all six core resource kinds (verified `grep -c '^kind:' == 6`; verified `yaml.safe_load_all` parses 6 documents with the expected kinds).
- [x] Rendered Deployment has `runAsNonRoot: true` + `runAsUser: 1001` + `seccompProfile: RuntimeDefault` at the Pod level and `allowPrivilegeEscalation: false` + `readOnlyRootFilesystem: true` + `capabilities.drop: [ALL]` at the container level.
- [x] Rendered Service is `type: ClusterIP` on `port: 8000` with `targetPort: http` matching the Deployment's `containerPort: 8000`.
- [x] Rendered Ingress has `tls.hosts == ["meho.test"]` + `secretName: meho-tls` + `cert-manager.io/cluster-issuer: letsencrypt-prod`.
- [x] Rendered NetworkPolicy has `policyTypes: [Ingress, Egress]` with explicit egress rules for Postgres/Vault/Keycloak (CIDR-pinned), Redis (in-cluster `podSelector`), and DNS (UDP/53 → `k8s-app: kube-dns`); ingress only from `kubernetes.io/metadata.name: ingress-nginx`.

## Out of scope (sibling tasks)
- `values.yaml` safe defaults + typed `values.schema.json` — G2.5-T2 (#38)
- Probe target wiring (`/healthz` / `/ready` / `/version`) — G2.5-T2 (#38)
- Pre-install migration Job + Redis subchart — G2.5-T3 (#39)
- `deploy/values-examples/values-rdc-example.yaml` + ESO docs — G2.5-T4 (#40)
- OCI publish workflow to `ghcr.io/evoila/meho-chart` + cosign signing — G2.5-T5 (#41)

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm chart for Kubernetes deployment with configurable templates for Deployments, Services, Ingress, ConfigMaps, and NetworkPolicies.
  * Included support for pod security, resource management, health probes, and container image configuration.

* **Documentation**
  * Added deployment documentation covering Helm chart structure, configuration options, and verification procedures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->