### PR TITLE
feat(deploy): values-rdc-example.yaml + ESO sync patterns (G2.5-T4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,28 @@ See [`docs/codebase/devops.md`](./docs/codebase/devops.md) for the full
 chart contract, probe semantics, NetworkPolicy posture, install/upgrade
 flow, and verification commands.
 
+## Deploy
+
+A sanitized example values file for a Vault + Keycloak + Postgres +
+ingress-nginx-shaped cluster (the same shape as the RDC Hetzner
+dogfooding lab) lives at
+[`deploy/values-examples/values-rdc-example.yaml`](./deploy/values-examples/values-rdc-example.yaml);
+the substitution recipe and the **External Secrets Operator (ESO) sync
+patterns** the chart expects are documented in
+[`deploy/values-examples/README.md`](./deploy/values-examples/README.md).
+
+Once v0.1 is released the chart will also be published as an OCI artifact
+at `oci://ghcr.io/evoila/meho-chart` (Task #41); until then, install
+directly from the repository tree:
+
+```bash
+helm upgrade --install meho ./deploy/charts/meho/ \
+  --namespace meho --create-namespace \
+  -f deploy/values-examples/values-rdc-example.yaml \
+  --set image.tag=sha-<git-sha>
+  # ...plus the substitutions documented in deploy/values-examples/README.md
+```
+
 ## Documentation
 
 (Placeholder — `docs.meho.ai` will land before v0.1.)

--- a/deploy/charts/meho/templates/externalsecrets.yaml
+++ b/deploy/charts/meho/templates/externalsecrets.yaml
@@ -1,0 +1,82 @@
+{{- /*
+Optional chart-side External Secrets Operator (ESO) ExternalSecret resources.
+
+Default off (`eso.enabled: false`) — the chart references operator-provisioned
+k8s Secrets by name and leaves the sync to the consumer's GitOps repo. This
+file renders only when the consumer explicitly opts in via `eso.enabled: true`.
+
+When enabled, the chart materialises:
+
+  * One ExternalSecret named `<fullname>-postgres` that pulls `DATABASE_URL`
+    from `<eso.postgres.remoteKey | default "<vault.paths.kv>/postgres">` at
+    property `<eso.postgres.remoteProperty | default "url">` into the k8s
+    Secret named in `.Values.postgres.credentialsSecret`, key `url`. The
+    Deployment's `DATABASE_URL` env reads that key directly.
+
+  * (Optional, when `eso.keycloak.enabled: true`) One ExternalSecret named
+    `<fullname>-keycloak-client` that pulls the Keycloak OAuth client secret
+    from `<keycloak.clientSecretSyncFromVault>` into a Secret of the same
+    name keyed `client_secret`. v0.1 does not yet consume this Secret in
+    the Deployment env — it's rendered so the consumer can verify sync
+    end-to-end before the v0.2 Keycloak federation wiring lands.
+
+The chart deliberately does NOT render the SecretStore / ClusterSecretStore —
+that resource is consumer-owned (it carries the Vault auth credentials and
+must outlive any given chart release).
+
+ESO ExternalSecret API reference:
+  https://external-secrets.io/latest/api/externalsecret/
+*/}}
+{{- if .Values.eso.enabled }}
+{{- $fullname := include "meho.fullname" . -}}
+{{- $labels := include "meho.labels" . -}}
+{{- $storeName := .Values.eso.secretStore.name -}}
+{{- $storeKind := .Values.eso.secretStore.kind -}}
+{{- $refresh := default "1h" .Values.eso.refreshInterval -}}
+{{- $kvBase := .Values.vault.paths.kv -}}
+{{- $pgRemoteKey := default (printf "%s/postgres" $kvBase) .Values.eso.postgres.remoteKey -}}
+{{- $pgRemoteProperty := default "url" .Values.eso.postgres.remoteProperty -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $fullname }}-postgres
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $storeName }}
+    kind: {{ $storeKind }}
+  target:
+    # Must match `.Values.postgres.credentialsSecret` so the Deployment's
+    # `secretKeyRef.name` resolves to this synced Secret.
+    name: {{ .Values.postgres.credentialsSecret }}
+    creationPolicy: Owner
+  data:
+    - secretKey: url
+      remoteRef:
+        key: {{ $pgRemoteKey }}
+        property: {{ $pgRemoteProperty }}
+{{- if .Values.eso.keycloak.enabled }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $fullname }}-keycloak-client
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $storeName }}
+    kind: {{ $storeKind }}
+  target:
+    name: {{ $fullname }}-keycloak-client
+    creationPolicy: Owner
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: {{ .Values.keycloak.clientSecretSyncFromVault }}
+        property: {{ default "client_secret" .Values.eso.keycloak.remoteProperty }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -25,7 +25,8 @@
         "tag": {
           "type": "string",
           "minLength": 1,
-          "description": "Image tag. Empty fails the schema — Goal #11 deploy discipline requires every install to pin an immutable tag."
+          "pattern": "^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$",
+          "description": "Image tag. Empty fails the schema — Goal #11 deploy discipline requires every install to pin an immutable tag. The pattern matches the OCI tag grammar (`[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}`) so a forgotten `<REPLACE: ...>` placeholder from an example values file fails at install instead of producing an image reference Kubernetes rejects at Pod create."
         },
         "pullPolicy": {
           "type": "string",
@@ -395,6 +396,84 @@
           "items": { "type": "string", "minLength": 1 }
         }
       }
+    },
+    "eso": {
+      "type": "object",
+      "description": "Optional chart-side External Secrets Operator (ESO) resource rendering. The default `enabled: false` keeps the chart decoupled from the secret-sync mechanism — Goal #11's cross-repo convention is that the consumer's GitOps repo owns the ExternalSecret manifests. Flipping `enabled: true` renders ExternalSecret CRs for `postgres.credentialsSecret` and (when `eso.keycloak.enabled: true`) the Keycloak client secret, both referencing the named SecretStore. The chart never renders the SecretStore / ClusterSecretStore itself — the consumer installs ESO and creates the store before applying this chart. `eso.secretStore.name` and `eso.postgres.remoteKey` are allowed empty in the default-disabled mode; the conditional `allOf` below enforces non-empty values + the ESO API shape only when `eso.enabled: true`, so a misconfigured opt-in still fails at install time.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "secretStore": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the existing SecretStore / ClusterSecretStore the rendered ExternalSecret references. Required (non-empty) when `eso.enabled: true`."
+            },
+            "kind": {
+              "type": "string",
+              "enum": ["SecretStore", "ClusterSecretStore"],
+              "description": "Kind of the referenced store. ClusterSecretStore is the typical choice on RKE2 clusters because the store lives once cluster-wide; SecretStore is namespace-scoped."
+            }
+          }
+        },
+        "refreshInterval": {
+          "type": "string",
+          "pattern": "^[0-9]+(s|m|h)$",
+          "description": "ESO refresh interval (e.g. `1h`, `15m`). Defaults to `1h`."
+        },
+        "postgres": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "remoteKey": {
+              "type": "string",
+              "description": "Vault KV path that holds the DATABASE_URL value. Empty → the template derives it as `<vault.paths.kv>/postgres` at render time."
+            },
+            "remoteProperty": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Property within the remote KV entry that holds the DATABASE_URL string. Defaults to `url` to match the chart's Deployment env, which reads the synced Secret's `url` key."
+            }
+          }
+        },
+        "keycloak": {
+          "type": "object",
+          "description": "Optional ExternalSecret for the Keycloak client secret. v0.1 does not yet consume this Secret in the Deployment env — it is rendered so the consumer's CI can verify the sync end-to-end before the v0.2 Keycloak federation wiring lands. Target Secret name is `<release>-keycloak-client`, keyed `client_secret`.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "remoteProperty": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          },
+          "then": {
+            "required": ["secretStore"],
+            "properties": {
+              "secretStore": {
+                "required": ["name", "kind"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "networkPolicy": {
       "type": "object",

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -297,6 +297,50 @@ connectors:
   # surface lands post-Goal-2 with the first product ticket.
   enabled: []
 
+# Optional chart-side External Secrets Operator (ESO) resource rendering.
+#
+# Default `enabled: false` — the chart references operator-provisioned
+# Kubernetes Secrets *by name* (e.g. `postgres.credentialsSecret`) and
+# leaves the sync mechanism to the consumer's GitOps repo. This matches
+# Goal #11's cross-repo convention where
+# `evoila-bosnia/claude-rdc-hetzner-dc` owns the ExternalSecret manifests.
+#
+# Flipping `enabled: true` makes the chart render ExternalSecret CRs for
+# `postgres.credentialsSecret` and (when `eso.keycloak.enabled: true`) the
+# Keycloak client secret. The chart does NOT render the SecretStore /
+# ClusterSecretStore itself — install ESO and create the store first.
+#
+# When `enabled: true` the schema also requires `eso.secretStore.name` and
+# `eso.secretStore.kind`. See `deploy/values-examples/README.md` for the
+# expected ClusterSecretStore + ExternalSecret pattern.
+eso:
+  enabled: false
+  secretStore:
+    # -- Name of the existing SecretStore / ClusterSecretStore.
+    name: ""
+    # -- Kind: `ClusterSecretStore` is the typical RKE2 choice (the store
+    # lives once cluster-wide); `SecretStore` is namespace-scoped.
+    kind: ClusterSecretStore
+  # -- ESO refresh interval. ESO re-pulls from the upstream store at this
+  # cadence; `1h` is the project default and balances rotation latency
+  # against API load on Vault.
+  refreshInterval: 1h
+  postgres:
+    # -- Vault KV path holding the DATABASE_URL value. Empty = derive from
+    # `<vault.paths.kv>/postgres` at render time.
+    remoteKey: ""
+    # -- Property within the remote KV entry that holds the DATABASE_URL.
+    # Must be `url` to match the Deployment env's `secretKeyRef.key: url`.
+    remoteProperty: url
+  keycloak:
+    # -- Render an ExternalSecret for the Keycloak client secret. The
+    # resulting Secret is named `<release>-keycloak-client`, keyed
+    # `client_secret`. v0.1 does not yet consume this Secret in the
+    # Deployment env — set this `true` to verify the sync end-to-end
+    # before the v0.2 federation wiring lands.
+    enabled: false
+    remoteProperty: client_secret
+
 networkPolicy:
   # -- Whether to ship the default-deny NetworkPolicy. Disable only on
   # clusters running an equivalent mesh-level policy (Istio AuthorizationPolicy

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -1,0 +1,226 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# values-examples — sanitized chart-values templates
+
+This directory ships **sanitized example values files** for the MEHO Helm
+chart at [`deploy/charts/meho/`](../charts/meho/). Each file targets a
+specific deployment shape (today: the RDC Hetzner dogfooding lab) and is
+designed to be copied into a private deploy repo, the placeholders
+substituted, and applied via `helm install` / `helm upgrade`.
+
+The files here ship **no real secrets, no real CIDRs**. Every
+site-specific field uses a `<REPLACE: ...>` placeholder that fails
+`values.schema.json` validation at install time, so an operator who
+forgets to substitute one fails-loud at `helm install` rather than
+silently connecting to the wrong system or CrashLoopBackOff'ing at first
+request.
+
+## Files
+
+| File | Targets | Backed by |
+| --- | --- | --- |
+| [`values-rdc-example.yaml`](./values-rdc-example.yaml) | The RDC Hetzner lab (`*.evba.lab` hosts, rke2-infra ingress-nginx, cluster-internal Postgres + Vault + Keycloak). | The actual, private file lives in [`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)'s `manifests/meho/values-rdc.yaml`; this file is the sanitized template for other Vault-+-Keycloak-+-Postgres-shaped labs. |
+
+## Using `values-rdc-example.yaml`
+
+1. **Copy** the file into your private deploy repo. Do not put real
+   CIDRs / hostnames / image tags into a public repo.
+
+2. **Substitute** the `<REPLACE: ...>` placeholders. The minimum required
+   set:
+
+    | Placeholder | What to put |
+    | --- | --- |
+    | `image.tag` | An immutable tag from the G2.4 image pipeline. Production: `sha-<40-char-git-sha>` from a green CI run. Pre-prod / lab: `v0.1.0` once the release tag exists. **`:latest` and `:main` are forbidden by Goal #11 deploy discipline.** |
+    | `config.keycloakIssuerUrl` / `keycloak.issuer` realm | Your Keycloak realm name. Both fields must agree — the ConfigMap-sourced env mirrors the values block (`config.keycloakIssuerUrl` is what the backplane process reads at startup). |
+    | `networkPolicy.postgresCIDR` | The IPv4 CIDR of your Postgres Service. Recover via `kubectl get endpoints <pg-svc> -n <ns> -o jsonpath='{.subsets[].addresses[].ip}'` and widen to the controlling subnet. |
+    | `networkPolicy.vaultCIDR` | Same, for Vault. |
+    | `networkPolicy.keycloakCIDR` | Same, for Keycloak. |
+
+3. **Provision** the Kubernetes Secrets named in the values file. The
+   chart references `postgres.credentialsSecret` by name; the Pod will
+   not start until that Secret exists with a `url` key holding the
+   `DATABASE_URL`. The recommended sync mechanism is **External Secrets
+   Operator (ESO)** — see [§ ESO sync patterns](#eso-sync-patterns) below.
+
+4. **Install** (after ESO has populated the target Secret — see install
+   flow below):
+
+    ```bash
+    helm upgrade --install meho ./deploy/charts/meho/ \
+      --namespace meho --create-namespace \
+      -f values-rdc.yaml
+    ```
+
+5. **Verify** the release came up clean:
+
+    ```bash
+    kubectl -n meho rollout status deploy/meho
+    kubectl -n meho get pods -l app.kubernetes.io/name=meho
+    kubectl -n meho logs deploy/meho --tail=50
+    ```
+
+## ESO sync patterns
+
+The MEHO chart references operator-provisioned Kubernetes Secrets *by
+name* — it does not embed credentials in `values.yaml`, and it does not
+ship a `Secret` template that consumers `--set` values into. Instead, the
+chart expects the consumer to sync secrets from a backing store (Vault,
+1Password Connect, AWS Secrets Manager, …) into Kubernetes via
+[**External Secrets Operator (ESO)**](https://external-secrets.io/).
+
+The RDC lab uses ESO with **HashiCorp Vault** as the backend
+([provider docs](https://external-secrets.io/latest/provider/hashicorp-vault/)).
+Two resources combine to materialise a Secret the chart can consume:
+
+1. **`ClusterSecretStore`** — cluster-scoped pointer at the upstream
+   store. Carries the Vault address, auth method, and (for JWT/Kubernetes
+   auth) the SA token. Created once, by the platform team. **Lives
+   outside this chart by design**: it outlives any given release and
+   carries the cluster's Vault credentials, so it belongs in the
+   consumer's GitOps repo, not the application chart.
+
+    ```yaml
+    apiVersion: external-secrets.io/v1beta1
+    kind: ClusterSecretStore
+    metadata:
+      name: vault-store
+    spec:
+      provider:
+        vault:
+          server: https://vault.evba.lab
+          path: secret          # KV v2 mount
+          version: v2
+          auth:
+            kubernetes:
+              mountPath: kubernetes
+              role: external-secrets
+              serviceAccountRef:
+                name: external-secrets
+                namespace: external-secrets
+    ```
+
+2. **`ExternalSecret`** — namespaced resource that pulls one or more
+   keys out of the upstream store and projects them into a Kubernetes
+   Secret in the same namespace. **Two options for who owns this**:
+
+    - **Default (consumer-managed):** the consumer's GitOps repo applies
+      ExternalSecret manifests alongside (or before) the chart. The
+      chart references the resulting Secret by name. This is the RDC
+      lab's convention and stays out of the chart entirely.
+
+      ```yaml
+      apiVersion: external-secrets.io/v1beta1
+      kind: ExternalSecret
+      metadata:
+        name: meho-postgres
+        namespace: meho
+      spec:
+        refreshInterval: 1h
+        secretStoreRef:
+          name: vault-store
+          kind: ClusterSecretStore
+        target:
+          # MUST match `.Values.postgres.credentialsSecret` in the chart.
+          name: meho-postgres
+          creationPolicy: Owner
+        data:
+          - secretKey: url       # the Secret's data key — MUST be `url`
+            remoteRef:
+              key: secret/meho/postgres   # Vault KV path
+              property: url               # the JSON property holding DATABASE_URL
+      ```
+
+      The chart's Deployment env reads `DATABASE_URL` from this Secret's
+      `url` key — see [`deploy/charts/meho/templates/deployment.yaml`](../charts/meho/templates/deployment.yaml).
+
+    - **Opt-in (chart-managed):** set `eso.enabled: true` in your
+      values file and the chart renders the ExternalSecret itself. Use
+      this when you'd rather keep one source of truth (`helm template`
+      shows everything) and you're not running a sibling GitOps
+      operator that already owns the ExternalSecrets.
+
+      ```yaml
+      eso:
+        enabled: true
+        secretStore:
+          name: vault-store
+          kind: ClusterSecretStore
+        refreshInterval: 1h
+        postgres:
+          remoteKey: secret/meho/postgres
+          remoteProperty: url
+        keycloak:
+          enabled: false        # v0.1 does not yet consume this in env
+      ```
+
+      The schema enforces `secretStore.name` + `secretStore.kind` when
+      `eso.enabled: true`, so a misconfigured opt-in fails at install
+      time. With `eso.enabled: false` (the default) the chart never
+      renders ExternalSecret resources — verify with
+      `helm template ... | grep -c ExternalSecret` → `0`.
+
+### Vault paths the chart expects
+
+| Vault KV path | What's stored | Consumed by |
+| --- | --- | --- |
+| `secret/meho/postgres` (property `url`) | The full `DATABASE_URL`: `postgresql+asyncpg://<user>:<pass>@<host>:<port>/<db>` | The Deployment env `DATABASE_URL` via `postgres.credentialsSecret` |
+| `secret/meho/keycloak/client_secret` (property `client_secret`) | The Keycloak OAuth client secret backing `keycloak.audience` | v0.2 federation wiring (rendered optionally today for end-to-end sync verification) |
+
+The `secret/meho` base is configurable via `vault.paths.kv` — adjust the
+KV paths above accordingly if you remount Vault elsewhere.
+
+## End-to-end install flow
+
+The order matters because the chart's migration Job runs as a
+`pre-install,pre-upgrade` hook and refuses to start without
+`DATABASE_URL`.
+
+```bash
+# 0. Once per cluster: install External Secrets Operator.
+helm repo add external-secrets https://charts.external-secrets.io
+helm install external-secrets external-secrets/external-secrets \
+  -n external-secrets --create-namespace
+
+# 1. Once per cluster: create the ClusterSecretStore pointing at Vault.
+#    (Owned by your GitOps repo, not this chart — see above.)
+kubectl apply -f cluster-secret-store-vault.yaml
+
+# 2. Per release: provision the ExternalSecret(s) the chart references.
+#    Skip this step if you set `eso.enabled: true` in values — the chart
+#    renders them itself.
+kubectl apply -n meho -f externalsecret-meho-postgres.yaml
+
+# 3. Wait for the target Secret to materialise. The chart's pre-install
+#    migration Job mounts it; if it isn't ready, the Job fails fast.
+kubectl -n meho wait --for=create secret/meho-postgres --timeout=60s
+kubectl -n meho get externalsecret meho-postgres -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+# → "True"
+
+# 4. Apply the chart.
+helm upgrade --install meho ./deploy/charts/meho/ \
+  --namespace meho --create-namespace \
+  -f values-rdc.yaml
+```
+
+## Out of scope for v0.1
+
+- The actual `values-rdc.yaml` (private, lives in the consumer's repo).
+- The `ClusterSecretStore` / `SecretStore` manifest itself — consumer-owned.
+- Multi-environment overlays (staging, prod) — v0.1 ships only the lab shape.
+- Helm `--values=secret://` plugin integration — v0.2 if the dual-source
+  ExternalSecret pattern proves friction-heavy.
+- ApplicationSet (ArgoCD) — v0.2.
+
+## References
+
+- Parent Goal: [#11 — Deployable v0.1](https://github.com/evoila-bosnia/meho-internal/issues/11)
+- Parent Initiative: [#36 — G2.5 Helm chart](https://github.com/evoila-bosnia/meho-internal/issues/36)
+- This task: [#40 — values-rdc-example.yaml + ESO sync patterns documented](https://github.com/evoila-bosnia/meho-internal/issues/40)
+- External Secrets Operator: <https://external-secrets.io/>
+- ESO Vault provider: <https://external-secrets.io/latest/provider/hashicorp-vault/>
+- ESO ExternalSecret API: <https://external-secrets.io/latest/api/externalsecret/>
+- Chart documentation: [`docs/codebase/devops.md`](../../docs/codebase/devops.md)

--- a/deploy/values-examples/values-rdc-example.yaml
+++ b/deploy/values-examples/values-rdc-example.yaml
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Example chart values for the RDC Hetzner dogfooding lab.
+#
+# The *actual* values-rdc.yaml is environment-private and lives in
+# `evoila-bosnia/claude-rdc-hetzner-dc/manifests/meho/values-rdc.yaml`
+# (per Goal #11 cross-repo deps). This file is a SANITIZED EXAMPLE
+# that other operators copy as a template: no real secrets, no real
+# CIDRs, and every site-specific field uses a `<REPLACE: ...>`
+# placeholder so a forgotten substitution fails values.schema.json
+# validation at `helm install` time instead of CrashLoopBackOff'ing
+# silently against the wrong system.
+#
+# See `deploy/values-examples/README.md` for the substitution recipe
+# and the External Secrets Operator (ESO) sync patterns the chart
+# expects the consumer to provision before install.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/evoila/meho
+  # MUST be set. Pin to an immutable tag: `sha-<40-char-git-sha>` from CI
+  # (preferred for production deploys) or `v<x.y.z>` for a tagged release.
+  # `:latest` and `:main` are forbidden by Goal #11 deploy discipline.
+  # install.sh injects this via `--set image.tag=...` so the example file
+  # leaves it as the schema's reject-empty trigger.
+  tag: "<REPLACE: sha-<40-char-git-sha> or v0.1.0>"
+  pullPolicy: IfNotPresent
+
+# RDC GHCR pulls are anonymous (public package). No pullSecret needed.
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  # The RDC lab uses ESO + Vault for secret sync, not workload-identity
+  # bindings, so the SA carries no IAM/IRSA annotations.
+  annotations: {}
+
+# Pod-level security context inherits from chart defaults (runAsNonRoot,
+# runAsUser: 1001, seccompProfile: RuntimeDefault). Overriding here is
+# rarely needed and would conflict with the chart's Dockerfile USER.
+
+service:
+  type: ClusterIP
+  port: 8000
+  portName: http
+
+ingress:
+  enabled: true
+  # rke2-infra ships ingress-nginx as the default IngressClass.
+  className: nginx
+  # RDC lab hostname. cert-manager (Cluster Issuer `letsencrypt-prod`)
+  # publishes the certificate; the Secret name below matches the one the
+  # Certificate resource projects.
+  host: meho.evba.lab
+  path: /
+  pathType: Prefix
+  # cert-manager-on-Ingress annotation: cert-manager watches Ingress
+  # objects and provisions the Certificate + Secret on first reconcile.
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  tls:
+    enabled: true
+    secretName: meho-tls
+
+probes:
+  liveness:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /ready
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 3
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# ConfigMap-sourced env vars. These mirror the vault/keycloak block below
+# (the backplane reads its config from the ConfigMap, not from Helm values
+# directly) so the two must stay in lockstep. The RDC lab realm name is a
+# placeholder — substitute before install.
+config:
+  keycloakIssuerUrl: "https://keycloak.evba.lab/realms/<REPLACE: realm-name>"
+  keycloakAudience: meho-backplane
+  keycloakJwksCacheTtlSeconds: "300"
+  keycloakJwtLeewaySeconds: "30"
+  vaultAddr: https://vault.evba.lab
+  vaultOidcRole: meho-mcp
+  vaultOidcMountPath: jwt
+  vaultTimeoutSeconds: "10.0"
+  databasePoolSize: "10"
+  databasePoolTimeout: "30.0"
+
+postgres:
+  # Cluster-internal Postgres on rke2-infra (per Goal #11 cross-repo deps).
+  host: postgres.evba.lab
+  port: 5432
+  database: meho
+  # K8s Secret holding DATABASE_URL at key `url`. The consumer's ESO
+  # ExternalSecret materialises this Secret from Vault path
+  # `secret/meho/postgres` — see deploy/values-examples/README.md for the
+  # ExternalSecret manifest.
+  credentialsSecret: meho-postgres
+
+vault:
+  address: https://vault.evba.lab
+  authMethod: oidc
+  # Provisioned by the consumer per Goal #11 cross-repo deps (Vault role
+  # bound to the Keycloak issuer configured above).
+  role: meho-mcp
+  paths:
+    kv: secret/meho
+
+keycloak:
+  # MUST be substituted: the realm segment is environment-specific.
+  issuer: "https://keycloak.evba.lab/realms/<REPLACE: realm-name>"
+  audience: meho-backplane
+  clientSecretSyncFromVault: secret/meho/keycloak/client_secret
+
+audit:
+  # v0.1: audit rows written to PostgreSQL only. The S3 / object-store
+  # mirror is v0.2 per Goal #11 scope.
+  postgresOnly: true
+
+broadcast:
+  # v0.1: chart-bundled Valkey 9.x subchart, single-replica, ephemeral
+  # streams (ADR 0005). Operators with an external managed Valkey/Redis
+  # flip this to `false` once the externalEndpoint opt-out lands in v0.2.
+  enabled: true
+  image:
+    repository: valkey/valkey
+    tag: "9.0-alpine"
+    pullPolicy: IfNotPresent
+  replicas: 1
+
+connectors:
+  # v0.1 ships the chassis only — no connectors enabled by default.
+  # The connector surface lands post-Goal-2 with the first product ticket.
+  enabled: []
+
+networkPolicy:
+  enabled: true
+  # rke2-infra labels the controller namespace `ingress-nginx`.
+  ingressControllerNamespace: ingress-nginx
+  # MUST be substituted: site-specific CIDRs. The schema's IPv4-CIDR
+  # pattern rejects `<REPLACE: ...>` literals so a forgotten substitution
+  # fails-loud at `helm install` time. Recover the actual CIDRs from
+  # `kubectl get endpoints <svc> -n <ns> -o yaml` against the rke2-infra
+  # PG / vault.evba.lab / keycloak.evba.lab services.
+  postgresCIDR: "<REPLACE: rke2-infra Postgres CIDR, e.g. 10.0.1.0/24>"
+  vaultCIDR: "<REPLACE: vault.evba.lab CIDR, e.g. 10.0.2.0/24>"
+  keycloakCIDR: "<REPLACE: keycloak.evba.lab CIDR, e.g. 10.0.3.0/24>"
+
+# Optional chart-side ExternalSecret rendering. Default `false` — the
+# RDC lab convention (per Goal #11 cross-repo deps) is that the
+# consumer's GitOps repo owns the ExternalSecret manifests so that the
+# chart stays decoupled from the secret-sync mechanism. Flip to `true`
+# only if you want the chart to render ExternalSecret resources for
+# `postgres.credentialsSecret` and `keycloak.clientSecretSyncFromVault`
+# itself; see deploy/values-examples/README.md for the contract.
+eso:
+  enabled: false

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -340,11 +340,85 @@ Three properties make this the right contract:
 
 `helm lint` against the unmodified `values.yaml` **deliberately fails**
 with the safe-by-default empty fields. The chart's CI / lint workflow
-(G2.5-T5) and `deploy/values-examples/values-rdc-example.yaml` (G2.5-T4)
+(G2.5-T5) and
+[`deploy/values-examples/values-rdc-example.yaml`](../../deploy/values-examples/values-rdc-example.yaml)
 both supply the required overrides; ad-hoc lint invocations pass them via
 `--set` or `-f`.
 
+### Example values + ESO patterns
+
+A sanitized example values file lives at
+[`deploy/values-examples/values-rdc-example.yaml`](../../deploy/values-examples/values-rdc-example.yaml).
+It targets the RDC Hetzner dogfooding lab shape (cluster-internal
+Postgres + Vault + Keycloak on `*.evba.lab`, rke2-infra ingress-nginx) and
+is structured so that other Vault-+-Keycloak-+-Postgres-shaped labs can
+copy it, substitute the `<REPLACE: ...>` placeholders, and apply it.
+
+The placeholders are deliberate: every site-specific field
+(`image.tag`, the Keycloak realm in `config.keycloakIssuerUrl` /
+`keycloak.issuer`, the three NetworkPolicy CIDRs) is left as a
+`<REPLACE: ...>` literal that fails the schema's `format: uri` /
+`format: hostname` / IPv4-CIDR pattern at `helm install` time. A
+forgotten substitution surfaces as `at '/networkPolicy/postgresCIDR':
+'<REPLACE: ...>' does not match pattern …` instead of silently rendering
+a NetworkPolicy that allows everything (or nothing).
+
+The actual `values-rdc.yaml` for the dogfooding consumer is environment-
+private and lives in
+[`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)'s
+`manifests/meho/values-rdc.yaml` per Goal #11 cross-repo deps; the
+example here is the public template.
+
+**External Secrets Operator (ESO) sync patterns.** The chart references
+operator-provisioned Kubernetes Secrets *by name*
+(`postgres.credentialsSecret` and, in v0.2, a Keycloak client-secret
+Secret). It does not ship a `Secret` template or accept secret values
+via `--set`. The recommended sync mechanism is
+[ESO](https://external-secrets.io/) with the upstream store of the
+operator's choice (the RDC lab uses
+[HashiCorp Vault](https://external-secrets.io/latest/provider/hashicorp-vault/)).
+Two resources combine to materialise a chart-consumable Secret:
+
+1. **`ClusterSecretStore`** (cluster-scoped pointer at Vault, carrying
+   the auth credentials). Created once per cluster by the platform team.
+   **Owned by the consumer's GitOps repo**, not this chart — it outlives
+   any release and embeds cluster-level Vault credentials.
+2. **`ExternalSecret`** (namespaced resource that pulls keys out of the
+   upstream store into a target k8s Secret). Two ownership options:
+    - **Default (consumer-managed):** the consumer's GitOps repo applies
+      the ExternalSecret alongside or before the chart. The chart
+      references the resulting Secret by name. This is the RDC convention.
+    - **Opt-in (chart-managed):** flip `eso.enabled: true` in values and
+      the chart renders the ExternalSecret(s) itself via
+      `templates/externalsecrets.yaml`. The schema requires
+      `eso.secretStore.{name,kind}` when `eso.enabled: true`, so a
+      misconfigured opt-in fails at install. With the default
+      `eso.enabled: false`, `helm template ... | grep -c ExternalSecret`
+      returns `0`.
+
+The full ExternalSecret + ClusterSecretStore manifests, the Vault KV
+path mapping (`secret/meho/postgres` → `DATABASE_URL`, etc.), and the
+end-to-end install ordering (ESO → ClusterSecretStore → ExternalSecret →
+wait-for-Secret → `helm install`) are in
+[`deploy/values-examples/README.md`](../../deploy/values-examples/README.md).
+
 ## Install / upgrade
+
+The recommended flow uses the example values file rather than long
+`--set` strings:
+
+```bash
+# Copy + substitute the example into your private deploy repo first
+# (see deploy/values-examples/README.md).
+helm upgrade --install meho ./deploy/charts/meho/ \
+  --namespace meho \
+  --create-namespace \
+  --set image.tag=sha-<git-sha> \
+  -f values-rdc.yaml
+```
+
+The bare-`--set` equivalent (no values file) — useful for CI smoke
+tests:
 
 ```bash
 helm install meho ./deploy/charts/meho/ \
@@ -362,8 +436,6 @@ helm install meho ./deploy/charts/meho/ \
   --set networkPolicy.postgresCIDR=10.0.1.0/24 \
   --set networkPolicy.vaultCIDR=10.0.2.0/24 \
   --set networkPolicy.keycloakCIDR=10.0.3.0/24
-
-helm upgrade --install meho ./deploy/charts/meho/ -f values-rdc.yaml
 ```
 
 Missing any required override fails the schema validation at install
@@ -426,12 +498,13 @@ helm template test deploy/charts/meho/ --set bogus.field=x 2>&1 | grep "addition
   `helm dependency update` needed).
 - External Secrets Operator (ESO) — owns the Kubernetes Secrets the chart
   references (`postgres.credentialsSecret`, future Keycloak client secret,
-  future Vault role bindings). ESO is consumer-owned; the chart references
-  the synced Secrets by name only.
+  future Vault role bindings). ESO is consumer-owned by default; the chart
+  references the synced Secrets by name only. The chart can optionally
+  render `ExternalSecret` resources itself when `eso.enabled: true` — see
+  the ESO patterns section above.
 
 ## Known gaps (filled by sibling tasks)
 
-- `deploy/values-examples/values-rdc-example.yaml` — G2.5-T4 (#40).
 - OCI publish to `ghcr.io/evoila/meho-chart` + cosign signing — G2.5-T5
   (#41).
 - HPA / PDB / topologySpreadConstraints / ServiceMonitor / PrometheusRule
@@ -449,3 +522,6 @@ helm template test deploy/charts/meho/ --set bogus.field=x 2>&1 | grep "addition
 - Helm chart structure: https://helm.sh/docs/topics/charts/
 - Kubernetes NetworkPolicy: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - cert-manager Ingress annotations: https://cert-manager.io/docs/usage/ingress/
+- External Secrets Operator: https://external-secrets.io/
+- ESO Vault provider: https://external-secrets.io/latest/provider/hashicorp-vault/
+- ESO ExternalSecret API: https://external-secrets.io/latest/api/externalsecret/


### PR DESCRIPTION
## Summary

Ships the sanitized chart-values template and documents the External Secrets Operator (ESO) sync patterns the chart expects the consumer to provision. Wave 4 of G2.5 (Helm chart).

- `deploy/values-examples/values-rdc-example.yaml` — sanitized RDC-lab template; every site-specific field uses a `<REPLACE: ...>` placeholder that fails `values.schema.json` at `helm install` time (CIDRs fail the IPv4 pattern; `image.tag` fails the new OCI-tag pattern). A forgotten substitution surfaces immediately instead of CrashLoopBackOff'ing against the wrong system.
- `deploy/values-examples/README.md` — substitution recipe, full `ClusterSecretStore` + `ExternalSecret` manifests, Vault KV path mapping (`secret/meho/postgres` → `DATABASE_URL`), and the end-to-end install ordering (ESO → ClusterSecretStore → ExternalSecret → wait-for-Secret → `helm install`).
- `deploy/charts/meho/templates/externalsecrets.yaml` — optional chart-side rendering gated on `eso.enabled: false` (default). When `eso.enabled: true`, renders an `ExternalSecret` for `postgres.credentialsSecret`; with `eso.keycloak.enabled: true`, a second one for the Keycloak client secret. Chart never renders the SecretStore — that's consumer-owned (it outlives releases and embeds cluster Vault creds).
- `values.schema.json` — adds the `eso` block with conditional `allOf` requiring `secretStore.{name,kind}` only when `eso.enabled: true`; tightens `image.tag` to the OCI tag grammar so placeholders fail-loud.
- `docs/codebase/devops.md` — adds an "Example values + ESO patterns" section and removes the now-filled known-gap entry. Top-level `README.md` gets a "Deploy" section linking to the example.

Goal #11 cross-repo convention: the *actual* `values-rdc.yaml` is environment-private and lives in `evoila-bosnia/claude-rdc-hetzner-dc`. This PR ships the public, sanitized template.

## Test plan

- [x] `helm lint deploy/charts/meho/` clean with default values + required overrides.
- [x] `helm install --dry-run=client meho deploy/charts/meho/ --values /tmp/values-rdc-real.yaml` → exit 0 after substituting placeholders.
- [x] `helm template ... -f deploy/values-examples/values-rdc-example.yaml` → fails-loud on `<REPLACE: ...>` for `image.tag` and all three CIDRs.
- [x] After substitution: `helm template ... | grep -c '^kind:'` → 10 (Deployment, Service, Ingress, ConfigMap, SA, NetworkPolicy, Job, broadcast Deployment/Service/ConfigMap).
- [x] `helm template ... | grep -c 'kind: ExternalSecret'` → 0 with defaults; 1 with `--set eso.enabled=true --set eso.secretStore.name=vault-store`; 2 with `--set eso.keycloak.enabled=true`.
- [x] `helm template ... --set eso.enabled=true` (no secretStore.name) → `at '/eso/secretStore/name': minLength: got 0, want 1`.
- [x] `helm template ... --set bogus.field=x` → `additional properties 'bogus' not allowed`.

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added External Secrets Operator (ESO) integration for automated Kubernetes secret provisioning from Vault.
  * Support for syncing Postgres and Keycloak credentials with optional chart-managed configuration.

* **Documentation**
  * Added comprehensive deployment guide with Helm chart configuration and ESO usage patterns.
  * Provided sanitized example values file for production deployments.
  * Strengthened chart configuration schema validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/172)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->