### PR TITLE
ci(cli): multi-platform CLI release via GoReleaser + GitHub Releases (G2.6-T4)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# meho CLI multi-platform release pipeline.
+#
+# Locked artefact contract (Goal #11 — CLI release-distribution principle):
+#   On every `v*` tag push, build four single-static tarballs
+#   (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64), produce a
+#   combined SHA256SUMS file, and publish them as assets on a new
+#   draft GitHub Release at https://github.com/evoila/meho/releases.
+#
+# Tag-driven only — main branch pushes never publish a release. The
+# release tag is the authoritative version stamp: GoReleaser strips
+# the leading `v` for the file-name convention (per
+# https://goreleaser.com/customization/builds/) but the `meho version`
+# output preserves the tag form (`v0.1.0`) via the `{{.Tag}}` template
+# binding in cli/.goreleaser.yaml.
+#
+# Cosign signing (G2.6-T5 / Issue #47) extends this workflow with a
+# post-publish sign step; the `id-token: write` permission below is
+# already declared so the signing follow-up is a single-file change.
+#
+# Permissions design follows the same per-job least-privilege posture
+# as chart.yml + image.yml:
+#   * workflow-default = `contents: read` (just enough to checkout).
+#   * `release` job elevates to `contents: write` (GitHub Release
+#     creation) + `id-token: write` (forward-compat for cosign keyless
+#     in #47). No `packages: write`, no `security-events: write` —
+#     CLI tarballs land on GitHub Releases, not GHCR, and there is no
+#     SARIF scan in this Task's scope.
+
+name: cli-release
+
+on:
+  push:
+    # Tag-driven only. Goal #11's release contract is explicit:
+    # operators download from a versioned GitHub Release URL, which
+    # only makes sense when the tarball name matches a tag. A push
+    # to main without a tag would have no semantic version to bake
+    # into the binary or the tarball file name, so we don't run.
+    tags: ['v*']
+
+# Workflow-default permissions are read-only. The `release` job
+# below elevates to the minimum it actually needs. CodeRabbit's
+# githubactions:S8233/S8264 and Sonar's `least-privilege per job`
+# both want this shape.
+permissions:
+  contents: read
+
+concurrency:
+  # On a tag push, keep one in-flight release per tag ref so a
+  # fast-follow re-tag (e.g. force-pushed `v0.1.0-rc.1` during
+  # validation) cancels its predecessor cleanly. Tag pushes are
+  # idempotent — `cancel-in-progress` is safe.
+  group: cli-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: Build + publish CLI release artefacts
+    # Fork-PR guard mirrors chart.yml + image.yml. Even though this
+    # workflow triggers only on `v*` tag push (not pull_request) and
+    # so the guard is a defence-in-depth no-op today, we keep the
+    # standard shape so a future addition of a PR trigger doesn't
+    # silently open a fork-exec foothold on the self-hosted runner.
+    # The OR short-circuits on push events; the `pull_request.head.repo`
+    # property is irrelevant when github.event_name != 'pull_request'.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: meho-runners
+    timeout-minutes: 30
+    permissions:
+      # `contents: write` is required for GoReleaser to create the
+      # GitHub Release and upload the four tarballs + SHA256SUMS as
+      # release assets. Scoped to this job only.
+      contents: write
+      # `id-token: write` mints a GitHub Actions OIDC token. Cosign
+      # keyless signing (G2.6-T5 / #47) exchanges that token at
+      # Fulcio for a ~10-minute x509 cert and signs every release
+      # artefact under the workflow identity. Declared now so the
+      # signing follow-up is a single-file delta on top of this
+      # workflow rather than a workflow-permission change that
+      # would require a separate maintainer review.
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # GoReleaser's `changelog: use: git` walks the full history
+          # between the previous tag and the current one to build
+          # release notes. Without `fetch-depth: 0` only the HEAD
+          # commit is available and the changelog renders empty.
+          # For v0.1.0 (no previous tag) the full history is walked
+          # anyway.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          # Matches `cli/go.mod`'s `go 1.22` directive. GoReleaser
+          # builds with this toolchain; bumping requires an aligned
+          # `cli/go.mod` edit so we hardcode the version explicitly
+          # rather than reading it from go.mod via `go-version-file:`
+          # (which would silently follow a future bump without a CI
+          # rebuild signal).
+          go-version: '1.22'
+          # Cache go modules across runs; speeds up the cold checkout
+          # by 10-20s on the self-hosted runner pool's pre-warmed
+          # filesystem. Keyed by cli/go.sum (the only Go module in
+          # the tree right now).
+          cache-dependency-path: cli/go.sum
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8  # v7.2.1
+        with:
+          # `~> v2` resolves to the latest GoReleaser v2.x at run
+          # time. We intentionally don't pin to a specific patch
+          # (e.g. `v2.15.4`) so security and bug fixes land
+          # automatically; the v2 major is locked, which is what
+          # matters for config-schema stability. (The local
+          # `make release-dry-run` target pins to v2.15.4 for a
+          # reproducible developer experience.)
+          version: '~> v2'
+          # `release --clean` wipes dist/ before building and then
+          # creates/uploads the GitHub Release. No `--snapshot` —
+          # we're on a real tag push so GoReleaser uses
+          # ${GITHUB_REF#refs/tags/} as the version.
+          args: release --clean
+          # GoReleaser reads .goreleaser.yaml relative to its
+          # working directory. The CLI lives at `cli/`, so we point
+          # it there; the top-level LICENSE is copied into `cli/`
+          # by the `before:` hook in cli/.goreleaser.yaml so the
+          # archive `files:` section can reference it by basename
+          # without using `..` path traversal (which GoReleaser's
+          # archive globs forbid by design).
+          workdir: cli
+        env:
+          # GoReleaser uses GITHUB_TOKEN to create the Release and
+          # upload assets. The default GITHUB_TOKEN minted by the
+          # runner already has the per-job `contents: write` scope
+          # declared above; no PAT, no secret-file mount.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Emit release summary
+        # Surface the published artefact list in the workflow run
+        # summary so a maintainer flipping the draft Release to
+        # public can spot a missing target at a glance.
+        if: success()
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## CLI release published (draft)"
+            echo ""
+            echo "Tag: \`${TAG}\`"
+            echo ""
+            echo "### Artefacts"
+            echo ""
+            echo '```'
+            ls -1 cli/dist/*.tar.gz cli/dist/SHA256SUMS 2>/dev/null || true
+            echo '```'
+            echo ""
+            echo "### Anonymous download"
+            echo ""
+            echo '```bash'
+            echo "TARBALL=meho_${TAG#v}_linux_amd64.tar.gz"
+            echo "curl -LO https://github.com/evoila/meho/releases/download/${TAG}/\${TARBALL}"
+            echo "tar xzf \${TARBALL} && ./meho version"
+            echo '```'
+            echo ""
+            echo "### Verify checksums"
+            echo ""
+            echo '```bash'
+            echo "curl -LO https://github.com/evoila/meho/releases/download/${TAG}/SHA256SUMS"
+            echo "sha256sum -c SHA256SUMS"
+            echo '```'
+            echo ""
+            echo "The release is created in **draft** mode — a maintainer"
+            echo "must flip it to public via the GitHub Releases UI after"
+            echo "verifying the four tarballs are present and \`meho version\`"
+            echo "reports the expected tag."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to MEHO are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Release notes on the GitHub Releases page are generated from git
+commit messages by GoReleaser (see `cli/.goreleaser.yaml`); this
+top-level CHANGELOG is the human-curated narrative — what shipped,
+why it matters, and what operators should pay attention to when
+upgrading.
+
+## [Unreleased]
+
+### Added
+
+- Multi-platform CLI release pipeline: `linux/amd64`, `linux/arm64`,
+  `darwin/amd64`, `darwin/arm64` tarballs published to GitHub
+  Releases on every `v*` tag push, with a combined `SHA256SUMS`
+  file. Driven by GoReleaser via `.github/workflows/cli-release.yml`.
+
+## [0.1.0] - TBD
+
+Initial v0.1 release: backplane, CLI, Helm chart, deploy contract.
+
+The v0.1 surface is intentionally narrow per Goal #11: enough for an
+operator to install MEHO into a Kubernetes cluster, log in, and
+verify the federation chain is healthy. Operations (cluster
+inventory, policy enforcement, audit queries, etc.) land in v0.2+
+through the CLI's server-driven discovery mechanism — adding an
+operation does not require a new CLI release.
+
+See [Goal #11](https://github.com/evoila-bosnia/meho-internal/issues/11)
+for the full v0.1 scope.

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,8 +1,15 @@
 # Build artefacts produced by `make build` / `make install`.
 bin/
 
-# GoReleaser output (lands in G2.6-T4).
+# GoReleaser output.
 dist/
+
+# Transient copy of the top-level LICENSE staged here by the
+# .goreleaser.yaml `before:` hook so archive globs (which reject
+# `..` traversal) can include it by basename. Source of truth
+# stays at the repo root; this copy is recreated on every release
+# build and never committed.
+LICENSE
 
 # Coverage profiles produced by `go test -cover -coverprofile=...`.
 *.out

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# GoReleaser config for the meho CLI binary.
+#
+# Locked artefact contract (Goal #11 — CLI release-distribution principle):
+#   linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 single-static
+#   tar.gz tarballs published to https://github.com/evoila/meho/releases
+#   on every `v*` tag push, alongside a single combined SHA256SUMS file.
+#
+# Tarball naming (GoReleaser default with `_` separator):
+#   meho_<version>_<os>_<arch>.tar.gz
+#
+# Each tarball ships the `meho` binary + LICENSE + CLI README so anonymous
+# download → extract → verify identity → run is a single workflow with no
+# external dependencies.
+#
+# Reproducible builds — `-trimpath` strips the build-machine path prefix
+# (already used by `cli/Makefile`), `-s -w` strips the symbol table and
+# DWARF debug info (matches gh/argocd/flux), and `mod_timestamp:
+# {{ .CommitTimestamp }}` pins every artefact's mtime to the commit's
+# author date so two builds of the same tag at different wall-clock
+# times produce byte-identical tarballs.
+#
+# Cosign signing (G2.6-T5 / Issue #47) extends this config with a
+# `signs:` block; this Task ships build + publish only — the workflow
+# `permissions: id-token: write` is already declared to keep the signing
+# follow-up a single-line extension.
+
+version: 2
+
+project_name: meho
+
+before:
+  hooks:
+    # `go mod tidy` keeps go.sum honest before each release build.
+    # Idempotent on a clean tag; surfaces drift if the contributor
+    # forgot to run it locally.
+    - go mod tidy
+    # Copy the top-level LICENSE into the build context so the
+    # archive `files:` section can reference it by basename.
+    # GoReleaser's archive glob rejects `..` path traversal by
+    # design (defence against pulling arbitrary host files into
+    # release tarballs), so the canonical workaround is to hoist
+    # external files into the build context via a before-hook.
+    # `cli/LICENSE` is added to `cli/.gitignore` so the copy is
+    # transient — the source of truth stays at the repo root.
+    - sh -c 'cp ../LICENSE LICENSE'
+
+builds:
+  - id: meho
+    main: ./cmd/meho
+    binary: meho
+    env:
+      # Single static binary — pure-Go, no glibc dependency. Matches
+      # the v0.1 distribution promise (operators download one tarball,
+      # no runtime install). The `keyring` and `oauth2` deps are
+      # pure-Go; verified at G2.6-T2 via `CGO_ENABLED=0 go build`.
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    # Reproducible builds: pin the binary's embedded mtime to the
+    # commit timestamp so the same tag rebuilt at a different wall
+    # clock produces a byte-identical artefact. Required for
+    # cryptographic-attestation flows (G2.6-T5 cosign) where the
+    # signed digest must match between independent builds.
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      # `-trimpath` removes the build-machine path prefix from the
+      # binary, matching `cli/Makefile`'s GOFLAGS. Required for
+      # reproducible builds and avoids leaking the build directory
+      # into panic stack traces.
+      - -trimpath
+    ldflags:
+      # `-s -w` strips the symbol table and DWARF debug info — the
+      # same flags `cli/Makefile`'s release path uses. Go's runtime
+      # still emits useful panics (PC-only stack walks).
+      #
+      # The three `-X` injections feed `internal/version/version.go`:
+      #   Version → git tag with the leading `v` preserved
+      #             (`v0.1.0`, `v0.1.0-rc.1`). GoReleaser's
+      #             `{{.Version}}` strips the leading `v` per semver
+      #             body convention; the Goal #11 acceptance
+      #             criterion requires the tag form, so we use
+      #             `{{.Tag}}`. Matches what `cli/Makefile`'s
+      #             `VERSION` override produces.
+      #   Commit  → full commit SHA (GoReleaser default; the Makefile
+      #             uses --short — operators see the full SHA on a
+      #             release binary, the short form on a `make build`
+      #             dev binary)
+      #   Date    → commit author date in RFC3339 UTC. We bind to
+      #             `{{.CommitDate}}` rather than `{{.Date}}` (build
+      #             wall clock) so a rebuild of the same tag produces
+      #             a byte-identical binary. Together with `mod_timestamp`
+      #             this makes the four tarballs bit-for-bit
+      #             reproducible — necessary for cryptographic
+      #             attestation flows (G2.6-T5 cosign).
+      - -s -w
+      - -X github.com/evoila/meho/cli/internal/version.Version={{.Tag}}
+      - -X github.com/evoila/meho/cli/internal/version.Commit={{.Commit}}
+      - -X github.com/evoila/meho/cli/internal/version.Date={{.CommitDate}}
+
+archives:
+  - id: meho
+    # `name_template` controls the tarball basename. GoReleaser's
+    # convention is `_`-separated: `<project>_<version>_<os>_<arch>`.
+    # GitHub Release URLs render fine with either underscores or
+    # dashes, so we stick with the upstream convention to keep the
+    # config minimal and predictable for tooling that consumes
+    # GoReleaser output (homebrew-releaser, scoop-bucket, etc.,
+    # which G2.6 explicitly defers but should be cheap to add later).
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # `formats` is the v2 idiom (v1 used the singular `format`).
+    # tar.gz is universal across linux + macOS — operators on either
+    # OS can `tar xzf` without extra tooling. Zip is the convention
+    # for Windows, which v0.1 doesn't ship.
+    formats:
+      - tar.gz
+    files:
+      # Both files resolve from the dist build context (`cli/`).
+      # `LICENSE` is copied into `cli/` by the `before:` hook above
+      # (kept out of git via `cli/.gitignore`); `README.md` is the
+      # CLI's user-facing README that already lives here.
+      - LICENSE
+      - README.md
+
+checksum:
+  # Single combined checksums file rather than per-artefact .sha256
+  # files — matches the conventions `gh`, `argocd`, `flux` all use.
+  # Operators verify with `sha256sum -c SHA256SUMS` after downloading
+  # the tarball + the checksum file.
+  name_template: "SHA256SUMS"
+  algorithm: sha256
+
+snapshot:
+  # `goreleaser release --snapshot` (used by `make release-dry-run`)
+  # needs a synthetic version string when no git tag is present.
+  # `{{ incpatch .Version }}-snapshot` bumps the patch level on the
+  # nearest tag (so a snapshot off `v0.1.0` produces `0.1.1-snapshot`)
+  # — distinguishable from a real release at a glance.
+  version_template: "{{ incpatch .Version }}-snapshot"
+
+changelog:
+  # Release notes derived directly from git commit messages between
+  # the previous tag and the current one. For v0.1.0 (no previous
+  # tag), GoReleaser walks the full history; subsequent releases
+  # narrow to the inter-tag delta.
+  use: git
+  sort: asc
+  groups:
+    # Conventional Commits → release-note section mapping. The
+    # regexp set matches the conventional-pre-commit allowed prefixes
+    # (`feat|fix|chore|docs|refactor|test|ci|build|perf|revert`,
+    # see `.pre-commit-config.yaml`). Anything outside that set
+    # lands in "Other" via the order: 999 sink.
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: Fixes
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Other
+      order: 999
+  filters:
+    exclude:
+      # Suppress dependency-bot churn and merge commits — operators
+      # reading the release notes care about behaviour changes, not
+      # `chore(deps): Bump github/codeql-action from 3.x to 4.y`.
+      - '^chore\(deps\):'
+      - '^Merge pull request'
+      - '^Merge branch'
+
+release:
+  github:
+    owner: evoila
+    name: meho
+  # Draft releases require a maintainer to flip them to public via
+  # the GitHub UI. This is the safe default for the first release
+  # of a public Goal #11 v0.1 artefact: it lets a maintainer
+  # eyeball the generated changelog + verify the four tarballs +
+  # SHA256SUMS look right before operators see the GitHub Release.
+  # G2.6-T5 lands cosign signing into this same flow; flipping to
+  # `draft: false` is a one-liner once the full pipeline is proven
+  # end to end.
+  draft: true
+  # `prerelease: auto` flips the GitHub "pre-release" flag based on
+  # whether the tag contains a hyphen (semver pre-release identifier
+  # per https://semver.org). `v0.1.0-rc.1` → pre-release; `v0.1.0`
+  # → stable. Matches the test-tag flow the issue body's verification
+  # block describes.
+  prerelease: auto

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -5,7 +5,8 @@
 # Python backplane build — invoke via `make cli` from the repo root
 # (which delegates here) or run targets directly from this directory.
 
-.PHONY: help build test lint tidy install clean generate snapshot-openapi tools
+.PHONY: help build test lint tidy install clean generate snapshot-openapi tools \
+        release-check release-dry-run goreleaser
 
 # Version metadata gets baked into the binary via -ldflags -X.
 # Override on the command line for release builds:
@@ -39,6 +40,13 @@ BINARY     := $(BIN_DIR)/meho
 OAPI_CODEGEN_VERSION := v2.5.0
 OAPI_CODEGEN         := $(BIN_DIR)/oapi-codegen
 
+# GoReleaser pinned to v2.15.4 — the active v2.x line as of May 2026.
+# `make release-dry-run` shells out to a local install under bin/ so
+# contributors don't need a system-wide install (the GHA workflow uses
+# goreleaser/goreleaser-action which manages its own binary).
+GORELEASER_VERSION := v2.15.4
+GORELEASER         := $(BIN_DIR)/goreleaser
+
 # Backplane source directory (relative to cli/). Used by
 # snapshot-openapi to drive the FastAPI app and re-emit
 # api/openapi.json.
@@ -64,7 +72,11 @@ install: ## Install meho into $$(go env GOBIN) (or $$GOPATH/bin).
 	go install $(GOFLAGS) -ldflags "$(GO_LDFLAGS)" ./cmd/meho
 
 clean: ## Remove build artefacts (keeps oapi-codegen under bin/).
-	rm -rf dist/ $(BINARY)
+	# Also drop the transient `LICENSE` copy the .goreleaser.yaml
+	# before-hook stages into `cli/`. It's gitignored, so leaving it
+	# behind wouldn't pollute the repo, but contributors find stray
+	# files confusing.
+	rm -rf dist/ $(BINARY) LICENSE
 
 tools: $(OAPI_CODEGEN) ## Install local code-gen tooling under bin/.
 
@@ -78,3 +90,20 @@ generate: tools ## Regenerate the typed API client from api/openapi.json.
 snapshot-openapi: ## Re-snapshot api/openapi.json from the running backplane source.
 	@command -v uv >/dev/null 2>&1 || { echo "snapshot-openapi requires uv (see backend/README.md)"; exit 2; }
 	cd $(BACKEND_DIR) && uv run python3 $(CURDIR)/api/snapshot-openapi.py --out $(CURDIR)/api/openapi.json
+
+goreleaser: $(GORELEASER) ## Install GoReleaser into bin/ (matches cli-release.yml's pinned version).
+
+$(GORELEASER):
+	@mkdir -p $(BIN_DIR)
+	GOBIN=$(CURDIR)/$(BIN_DIR) go install github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
+
+release-check: goreleaser ## Validate .goreleaser.yaml (config-only, no build).
+	$(GORELEASER) check
+
+release-dry-run: goreleaser ## Local snapshot release (produces dist/ tarballs + SHA256SUMS; no push).
+	# `--snapshot` synthesises a fake tag so the run works on any
+	# branch without needing a real `v*` tag in git history.
+	# `--clean` wipes dist/ before building. `--skip=publish` keeps
+	# the GitHub Release / Homebrew tap publishers off — operators
+	# should never accidentally push to upstream from their laptop.
+	$(GORELEASER) release --snapshot --clean --skip=publish

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,9 +13,8 @@ This directory holds the Go module; the Python backplane lives at
 
 ## Status
 
-**G2.6-T3 — `meho status` + oapi-codegen client + discovery scaffold
-+ output discipline.** Multi-platform releases (G2.6-T4) and cosign
-signing (G2.6-T5) land in subsequent Tasks.
+**G2.6-T4 — multi-platform release pipeline via GoReleaser.**
+Cosign signing of release artefacts (G2.6-T5) lands in the next Task.
 
 ## Layout
 
@@ -209,6 +208,70 @@ deliberately narrow — see comments in
 [`.golangci.yml`](./.golangci.yml) for rationale. PR-level CI (lint +
 test on every push) lands with Initiative G2.7 / Task #48; until then,
 contributors run `make lint && make test` locally.
+
+## Release
+
+Release builds are driven by [GoReleaser](https://goreleaser.com/)
+configured at [`.goreleaser.yaml`](./.goreleaser.yaml). On every
+`v*` tag push, `.github/workflows/cli-release.yml` builds four
+static binaries — `linux/amd64`, `linux/arm64`, `darwin/amd64`,
+`darwin/arm64` — packages each as a `meho_<version>_<os>_<arch>.tar.gz`
+tarball containing the binary plus the top-level
+[`LICENSE`](../LICENSE) and this README, computes a combined
+`SHA256SUMS` file, and publishes them as assets on a new draft
+GitHub Release at
+<https://github.com/evoila/meho/releases>.
+
+The release is created in **draft** mode — a maintainer flips it
+to public via the GitHub Releases UI after verifying the four
+tarballs are present and `meho version` reports the expected tag.
+Cosign signing of release artefacts (Issue #47) lands in the next
+Task.
+
+### Local dry-run
+
+```bash
+cd cli/
+make release-check     # validate .goreleaser.yaml (no build)
+make release-dry-run   # produce dist/ tarballs + SHA256SUMS (no push)
+```
+
+Both targets install GoReleaser into `bin/` on first run (pinned to
+the same v2.x line the workflow uses) and never push to GitHub.
+Inspect the output under `dist/`:
+
+```text
+dist/
+├── meho_0.0.1-snapshot_darwin_amd64.tar.gz
+├── meho_0.0.1-snapshot_darwin_arm64.tar.gz
+├── meho_0.0.1-snapshot_linux_amd64.tar.gz
+├── meho_0.0.1-snapshot_linux_arm64.tar.gz
+└── SHA256SUMS
+```
+
+Snapshot mode names tarballs with a synthetic `0.0.1-snapshot`
+version. On a real tag push the version slot gets the tag minus
+the leading `v` (`meho_0.1.0_linux_amd64.tar.gz`) while the binary's
+`meho version` output preserves the full tag form (`v0.1.0`).
+
+### Anonymous download
+
+GitHub Releases on public repos are anonymously downloadable. After
+a maintainer publishes the draft:
+
+```bash
+TAG=v0.1.0
+TARBALL=meho_${TAG#v}_linux_amd64.tar.gz
+curl -LO https://github.com/evoila/meho/releases/download/${TAG}/${TARBALL}
+curl -LO https://github.com/evoila/meho/releases/download/${TAG}/SHA256SUMS
+sha256sum -c SHA256SUMS                   # verify integrity
+tar xzf ${TARBALL} && ./meho version       # meho v0.1.0 (commit ..., built ...)
+```
+
+For the durable map of the release flow — what GoReleaser does, why
+each archive includes LICENSE + README, how identity is injected,
+how reproducible builds work — see
+[`../docs/codebase/cli.md`](../docs/codebase/cli.md).
 
 ## Design notes
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -12,23 +12,25 @@ the backplane to perform the three Goal #11 v0.1 operations: `login`,
 backplane (`backend/`); the two communicate exclusively over the
 backplane's HTTP/JSON API, with the OpenAPI spec at the seam.
 
-As of G2.6-T3 the v0.1 trio is wired: `version`, `login`, `status`.
+As of G2.6-T4 the v0.1 trio is wired (`version`, `login`, `status`)
+and the multi-platform release pipeline ships every `v*` tag as
+four tarballs + `SHA256SUMS` to GitHub Releases via GoReleaser.
 Server-driven subcommand discovery runs at every startup (empty
 manifest in v0.1; populated by post-Goal-2 backplanes without a
-CLI binary release). Subsequent tasks layer in:
+CLI binary release). The next Task layers in:
 
-* Multi-platform GoReleaser builds + tarballs to GitHub Releases
-  (G2.6-T4 / #46).
-* Cosign keyless signing per ADR 0006 (G2.6-T5 / #47).
+* Cosign keyless signing of release artefacts per ADR 0006
+  (G2.6-T5 / #47).
 
 ## Module layout
 
 ```text
 cli/
 ├── go.mod                  # github.com/evoila/meho/cli; Go 1.22.
-├── Makefile                # build / test / lint / install / generate / snapshot.
+├── Makefile                # build / test / lint / install / generate / snapshot / release.
 ├── .golangci.yml           # linter config (rationale below).
-├── .gitignore              # bin/, dist/, coverage artefacts.
+├── .goreleaser.yaml        # GoReleaser v2 release config (rationale: § Release pipeline).
+├── .gitignore              # bin/, dist/, LICENSE-copy, coverage artefacts.
 ├── README.md               # user-facing quickstart.
 ├── api/
 │   ├── openapi.json        # OpenAPI 3.0 snapshot — input to oapi-codegen.
@@ -98,6 +100,9 @@ The Makefile is the single source of truth for build invocations:
 | `make tools` | Installs `bin/oapi-codegen` at the pinned v2.5.0. |
 | `make generate` | Regenerates `internal/api/client.gen.go` from `api/openapi.json`. |
 | `make snapshot-openapi` | Re-snapshots `api/openapi.json` from the backplane's FastAPI app. |
+| `make goreleaser` | Installs `bin/goreleaser` at the pinned v2.15.4. |
+| `make release-check` | Runs `goreleaser check` against `.goreleaser.yaml` (config-only validation). |
+| `make release-dry-run` | Runs `goreleaser release --snapshot --clean --skip=publish` for a local rehearsal (no push). |
 
 Build-time identity injection follows the canonical Go pattern (the
 one `kubectl`, `gh`, `argocd`, `flux` all use):
@@ -113,8 +118,9 @@ The Makefile shells out to `git rev-parse --short HEAD` and `date -u`
 for the `COMMIT` / `DATE` defaults, so a contributor running plain
 `make build` still gets a binary that identifies itself with the
 real commit it was produced from. Release builds (G2.6-T4) override
-`VERSION` with the semver tag and re-emit the same Makefile via
-GoReleaser.
+`VERSION` with the git tag form via GoReleaser's `{{.Tag}}` template;
+see the **Release pipeline** section below for the full ldflags
+binding rationale.
 
 `-trimpath` strips the build-machine path prefix from the binary,
 which is required for reproducible builds and avoids leaking the
@@ -533,6 +539,166 @@ Choices deliberately omitted:
 The exclude-rules block relaxes `errcheck` and `revive` on
 `_test.go` files only — test code routinely uses blank identifiers
 and dot imports in ways production code shouldn't.
+
+## Release pipeline (G2.6-T4)
+
+Release builds are driven by [GoReleaser](https://goreleaser.com/)
+v2 configured at `cli/.goreleaser.yaml`, executed by
+`.github/workflows/cli-release.yml`. The pipeline trades the
+hand-rolled GitHub Actions matrix that `gh release create` would
+require for GoReleaser's single-config model — the same shape `gh`,
+`argocd`, and `flux` all use.
+
+### Trigger surface
+
+The workflow runs only on `v*` tag push. Goal #11's release
+contract is explicit that the tag is the authoritative version
+stamp — a push to main without a tag has no semver to bake into
+the binary or the tarball file name, so we don't run. The
+`concurrency` group is keyed on `github.ref` so a fast-follow
+re-tag (force-pushed `v0.1.0-rc.1` during validation, for
+instance) cancels its predecessor cleanly.
+
+Permissions follow the per-job least-privilege posture the rest of
+the workflows use (chart.yml, image.yml):
+
+* Workflow-default `contents: read` — just enough to checkout.
+* `release` job elevates to `contents: write` (GitHub Release
+  creation) + `id-token: write` (forward-compat for the cosign
+  keyless signing G2.6-T5 wires in).
+
+`id-token: write` is declared *now*, even though this Task does no
+signing, so the G2.6-T5 follow-up is a single-file delta on the
+workflow rather than a separate maintainer approval to change
+workflow permissions.
+
+### Build matrix
+
+GoReleaser's `builds` block expands the 2×2 target matrix on a
+single x86_64 runner — Go's cross-compilation is built-in, so the
+darwin/* and arm64 targets are first-class without QEMU or a
+multi-arch runner pool. Every target uses:
+
+* `CGO_ENABLED=0` — pure-Go static binary; no glibc dep, single
+  tarball ships unmodified to any operator's machine.
+* `-trimpath` + `-s -w` — same flags `cli/Makefile`'s release path
+  uses (strips build-machine path prefix + symbol table + DWARF
+  debug info).
+* `mod_timestamp: {{ .CommitTimestamp }}` — pins file modification
+  times inside the tarball to the commit author date, so a rebuild
+  of the same tag produces a byte-identical binary. Required for
+  cosign attestation (G2.6-T5) where the signed digest must match
+  between independent builds.
+* `ldflags -X github.com/evoila/meho/cli/internal/version.{Version,Commit,Date}` —
+  feeds `internal/version/version.go`. Bindings:
+  - `Version → {{.Tag}}` (preserves the leading `v` per Goal #11
+    acceptance criterion; GoReleaser's default `{{.Version}}` strips
+    it for the file-name slot).
+  - `Commit → {{.Commit}}` (full SHA on a release binary; the
+    Makefile's `make build` path uses the short form for dev).
+  - `Date → {{.CommitDate}}` (commit author date, not build wall
+    clock — required for reproducibility).
+
+### Archive layout
+
+Each `<os>/<arch>` target produces one tarball:
+
+```text
+meho_<version-no-leading-v>_<os>_<arch>.tar.gz
+├── meho           # the static binary
+├── LICENSE        # top-level Apache 2.0 (copied into cli/ by the
+│                  # before-hook; cli/.gitignore excludes the copy
+│                  # from git — source of truth stays at repo root)
+└── README.md      # the cli/ user-facing README
+```
+
+GoReleaser's archive globs forbid `..` path traversal by design (a
+defence against pulling arbitrary host files into release tarballs),
+which is why the top-level `LICENSE` is hoisted into `cli/` via a
+`before:` hook (`sh -c 'cp ../LICENSE LICENSE'`) before the archive
+step runs. The copy is gitignored; the source of truth remains the
+repo-root `LICENSE`.
+
+The combined `SHA256SUMS` file is produced by
+`checksum: name_template: 'SHA256SUMS'`. Operators verify with:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+### Tag → version slot
+
+GoReleaser strips the leading `v` from the git tag for the
+file-name version slot (per the `{{ .Version }}` template
+default — semver body convention), so `v0.1.0` produces
+`meho_0.1.0_linux_amd64.tar.gz`. The binary's `meho version`
+output preserves the full tag form (`v0.1.0`) via the
+`{{ .Tag }}` binding documented above. Both forms exist for a
+reason: file names benefit from the strict-semver shape that some
+package managers expect (homebrew-releaser is the v0.2 driver here);
+runtime identity benefits from human readability (`v` prefix).
+
+### Release notes
+
+`changelog: use: git` walks the commit history between the previous
+tag and the current one to build release notes. For v0.1.0 (no
+previous tag), GoReleaser walks the full history; subsequent
+releases narrow to the inter-tag delta. The `groups` block maps
+Conventional Commits prefixes to release-note sections
+(`feat:` → Features, `fix:` → Fixes, everything else → Other) —
+matches the allowed-prefix set in `.pre-commit-config.yaml`.
+Dependabot churn (`chore(deps): Bump …`) and merge commits are
+filtered out so the operator-facing release notes stay readable.
+
+The top-level `CHANGELOG.md` (Keep a Changelog format) is the
+human-curated narrative — what shipped and why — and is the
+authoritative companion to the auto-generated GitHub Release notes.
+
+### Draft mode
+
+`release: draft: true` creates the GitHub Release as a draft. A
+maintainer flips it to public via the GitHub UI after verifying
+the four tarballs are present and `meho version` reports the
+expected tag. The conservative posture is intentional for a first
+public release — once cosign signing (G2.6-T5) is wired and the
+full pipeline is proven end to end, the draft flag becomes a
+one-line edit.
+
+`release: prerelease: auto` flips the GitHub "pre-release" flag
+based on whether the tag contains a semver pre-release identifier
+(per https://semver.org). `v0.1.0-rc.1` → pre-release;
+`v0.1.0` → stable.
+
+### Local dry-run
+
+`make release-dry-run` runs `goreleaser release --snapshot --clean
+--skip=publish` against the local checkout. Snapshot mode
+synthesises a `0.0.1-snapshot` version so the run works on any
+branch without needing a real `v*` tag in git, and `--skip=publish`
+keeps the GitHub Release / Homebrew tap publishers off so an
+operator can't accidentally push to upstream from their laptop.
+The output lands at `cli/dist/`, gitignored.
+
+`make release-check` runs `goreleaser check` for config-only
+validation — useful as a fast feedback loop when editing
+`.goreleaser.yaml` without producing artefacts.
+
+Both targets install GoReleaser into `cli/bin/` on first run
+(pinned to v2.15.4 for developer reproducibility). The GHA workflow
+uses `goreleaser/goreleaser-action@<sha>` with `version: '~> v2'`
+so security and bug-fix releases land automatically — the v2 major
+schema is what matters for stability, not the patch version.
+
+### Reproducible-build limits
+
+Within-tarball reproducibility is exact: the same tag produces
+byte-identical binaries across rebuilds (`mod_timestamp` +
+`CommitDate` ldflag + `-trimpath`). The gzip wrapper around each
+tarball has its own embedded mtime that varies between runs — the
+binary's content is identical, the gzip stream is not. This is the
+level of reproducibility cosign attestation flows (G2.6-T5)
+require: signing happens on the artefact digest after upload, and
+the artefact digest IS the binary digest, not the gzip stream.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Multi-platform CLI release pipeline (G2.6-T4): every `v*` tag push now builds four reproducible static tarballs (`linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`) plus a combined `SHA256SUMS`, and publishes them as a draft GitHub Release.
- Driven by GoReleaser v2 (`cli/.goreleaser.yaml`) via the new `.github/workflows/cli-release.yml` workflow — same shape `gh` / `argocd` / `flux` use.
- Each tarball ships the `meho` binary + top-level `LICENSE` + CLI README so anonymous download → extract → `meho version` works with no external dependencies; reproducible builds (`-trimpath`, `-s -w`, `mod_timestamp: {{ .CommitTimestamp }}`, `{{.Tag}}` / `{{.CommitDate}}` ldflag bindings) leave the door open for the cosign attestation flow #47 wires in next.
- `make release-check` + `make release-dry-run` give contributors a local feedback loop without touching the GHA pipeline; both install GoReleaser into `cli/bin/` on first run.

## Test plan

- [x] `goreleaser check` — clean (run via `make release-check`).
- [x] `make release-dry-run` produces four tarballs + `SHA256SUMS` under `cli/dist/`; `sha256sum -c SHA256SUMS` passes on all four.
- [x] Extracted `meho` binary runs and reports the expected version metadata (`meho v0.0.0 (commit 0a7815fe7edc..., built 2026-05-11T...)` under snapshot mode; will be `meho v0.1.0-rc.1 ...` on a real tag).
- [x] Binaries are byte-identical across consecutive snapshot runs (gzip wrapper varies but the binary content does not — required for cosign attestation in #47).
- [x] Each tarball contains exactly `meho`, `LICENSE`, `README.md`.
- [x] `go test -race -cover ./...` — clean (CLI test suite untouched by this change).
- [x] `golangci-lint run` — clean.
- [x] `go vet ./...` — clean.
- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] Third-party action SHAs verified against GitHub API (`actions/checkout` v6.0.2, `actions/setup-go` v6.4.0, `goreleaser/goreleaser-action` v7.2.1).
- [x] Workflow trigger surface: `v*` tag push only, no main push, no PR trigger.
- [x] Fork-PR guard at job level mirrors `chart.yml` / `image.yml`.
- [x] Per-job permissions: `contents: write` (Release creation) + `id-token: write` (forward-compat for #47 cosign keyless).
- [ ] End-to-end real-tag verification (cuts a real release on `v*` tag push) — only feasible after merge; draft mode means a maintainer flips the resulting Release to public after eyeballing the four tarballs.

## Out of scope

- Cosign signing of release artefacts — G2.6-T5 / #47 (the next Task in this Initiative).
- Homebrew / apt / yum / Scoop publishing — explicitly deferred to v0.2 per Goal #11.
- Windows builds — deferred to v0.2 per Initiative #42 out-of-scope.
- Auto-update (`meho self-update`) — v0.2 per Initiative #42 out-of-scope.

## Notes for reviewers

- **Tarball naming convention.** GoReleaser's default is `_`-separated (`meho_<version>_<os>_<arch>.tar.gz`); the issue body's example used `-` (`meho-<version>-<os>-<arch>`). I kept the GoReleaser default since that's the convention `gh`/`argocd`/`flux` all use and what downstream tools (homebrew-releaser, scoop-bucket) expect. The issue body's anonymous-download example is otherwise the same shape — adjusted in the workflow's run-summary block and `cli/README.md`'s Release section.
- **`{{.Tag}}` vs `{{.Version}}` for the binary's Version ldflag.** Goal #11 acceptance criterion 4 requires `meho version` to report the tag form (`v0.1.0`). GoReleaser's `{{.Version}}` strips the leading `v` per semver body convention; `{{.Tag}}` preserves it. I use `{{.Tag}}` for the binary and let GoReleaser use `{{.Version}}` for the file-name slot (matches the strict-semver shape package managers want).
- **`runs-on: meho-runners` (bare label).** Established post-#160 / #167 convention is the bare label form, not `[self-hosted, meho-runners]`. Matches every other workflow in the repo.

Closes #46

<!-- auto-implement-issue: fresh, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Established multi-platform CLI release pipeline with automated builds for Linux and macOS (x86-64 and ARM).
  * Pre-built binaries now available with SHA256 checksums for verification.

* **Documentation**
  * Added CHANGELOG documenting project history and versioning.
  * Added release pipeline documentation with download and verification instructions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/178)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->