### PR TITLE
ci: fix stale workflow bugs surfaced by runner switch

### DIFF
--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -25,14 +25,14 @@ on:
   push:
     branches: [main]
     paths:
-      - 'pyproject.toml'
+      - '**/pyproject.toml'
       - '**/package.json'
       - '**/package-lock.json'
       - '.github/workflows/dependency-license-check.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'pyproject.toml'
+      - '**/pyproject.toml'
       - '**/package.json'
       - '**/package-lock.json'
       - '.github/workflows/dependency-license-check.yml'
@@ -50,17 +50,21 @@ jobs:
     name: Python License Check
     runs-on: meho-runners
     timeout-minutes: 10
-    if: hashFiles('pyproject.toml') != ''
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        if: hashFiles('**/pyproject.toml') != ''
         with:
           python-version: "3.13"
       - name: Install pip-licenses
+        if: hashFiles('**/pyproject.toml') != ''
         run: pip install pip-licenses==5.0.0
       - name: Install project deps
-        run: pip install -e .
+        if: hashFiles('**/pyproject.toml') != ''
+        # Only Python project today is backend/. Promote to a matrix when more land.
+        run: pip install -e ./backend
       - name: Verify license compatibility
+        if: hashFiles('**/pyproject.toml') != ''
         # Apache 2.0 outbound: permissive + weak-copyleft inbound is fine.
         # AGPL inbound is forbidden (would flip combined work to AGPL).
         # Multiple identifier forms covered because pip-licenses falls back
@@ -93,15 +97,17 @@ jobs:
     name: NPM License Check
     runs-on: meho-runners
     timeout-minutes: 10
-    if: hashFiles('**/package-lock.json') != ''
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        if: hashFiles('**/package-lock.json') != ''
         with:
           node-version: "20"
       - name: Install license-checker
+        if: hashFiles('**/package-lock.json') != ''
         run: npm install -g license-checker@25.0.1
       - name: Verify license compatibility
+        if: hashFiles('**/package-lock.json') != ''
         run: >
           license-checker --onlyAllow "Apache-2.0;MIT;BSD-2-Clause;BSD-3-Clause;ISC;CC0-1.0;0BSD;Unlicense;MPL-2.0"
           --excludePrivatePackages

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Upload SARIF as job artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: always()
+        continue-on-error: true  # tolerate org artifact-storage quota; SARIF goes to Code Scanning regardless
         with:
           name: semgrep-sarif
           path: semgrep-results.sarif


### PR DESCRIPTION
## Why

After #167 fixed the runs-on syntax and CI started actually running again, two pre-existing bugs surfaced that had been silently failing while jobs were stuck queued:

### 1. \`dependency-license-check.yml\` — 0s startup failures on every push

\`hashFiles()\` was used in **job-level** \`if:\` conditions ([lines 53 and 96 on main](https://github.com/evoila/meho/blob/main/.github/workflows/dependency-license-check.yml#L53)). GitHub Actions silently rejects this — \`hashFiles\` is only valid in step contexts ([docs/context-availability](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability)). Result: every triggered run shows "0s failure — workflow file issue."

Caught by \`actionlint\`:
\`\`\`
.github/workflows/dependency-license-check.yml:53:9: calling function "hashFiles" is not allowed here.
.github/workflows/dependency-license-check.yml:96:9: calling function "hashFiles" is not allowed here.
\`\`\`

**Fix:** Move the guards to **step-level** \`if:\`s on each install/verify step. Also two related corrections that would have made the fix meaningless otherwise:

- **Path filter broadened** from \`pyproject.toml\` (matches only repo-root) to \`**/pyproject.toml\` (matches \`backend/pyproject.toml\`, where the only Python project actually lives). The old glob never matched, so the workflow never triggered on backend dep changes.
- **\`pip install -e .\` → \`pip install -e ./backend\`** because there's no root \`pyproject.toml\`. Comment notes to promote to a matrix when a second Python project lands.

### 2. \`security-scan.yml\` — Semgrep job fails on artifact storage quota

The Semgrep scan itself completes cleanly and uploads SARIF to Code Scanning. But the secondary "Upload SARIF as job artifact" step errors with:

\`\`\`
Failed to CreateArtifact: Artifact storage quota has been hit.
Unable to upload any new artifacts. Usage is recalculated every 6-12 hours.
\`\`\`

That step is just a 14-day backup copy — the real result is already in Code Scanning, whose upload step is already guarded with \`continue-on-error: true\`. Adding the same guard here so the job doesn't fail when storage is full.

## Verification

\`\`\`
$ actionlint .github/workflows/dependency-license-check.yml .github/workflows/security-scan.yml
$ echo \$?
0
\`\`\`

## Test plan
- [ ] After merge, \`dependency-license-check.yml\` runs end-to-end on the next push that touches \`backend/pyproject.toml\` or the workflow file itself (no longer 0s startup-failure)
- [ ] Trigger via \`workflow_dispatch\` to verify the step-level guards still no-op cleanly if a manifest were missing
- [ ] \`Security Scan\` completes green even with artifact storage over quota (the upload-artifact step may still warn, but the job overall passes)

## Out of scope (called out for the next ticket)

- 5 ruff lint errors on main in \`backend/src/meho_backplane/\` — 2× A005 (\`operator.py\`, \`logging.py\` shadowing stdlib) and 3× UP038. The A005 ones need a rename or a deliberate suppression decision; the UP038s are mechanical. Best filed as its own issue.
- The artifact storage quota itself — this PR makes a single workflow tolerant of it, but the org likely wants to either prune old artifacts or shorten retention across the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized dependency license check workflow to run only when relevant dependency files change
  * Enhanced security scan workflow resilience to tolerate potential upload issues

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/169)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->