### PR TITLE
docs(repo): lock v0.1 positioning across README + repo metadata (G2.7-T4)

### DIFF
--- a/.github/repo-config.yml
+++ b/.github/repo-config.yml
@@ -1,0 +1,47 @@
+# Declarative source of truth for `evoila/meho` GitHub repo metadata.
+#
+# The actual repo description and topics live in the GitHub UI / API.
+# This file documents the desired state so drift is detectable and the
+# settings can be re-applied idempotently via:
+#
+#   scripts/setup/repo-metadata.sh
+#
+# Schema is loosely modelled on the Probot Settings App
+# (https://github.com/repository-settings/app) so it can be promoted to
+# an enforced sync if/when that app (or an equivalent action) is
+# installed on the org. Today it is documentation only.
+#
+# Owner: maintainers. Bump alongside any positioning change so README,
+# repo description, and topics stay in lockstep.
+repository:
+  # Match the README tagline (line 3-4) verbatim.
+  description: >-
+    Governance backplane for AI agents acting on infrastructure —
+    policy-gated, audit-grade, MCP-native. Apache 2.0.
+
+  # GitHub topic rules: lowercase, alphanumeric + hyphens, ≤ 50 chars,
+  # max 20 per repo. Order is not semantic but kept alphabetical for
+  # diff stability.
+  topics:
+    - ai-agents
+    - apache-2-0
+    - audit
+    - devops
+    - governance
+    - helm-chart
+    - infrastructure
+    - kubernetes
+    - mcp
+    - multi-tenant
+    - oidc
+    - oss
+    - policy
+    - sigstore
+
+  # Topics intentionally NOT set:
+  #
+  # - `vmware`  — v0.1 has no VMware connector; this was a leftover from
+  #               the MEHO.X "multi-vendor IaC" framing. Re-add when a
+  #               real vCenter / VCF connector lands (v0.2+).
+  # - `cncf`    — aspirational only; do not claim until the project is
+  #               actually filed with the CNCF Sandbox process.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MEHO
 
-> An MCP-native governance layer that lets any AI agent operate safely
-> against shared infrastructure. Policy-gated. Audit-grade. Multi-tenant.
+> Governance backplane for AI agents acting on infrastructure —
+> policy-gated, audit-grade, MCP-native. Apache 2.0.
 
 **Status:** v0.1 in development. No released artifact yet.
 

--- a/scripts/setup/repo-metadata.sh
+++ b/scripts/setup/repo-metadata.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Apply the desired GitHub repo metadata (description + topics) for
+# `evoila/meho` from the declarative source of truth at
+# `.github/repo-config.yml`.
+#
+# Idempotent: re-applies the same description + topics every run.
+# Requires: `gh` (authenticated as a maintainer with repo:admin or
+# equivalent), and either `yq` (preferred) or Python 3 with PyYAML.
+#
+# Usage:
+#   scripts/setup/repo-metadata.sh           # apply
+#   scripts/setup/repo-metadata.sh --dry-run # print, do not mutate
+#
+# Verify after:
+#   gh api repos/evoila/meho --jq '{description, topics}'
+set -euo pipefail
+
+REPO="${REPO:-evoila/meho}"
+CONFIG_FILE="${CONFIG_FILE:-$(git rev-parse --show-toplevel)/.github/repo-config.yml}"
+DRY_RUN=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h | --help)
+      sed -n '2,18p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f $CONFIG_FILE ]]; then
+  echo "config file not found: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required but not installed" >&2
+  exit 1
+fi
+
+# Parse description + topics from YAML. Prefer yq; fall back to python.
+if command -v yq >/dev/null 2>&1; then
+  DESCRIPTION="$(yq -r '.repository.description' "$CONFIG_FILE")"
+  # yq emits one topic per line on `.[] | .repository.topics[]`.
+  mapfile -t TOPICS < <(yq -r '.repository.topics[]' "$CONFIG_FILE")
+elif command -v python3 >/dev/null 2>&1; then
+  read -r DESCRIPTION < <(python3 - "$CONFIG_FILE" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    cfg = yaml.safe_load(f)
+desc = cfg["repository"]["description"]
+# Collapse YAML folded-scalar whitespace ("foo\n  bar" -> "foo bar").
+print(" ".join(desc.split()))
+PY
+  )
+  mapfile -t TOPICS < <(python3 - "$CONFIG_FILE" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    cfg = yaml.safe_load(f)
+for t in cfg["repository"]["topics"]:
+    print(t)
+PY
+  )
+else
+  echo "neither yq nor python3+PyYAML available to parse YAML" >&2
+  exit 1
+fi
+
+if [[ -z $DESCRIPTION ]] || [[ ${#TOPICS[@]} -eq 0 ]]; then
+  echo "failed to parse description or topics from $CONFIG_FILE" >&2
+  exit 1
+fi
+
+# Build JSON array of topics for the topics endpoint.
+TOPICS_JSON="$(printf '%s\n' "${TOPICS[@]}" | jq -R . | jq -sc .)"
+
+echo "repo:         $REPO"
+echo "description:  $DESCRIPTION"
+echo "topics:       ${TOPICS[*]}"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "(dry-run; no API calls)"
+  exit 0
+fi
+
+echo "==> PATCH repos/$REPO (description)"
+gh api --method PATCH "repos/$REPO" \
+  -f description="$DESCRIPTION" \
+  --jq '{description: .description}'
+
+echo "==> PUT repos/$REPO/topics"
+# The topics endpoint requires a JSON body with a "names" array; build
+# it via `--input -` so the array is preserved (not flattened by `-f`).
+jq -nc --argjson names "$TOPICS_JSON" '{names: $names}' |
+  gh api --method PUT "repos/$REPO/topics" --input - \
+    --jq '{topics: .names}'
+
+echo "==> done. Verify:"
+echo "    gh api repos/$REPO --jq '{description, topics}'"


### PR DESCRIPTION
## Summary

- Lock the v0.1 positioning across the README tagline and the
  GitHub repo description so the repo card and the README open with
  the same sentence. (`Goal #11` spec section 8 locks this sentence.)
- Ship `.github/repo-config.yml` as the declarative source of truth
  for the repo's description + topics — future drift is now
  reviewable as a normal diff. Schema is Probot-Settings-App-shaped
  so it can be promoted to an enforced sync later without reshaping.
- Add `scripts/setup/repo-metadata.sh` as an idempotent applier
  (`--dry-run` supported) that drives `gh api PATCH repos/...` for
  the description and `gh api PUT repos/.../topics` (replace-all)
  for the topics set. Runs as a maintainer with `repo:admin`.

Topics delta vs. current state (per #52 AC2):

- **drop**: `vmware` (no v0.1 connector — was a leftover from the
  MEHO.X "multi-vendor IaC" framing).
- **add**: `oidc`, `sigstore`, `helm-chart`, `oss`, `apache-2-0`.

## Acceptance criteria

- [x] AC3: Top-level `README.md` short tagline (lines 3-4) matches
      the description verbatim — single source of truth.
- [x] AC4: `.github/repo-config.yml` documents desired settings so
      future drift is detectable.
- [ ] AC1 + AC2: actual GitHub description + topics updated. **Needs
      a maintainer to run** `scripts/setup/repo-metadata.sh` (or the
      equivalent commands documented in `/tmp/repo-metadata-update.sh`
      on the orchestrator machine). The auto-mode classifier refuses
      direct `gh api PATCH repos/evoila/meho` from the agent runtime,
      so this PR ships the source of truth and the applier; the
      mutation itself is the one human step.

      Verify after running:

      ```bash
      gh api repos/evoila/meho --jq '{description, topics}'
      ```

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/repo-config.yml'))"` — parses; expected description and topics list.
- [x] `bash -n scripts/setup/repo-metadata.sh` — clean.
- [x] `scripts/setup/repo-metadata.sh --dry-run` — prints the
      exact desired description and the 14 expected topics in order;
      no API calls. (Equivalent run captured during implementation.)
- [x] Trailing whitespace + EOF newline check across all three
      changed files — clean.
- [x] Commit carries `Signed-off-by` (DCO) and `Co-Authored-By` —
      single occurrence of each.

## Out of scope

- Sibling task #60 (OSS day-1 docs) — adds README deploy sections
  + CONTRIBUTING + project-wide CHANGELOG; this PR limits its
  README touch to the tagline only.
- Sibling task #51 (`repository_dispatch` to claude-rdc-hetzner-dc).
- Logo / social preview, GitHub Pages — v0.2 per #52 out-of-scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #52


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project description to reflect MEHO as a governance backplane for AI agents with policy-gated, audit-grade, MCP-native capabilities.

* **Chores**
  * Added repository metadata configuration and automation for managing repository settings declaratively.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->