### PR TITLE
ci(image): repository_dispatch on main push to claude-rdc-hetzner-dc (G2.7-T3)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -58,6 +58,19 @@
 #     findings. SARIF results land both on the GitHub Security tab (Code
 #     scanning alerts) and as a 30-day workflow artefact. v0.2 will flip on a
 #     severity-based gate once the baseline noise level is known.
+#
+# Cross-repo deploy trigger (Task #51):
+#   - After image push on main, the workflow POSTs a `repository_dispatch`
+#     event of type `meho-image-pushed` to evoila-bosnia/claude-rdc-hetzner-dc
+#     so the dogfooding consumer can roll forward its deploy without polling.
+#     The event shape (image, digest, tag, commit, ref) is the canonical
+#     handshake documented at `docs/cross-repo/rke2-infra-coordination.md`.
+#   - Cross-repo dispatch requires a PAT — the default GITHUB_TOKEN is scoped
+#     to this repo only. The PAT is stored as the `RDC_DISPATCH_TOKEN` secret
+#     (fine-grained, single-repo, `metadata: read` + `actions: write` on
+#     claude-rdc-hetzner-dc). The dispatch step is skipped (not failed) when
+#     the secret is missing, so a rotated/revoked PAT degrades gracefully —
+#     the image is still built, pushed, signed, and attested.
 
 name: image
 
@@ -103,6 +116,13 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: meho-runners
     timeout-minutes: 45  # arm64 emulation under QEMU is 3-5x slower than native
+    env:
+      # Surfaced at the job level so the `Notify claude-rdc-hetzner-dc` step
+      # below can skip when the secret is unset. Secrets can't be referenced
+      # in `if:` directly (GitHub Actions docs, "Using secrets") — the
+      # documented pattern is to expose them via env and test `env.X != ''`.
+      # Missing/rotated PAT degrades to skip-not-fail (Task #51 AC #5).
+      RDC_DISPATCH_TOKEN: ${{ secrets.RDC_DISPATCH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -312,3 +332,59 @@ jobs:
           path: trivy-results.sarif
           retention-days: 30
           if-no-files-found: error
+
+      - name: Notify claude-rdc-hetzner-dc (repository_dispatch)
+        # Cross-repo deploy trigger (Task #51). On every main-push that lands
+        # a new image, send a `meho-image-pushed` repository_dispatch event
+        # to the dogfooding consumer carrying the immutable digest. The
+        # consumer's `.github/workflows/meho-deploy.yml` (consumer-owned)
+        # listens for the event and rolls the rke2-infra lab forward.
+        #
+        # Gate (three conjuncts):
+        #   1. github.event_name == 'push'  — never PRs (no token, no need).
+        #   2. github.ref == 'refs/heads/main' — main only. Tag pushes
+        #      (v* releases) are out of scope for v0.1: the dogfooding
+        #      consumer tracks main, not tagged releases. The cross-repo
+        #      handshake at docs/cross-repo/rke2-infra-coordination.md
+        #      locks `client_payload.ref` to refs/heads/main.
+        #   3. env.RDC_DISPATCH_TOKEN != ''  — skip when the PAT is missing.
+        #      AC #5 requires graceful degradation: a rotated or revoked
+        #      token must not fail the workflow; downstream operators
+        #      monitor the consumer-side deploy independently. Secrets
+        #      cannot be referenced in `if:` directly, hence the
+        #      job-level env block above.
+        #
+        # Auth: cross-repo dispatches need a PAT (fine-grained, single-repo
+        # on claude-rdc-hetzner-dc, scoped to `metadata: read` +
+        # `actions: write`). The default GITHUB_TOKEN is scoped to this
+        # repo only and the API returns 404 if used cross-repo.
+        #
+        # Failure mode: fail-loud on PAT-present but dispatch fails. A 401
+        # (revoked/wrong token) or 422 (bad payload shape) means the
+        # consumer never learns about the new image; silent swallow would
+        # leave the lab on a stale revision indefinitely. No
+        # `continue-on-error`.
+        #
+        # Payload shape is the canonical handshake from
+        # docs/cross-repo/rke2-infra-coordination.md (Section 3, "Event
+        # contract"). Top-level key cardinality (5) sits well under the
+        # GitHub API ceiling (10 keys, 64KB total). All values are strings;
+        # `-f` (raw-field) keeps gh from re-typing integers as JSON
+        # numbers — image digests, tags, and refs are all opaque strings.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.RDC_DISPATCH_TOKEN != ''
+        env:
+          # gh CLI reads GH_TOKEN for auth; the job-level RDC_DISPATCH_TOKEN
+          # is the PAT minted on claude-rdc-hetzner-dc.
+          GH_TOKEN: ${{ env.RDC_DISPATCH_TOKEN }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          gh api repos/evoila-bosnia/claude-rdc-hetzner-dc/dispatches \
+            --method POST \
+            --silent \
+            -f event_type=meho-image-pushed \
+            -f client_payload[image]=ghcr.io/evoila/meho \
+            -f client_payload[digest]="${DIGEST}" \
+            -f client_payload[tag]="${TAGS}" \
+            -f client_payload[commit]="${GITHUB_SHA}" \
+            -f client_payload[ref]="${GITHUB_REF}"

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -567,6 +567,83 @@ a trailing comment: `anchore/sbom-action@…` (v0.24.0),
 `actions/upload-artifact@…` (v7.0.1). Renovate / Dependabot bumps
 these on the same review cadence as `sigstore/cosign-installer`.
 
+### Cross-repo deploy trigger (Task #51)
+
+After image push, sign, attest, and scan, `image.yml`'s final step
+fires a `repository_dispatch` event of type `meho-image-pushed` at
+[`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)
+— the dogfooding consumer that operates MEHO against the rke2-infra
+lab cluster. The dispatch is the upstream half of the cross-repo
+handshake; the consumer-side listener (`.github/workflows/meho-deploy.yml`
+on the consumer) is consumer-owned per Goal #11's cross-repo deps.
+
+The full event-shape spec lives in
+[`docs/cross-repo/rke2-infra-coordination.md`](../cross-repo/rke2-infra-coordination.md);
+that doc is the canonical source of truth for the payload — keep it
+and `image.yml` in lock-step.
+
+| Aspect | Value | Rationale |
+| --- | --- | --- |
+| `event_type` | `meho-image-pushed` | Single event type; consumer matches on `types: [meho-image-pushed]` in its workflow's `on:` block |
+| `client_payload.image` | `ghcr.io/evoila/meho` | Static; the consumer reads `image@digest` to pull |
+| `client_payload.digest` | `sha256:<64-hex>` from `docker/build-push-action` output | Immutable handle; the consumer deploys by digest, never by tag |
+| `client_payload.tag` | `${{ steps.meta.outputs.tags }}` (newline-joined list from metadata-action) | Human-readable cross-reference; not used for pulls |
+| `client_payload.commit` | `${{ github.sha }}` (full 40-char SHA) | Surfaces in the consumer's run logs so operators can trace which evoila/meho commit produced the deploy |
+| `client_payload.ref` | `${{ github.ref }}` (always `refs/heads/main` here) | Confirms the trigger origin; the consumer can branch on tag vs branch pushes if needed |
+
+**Trigger gating.** Three conjuncts on the step's `if:`:
+
+1. `github.event_name == 'push'` — never on PRs. PRs build the
+   image but don't push it, so there's no new artefact to advertise.
+2. `github.ref == 'refs/heads/main'` — main only. Tag pushes (v*
+   releases) are out of scope for v0.1; the dogfooding consumer
+   tracks main, not tagged releases. The cross-repo doc locks
+   `ref` to `refs/heads/main`.
+3. `env.RDC_DISPATCH_TOKEN != ''` — skip when the secret is missing.
+   Secrets cannot be referenced inside `if:` directly per GitHub
+   Actions docs; the workflow exposes the PAT via a job-level
+   `env:` block (`RDC_DISPATCH_TOKEN`) so the step can test
+   `env.RDC_DISPATCH_TOKEN != ''`. A rotated or revoked PAT
+   degrades the workflow to "image still gets built, signed,
+   attested, and pushed, just no downstream advertisement" rather
+   than failing the whole run.
+
+**Cross-repo auth: PAT, not GITHUB_TOKEN.** The default
+`GITHUB_TOKEN` is scoped to the originating repo only and returns
+404 against `/repos/evoila-bosnia/claude-rdc-hetzner-dc/dispatches`.
+A maintainer-provisioned fine-grained PAT lives in `evoila/meho`
+secrets as `RDC_DISPATCH_TOKEN`, scoped to:
+
+- Target repository: `evoila-bosnia/claude-rdc-hetzner-dc` (single repo)
+- Permissions: `metadata: read` + `actions: write` (the minimum
+  surface for `POST /repos/{owner}/{repo}/dispatches`)
+
+**One-time maintainer setup.** The PAT is not workflow-creatable; a
+maintainer with org-admin access on `evoila-bosnia/claude-rdc-hetzner-dc`
+mints it, then stores it as the `RDC_DISPATCH_TOKEN` secret on
+`evoila/meho` (Settings → Secrets and variables → Actions). When
+the PAT is missing the step skips silently; when the PAT is present
+but invalid (revoked, wrong scope) the step fails-loud — a 401/403
+surfaces in the workflow log so the operator knows to rotate.
+
+**v0.2 improvement on the horizon.** The PAT is the v0.1 expedient.
+A GitHub App + installation token would carry shorter-lived
+credentials (1-hour installation tokens vs PATs that live until
+manually rotated), and CodeRabbit consistently flags long-lived PATs
+as such. The GitHub App migration is tracked separately; v0.1 ships
+with the PAT because the rotation discipline is captured on the
+coordination tracker
+([`docs/cross-repo/rke2-infra-coordination.md`](../cross-repo/rke2-infra-coordination.md))
+and the consumer-side acceptance bullet covers it.
+
+**Failure semantics.** No `continue-on-error` on the dispatch
+step. A silent dispatch failure means the consumer never learns
+about the new image — the lab would deploy stale revisions
+indefinitely. The fail-loud posture turns rotation issues into
+visible alerts (red workflow run) instead of silent drift. Per
+issue #51 AC #5 the *missing-secret* path skips; the
+*invalid-secret* path fails — the two are intentionally distinct.
+
 ## Known issues
 
 `/ready` returns 503 until every registered probe passes. After Task
@@ -632,6 +709,7 @@ ecosystem catches up to the 1.0.0 format, the constant in
 - Task #32 — Multi-stage Dockerfile finalized + multi-arch buildx (linux/amd64 + linux/arm64); base image digest-pinned
 - Task #33 — GHCR image push workflow (`.github/workflows/image.yml`)
 - Task #34 — Cosign keyless signing of pushed images via GitHub Actions OIDC (per ADR 0006)
+- Task #51 — `repository_dispatch` to claude-rdc-hetzner-dc on main image push (`meho-image-pushed` event)
 - [OCI image-spec annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
 - [Sigstore cosign keyless signing overview](https://docs.sigstore.dev/cosign/signing/overview/)
 - [Sigstore CI quickstart (GitHub Actions OIDC)](https://docs.sigstore.dev/quickstart/quickstart-ci/)

--- a/docs/cross-repo/rke2-infra-coordination.md
+++ b/docs/cross-repo/rke2-infra-coordination.md
@@ -243,15 +243,21 @@ returns `yes`. The Verification section below scripts both checks.
 
 `evoila/meho`'s `main` push image workflow (G2.7-T3, #51) sends a
 `repository_dispatch` event to
-`evoila-bosnia/claude-rdc-hetzner-dc` with:
+`evoila-bosnia/claude-rdc-hetzner-dc` with the shape below. The
+producer-side step lives at the tail of
+[`.github/workflows/image.yml`](../../.github/workflows/image.yml)
+(`Notify claude-rdc-hetzner-dc (repository_dispatch)`); its
+implementation rationale is documented in
+[`docs/codebase/backend.md`](../codebase/backend.md) under
+"Cross-repo deploy trigger (Task #51)".
 
 | Field | Value |
 | --- | --- |
 | `event_type` | `meho-image-pushed` (≤100 chars per GitHub API limit) |
 | `client_payload.image` | `ghcr.io/evoila/meho` |
-| `client_payload.digest` | `sha256:<64-hex>` of the pushed manifest |
-| `client_payload.tag` | The calver-stamped tag (`0.1.YYYYMMDD-<short-sha>`) |
-| `client_payload.commit` | The full 40-char git SHA of `main` |
+| `client_payload.digest` | `sha256:<64-hex>` of the pushed manifest list (immutable; what the consumer pulls) |
+| `client_payload.tag` | The full tag list emitted by `docker/metadata-action`, newline-joined — on a main push this is `ghcr.io/evoila/meho:sha-<long>` and `ghcr.io/evoila/meho:main`. Human-readable cross-reference; the consumer pulls by digest, not by tag |
+| `client_payload.commit` | The full 40-char git SHA of `main` (`${{ github.sha }}`) |
 | `client_payload.ref` | The git ref that was pushed (always `refs/heads/main` for this trigger) |
 
 `client_payload` has a 10-top-level-key + 65535-character total ceiling


### PR DESCRIPTION
## Summary

- Extend `.github/workflows/image.yml` with a final step that fires a `meho-image-pushed` `repository_dispatch` event at `evoila-bosnia/claude-rdc-hetzner-dc` on every main-push image build, so the dogfooding consumer rolls its rke2-infra lab forward without polling GHCR.
- Three-conjunct step gate (`push` event + `refs/heads/main` + `env.RDC_DISPATCH_TOKEN != ''`) — PAT-missing path skips, PAT-invalid path fails-loud; distinguishes graceful rotation from silent drift per AC #5.
- Payload shape (`image`, `digest`, `tag`, `commit`, `ref`) matches the canonical handshake already documented in `docs/cross-repo/rke2-infra-coordination.md`; the `tag` field's description is corrected to reflect what `image.yml` actually emits (metadata-action tag list, not the calver chart tag).
- `docs/codebase/backend.md` gains a "Cross-repo deploy trigger (Task #51)" section covering gate logic, the PAT-vs-GITHUB_TOKEN rationale, the v0.2 GitHub App migration trajectory, and the one-time maintainer setup for `RDC_DISPATCH_TOKEN`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/image.yml'))"` — image.yml parses cleanly
- [x] Pre-commit hooks (`check-yaml`, `gitleaks`, `conventional-pre-commit`, trailing-ws, EOF-fixer) — green on commit
- [x] AC #1 — `Notify claude-rdc-hetzner-dc` step gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`; PR builds and non-main pushes skip the step
- [x] AC #4 — `client_payload` carries `image`, `digest`, `tag`, `commit`, `ref` matching the consumer-side handshake spec
- [x] AC #5 — third `if:` conjunct `env.RDC_DISPATCH_TOKEN != ''` skips (not fails) the step when the secret is unset. Job-level `env:` exposure of the secret follows the documented GitHub Actions pattern (secrets aren't allowed in `if:` directly).
- [ ] AC #2 — `RDC_DISPATCH_TOKEN` secret provisioned on `evoila/meho`: maintainer one-time setup, out of scope for this PR. Verifiable post-merge via `gh secret list --repo evoila/meho | grep RDC_DISPATCH_TOKEN`.
- [ ] AC #3 — first real merge to `main` after the secret is in place: a `meho-image-pushed` event reaches `claude-rdc-hetzner-dc`. Verified post-merge by the consumer side's run-list listener.

## Out of scope

- Provisioning the `RDC_DISPATCH_TOKEN` secret — one-time maintainer action (documented in `docs/codebase/backend.md` "Cross-repo deploy trigger").
- Consumer-side `.github/workflows/meho-deploy.yml` — owned by `evoila-bosnia/claude-rdc-hetzner-dc` per Goal #11 cross-repo deps (tracked via #53).
- Retry/idempotency hardening on the dispatch call — v0.2.
- GitHub App + short-lived installation token migration — v0.2; v0.1 uses a fine-grained PAT and the rotation discipline is tracked on the coordination doc.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cross-repository deployment coordination and event contract documentation.

* **Chores**
  * Enhanced CI/CD workflow to enable automated deployment notifications across repositories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/185)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->