### PR TITLE
feat(deploy): pre-install migration Job + Valkey broadcast subchart (G2.5-T3)

### DIFF
--- a/deploy/charts/meho/Chart.yaml
+++ b/deploy/charts/meho/Chart.yaml
@@ -31,3 +31,15 @@ keywords:
   - audit
   - kubernetes
   - backplane
+
+# The broadcast subchart lives in-tree at `charts/broadcast/` (ADR 0005:
+# custom Valkey 9.x chart, not Bitnami). `repository: ""` is the documented
+# Helm shape for an unpacked local subchart — no `helm dependency update`
+# is required, and no Chart.lock is produced. The `condition:` flag flips
+# the entire subchart off when an operator points the backplane at an
+# external Valkey/Redis endpoint instead (v0.2+ wiring).
+dependencies:
+  - name: broadcast
+    version: 0.1.0
+    repository: ""
+    condition: broadcast.enabled

--- a/deploy/charts/meho/charts/broadcast/Chart.yaml
+++ b/deploy/charts/meho/charts/broadcast/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: broadcast
+description: |
+  Redis-protocol-compatible activity-broadcast store for the MEHO backplane.
+  Runs Valkey 9.x OSS — the BSD-3-Clause Linux Foundation fork of Redis 7.2.4
+  — as a single-replica Deployment with ephemeral streams. Subchart slug is
+  `broadcast` rather than `redis` because the protocol contract matters more
+  than the brand (ADR 0005). The Service name (`<release>-broadcast`) is the
+  endpoint the backplane connects to via `REDIS_URL`.
+
+# Subchart version is independent of the parent chart's calver. Bump on
+# breaking subchart-values changes; rev the patch level on image-tag bumps.
+type: application
+version: 0.1.0
+appVersion: "9.0"
+
+kubeVersion: ">=1.28.0-0"
+
+sources:
+  - https://github.com/evoila/meho
+  - https://github.com/valkey-io/valkey
+
+maintainers:
+  - name: evoila Group
+    url: https://github.com/evoila
+
+keywords:
+  - valkey
+  - redis
+  - broadcast
+  - streams

--- a/deploy/charts/meho/charts/broadcast/templates/_helpers.tpl
+++ b/deploy/charts/meho/charts/broadcast/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Broadcast subchart helpers. The subchart is rendered with its own scope
+(`.Chart.Name == "broadcast"`); helpers mirror the umbrella chart's shape so
+operators reading both see the same conventions.
+*/}}
+
+{{/*
+Expand the name of the subchart.
+*/}}
+{{- define "broadcast.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully-qualified name. The parent's release name is the prefix so multiple
+MEHO installations on a single namespace remain distinct.
+*/}}
+{{- define "broadcast.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Chart label (chart-name + version).
+*/}}
+{{- define "broadcast.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to every broadcast resource.
+*/}}
+{{- define "broadcast.labels" -}}
+helm.sh/chart: {{ include "broadcast.chart" . }}
+{{ include "broadcast.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: broadcast
+{{- end }}
+
+{{/*
+Selector labels — applied to `spec.selector.matchLabels`, the Pod template
+labels, and the parent chart's NetworkPolicy egress rule so the selectors
+all line up.
+*/}}
+{{- define "broadcast.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "broadcast.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/charts/meho/charts/broadcast/templates/configmap.yaml
+++ b/deploy/charts/meho/charts/broadcast/templates/configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "broadcast.fullname" . }}-config
+  labels:
+    {{- include "broadcast.labels" . | nindent 4 }}
+data:
+  # Minimal Valkey config for the v0.1 ephemeral-streams workload.
+  #
+  # * `bind 0.0.0.0` — listen on the Pod IP only; access is gated by the
+  #   parent chart's NetworkPolicy (the broadcast podSelector + port-6379
+  #   egress rule). Cluster network is the only path into the pod.
+  # * `protected-mode no` — Valkey's protected-mode is a defense for
+  #   exposed-without-auth listeners running on a loopback. NetworkPolicy
+  #   gates ingress here, so disabling protected-mode is what allows the
+  #   bound port to accept connections from the backplane pod.
+  # * No `requirepass` — v0.1 single-tenant; auth is reserved for v0.2+ when
+  #   the broadcast feature actually carries cross-tenant streams.
+  # * No `save` lines / `appendonly no` — streams are ephemeral by design;
+  #   persistence is explicitly out of scope for v0.1.
+  # * `maxmemory-policy allkeys-lru` — caps memory growth without dropping
+  #   the entire stream history; tune via override when streams grow.
+  # * `dir /data` — points Valkey at the emptyDir-backed writable mount so
+  #   readOnlyRootFilesystem: true holds.
+  valkey.conf: |
+    bind 0.0.0.0
+    protected-mode no
+    port 6379
+    dir /data
+    save ""
+    appendonly no
+    maxmemory-policy allkeys-lru

--- a/deploy/charts/meho/charts/broadcast/templates/deployment.yaml
+++ b/deploy/charts/meho/charts/broadcast/templates/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "broadcast.fullname" . }}
+  labels:
+    {{- include "broadcast.labels" . | nindent 4 }}
+spec:
+  # Hard-capped at 1 for v0.1: streams are ephemeral, no Sentinel sidecar
+  # ships in this chart, and the parent values.schema.json rejects any
+  # value > 1. HA via Sentinel/Cluster lands at v0.2+ (ADR 0005).
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "broadcast.selectorLabels" . | nindent 6 }}
+  strategy:
+    # Single-replica + ephemeral data → Recreate is safer than RollingUpdate.
+    # A RollingUpdate would briefly run two pods, both binding port 6379;
+    # the second would fail readiness and the first would still be torn down
+    # by the rollout controller. Recreate avoids the dance.
+    type: Recreate
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "broadcast.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: broadcast
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Valkey loads the operator-supplied config from /etc/valkey/valkey.conf
+          # mounted from the ConfigMap. The image's entrypoint takes the path as
+          # the first positional argument; no `redis-server` shim is needed.
+          args:
+            - /etc/valkey/valkey.conf
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          # TCP liveness keeps the probe surface minimal — a successful TCP
+          # accept on 6379 is sufficient evidence that the server loop is up.
+          # `redis-cli PING` would be more thorough but couples the probe to
+          # the existence of `redis-cli` in the image, which Valkey OSS does
+          # ship but not under that exact binary name in every variant.
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 1
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey
+              readOnly: true
+            # Valkey writes to its data directory even with persistence
+            # disabled (PID file, ephemeral working state). With
+            # readOnlyRootFilesystem: true we mount an emptyDir at the
+            # configured `dir` path so the server can start.
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "broadcast.fullname" . }}-config
+        - name: data
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/meho/charts/broadcast/templates/service.yaml
+++ b/deploy/charts/meho/charts/broadcast/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "broadcast.fullname" . }}
+  labels:
+    {{- include "broadcast.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: redis
+      port: {{ .Values.service.port }}
+      targetPort: redis
+      protocol: TCP
+  selector:
+    {{- include "broadcast.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/meho/charts/broadcast/values.yaml
+++ b/deploy/charts/meho/charts/broadcast/values.yaml
@@ -1,0 +1,82 @@
+# Default values for the broadcast subchart (Valkey 9.x).
+#
+# The subchart ships as part of the umbrella `meho` chart; operators override
+# values via the parent chart's `broadcast:` block. ADR 0005 locks the
+# upstream image (Valkey, BSD-3-Clause) and the workload shape (single-
+# replica Deployment, no PVC — broadcast streams are ephemeral in v0.1).
+
+# -- Master switch for the subchart. The parent Chart.yaml's `dependencies`
+# entry references this via `condition: broadcast.enabled`, so flipping to
+# `false` skips all subchart resources at render time. Operators on
+# clusters with an external Redis/Valkey can disable and (in v0.2+) point
+# the backplane at the external endpoint.
+enabled: true
+
+image:
+  # -- Image repository. Defaults to upstream Valkey OSS on Docker Hub.
+  repository: valkey/valkey
+  # -- Image tag. Pinned to a stable Valkey 9.x alpine variant; bump on
+  # security advisories. ADR 0005 locked Valkey 9.x; the patch level is
+  # operator-tunable.
+  tag: "9.0-alpine"
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Number of broadcast replicas. v0.1 is capped at 1 — Valkey is run as a
+# single-replica Deployment without persistence, and the activity-broadcast
+# pillar's streams are ephemeral by design. HA via Sentinel/Cluster lands at
+# v0.2+ per Goal #11 scope; raising this value in v0.1 will not produce a
+# working HA topology (no Sentinel sidecar is shipped) and is therefore
+# rejected by the schema.
+replicas: 1
+
+# -- Pod-level security context. Matches the umbrella chart's `runAsNonRoot`
+# discipline; UID 999 is the upstream Valkey image's default user.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 999
+  fsGroup: 999
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context. `readOnlyRootFilesystem: true` is
+# safe because Valkey only writes to its configurable data directory; we
+# mount that as an `emptyDir` so the read-only root invariant holds.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# -- Container resources. Sized for v0.1 streams workload (small messages,
+# low rate). Tune limits up if the broadcast traffic grows.
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+service:
+  # -- Service type. ClusterIP is the only sensible choice for v0.1 — the
+  # broadcast store is consumed by the in-cluster backplane only.
+  type: ClusterIP
+  # -- Service port (Redis-protocol default 6379).
+  port: 6379
+
+# -- Pod-level annotations.
+podAnnotations: {}
+
+# -- Pod-level labels.
+podLabels: {}
+
+# -- Node selector.
+nodeSelector: {}
+
+# -- Tolerations.
+tolerations: []
+
+# -- Affinity rules.
+affinity: {}

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -50,6 +50,18 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.postgres.credentialsSecret }}
                   key: url
+            {{- if .Values.broadcast.enabled }}
+            # REDIS_URL points the backplane at the in-cluster broadcast
+            # store. The activity-broadcast pillar's full implementation
+            # lands in v0.2 (Goal #11 scope: chassis-only in v0.1) but the
+            # env var is forward-prepared here so the backplane chassis
+            # discovers the endpoint as soon as the broadcast code uses
+            # it. ADR 0005 locks the wire-protocol-compatible store as
+            # Valkey 9.x; `redis-py` (locked driver) parses the
+            # `redis://` scheme unchanged.
+            - name: REDIS_URL
+              value: "redis://{{ .Release.Name }}-broadcast:{{ .Values.broadcast.service.port }}/0"
+            {{- end }}
             # Other operator-supplied secrets (Keycloak client secret, Vault
             # role bindings) come via ESO-synced Kubernetes Secrets; G2.6
             # wires the references when each surface lands.

--- a/deploy/charts/meho/templates/migration-job.yaml
+++ b/deploy/charts/meho/templates/migration-job.yaml
@@ -1,0 +1,114 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "meho.fullname" . }}-migrate
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+    # The chassis-stage migration runner exits 0 on success / 1 on any
+    # Alembic failure (`backend/src/meho_backplane/db/migrate.py`). When the
+    # Job exhausts `backoffLimit` retries, Helm fails the release at the
+    # pre-install/pre-upgrade hook step — the Deployment is never created
+    # against an unmigrated schema. This is the contract Goal #11 spec
+    # section 6 locks: migration failure blocks rollout.
+  annotations:
+    # `pre-install,pre-upgrade` runs the Job before the Deployment is
+    # created (install) or rolled forward (upgrade). `hook-weight: "-10"`
+    # is well below the default 0 weight used by Deployment + Service +
+    # NetworkPolicy hooks (when those run as hooks; the chart's own
+    # resources are not hooks but Helm still creates them after weighted
+    # hook resources resolve). The negative weight is documentary — even
+    # at weight 0 the migration Job would precede the Deployment because
+    # only hooks weighted in this Job render at the pre-install phase.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    # `before-hook-creation` lets a fresh `helm upgrade` retry overwrite
+    # the previous Job. `hook-succeeded` GCs the Job once it exits 0 so a
+    # successful migration doesn't accumulate in the namespace.
+    # `hook-failed` is intentionally **not** in the list: when the Job
+    # fails the operator needs the Pod logs for forensic, and Helm leaves
+    # the Job in place. `helm uninstall` cleans it up at release-removal
+    # time.
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  # `ttlSecondsAfterFinished` is a hard backstop on the Kubernetes side:
+  # even if the operator's `helm uninstall` is delayed (or the release is
+  # abandoned), the Job + its Pod log are garbage-collected after the
+  # configured window. Tune via `.Values.migrationJob.ttlSecondsAfterFinished`.
+  ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished }}
+  # `backoffLimit` retries on non-zero exit. Alembic migrations are
+  # idempotent (a partially-applied migration leaves the database in the
+  # same logical state it started in — Alembic's transactional wrapping
+  # rolls back the half-applied step). Default 3 catches transient
+  # network blips between the Job pod and PostgreSQL without masking a
+  # real schema mismatch.
+  backoffLimit: {{ .Values.migrationJob.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "meho.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      # `OnFailure` lets the Pod restart in-place on container failure
+      # (subject to `backoffLimit`), which is cheaper than re-scheduling
+      # the whole Pod for transient asyncpg connection errors.
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "meho.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          # Same image as the backplane Deployment — the migration runner
+          # (`python -m meho_backplane.db.migrate`) lives in the backplane
+          # wheel and shares the chassis's Alembic config / SQLAlchemy
+          # version. A separate migration image would drift; using the
+          # same image guarantees the migrations applied are exactly the
+          # ones the rolling-out Deployment expects.
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # The runner takes no CLI flags by design — its contract is
+          # `alembic upgrade head` against the env-supplied DATABASE_URL.
+          # Partial upgrades are deliberately not exposed (the operator
+          # cannot accidentally pin to an intermediate revision).
+          command: ["python", "-m", "meho_backplane.db.migrate"]
+          envFrom:
+            # Reuse the backplane's ConfigMap so any Alembic-relevant
+            # env vars (pool sizes, timeouts) stay in lock-step. The
+            # runner ignores the FastAPI-only keys.
+            - configMapRef:
+                name: {{ include "meho.fullname" . }}-config
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.credentialsSecret }}
+                  key: url
+          resources:
+            {{- toYaml .Values.migrationJob.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            # Migrations don't write to the root FS, but the same libraries
+            # the backplane uses may touch /tmp on import; mounting it as
+            # emptyDir keeps readOnlyRootFilesystem: true valid.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/meho/templates/networkpolicy.yaml
+++ b/deploy/charts/meho/templates/networkpolicy.yaml
@@ -48,16 +48,23 @@ spec:
       ports:
         - port: 443
           protocol: TCP
-    # Redis — in-cluster subchart (G2.5-T3) selected by the conventional
-    # Helm labels Bitnami's redis subchart sets.
+    {{- if .Values.broadcast.enabled }}
+    # Activity-broadcast subchart (`charts/broadcast/` — Valkey per ADR
+    # 0005). Selectors match the broadcast subchart's `_helpers.tpl`
+    # `broadcast.selectorLabels` exactly so this rule lines up with the
+    # Pods the subchart renders. Egress is conditional on
+    # `broadcast.enabled` — when the operator points at an external
+    # endpoint the rule disappears and no in-cluster port-6379 traffic
+    # is permitted.
     - to:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: redis
+              app.kubernetes.io/name: broadcast
               app.kubernetes.io/instance: {{ .Release.Name }}
       ports:
-        - port: 6379
+        - port: {{ .Values.broadcast.service.port }}
           protocol: TCP
+    {{- end }}
     # DNS — UDP/53 to kube-dns / CoreDNS. Without this rule every other
     # egress rule above fails on name resolution. The selector matches the
     # standard `k8s-app: kube-dns` label CoreDNS ships with by default.

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -4,7 +4,7 @@
   "description": "Typed contract for the MEHO Helm chart. Helm validates `.Values` against this schema on `helm install` / `helm upgrade` / `helm template` / `helm lint` (Helm uses JSON Schema draft-07). `additionalProperties: false` is set at every object level so typos and stale keys fail loudly with a clear path. Required-but-blank fields use `minLength: 1` to reject the safe-by-default empty placeholders shipped in `values.yaml` — operators MUST override them via `--set` or a values overlay.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["image", "ingress", "postgres", "vault", "keycloak", "networkPolicy"],
+  "required": ["image", "ingress", "postgres", "vault", "keycloak", "networkPolicy", "broadcast", "migrationJob"],
   "properties": {
     "replicaCount": {
       "type": "integer",
@@ -273,15 +273,114 @@
     },
     "broadcast": {
       "type": "object",
+      "description": "Activity-broadcast subchart values (Valkey 9.x per ADR 0005). When `broadcast.enabled` is false the subchart resources are skipped entirely; the rest of this block may be left at defaults in that mode. When enabled, the subchart's own values.schema.json (charts/broadcast/values.yaml shape) is also enforced — this block declares the top-level surface visible to the parent chart.",
       "additionalProperties": false,
-      "required": ["redis"],
+      "required": ["enabled"],
       "properties": {
-        "redis": {
+        "enabled": { "type": "boolean" },
+        "image": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["bundled"],
+          "required": ["repository", "tag"],
           "properties": {
-            "bundled": { "type": "boolean" }
+            "repository": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*$"
+            },
+            "tag": { "type": "string", "minLength": 1 },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1,
+          "description": "v0.1 caps the broadcast subchart at one replica — no Sentinel sidecar ships in this chart and streams are ephemeral by design. HA via Sentinel/Cluster lands at v0.2+ (ADR 0005). Raising this above 1 in v0.1 would not produce a working HA topology and is rejected by the schema."
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "securityContext": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limits": { "$ref": "#/definitions/resourceQuantities" },
+            "requests": { "$ref": "#/definitions/resourceQuantities" }
+          }
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "port"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+            },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "podAnnotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "podLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "nameOverride": { "type": "string" },
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "tolerations": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "affinity": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "global": {
+          "type": "object",
+          "description": "Helm injects the parent chart's `.Values.global` into every subchart's values namespace. The key must be permitted by the schema; the contents are arbitrary (operators use it to pass shared values across subcharts).",
+          "additionalProperties": true
+        }
+      }
+    },
+    "migrationJob": {
+      "type": "object",
+      "description": "Pre-install / pre-upgrade migration Job (Helm hook) running `python -m meho_backplane.db.migrate` before the Deployment rolls forward.",
+      "additionalProperties": false,
+      "required": ["backoffLimit", "ttlSecondsAfterFinished"],
+      "properties": {
+        "backoffLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Number of Kubernetes-side retries on non-zero exit. Bounded at 10 to keep the hook latency predictable; raise via override only when a known-transient upstream dependency demands it."
+        },
+        "ttlSecondsAfterFinished": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 86400,
+          "description": "Seconds after Job completion before Kubernetes garbage-collects the Job. Capped at 24h — longer retention is the operator's responsibility via `kubectl get jobs -o yaml > backup` before TTL fires."
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limits": { "$ref": "#/definitions/resourceQuantities" },
+            "requests": { "$ref": "#/definitions/resourceQuantities" }
           }
         }
       }

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -217,12 +217,80 @@ audit:
   # mirror is explicitly v0.2 per Goal #11 spec.
   postgresOnly: true
 
+# Activity-broadcast subchart values (Valkey 9.x, per ADR 0005).
+#
+# The umbrella chart vendors a custom in-tree subchart at `charts/broadcast/`
+# running Valkey OSS as a single-replica Deployment with ephemeral streams.
+# Subchart slug is `broadcast` rather than `redis` because the protocol
+# contract matters more than the brand. The backplane connects via the
+# `REDIS_URL` env var (operator-facing) rendered against the Service name
+# `<release>-broadcast`.
+#
+# Operators on clusters running an external Valkey/Redis can flip
+# `broadcast.enabled: false` and (in v0.2+) point the backplane at the
+# external endpoint via `broadcast.externalEndpoint`. v0.1 ships the
+# `enabled: true` path only — the `externalEndpoint` opt-out is reserved
+# for the v0.2 broadcast feature work.
 broadcast:
-  redis:
-    # -- v0.1: the chart deploys its own Redis subchart (G2.5-T3 #39 adds
-    # the dependency + values plumbing). `bundled: false` would let a
-    # consumer point at an external Redis; not used in v0.1.
-    bundled: true
+  enabled: true
+  image:
+    repository: valkey/valkey
+    tag: "9.0-alpine"
+    pullPolicy: IfNotPresent
+  # -- Replica count. Hard-capped at 1 in v0.1 (no Sentinel, ephemeral
+  # streams); the schema rejects any higher value.
+  replicas: 1
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    fsGroup: 999
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+  service:
+    type: ClusterIP
+    port: 6379
+
+# Pre-install / pre-upgrade migration Job (Helm hook).
+#
+# Runs `python -m meho_backplane.db.migrate` (the entrypoint shipped by
+# G2.3-T3 #29) before the Deployment is created or rolled forward. The
+# migration runner exits non-zero on any Alembic failure, which fails the
+# Helm release and prevents an unmigrated Pod from accepting traffic.
+# Failed Jobs are NOT garbage-collected by the hook delete policy so the
+# operator can inspect logs; the k8s-side `ttlSecondsAfterFinished` is
+# the backstop.
+migrationJob:
+  # -- Number of times Kubernetes retries the migration Job on non-zero
+  # exit. Alembic migrations are idempotent; the retries catch transient
+  # network blips, not real schema mismatches.
+  backoffLimit: 3
+  # -- Seconds after Job completion (success or failure) before
+  # Kubernetes garbage-collects the Job + its Pods. 10 minutes leaves
+  # enough time for an operator to `kubectl logs` a failed Job and is
+  # cleaned up promptly after successful installs.
+  ttlSecondsAfterFinished: 600
+  # -- Container resources for the migration runner. Migrations are
+  # short-lived; the limits are conservative.
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 256Mi
 
 connectors:
   # -- v0.1 ships the chassis with no connectors enabled. The connector

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -8,7 +8,7 @@
 Everything a consumer needs to install MEHO onto a Kubernetes cluster lives
 under `deploy/`. The Helm chart at `deploy/charts/meho/` is the **single
 contract** between MEHO and the deployment environment — `helm install` /
-`helm upgrade --install` consumes it and produces all six core Kubernetes
+`helm upgrade --install` consumes it and produces the core Kubernetes
 resources that make up a running backplane:
 
 - Deployment — the backplane Pod (FastAPI app, `uvicorn` on port 8000).
@@ -17,25 +17,39 @@ resources that make up a running backplane:
 - ConfigMap — non-secret env (Keycloak URLs, Vault address, pool sizes).
 - ServiceAccount — Pod identity, `automountServiceAccountToken: false`.
 - NetworkPolicy — default-deny ingress + explicit egress allow-list to
-  Postgres, Vault, Keycloak, in-cluster Redis, and CoreDNS only.
+  Postgres, Vault, Keycloak, the broadcast subchart, and CoreDNS only.
+- Migration Job — `pre-install,pre-upgrade` Helm hook running
+  `python -m meho_backplane.db.migrate` before the Deployment rolls forward.
+- Broadcast subchart — in-tree Valkey 9.x Deployment + Service + ConfigMap
+  per ADR 0005.
 
 ## Chart layout
 
 ```
 deploy/charts/meho/
-├── Chart.yaml              # apiVersion v2, kubeVersion >=1.28
+├── Chart.yaml              # apiVersion v2, kubeVersion >=1.28, dependencies: broadcast
 ├── .helmignore             # standard exclusions
 ├── values.yaml             # safe-by-default; required fields are blank
 ├── values.schema.json      # draft-07 typed contract; rejects typos and empty required fields
-└── templates/
-    ├── _helpers.tpl        # name / fullname / labels / SA helpers
-    ├── deployment.yaml     # backplane Pod + probes (/healthz, /ready)
-    ├── service.yaml        # ClusterIP :8000
-    ├── ingress.yaml        # TLS + cert-manager
-    ├── configmap.yaml      # non-secret env
-    ├── serviceaccount.yaml # Pod identity
-    ├── networkpolicy.yaml  # default-deny + explicit egress
-    └── NOTES.txt           # post-install hints
+├── templates/
+│   ├── _helpers.tpl        # name / fullname / labels / SA helpers
+│   ├── deployment.yaml     # backplane Pod + probes (/healthz, /ready)
+│   ├── service.yaml        # ClusterIP :8000
+│   ├── ingress.yaml        # TLS + cert-manager
+│   ├── configmap.yaml      # non-secret env
+│   ├── serviceaccount.yaml # Pod identity
+│   ├── networkpolicy.yaml  # default-deny + explicit egress (broadcast egress conditional)
+│   ├── migration-job.yaml  # pre-install/pre-upgrade Helm hook (alembic upgrade head)
+│   └── NOTES.txt           # post-install hints
+└── charts/
+    └── broadcast/          # in-tree Valkey 9.x subchart (ADR 0005)
+        ├── Chart.yaml
+        ├── values.yaml
+        └── templates/
+            ├── _helpers.tpl
+            ├── deployment.yaml   # single-replica Recreate; readonly rootfs + emptyDir /data
+            ├── service.yaml      # ClusterIP :6379 (port name "redis")
+            └── configmap.yaml    # minimal valkey.conf (no auth, no persistence)
 ```
 
 ## Chart contract
@@ -126,8 +140,11 @@ egress rules to:
 - Postgres — `tcp/5432` to `networkPolicy.postgresCIDR`
 - Vault — `tcp/8200` to `networkPolicy.vaultCIDR`
 - Keycloak — `tcp/443` to `networkPolicy.keycloakCIDR`
-- Redis — `tcp/6379` to a `podSelector` matching the in-cluster Redis
-  subchart (G2.5-T3)
+- Broadcast subchart — `tcp/<broadcast.service.port>` (default 6379) to a
+  `podSelector` matching the in-cluster broadcast subchart's selector
+  labels (`app.kubernetes.io/name: broadcast`); the rule is conditional
+  on `broadcast.enabled: true` and is omitted when the broadcast subchart
+  is disabled
 - DNS — `udp/53` to the `k8s-app: kube-dns` selector (matches CoreDNS)
 
 Ingress is permitted only from the namespace whose
@@ -150,6 +167,117 @@ requirements in that mode so the values overlay does not need to
 populate them. Disabling without a replacement policy in place removes
 the chart's least-privilege egress story — only do it when an
 equivalent control is enforced upstream.
+
+### Migration Job (`templates/migration-job.yaml`)
+
+A Kubernetes `Job` runs as a Helm hook before the Deployment is created
+(install) or rolled forward (upgrade). The container executes
+`python -m meho_backplane.db.migrate` — the entrypoint shipped by Task
+#29 — which invokes `alembic upgrade head` against the same
+`DATABASE_URL` Secret the backplane Deployment consumes. The Job uses
+the same image as the backplane (`{{ .Values.image.repository }}:{{ .Values.image.tag }}`)
+so the migrations applied match exactly the revision the rolling-out
+Deployment expects — a separate migration image would drift.
+
+Hook semantics:
+
+| Annotation | Value | Meaning |
+| --- | --- | --- |
+| `helm.sh/hook` | `pre-install,pre-upgrade` | Runs the Job both on a fresh `helm install` and every `helm upgrade` |
+| `helm.sh/hook-weight` | `"-10"` | Runs ahead of any other hook resources (only documentary at the chassis stage — no other hooks ship yet) |
+| `helm.sh/hook-delete-policy` | `before-hook-creation,hook-succeeded` | Overwrites the previous Job on retry; GCs the Job once it exits 0. `hook-failed` is **intentionally absent** — failed Jobs stay in the namespace for `kubectl logs` forensics |
+
+Pod spec:
+
+- `restartPolicy: OnFailure` — retry in-place on transient asyncpg
+  errors without re-scheduling the whole Pod.
+- `backoffLimit: 3` (operator-tunable via `.Values.migrationJob.backoffLimit`) —
+  catches transient network blips between the Job pod and PostgreSQL.
+  Alembic migrations are idempotent so re-running a partially-applied
+  step is safe.
+- `ttlSecondsAfterFinished: 600` (operator-tunable via
+  `.Values.migrationJob.ttlSecondsAfterFinished`) — Kubernetes-side
+  garbage-collection backstop: even if `helm uninstall` is delayed, the
+  Job + Pod logs are reaped after the configured window (10 minutes by
+  default).
+- Same `serviceAccountName`, `imagePullSecrets`, and pod/container
+  `securityContext` as the backplane Deployment (`runAsNonRoot`,
+  `readOnlyRootFilesystem`, `drop: [ALL]`), with `/tmp` mounted as an
+  `emptyDir` to keep the read-only root invariant.
+- `envFrom` reuses the backplane's ConfigMap so any Alembic-relevant env
+  vars (pool sizes, timeouts) stay in lock-step; `DATABASE_URL` is
+  pulled from `Values.postgres.credentialsSecret` at the `url` key
+  exactly like the Deployment does.
+
+**Failure semantics.** When the Job exhausts `backoffLimit`, Helm fails
+the release at the pre-install/pre-upgrade hook step. The Deployment is
+never created against an unmigrated schema. The failed Job is left in
+the namespace; `kubectl logs -n <ns> job/<release>-meho-migrate` shows
+the Alembic error (rendered to stderr by the runner as
+`migration_failed: <ExcClass>: <msg>`).
+
+### Broadcast subchart (`charts/broadcast/`)
+
+A custom in-tree Helm subchart deploys Valkey 9.x as the
+Redis-protocol-compatible activity-broadcast store. ADR 0005 locks the
+upstream choice and the workload shape; the subchart is the
+implementation of that decision.
+
+| Aspect | Value | Rationale |
+| --- | --- | --- |
+| Upstream image | `valkey/valkey:9.0-alpine` (Docker Hub) | BSD-3-Clause; Linux Foundation governance; carries Redis 7.2.4's last permissive license forward |
+| Slug | `broadcast` (not `redis`) | The protocol contract matters more than the brand |
+| Workload | `Deployment` (not `StatefulSet`), single replica | Streams are ephemeral in v0.1; HA via Sentinel/Cluster is v0.2+ |
+| Persistence | None (no PVC, `save ""`, `appendonly no`) | Restart-loss of stream history is acceptable in v0.1 |
+| Auth | None (no `requirepass`) | v0.1 single-tenant; gated at the network layer by the umbrella chart's NetworkPolicy |
+| Update strategy | `Recreate` | Single-replica + port-bind constraint makes RollingUpdate worse |
+| Probes | TCP `connect` on 6379 | Minimal — avoids coupling to `redis-cli` / `valkey-cli` binary naming variance |
+| Service | ClusterIP `<release>-broadcast:6379` (port name `redis`) | In-cluster only; backplane consumes via the operator-facing `REDIS_URL` env |
+
+The subchart lives unpacked at `deploy/charts/meho/charts/broadcast/`.
+The parent `Chart.yaml` declares it as a dependency with
+`repository: ""` (the documented Helm shape for an unpacked local
+subchart — `helm dependency update` is not required and would fail
+trying to fetch from a remote registry). `condition: broadcast.enabled`
+lets operators flip the entire subchart off with a single boolean — for
+example, on clusters where an external managed Valkey/Redis (Azure
+Cache, AWS ElastiCache, GCP Memorystore) is already available. The
+v0.2+ `broadcast.externalEndpoint` opt-out lands when the broadcast
+feature actually carries cross-deployment streams.
+
+**Schema interaction with the parent.** The umbrella chart's
+`values.schema.json` declares a `broadcast` property with
+`additionalProperties: false` plus an explicit list of permitted keys,
+**plus a permissive `global` property** because Helm injects
+`.Values.global` into every subchart's values namespace. Without the
+`global` allowance, `helm lint` reports
+`at '/broadcast': additional properties 'global' not allowed`. The
+subchart's own values.yaml shape is also enforced by Helm independently —
+this parent block is the surface visible to the umbrella's `--set` flags.
+
+**Backplane wiring.** When `broadcast.enabled: true` (the default), the
+backplane Deployment renders a `REDIS_URL` env var pointing at
+`redis://{{ .Release.Name }}-broadcast:{{ .Values.broadcast.service.port }}/0`.
+The full broadcast feature is v0.2 work; the env var is forward-prepared
+in v0.1 so the chassis discovers the endpoint as soon as the broadcast
+code uses it. ADR 0005 locked `redis-py` as the driver — it parses
+`redis://` schemes against a Valkey endpoint unchanged (wire-protocol
+compatibility carries from Redis 7.2.4).
+
+**Operator-supplied secrets.** The Job + the backplane both consume
+`DATABASE_URL` from a Kubernetes Secret named by
+`postgres.credentialsSecret` at key `url`. The chart references this
+Secret by name only — provisioning it is the operator's job. Production
+deployments use **External Secrets Operator (ESO)** to sync the value
+from HashiCorp Vault (G2.5-T4 ships the example overlay; G2.6 wires the
+ESO ExternalSecret resources). Dev installs may pre-provision the Secret
+manually:
+
+```bash
+kubectl create secret generic meho-postgres \
+  --from-literal=url='postgresql+asyncpg://meho:<password>@<host>:5432/meho' \
+  --namespace meho
+```
 
 ### Safe-by-default values
 
@@ -201,10 +329,14 @@ Three properties make this the right contract:
    on URLs / hostnames / CIDRs.** The safe-by-default empty placeholders
    in `values.yaml` are intentionally rejected, surfacing the exact field
    the operator must override.
-3. **Subchart compatibility.** When G2.5-T3 (#39) adds the Redis subchart
-   dependency, the top-level `properties` map gains a `redis` key and the
-   subchart's own `values.schema.json` (if present) is also enforced —
-   the parent chart cannot circumvent subchart restrictions.
+3. **Subchart compatibility.** The umbrella's `properties` map declares
+   a `broadcast` key for the in-tree subchart at `charts/broadcast/`, and
+   the subchart's own `values.schema.json` (if shipped) is also enforced
+   by Helm independently — the parent chart cannot circumvent subchart
+   restrictions. A permissive `broadcast.global` allowance is required
+   because Helm injects `.Values.global` into every subchart's
+   values namespace; omitting it causes
+   `at '/broadcast': additional properties 'global' not allowed`.
 
 `helm lint` against the unmodified `values.yaml` **deliberately fails**
 with the safe-by-default empty fields. The chart's CI / lint workflow
@@ -285,9 +417,13 @@ helm template test deploy/charts/meho/ --set bogus.field=x 2>&1 | grep "addition
 
 - Image — `ghcr.io/evoila/meho:<tag>` from G2.4 (#31). Multi-arch
   (amd64 + arm64), cosign-signed, SBOM-attested.
-- Migration runner — invoked by a pre-install/pre-upgrade Job hook landed
-  in G2.5-T3 (#39); shells out to the entrypoint added in G2.3-T3 (#29).
-- Redis subchart — added by G2.5-T3 (#39) per ADR 0005.
+- Migration runner — invoked by the `pre-install,pre-upgrade` Job hook
+  defined in `templates/migration-job.yaml`; shells out to the
+  entrypoint added in G2.3-T3 (#29) — `python -m meho_backplane.db.migrate`.
+- Broadcast subchart — in-tree at `charts/broadcast/`, Valkey 9.x per
+  ADR 0005. Declared in `Chart.yaml`'s `dependencies:` block with
+  `repository: ""` (local unpacked subchart; no
+  `helm dependency update` needed).
 - External Secrets Operator (ESO) — owns the Kubernetes Secrets the chart
   references (`postgres.credentialsSecret`, future Keycloak client secret,
   future Vault role bindings). ESO is consumer-owned; the chart references
@@ -295,14 +431,16 @@ helm template test deploy/charts/meho/ --set bogus.field=x 2>&1 | grep "addition
 
 ## Known gaps (filled by sibling tasks)
 
-- Pre-install migration Job + Redis subchart — G2.5-T3 (#39). The subchart
-  will extend `values.yaml` with a top-level `redis:` key and the matching
-  schema branch.
 - `deploy/values-examples/values-rdc-example.yaml` — G2.5-T4 (#40).
 - OCI publish to `ghcr.io/evoila/meho-chart` + cosign signing — G2.5-T5
   (#41).
 - HPA / PDB / topologySpreadConstraints / ServiceMonitor / PrometheusRule
   — deferred to v0.2. v0.1 is single-replica per Goal #11 scope.
+- Broadcast subchart HA (Sentinel/Cluster), persistence, auth —
+  deferred to v0.2 per ADR 0005.
+- `broadcast.externalEndpoint` opt-out for operators with a managed
+  Redis/Valkey already running — deferred to v0.2 (the
+  `broadcast.enabled: false` knob lands in v0.1 as the disable path).
 
 ## References
 


### PR DESCRIPTION
## Summary

- Adds the pre-install/pre-upgrade migration Job (`templates/migration-job.yaml`) running `python -m meho_backplane.db.migrate` so a failed Alembic upgrade fails `helm install` / `helm upgrade` at the hook step instead of letting an unmigrated Pod come up.
- Adds the in-tree broadcast subchart (`charts/broadcast/`) deploying Valkey 9.x per ADR 0005 — single-replica `Deployment` (Recreate strategy), ClusterIP `<release>-broadcast:6379`, no persistence, no auth. Slug is `broadcast` (not `redis`) because the protocol contract matters more than the brand; `redis-py` connects unchanged over the Redis wire protocol.
- Backplane Deployment renders `REDIS_URL=redis://<release>-broadcast:6379/0` conditional on `broadcast.enabled`. Full broadcast feature is v0.2; the env var is forward-prepared so the chassis discovers the endpoint as soon as the v0.2 code uses it.
- NetworkPolicy egress for broadcast updated to the new selector (`app.kubernetes.io/name: broadcast`) and made conditional on `broadcast.enabled` so the rule disappears when the operator points at an external endpoint.
- `values.schema.json` replaces the placeholder `broadcast.redis.bundled` shape with the ADR-locked `broadcast.enabled` + `image`/`replicas`/`resources`/`service` block, adds `migrationJob`, and includes the permissive `broadcast.global` allowance Helm's global-values injection requires.
- `docs/codebase/devops.md` extended with Migration Job + Broadcast subchart sections and the operator's `DATABASE_URL` secret-shape expectation.

## Test plan

- [x] `helm lint deploy/charts/meho/ --set <full overrides>` — clean (and clean with `--strict`)
- [x] `helm template test deploy/charts/meho/ --set <full overrides>` — renders 10 docs including the migration Job (annotated `helm.sh/hook: pre-install,pre-upgrade`, `helm.sh/hook-weight: "-10"`, `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`), broadcast Deployment + Service + ConfigMap, and a `REDIS_URL` env on the backplane Deployment
- [x] `helm template --set broadcast.enabled=false` — skips all subchart resources, drops the `REDIS_URL` env on the backplane, drops the broadcast NetworkPolicy egress rule
- [x] Schema negative tests: `--set broadcast.bogusField=x` rejected with `at '/broadcast': additional properties 'bogusField' not allowed`; `--set broadcast.replicas=3` rejected with `at '/broadcast/replicas': maximum: got 3, want 1`
- [x] Migration Job command override verified: `["python", "-m", "meho_backplane.db.migrate"]`; runs as `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `drop: [ALL]`; mounts `DATABASE_URL` from `postgres.credentialsSecret` exactly as the Deployment does
- [x] Migration failure path: `hook-failed` is **not** in the hook-delete-policy, so a failed Job stays in the namespace for `kubectl logs job/<release>-meho-migrate`
- [x] All rendered docs parse as valid YAML with required `apiVersion`/`kind`/`metadata.name`

## Out of scope

- `deploy/values-examples/values-rdc-example.yaml` — G2.5-T4 (#40)
- OCI publish + cosign signing — G2.5-T5 (#41)
- Broadcast subchart HA (Sentinel/Cluster), persistence, auth, `broadcast.externalEndpoint` opt-out — deferred to v0.2 per ADR 0005
- HPA / PDB / topologySpreadConstraints / ServiceMonitor / PrometheusRule — deferred to v0.2

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #39


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time activity broadcast service now integrated with all deployments
  * Database schema migrations automatically execute before deployment to ensure consistency
  * Network policies enhanced to enable secure broadcast service communication

* **Documentation**
  * Deployment guide updated with broadcast service and database migration setup information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/171)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->