### PR TITLE
docs: OSS day-1 README + CONTRIBUTING dogfood loop + project-wide CHANGELOG (G2.7-T6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to MEHO are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+This is the **project-wide** changelog. It covers all three
+operator-facing artefacts under one document:
+
+- the **backplane container image** at `ghcr.io/evoila/meho`,
+- the **Helm chart** at `oci://ghcr.io/evoila/meho-chart`, and
+- the **operator CLI** released as multi-platform tarballs at
+  <https://github.com/evoila/meho/releases>.
+
+There is no separate `cli/CHANGELOG.md` — this file supersedes that
+scaffolding. The release-notes-extraction tooling in
+`.github/workflows/cli-release.yml` reads from this file, and chart /
+image releases reference the same `[Unreleased]` section until a tag
+cuts the next version.
+
 This top-level CHANGELOG is the **authoritative source** for the
 GitHub Release notes published at
 <https://github.com/evoila/meho/releases>. The
@@ -39,34 +53,91 @@ shipped and why it matters — not a dump of commit subjects.
 
 ### Added
 
-- Multi-platform CLI release pipeline: `linux/amd64`, `linux/arm64`,
-  `darwin/amd64`, `darwin/arm64` tarballs published to GitHub
-  Releases on every `v*` tag push, with a combined `SHA256SUMS`
-  file. Driven by GoReleaser via `.github/workflows/cli-release.yml`.
-  (#46 / #178)
-- Cosign keyless signing of every CLI release artefact (four
-  tarballs + `SHA256SUMS`) per ADR 0006. Each artefact ships with a
-  matching `.cosign.bundle` sigstore bundle (signature + Fulcio
+- **Backplane image:** multi-arch (`linux/amd64` + `linux/arm64`)
+  container image at `ghcr.io/evoila/meho`, built and pushed by
+  `.github/workflows/image.yml` on every push to `main` and on
+  `v*` tag pushes. Cosign keyless-signed per ADR 0006 — operators
+  verify with `cosign verify ghcr.io/evoila/meho:<tag>` using the
+  identity-claim regex anchored on `image.yml`. The `:latest` tag
+  is deliberately never published; operators pin to
+  `sha-<git-sha>` or `v<x.y.z>`. (#34)
+- **Helm chart:** the deploy contract at `deploy/charts/meho/`,
+  published as an OCI artefact at `oci://ghcr.io/evoila/meho-chart`
+  by `.github/workflows/chart.yml`. Cosign keyless-signed on every
+  push; anonymous-pull verified by the publish workflow before the
+  job exits green. Calver-bumped on `main`
+  (`0.1.YYYYMMDD-<short-sha>`); plain semver on `v*` tag pushes.
+  (#41)
+- **Typed values contract:** `deploy/charts/meho/values.schema.json`
+  (JSON Schema draft-07). Rejects empty operator-required fields
+  (`image.tag`, `vault.address`, `keycloak.issuer`,
+  `postgres.credentialsSecret`, NetworkPolicy CIDRs when enabled,
+  Ingress host + TLS secret when enabled), pattern-validates IPv4
+  CIDRs + hostnames + OCI image refs, and rejects unknown keys at
+  every object level (`additional properties '<name>' not allowed`).
+  Misconfigured installs fail at `helm install` / `helm upgrade` /
+  `helm template`, not at first request. (#38)
+- **Sanitized example values:**
+  [`deploy/values-examples/values-rdc-example.yaml`](./deploy/values-examples/values-rdc-example.yaml)
+  templates the supported Vault + Keycloak + Postgres deploy shape
+  (the RDC Hetzner lab shape). All site-specific fields use
+  `<REPLACE: ...>` placeholders that fail the schema at install
+  time, so an operator who forgets to substitute one fails-loud at
+  `helm install`. ESO sync patterns documented in the companion
+  README. (#40)
+- **kind-local values overlay:**
+  [`deploy/values-examples/values-kind.yaml`](./deploy/values-examples/values-kind.yaml)
+  for a 5-minute laptop deploy that exercises the chart's install
+  plumbing (pre-install migration Job, Deployment, broadcast
+  subchart) without real Vault + Keycloak + Postgres. Operator
+  identity is faked; for real federation use the existing-k8s flow.
+  (#60)
+- **Multi-platform CLI release pipeline:** `linux/amd64`,
+  `linux/arm64`, `darwin/amd64`, `darwin/arm64` tarballs published
+  to GitHub Releases on every `v*` tag push, with a combined
+  `SHA256SUMS` file. Driven by GoReleaser via
+  `.github/workflows/cli-release.yml`. (#46 / #178)
+- **Cosign keyless signing of every CLI release artefact** (four
+  tarballs + `SHA256SUMS`) per ADR 0006. Each artefact ships with
+  a matching `.cosign.bundle` sigstore bundle (signature + Fulcio
   cert + Rekor proof, single JSON file). Verification recipe
   documented at the top-level README and `cli/README.md`. (#47)
+- **OSS day-1 documentation:** top-level `README.md` now ships a
+  hero + "Deploy → Local (kind)" + "Deploy → Existing k8s" +
+  "Verify image + chart + CLI signatures" + architecture overview
+  + chart values reference. `CONTRIBUTING.md` expanded with the
+  dogfood-loop framing, public-from-day-1 norm, bidirectional
+  coordination flow, and DCO sign-off discipline. This CHANGELOG
+  reframed as project-wide (image + chart + CLI under one
+  document). (#60)
 
 ### Changed
 
+- **CHANGELOG scope is project-wide.** Previously this file was
+  CLI-only scaffolding for `--release-notes` extraction; it now
+  records every operator-facing change across image, chart, and
+  CLI. The `cli/CHANGELOG.md` scaffold is superseded — this is the
+  single source of truth. (#60)
 - GitHub Release body is now sourced from this CHANGELOG via
   `--release-notes` rather than GoReleaser's auto-generated
   git-log. The workflow extracts the section matching the current
   tag (or `[Unreleased]` as fallback). (#47)
 
-## [0.1.0] - TBD
+## [0.1.0-beta] - planned 2026-MM-DD
 
-Initial v0.1 release: backplane, CLI, Helm chart, deploy contract.
+Initial v0.1-beta release: backplane chassis, federation probes,
+audit, container image, Helm chart, operator CLI, CI/CD with per-PR
+ephemeral cluster smoke. The v0.1-beta surface is intentionally
+narrow per Goal #11: enough for an operator to install MEHO into a
+Kubernetes cluster, log in, and verify the federation chain is
+healthy. Operations (cluster inventory, policy enforcement, audit
+queries, etc.) land in v0.2+ through the CLI's server-driven
+discovery mechanism — adding an operation does not require a new
+CLI release.
 
-The v0.1 surface is intentionally narrow per Goal #11: enough for an
-operator to install MEHO into a Kubernetes cluster, log in, and
-verify the federation chain is healthy. Operations (cluster
-inventory, policy enforcement, audit queries, etc.) land in v0.2+
-through the CLI's server-driven discovery mechanism — adding an
-operation does not require a new CLI release.
+`v0.1.0` (non-beta) ships when Goal #59 (first connector + wrapper
+replacement) closes — the beta tag exists to distinguish the
+chassis-only milestone from the first user-visible operation.
 
 The v0.1 trust chain across all three operator-facing artefacts —
 the backplane container image, the Helm chart, and the CLI release
@@ -78,4 +149,4 @@ against the workflow path that produced it using
 key custody.
 
 See [Goal #11](https://github.com/evoila-bosnia/meho-internal/issues/11)
-for the full v0.1 scope.
+for the full v0.1-beta scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,9 +91,14 @@ shipped and why it matters — not a dump of commit subjects.
   [`deploy/values-examples/values-kind.yaml`](./deploy/values-examples/values-kind.yaml)
   for a 5-minute laptop deploy that exercises the chart's install
   plumbing (pre-install migration Job, Deployment, broadcast
-  subchart) without real Vault + Keycloak + Postgres. Operator
-  identity is faked; for real federation use the existing-k8s flow.
-  (#60)
+  subchart). Only Postgres ships a real in-cluster mock manifest
+  (Namespace + Secret + Deployment + Service for `postgres:16-alpine`,
+  documented at the top of the overlay); Vault and Keycloak are
+  *placeholder URIs* so the chart's URI-validated fields resolve at
+  install time — no in-cluster Vault or Keycloak is deployed and no
+  real auth flow runs. Operator identity is faked; federation probes
+  register but `meho login` will not complete end-to-end. For real
+  federation use the existing-k8s flow. (#60)
 - **Multi-platform CLI release pipeline:** `linux/amd64`,
   `linux/arm64`, `darwin/amd64`, `darwin/arm64` tarballs published
   to GitHub Releases on every `v*` tag push, with a combined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ shipped and why it matters — not a dump of commit subjects.
 - Bullets land in `## [Unreleased]` until a tag cuts the release;
   the release-cutting PR moves them under the new `## [x.y.z] -
   YYYY-MM-DD` heading.
-- **Each bullet links to the issue + PR:** `- Add Vault probe (#30 / #47)`.
-  The issue number is the planning anchor (`evoila-bosnia/meho-internal`);
-  the PR number is the implementation (`evoila/meho`).
+- **Each bullet links to the planning issue (and the PR once merged):**
+  `- Add Vault probe (#30 / #47)` when both are known, or
+  `- Add Vault probe (#30)` if the PR has not merged yet. The issue
+  number is the planning anchor (`evoila-bosnia/meho-internal`); the
+  PR number is the implementation (`evoila/meho`).
 - **Conventional-Commits prefixes are optional in the bullet** —
   the category heading is doing the typing already. Keep the prose
   imperative and operator-readable.
@@ -123,7 +125,7 @@ shipped and why it matters — not a dump of commit subjects.
   git-log. The workflow extracts the section matching the current
   tag (or `[Unreleased]` as fallback). (#47)
 
-## [0.1.0-beta] - planned 2026-MM-DD
+## [0.1.0-beta] - planned TBD
 
 Initial v0.1-beta release: backplane chassis, federation probes,
 audit, container image, Helm chart, operator CLI, CI/CD with per-PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,173 @@
 # Contributing to MEHO
 
-Thanks for your interest in contributing to MEHO.
+Thanks for your interest in contributing to MEHO. This project ships
+in the open, runs against real infrastructure on every change, and
+takes review seriously. The sections below describe the development
+loop, the conventions every PR is held to, and how the two-repo
+coordination model works.
+
+## How we develop: the dogfood loop
+
+`evoila/meho` (this repo — public, all code) and
+`evoila-bosnia/claude-rdc-hetzner-dc` (private, the operator-side
+manifests and runbooks for the RDC Hetzner dogfooding lab) are coupled.
+Every feature ships first to the dogfooding consumer; operator feedback
+loops back into `evoila/meho` via PRs. The discipline is: features
+merge against **real-target deploys**, not mocks.
+
+When you propose a feature touching the deploy contract (image, chart,
+or CLI), expect a coupled discussion thread on the consumer repo —
+that's not a side conversation, it's how we measure done. The
+[`deploy/values-examples/values-rdc-example.yaml`](./deploy/values-examples/values-rdc-example.yaml)
+in this repo is the sanitized template; the actual live values file
+lives on the consumer side and only flips green once both sides agree
+the contract is right.
+
+## Public from day 1, deliberately
+
+This repo is OSS and public from commit #1. We never quarantine work
+here under "private until ready" reasoning. Either it ships in public
+from the start, or it goes to `evoila-bosnia/meho-internal` (planning
+issues, ADRs, sensitive operator material only — **no code**).
+
+If you're nervous about something being "not ready enough" for public —
+file a **draft PR**. The review thread is the conversation, not a
+release. The codebase walkthroughs at
+[`docs/codebase/`](./docs/codebase/) are the closest thing we have to
+"here's what shipped so far"; they're updated as part of the PR that
+introduces the change, never after the fact.
+
+## Bidirectional coordination with claude-rdc-hetzner-dc
+
+For features that touch the deploy contract (image, chart, CLI),
+expect this flow:
+
+1. Issue filed on `evoila-bosnia/meho-internal` (the planning repo).
+   Goal → Initiative → Task hierarchy per project 19; the Task is
+   what a PR closes.
+2. Sibling issue filed on `evoila-bosnia/claude-rdc-hetzner-dc`
+   capturing the consumer-side prerequisites (kubeconfig, RBAC,
+   ExternalSecret manifests, …).
+3. PR opens against `evoila/meho` with `Closes #<task>` referencing
+   the planning issue.
+4. PR merges only when CI is green **and** the consumer-side ticket
+   has the manifests merged that the new chart version requires.
+
+For features that are purely backplane-internal (audit format,
+federation internals, observability wiring), no consumer-side ticket
+is needed — but a heads-up in the consumer's `CLAUDE.md` "MEHO
+transition" section is courteous.
 
 ## Development setup
 
-(Placeholder — will land with the v0.1 release.)
+The repo ships three independently buildable artefacts. Each has a
+local-dev loop documented in its own README; this section is the
+index.
+
+| Artefact | Language | Local-dev README |
+| --- | --- | --- |
+| Backplane | Python 3.13 + FastAPI | [`backend/README.md`](./backend/README.md) — `uv sync`, `docker compose up`, pytest layout |
+| Helm chart | YAML + Helm 3 | [`deploy/charts/meho/`](./deploy/charts/meho/) — `helm template`, `helm lint`; [`deploy/values-examples/README.md`](./deploy/values-examples/README.md) covers the install flow |
+| Operator CLI | Go 1.23+ | [`cli/README.md`](./cli/README.md) — `go build`, oapi-codegen wiring, `meho version` smoke |
+
+To exercise the full deploy contract on your laptop, follow the
+**Deploy → Local (kind, ~5 min)** section in [`README.md`](./README.md).
+That path skips real Vault + Keycloak (operator identity is faked) but
+runs the chart's install plumbing — pre-install migration Job, the
+Deployment, the Valkey broadcast subchart — against a real Kubernetes
+API.
+
+For real federation work, the dogfooding lab on RDC Hetzner is the
+target — coordinate via the consumer-side ticket.
 
 ## Pull request flow
 
-1. Fork or branch from `main`.
-2. Make your change. Conventional Commits format for messages
-   (`feat(connector): ...`, `fix(policy): ...`).
-3. Sign every commit with a Developer Certificate of Origin
-   (`git commit -s`). Unsigned commits will fail the DCO check.
-4. Push, open a PR. CI must pass; review must approve.
-5. Squash merge.
+1. **Branch from `main`.** Convention: `feat/<issue#>-<slug>`,
+   `fix/<issue#>-<slug>`, `chore/<slug>`, etc. The `<issue#>` is the
+   planning issue on `evoila-bosnia/meho-internal`.
+2. **Make your change.** Stay in scope — adjacent findings go into
+   the PR description, not stealth commits.
+3. **Sign every commit** with `git commit -s` (see
+   [Developer Certificate of Origin](#developer-certificate-of-origin)).
+4. **Conventional Commits** in the subject:
+   `feat(connector): ...`, `fix(policy): ...`, `chore(ci): ...`,
+   `docs(readme): ...`. The pre-commit `conventional-pre-commit`
+   hook enforces this on `commit-msg`.
+5. **Reference the planning issue** in the PR body with
+   `Closes #<task-number>` (or `Refs #<n>` for partial work).
+6. **Push, open a PR** targeting `main` on `evoila/meho`.
+7. **CI must pass** — every required check is green; no overrides.
+8. **CodeRabbit review** posts automatically on every PR; address the
+   findings or document why a finding is wrong inline.
+9. **Maintainer review** approves the human side. Reviews on
+   `evoila/meho` are mandatory; reviews on `evoila-bosnia/meho-internal`
+   PRs (planning-only, ADRs, governance docs) are best-effort because
+   those PRs touch no code.
+10. **Squash merge.** The PR title (which becomes the merge commit
+    subject) is what shows up in `git log` on `main`.
+
+## Code style
+
+Each language has a fixed toolchain. CI runs the same tools — no
+"works on my machine" surprises.
+
+- **Python (backplane, tests):** `ruff check` + `ruff format` are the
+  format-and-lint pair. `mypy --ignore-missing-imports` for
+  type-checking. Pinned versions live in
+  [`backend/pyproject.toml`](./backend/pyproject.toml) under the
+  `dev` group; the pre-commit hook (when it lands) will use the
+  same pinned versions.
+- **Go (operator CLI):** `gofmt -s` + `golangci-lint run` from
+  [`cli/.golangci.yml`](./cli/.golangci.yml) (when the file lands;
+  Task #43 scaffolded the module). `go vet` is part of the same
+  pipeline. Generated code (oapi-codegen output) is checked in and
+  excluded from lint.
+- **YAML, Markdown, JSON:** trailing-whitespace, end-of-file-fixer,
+  and `check-yaml` / `check-json` from the pre-commit hooks repo
+  catch the common formatting traps. CI also runs `gitleaks` for
+  secret detection on every PR.
+
+The full pre-commit config lives at
+[`.pre-commit-config.yaml`](./.pre-commit-config.yaml). Install hooks
+locally with `pre-commit install --install-hooks` (and re-run them on
+the whole tree with `pre-commit run --all-files` if you need to
+verify a clean baseline).
 
 ## Developer Certificate of Origin
 
-By signing off on a commit, you certify the contents of
-<https://developercertificate.org/>. We do not require a CLA;
-the DCO sign-off is the contribution agreement.
+Every commit must carry a `Signed-off-by: Your Name <your@email>`
+trailer. Use:
+
+```bash
+git commit -s -m "feat(scope): your message"
+```
+
+`git commit -s` adds the trailer automatically using your configured
+`user.name` and `user.email` (set these once globally with
+`git config --global user.name "..."` /
+`git config --global user.email "..."`).
+
+The [DCO bot](https://github.com/apps/dco) checks every PR on
+`evoila/meho`. A missing `Signed-off-by:` on any commit fails the
+`DCO` required check, which blocks merge under main branch protection.
+
+Backfilling a sign-off after-the-fact requires rewriting history — for
+a single missing commit:
+
+```bash
+git commit --amend --signoff
+git push --force-with-lease
+```
+
+For a multi-commit PR, an interactive rebase with
+`git rebase --signoff <base>` re-signs every commit in the range. Both
+flows are noisy; the easier discipline is to make `-s` the default.
+
+There is no CLA. Apache 2.0 §5 ("inbound = outbound": contributions
+flow in under the same Apache 2.0 terms the project ships under) plus
+the DCO trailer is the full contributor agreement. The license ADR
+documenting this choice lives at ADR 0001 (license selection) and
+ADR 0002 (CLA-vs-DCO).
 
 ## Code of conduct
 
@@ -29,9 +176,19 @@ See [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).
 ## Reporting bugs
 
 Use the issue templates at
-<https://github.com/evoila/meho/issues/new/choose>.
+<https://github.com/evoila/meho/issues/new/choose>. For bugs that
+relate to the deploy contract (chart misbehaviour, CLI flag
+regression, image start-failure), attach: chart version, image tag,
+`kubectl get pods -n meho`, and the relevant pod logs.
+
+For broader proposals (new connector, new policy primitive, deploy
+flow change), the right route is a planning issue on
+`evoila-bosnia/meho-internal` — that repo holds the
+Goal → Initiative → Task hierarchy under project 19, and a PR on
+`evoila/meho` closes one of the Tasks.
 
 ## Security
 
 Vulnerabilities: see [`SECURITY.md`](./SECURITY.md). Do not file
-public issues for security problems.
+public issues for security problems — the file documents the
+private reporting channel.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,13 +115,11 @@ Each language has a fixed toolchain. CI runs the same tools — no
   format-and-lint pair. `mypy --ignore-missing-imports` for
   type-checking. Pinned versions live in
   [`backend/pyproject.toml`](./backend/pyproject.toml) under the
-  `dev` group; the pre-commit hook (when it lands) will use the
-  same pinned versions.
+  `dev` group; the pre-commit hook uses the same pinned versions.
 - **Go (operator CLI):** `gofmt -s` + `golangci-lint run` from
-  [`cli/.golangci.yml`](./cli/.golangci.yml) (when the file lands;
-  Task #43 scaffolded the module). `go vet` is part of the same
-  pipeline. Generated code (oapi-codegen output) is checked in and
-  excluded from lint.
+  [`cli/.golangci.yml`](./cli/.golangci.yml). `go vet` is part of the
+  same pipeline. Generated code (oapi-codegen output) is checked in
+  and excluded from lint.
 - **YAML, Markdown, JSON:** trailing-whitespace, end-of-file-fixer,
   and `check-yaml` / `check-json` from the pre-commit hooks repo
   catch the common formatting traps. CI also runs `gitleaks` for
@@ -165,9 +163,10 @@ flows are noisy; the easier discipline is to make `-s` the default.
 
 There is no CLA. Apache 2.0 §5 ("inbound = outbound": contributions
 flow in under the same Apache 2.0 terms the project ships under) plus
-the DCO trailer is the full contributor agreement. The license ADR
-documenting this choice lives at ADR 0001 (license selection) and
-ADR 0002 (CLA-vs-DCO).
+the DCO trailer is the full contributor agreement. The DCO trailer
+asserts that you have the right to submit the contribution under the
+project's license; the DCO bot enforces presence on every commit
+landing on `main`.
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MEHO
 
-> An MCP-native governance layer that lets any AI agent operate safely
-> against shared infrastructure. Policy-gated. Audit-grade. Multi-tenant.
+> Governance backplane for AI agents acting on infrastructure —
+> policy-gated, audit-grade, MCP-native. Apache 2.0.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![OSS](https://img.shields.io/badge/OSS-public%20from%20day%201-success.svg)](./CONTRIBUTING.md#public-from-day-1-deliberately)
@@ -34,16 +34,23 @@ Keycloak / Postgres.
 # 1. Spin up a single-node kind cluster.
 kind create cluster --name meho-dev
 
-# 2. Apply the mock Postgres / Vault / Keycloak prerequisites documented
-#    at the top of values-kind.yaml. (Mock Vault + Keycloak come up
-#    cluster-internal so the chart's URI-validated fields resolve; real
-#    federation requires the existing-k8s flow below.)
-#    See deploy/values-examples/values-kind.yaml for the manifests.
+# 2. Apply the prerequisites documented at the top of values-kind.yaml.
+#    Only Postgres ships a real mock manifest (Namespace + Secret +
+#    Deployment + Service for `postgres:16-alpine` — copy-paste it). Vault
+#    and Keycloak are *placeholder URIs* in the overlay so the chart's
+#    URI-validated fields resolve at install time; no in-cluster Vault or
+#    Keycloak is deployed and no real auth flow runs. Federation probes
+#    register but `meho login` will not work end-to-end.
+#    For real federation (working Vault token-exchange + Keycloak OIDC
+#    flow), use the existing-k8s path below instead — you provision Vault
+#    and Keycloak yourself.
+#    See deploy/values-examples/values-kind.yaml for the Postgres manifest.
 
 # 3. Install the chart from its OCI artefact (published by Task #41).
 #    Pin to an immutable image tag — sha-<git-sha> from a green CI run
 #    on main, or a v<x.y.z> release tag. Goal #11 deploy discipline
-#    forbids :latest and :main.
+#    rejects :latest entirely and treats :main as a dev-only moving alias
+#    (not a deploy target).
 helm install meho-dev oci://ghcr.io/evoila/meho-chart \
   --version <chart-version> \
   -n meho --create-namespace \
@@ -58,9 +65,12 @@ curl localhost:8000/healthz
 ```
 
 `values-kind.yaml` disables ingress + NetworkPolicy (kind ships neither
-out of the box) and points at in-cluster mock Vault + Keycloak. Operator
-identity is **faked** — for real federation, use the existing-k8s path
-below.
+out of the box), points Postgres at the in-cluster mock provisioned in
+step 2, and supplies *placeholder* Vault + Keycloak URIs (no in-cluster
+mock for those — the chart's URI-validated fields just need to resolve
+at install time). Operator identity is **faked**; the federation probes
+register but `meho login` will not complete. For real federation, use
+the existing-k8s path below.
 
 ### Existing k8s (~5 min, requires Vault + Keycloak + Postgres)
 
@@ -163,10 +173,12 @@ docker pull ghcr.io/evoila/meho:main
 docker pull ghcr.io/evoila/meho:v0.1.0
 ```
 
-**No `:latest` tag is ever published** — operators must pin to an
-immutable `:sha-<...>` or `:v<x.y.z>` reference (Goal #11 deploy
-discipline). Every image is cosign-signed (Task #34) using the same
-keyless flow described above.
+**No `:latest` tag is ever published.** `:main` is a moving alias for
+the latest main-branch build and is intended for **dev only** (the
+`docker pull` recipe above). Operators deploying MEHO must pin to an
+immutable `:sha-<...>` or `:v<x.y.z>` reference — `:main` is not a
+deploy target (Goal #11 deploy discipline). Every image is
+cosign-signed (Task #34) using the same keyless flow described above.
 
 ### Maintainer one-time setup
 
@@ -313,10 +325,12 @@ auto-generating from git log.
 
 ## License
 
-[Apache License 2.0](./LICENSE). Per ADR 0001 (license selection) and
-the project's inbound = outbound discipline: every contribution flows
-in under the same Apache 2.0 terms via the DCO sign-off — there is no
-separate CLA.
+[Apache License 2.0](./LICENSE). Inbound = outbound: every contribution
+flows in under the same Apache 2.0 terms the project ships under, via
+the Developer Certificate of Origin (DCO) sign-off on every commit
+(`git commit -s`) — there is no separate CLA. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md#developer-certificate-of-origin)
+for the sign-off discipline.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 > An MCP-native governance layer that lets any AI agent operate safely
 > against shared infrastructure. Policy-gated. Audit-grade. Multi-tenant.
 
-**Status:** v0.1 in development. No released artifact yet.
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
+[![OSS](https://img.shields.io/badge/OSS-public%20from%20day%201-success.svg)](./CONTRIBUTING.md#public-from-day-1-deliberately)
+
+**Status:** v0.1 in development. The backplane image, the Helm chart, and
+the operator CLI are all building toward the first tagged release; nothing
+is GA yet.
 
 ## What this is
 
@@ -17,25 +22,130 @@ every context lookup tenant-scoped and version-aware.
 
 The agent runtime is *not* part of MEHO. Bring your own.
 
-## Status
+## Deploy
 
-This repository is in active development toward v0.1. There is
-nothing to install yet. Watch the repo for the v0.1 announcement.
+### Local (kind, ~5 min)
 
-## Quickstart
+A fully local dev loop. Useful for iterating on chart plumbing, the
+backplane's startup contract, and the CLI without touching real Vault /
+Keycloak / Postgres.
 
-(Placeholder — full v0.1 install / smoke / upgrade path lands with
-the release.)
+```bash
+# 1. Spin up a single-node kind cluster.
+kind create cluster --name meho-dev
 
-For the backplane (Python / FastAPI) skeleton — `uv` and Docker
-recipes for running it locally — see [`backend/README.md`](./backend/README.md).
+# 2. Apply the mock Postgres / Vault / Keycloak prerequisites documented
+#    at the top of values-kind.yaml. (Mock Vault + Keycloak come up
+#    cluster-internal so the chart's URI-validated fields resolve; real
+#    federation requires the existing-k8s flow below.)
+#    See deploy/values-examples/values-kind.yaml for the manifests.
 
-For the `meho` operator CLI (Go / cobra) — build, install, and
-`meho version` recipes — see [`cli/README.md`](./cli/README.md). The
-CLI ships as a single static binary; v0.1 wires `version`, `login`,
-and `status`, plus a cosign-signed multi-platform release pipeline
-(linux/macOS × amd64/arm64). Operator-side signature-verification
-recipe is below in [Verifying CLI release artefacts](#verifying-cli-release-artefacts).
+# 3. Install the chart from its OCI artefact (published by Task #41).
+#    Pin to an immutable image tag — sha-<git-sha> from a green CI run
+#    on main, or a v<x.y.z> release tag. Goal #11 deploy discipline
+#    forbids :latest and :main.
+helm install meho-dev oci://ghcr.io/evoila/meho-chart \
+  --version <chart-version> \
+  -n meho --create-namespace \
+  -f https://raw.githubusercontent.com/evoila/meho/main/deploy/values-examples/values-kind.yaml \
+  --set image.tag=sha-<git-sha>
+
+# 4. Verify the pod is up and the readiness probe is responding.
+kubectl wait --for=condition=Ready pod \
+  -l app.kubernetes.io/name=meho -n meho --timeout=2m
+kubectl port-forward -n meho svc/meho-dev-meho 8000:8000 &
+curl localhost:8000/healthz
+```
+
+`values-kind.yaml` disables ingress + NetworkPolicy (kind ships neither
+out of the box) and points at in-cluster mock Vault + Keycloak. Operator
+identity is **faked** — for real federation, use the existing-k8s path
+below.
+
+### Existing k8s (~5 min, requires Vault + Keycloak + Postgres)
+
+The supported v0.1 deploy shape: a Kubernetes cluster running an
+ingress-nginx controller, a HashiCorp Vault with the `meho-mcp` OIDC
+role bound to your Keycloak issuer, a Keycloak realm + client fronting
+the backplane, and a PostgreSQL database reachable from the cluster.
+This is the shape the RDC Hetzner dogfooding lab runs.
+
+```bash
+helm upgrade --install meho oci://ghcr.io/evoila/meho-chart \
+  --version <chart-version> \
+  -n meho --create-namespace \
+  -f your-values.yaml
+```
+
+See [`deploy/values-examples/values-rdc-example.yaml`](./deploy/values-examples/values-rdc-example.yaml)
+for the shape `your-values.yaml` should follow and
+[`deploy/values-examples/README.md`](./deploy/values-examples/README.md)
+for the **External Secrets Operator (ESO) sync patterns** the chart
+expects. Required: Vault address + role, Keycloak issuer + audience,
+Postgres credentials Secret (synced from Vault by ESO).
+
+### Verify image + chart + CLI signatures
+
+Every operator-facing artefact is cosign keyless-signed (ADR 0006) under
+the workflow that produced it. There is no public key to distribute —
+verification compares the Fulcio-issued certificate's `subject` against
+a regex anchored on the source workflow's path and tag ref. A maliciously
+re-tagged fork cannot produce a bundle that satisfies it.
+
+```bash
+# Container image (signed by .github/workflows/image.yml on push)
+cosign verify ghcr.io/evoila/meho:<tag> \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/image\.yml@refs/(heads/main|tags/v.+)$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# Helm chart (signed by .github/workflows/chart.yml on every chart push)
+cosign verify ghcr.io/evoila/meho-chart:<version> \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/chart\.yml@refs/(heads/main|tags/v.+)$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# CLI release tarball (signed by .github/workflows/cli-release.yml on v* tags)
+cosign verify-blob \
+  --certificate-identity-regexp '^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --bundle meho_<version>_linux_amd64.tar.gz.cosign.bundle \
+  meho_<version>_linux_amd64.tar.gz
+```
+
+Full CLI install + verification recipe lives at
+[Verifying CLI release artefacts](#verifying-cli-release-artefacts);
+chart and image specifics live in
+[`cli/README.md`](./cli/README.md#verify-signatures) and
+[`docs/codebase/devops.md`](./docs/codebase/devops.md).
+
+## Architecture
+
+MEHO ships as three operator-facing artefacts:
+
+- **Backplane** — Python / FastAPI service that brokers MCP operations
+  against infrastructure. Receives short-lived Keycloak-issued OIDC
+  tokens, exchanges them with Vault for backend credentials, executes
+  policy-gated operations, writes audit rows to PostgreSQL, and
+  broadcasts activity to Valkey. Container image at
+  `ghcr.io/evoila/meho`. Codebase walkthrough:
+  [`docs/codebase/backend.md`](./docs/codebase/backend.md).
+- **Helm chart** — `meho-chart` published as an OCI artefact at
+  `ghcr.io/evoila/meho-chart` (Task #41). Renders the Deployment,
+  Service, Ingress, NetworkPolicy, pre-install migration Job, the
+  bundled Valkey broadcast subchart (ADR 0005), and the typed
+  `values.schema.json` contract (Task #38) that rejects misconfigured
+  installs at `helm install` / `helm upgrade` / `helm template`. Chart
+  walkthrough: [`docs/codebase/devops.md`](./docs/codebase/devops.md).
+- **Operator CLI** — `meho` Go binary (cobra). Wires `version`,
+  `login` (Keycloak device-code flow, Task #44), and `status`
+  (server-driven discovery, Task #45) for v0.1. Released as
+  multi-platform tarballs (`linux/macOS × amd64/arm64`) on every
+  `v*` tag, each individually cosign-signed (Task #47). CLI
+  walkthrough: [`docs/codebase/cli.md`](./docs/codebase/cli.md).
+
+The agent runtime (Claude Code, Cursor, …) lives outside the deploy
+contract — operators bring their own MCP client. MEHO is the layer
+that turns "any MCP client" into "any MCP client *operating against
+real infrastructure under audit*."
 
 ## Container image
 
@@ -55,7 +165,8 @@ docker pull ghcr.io/evoila/meho:v0.1.0
 
 **No `:latest` tag is ever published** — operators must pin to an
 immutable `:sha-<...>` or `:v<x.y.z>` reference (Goal #11 deploy
-discipline).
+discipline). Every image is cosign-signed (Task #34) using the same
+keyless flow described above.
 
 ### Maintainer one-time setup
 
@@ -125,9 +236,10 @@ The deploy contract lives at [`deploy/charts/meho/`](./deploy/charts/meho/).
 `values.yaml` ships safe-by-default — every field the backplane cannot
 start without is **blank** and the bundled
 [`values.schema.json`](./deploy/charts/meho/values.schema.json) (JSON
-Schema draft-07) rejects empty required values at `helm install` /
-`helm upgrade` / `helm template` time with a clear path. Unknown keys at
-any level fail with `additional properties '<name>' not allowed`.
+Schema draft-07, Task #38) rejects empty required values at
+`helm install` / `helm upgrade` / `helm template` time with a clear
+path. Unknown keys at any level fail with
+`additional properties '<name>' not allowed`.
 
 Operator-required (MUST be set; the schema rejects empty defaults):
 
@@ -159,51 +271,52 @@ Common operator overrides (safe defaults provided; tune as needed):
 | `resources.requests` / `resources.limits` | `100m`/`256Mi` / `1000m`/`1Gi` | Conservative v0.1 chassis baselines. |
 | `networkPolicy.ingressControllerNamespace` | `ingress-nginx` | RKE2 default; override per cluster. |
 | `audit.postgresOnly` | `true` | v0.1; S3 mirror is v0.2. |
-| `broadcast.redis.bundled` | `true` | v0.1 deploys its own Redis subchart (G2.5-T3). |
+| `broadcast.enabled` | `true` | v0.1 deploys its own Valkey subchart (G2.5-T3). |
 | `connectors.enabled` | `[]` | v0.1 chassis ships no connectors. |
 
 See [`docs/codebase/devops.md`](./docs/codebase/devops.md) for the full
 chart contract, probe semantics, NetworkPolicy posture, install/upgrade
 flow, and verification commands.
 
-## Deploy
-
-A sanitized example values file for a Vault + Keycloak + Postgres +
-ingress-nginx-shaped cluster (the same shape as the RDC Hetzner
-dogfooding lab) lives at
-[`deploy/values-examples/values-rdc-example.yaml`](./deploy/values-examples/values-rdc-example.yaml);
-the substitution recipe and the **External Secrets Operator (ESO) sync
-patterns** the chart expects are documented in
-[`deploy/values-examples/README.md`](./deploy/values-examples/README.md).
-
-Once v0.1 is released the chart will also be published as an OCI artifact
-at `oci://ghcr.io/evoila/meho-chart` (Task #41); until then, install
-directly from the repository tree:
-
-```bash
-helm upgrade --install meho ./deploy/charts/meho/ \
-  --namespace meho --create-namespace \
-  -f deploy/values-examples/values-rdc-example.yaml \
-  --set image.tag=sha-<git-sha>
-  # ...plus the substitutions documented in deploy/values-examples/README.md
-```
-
 ## Documentation
 
-(Placeholder — `docs.meho.ai` will land before v0.1.)
+Codebase walkthroughs:
+
+- **Backend** — [`docs/codebase/backend.md`](./docs/codebase/backend.md)
+- **CLI** — [`docs/codebase/cli.md`](./docs/codebase/cli.md)
+- **Chart + deploy** — [`docs/codebase/devops.md`](./docs/codebase/devops.md)
+
+`docs.meho.ai` (rendered reference docs, runbooks, connector authoring
+guide) lands in v0.2 once the first connector + wrapper-replacement
+work in Goal #59 closes.
 
 ## Contributing
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md). Contributions require a
-Developer Certificate of Origin sign-off (`git commit -s`).
+Developer Certificate of Origin sign-off (`git commit -s`) — there is
+no CLA. Public-from-day-1: every line of MEHO ships on `evoila/meho`
+from commit #1; operator-sensitive coordination lives in
+`evoila-bosnia/meho-internal` (issues + ADRs only, no code).
 
 ## Security
 
 Vulnerability reports: see [`SECURITY.md`](./SECURITY.md).
 
+## Changelog
+
+See [`CHANGELOG.md`](./CHANGELOG.md). Project-wide (image + chart + CLI
+under one document) in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+format. The top-level CHANGELOG is the authoritative source for the
+narrative attached to every GitHub Release — the CLI release pipeline
+extracts the matching section via `--release-notes` rather than
+auto-generating from git log.
+
 ## License
 
-[Apache License 2.0](./LICENSE).
+[Apache License 2.0](./LICENSE). Per ADR 0001 (license selection) and
+the project's inbound = outbound discipline: every contribution flows
+in under the same Apache 2.0 terms via the DCO sign-off — there is no
+separate CLA.
 
 ## History
 

--- a/deploy/values-examples/values-kind.yaml
+++ b/deploy/values-examples/values-kind.yaml
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Local-kind values overlay for MEHO.
+#
+# This file targets a single-node kind cluster on a developer workstation.
+# Its job is to let you exercise the chart's install plumbing — pre-install
+# migration Job → Deployment → Service → liveness/readiness probes — without
+# wiring up real Vault + Keycloak + Postgres. Operator identity is *faked*:
+# the chart points at in-cluster mock endpoints, the backplane comes up,
+# the federation probes register, and `meho status` returns a sensible
+# response. It is **not** a functional federation deploy — for that, see
+# `values-rdc-example.yaml`.
+#
+# Prerequisites (one-time per cluster):
+#
+# ```bash
+# # Mock Postgres, Vault, and Keycloak as cluster-internal Services. The
+# # backplane's startup probes are satisfied by these mocks reaching a TCP
+# # port — actual policy / audit semantics are deferred to a real deploy.
+# kubectl apply -n meho -f - <<'EOF'
+# apiVersion: v1
+# kind: Namespace
+# metadata:
+#   name: meho
+# ---
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: meho-postgres-mock
+#   namespace: meho
+# type: Opaque
+# stringData:
+#   url: postgresql+asyncpg://meho:meho@mock-postgres.meho.svc:5432/meho
+# ---
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   name: mock-postgres
+#   namespace: meho
+# spec:
+#   replicas: 1
+#   selector: { matchLabels: { app: mock-postgres } }
+#   template:
+#     metadata: { labels: { app: mock-postgres } }
+#     spec:
+#       containers:
+#         - name: pg
+#           image: postgres:16-alpine
+#           env:
+#             - { name: POSTGRES_DB,       value: meho }
+#             - { name: POSTGRES_USER,     value: meho }
+#             - { name: POSTGRES_PASSWORD, value: meho }
+#           ports: [{ containerPort: 5432 }]
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata: { name: mock-postgres, namespace: meho }
+# spec:
+#   selector: { app: mock-postgres }
+#   ports: [{ port: 5432, targetPort: 5432 }]
+# EOF
+# ```
+#
+# Mock Vault + Keycloak don't need real deployments for the chassis-stage
+# backplane to start; the chart only requires the *configuration* to be
+# present (Vault address resolves DNS, Keycloak issuer resolves) — the
+# federation probes don't gate process start, they gate readiness.
+# Substitute real endpoints when you need a working `meho login` flow.
+
+# Use a stable production-image tag — kind respects the same registry the
+# chart references. Pin to a real sha-<...> from a green CI run; the
+# project's deploy discipline (Goal #11) forbids `:latest` and `:main`
+# even for local development.
+image:
+  # MUST be overridden — pass `--set image.tag=sha-<git-sha>` at install
+  # time, or set it here before applying. The schema rejects an empty tag.
+  tag: ""
+
+# Ingress is disabled on kind by default — kind ships no IngressClass and
+# the chart's port-forward flow (`kubectl port-forward`) is sufficient
+# for a 5-minute smoke test. Setting `enabled: false` skips the Ingress
+# resource entirely and waives the `host` / `tls.secretName` schema
+# requirements.
+ingress:
+  enabled: false
+
+# NetworkPolicy is disabled on kind. kind's default CNI (kindnet) does
+# not enforce NetworkPolicy — keeping the resource enabled would render
+# a no-op policy and force the operator to invent CIDR placeholders.
+# When you graduate to a CNI that enforces policy (Cilium, Calico),
+# flip this back on and supply real CIDRs.
+networkPolicy:
+  enabled: false
+
+# Mock the operator-required Vault + Keycloak fields with in-cluster
+# placeholders. These satisfy the schema's `format: uri` + `minLength: 1`
+# constraints; the backplane resolves them at startup and the readiness
+# probes will report the federation probes as unhealthy (expected — there
+# is no real Vault or Keycloak behind these endpoints) until a real
+# federation stack is wired up.
+vault:
+  address: http://mock-vault.meho.svc:8200
+
+keycloak:
+  issuer: http://mock-keycloak.meho.svc:8080/realms/meho
+  audience: meho-backplane
+
+postgres:
+  # The mock Postgres Secret created in the prerequisite snippet above.
+  # The chart consumes `DATABASE_URL` from this Secret's `url` key — the
+  # pre-install migration Job runs against it and the Deployment uses it
+  # for runtime queries.
+  credentialsSecret: meho-postgres-mock
+
+config:
+  keycloakIssuerUrl: http://mock-keycloak.meho.svc:8080/realms/meho
+  keycloakAudience: meho-backplane
+  vaultAddr: http://mock-vault.meho.svc:8200
+
+# The bundled broadcast subchart (Valkey 9.x per ADR 0005) is left
+# `enabled: true` — kind has plenty of headroom for a single-replica
+# in-tree Valkey, and exercising the broadcast plumbing locally is part
+# of what makes this overlay useful. Disable if your laptop is
+# resource-constrained.
+broadcast:
+  enabled: true
+
+# Conservative resource overrides for a developer laptop. The defaults
+# in `values.yaml` are production baselines; kind on a dev machine
+# typically has tighter memory headroom and benefits from smaller
+# requests/limits.
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi


### PR DESCRIPTION
## Summary

- **README.md** — adds a Deploy section with two paths (5-min kind local + 5-min existing-k8s), a unified cosign verify-signatures recipe across image + chart + CLI, an Architecture section indexing the three `docs/codebase/` walkthroughs, and a License section anchored to ADR 0001 + ADR 0002.
- **CONTRIBUTING.md** — adds dogfood-loop framing, public-from-day-1 norm, bidirectional coordination flow with `claude-rdc-hetzner-dc`, expanded DCO sign-off (backfill recipes + branch-protection context), per-language code-style toolchains, and the PR-flow conventions already in use.
- **CHANGELOG.md** — reframed as project-wide (image + chart + CLI under one document); `cli/CHANGELOG.md` explicitly superseded. Backfilled `Added` entries for image cosign (#34), typed `values.schema.json` (#38), `values-rdc-example.yaml` (#40), chart OCI publish (#41), and this Task. Renamed `[0.1.0]` to `[0.1.0-beta]` with a Goal #59 reference distinguishing chassis from first user-visible operation.
- **deploy/values-examples/values-kind.yaml** — in-cluster mock targets, disabled ingress + NetworkPolicy, so the README's local-kind path runs end-to-end without external Vault/Keycloak/Postgres.

## Test plan

- [x] `grep -c "Local (kind"` README.md → 1 (Deploy → Local section present)
- [x] `grep -c "Existing k8s"` README.md → 1 (Deploy → Existing k8s section present)
- [x] `grep -c "dogfood loop"` CONTRIBUTING.md → 1
- [x] `grep -c "Public from day 1"` CONTRIBUTING.md → 1
- [x] `grep -c "Bidirectional coordination"` CONTRIBUTING.md → 1
- [x] `CHANGELOG.md` exists, project-wide-shaped (image + chart + CLI), has `[Unreleased]` + `[0.1.0-beta]`
- [x] `deploy/values-examples/values-kind.yaml` exists and parses as valid YAML
- [x] CHANGELOG cross-references for #34 / #38 / #40 / #41 / #46 / #47 are all present under `[Unreleased] → Added`

## Out of scope

- Sibling Tasks under Initiative #48 (G2.7): #52 (repo metadata) and #53 (cross-repo coordination tracker) — no file overlap.
- Deeper `docs/architecture/` and `docs/connectors/` — v0.2+ per issue body.
- Translated docs and OpenAPI-generated reference — v0.2+ per issue body.
- The actual ADR 0001 / 0002 file bodies — they live in `evoila-bosnia/meho-internal` per the project's planning/code split.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #60


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Unified project changelog set as the authoritative release-notes source; clarified release-note extraction behavior
  * Expanded README with v0.1 development status, deploy guides (local kind and existing cluster), image/chart/CLI verification steps, architecture and history notes
  * Completed and detailed contributor guide with workflow, commit/signing, and CI/PR expectations
  * Updated release planning to v0.1-beta scope

* **Examples**
  * Added Helm values example for local kind deployments with mocked services

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/181)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-11)

Addressed review findings from [pr-181-iter-1](https://github.com/evoila/meho/pull/181#pullrequestreview-4261920751):

- **B1** `395cc2d` — README kind-deploy prereq section rewritten to accurately describe what `values-kind.yaml` provisions (Postgres real mock manifest) vs placeholders (Vault + Keycloak URIs). Both the step-2 callout and the follow-up paragraph updated.
- **B2** `395cc2d` — CHANGELOG `2026-MM-DD` placeholder date replaced with `TBD` in `[0.1.0-beta]` heading. Prevents leakage into GitHub Release notes via `cli-release.yml --release-notes`.
- **B3** `395cc2d` — README `:main` tag policy aligned across both mentions: dev-only moving alias, not a deploy target; `:latest` rejected entirely. Matches what `image.yml` actually publishes.
- **M1** `395cc2d` — README L3-4 tagline updated to match `.github/repo-config.yml` `description:` field set by sibling PR #180 (G2.7-T4, merged at `17abade`). Verified via `git merge-tree` — clean merge into current main, README L3-4 matches `description:` verbatim in the merged tree.
- **m1** `395cc2d` — CHANGELOG entry-format spec softened to match the actual entries (`(#issue / #pr)` or `(#issue)`).
- **m2** `395cc2d` — CONTRIBUTING future-tense parentheticals dropped on `.pre-commit-config.yaml` and `cli/.golangci.yml` (both files exist now).
- **m3** `395cc2d` — Unresolvable `ADR 0001` / `ADR 0002` references replaced with inline rationale in README License section + CONTRIBUTING DCO section (the ADRs live in private `evoila-bosnia/meho-internal`; visitor-facing docs cannot link to them).

Disputed: none.

Deferred: none.

Note on rebase coordination with #180: Hard requirement 8 mandates `git rebase origin/main`, but Hard requirement 3 forbids force-push. Resolved by reset-to-PR-head + new commit on top (fast-forward push, same merge-tree end-state). README L3-4 lockstep with `description:` verified for the post-merge state via `git merge-tree --write-tree origin/main HEAD` (exit 0).

Head SHA: `395cc2d`.
