### PR TITLE
ci(chart): OCI publish + cosign keyless sign + anonymous-pull verify (G2.5-T5)

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -274,9 +274,13 @@ jobs:
         run: |
           set -euo pipefail
           # Use python3+pyyaml on the self-hosted runner so we don't pull in
-          # an extra `yq` dependency for two field edits. PyYAML preserves
-          # block style for typical Chart.yaml shapes; we re-read after write
-          # to assert the edits applied.
+          # an extra `yq` dependency for two field edits. yaml.safe_dump
+          # strips comments and may reorder keys vs the source file (we pass
+          # sort_keys=False to suppress reordering); for our purposes that
+          # is fine because the stamped Chart.yaml is workflow-local — it is
+          # consumed by `helm package` in the next step and never committed
+          # back to the repo. The in-tree Chart.yaml retains its hand-tuned
+          # form (comments and all).
           python3 - <<'PY'
           import os
           import yaml

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -65,8 +65,11 @@ on:
 
 permissions:
   contents: read
-  packages: write       # push to ghcr.io/evoila/meho-chart
-  id-token: write       # cosign keyless OIDC (ADR 0006)
+  # `packages: write` (GHCR push) and `id-token: write` (cosign OIDC) are
+  # granted per-job on `publish` only. validate and verify-anonymous-pull
+  # inherit the workflow-default `contents: read` with no elevation, which
+  # satisfies SonarCloud githubactions:S8233/S8264 (least-privilege per job)
+  # and CodeRabbit's same finding. See the `publish` job below.
 
 concurrency:
   # On main/tag pushes: keep one in-flight publish per ref so a fast follow-up
@@ -201,6 +204,13 @@ jobs:
     needs: validate
     runs-on: meho-runners
     timeout-minutes: 15
+    permissions:
+      # Per-job scope: only `publish` needs to push to GHCR and mint an OIDC
+      # token for cosign keyless signing. validate (lint+kubeconform) and
+      # verify-anonymous-pull (anonymous helm pull) get neither.
+      contents: read
+      packages: write       # push to ghcr.io/evoila/meho-chart
+      id-token: write       # cosign keyless OIDC (ADR 0006)
     outputs:
       chart_version: ${{ steps.ver.outputs.version }}
     steps:

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Helm chart package + OCI publish + cosign-sign pipeline.
+#
+# Locked artefact location (Goal #11 — chart contract section 2):
+#   oci://ghcr.io/evoila/meho-chart          (public OCI Helm chart)
+#
+# Tag scheme:
+#   pull_request -> main : lint + template + kubeconform; NO push (validation gate).
+#   push to main         : push :0.1.<YYYYMMDD>-<short-sha>   (calver, immutable).
+#   push tag v*          : push :<x.y.z>                       (semver, immutable).
+#
+# The artefact name `meho-chart` (not `meho`) is derived from the chart's
+# `name` field in deploy/charts/meho/Chart.yaml. The umbrella sets
+# `nameOverride: meho` in values.yaml so rendered resources retain
+# `app.kubernetes.io/name: meho` — the rename is purely a publish-coordinate
+# concern. The image package at ghcr.io/evoila/meho (Task #33) and the chart
+# package at ghcr.io/evoila/meho-chart are intentionally distinct GHCR
+# packages so visibility, retention, and signing identities can be managed
+# independently.
+#
+# Cosign keyless signing (ADR 0006, Task #34 precedent):
+#   - id-token: write at workflow level lets the runner mint a GitHub Actions
+#     OIDC token. cosign exchanges it at Fulcio for a ~10-minute x509 cert,
+#     signs the chart's OCI manifest digest, and uploads {signature,
+#     certificate} to the public Rekor transparency log.
+#   - The signature binds to the digest, so every tag alias of the same
+#     digest is covered by one `cosign sign` invocation.
+#   - The certificate identity an operator verifies against is the workflow
+#     file path + ref pattern:
+#       https://github.com/evoila/meho/.github/workflows/chart.yml@<ref>
+#     where <ref> is `refs/heads/main` for main pushes or `refs/tags/v*` for
+#     tag pushes. Operator copy-paste verification lives in backend/README.md.
+#
+# Anonymous-pull verification (Goal #11 DoD):
+#   A separate `verify` job runs after `publish` on main/tag pushes only.
+#   It uses azure/setup-helm in a clean environment and intentionally does
+#   NOT call `helm registry login`, so a successful
+#   `helm pull oci://ghcr.io/evoila/meho-chart --version <ver>` proves the
+#   package is reachable without GHCR credentials. The first time the chart
+#   is pushed the GHCR package is created PRIVATE by default; a maintainer
+#   must flip visibility to public ONCE via
+#     gh api --method PATCH /orgs/evoila/packages/container/meho-chart \
+#       -f visibility=public
+#   (or the GHCR UI). README.md documents the one-time step. Until the flip,
+#   the verify job will fail with `unauthorized` — that is the intended fail-
+#   closed signal, not a workflow bug.
+
+name: chart
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'deploy/charts/meho/**'
+      - '.github/workflows/chart.yml'
+  push:
+    # No `paths:` filter here. Path filtering applies to BOTH branch and tag
+    # pushes when set, which would cause a v* tag annotating a non-chart
+    # commit on main to skip the chart publish. Releases must always publish;
+    # mirrors the same decision documented in image.yml.
+    branches: [main]
+    tags: ['v*']
+
+permissions:
+  contents: read
+  packages: write       # push to ghcr.io/evoila/meho-chart
+  id-token: write       # cosign keyless OIDC (ADR 0006)
+
+concurrency:
+  # On main/tag pushes: keep one in-flight publish per ref so a fast follow-up
+  # commit cancels its predecessor. On PRs: scoped by PR ref the same way.
+  group: chart-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Lint + template + kubeconform (PR build gate)
+    # Fork-PR guard: never execute chart logic from a fork on the self-hosted
+    # runner pool. Mirrors image.yml's stance — `runs-on` is internal infra,
+    # so fork PRs are skipped entirely. push events (main, v*) short-circuit
+    # the OR.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: meho-runners
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
+        with:
+          version: v3.16.4  # pin at execution time; >=3.8 ships OCI helm push
+
+      - name: Install kubeconform
+        # kubeconform validates rendered manifests against Kubernetes JSON
+        # Schemas (offline; no API server needed). Pinned to v0.6.7 by SHA256
+        # to match devops_best_practices.md's no-`curl|sh`-unpinned rule.
+        # The shasum line is the upstream-published checksum for the
+        # linux-amd64 tarball of v0.6.7.
+        run: |
+          set -euo pipefail
+          KC_VER=v0.6.7
+          KC_SHA=95f14e87aa28c09d5941f11bd024c1d02fdc0303ccaa23f61cef67bc92619d73
+          curl -fsSL -o /tmp/kubeconform.tar.gz \
+            "https://github.com/yannh/kubeconform/releases/download/${KC_VER}/kubeconform-linux-amd64.tar.gz"
+          echo "${KC_SHA}  /tmp/kubeconform.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/kubeconform.tar.gz -C /tmp/ kubeconform
+          install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: Helm lint
+        # The chart ships safe-by-default empty fields that values.schema.json
+        # rejects at lint time on purpose; we pass the same overrides
+        # docs/codebase/devops.md uses in its Verification block so the lint
+        # exercises the typed-schema contract end-to-end.
+        run: |
+          helm lint deploy/charts/meho/ \
+            --set image.tag=test \
+            --set ingress.host=meho.test \
+            --set ingress.tls.secretName=meho-tls \
+            --set postgres.credentialsSecret=meho-postgres \
+            --set vault.address=https://vault.test \
+            --set keycloak.issuer=https://keycloak.test/realms/meho \
+            --set config.keycloakIssuerUrl=https://keycloak.test/realms/meho \
+            --set config.keycloakAudience=meho-backplane \
+            --set config.vaultAddr=https://vault.test \
+            --set networkPolicy.postgresCIDR=10.0.1.0/24 \
+            --set networkPolicy.vaultCIDR=10.0.2.0/24 \
+            --set networkPolicy.keycloakCIDR=10.0.3.0/24
+
+      - name: Helm template + kubeconform
+        # Render the chart with the same override set, then validate every
+        # manifest against upstream Kubernetes JSON Schemas. The schemas
+        # source is the community-maintained
+        # https://github.com/yannh/kubernetes-json-schema mirror — same
+        # source kubeconform defaults to. `--strict` rejects unknown fields;
+        # `--kubernetes-version 1.28.0` matches Chart.yaml's kubeVersion
+        # floor. CRDs (ExternalSecret) are not validated upstream so we add
+        # `--schema-location` pointing at the ESO repo's published schema
+        # mirror, falling back to `ignore_missing_schemas` for any CRD
+        # without a hosted schema.
+        run: |
+          helm template test deploy/charts/meho/ \
+            --set image.tag=test \
+            --set ingress.host=meho.test \
+            --set ingress.tls.secretName=meho-tls \
+            --set postgres.credentialsSecret=meho-postgres \
+            --set vault.address=https://vault.test \
+            --set keycloak.issuer=https://keycloak.test/realms/meho \
+            --set config.keycloakIssuerUrl=https://keycloak.test/realms/meho \
+            --set config.keycloakAudience=meho-backplane \
+            --set config.vaultAddr=https://vault.test \
+            --set networkPolicy.postgresCIDR=10.0.1.0/24 \
+            --set networkPolicy.vaultCIDR=10.0.2.0/24 \
+            --set networkPolicy.keycloakCIDR=10.0.3.0/24 \
+            > /tmp/rendered.yaml
+
+          kubeconform \
+            -strict \
+            -kubernetes-version 1.28.0 \
+            -ignore-missing-schemas \
+            -summary \
+            /tmp/rendered.yaml
+
+  publish:
+    name: Package + push + sign chart
+    # Skip on pull_request entirely — PRs don't push. The same fork-PR guard
+    # would never fire here because the trigger above already filters PRs,
+    # but the explicit `if` makes intent visible.
+    if: github.event_name != 'pull_request'
+    needs: validate
+    runs-on: meho-runners
+    timeout-minutes: 15
+    outputs:
+      chart_version: ${{ steps.ver.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # short-sha derivation needs at least the HEAD commit; default
+          # fetch-depth: 1 is sufficient because we only ever read HEAD.
+          fetch-depth: 1
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
+        with:
+          version: v3.16.4
+
+      - name: Install cosign
+        # Pinned to cosign-installer v4.1.2 (ships cosign v3.0.6 by default).
+        # v4.x dropped pre-2.0 cosign support; v3.x of cosign has
+        # keyless-by-default semantics — no COSIGN_EXPERIMENTAL=1 needed.
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Log in to GHCR (Helm registry)
+        # GITHUB_TOKEN is piped via stdin so the secret never lands in
+        # `ps`/process listings (devops_best_practices: "No secrets in logs").
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_PASS: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${GHCR_PASS}" | helm registry login ghcr.io \
+            --username "${GHCR_USER}" --password-stdin
+
+      - name: Compute chart version (calver or tag)
+        id: ver
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF}" == refs/tags/v* ]]; then
+            # v* tag push: strip the leading `v` so the chart version is plain
+            # semver (Helm rejects a leading-v in Chart.yaml's version field).
+            VERSION="${REF#refs/tags/v}"
+          else
+            # main branch push: calver = 0.1.<YYYYMMDD>-<short-sha>. Sortable,
+            # immutable per commit, no ambiguity with semver-tagged releases.
+            DATE="$(date -u +%Y%m%d)"
+            SHA="$(git rev-parse --short HEAD)"
+            VERSION="0.1.${DATE}-${SHA}"
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Chart version: ${VERSION}"
+
+      - name: Stamp Chart.yaml with version + appVersion
+        # `helm package` reads `name`, `version`, and `appVersion` from
+        # Chart.yaml. We rewrite version (chart calver) and appVersion (git
+        # sha — the deployable image tag) in place; the in-tree Chart.yaml
+        # placeholders (`0.1.0` / `"0.1.0"`) exist only so `helm lint` /
+        # `helm template` succeed on a fresh checkout.
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Use python3+pyyaml on the self-hosted runner so we don't pull in
+          # an extra `yq` dependency for two field edits. PyYAML preserves
+          # block style for typical Chart.yaml shapes; we re-read after write
+          # to assert the edits applied.
+          python3 - <<'PY'
+          import os
+          import yaml
+
+          path = "deploy/charts/meho/Chart.yaml"
+          with open(path, "r", encoding="utf-8") as f:
+              data = yaml.safe_load(f)
+          data["version"] = os.environ["VERSION"]
+          data["appVersion"] = os.environ["GIT_SHA"]
+          with open(path, "w", encoding="utf-8") as f:
+              yaml.safe_dump(data, f, sort_keys=False)
+          PY
+          echo "--- Chart.yaml after stamp ---"
+          cat deploy/charts/meho/Chart.yaml
+
+      - name: Helm package
+        id: package
+        # The in-tree broadcast subchart at deploy/charts/meho/charts/broadcast/
+        # is already unpacked (Chart.yaml dependency block declares
+        # `repository: ""` per the documented local-subchart shape). No
+        # `helm dependency update` is needed and running it would fail — the
+        # subchart is not on a remote registry.
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/charts
+          helm package deploy/charts/meho/ -d /tmp/charts/
+          TARBALL="$(ls /tmp/charts/*.tgz)"
+          echo "tarball=${TARBALL}" >> "${GITHUB_OUTPUT}"
+          echo "Packaged: ${TARBALL}"
+
+      - name: Helm push to OCI
+        id: push
+        # `helm push <tgz> oci://ghcr.io/evoila` lands the artefact at
+        # ghcr.io/evoila/<chart-name>:<chart-version> — Helm derives the
+        # basename from Chart.yaml's `name` field (which we keep as
+        # `meho-chart` permanently in-tree to give the published artefact a
+        # distinct GHCR package from the backplane image at
+        # ghcr.io/evoila/meho).
+        run: |
+          set -euo pipefail
+          OUTPUT="$(helm push "${{ steps.package.outputs.tarball }}" oci://ghcr.io/evoila 2>&1)"
+          echo "${OUTPUT}"
+          # `helm push` prints a `Digest: sha256:...` line on success. Grep
+          # is anchored to the line start so a chart name containing the
+          # word "Digest" can't confuse the parser. `awk` extracts the
+          # digest field directly.
+          DIGEST="$(printf '%s\n' "${OUTPUT}" | awk '/^Digest:/ {print $2; exit}')"
+          if [[ -z "${DIGEST}" ]]; then
+            echo "::error::Could not parse digest from helm push output" >&2
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
+          echo "Pushed digest: ${DIGEST}"
+
+      - name: Sign chart with cosign (keyless OIDC)
+        # Keyless signing flow: cosign requests an OIDC token from GitHub
+        # Actions (id-token: write), Fulcio mints a ~10-min x509 cert bound
+        # to the workflow identity, cosign signs the chart's OCI manifest
+        # digest and uploads {signature, certificate} to Rekor. --yes is
+        # the non-interactive confirmation (CI has no TTY).
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          cosign sign --yes "ghcr.io/evoila/meho-chart@${DIGEST}"
+
+      - name: Emit verification summary
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          {
+            echo "## Chart published"
+            echo ""
+            echo "- Package: \`oci://ghcr.io/evoila/meho-chart\`"
+            echo "- Version: \`${VERSION}\`"
+            echo "- Digest: \`${DIGEST}\`"
+            echo ""
+            echo "### Pull"
+            echo ""
+            echo '```bash'
+            echo "helm pull oci://ghcr.io/evoila/meho-chart --version ${VERSION}"
+            echo '```'
+            echo ""
+            echo "### Verify signature"
+            echo ""
+            echo '```bash'
+            echo "cosign verify ghcr.io/evoila/meho-chart:${VERSION} \\"
+            echo "  --certificate-identity-regexp '^https://github\\.com/evoila/meho/\\.github/workflows/chart\\.yml@.*\$' \\"
+            echo "  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' | jq ."
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  verify-anonymous-pull:
+    name: "Verify anonymous pull (Goal #11 DoD)"
+    # Runs only on push events (main / v*) — anonymous-pull verification of a
+    # PR build makes no sense (PRs don't push). We split this into its own
+    # job rather than running inside `publish` so the `helm registry login`
+    # state from the push step cannot accidentally satisfy the pull. A fresh
+    # job ships a clean filesystem with no GHCR credentials anywhere — a
+    # successful `helm pull` here can only mean the GHCR package is public.
+    if: github.event_name != 'pull_request'
+    needs: publish
+    runs-on: meho-runners
+    timeout-minutes: 10
+    steps:
+      - name: Install Helm (no checkout — keeps env scrubbed of repo state)
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
+        with:
+          version: v3.16.4
+
+      - name: Pull chart anonymously
+        # No `helm registry login` step. If the GHCR package is private,
+        # this step fails with `unauthorized` and surfaces the missing
+        # one-time visibility-flip step (documented in backend/README.md).
+        env:
+          VERSION: ${{ needs.publish.outputs.chart_version }}
+        run: |
+          set -euo pipefail
+          # Belt-and-braces: scrub any latent helm registry config that
+          # might leak from a prior run on the same self-hosted runner.
+          rm -f "${HOME}/.config/helm/registry/config.json"
+          rm -rf "${HOME}/.cache/helm/registry"
+          mkdir -p /tmp/anon-pull
+          cd /tmp/anon-pull
+          helm pull "oci://ghcr.io/evoila/meho-chart" --version "${VERSION}"
+          ls -l "meho-chart-${VERSION}.tgz"
+          echo "Anonymous pull OK: meho-chart-${VERSION}.tgz"

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -99,6 +99,16 @@ jobs:
         # to match devops_best_practices.md's no-`curl|sh`-unpinned rule.
         # The shasum line is the upstream-published checksum for the
         # linux-amd64 tarball of v0.6.7.
+        #
+        # Install target is `$HOME/.local/bin` — a runner-owned directory —
+        # rather than `/usr/local/bin`, because the self-hosted `meho-runners`
+        # pool runs as a non-root user that cannot write to system paths
+        # (writing /usr/local/bin returned `Permission denied` in CI run
+        # 25644668781). Appending the directory to `$GITHUB_PATH` is the
+        # documented GitHub Actions mechanism for surfacing the binary to
+        # *subsequent* steps' PATH; within this step we invoke kubeconform
+        # by its full path for the smoke check so the verification doesn't
+        # depend on PATH propagation that hasn't happened yet.
         run: |
           set -euo pipefail
           KC_VER=v0.6.7
@@ -107,7 +117,25 @@ jobs:
             "https://github.com/yannh/kubeconform/releases/download/${KC_VER}/kubeconform-linux-amd64.tar.gz"
           echo "${KC_SHA}  /tmp/kubeconform.tar.gz" | sha256sum -c -
           tar -xzf /tmp/kubeconform.tar.gz -C /tmp/ kubeconform
-          install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform
+          mkdir -p "${HOME}/.local/bin"
+          install -m 0755 /tmp/kubeconform "${HOME}/.local/bin/kubeconform"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          # Smoke test the freshly installed binary. PATH for *this* step
+          # was frozen before $GITHUB_PATH was appended above, so call by
+          # the absolute path; subsequent steps pick it up via PATH.
+          "${HOME}/.local/bin/kubeconform" -v
+
+      - name: Verify kubeconform on PATH for subsequent steps
+        # Independent of the install step's own shell. By the time this
+        # step starts, the runner has merged `$GITHUB_PATH` into PATH, so
+        # `kubeconform` must resolve via plain command lookup. Failure here
+        # means the install step "succeeded" but downstream steps would
+        # still hit `kubeconform: command not found` — the exact regression
+        # B1 is meant to prevent. This is the authoritative end-to-end
+        # check that the self-hosted runner fix works.
+        run: |
+          set -euo pipefail
+          which kubeconform
           kubeconform -v
 
       - name: Helm lint

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -399,10 +399,23 @@ jobs:
           VERSION: ${{ needs.publish.outputs.chart_version }}
         run: |
           set -euo pipefail
-          # Belt-and-braces: scrub any latent helm registry config that
-          # might leak from a prior run on the same self-hosted runner.
-          rm -f "${HOME}/.config/helm/registry/config.json"
-          rm -rf "${HOME}/.cache/helm/registry"
+          # Isolate Helm from any persisted runner-local auth/config.
+          # The self-hosted `meho-runners` pool does not guarantee a clean
+          # HOME between jobs (https://docs.github.com/en/actions/hosting-your-own-runners);
+          # Helm 3.8+ falls back to ~/.docker/config.json for OCI creds when
+          # HELM_REGISTRY_CONFIG isn't set (helm/helm#7776), so deleting only
+          # Helm's own config can false-pass this DoD check if a prior job
+          # left a docker login behind. A throwaway HOME forces Helm to see
+          # an empty config tree regardless of what persists on the runner.
+          HOME="$(mktemp -d)"
+          export HOME
+          export XDG_CONFIG_HOME="${HOME}/.config"
+          export XDG_CACHE_HOME="${HOME}/.cache"
+          mkdir -p "${XDG_CONFIG_HOME}" "${XDG_CACHE_HOME}"
+          # Visibility: log the sandbox so CI output proves it is truly empty.
+          echo "HOME=${HOME}"
+          ls -la "${HOME}"
+          helm registry list 2>/dev/null || true
           mkdir -p /tmp/anon-pull
           cd /tmp/anon-pull
           helm pull "oci://ghcr.io/evoila/meho-chart" --version "${VERSION}"

--- a/backend/README.md
+++ b/backend/README.md
@@ -204,6 +204,86 @@ The downstream `install.sh` from
 can run this exact command to confirm the SBOM is intact and the bill of
 materials matches the image being pulled.
 
+## Verifying chart signatures
+
+The Helm chart at [`deploy/charts/meho/`](../deploy/charts/meho/) is published
+as a public OCI artefact at `oci://ghcr.io/evoila/meho-chart` and signed with
+the same cosign keyless OIDC flow as the image, from
+`.github/workflows/chart.yml`. The chart's GHCR package is intentionally a
+separate package from the image package (`ghcr.io/evoila/meho`) so visibility,
+retention, and signing identities can be managed independently.
+
+Like the image signature, the chart signature is bound to the OCI manifest
+digest, so the same signature verifies every tag alias of that digest.
+
+Verify a calver release (main push):
+
+```bash
+cosign verify ghcr.io/evoila/meho-chart:0.1.20260510-abc1234 \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/chart\.yml@refs/heads/main$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  | jq .
+```
+
+Verify a `v*` release tag:
+
+```bash
+cosign verify ghcr.io/evoila/meho-chart:0.1.0 \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/chart\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  | jq .
+```
+
+Accept any ref (calver or tag) by widening the identity regex:
+
+```bash
+cosign verify ghcr.io/evoila/meho-chart:<version> \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/chart\.yml@.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  | jq .
+```
+
+A successful verification prints a JSON array of signature payload objects;
+exit status is `0`. Verification failure (wrong identity, unsigned chart,
+tampered registry) exits non-zero with a structured error.
+
+## Pulling the chart anonymously
+
+The chart's GHCR package is **public** — no GitHub login is required to
+pull it. The CI pipeline asserts this on every main / `v*` tag push by
+running a dedicated `verify-anonymous-pull` job in a clean environment
+that never calls `helm registry login` (Goal #11 DoD).
+
+```bash
+docker logout ghcr.io 2>/dev/null
+helm registry logout ghcr.io 2>/dev/null
+helm pull oci://ghcr.io/evoila/meho-chart --version <version>
+ls meho-chart-*.tgz
+```
+
+This works from any network with outbound internet — no GitHub login
+required. If the pull fails with `unauthorized` and you have not logged
+in to GHCR, the chart package is private and a maintainer needs to flip
+visibility to public (one-time, per package — same pattern as the image
+package on its first push):
+
+```bash
+gh api --method PATCH /orgs/evoila/packages/container/meho-chart \
+  -f visibility=public
+```
+
+After the chart is pulled, inspect it with `helm show chart`:
+
+```bash
+helm show chart oci://ghcr.io/evoila/meho-chart --version <version>
+```
+
+The published chart's `name` field is `meho-chart` (the OCI artefact
+basename) while `app.kubernetes.io/name` labels on rendered resources
+remain `meho` — the chart's `values.yaml` defaults `nameOverride: meho`
+to preserve the label invariant. Operators selecting against the rendered
+resources continue to use `app.kubernetes.io/name=meho`.
+
 ## Vulnerability scan
 
 Every pushed image is scanned by [trivy](https://github.com/aquasecurity/trivy)

--- a/deploy/charts/meho/Chart.yaml
+++ b/deploy/charts/meho/Chart.yaml
@@ -1,12 +1,20 @@
 apiVersion: v2
-name: meho
+# `name` is the OCI artefact basename — `helm push` derives the published
+# package path (`ghcr.io/evoila/meho-chart`) from this field. We keep it as
+# `meho-chart` permanently so the GHCR package stays distinct from the
+# backplane image package at `ghcr.io/evoila/meho` (Task #33). To preserve
+# the existing resource-label invariant (`app.kubernetes.io/name: meho`)
+# the umbrella sets `nameOverride: meho` in values.yaml; the chart name
+# rename is purely a publish-coordinate concern.
+name: meho-chart
 description: Governance backplane for AI agents acting on infrastructure
 type: application
 
-# version is the *chart* version (calver-bumped by G2.5-T5 CI: 0.1.YYYYMMDD-<sha>).
-# appVersion is the *application* version — overridden by G2.5-T5 CI to the git
-# sha being deployed. Both values are placeholders here; the publish workflow
-# rewrites them at OCI push time.
+# version is the *chart* version (calver-bumped by .github/workflows/chart.yml:
+# 0.1.YYYYMMDD-<short-sha> on main pushes, plain semver on v* tag pushes).
+# appVersion is the *application* version — overridden by the same workflow
+# to the git sha being deployed. Both values are placeholders here; the
+# publish workflow rewrites them at OCI push time.
 version: 0.1.0
 appVersion: "0.1.0"
 

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -34,8 +34,14 @@ image:
 # no secret; the list is empty by default.
 imagePullSecrets: []
 
-# -- Override `<chart-name>` portion of resource names.
-nameOverride: ""
+# -- Override `<chart-name>` portion of resource names. Defaults to `meho` so
+# every rendered resource carries `app.kubernetes.io/name: meho` regardless
+# of the chart's OCI artefact name (`meho-chart` per Chart.yaml). NetworkPolicy
+# pod selectors, ServiceMonitor matchLabels, and any consumer-side label
+# selectors that target this release continue to use
+# `app.kubernetes.io/name=meho`. Override only when running two MEHO releases
+# in the same namespace and they need distinct selector labels.
+nameOverride: "meho"
 # -- Override the full resource name (`<release-name>-<chart-name>`).
 fullnameOverride: ""
 

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -57,16 +57,27 @@ deploy/charts/meho/
 ### `Chart.yaml`
 
 - `apiVersion: v2` — required for Helm 3 / 4.
-- `version` is the **chart** version (calver-bumped by the publish workflow
-  in G2.5-T5 to `0.1.YYYYMMDD-<sha>`); `appVersion` is the **application**
-  version, overridden by the same workflow to the git sha being deployed.
-  The values shipped in `Chart.yaml` are placeholders — they exist only so
-  `helm lint` / `helm template` succeed on a fresh checkout.
+- `name: meho-chart` is the **OCI artefact basename**. `helm push` derives
+  the published package path (`ghcr.io/evoila/meho-chart`) from this field.
+  The chart is named `meho-chart` rather than `meho` so the GHCR package
+  stays distinct from the backplane image package at `ghcr.io/evoila/meho`
+  — visibility, retention, and signing identities are managed
+  independently on each package. To preserve the existing resource-label
+  invariant (`app.kubernetes.io/name: meho`) the chart sets
+  `nameOverride: meho` in `values.yaml`; the rename is purely a publish-
+  coordinate concern.
+- `version` is the **chart** version (calver-bumped by
+  `.github/workflows/chart.yml` to `0.1.YYYYMMDD-<short-sha>` on main
+  pushes, plain semver on `v*` tag pushes); `appVersion` is the
+  **application** version, overridden by the same workflow to the git sha
+  being deployed. The values shipped in `Chart.yaml` are placeholders —
+  they exist only so `helm lint` / `helm template` succeed on a fresh
+  checkout.
 - `kubeVersion: ">=1.28.0-0"` — matches Goal #11's RKE2 target. The
   manifests use only API versions that have been stable since 1.19; the
   floor is set higher than strictly required to align with the test bed.
 - `sources` + `maintainers` + `keywords` follow Artifact Hub norms for
-  discoverability after the OCI publish workflow lands.
+  discoverability now that the OCI publish workflow has landed.
 
 ### Image reference
 
@@ -339,8 +350,8 @@ Three properties make this the right contract:
    `at '/broadcast': additional properties 'global' not allowed`.
 
 `helm lint` against the unmodified `values.yaml` **deliberately fails**
-with the safe-by-default empty fields. The chart's CI / lint workflow
-(G2.5-T5) and
+with the safe-by-default empty fields. The chart's `validate` job in
+[`.github/workflows/chart.yml`](../../.github/workflows/chart.yml) and
 [`deploy/values-examples/values-rdc-example.yaml`](../../deploy/values-examples/values-rdc-example.yaml)
 both supply the required overrides; ad-hoc lint invocations pass them via
 `--set` or `-f`.
@@ -485,6 +496,91 @@ helm template test deploy/charts/meho/ 2>&1 | grep -E "minLength|valid"
 helm template test deploy/charts/meho/ --set bogus.field=x 2>&1 | grep "additional properties"
 ```
 
+## Publish workflow (`.github/workflows/chart.yml`)
+
+The chart is packaged, pushed to OCI, and cosign-signed by
+`.github/workflows/chart.yml`. The workflow targets `meho-runners` (the
+project's self-hosted runner pool, per #160 + #167) and shares the
+hardening conventions of `image.yml` (Task #33): job-level fork-PR guard,
+SHA-pinned actions with `# vX.Y.Z` comments, minimum `permissions:` block
+(`contents: read`, `packages: write`, `id-token: write`), per-job
+`timeout-minutes`, and a `concurrency:` group that cancels stale runs per
+ref.
+
+### Triggers and locked publish behaviour
+
+| Trigger | Jobs run | Side effects |
+| --- | --- | --- |
+| `pull_request` against `main` (same-repo PRs only) | `validate` | Lint + render + kubeconform; no push, no sign |
+| `push` to `main` (chart paths) | `validate` -> `publish` -> `verify-anonymous-pull` | Push at calver `0.1.YYYYMMDD-<short-sha>`, cosign-sign, anonymous-pull check |
+| `push` of a `v*` tag | `validate` -> `publish` -> `verify-anonymous-pull` | Push at plain semver `<x.y.z>` (leading `v` stripped), cosign-sign, anonymous-pull check |
+| Fork PR | (skipped at job level) | None — `head.repo.full_name != github.repository` short-circuits |
+
+The `push:` block intentionally has no `paths:` filter — path filtering
+applies to both branch and tag pushes when set, which would silently skip
+a `v*` tag annotating a non-chart commit. Releases always publish; the
+cost of an occasional chart re-publish on a non-chart main push is
+negligible.
+
+### Version stamping
+
+Inline Python (with the standard-library + PyYAML on the runner) reads
+`Chart.yaml`, rewrites `version` and `appVersion` in place, and re-dumps
+the file before `helm package` runs. The chart's `name` field stays
+`meho-chart` (set permanently in-tree); only `version` and `appVersion`
+are workflow-stamped. The post-stamp `cat` of `Chart.yaml` lands in the
+workflow log so operators can confirm the published metadata.
+
+### OCI push and signing
+
+`helm push <tgz> oci://ghcr.io/evoila` lands the artefact at
+`ghcr.io/evoila/meho-chart:<version>` because Helm derives the basename
+from `Chart.yaml`'s `name` field. The push step parses the `Digest:
+sha256:...` line from Helm's stdout and exposes it as a step output;
+`cosign sign --yes "ghcr.io/evoila/meho-chart@<digest>"` then signs the
+chart by digest under the same keyless OIDC identity as the image — the
+operator-facing verification command shape is identical between the two
+packages (one workflow file path differs from the other, matched by the
+`--certificate-identity-regexp`).
+
+### Anonymous-pull verification (Goal #11 DoD)
+
+A dedicated `verify-anonymous-pull` job runs after `publish` on main / tag
+pushes. It installs Helm in a fresh job context and intentionally does
+**not** call `helm registry login`. The job also scrubs any stale
+`HELM_REGISTRY_CONFIG` left over from a prior run on the same self-hosted
+runner. `helm pull oci://ghcr.io/evoila/meho-chart --version <ver>` from
+that scrubbed environment can only succeed if the GHCR package is public
+— a successful pull is the DoD signal.
+
+### First-time public-package step
+
+GHCR creates a new package PRIVATE by default. The first time
+`chart.yml` pushes to `ghcr.io/evoila/meho-chart`, the
+`verify-anonymous-pull` job will fail with `unauthorized` until a
+maintainer flips visibility to public **once**:
+
+```bash
+gh api --method PATCH /orgs/evoila/packages/container/meho-chart \
+  -f visibility=public
+```
+
+(Or via the GHCR UI: org -> Packages -> meho-chart -> Package settings ->
+Change visibility -> Public.) The workflow itself cannot do this safely
+from CI — visibility is org-scoped and changing it from a workflow would
+require a PAT with org-admin scope, which the `GITHUB_TOKEN` lacks. The
+image package at `ghcr.io/evoila/meho` had the same one-time gate
+documented in `image.yml`'s header comment.
+
+### Verification commands (operator copy-paste)
+
+The published-chart's verification commands live in
+[`backend/README.md`](../../backend/README.md) (sections "Verifying chart
+signatures" and "Pulling the chart anonymously"), alongside the image's
+equivalent commands so an operator learns one verification pattern for
+both artefacts. The workflow itself also emits the verification block
+into `GITHUB_STEP_SUMMARY` on every successful publish.
+
 ## Dependencies
 
 - Image — `ghcr.io/evoila/meho:<tag>` from G2.4 (#31). Multi-arch
@@ -505,8 +601,6 @@ helm template test deploy/charts/meho/ --set bogus.field=x 2>&1 | grep "addition
 
 ## Known gaps (filled by sibling tasks)
 
-- OCI publish to `ghcr.io/evoila/meho-chart` + cosign signing — G2.5-T5
-  (#41).
 - HPA / PDB / topologySpreadConstraints / ServiceMonitor / PrometheusRule
   — deferred to v0.2. v0.1 is single-replica per Goal #11 scope.
 - Broadcast subchart HA (Sentinel/Cluster), persistence, auth —


### PR DESCRIPTION
## Summary

- New `.github/workflows/chart.yml` packages, pushes (`helm push`), and cosign-signs the Helm chart to `oci://ghcr.io/evoila/meho-chart` on every main / `v*` tag push, with a dedicated `verify-anonymous-pull` job that pulls the chart in a clean, never-logged-in environment to prove the GHCR package is public (Goal #11 DoD).
- Renames the chart `name` to `meho-chart` in `Chart.yaml` so the published OCI package is distinct from the image package at `ghcr.io/evoila/meho`; sets `nameOverride: meho` in `values.yaml` so every rendered resource continues to carry `app.kubernetes.io/name: meho` (label invariant preserved for NetworkPolicy selectors and `values-rdc-example.yaml`).
- Workflow mirrors `image.yml`'s hardening — SHA-pinned actions with `# vX.Y.Z` comments, job-level fork-PR guard, minimum-scope `permissions:`, `meho-runners`, per-job timeouts, concurrency cancellation. PR builds run `helm lint` + `helm template` + `kubeconform` (no push); main / tag pushes also do `helm push` + `cosign sign` + the anonymous-pull check.
- Extends `backend/README.md` with chart-side `cosign verify` and anonymous-pull commands alongside the existing image equivalents; updates `docs/codebase/devops.md` with a Publish-workflow section, the chart-name rename rationale, and a corrected Known-gaps list.

## Deviation from issue body

The issue body's draft pushes to `oci://ghcr.io/evoila`, which would land the chart at `ghcr.io/evoila/meho` — collision with the image package. This PR pushes to `oci://ghcr.io/evoila` with the chart renamed to `meho-chart`, so the artefact lands at the goal-mandated `ghcr.io/evoila/meho-chart`. The rename is wrapped by `nameOverride: meho` so no rendered-resource labels change. This is the minimum-blast-radius answer to Goal #11's distinct-package mandate.

## Test plan

- [x] `helm lint` with the same overrides used in `docs/codebase/devops.md` passes — `1 chart(s) linted, 0 chart(s) failed`.
- [x] `helm template` renders 10 resources; `app.kubernetes.io/name: meho` preserved on all umbrella resources; `helm.sh/chart: meho-chart-0.1.0` (chart-level metadata only, not selector-load-bearing).
- [x] `helm package deploy/charts/meho/` produces `meho-chart-0.1.0.tgz` — confirms `helm push <tgz> oci://ghcr.io/evoila` lands at `ghcr.io/evoila/meho-chart:0.1.0`.
- [x] Schema negative tests still fail-loud: `helm template test ./deploy/charts/meho/` with no overrides reports `at '/vault/address': '' is not valid uri` etc.; `--set bogus.field=x` still rejected.
- [x] `yamllint` clean on `.github/workflows/chart.yml`; `python -c 'import yaml; yaml.safe_load(...)'` parses the workflow cleanly.
- [x] No `actionlint` locally (binary not permitted in agent sandbox); workflow shape mirrors `image.yml`'s exact `runs-on`, `permissions`, fork-PR-guard, SHA-pin patterns that already pass repo's actionlint config (`.github/actionlint.yaml` declares the `meho-runners` self-hosted label).

## Acceptance criteria (issue #41)

- [x] `.github/workflows/chart.yml` exists; runs on `main` push + `v*` tag push for paths under `deploy/charts/meho/**` (and `.github/workflows/chart.yml`).
- [x] First successful run will push to `oci://ghcr.io/evoila/meho-chart` with calver `0.1.YYYYMMDD-<short-sha>`. Verifiable post-merge via `helm show chart oci://ghcr.io/evoila/meho-chart --version <ver>`.
- [x] cosign-signs the chart by digest with the same identity claim format as the image (`workflows/chart.yml@<ref>`).
- [x] `verify-anonymous-pull` job asserts public-package status on every publish; first push will fail until a maintainer flips visibility (one-time step documented in README + workflow header).
- [x] `Chart.yaml`'s `appVersion` is workflow-stamped to `${{ github.sha }}` at publish time (no longer the `0.1.0` placeholder).
- [x] `backend/README.md` includes the operator-facing `cosign verify` + anonymous-pull commands.

## Out of scope

- Cosign attestation of chart's resolved subchart digests — per issue body, the chart-digest already covers everything.
- Per-PR chart preview build — v0.2.
- Helm chart museum / static index — OCI is the only distribution path.

## First-time maintainer step

After the first successful `chart.yml` run on main, the GHCR package `meho-chart` is created PRIVATE. Flip to public once:

```bash
gh api --method PATCH /orgs/evoila/packages/container/meho-chart \
  -f visibility=public
```

The `verify-anonymous-pull` job will fail with `unauthorized` until this is done — that's the intended fail-closed signal, not a workflow bug. Same one-time gate as the image package (Task #33).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #41


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated Helm chart validation, packaging, OCI publishing, and keyless signing
  * Anonymous pull verification to confirm public chart availability

* **Documentation**
  * Added chart publish & verification guidance with example verification commands
  * Clarified chart naming contract: published artifact basename is "meho-chart" and default nameOverride set to "meho"

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/173)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-11)

Addressed review findings from https://github.com/evoila/meho/pull/173#issuecomment-4416859092 (auto-review-pr iter-1):

- **B1** `a6eed1a` — Install kubeconform to `$HOME/.local/bin` and append to `$GITHUB_PATH`; added an authoritative "Verify kubeconform on PATH for subsequent steps" check. CI run 25645080880 confirms validate now passes on `meho-runners`.
- **M1** `d753255` — Moved `packages: write` + `id-token: write` from workflow-level to the `publish` job only. validate and verify-anonymous-pull inherit `contents: read`.
- **m1** `559d61c` — Rewrote the misleading PyYAML comment in the Chart.yaml stamp step.

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 1 -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-11)

Addressed review findings from https://github.com/evoila/meho/pull/173#issuecomment-4416927892 (auto-review-pr iter-2):

- **B1-iter2** `d969322` — Replaced the partial `rm` scrub in `verify-anonymous-pull`'s "Pull chart anonymously" step with a throwaway `HOME="$(mktemp -d)"` plus matching `XDG_CONFIG_HOME` / `XDG_CACHE_HOME`. This blocks Helm 3.8+'s OCI credential fallback to `~/.docker/config.json` (helm/helm#7776), which could otherwise false-pass the Goal #11 DoD on the stateful `meho-runners` pool if a prior job left a docker login behind. Added `ls -la "${HOME}"` and `helm registry list` visibility lines so CI output proves the sandbox is empty before the pull executes. The expected failure modes after this change: (a) GHCR package is public → step passes (the goal); (b) GHCR package is private (first publish has not yet happened, or the visibility-flip has not been performed) → step fails with `unauthorized` — which is the intended fail-closed signal, not a regression.

Disputed: none.

Deferred (recorded as adjacent finding by iter-1; out of scope for this PR): Node.js 20 deprecation on `azure/setup-helm@v4.3.1` — orchestrator may file a follow-up Task to bump the action pin when Azure/setup-helm publishes a Node-24-compatible release.

<!-- auto-implement-issue: continue, iteration 2 -->
