### PR TITLE
ci: unblock CI on every PR — fix three independent failures

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -226,6 +226,20 @@ jobs:
         with:
           version: v3.16.4
 
+      - name: Ensure envsubst (gettext-base) — cosign-installer dep
+        # sigstore/cosign-installer's signature-verification bootstrap shells
+        # out to `envsubst`. github-hosted ubuntu-latest ships it preinstalled;
+        # the actions-runner-controller scale-set image is minimal and omits
+        # gettext-base, which makes the next step exit 127.
+        shell: bash
+        run: |
+          if command -v envsubst >/dev/null 2>&1; then exit 0; fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -q && sudo apt-get install -y --no-install-recommends gettext-base
+          else
+            apt-get update -q && apt-get install -y --no-install-recommends gettext-base
+          fi
+
       - name: Install cosign
         # Pinned to cosign-installer v4.1.2 (ships cosign v3.0.6 by default).
         # v4.x dropped pre-2.0 cosign support; v3.x of cosign has

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -111,6 +111,17 @@ jobs:
           # the tree right now).
           cache-dependency-path: cli/go.sum
 
+      - name: Ensure envsubst (gettext-base) — cosign-installer dep
+        # See chart.yml for context.
+        shell: bash
+        run: |
+          if command -v envsubst >/dev/null 2>&1; then exit 0; fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -q && sudo apt-get install -y --no-install-recommends gettext-base
+          else
+            apt-get update -q && apt-get install -y --no-install-recommends gettext-base
+          fi
+
       - name: Install cosign
         # Pinned to cosign-installer v4.1.2 (ships cosign v3.x by
         # default). Same SHA as chart.yml's signing step so a single
@@ -186,8 +197,12 @@ jobs:
 
           # Export the path for the next step. Use a stable variable
           # name (not a step output) so the GoReleaser step's `args:`
-          # template can reference it via `${{ env.RELEASE_NOTES_FILE
-          # }}`.
+          # template can reference it as an env-context expression
+          # (env.RELEASE_NOTES_FILE in the `args:` line below).
+          # Note: the literal expression syntax is intentionally not
+          # written out here — GitHub Actions parses ${ followed by
+          # double-braces from anywhere in the workflow file regardless
+          # of YAML comments, so embedding it would break this file.
           echo "RELEASE_NOTES_FILE=${NOTES_FILE}" >> "${GITHUB_ENV}"
 
       - name: Run GoReleaser

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -173,6 +173,19 @@ jobs:
         if: github.event_name != 'pull_request'
         run: echo "Pushed digest=${{ steps.build.outputs.digest }}"
 
+      - name: Ensure envsubst (gettext-base) — cosign-installer dep
+        # See chart.yml for context. Same PR-skip gate as the cosign step
+        # so PR-only builds don't burn apt time on a package they won't use.
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          if command -v envsubst >/dev/null 2>&1; then exit 0; fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -q && sudo apt-get install -y --no-install-recommends gettext-base
+          else
+            apt-get update -q && apt-get install -y --no-install-recommends gettext-base
+          fi
+
       - name: Install cosign
         # Pinned to cosign-installer v4.1.2 (ships cosign v3.0.6 by default;
         # see action.yml). v4.x dropped pre-2.0 cosign support; v3.x of cosign

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -74,6 +74,14 @@ select = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]  # asserts allowed in tests
+# A005 flags any module name that matches a stdlib module by short name,
+# regardless of package path. These two are namespaced under
+# `meho_backplane.*` and are never imported as bare `operator` / `logging`,
+# so the shadowing risk A005 is designed to catch does not apply.
+# Revisit if a future caller does `from meho_backplane.auth import operator`
+# and then `operator.attrgetter(...)` — that pattern WOULD be confusing.
+"src/meho_backplane/auth/operator.py" = ["A005"]
+"src/meho_backplane/logging.py" = ["A005"]
 
 [tool.ruff.lint.flake8-bugbear]
 # FastAPI's standard dependency-injection pattern relies on calling

--- a/backend/tests/test_auth_vault.py
+++ b/backend/tests/test_auth_vault.py
@@ -419,7 +419,7 @@ async def test_vault_other_error_wraps_to_client_error(
         async with vault_client_for_operator(_make_operator()):
             pytest.fail("body should not run when login raises")
     # Must NOT be a subclass — it's the generic catchall.
-    assert not isinstance(exc_info.value, (VaultUnreachableError, VaultRoleDeniedError))
+    assert not isinstance(exc_info.value, VaultUnreachableError | VaultRoleDeniedError)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -257,7 +257,7 @@ def test_request_completed_log_shape(client: TestClient, log_buffer: io.StringIO
     assert entry["method"] == "GET"
     assert entry["path"] == "/"
     assert entry["status"] == 200
-    assert isinstance(entry["duration_ms"], (int, float))
+    assert isinstance(entry["duration_ms"], int | float)
     assert entry["duration_ms"] >= 0
 
 

--- a/backend/tests/test_vault_failures.py
+++ b/backend/tests/test_vault_failures.py
@@ -328,7 +328,7 @@ async def test_vault_invalid_request_during_login_raises_client_error(
     with pytest.raises(VaultClientError) as exc_info:
         async with vault_client_for_operator(_make_operator()):
             pytest.fail("body must not run when login raises")
-    assert not isinstance(exc_info.value, (VaultUnreachableError, VaultRoleDeniedError))
+    assert not isinstance(exc_info.value, VaultUnreachableError | VaultRoleDeniedError)
 
 
 async def test_vault_internal_server_error_during_login_raises_client_error(


### PR DESCRIPTION
## Why every PR is currently red

After #167 (runner routing) and #169 (stale workflow YAML), three further pre-existing failures kept every PR red. None overlap, but each alone leaves the board red and each fix is small, so bundling.

### 1. `cli-release.yml` is invalid YAML → 0s startup failure on every push

`actionlint` flagged:

\`\`\`
cli-release.yml:144: got unexpected character '#' while lexing expression,
                     expecting [valid expression tokens]
\`\`\`

Lines 187-190 had a YAML comment containing a literal \`\${{ ... }}\` expression split across two lines:

\`\`\`yaml
# template can reference it via \`\${{ env.RELEASE_NOTES_FILE
# }}\`.
\`\`\`

GitHub Actions parses \`\${{ ... }}\` from the **whole workflow string regardless of YAML comments** — it tried to interpret the embedded \`#\` (start of the next line's comment) inside the expression and rejected the file. Reworded the comment to reference \`env.RELEASE_NOTES_FILE\` without literal braces; added a one-line note explaining the trap.

### 2. \`chart\`, \`image\`, and CLI release: \`envsubst: command not found\`

The actions-runner-controller scale-set image is minimal — it ships without \`gettext-base\` (which provides \`envsubst\`). github-hosted \`ubuntu-latest\` has it preinstalled. \`sigstore/cosign-installer\`'s bootstrap shells out to \`envsubst\` for signature verification, so every cosign step exit-127s with:

\`\`\`
/home/runner/_work/_temp/...sh: line 3: envsubst: command not found
##[error]Process completed with exit code 127.
\`\`\`

Added an \"Ensure envsubst\" step before \`sigstore/cosign-installer\` in all three workflows. Snippet is no-op if envsubst is already present (forward-compat for when the runner image grows it), and works root-or-sudo:

\`\`\`yaml
- name: Ensure envsubst (gettext-base) — cosign-installer dep
  shell: bash
  run: |
    if command -v envsubst >/dev/null 2>&1; then exit 0; fi
    if command -v sudo >/dev/null 2>&1; then
      sudo apt-get update -q && sudo apt-get install -y --no-install-recommends gettext-base
    else
      apt-get update -q && apt-get install -y --no-install-recommends gettext-base
    fi
\`\`\`

**Better long-term fix:** bake \`gettext-base\` into the ARC runner image so every new workflow Just Works. Worth a follow-up ticket against the runner-image repo — please file it on your side, I don't have access to the runner-controller config.

### 3. Pre-existing 5 ruff errors blocking \`CI\` on every push

Flagged in earlier triage. Fixed both kinds:

- **3× UP038** in test files (\`test_auth_vault.py:422\`, \`test_observability.py:260\`, \`test_vault_failures.py:331\`): mechanical \`isinstance(x, (A, B))\` → \`isinstance(x, A | B)\`. PEP 604 union form, already in heavy use across the codebase.
- **2× A005** (\`operator.py\`, \`logging.py\` shadow stdlib short names): added narrow **per-file-ignore** in \`backend/pyproject.toml\` rather than renaming. Both modules are namespaced under \`meho_backplane.*\` and never imported as bare \`operator\` / \`logging\` — the shadowing-confusion risk A005 catches doesn't apply here. The pyproject comment records when to revisit (if a future caller does \`from meho_backplane.auth import operator\` then \`operator.attrgetter(...)\`, that pattern WOULD be confusing).

**If you'd rather rename the modules** (\`operator.py\` → \`operator_auth.py\` or similar, \`logging.py\` → \`log_config.py\`), say the word and I'll redo as a rename PR. The ignore is a deliberate, narrow choice — not a hide-the-warning hack.

## Verification

\`\`\`
$ actionlint .github/workflows/*.yml
[only pre-existing SC2028 info-level shellcheck warnings remain; exit 0]

$ cd backend && uvx ruff@0.9.6 check .
All checks passed!
\`\`\`

## Test plan
- [ ] PR's own \`CI\` (ruff), \`chart\` (cosign), \`image\` (cosign), \`Security Scan\`, \`Secret Scan\`, \`Dependency License Check\` all green
- [ ] \`cli-release.yml\` no longer 0s-fails when a tag push triggers it (no easy way to test in this PR — verified by actionlint parse + the fix is comment-only)
- [ ] After merge, the queued-up dependabot PR #176 and the docs PRs #181 / #182 turn green when re-run

## Out of scope (next tickets)
- **Bake \`gettext-base\` into the ARC runner image** so future cosign callers don't need the workaround step. (Runner-controller repo, not this one.)
- **The Helm chart job's downstream steps** beyond cosign-install — they may surface new issues once cosign installs cleanly; we'll find out post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD pipeline reliability by ensuring required dependencies are available before signing operations across chart, CLI release, and image build workflows.
  * Updated internal test assertions and linting configuration to use modern Python syntax patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->