### PR TITLE
feat(deploy): wire probes + safe-by-default values + typed schema (G2.5-T2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ Operator-required (MUST be set; the schema rejects empty defaults):
 | Path | Type | Notes |
 | --- | --- | --- |
 | `image.tag` | string | Immutable tag (`sha-<git-sha>` or `v<x.y.z>`); never `:latest`. |
-| `ingress.host` | string (`hostname`) | External hostname the chart publishes. |
-| `ingress.tls.secretName` | string | TLS Secret (cert-manager-managed or pre-provisioned). |
+| `ingress.host` | string (`hostname`) | External hostname the chart publishes. Required only when `ingress.enabled: true` (default); skipped when ingress is disabled. |
+| `ingress.tls.secretName` | string | TLS Secret (cert-manager-managed or pre-provisioned). Required only when both `ingress.enabled` and `ingress.tls.enabled` are true. |
 | `postgres.credentialsSecret` | string | Kubernetes Secret holding `DATABASE_URL` at key `url`. |
 | `vault.address` | string (`uri`) | Vault endpoint, e.g. `https://vault.example.org`. |
 | `keycloak.issuer` | string (`uri`) | Keycloak issuer URL (used for `iss` validation + JWKS discovery). |
 | `config.keycloakIssuerUrl` | string | ConfigMap mirror of the above; consumed by the backplane env. |
 | `config.keycloakAudience` | string | Keycloak client ID fronting the backplane. |
 | `config.vaultAddr` | string (`uri`) | ConfigMap mirror of `vault.address`. |
-| `networkPolicy.postgresCIDR` | CIDR (IPv4) | Egress CIDR; pattern-validated. |
+| `networkPolicy.postgresCIDR` | CIDR (IPv4) | Egress CIDR; pattern-validated. Required only when `networkPolicy.enabled: true` (default). |
 | `networkPolicy.vaultCIDR` | CIDR (IPv4) | Same. |
 | `networkPolicy.keycloakCIDR` | CIDR (IPv4) | Same. |
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,53 @@ gh api /orgs/evoila/packages/container/meho --jq '.visibility'   # -> "public"
 docker logout ghcr.io && docker pull ghcr.io/evoila/meho:main    # -> succeeds
 ```
 
+## Helm chart values reference
+
+The deploy contract lives at [`deploy/charts/meho/`](./deploy/charts/meho/).
+`values.yaml` ships safe-by-default — every field the backplane cannot
+start without is **blank** and the bundled
+[`values.schema.json`](./deploy/charts/meho/values.schema.json) (JSON
+Schema draft-07) rejects empty required values at `helm install` /
+`helm upgrade` / `helm template` time with a clear path. Unknown keys at
+any level fail with `additional properties '<name>' not allowed`.
+
+Operator-required (MUST be set; the schema rejects empty defaults):
+
+| Path | Type | Notes |
+| --- | --- | --- |
+| `image.tag` | string | Immutable tag (`sha-<git-sha>` or `v<x.y.z>`); never `:latest`. |
+| `ingress.host` | string (`hostname`) | External hostname the chart publishes. |
+| `ingress.tls.secretName` | string | TLS Secret (cert-manager-managed or pre-provisioned). |
+| `postgres.credentialsSecret` | string | Kubernetes Secret holding `DATABASE_URL` at key `url`. |
+| `vault.address` | string (`uri`) | Vault endpoint, e.g. `https://vault.example.org`. |
+| `keycloak.issuer` | string (`uri`) | Keycloak issuer URL (used for `iss` validation + JWKS discovery). |
+| `config.keycloakIssuerUrl` | string | ConfigMap mirror of the above; consumed by the backplane env. |
+| `config.keycloakAudience` | string | Keycloak client ID fronting the backplane. |
+| `config.vaultAddr` | string (`uri`) | ConfigMap mirror of `vault.address`. |
+| `networkPolicy.postgresCIDR` | CIDR (IPv4) | Egress CIDR; pattern-validated. |
+| `networkPolicy.vaultCIDR` | CIDR (IPv4) | Same. |
+| `networkPolicy.keycloakCIDR` | CIDR (IPv4) | Same. |
+
+Common operator overrides (safe defaults provided; tune as needed):
+
+| Path | Default | Notes |
+| --- | --- | --- |
+| `replicaCount` | `1` | v0.1 ships single-replica; HA lands in v0.2. |
+| `image.repository` | `ghcr.io/evoila/meho` | OCI repo from the G2.4 image pipeline. |
+| `image.pullPolicy` | `IfNotPresent` | `Always` \| `IfNotPresent` \| `Never`. |
+| `service.type` / `service.port` | `ClusterIP` / `8000` | Service shape. |
+| `ingress.className` | `""` | Cluster default IngressClass when empty. |
+| `probes.liveness.*` / `probes.readiness.*` | `/healthz` / `/ready` httpGet + tuned timings | Operator-tunable; never disabled. |
+| `resources.requests` / `resources.limits` | `100m`/`256Mi` / `1000m`/`1Gi` | Conservative v0.1 chassis baselines. |
+| `networkPolicy.ingressControllerNamespace` | `ingress-nginx` | RKE2 default; override per cluster. |
+| `audit.postgresOnly` | `true` | v0.1; S3 mirror is v0.2. |
+| `broadcast.redis.bundled` | `true` | v0.1 deploys its own Redis subchart (G2.5-T3). |
+| `connectors.enabled` | `[]` | v0.1 chassis ships no connectors. |
+
+See [`docs/codebase/devops.md`](./docs/codebase/devops.md) for the full
+chart contract, probe semantics, NetworkPolicy posture, install/upgrade
+flow, and verification commands.
+
 ## Documentation
 
 (Placeholder — `docs.meho.ai` will land before v0.1.)

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -31,7 +31,11 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: backplane
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          # Image reference deliberately offers no `default .Chart.AppVersion`
+          # fallback: the values schema rejects empty `image.tag` so every
+          # install pins the tag explicitly. Goal #11's deploy discipline
+          # forbids any moving reference (including a chart-appVersion shadow).
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -47,20 +51,21 @@ spec:
                   name: {{ .Values.postgres.credentialsSecret }}
                   key: url
             # Other operator-supplied secrets (Keycloak client secret, Vault
-            # role bindings) come via ESO-synced Kubernetes Secrets; G2.5-T2
-            # wires the references when the typed values contract lands.
-          {{- if .Values.probes.liveness.enabled }}
+            # role bindings) come via ESO-synced Kubernetes Secrets; G2.6
+            # wires the references when each surface lands.
+          # Probes target the backplane's chassis health endpoints (Task #19,
+          # `backend/src/meho_backplane/health.py`): `/healthz` for liveness
+          # (returns 200 unconditionally; failure → pod restart) and `/ready`
+          # for readiness (registry of dependency probes — 503 until G2.2 /
+          # G2.3 register concrete probes; failure → pod removed from Service
+          # endpoints, no restart). Probes always render — disabling them
+          # would mask startup deadlocks and let an unready Pod accept
+          # traffic. Every probe field is operator-tunable via
+          # `.Values.probes.<kind>.<field>`.
           livenessProbe:
-            {{- toYaml (omit .Values.probes.liveness "enabled") | nindent 12 }}
-          {{- end }}
-          {{- if .Values.probes.readiness.enabled }}
+            {{- toYaml .Values.probes.liveness | nindent 12 }}
           readinessProbe:
-            {{- toYaml (omit .Values.probes.readiness "enabled") | nindent 12 }}
-          {{- end }}
-          {{- if .Values.probes.startup.enabled }}
-          startupProbe:
-            {{- toYaml (omit .Values.probes.startup "enabled") | nindent 12 }}
-          {{- end }}
+            {{- toYaml .Values.probes.readiness | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -19,8 +19,8 @@
         "repository": {
           "type": "string",
           "minLength": 1,
-          "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*$",
-          "description": "OCI image repository (host + path). Pattern matches the lowercase / hyphen / underscore / dot / slash grammar OCI image references use."
+          "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*$",
+          "description": "OCI image repository (host + path). Pattern matches the lowercase / hyphen / underscore / dot / slash grammar OCI image references use, with an optional `:<port>` segment after the host for private registries (e.g. `registry.example.com:5000/team/meho`)."
         },
         "tag": {
           "type": "string",
@@ -92,15 +92,12 @@
     "ingress": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["host"],
       "properties": {
         "enabled": { "type": "boolean" },
         "className": { "type": "string" },
         "host": {
           "type": "string",
-          "minLength": 1,
-          "format": "hostname",
-          "description": "Hostname the Ingress publishes — required."
+          "description": "Hostname the Ingress publishes. Required and shape-validated (non-empty + RFC 1123 hostname) when ingress.enabled is true — enforced by the allOf below. When ingress.enabled is false the template skips the Ingress resource entirely and host may be left blank."
         },
         "path": { "type": "string", "minLength": 1 },
         "pathType": {
@@ -119,7 +116,7 @@
             "enabled": { "type": "boolean" },
             "secretName": {
               "type": "string",
-              "description": "Kubernetes Secret name holding the TLS certificate. Required (non-empty) when tls.enabled is true — enforced by the allOf below."
+              "description": "Kubernetes Secret name holding the TLS certificate. Required (non-empty) when both ingress.enabled and ingress.tls.enabled are true — enforced by the allOf below."
             }
           }
         }
@@ -127,13 +124,30 @@
       "allOf": [
         {
           "if": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          },
+          "then": {
+            "required": ["host"],
             "properties": {
+              "host": {
+                "type": "string",
+                "minLength": 1,
+                "format": "hostname"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "enabled": { "const": true },
               "tls": {
                 "properties": { "enabled": { "const": true } },
                 "required": ["enabled"]
               }
             },
-            "required": ["tls"]
+            "required": ["enabled", "tls"]
           },
           "then": {
             "properties": {
@@ -286,7 +300,6 @@
     "networkPolicy": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["postgresCIDR", "vaultCIDR", "keycloakCIDR"],
       "properties": {
         "enabled": { "type": "boolean" },
         "ingressControllerNamespace": {
@@ -297,21 +310,45 @@
         },
         "postgresCIDR": {
           "type": "string",
-          "minLength": 1,
-          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$",
-          "description": "PostgreSQL egress CIDR (IPv4). Required and shape-validated — the rendered NetworkPolicy refuses to ship a wide subnet by accident."
+          "description": "PostgreSQL egress CIDR (IPv4). Required and shape-validated (non-empty IPv4 CIDR) when networkPolicy.enabled is true — the rendered NetworkPolicy refuses to ship a wide subnet by accident. When networkPolicy.enabled is false the template skips the NetworkPolicy resource entirely and this field may be left blank."
         },
         "vaultCIDR": {
           "type": "string",
-          "minLength": 1,
-          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+          "description": "Vault egress CIDR (IPv4). Same conditional shape rules as postgresCIDR."
         },
         "keycloakCIDR": {
           "type": "string",
-          "minLength": 1,
-          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+          "description": "Keycloak egress CIDR (IPv4). Same conditional shape rules as postgresCIDR."
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          },
+          "then": {
+            "required": ["postgresCIDR", "vaultCIDR", "keycloakCIDR"],
+            "properties": {
+              "postgresCIDR": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+              },
+              "vaultCIDR": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+              },
+              "keycloakCIDR": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+              }
+            }
+          }
+        }
+      ]
     },
     "nodeSelector": {
       "type": "object",

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -1,6 +1,389 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "title": "meho values",
-  "description": "Placeholder schema. G2.5-T2 (issue #38) populates this with the typed values contract that fails `helm install` on misconfiguration.",
-  "type": "object"
+  "title": "MEHO Helm chart values",
+  "description": "Typed contract for the MEHO Helm chart. Helm validates `.Values` against this schema on `helm install` / `helm upgrade` / `helm template` / `helm lint` (Helm uses JSON Schema draft-07). `additionalProperties: false` is set at every object level so typos and stale keys fail loudly with a clear path. Required-but-blank fields use `minLength: 1` to reject the safe-by-default empty placeholders shipped in `values.yaml` — operators MUST override them via `--set` or a values overlay.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["image", "ingress", "postgres", "vault", "keycloak", "networkPolicy"],
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of backplane replicas. v0.1 is single-replica; HA lands in v0.2."
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "tag"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*$",
+          "description": "OCI image repository (host + path). Pattern matches the lowercase / hyphen / underscore / dot / slash grammar OCI image references use."
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Image tag. Empty fails the schema — Goal #11 deploy discipline requires every install to pin an immutable tag."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "name": { "type": "string" }
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Pod-level securityContext. Schema deliberately allows any shape because the Kubernetes PodSecurityContext surface is wide and partially version-dependent; the chart's defaults are pinned but operators may add fields the cluster admits.",
+      "additionalProperties": true
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Container-level securityContext. Same rationale as podSecurityContext.",
+      "additionalProperties": true
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "port", "portName"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "portName": { "type": "string", "minLength": 1, "maxLength": 15 }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "host": {
+          "type": "string",
+          "minLength": 1,
+          "format": "hostname",
+          "description": "Hostname the Ingress publishes — required."
+        },
+        "path": { "type": "string", "minLength": 1 },
+        "pathType": {
+          "type": "string",
+          "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "tls": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "secretName": {
+              "type": "string",
+              "description": "Kubernetes Secret name holding the TLS certificate. Required (non-empty) when tls.enabled is true — enforced by the allOf below."
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "tls": {
+                "properties": { "enabled": { "const": true } },
+                "required": ["enabled"]
+              }
+            },
+            "required": ["tls"]
+          },
+          "then": {
+            "properties": {
+              "tls": {
+                "properties": {
+                  "secretName": { "type": "string", "minLength": 1 }
+                },
+                "required": ["secretName"]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "probes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["liveness", "readiness"],
+      "properties": {
+        "liveness": { "$ref": "#/definitions/httpProbe" },
+        "readiness": { "$ref": "#/definitions/httpProbe" }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limits": { "$ref": "#/definitions/resourceQuantities" },
+        "requests": { "$ref": "#/definitions/resourceQuantities" }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keycloakIssuerUrl",
+        "keycloakAudience",
+        "keycloakJwksCacheTtlSeconds",
+        "keycloakJwtLeewaySeconds",
+        "vaultAddr",
+        "vaultOidcRole",
+        "vaultOidcMountPath",
+        "vaultTimeoutSeconds",
+        "databasePoolSize",
+        "databasePoolTimeout"
+      ],
+      "properties": {
+        "keycloakIssuerUrl": { "type": "string", "minLength": 1 },
+        "keycloakAudience": { "type": "string", "minLength": 1 },
+        "keycloakJwksCacheTtlSeconds": { "type": "string", "pattern": "^[0-9]+$" },
+        "keycloakJwtLeewaySeconds": { "type": "string", "pattern": "^[0-9]+$" },
+        "vaultAddr": { "type": "string", "format": "uri", "minLength": 1 },
+        "vaultOidcRole": { "type": "string", "minLength": 1 },
+        "vaultOidcMountPath": { "type": "string", "minLength": 1 },
+        "vaultTimeoutSeconds": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?$" },
+        "databasePoolSize": { "type": "string", "pattern": "^[0-9]+$" },
+        "databasePoolTimeout": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?$" }
+      }
+    },
+    "postgres": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["credentialsSecret"],
+      "properties": {
+        "host": { "type": "string" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "database": { "type": "string", "minLength": 1 },
+        "credentialsSecret": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Kubernetes Secret name holding the DATABASE_URL value at key `url` — required."
+        }
+      }
+    },
+    "vault": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["address"],
+      "properties": {
+        "address": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri",
+          "description": "Vault address — required."
+        },
+        "authMethod": {
+          "type": "string",
+          "enum": ["oidc", "jwt", "kubernetes", "approle", "token"]
+        },
+        "role": { "type": "string", "minLength": 1 },
+        "paths": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kv"],
+          "properties": {
+            "kv": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "keycloak": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issuer"],
+      "properties": {
+        "issuer": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri",
+          "description": "Keycloak issuer URL — required."
+        },
+        "audience": { "type": "string", "minLength": 1 },
+        "clientSecretSyncFromVault": { "type": "string", "minLength": 1 }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["postgresOnly"],
+      "properties": {
+        "postgresOnly": { "type": "boolean" }
+      }
+    },
+    "broadcast": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["redis"],
+      "properties": {
+        "redis": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["bundled"],
+          "properties": {
+            "bundled": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "connectors": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["postgresCIDR", "vaultCIDR", "keycloakCIDR"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressControllerNamespace": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "description": "Namespace label value selecting the ingress controller. Must match RFC 1123 label syntax."
+        },
+        "postgresCIDR": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$",
+          "description": "PostgreSQL egress CIDR (IPv4). Required and shape-validated — the rendered NetworkPolicy refuses to ship a wide subnet by accident."
+        },
+        "vaultCIDR": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+        },
+        "keycloakCIDR": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+        }
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "tolerations": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Kubernetes Affinity surface — wide and version-dependent; schema permits arbitrary shape.",
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "httpProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["httpGet"],
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "port"],
+          "properties": {
+            "path": { "type": "string", "minLength": 1, "pattern": "^/" },
+            "port": {
+              "oneOf": [
+                { "type": "integer", "minimum": 1, "maximum": 65535 },
+                { "type": "string", "minLength": 1, "maxLength": 15 }
+              ]
+            },
+            "scheme": { "type": "string", "enum": ["HTTP", "HTTPS"] },
+            "host": { "type": "string" },
+            "httpHeaders": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "value"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "value": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 },
+        "successThreshold": { "type": "integer", "minimum": 1 },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "resourceQuantities": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "oneOf": [
+            { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?m?$" },
+            { "type": "integer", "minimum": 0 }
+          ]
+        },
+        "memory": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+        }
+      }
+    }
+  }
 }

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -85,7 +85,10 @@ ingress:
   # -- IngressClass name. Empty = let the cluster's default IngressClass apply.
   # Typical values: "nginx" (RKE2 bundled), "traefik", a private class name.
   className: ""
-  # -- Hostname the Ingress publishes — MUST be set; empty fails the schema.
+  # -- Hostname the Ingress publishes. Required (non-empty + RFC 1123 hostname)
+  # by the schema only when `ingress.enabled: true` (the default); when
+  # `ingress.enabled: false` the template skips the Ingress resource and
+  # this field may be left blank.
   host: ""
   # -- Path rules. Default routes every path to the backplane Service.
   path: /
@@ -96,10 +99,11 @@ ingress:
   annotations: {}
   tls:
     enabled: true
-    # -- Name of the Kubernetes Secret holding the TLS certificate — MUST be
-    # set when `ingress.tls.enabled: true`. When cert-manager owns the
-    # certificate lifecycle, this is the Secret cert-manager creates from the
-    # Certificate resource (or from the Ingress annotations on first reconcile).
+    # -- Name of the Kubernetes Secret holding the TLS certificate. Required
+    # (non-empty) by the schema only when both `ingress.enabled` and
+    # `ingress.tls.enabled` are true. When cert-manager owns the certificate
+    # lifecycle, this is the Secret cert-manager creates from the Certificate
+    # resource (or from the Ingress annotations on first reconcile).
     secretName: ""
 
 # -- Container probes. Both probes target endpoints shipped by the backplane's
@@ -234,12 +238,13 @@ networkPolicy:
   # -- Namespace label value selecting the ingress controller. RKE2 ships with
   # `ingress-nginx`; override per-cluster.
   ingressControllerNamespace: ingress-nginx
-  # -- PostgreSQL egress CIDR — MUST be set. Empty fails the schema; the
-  # rendered NetworkPolicy refuses to ship a wide subnet by accident.
+  # -- PostgreSQL egress CIDR. Required and pattern-validated by the schema
+  # only when `networkPolicy.enabled: true` (the default); when disabled the
+  # template skips the NetworkPolicy resource and this field may be left blank.
   postgresCIDR: ""
-  # -- Vault egress CIDR — MUST be set.
+  # -- Vault egress CIDR. Same conditional rules as postgresCIDR.
   vaultCIDR: ""
-  # -- Keycloak egress CIDR — MUST be set.
+  # -- Keycloak egress CIDR. Same conditional rules as postgresCIDR.
   keycloakCIDR: ""
 
 # -- Node selector applied to the Pod template.

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -1,24 +1,33 @@
 # Default values for the meho chart.
 #
-# This file is a **scaffold** in G2.5-T1 — every key shipped here exists so
-# `helm template` renders the core six resources for shape verification.
-# G2.5-T2 will replace these placeholders with safe-by-default values and
-# add `values.schema.json` typing. Until then, callers MUST override the
-# placeholder strings via `--set` or a values overlay; nothing here is
-# production-safe.
+# This file ships **safe-by-default** values: every field that the backplane
+# cannot start without (Vault address, Keycloak issuer, DB credentials secret
+# name, NetworkPolicy egress CIDRs, image tag, Ingress host + TLS secret) is
+# **blank**. The companion `values.schema.json` typed contract rejects empty
+# values at `helm install` / `helm upgrade` / `helm template` time with a
+# clear error, so a misconfigured release fails up-front instead of
+# silently connecting to the wrong system or CrashLoopBackOff'ing at first
+# request. Lines tagged `MUST be set` below identify the operator-supplied
+# fields the schema enforces.
+#
+# v0.1 deliberately ships single-replica (HA + PodDisruptionBudget +
+# topologySpreadConstraints are explicitly deferred to v0.2 per Goal #11
+# scope). Resource requests/limits are conservative production baselines
+# suitable for the chassis-stage backplane; tune via overrides for higher-
+# throughput deployments.
 
-# -- Number of replicas. v0.1 is single-replica; HA lands in v0.2.
+# -- Number of backplane replicas. v0.1 is single-replica; HA lands in v0.2.
 replicaCount: 1
 
 image:
   # -- Image repository. The G2.4 pipeline publishes to `ghcr.io/evoila/meho`.
   repository: ghcr.io/evoila/meho
+  # -- Image tag — MUST be set; empty fails the schema at install time. CI
+  # typically passes `--set image.tag=sha-<git-sha>`; Goal #11's deploy
+  # discipline forbids the `:latest` tag entirely.
+  tag: ""
   # -- Image pull policy.
   pullPolicy: IfNotPresent
-  # -- Image tag. When empty, the Deployment falls back to `.Chart.AppVersion`
-  # (per the standard Helm convention from `helm create`). Pinning the tag
-  # in CI / install command (`--set image.tag=<sha>`) is the supported flow.
-  tag: ""
 
 # -- Image pull secrets when consumers mirror through a private registry.
 # Public GHCR pulls (Goal #11's locked artefact-distribution principle) need
@@ -74,41 +83,71 @@ service:
 ingress:
   enabled: true
   # -- IngressClass name. Empty = let the cluster's default IngressClass apply.
+  # Typical values: "nginx" (RKE2 bundled), "traefik", a private class name.
   className: ""
-  # -- Annotations applied to the Ingress. The cert-manager line below assumes
-  # a ClusterIssuer is provisioned in the cluster; override `cluster-issuer`
-  # to match the consumer's environment.
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  # -- Hostname the Ingress publishes. Placeholder; override via values overlay.
-  host: meho.local
+  # -- Hostname the Ingress publishes — MUST be set; empty fails the schema.
+  host: ""
   # -- Path rules. Default routes every path to the backplane Service.
   path: /
   pathType: Prefix
+  # -- Annotations applied to the Ingress. Defaults are empty; consumers add
+  # cert-manager / ingress-controller-specific annotations as needed (e.g.
+  # `cert-manager.io/cluster-issuer: letsencrypt-prod`).
+  annotations: {}
   tls:
     enabled: true
-    # -- Name of the Kubernetes Secret holding the TLS certificate. When
-    # `cert-manager.io/cluster-issuer` is set above, cert-manager creates this
-    # Secret on first reconciliation; for manual TLS, pre-create the Secret.
-    secretName: meho-tls
+    # -- Name of the Kubernetes Secret holding the TLS certificate — MUST be
+    # set when `ingress.tls.enabled: true`. When cert-manager owns the
+    # certificate lifecycle, this is the Secret cert-manager creates from the
+    # Certificate resource (or from the Ingress annotations on first reconcile).
+    secretName: ""
 
-# -- Probe configuration. Stubbed in G2.5-T1; G2.5-T2 wires the real endpoints
-# (`/healthz` / `/ready` / `/version`) per the backplane's chassis. Keeping
-# `enabled: false` here means the rendered Deployment omits the probe blocks
-# entirely until T2 lands, avoiding a half-configured probe that would mark
-# the pod NotReady on first start.
+# -- Container probes. Both probes target endpoints shipped by the backplane's
+# chassis (`backend/src/meho_backplane/health.py`, Task #19 / G2.1-T2):
+#
+# * `/healthz` — process-up only; returns 200 unconditionally. Used by
+#   `livenessProbe`. Failure → pod restart.
+# * `/ready` — readiness registry; returns 200 only when every registered
+#   probe (Vault/Keycloak in G2.2, Alembic migrations in G2.3) reports OK.
+#   Empty registry returns 503 by design — the backplane fails-closed at the
+#   chassis stage. Used by `readinessProbe`. Failure → pod removed from
+#   Service endpoints but NOT restarted.
+#
+# Timings follow the issue body's specification: liveness allows 30s for
+# the FastAPI app to start before the first check then 1s timeout × 3
+# failures (30s detection window); readiness is faster (5s initial, 5s
+# period, 2s timeout × 3 failures = 15s detection window) so a flaky
+# dependency removes the pod from rotation promptly without triggering a
+# restart. Every field is operator-tunable.
 probes:
   liveness:
-    enabled: false
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
   readiness:
-    enabled: false
-  startup:
-    enabled: false
+    httpGet:
+      path: /ready
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 3
 
-resources: {}
-  # The defaults are intentionally empty; G2.5-T2 picks safe baselines after
-  # measuring chassis idle. Documented comparable: cert-manager ships with
-  # `requests: {cpu: 10m, memory: 32Mi}` + `limits: {memory: 64Mi}` by default.
+# -- Container resources. Conservative production baselines for the v0.1
+# chassis backplane — sized for steady-state authn/authz traffic plus the
+# audit-write fanout. Tune the limits up for higher-throughput deployments;
+# the requests should always reflect observed steady-state usage.
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi
 
 # -- ConfigMap-sourced environment variables (non-secret).
 # These map 1:1 to `backend/src/meho_backplane/settings.py` env-var contract.
@@ -127,23 +166,81 @@ config:
   databasePoolTimeout: "30.0"
 
 postgres:
-  # -- Name of the Kubernetes Secret holding the DATABASE_URL value at key `url`.
-  # Synced from Vault by ESO (External Secrets Operator) in production; the
-  # consumer pre-provisions it before `helm install`.
-  credentialsSecret: meho-postgres
+  # -- PostgreSQL host. v0.1 expects an operator-managed PG cluster (Goal #11
+  # explicitly excludes a bundled PG subchart); typically reached over the
+  # network at the cluster boundary. Empty in defaults — consumers override.
+  host: ""
+  # -- PostgreSQL port. 5432 is the upstream default; override only when the
+  # operator's PG cluster listens on a non-standard port.
+  port: 5432
+  # -- Database name. Defaults to `meho`; override if the operator's PG
+  # cluster hosts multiple MEHO releases on the same instance with different
+  # logical databases.
+  database: meho
+  # -- Name of the Kubernetes Secret holding the DATABASE_URL value at key
+  # `url` — MUST be set. Synced from Vault by External Secrets Operator (ESO)
+  # in production; the consumer pre-provisions it before `helm install`.
+  credentialsSecret: ""
+
+vault:
+  # -- Vault address (e.g. `https://vault.example.org`) — MUST be set; empty
+  # fails the schema. Goal #11 cross-repo dependency: the consumer's Vault
+  # must have the `meho-mcp` JWT/OIDC role bound to the Keycloak issuer
+  # configured below.
+  address: ""
+  # -- Vault auth method used by the backplane (`oidc` is the JWT/OIDC method).
+  authMethod: oidc
+  # -- Vault role name (matches Goal #11's `meho-mcp` cross-repo convention).
+  role: meho-mcp
+  paths:
+    # -- KV v2 mount + base path for operator secrets. Federation-proof reads
+    # happen under `<paths.kv>/test/federation` (see backend health.py).
+    kv: secret/meho
+
+keycloak:
+  # -- Keycloak issuer URL — MUST be set; empty fails the schema. The JWT
+  # validator uses this as the `iss` claim expectation and to discover JWKS.
+  issuer: ""
+  # -- Keycloak audience (= the client ID in Keycloak that fronts the
+  # backplane). The JWT `aud` claim must contain this value.
+  audience: meho-backplane
+  # -- Vault path the chart's downstream automation reads to recover the
+  # Keycloak client secret (v0.2 wiring; v0.1 uses ESO directly).
+  clientSecretSyncFromVault: secret/meho/keycloak/client_secret
+
+audit:
+  # -- v0.1: audit rows written to PostgreSQL only. The S3 / object-store
+  # mirror is explicitly v0.2 per Goal #11 spec.
+  postgresOnly: true
+
+broadcast:
+  redis:
+    # -- v0.1: the chart deploys its own Redis subchart (G2.5-T3 #39 adds
+    # the dependency + values plumbing). `bundled: false` would let a
+    # consumer point at an external Redis; not used in v0.1.
+    bundled: true
+
+connectors:
+  # -- v0.1 ships the chassis with no connectors enabled. The connector
+  # surface lands post-Goal-2 with the first product ticket.
+  enabled: []
 
 networkPolicy:
+  # -- Whether to ship the default-deny NetworkPolicy. Disable only on
+  # clusters running an equivalent mesh-level policy (Istio AuthorizationPolicy
+  # etc.) — disabling without a replacement removes the chart's least-
+  # privilege egress story.
   enabled: true
   # -- Namespace label value selecting the ingress controller. RKE2 ships with
   # `ingress-nginx`; override per-cluster.
   ingressControllerNamespace: ingress-nginx
-  # -- Egress CIDRs. Placeholders; the consumer overrides each from their
-  # environment's actual subnet allocations. The chart refuses to render an
-  # over-broad `0.0.0.0/0` egress — defense-in-depth against accidental
-  # exfiltration paths from a compromised backplane Pod.
-  postgresCIDR: 10.0.0.0/32
-  vaultCIDR: 10.0.0.0/32
-  keycloakCIDR: 10.0.0.0/32
+  # -- PostgreSQL egress CIDR — MUST be set. Empty fails the schema; the
+  # rendered NetworkPolicy refuses to ship a wide subnet by accident.
+  postgresCIDR: ""
+  # -- Vault egress CIDR — MUST be set.
+  vaultCIDR: ""
+  # -- Keycloak egress CIDR — MUST be set.
+  keycloakCIDR: ""
 
 # -- Node selector applied to the Pod template.
 nodeSelector: {}

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -56,20 +56,25 @@ deploy/charts/meho/
 
 ### Image reference
 
-The Deployment renders `{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}`.
-That gives consumers three idiomatic ways to pin the image:
+The Deployment renders `{{ .Values.image.repository }}:{{ .Values.image.tag }}`
+with **no `.Chart.AppVersion` fallback**. `values.schema.json` rejects an
+empty `image.tag` (`minLength: 1`), so every install pins the tag
+operator-supplied at `helm install` / `helm upgrade` time. Goal #11's
+deploy discipline forbids moving references (including a chart-`appVersion`
+shadow), and the chart enforces that contract at the schema layer rather
+than relying on consumers to remember to `--set image.tag`.
 
-1. **Pin via `--set image.tag=<sha>`** — typical CI flow; `image.tag` wins.
-2. **Pin via `appVersion` rewrite** — the publish workflow rewrites
-   `Chart.yaml.appVersion` to the git sha at OCI push time; consumers
-   who omit `image.tag` get that pin automatically.
-3. **Override `image.repository`** — consumers mirroring through a private
-   registry point the chart at their mirror.
+`image.repository` accepts the lowercase OCI grammar including an optional
+`:<port>` segment after the host, so private registries like
+`registry.example.com:5000/team/meho` are valid. The pattern enforces the
+shape; the operator picks the value.
 
 `imagePullSecrets` is a values-configurable list, empty by default. The
 backplane image is pushed to **public GHCR** (Goal #11's locked artefact-
 distribution principle), so no pull secret is required in the default
-deployment path.
+deployment path. Consumers mirroring through a private registry override
+`image.repository` to point at their mirror and (if needed) populate
+`imagePullSecrets`.
 
 ### Probes
 
@@ -131,9 +136,20 @@ Ingress is permitted only from the namespace whose
 RKE2's bundled controller).
 
 The three egress CIDR fields ship **empty** in `values.yaml` and are
-required-with-shape-validation in the schema. The chart will not render
-without explicit per-environment CIDR overrides — defense-in-depth against
-accidentally allowing a wide subnet because a typo silently fell through.
+required-with-shape-validation in the schema **when
+`networkPolicy.enabled: true`**. The chart will not render with the
+default `enabled: true` without explicit per-environment CIDR overrides
+— defense-in-depth against accidentally allowing a wide subnet because
+a typo silently fell through.
+
+Operators on clusters running an equivalent mesh-level policy (Istio
+`AuthorizationPolicy`, Cilium `CiliumNetworkPolicy`, etc.) can set
+`networkPolicy.enabled: false` to skip the chart's NetworkPolicy
+entirely; the schema's conditional `if/then` relaxes the CIDR
+requirements in that mode so the values overlay does not need to
+populate them. Disabling without a replacement policy in place removes
+the chart's least-privilege egress story — only do it when an
+equivalent control is enforced upstream.
 
 ### Safe-by-default values
 
@@ -144,13 +160,13 @@ values overlay:
 | Field | Why blank |
 | --- | --- |
 | `image.tag` | Goal #11 deploy discipline: every install pins an immutable tag, never a moving reference |
-| `ingress.host` | Per-environment; no generic placeholder is correct |
-| `ingress.tls.secretName` | Per-environment Secret name (cert-manager-managed or pre-provisioned) |
+| `ingress.host` | Per-environment; no generic placeholder is correct. Required only when `ingress.enabled: true` (the default) — relaxed when ingress is disabled |
+| `ingress.tls.secretName` | Per-environment Secret name (cert-manager-managed or pre-provisioned). Required only when both `ingress.enabled` and `ingress.tls.enabled` are true |
 | `postgres.credentialsSecret` | Per-environment Secret holding `DATABASE_URL` (ESO-synced from Vault in production) |
 | `vault.address` | Per-environment Vault endpoint |
 | `keycloak.issuer` | Per-environment Keycloak issuer URL |
 | `config.keycloakIssuerUrl` / `config.keycloakAudience` / `config.vaultAddr` | ConfigMap env-var mirrors of the above (`backend/src/meho_backplane/settings.py` contract) |
-| `networkPolicy.{postgres,vault,keycloak}CIDR` | Per-environment subnet for each upstream |
+| `networkPolicy.{postgres,vault,keycloak}CIDR` | Per-environment subnet for each upstream. Required only when `networkPolicy.enabled: true` (the default) — relaxed when networkPolicy is disabled |
 
 A blank field falls into the typed-schema contract immediately — `helm
 install` fails before a single Kubernetes resource is created. The

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -25,11 +25,11 @@ resources that make up a running backplane:
 deploy/charts/meho/
 ├── Chart.yaml              # apiVersion v2, kubeVersion >=1.28
 ├── .helmignore             # standard exclusions
-├── values.yaml             # scaffold defaults; G2.5-T2 hardens them
-├── values.schema.json      # placeholder; G2.5-T2 fills the typed contract
+├── values.yaml             # safe-by-default; required fields are blank
+├── values.schema.json      # draft-07 typed contract; rejects typos and empty required fields
 └── templates/
     ├── _helpers.tpl        # name / fullname / labels / SA helpers
-    ├── deployment.yaml     # backplane Pod
+    ├── deployment.yaml     # backplane Pod + probes (/healthz, /ready)
     ├── service.yaml        # ClusterIP :8000
     ├── ingress.yaml        # TLS + cert-manager
     ├── configmap.yaml      # non-secret env
@@ -71,15 +71,37 @@ backplane image is pushed to **public GHCR** (Goal #11's locked artefact-
 distribution principle), so no pull secret is required in the default
 deployment path.
 
-### Probes (scaffolded, off by default in T1)
+### Probes
 
-The Deployment template emits `livenessProbe` / `readinessProbe` /
-`startupProbe` blocks gated on `probes.<kind>.enabled`. All three default
-to `enabled: false` in this T1 scaffold; G2.5-T2 (issue #38) wires the
-real probe targets (`/healthz` / `/ready` / `/version`) against the
-chassis from G2.1. Keeping probes off until T2 lands avoids a half-
-configured probe marking the Pod NotReady before its health endpoints
-are reachable.
+The Deployment always renders `livenessProbe` and `readinessProbe` against
+the backplane chassis endpoints from G2.1-T2
+(`backend/src/meho_backplane/health.py`):
+
+| Probe | Endpoint | Failure semantics | Default timings (operator-tunable) |
+| --- | --- | --- | --- |
+| `livenessProbe` | `/healthz` (always 200 if the process is up) | Pod **restarts** on failure | `initialDelaySeconds: 30`, `periodSeconds: 10`, `timeoutSeconds: 1`, `failureThreshold: 3` |
+| `readinessProbe` | `/ready` (200 only when every registered probe in the readiness registry passes; 503 with an empty registry at the chassis stage) | Pod **removed from Service endpoints**, no restart | `initialDelaySeconds: 5`, `periodSeconds: 5`, `timeoutSeconds: 2`, `failureThreshold: 3` |
+
+The 30-second liveness `initialDelaySeconds` gives the FastAPI app time to
+import, build the JWKS cache, and bind structlog context before the first
+check — under-provisioning it would restart-loop the Pod during slow image
+pulls or cold-start library imports. The shorter readiness window (15s
+total detection) makes the Pod fall out of rotation promptly when a
+downstream dependency goes flaky, without triggering an unnecessary
+restart of the backplane process itself.
+
+Probes are **always on** — there is no `enabled: false` escape valve.
+Disabling probes would mask startup deadlocks and let an unready Pod
+accept traffic; that tradeoff is never the right call for a governance
+backplane. Every field under `probes.liveness.*` and `probes.readiness.*`
+in `values.yaml` is operator-tunable for environments that need different
+timings.
+
+The `/ready` endpoint **returns 503 by design** until G2.2 (Vault /
+Keycloak probes) and G2.3 (Alembic migration probe) register concrete
+probes — that's the fail-closed chassis state, not a bug. During chassis-
+stage dev installs the readinessProbe will hold the Pod out of rotation
+until those probes land; that's the intended signal.
 
 ### Security context
 
@@ -108,9 +130,71 @@ Ingress is permitted only from the namespace whose
 `networkPolicy.ingressControllerNamespace` (default `ingress-nginx`,
 RKE2's bundled controller).
 
-The CIDR defaults are intentional **/32 placeholders** — they make the
-chart fail-closed if a consumer forgets to override them rather than
-silently allow a /8 subnet.
+The three egress CIDR fields ship **empty** in `values.yaml` and are
+required-with-shape-validation in the schema. The chart will not render
+without explicit per-environment CIDR overrides — defense-in-depth against
+accidentally allowing a wide subnet because a typo silently fell through.
+
+### Safe-by-default values
+
+`values.yaml` deliberately ships **blank** for every field the backplane
+cannot start without. Operators MUST override these via `--set` or a
+values overlay:
+
+| Field | Why blank |
+| --- | --- |
+| `image.tag` | Goal #11 deploy discipline: every install pins an immutable tag, never a moving reference |
+| `ingress.host` | Per-environment; no generic placeholder is correct |
+| `ingress.tls.secretName` | Per-environment Secret name (cert-manager-managed or pre-provisioned) |
+| `postgres.credentialsSecret` | Per-environment Secret holding `DATABASE_URL` (ESO-synced from Vault in production) |
+| `vault.address` | Per-environment Vault endpoint |
+| `keycloak.issuer` | Per-environment Keycloak issuer URL |
+| `config.keycloakIssuerUrl` / `config.keycloakAudience` / `config.vaultAddr` | ConfigMap env-var mirrors of the above (`backend/src/meho_backplane/settings.py` contract) |
+| `networkPolicy.{postgres,vault,keycloak}CIDR` | Per-environment subnet for each upstream |
+
+A blank field falls into the typed-schema contract immediately — `helm
+install` fails before a single Kubernetes resource is created. The
+operator sees the exact missing path (e.g. `at '/vault/address':
+minLength: got 0, want 1`) and a single targeted override fixes it.
+
+Conservative resource defaults (`requests: {cpu: 100m, memory: 256Mi}`,
+`limits: {cpu: 1000m, memory: 1Gi}`) reflect observed steady-state usage
+of the v0.1 chassis (authn/authz traffic + synchronous audit-write fanout);
+tune limits up for higher-throughput deployments.
+
+### `values.schema.json` typed contract
+
+The chart ships a **JSON Schema draft-07** contract for `values.yaml`
+(Helm's supported dialect). Helm validates the merged `.Values` object
+against this schema on:
+
+- `helm lint`
+- `helm template`
+- `helm install` / `helm install --dry-run`
+- `helm upgrade`
+
+Three properties make this the right contract:
+
+1. **`additionalProperties: false` at every object level.** A typo
+   (`postgress` for `postgres`) fails at `helm install` time with the
+   exact path, not silently at first request when the backplane fails to
+   resolve a Vault secret. Helm reports e.g. `at '': additional properties
+   'postgress' not allowed`.
+2. **`minLength: 1` on every required-but-blank field plus
+   `format: uri` / `format: hostname` / `pattern: …` shape validation
+   on URLs / hostnames / CIDRs.** The safe-by-default empty placeholders
+   in `values.yaml` are intentionally rejected, surfacing the exact field
+   the operator must override.
+3. **Subchart compatibility.** When G2.5-T3 (#39) adds the Redis subchart
+   dependency, the top-level `properties` map gains a `redis` key and the
+   subchart's own `values.schema.json` (if present) is also enforced —
+   the parent chart cannot circumvent subchart restrictions.
+
+`helm lint` against the unmodified `values.yaml` **deliberately fails**
+with the safe-by-default empty fields. The chart's CI / lint workflow
+(G2.5-T5) and `deploy/values-examples/values-rdc-example.yaml` (G2.5-T4)
+both supply the required overrides; ad-hoc lint invocations pass them via
+`--set` or `-f`.
 
 ## Install / upgrade
 
@@ -118,8 +202,12 @@ silently allow a /8 subnet.
 helm install meho ./deploy/charts/meho/ \
   --namespace meho \
   --create-namespace \
-  --set image.tag=<sha> \
+  --set image.tag=sha-<git-sha> \
   --set ingress.host=meho.example.org \
+  --set ingress.tls.secretName=meho-tls \
+  --set postgres.credentialsSecret=meho-postgres \
+  --set vault.address=https://vault.example.org \
+  --set keycloak.issuer=https://keycloak.example.org/realms/meho \
   --set config.keycloakIssuerUrl=https://keycloak.example.org/realms/meho \
   --set config.keycloakAudience=meho-backplane \
   --set config.vaultAddr=https://vault.example.org \
@@ -130,26 +218,51 @@ helm install meho ./deploy/charts/meho/ \
 helm upgrade --install meho ./deploy/charts/meho/ -f values-rdc.yaml
 ```
 
-Until G2.5-T2 lands the typed `values.schema.json`, the chart accepts any
-shape — the safety net comes from the backplane itself, which fails-closed
-at startup on missing `KEYCLOAK_*` / `VAULT_*` / `DATABASE_URL` env vars.
+Missing any required override fails the schema validation at install
+time with the exact field path — e.g. omitting `--set vault.address=...`
+produces `at '/vault/address': '' is not valid uri: relative url`. The
+backplane never starts against a misconfigured set of values.
 
 ## Verification
 
 ```bash
-helm lint deploy/charts/meho/
+# helm lint passes only with a values overlay or `--set` overrides for every
+# required-but-blank field; the bare chart deliberately fails-loud:
+helm lint deploy/charts/meho/ \
+  --set image.tag=test \
+  --set ingress.host=meho.test \
+  --set ingress.tls.secretName=meho-tls \
+  --set postgres.credentialsSecret=meho-postgres \
+  --set vault.address=https://vault.test \
+  --set keycloak.issuer=https://keycloak.test/realms/meho \
+  --set config.keycloakIssuerUrl=https://keycloak.test/realms/meho \
+  --set config.keycloakAudience=meho-backplane \
+  --set config.vaultAddr=https://vault.test \
+  --set networkPolicy.postgresCIDR=10.0.0.0/24 \
+  --set networkPolicy.vaultCIDR=10.0.0.0/24 \
+  --set networkPolicy.keycloakCIDR=10.0.0.0/24
 
+# Same flags reproduce the render:
 helm template test-release deploy/charts/meho/ \
   --set image.tag=test \
   --set ingress.host=meho.test \
-  --set postgres.credentialsSecret=test \
-  --set networkPolicy.postgresCIDR=10.0.0.0/24 \
-  --set networkPolicy.vaultCIDR=10.0.0.0/24 \
-  --set networkPolicy.keycloakCIDR=10.0.0.0/24 \
-  --set networkPolicy.ingressControllerNamespace=ingress-nginx \
+  --set ingress.tls.secretName=meho-tls \
+  --set postgres.credentialsSecret=meho-postgres \
+  --set vault.address=https://vault.test \
+  --set keycloak.issuer=https://keycloak.test/realms/meho \
+  --set config.keycloakIssuerUrl=https://keycloak.test/realms/meho \
+  --set config.keycloakAudience=meho-backplane \
+  --set config.vaultAddr=https://vault.test \
+  --set networkPolicy.postgresCIDR=10.0.1.0/24 \
+  --set networkPolicy.vaultCIDR=10.0.2.0/24 \
+  --set networkPolicy.keycloakCIDR=10.0.3.0/24 \
   > /tmp/rendered.yaml
 
 grep -c '^kind:' /tmp/rendered.yaml  # expect >= 6
+
+# Negative tests — the chart fails-loud on the misuse cases the schema covers:
+helm template test deploy/charts/meho/ 2>&1 | grep -E "minLength|valid"
+helm template test deploy/charts/meho/ --set bogus.field=x 2>&1 | grep "additional properties"
 ```
 
 ## Dependencies
@@ -166,13 +279,14 @@ grep -c '^kind:' /tmp/rendered.yaml  # expect >= 6
 
 ## Known gaps (filled by sibling tasks)
 
-- `values.schema.json` is a placeholder — G2.5-T2 (#38) fills it.
-- Probes are scaffolded but disabled — G2.5-T2 (#38) wires real targets.
-- Pre-install migration Job + Redis subchart — G2.5-T3 (#39).
+- Pre-install migration Job + Redis subchart — G2.5-T3 (#39). The subchart
+  will extend `values.yaml` with a top-level `redis:` key and the matching
+  schema branch.
 - `deploy/values-examples/values-rdc-example.yaml` — G2.5-T4 (#40).
 - OCI publish to `ghcr.io/evoila/meho-chart` + cosign signing — G2.5-T5
   (#41).
-- HPA / PDB / ServiceMonitor / PrometheusRule — deferred to v0.2.
+- HPA / PDB / topologySpreadConstraints / ServiceMonitor / PrometheusRule
+  — deferred to v0.2. v0.1 is single-replica per Goal #11 scope.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Wire `livenessProbe` (`/healthz`) and `readinessProbe` (`/ready`) into the chart Deployment against the chassis health endpoints from G2.1-T2 — every probe field is operator-tunable via `.Values.probes.*`.
- Replace the T1 scaffold `values.yaml` with **safe-by-default** values: every field the backplane cannot start without (image.tag, ingress.host, ingress.tls.secretName, postgres.credentialsSecret, vault.address, keycloak.issuer, the ConfigMap mirrors, and the three networkPolicy egress CIDRs) is BLANK and rejected by the schema.
- Ship the real `values.schema.json` typed contract: JSON Schema draft-07 (Helm's supported dialect), `additionalProperties: false` at every object level (typos fail with the exact path), `minLength: 1` + `format: uri` / `format: hostname` / `pattern: ...` on every required-but-blank field, conditional `secretName` requirement when `ingress.tls.enabled: true`.
- Update `docs/codebase/devops.md` and `README.md` with the probe wiring, safe-defaults rationale, the schema-validation behavior, and a chart-values reference table.

## Test plan

- [x] `helm lint deploy/charts/meho/ --set <required overrides>` — clean (`1 chart(s) linted, 0 chart(s) failed`).
- [x] `helm template test deploy/charts/meho/ --set <required overrides>` — renders 268 lines / 6 documents (Deployment, Service, Ingress, ConfigMap, ServiceAccount, NetworkPolicy).
- [x] `livenessProbe` rendered as `httpGet { path: /healthz, port: http }`, `initialDelaySeconds: 30`, `periodSeconds: 10`, `timeoutSeconds: 1`, `failureThreshold: 3`.
- [x] `readinessProbe` rendered as `httpGet { path: /ready, port: http }`, `initialDelaySeconds: 5`, `periodSeconds: 5`, `timeoutSeconds: 2`, `failureThreshold: 3`.
- [x] `helm template test deploy/charts/meho/` (no overrides) fails with `at '/vault/address': '' is not valid uri: relative url`, `at '/ingress/tls/secretName': minLength: got 0, want 1`, and similar for every required-but-blank field — schema fail-loud confirmed.
- [x] `helm template test deploy/charts/meho/ --set <valid overrides> --set bogus.field=x` fails with `at '': additional properties 'bogus' not allowed`.
- [x] `helm install test deploy/charts/meho/ --dry-run --debug` (no overrides) fails with `Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s)` and the exact field paths — schema validation at install time confirmed.
- [x] `python3 -c "import json; json.load(open('deploy/charts/meho/values.schema.json'))"` — schema parses as valid JSON (25 top-level properties + 2 reusable definitions).

## Acceptance criteria (from #38)

- [x] Liveness `/healthz` + readiness `/ready` rendered with the spec'd timeouts/thresholds.
- [x] `values.yaml` contains every top-level section (image, ingress, postgres, vault, keycloak, audit, broadcast, connectors, networkPolicy, serviceAccount, resources); every required-but-blank field is documented `MUST be set` in a comment.
- [x] `values.schema.json` rejects unknown fields (`additionalProperties: false` at every object level); `helm template ... --set bogus.field=x` fails with schema error.
- [x] `helm template ... -f /dev/null` fails with required-field-missing errors (empty values fall through the safe-by-default scheme and hit the schema's `minLength`/`format` rejections).
- [x] Schema validation happens at `helm install` time (verifiable by `helm install --dry-run --debug` failing with schema errors when required fields are missing).

## Out of scope

- Migration Job (G2.5-T3 / #39).
- Redis subchart dependency + the `redis` top-level values block (G2.5-T3 / #39 — the schema's top-level `additionalProperties: false` leaves room; T3 adds `redis` to `properties` and the dependency in `Chart.yaml`).
- `deploy/values-examples/values-rdc-example.yaml` (G2.5-T4 / #40).
- OCI publish + cosign signing (G2.5-T5 / #41).
- HorizontalPodAutoscaler, PodDisruptionBudget, topologySpreadConstraints — v0.2 per Goal #11 scope (HA / multi-replica explicitly out-of-scope for v0.1).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #38


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Helm chart adds a strict typed schema: required operational fields (image tag, ingress host/TLS secret, DB/Vault/Keycloak endpoints and secrets, network CIDRs) must be provided; unknown keys rejected.
  * Defaults are safe-by-default blanks; installs/upgrades fail validation without supplied overrides.
  * Deployment now mandates an explicit image tag (no fallback); liveness/readiness probes always rendered and configurable; startup probe removed.

* **Documentation**
  * Deployment and ops docs expanded with full chart contract, install/verification, and lint/template guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/170)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-11)

Addressed review findings from https://github.com/evoila/meho/pull/170#issuecomment-4416609542 in `5f97698`:

- **B1** — Rewrote `docs/codebase/devops.md` Image-reference section to drop the `.Chart.AppVersion` fallback (removed in this PR) and document the new `:<port>` regex tolerance. Also flagged conditional gating on ingress / networkPolicy in the NetworkPolicy + Safe-by-default sections + the README chart-values table.
- **M1** — Extended `image.repository` pattern with an optional `:<port>` segment so private registries like `registry.example.com:5000/team/meho` validate. Negative cases (`:notaport`) still fail.
- **M2** — `ingress.host` (+ `ingress.tls.secretName`) are now required only when `ingress.enabled: true`, expressed as an `allOf` `if/then` on the ingress object. Verified `--set ingress.enabled=false` renders without overrides; positive cases still fail loud when `enabled=true` and host is missing.
- **M3** — `networkPolicy.{postgres,vault,keycloak}CIDR` are required + pattern-validated only when `networkPolicy.enabled: true`, same technique. Verified `--set networkPolicy.enabled=false` renders without overrides.

Disputed:

- **m1** — Always-rendered readiness probe = permanent NotReady. Task #38 body explicitly accepts this at the chassis stage ("With v0.1's empty readiness registry, the Pod will never go ready until G2.2/G2.3 land — that's intentional during dev"). The probe wiring is correct for the chassis-stage backplane. No change.

<!-- auto-implement-issue: continue, iteration 1 -->
