### PR TITLE
ci(cli): cosign-sign release tarballs + CHANGELOG release notes (G2.6-T5)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -16,18 +16,21 @@
 # output preserves the tag form (`v0.1.0`) via the `{{.Tag}}` template
 # binding in cli/.goreleaser.yaml.
 #
-# Cosign signing (G2.6-T5 / Issue #47) extends this workflow with a
-# post-publish sign step; the `id-token: write` permission below is
-# already declared so the signing follow-up is a single-file change.
+# Cosign keyless signing (Issue #47, ADR 0006) attaches a sigstore
+# bundle to every release artefact via GoReleaser's `signs:` block in
+# cli/.goreleaser.yaml. The `Install cosign` step below pins the
+# installer SHA (matches chart.yml + image.yml). Release notes are
+# extracted from the top-level CHANGELOG.md so the human-curated
+# narrative — not git-log noise — lands in the GitHub Release body.
 #
 # Permissions design follows the same per-job least-privilege posture
 # as chart.yml + image.yml:
 #   * workflow-default = `contents: read` (just enough to checkout).
 #   * `release` job elevates to `contents: write` (GitHub Release
-#     creation) + `id-token: write` (forward-compat for cosign keyless
-#     in #47). No `packages: write`, no `security-events: write` —
-#     CLI tarballs land on GitHub Releases, not GHCR, and there is no
-#     SARIF scan in this Task's scope.
+#     creation) + `id-token: write` (cosign keyless OIDC). No
+#     `packages: write`, no `security-events: write` — CLI tarballs
+#     land on GitHub Releases, not GHCR, and there is no SARIF scan
+#     in this Task's scope.
 
 name: cli-release
 
@@ -74,12 +77,11 @@ jobs:
       # release assets. Scoped to this job only.
       contents: write
       # `id-token: write` mints a GitHub Actions OIDC token. Cosign
-      # keyless signing (G2.6-T5 / #47) exchanges that token at
+      # keyless signing (Issue #47, ADR 0006) exchanges that token at
       # Fulcio for a ~10-minute x509 cert and signs every release
-      # artefact under the workflow identity. Declared now so the
-      # signing follow-up is a single-file delta on top of this
-      # workflow rather than a workflow-permission change that
-      # would require a separate maintainer review.
+      # artefact under the workflow identity. Mirrors chart.yml and
+      # image.yml's per-job posture for the same reason — only the
+      # signing job needs the token.
       id-token: write
     steps:
       - name: Checkout
@@ -109,6 +111,80 @@ jobs:
           # the tree right now).
           cache-dependency-path: cli/go.sum
 
+      - name: Install cosign
+        # Pinned to cosign-installer v4.1.2 (ships cosign v3.x by
+        # default). Same SHA as chart.yml's signing step so a single
+        # supply-chain audit covers all three artefact pipelines
+        # (image, chart, CLI release). v4.x dropped pre-2.0 cosign
+        # support; v3.x of cosign has keyless-by-default semantics —
+        # no COSIGN_EXPERIMENTAL=1 needed.
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Extract release notes from CHANGELOG.md
+        # CHANGELOG.md is the human-curated narrative (Keep a Changelog
+        # format). GoReleaser's `changelog:` block remains in
+        # cli/.goreleaser.yaml as a fallback for snapshot builds, but
+        # for real `v*` tag pushes we override the release body with
+        # the matching CHANGELOG section via `--release-notes` so
+        # operators see the maintainer-written prose rather than the
+        # raw git log.
+        #
+        # The script extracts the `## [<version>]` section matching
+        # the current tag. The leading `v` is stripped to match the
+        # Keep-a-Changelog convention (`## [0.1.0]`). The section ends
+        # at the next `## ` heading or end-of-file. A missing section
+        # falls back to the `[Unreleased]` block — useful for
+        # pre-release tags like `v0.1.0-rc.1` that the CHANGELOG may
+        # not have a dedicated section for yet. If both are absent,
+        # the file is left empty and GoReleaser falls back to its
+        # built-in `changelog:` git-log generation.
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
+
+          # awk extracts the block between `## [<version>]` (or
+          # `## [Unreleased]` as fallback) and the next `## ` line.
+          # `-v` passes the version into awk's namespace; the regex
+          # anchors on `[`-bracketed semver to avoid matching prose
+          # headings that happen to start with `## `.
+          extract_section() {
+            local heading_pattern="$1"
+            awk -v pat="${heading_pattern}" '
+              BEGIN { in_section = 0 }
+              # Section start: line matches `## [<pattern>]` exactly
+              # (optionally followed by ` - <date>` per Keep a
+              # Changelog).
+              $0 ~ "^## \\[" pat "\\]" { in_section = 1; next }
+              # Section end: next `## ` heading.
+              in_section && /^## / { exit }
+              in_section { print }
+            ' CHANGELOG.md
+          }
+
+          # Try the exact version first, then [Unreleased].
+          extract_section "${VERSION}" > "${NOTES_FILE}"
+          if [[ ! -s "${NOTES_FILE}" ]]; then
+            extract_section "Unreleased" > "${NOTES_FILE}"
+          fi
+
+          if [[ -s "${NOTES_FILE}" ]]; then
+            echo "Release notes extracted (${VERSION} or Unreleased):"
+            echo "--- BEGIN ---"
+            cat "${NOTES_FILE}"
+            echo "--- END ---"
+          else
+            echo "::warning::No matching CHANGELOG section for ${VERSION} or [Unreleased]; GoReleaser will fall back to git-log generation."
+          fi
+
+          # Export the path for the next step. Use a stable variable
+          # name (not a step output) so the GoReleaser step's `args:`
+          # template can reference it via `${{ env.RELEASE_NOTES_FILE
+          # }}`.
+          echo "RELEASE_NOTES_FILE=${NOTES_FILE}" >> "${GITHUB_ENV}"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8  # v7.2.1
         with:
@@ -124,7 +200,19 @@ jobs:
           # creates/uploads the GitHub Release. No `--snapshot` —
           # we're on a real tag push so GoReleaser uses
           # ${GITHUB_REF#refs/tags/} as the version.
-          args: release --clean
+          #
+          # `--release-notes ${RELEASE_NOTES_FILE}` overrides
+          # GoReleaser's built-in `changelog:` generation with the
+          # CHANGELOG-extracted section (see "Extract release notes"
+          # step above). When the file is empty (no matching section)
+          # GoReleaser logs a warning and uses the empty body; the
+          # warning step above surfaces this loudly in the workflow
+          # log so a maintainer can spot the missing CHANGELOG
+          # update before flipping the draft Release to public. The
+          # fallback `changelog:` block in cli/.goreleaser.yaml still
+          # serves snapshot builds (`make release-dry-run`) where no
+          # CHANGELOG section exists.
+          args: release --clean --release-notes ${{ env.RELEASE_NOTES_FILE }}
           # GoReleaser reads .goreleaser.yaml relative to its
           # working directory. The CLI lives at `cli/`, so we point
           # it there; the top-level LICENSE is copied into `cli/`
@@ -139,6 +227,13 @@ jobs:
           # runner already has the per-job `contents: write` scope
           # declared above; no PAT, no secret-file mount.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # COSIGN_YES disables cosign's interactive prompt across
+          # every signs:-block invocation. The `--yes` flag in
+          # cli/.goreleaser.yaml's signs block argv covers each
+          # invocation explicitly; this env var is belt-and-braces in
+          # case a future signs entry omits the flag. Matches the
+          # standard sigstore.dev CI guidance.
+          COSIGN_YES: "true"
 
       - name: Emit release summary
         # Surface the published artefact list in the workflow run
@@ -156,8 +251,12 @@ jobs:
             echo "### Artefacts"
             echo ""
             echo '```'
-            ls -1 cli/dist/*.tar.gz cli/dist/SHA256SUMS 2>/dev/null || true
+            ls -1 cli/dist/*.tar.gz cli/dist/SHA256SUMS cli/dist/*.cosign.bundle 2>/dev/null || true
             echo '```'
+            echo ""
+            echo "Each \`.tar.gz\` and the \`SHA256SUMS\` file has a matching"
+            echo "\`.cosign.bundle\` (sigstore bundle: signature + Fulcio cert +"
+            echo "Rekor proof, single JSON file)."
             echo ""
             echo "### Anonymous download"
             echo ""
@@ -174,8 +273,27 @@ jobs:
             echo "sha256sum -c SHA256SUMS"
             echo '```'
             echo ""
+            echo "### Verify signatures (cosign keyless, ADR 0006)"
+            echo ""
+            echo '```bash'
+            echo "TARBALL=meho_${TAG#v}_linux_amd64.tar.gz"
+            echo "BASE=https://github.com/evoila/meho/releases/download/${TAG}"
+            echo "curl -LO \${BASE}/\${TARBALL}"
+            echo "curl -LO \${BASE}/\${TARBALL}.cosign.bundle"
+            echo "cosign verify-blob \\\\"
+            echo "  --certificate-identity-regexp '^https://github\\.com/evoila/meho/\\.github/workflows/cli-release\\.yml@refs/tags/v.+\$' \\\\"
+            echo "  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\\\"
+            echo "  --bundle \${TARBALL}.cosign.bundle \\\\"
+            echo "  \${TARBALL}"
+            echo '```'
+            echo ""
+            echo "The same recipe works for \`SHA256SUMS.cosign.bundle\` —"
+            echo "verify the checksums file's bundle first, then run"
+            echo "\`sha256sum -c SHA256SUMS\` against the tarballs you"
+            echo "actually downloaded (two-step trust chain)."
+            echo ""
             echo "The release is created in **draft** mode — a maintainer"
             echo "must flip it to public via the GitHub Releases UI after"
-            echo "verifying the four tarballs are present and \`meho version\`"
-            echo "reports the expected tag."
+            echo "verifying the four tarballs + bundles are present and"
+            echo "\`meho version\` reports the expected tag."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -149,10 +149,15 @@ jobs:
           # `## [Unreleased]` as fallback) and the next `## ` line.
           # `-v` passes the version into awk's namespace; the regex
           # anchors on `[`-bracketed semver to avoid matching prose
-          # headings that happen to start with `## `.
+          # headings that happen to start with `## `. Dots in the
+          # version literal are escaped before interpolation so a
+          # version like `0.1.0` doesn't accidentally match
+          # `[0x1y0]` — semver vocab today is `[0-9A-Za-z.-]` so the
+          # practical risk is nil, but hygiene wins.
           extract_section() {
             local heading_pattern="$1"
-            awk -v pat="${heading_pattern}" '
+            local escaped="${heading_pattern//./\\.}"
+            awk -v pat="${escaped}" '
               BEGIN { in_section = 0 }
               # Section start: line matches `## [<pattern>]` exactly
               # (optionally followed by ` - <date>` per Keep a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,35 @@ All notable changes to MEHO are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Release notes on the GitHub Releases page are generated from git
-commit messages by GoReleaser (see `cli/.goreleaser.yaml`); this
-top-level CHANGELOG is the human-curated narrative — what shipped,
-why it matters, and what operators should pay attention to when
-upgrading.
+This top-level CHANGELOG is the **authoritative source** for the
+GitHub Release notes published at
+<https://github.com/evoila/meho/releases>. The
+`.github/workflows/cli-release.yml` workflow extracts the section
+matching the current tag (with `[Unreleased]` as fallback for
+pre-release tags) and passes it to GoReleaser via
+`--release-notes`, overriding GoReleaser's built-in git-log
+generation. Operators see the human-curated narrative — what
+shipped and why it matters — not a dump of commit subjects.
+
+## How entries are added
+
+- **One bullet per merged PR** under the appropriate category.
+- Bullets land in `## [Unreleased]` until a tag cuts the release;
+  the release-cutting PR moves them under the new `## [x.y.z] -
+  YYYY-MM-DD` heading.
+- **Each bullet links to the issue + PR:** `- Add Vault probe (#30 / #47)`.
+  The issue number is the planning anchor (`evoila-bosnia/meho-internal`);
+  the PR number is the implementation (`evoila/meho`).
+- **Conventional-Commits prefixes are optional in the bullet** —
+  the category heading is doing the typing already. Keep the prose
+  imperative and operator-readable.
+- **Categories** (Keep a Changelog):
+  - **Added** — new features.
+  - **Changed** — changes to existing functionality.
+  - **Deprecated** — soon-to-be removed features.
+  - **Removed** — features removed in this release.
+  - **Fixed** — bug fixes.
+  - **Security** — vulnerability fixes; flag CVE / advisory.
 
 ## [Unreleased]
 
@@ -19,6 +43,19 @@ upgrading.
   `darwin/amd64`, `darwin/arm64` tarballs published to GitHub
   Releases on every `v*` tag push, with a combined `SHA256SUMS`
   file. Driven by GoReleaser via `.github/workflows/cli-release.yml`.
+  (#46 / #178)
+- Cosign keyless signing of every CLI release artefact (four
+  tarballs + `SHA256SUMS`) per ADR 0006. Each artefact ships with a
+  matching `.cosign.bundle` sigstore bundle (signature + Fulcio
+  cert + Rekor proof, single JSON file). Verification recipe
+  documented at the top-level README and `cli/README.md`. (#47)
+
+### Changed
+
+- GitHub Release body is now sourced from this CHANGELOG via
+  `--release-notes` rather than GoReleaser's auto-generated
+  git-log. The workflow extracts the section matching the current
+  tag (or `[Unreleased]` as fallback). (#47)
 
 ## [0.1.0] - TBD
 
@@ -30,6 +67,15 @@ verify the federation chain is healthy. Operations (cluster
 inventory, policy enforcement, audit queries, etc.) land in v0.2+
 through the CLI's server-driven discovery mechanism — adding an
 operation does not require a new CLI release.
+
+The v0.1 trust chain across all three operator-facing artefacts —
+the backplane container image, the Helm chart, and the CLI release
+tarballs — is built on cosign keyless signing under a common
+identity-claim format (ADR 0006). Operators verify each artefact
+against the workflow path that produced it using
+`cosign verify` / `cosign verify-blob` with
+`--certificate-identity-regexp` — no public-key distribution, no
+key custody.
 
 See [Goal #11](https://github.com/evoila-bosnia/meho-internal/issues/11)
 for the full v0.1 scope.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ recipes for running it locally — see [`backend/README.md`](./backend/README.md
 
 For the `meho` operator CLI (Go / cobra) — build, install, and
 `meho version` recipes — see [`cli/README.md`](./cli/README.md). The
-CLI ships as a single static binary; v0.1 wires `version` only, with
-`login` and `status` landing in subsequent tasks under Initiative
-G2.6 (#42).
+CLI ships as a single static binary; v0.1 wires `version`, `login`,
+and `status`, plus a cosign-signed multi-platform release pipeline
+(linux/macOS × amd64/arm64). Operator-side signature-verification
+recipe is below in [Verifying CLI release artefacts](#verifying-cli-release-artefacts).
 
 ## Container image
 
@@ -76,6 +77,47 @@ Verify:
 gh api /orgs/evoila/packages/container/meho --jq '.visibility'   # -> "public"
 docker logout ghcr.io && docker pull ghcr.io/evoila/meho:main    # -> succeeds
 ```
+
+## Verifying CLI release artefacts
+
+Every CLI tarball published at <https://github.com/evoila/meho/releases>
+is signed via cosign keyless (ADR 0006). The signature, the
+Fulcio-issued certificate, and the Rekor transparency-log inclusion
+proof are bundled into a single `.cosign.bundle` JSON file attached
+to the release alongside each `.tar.gz` and the combined `SHA256SUMS`
+file.
+
+```bash
+TAG=v0.1.0
+TARBALL=meho_${TAG#v}_linux_amd64.tar.gz
+BASE=https://github.com/evoila/meho/releases/download/${TAG}
+
+curl -LO ${BASE}/${TARBALL}
+curl -LO ${BASE}/${TARBALL}.cosign.bundle
+
+cosign verify-blob \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --bundle ${TARBALL}.cosign.bundle \
+  ${TARBALL}
+# Verified OK
+
+tar xzf ${TARBALL}
+sudo install meho /usr/local/bin/
+meho version
+```
+
+The identity-claim regex is anchored on `cli-release.yml` and
+`refs/tags/v` — same shape as `chart.yml` (chart signing) and
+`image.yml` (container image signing) per ADR 0006. A maliciously
+re-tagged workflow on a fork cannot produce a bundle that satisfies
+it.
+
+`SHA256SUMS` is signed the same way; verify it once, then
+`sha256sum -c SHA256SUMS` against any subset of tarballs the
+operator actually downloaded (two-step trust chain). The full
+recipe and ADR-0006 rationale live in
+[`cli/README.md#verify-signatures`](./cli/README.md#verify-signatures).
 
 ## Helm chart values reference
 

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -22,10 +22,11 @@
 # author date so two builds of the same tag at different wall-clock
 # times produce byte-identical tarballs.
 #
-# Cosign signing (G2.6-T5 / Issue #47) extends this config with a
-# `signs:` block; this Task ships build + publish only — the workflow
-# `permissions: id-token: write` is already declared to keep the signing
-# follow-up a single-line extension.
+# Cosign keyless signing (Issue #47, ADR 0006) attaches a sigstore
+# bundle to every release artefact via the `signs:` block below. The
+# workflow's `permissions: id-token: write` (declared in
+# .github/workflows/cli-release.yml) mints the GitHub Actions OIDC
+# token cosign exchanges at Fulcio for a ~10-minute x509 cert.
 
 version: 2
 
@@ -132,9 +133,77 @@ checksum:
   # Single combined checksums file rather than per-artefact .sha256
   # files — matches the conventions `gh`, `argocd`, `flux` all use.
   # Operators verify with `sha256sum -c SHA256SUMS` after downloading
-  # the tarball + the checksum file.
+  # the tarball + the checksum file. GoReleaser produces this BEFORE
+  # the `signs:` block runs, so SHA256SUMS lands inside the
+  # `artifacts: all` set the signer iterates — operators can
+  # verify-blob the checksums file then sha256sum -c against the
+  # tarballs (two-step trust chain).
   name_template: "SHA256SUMS"
   algorithm: sha256
+
+# Cosign keyless blob-signing (Issue #47, ADR 0006).
+#
+# GoReleaser runs this block AFTER `archives:` and `checksum:`, so the
+# `artifacts: all` glob includes the four tarballs + SHA256SUMS — every
+# operator-downloadable file gets a sigstore bundle. The bundle is a
+# single JSON document containing the signature, the Fulcio-issued
+# x509 cert, and the Rekor transparency-log inclusion proof, so the
+# operator verification command is a one-liner with no separate `.sig`
+# / `.cert` files to track.
+#
+# Identity claim format (locked by ADR 0006, mirrored at chart.yml /
+# image.yml):
+#
+#   ^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$
+#
+# Operators paste this regex into `cosign verify-blob
+# --certificate-identity-regexp` along with the OIDC issuer
+# `https://token.actions.githubusercontent.com`; see cli/README.md and
+# the top-level README.md for the full verification recipe.
+#
+# Snapshot builds (`make release-dry-run`) skip signing — the
+# goreleaser-action invocation passes `--skip=sign` only on `release
+# --snapshot`, and on a real tag push (where OIDC and Fulcio are
+# reachable) signing is unconditional. We do NOT add `skip:` flags to
+# this block; the `--skip=sign` CLI flag is the documented mechanism
+# for snapshot-only suppression so the config stays declarative.
+signs:
+  - id: cosign
+    # `artifacts: all` is the broadest setting (vs. `archive` or
+    # `checksum`). It iterates every artefact GoReleaser produces in
+    # the v0.1 pipeline — the four tarballs + SHA256SUMS — so an
+    # operator can verify the checksum file's signature first, then
+    # `sha256sum -c SHA256SUMS` against any subset of tarballs they
+    # actually downloaded. The two-step trust chain is what
+    # supply-chain attestation tooling (chainloop, scribe, etc.)
+    # expects of a "fully signed release".
+    artifacts: all
+    cmd: cosign
+    # Sigstore bundle (single JSON file) instead of two separate
+    # `.sig` + `.cert` files. The bundle contains signature +
+    # certificate + Rekor transparency-log proof; `cosign verify-blob
+    # --bundle <file>` is mutually exclusive with the legacy
+    # `--signature` + `--certificate` flag pair (sigstore.dev cosign
+    # docs). flux and recent argocd releases attach bundles.
+    signature: "${artifact}.cosign.bundle"
+    args:
+      - sign-blob
+      # `--yes` bypasses the interactive prompt (CI runners have no
+      # TTY); equivalent of `COSIGN_YES=true` but keeps the
+      # confirmation visible at the argv level for auditability.
+      - --yes
+      # `--bundle <file>` writes the modern sigstore-bundle format.
+      # The `${signature}` template variable expands to the
+      # `signature:` value above (`<artifact>.cosign.bundle`).
+      - --bundle=${signature}
+      - ${artifact}
+    # `output: true` echoes cosign's stdout/stderr to the workflow log
+    # so an operator (or `gh run view`) can inspect the Fulcio cert's
+    # SAN identity and the Rekor log entry index after the fact. The
+    # noise budget is small — one cosign invocation per artefact, five
+    # total in v0.1. Pinned at v2.13+ of GoReleaser (cli/Makefile pins
+    # v2.15.4).
+    output: true
 
 snapshot:
   # `goreleaser release --snapshot` (used by `make release-dry-run`)

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -161,12 +161,16 @@ checksum:
 # `https://token.actions.githubusercontent.com`; see cli/README.md and
 # the top-level README.md for the full verification recipe.
 #
-# Snapshot builds (`make release-dry-run`) skip signing — the
-# goreleaser-action invocation passes `--skip=sign` only on `release
-# --snapshot`, and on a real tag push (where OIDC and Fulcio are
-# reachable) signing is unconditional. We do NOT add `skip:` flags to
-# this block; the `--skip=sign` CLI flag is the documented mechanism
-# for snapshot-only suppression so the config stays declarative.
+# Snapshot builds (`make release-dry-run`) must pass `--skip=sign`
+# explicitly — `--snapshot` alone implies only `--skip=announce,
+# publish,validate` per `goreleaser release --help`, NOT `sign`. The
+# Makefile's release-dry-run target therefore uses
+# `--skip=publish,sign` so devs without cosign on PATH can still
+# produce snapshot tarballs locally. On a real tag push (where OIDC
+# and Fulcio are reachable) the CI workflow omits `--skip=sign` and
+# signing is unconditional. We do NOT add `skip:` flags to this
+# block; the `--skip=sign` CLI flag is the documented mechanism for
+# snapshot-only suppression so the config stays declarative.
 signs:
   - id: cosign
     # `artifacts: all` is the broadest setting (vs. `archive` or

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -100,10 +100,16 @@ $(GORELEASER):
 release-check: goreleaser ## Validate .goreleaser.yaml (config-only, no build).
 	$(GORELEASER) check
 
-release-dry-run: goreleaser ## Local snapshot release (produces dist/ tarballs + SHA256SUMS; no push).
+release-dry-run: goreleaser ## Local snapshot release (produces dist/ tarballs + SHA256SUMS; no push, no signing).
 	# `--snapshot` synthesises a fake tag so the run works on any
-	# branch without needing a real `v*` tag in git history.
-	# `--clean` wipes dist/ before building. `--skip=publish` keeps
-	# the GitHub Release / Homebrew tap publishers off — operators
-	# should never accidentally push to upstream from their laptop.
-	$(GORELEASER) release --snapshot --clean --skip=publish
+	# branch without needing a real `v*` tag in git history. Per
+	# `goreleaser release --help`, `--snapshot` implies
+	# `--skip=announce,publish,validate` — it does NOT skip signing,
+	# so we pass `--skip=sign` explicitly. Without it the `signs:`
+	# block fires and fails with `cosign: executable file not found`
+	# on any dev machine that doesn't have cosign installed (and
+	# would in any case require `id-token: write`, only available in
+	# CI). `--clean` wipes dist/ before building. `--skip=publish`
+	# keeps the GitHub Release / Homebrew tap publishers off so
+	# operators don't accidentally push from their laptop.
+	$(GORELEASER) release --snapshot --clean --skip=publish,sign

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,8 +13,10 @@ This directory holds the Go module; the Python backplane lives at
 
 ## Status
 
-**G2.6-T4 — multi-platform release pipeline via GoReleaser.**
-Cosign signing of release artefacts (G2.6-T5) lands in the next Task.
+**G2.6-T5 — multi-platform, cosign-signed release pipeline via GoReleaser.**
+Every release artefact (four tarballs + `SHA256SUMS`) ships with a
+matching `.cosign.bundle` sigstore bundle on the GitHub Release. The
+verification recipe lives in the [Release](#release) section below.
 
 ## Layout
 
@@ -224,9 +226,9 @@ GitHub Release at
 
 The release is created in **draft** mode — a maintainer flips it
 to public via the GitHub Releases UI after verifying the four
-tarballs are present and `meho version` reports the expected tag.
-Cosign signing of release artefacts (Issue #47) lands in the next
-Task.
+tarballs + matching `.cosign.bundle` files are present and
+`meho version` reports the expected tag. See the [Verify signatures](#verify-signatures)
+section below for the operator-side check.
 
 ### Local dry-run
 
@@ -268,10 +270,60 @@ sha256sum -c SHA256SUMS                   # verify integrity
 tar xzf ${TARBALL} && ./meho version       # meho v0.1.0 (commit ..., built ...)
 ```
 
+### Verify signatures
+
+Every release artefact is signed via cosign keyless (ADR 0006) — the
+GitHub Actions OIDC token is exchanged at Fulcio for a short-lived
+x509 cert bound to the workflow identity, cosign signs the artefact
+digest, and the {signature, certificate, Rekor proof} triple is
+attached to the GitHub Release as a single `.cosign.bundle` JSON
+file. No public key to distribute, no key custody to rotate.
+
+```bash
+TAG=v0.1.0
+TARBALL=meho_${TAG#v}_linux_amd64.tar.gz
+BASE=https://github.com/evoila/meho/releases/download/${TAG}
+
+curl -LO ${BASE}/${TARBALL}
+curl -LO ${BASE}/${TARBALL}.cosign.bundle
+
+cosign verify-blob \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --bundle ${TARBALL}.cosign.bundle \
+  ${TARBALL}
+# Verified OK
+```
+
+The identity-claim regex is anchored on `cli-release.yml` and the
+`refs/tags/v` prefix so a malicious workflow on a fork (or a non-tag
+push on this repo) cannot produce a bundle that satisfies it. Same
+regex format as image (`image.yml`) and chart (`chart.yml`) signing
+per ADR 0006.
+
+The `SHA256SUMS` file is signed the same way:
+
+```bash
+curl -LO ${BASE}/SHA256SUMS
+curl -LO ${BASE}/SHA256SUMS.cosign.bundle
+
+cosign verify-blob \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --bundle SHA256SUMS.cosign.bundle \
+  SHA256SUMS
+sha256sum -c SHA256SUMS                   # then verify the tarballs
+```
+
+The two-step chain — verify the checksums file's signature first,
+then `sha256sum -c` against the tarballs — lets operators verify
+once and trust a whole release worth of tarballs without re-running
+cosign for each one.
+
 For the durable map of the release flow — what GoReleaser does, why
 each archive includes LICENSE + README, how identity is injected,
-how reproducible builds work — see
-[`../docs/codebase/cli.md`](../docs/codebase/cli.md).
+how reproducible builds work, how the cosign signing block plugs in
+— see [`../docs/codebase/cli.md`](../docs/codebase/cli.md).
 
 ## Design notes
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -699,6 +699,28 @@ with the legacy `--signature` + `--certificate` flag pair per the
 sigstore.dev docs. flux and recent argocd releases attach bundles by
 the same shape.
 
+> **ADR 0006 deviation — bundle vs. legacy two-file form.** ADR
+> 0006's original G2.6 Implications block prescribed the legacy
+> `--output-signature` + `--output-certificate` two-file form.
+> The CLI release pipeline adopts the modern `--bundle` form
+> instead — it's current sigstore best practice, what flux and
+> recent argocd ship, and `cosign verify-blob --bundle` is
+> mutually exclusive with the legacy flag pair so a single recipe
+> covers all operators. The same evolution happened at
+> `chart.yml` (PR #173) and `image.yml` (PR #165); a follow-up
+> ADR amendment will record this across all three pipelines.
+
+> **ADR 0006 deviation — per-workflow split vs. single release.yml.**
+> ADR 0006 originally sketched a single `release.yml` covering
+> image + chart + CLI. The implemented architecture splits these
+> into three independent workflows (`image.yml`, `chart.yml`,
+> `cli-release.yml`) because each artefact has a distinct trigger
+> surface, permission set, and runner profile — putting them
+> behind one workflow would make `permissions:` either
+> over-broad or littered with per-step elevation. The per-workflow
+> split is now the canonical pattern; the identity-claim regex
+> shape stays uniform so operators learn one verification recipe.
+
 The cosign-installer GitHub Action (`sigstore/cosign-installer@<sha>`,
 pinned in `cli-release.yml` to the same v4.1.2 SHA `chart.yml` uses)
 puts a cosign binary on PATH before the GoReleaser step. v4.x of the

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -732,7 +732,7 @@ keyless-by-default semantics — no `COSIGN_EXPERIMENTAL=1` needed.
 The cert Fulcio issues binds to the workflow file path + ref of the
 run that minted the OIDC token. Operators verify against:
 
-```
+```text
 ^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$
 ```
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -744,12 +744,15 @@ top-level [`README.md`](../../README.md#verifying-cli-release-artefacts).
 #### Snapshot builds skip signing
 
 `make release-dry-run` shells `goreleaser release --snapshot --clean
---skip=publish` — the `--skip=publish` short-circuits before the
-`signs:` block would run because GoReleaser orders signing after
-upload by design (you can't sign an artefact-by-OIDC-identity unless
-you're in CI with `id-token: write`). Snapshot builds therefore
-produce only tarballs + `SHA256SUMS` under `cli/dist/`; the bundles
-are a tag-push-only artefact.
+--skip=publish,sign`. Per `goreleaser release --help`, `--snapshot`
+alone implies only `--skip=announce,publish,validate` — it does NOT
+skip the `signs:` block. We pass `--skip=sign` explicitly so the
+dry-run completes on a dev machine without cosign on PATH (and
+without the `id-token: write` permission that's only available in a
+real CI run). Snapshot builds therefore produce only tarballs +
+`SHA256SUMS` under `cli/dist/`; the `.cosign.bundle` files are a
+tag-push-only artefact, produced by the CI workflow which omits
+`--skip=sign`.
 
 ### Draft mode
 
@@ -770,12 +773,14 @@ based on whether the tag contains a semver pre-release identifier
 ### Local dry-run
 
 `make release-dry-run` runs `goreleaser release --snapshot --clean
---skip=publish` against the local checkout. Snapshot mode
+--skip=publish,sign` against the local checkout. Snapshot mode
 synthesises a `0.0.1-snapshot` version so the run works on any
-branch without needing a real `v*` tag in git, and `--skip=publish`
+branch without needing a real `v*` tag in git; `--skip=publish`
 keeps the GitHub Release / Homebrew tap publishers off so an
-operator can't accidentally push to upstream from their laptop.
-The output lands at `cli/dist/`, gitignored.
+operator can't accidentally push to upstream from their laptop; and
+`--skip=sign` keeps the cosign `signs:` block from firing locally
+(it requires cosign on PATH and `id-token: write` — neither
+available outside CI). The output lands at `cli/dist/`, gitignored.
 
 `make release-check` runs `goreleaser check` for config-only
 validation — useful as a fast feedback loop when editing

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -12,15 +12,14 @@ the backplane to perform the three Goal #11 v0.1 operations: `login`,
 backplane (`backend/`); the two communicate exclusively over the
 backplane's HTTP/JSON API, with the OpenAPI spec at the seam.
 
-As of G2.6-T4 the v0.1 trio is wired (`version`, `login`, `status`)
+As of G2.6-T5 the v0.1 trio is wired (`version`, `login`, `status`)
 and the multi-platform release pipeline ships every `v*` tag as
-four tarballs + `SHA256SUMS` to GitHub Releases via GoReleaser.
-Server-driven subcommand discovery runs at every startup (empty
-manifest in v0.1; populated by post-Goal-2 backplanes without a
-CLI binary release). The next Task layers in:
-
-* Cosign keyless signing of release artefacts per ADR 0006
-  (G2.6-T5 / #47).
+four tarballs + `SHA256SUMS` to GitHub Releases via GoReleaser. Each
+tarball and `SHA256SUMS` ships with a matching `.cosign.bundle`
+sigstore bundle (signature + Fulcio cert + Rekor proof) under the
+ADR 0006 identity-claim format. Server-driven subcommand discovery
+runs at every startup (empty manifest in v0.1; populated by
+post-Goal-2 backplanes without a CLI binary release).
 
 ## Module layout
 
@@ -540,14 +539,18 @@ The exclude-rules block relaxes `errcheck` and `revive` on
 `_test.go` files only — test code routinely uses blank identifiers
 and dot imports in ways production code shouldn't.
 
-## Release pipeline (G2.6-T4)
+## Release pipeline
 
 Release builds are driven by [GoReleaser](https://goreleaser.com/)
 v2 configured at `cli/.goreleaser.yaml`, executed by
 `.github/workflows/cli-release.yml`. The pipeline trades the
 hand-rolled GitHub Actions matrix that `gh release create` would
 require for GoReleaser's single-config model — the same shape `gh`,
-`argocd`, and `flux` all use.
+`argocd`, and `flux` all use. Cosign keyless signing (ADR 0006)
+attaches a sigstore bundle to every release artefact in the same
+GoReleaser invocation; the `signs:` block runs after `archives:`
+and `checksum:`, so the same single workflow produces both the
+artefacts and the signatures atomically.
 
 ### Trigger surface
 
@@ -564,13 +567,12 @@ the workflows use (chart.yml, image.yml):
 
 * Workflow-default `contents: read` — just enough to checkout.
 * `release` job elevates to `contents: write` (GitHub Release
-  creation) + `id-token: write` (forward-compat for the cosign
-  keyless signing G2.6-T5 wires in).
+  creation) + `id-token: write` (cosign keyless OIDC; cosign
+  exchanges this token at Fulcio for a ~10-minute x509 cert bound
+  to the workflow identity).
 
-`id-token: write` is declared *now*, even though this Task does no
-signing, so the G2.6-T5 follow-up is a single-file delta on the
-workflow rather than a separate maintainer approval to change
-workflow permissions.
+Only the release job carries the elevated scopes — the
+workflow-default `contents: read` stays as the floor.
 
 ### Build matrix
 
@@ -587,8 +589,10 @@ multi-arch runner pool. Every target uses:
 * `mod_timestamp: {{ .CommitTimestamp }}` — pins file modification
   times inside the tarball to the commit author date, so a rebuild
   of the same tag produces a byte-identical binary. Required for
-  cosign attestation (G2.6-T5) where the signed digest must match
-  between independent builds.
+  cosign attestation where the signed digest must match between
+  independent builds; the `signs:` block (see below) hashes the
+  artefact content, so a non-reproducible build would break
+  signature verification on the second run.
 * `ldflags -X github.com/evoila/meho/cli/internal/version.{Version,Commit,Date}` —
   feeds `internal/version/version.go`. Bindings:
   - `Version → {{.Tag}}` (preserves the leading `v` per Goal #11
@@ -640,29 +644,123 @@ runtime identity benefits from human readability (`v` prefix).
 
 ### Release notes
 
-`changelog: use: git` walks the commit history between the previous
-tag and the current one to build release notes. For v0.1.0 (no
-previous tag), GoReleaser walks the full history; subsequent
-releases narrow to the inter-tag delta. The `groups` block maps
-Conventional Commits prefixes to release-note sections
-(`feat:` → Features, `fix:` → Fixes, everything else → Other) —
-matches the allowed-prefix set in `.pre-commit-config.yaml`.
-Dependabot churn (`chore(deps): Bump …`) and merge commits are
-filtered out so the operator-facing release notes stay readable.
-
 The top-level `CHANGELOG.md` (Keep a Changelog format) is the
-human-curated narrative — what shipped and why — and is the
-authoritative companion to the auto-generated GitHub Release notes.
+authoritative source of release-note text. The workflow's
+`Extract release notes from CHANGELOG.md` step pulls the section
+matching the current tag's version (`## [0.1.0]`) — with
+`## [Unreleased]` as a fallback for pre-release tags — into
+`$RUNNER_TEMP/release-notes.md`, then passes the path via
+`--release-notes` to GoReleaser. GoReleaser uses the file content
+verbatim as the GitHub Release body, overriding its built-in
+`changelog:` git-log generation.
+
+`cli/.goreleaser.yaml` keeps the `changelog: use: git` block as a
+fallback for snapshot builds (`make release-dry-run` doesn't pass
+`--release-notes`). The `groups` block there maps Conventional
+Commits prefixes to release-note sections (`feat:` → Features,
+`fix:` → Fixes, everything else → Other) — matches the allowed
+prefix set in `.pre-commit-config.yaml`. Dependabot churn
+(`chore(deps): Bump …`) and merge commits are filtered out so the
+fallback release notes stay readable too.
+
+The CHANGELOG.md discipline (one bullet per merged PR, ticket+PR
+links, Keep-a-Changelog categories — see the "How entries are
+added" section in CHANGELOG.md itself) means the release body is
+deterministic and reviewable in a PR before a tag is cut, rather
+than reconstructed at tag time from commit messages.
+
+### Cosign signing (ADR 0006)
+
+GoReleaser's `signs:` block runs after `archives:` and `checksum:`,
+so the `artifacts: all` glob covers every file destined for the
+GitHub Release — the four tarballs **and** the combined `SHA256SUMS`
+file. Per artefact, cosign produces a single `.cosign.bundle` JSON
+file containing the signature, the Fulcio-issued certificate, and
+the Rekor transparency-log inclusion proof; the bundle file is
+uploaded to the Release alongside its artefact:
+
+```yaml
+signs:
+  - id: cosign
+    artifacts: all
+    cmd: cosign
+    signature: "${artifact}.cosign.bundle"
+    args:
+      - sign-blob
+      - --yes
+      - --bundle=${signature}
+      - ${artifact}
+    output: true
+```
+
+The `--bundle` flag writes the modern sigstore-bundle format (single
+JSON file); `cosign verify-blob --bundle <file>` is mutually exclusive
+with the legacy `--signature` + `--certificate` flag pair per the
+sigstore.dev docs. flux and recent argocd releases attach bundles by
+the same shape.
+
+The cosign-installer GitHub Action (`sigstore/cosign-installer@<sha>`,
+pinned in `cli-release.yml` to the same v4.1.2 SHA `chart.yml` uses)
+puts a cosign binary on PATH before the GoReleaser step. v4.x of the
+installer dropped pre-2.0 cosign support; v3.x of cosign has
+keyless-by-default semantics — no `COSIGN_EXPERIMENTAL=1` needed.
+
+#### Identity claim (locked by ADR 0006)
+
+The cert Fulcio issues binds to the workflow file path + ref of the
+run that minted the OIDC token. Operators verify against:
+
+```
+^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$
+```
+
+The anchor on `cli-release.yml` and the `refs/tags/v` prefix rejects
+bundles produced by a fork's workflow or by a non-tag push. The same
+regex shape (only the workflow basename changes) is used at
+`chart.yml` (chart signing) and `image.yml` (image signing) per
+ADR 0006 — operators have one identity-claim format to learn, three
+artefact types to apply it to.
+
+#### Two-step trust chain
+
+`SHA256SUMS` is itself signed, which lets operators verify once and
+trust a whole release worth of tarballs without re-running cosign
+per file:
+
+1. `cosign verify-blob --bundle SHA256SUMS.cosign.bundle SHA256SUMS`
+2. `sha256sum -c SHA256SUMS` against whichever tarballs they
+   actually downloaded.
+
+The order matters — verifying the signature on `SHA256SUMS` first
+proves the checksums come from the workflow identity; verifying
+checksums after that proves the tarballs match what was signed.
+Reversing the order would let an attacker swap tarballs without
+breaking the (still-valid) signature on the original `SHA256SUMS`.
+
+The full operator-side recipe lives at
+[`cli/README.md`](../../cli/README.md#verify-signatures) and at the
+top-level [`README.md`](../../README.md#verifying-cli-release-artefacts).
+
+#### Snapshot builds skip signing
+
+`make release-dry-run` shells `goreleaser release --snapshot --clean
+--skip=publish` — the `--skip=publish` short-circuits before the
+`signs:` block would run because GoReleaser orders signing after
+upload by design (you can't sign an artefact-by-OIDC-identity unless
+you're in CI with `id-token: write`). Snapshot builds therefore
+produce only tarballs + `SHA256SUMS` under `cli/dist/`; the bundles
+are a tag-push-only artefact.
 
 ### Draft mode
 
 `release: draft: true` creates the GitHub Release as a draft. A
 maintainer flips it to public via the GitHub UI after verifying
-the four tarballs are present and `meho version` reports the
-expected tag. The conservative posture is intentional for a first
-public release — once cosign signing (G2.6-T5) is wired and the
-full pipeline is proven end to end, the draft flag becomes a
-one-line edit.
+the four tarballs + matching `.cosign.bundle` files are present
+and `meho version` reports the expected tag. The conservative
+posture stays for the first few public releases — once the full
+pipeline (signing + verification + anonymous-pull) is proven end
+to end and dogfooding catches any regressions, the draft flag
+becomes a one-line edit.
 
 `release: prerelease: auto` flips the GitHub "pre-release" flag
 based on whether the tag contains a semver pre-release identifier
@@ -695,10 +793,19 @@ Within-tarball reproducibility is exact: the same tag produces
 byte-identical binaries across rebuilds (`mod_timestamp` +
 `CommitDate` ldflag + `-trimpath`). The gzip wrapper around each
 tarball has its own embedded mtime that varies between runs — the
-binary's content is identical, the gzip stream is not. This is the
-level of reproducibility cosign attestation flows (G2.6-T5)
-require: signing happens on the artefact digest after upload, and
-the artefact digest IS the binary digest, not the gzip stream.
+binary's content is identical, the gzip stream is not.
+
+Cosign signs the gzip stream the workflow actually uploads (the
+`signs:` block runs against the file on disk under `cli/dist/`),
+not the inner binary. A second tag-push of the exact same tag
+would therefore produce a different `.tar.gz` digest and a
+non-matching signature — but signatures aren't compared between
+runs; each is verified independently against the cert's Fulcio
+identity claim and the Rekor inclusion proof. The reproducibility
+that matters for the trust chain is the **binary**'s content (so
+operators can re-build from source and verify nothing was tampered
+with via `make build`); GoReleaser's gzip-stream non-determinism
+doesn't undermine that.
 
 ## Dependencies
 
@@ -771,11 +878,17 @@ have to trust to run `meho login` against their secrets.
 * Parent Goal: [#11](https://github.com/evoila-bosnia/meho-internal/issues/11)
 * Parent Initiative: [G2.6 #42](https://github.com/evoila-bosnia/meho-internal/issues/42)
 * Stack ADR (locked): [#13](https://github.com/evoila-bosnia/meho-internal/issues/13)
+* Cosign keyless ADR (locked): [#15](https://github.com/evoila-bosnia/meho-internal/issues/15) — same identity-claim format used by image (`image.yml`) and chart (`chart.yml`) signing.
 * cobra docs: https://github.com/spf13/cobra
 * zalando/go-keyring: https://github.com/zalando/go-keyring
 * golang.org/x/oauth2 device flow: https://pkg.go.dev/golang.org/x/oauth2#Config.DeviceAuth
 * RFC 8628 — Device Authorization Grant: https://datatracker.ietf.org/doc/html/rfc8628
 * golangci-lint config reference: https://golangci-lint.run/
-* Empirical comparables for the scaffold pattern: `gh` (GitHub CLI),
-  `argocd`, `flux`. All use cobra + ldflags-injected version, all
-  ship single static binaries.
+* GoReleaser `signs:` block: https://goreleaser.com/customization/sign/
+* cosign sign-blob: https://docs.sigstore.dev/cosign/signing/signing_with_blobs/
+* cosign verify (incl. verify-blob): https://docs.sigstore.dev/cosign/verifying/verify/
+* Empirical comparables for the scaffold + signed-release pattern:
+  `gh` (GitHub CLI), `argocd`, `flux`. All use cobra +
+  ldflags-injected version, all ship single static binaries, and
+  flux + recent argocd releases attach sigstore bundles by the same
+  shape this Task wires.


### PR DESCRIPTION
## Summary
- Wire GoReleaser `signs:` block to attach a sigstore bundle (`.cosign.bundle`) to every release artefact — four tarballs + `SHA256SUMS` — using cosign keyless under the ADR-0006 identity-claim format.
- Install pinned `sigstore/cosign-installer@<sha>` v4.1.2 in `cli-release.yml` (same SHA `chart.yml` uses) so a single supply-chain audit covers image + chart + CLI signing.
- Shift the GitHub Release body source from `changelog: use: git` (raw commit log) to a CHANGELOG.md-extracted section via `--release-notes`. CHANGELOG.md gains a "How entries are added" discipline section and populates the `[0.1.0]` body.
- Document the operator-side `cosign verify-blob --bundle ...` recipe at the top-level README, `cli/README.md`, and `docs/codebase/cli.md`.

## Implementation notes
- **Bundle format vs. legacy `.sig` + `.cert`.** The issue body sketched separate signature + certificate files; the orchestrator brief (Hard rule 10) mandated the modern sigstore-bundle. Following the brief — also matches what flux and recent argocd releases ship. `cosign verify-blob --bundle <file>` is mutually exclusive with `--signature` + `--certificate` per sigstore.dev's verify docs, so the bundle form gives operators a one-flag verification recipe.
- **Identity claim regex.** `^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$` — anchored on the workflow file path + `refs/tags/v` prefix so a malicious fork workflow or a non-tag push cannot produce a bundle that satisfies it. Same shape as `chart.yml` / `image.yml`.
- **Signs ordering.** `archives:` → `checksum:` → `signs:` — `artifacts: all` covers tarballs + `SHA256SUMS` because the checksum file is produced first. Two-step trust chain: verify `SHA256SUMS.cosign.bundle`, then `sha256sum -c` against any subset of tarballs.
- **CHANGELOG-driven release notes.** New workflow step extracts the section matching the current tag (with `[Unreleased]` as fallback for pre-release tags) into `$RUNNER_TEMP/release-notes.md`, then GoReleaser's `--release-notes <file>` overrides built-in changelog generation. The `changelog:` block in `.goreleaser.yaml` stays as a fallback for snapshot builds (`make release-dry-run`).
- **Snapshot builds skip signing — explicit `--skip=sign`.** `make release-dry-run` shells `goreleaser release --snapshot --clean --skip=publish,sign`. Per `goreleaser release --help`, `--snapshot` implies only `--skip=announce,publish,validate` — NOT `sign`. Without explicit `--skip=sign` the `signs:` block fires and fails on any dev machine that doesn't have cosign on PATH. The CI workflow omits `--skip=sign`, so signing is unconditional on a real tag push.

## Test plan
- [x] `python3 -c "yaml.safe_load(open('.github/workflows/cli-release.yml'))"` — valid YAML, 6 steps with expected names.
- [x] `python3 -c "yaml.safe_load(open('cli/.goreleaser.yaml'))"` — valid YAML, `signs[0]` shape verified (`artifacts: all`, `cmd: cosign`, `--bundle=${signature}` args, `signature: ${artifact}.cosign.bundle`).
- [x] `goreleaser check` — 1 configuration file validated.
- [x] `make release-dry-run` — succeeds locally **without cosign installed** (`skipping announce, publish, sign, and validate...`, produces 4 tarballs + SHA256SUMS in `cli/dist/`).
- [x] Identity-claim regex tested against 5 sample subjects (legit tag refs match; fork/wrong-workflow/branch-ref reject).
- [x] CHANGELOG extraction awk tested against the new CHANGELOG.md with dot-escaped pattern — `[Unreleased]` returns the 3-bullet new block, `[0.1.0]` returns the v0.1 narrative, `[9.9.9]` returns empty (fallback path), `[0x1y0]` correctly returns empty (regression guard for unescaped dots).
- [x] No trailing whitespace, all files end with newline, all under 500KB pre-commit cap.
- [ ] Full pipeline verification deferred to the first test-tag push: `git tag v0.1.0-rc.2 && git push origin v0.1.0-rc.2` should produce 4 tarballs + `SHA256SUMS` + 5 `.cosign.bundle` files on the draft Release, and `cosign verify-blob --bundle <bundle> --certificate-identity-regexp '...cli-release\.yml@refs/tags/v.+$' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' <tarball>` should exit 0.

## Acceptance criteria coverage (per #47)
- [x] `cli/.goreleaser.yaml` `signs` block configured with cosign keyless (no key file, OIDC-driven).
- [x] `.github/workflows/cli-release.yml` includes cosign-installer step + `permissions: id-token: write` (verified intact from #46).
- [ ] Per-artefact `.cosign.bundle` on the Release — deferred to test-tag push (bundle format replaces the issue body's `.sig` + `.cert` pair per Hard rule 10 of the orchestrator brief; same trust properties, different file layout).
- [ ] `cosign verify-blob ...` exits 0 on a real test tag — workflow logic verified, awaits test-tag CI run.
- [x] CHANGELOG.md has the per-PR-bullet discipline section + bullets describing the v0.1 scope (cosign-signing bullet under `[Unreleased]`, narrative under `[0.1.0]`).
- [x] Top-level `README.md` includes the `cosign verify-blob` example (new "Verifying CLI release artefacts" section).

## Out of scope
- SBOM generation for the CLI binary — Goal #11 v0.2.
- SLSA Level 3+ provenance — Goal #11 v0.2; cosign keyless gives effectively-Level-2.
- Reproducible-build verification across runs — v0.2; gzip-stream non-determinism doesn't undermine the trust chain because bundles sign the upload, not a deterministic hash.
- Build-from-source verification — v0.2.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #47

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-11)

Addressed review findings from the [iter-1 REQUEST_CHANGES review](https://github.com/evoila/meho/pull/179#issuecomment-4418535815):

- **B1** `af6366b` — `cli/Makefile`'s `release-dry-run` target now passes `--skip=publish,sign` so the dry-run completes on a dev machine without cosign installed. Inline narrative in `cli/.goreleaser.yaml` and the `docs/codebase/cli.md` "Snapshot builds skip signing" + "Local dry-run" sections updated to reflect the actual behaviour (`--snapshot` does NOT imply `--skip=sign`; explicit flag is the documented mechanism). Verified locally: `make release-dry-run` produces 4 tarballs + SHA256SUMS without cosign on PATH.
- **M1** `1a64a87` — Recorded two ADR 0006 deviations as block quotes in the "Cosign signing (ADR 0006)" section of `docs/codebase/cli.md`: (a) bundle vs. legacy `.sig`+`.cert` form (matches flux/argocd evolution), (b) per-workflow split (`image.yml` + `chart.yml` + `cli-release.yml`) vs. the ADR's original single-`release.yml` sketch. ADR amendment itself is a follow-up against `evoila-bosnia/meho-internal`.
- **m1** `f373694` — Added `text` language hint to the fenced identity-claim regex code block in `docs/codebase/cli.md` (CodeRabbit nitpick).
- **m2** `2eefde5` — Escaped `.` in the CHANGELOG version literal before interpolating into the awk regex in `cli-release.yml`'s `extract_section()` helper. Hygiene-only; semver vocab is restricted enough that no realistic false-match exists, but the fix is cheap.

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI release artifacts are now keyless-signed (Sigstore/cosign) and include .cosign.bundle files plus SHA256SUMS for verification.

* **Documentation**
  * CHANGELOG is now the authoritative source for GitHub release notes.
  * Added end-user guides in README and docs for verifying signed CLI releases and the two-step checksum+signature trust model.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/179)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
