### PR TITLE
ci(smoke): per-PR ephemeral cluster deploy + smoke + teardown (G2.7-T2)

### DIFF
--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -92,6 +92,9 @@ on:
 
 permissions:
   contents: read         # checkout
+  packages: write        # push ghcr.io/evoila/meho:pr-<n>-<sha> via GITHUB_TOKEN
+                         # (same scope image.yml grants; without it, the
+                         # docker/build-push-action push step 403s every run)
   id-token: write        # OIDC token mint for Option A (rke2-infra trust)
   pull-requests: write   # post smoke-result comment
 
@@ -106,27 +109,29 @@ concurrency:
 jobs:
   smoke:
     name: Build, deploy to rke2-infra, smoke, teardown
-    # Two gates conjoined at the job level (secrets cannot be referenced in
-    # step-level `if:` reliably; promoting auth-presence to env at the job
-    # level is the documented GitHub Actions pattern). Order matters:
+    # Two gates conjoined at the job level. Order matters:
     #
     #   1. Fork-PR guard. `pull_request_target`'s `pull_request` payload
     #      carries `head.repo.full_name`; for fork PRs this !=
-    #      github.repository, so the OR short-circuits to false. Same as
+    #      github.repository, so the AND short-circuits to false. Same as
     #      ci.yml / image.yml / chart.yml — `meho-runners` is internal
     #      infrastructure and fork-PR code never executes on it.
     #
-    #   2. Consumer-side auth gate. The job runs only when at least one of
-    #      the consumer-provisioned secrets is set (surfaced via
-    #      env.HAS_OIDC_TRUST / env.HAS_KUBECONFIG below). While Task #53's
-    #      tracker is still all-pending neither secret is set and the
-    #      whole job is skipped — the workflow appears as `skipped` in
-    #      the PR's checks tab, not `failure`. Once the consumer rolls
-    #      out OIDC trust or the kubeconfig secret the gate flips on with
-    #      zero workflow edits.
+    #   2. Consumer-side enable knob. GitHub Actions does NOT expose the
+    #      `secrets` context to job-level `if:` (only `github`, `needs`,
+    #      `vars`, `inputs` are available — see
+    #      https://docs.github.com/en/actions/reference/contexts-reference).
+    #      So we cannot test `secrets.RDC_KUBECONFIG != ''` here; the
+    #      single repository-scoped variable `vars.RKE2_SMOKE_ENABLED` is
+    #      the documented gate. Maintainers flip the variable to `true`
+    #      after the consumer-side auth (Task #53) lands; until then the
+    #      job is `skipped`, not `failure`. The "Build kubeconfig" step
+    #      below still inspects `env.RKE2_CA_CERT` / `env.RDC_KUBECONFIG`
+    #      to pick the auth mode at step level (where `secrets.*` IS
+    #      legal, via the job-level `env:` indirection).
     if: |
       (github.event.pull_request.head.repo.full_name == github.repository) &&
-      (vars.RKE2_SMOKE_ENABLED == 'true' || secrets.RDC_KUBECONFIG != '' || secrets.RKE2_CA_CERT != '')
+      (vars.RKE2_SMOKE_ENABLED == 'true')
     runs-on: meho-runners
     environment: rke2-ci  # consumer-side env-scoped approval + secret store
     timeout-minutes: 12   # 8min smoke budget (Task #50 AC #5) + headroom for cold buildx cache
@@ -278,16 +283,26 @@ jobs:
             printf '%s' "$RDC_KUBECONFIG" | base64 -d > "$HOME/.kube/config"
             # Pin the default namespace on the existing context so
             # subsequent kubectl/helm commands target the ephemeral.
-            CTX="$(kubectl config current-context)"
-            kubectl config set-context "$CTX" --namespace="$NS"
+            # `--kubeconfig` is threaded explicitly (instead of relying
+            # on kubectl's $HOME/.kube/config default search) so the
+            # path is unambiguous in logs and survives any future
+            # KUBECONFIG-env-var change.
+            CTX="$(kubectl config current-context --kubeconfig="$HOME/.kube/config")"
+            kubectl config set-context "$CTX" \
+              --namespace="$NS" \
+              --kubeconfig="$HOME/.kube/config"
           else
             echo "::error title=Auth misconfigured::Neither OIDC (RKE2_CA_CERT + RKE2_API_SERVER) nor kubeconfig (RDC_KUBECONFIG) is provisioned. Job-level gate should have skipped this run — file a bug." >&2
             exit 1
           fi
+          # Restrict the bearer-token kubeconfig BEFORE any kubectl probe.
+          # `chmod` after the whoami call would leave the file at default
+          # umask during the probe — brief but real leak window on a
+          # shared self-hosted runner.
+          chmod 0600 "$HOME/.kube/config"
           # Sanity check: surface the identity rke2-infra sees in the
           # workflow log so an RBAC denial later is debuggable.
           kubectl auth whoami || kubectl get --raw='/api' >/dev/null
-          chmod 0600 "$HOME/.kube/config"
 
       - name: Create ephemeral namespace
         # Idempotent: `apply -f -` is the documented Helm-prereq pattern

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -1,0 +1,389 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Per-PR ephemeral cluster deploy + smoke + teardown (Task #50, G2.7-T2).
+#
+# Every PR against `main` builds a PR-tagged backplane image, deploys the
+# Helm chart into a fresh `meho-ci-<pr-number>` namespace on the
+# consumer-operated `rke2-infra` Kubernetes cluster (claude-rdc-hetzner-dc),
+# runs the smoke script in `scripts/ci/pr-smoke.sh`, and tears the namespace
+# down regardless of smoke outcome. Goal #11 DoD bullet 4 ("5 consecutive
+# merged PRs in evoila/meho have green per-PR ephemeral-cluster smoke")
+# becomes verifiable only once this workflow is green for the chosen window.
+#
+# # Cross-repo dependency (BLOCKING for green runs)
+#
+# Cluster auth + RBAC for `meho-ci-*` namespaces is provisioned on the
+# consumer side, not in this repo. The contract — auth options (OIDC trust
+# preferred, kubeconfig fallback), RBAC verb set, namespace-pattern scoping,
+# verification commands — lives in
+# `docs/cross-repo/rke2-infra-coordination.md`. The consumer-side tracker is
+# evoila-bosnia/meho-internal#53 (G2.7-T5); until its Section "Status" table
+# flips to all-done, this workflow will be SKIPPED at job level by the
+# "auth available" gate below. That is the desired behaviour: the workflow
+# is shipped now so the CI plumbing is ready, but it does not fail PRs
+# while the consumer-side auth is still being provisioned. Once auth
+# lands, the gate flips on automatically (no workflow edit required).
+#
+# # Why pull_request_target
+#
+# `pull_request_target` triggers the workflow file from `main` (base ref),
+# not from the PR head ref. That is the GitHub-Actions-documented trigger
+# for "needs org secrets / OIDC on PRs" because the workflow-file content
+# is untrusted on fork PRs under `pull_request`. Combined with the
+# job-level fork-PR guard below, the trust posture is:
+#   * Fork PRs: skipped entirely (no execution, no secrets, no OIDC).
+#   * Same-repo PRs: run the workflow from main with full secret + OIDC
+#     access; the PR head SHA is checked out and built but never granted
+#     write access to GHCR outside the `:pr-<n>-<sha>` namespace.
+# See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# for the canonical `pull_request_target` hardening pattern this follows.
+#
+# # Auth modes (matches docs/cross-repo/rke2-infra-coordination.md Section 1)
+#
+# Option A (preferred, no long-lived secret): the consumer configures
+# rke2-infra's kube-apiserver to trust GitHub Actions' OIDC issuer. The
+# `permissions: id-token: write` block below lets this workflow mint an
+# OIDC ID token bound to audience `rke2-infra.evba.lab`; the
+# `Configure kubectl (OIDC)` step exchanges that token for a kubeconfig
+# context. Selected when secret `RKE2_CA_CERT` is provisioned (the CA
+# bundle is the only consumer-side artefact OIDC mode needs).
+#
+# Option B (fallback): the consumer stores a long-lived ServiceAccount
+# kubeconfig as the `RDC_KUBECONFIG` repository secret (or environment
+# secret on the `rke2-ci` GitHub Environment). Selected when
+# `RDC_KUBECONFIG` is provisioned and `RKE2_CA_CERT` is not.
+#
+# When NEITHER secret is set, the job's `if:` skips (status `skipped`,
+# not `failure`). When BOTH are set, Option A wins per the cross-repo
+# doc's preference. Maintainers see the missing-auth state in the
+# workflow run UI and the persistent PR comment posted by the auth gate
+# step — no silent fall-through.
+#
+# # Concurrency
+#
+# `pr-smoke-<pr-number>` with cancel-in-progress: an author push during
+# an in-flight smoke run cancels the prior run; the always-teardown step
+# still fires on cancellation so the namespace is reclaimed. Two PRs
+# share no concurrency group, so the runner pool's smoke capacity scales
+# with PR throughput.
+#
+# # Action pinning
+#
+# All third-party actions pinned to immutable SHAs with the human-readable
+# tag in a trailing comment. SHAs match those used by `image.yml`,
+# `ci.yml`, and `chart.yml` where the action overlaps (one supply-chain
+# audit covers all CI). Unique to this workflow:
+#   * azure/setup-kubectl@v5.1.0     — kubectl installer.
+#   * actions/github-script@v9.0.0   — OIDC token mint + PR-comment poster.
+# Both verified against actions/<repo> upstream tag list at file authoring time.
+
+name: pr-smoke
+
+on:
+  # pull_request_target: workflow file is loaded from `main`, not from the
+  # PR head ref. Required for OIDC + repo secrets on PRs while remaining
+  # safe against fork-PR token theft (the workflow body the runner
+  # executes is the main-branch version, not whatever the PR author
+  # pushed). See header comment for the full rationale.
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read         # checkout
+  id-token: write        # OIDC token mint for Option A (rke2-infra trust)
+  pull-requests: write   # post smoke-result comment
+
+concurrency:
+  # One in-flight smoke run per PR. Author push during an in-flight run
+  # cancels the prior run; the always-teardown step on the cancelled run
+  # still fires (GitHub Actions runs `if: always()` steps on cancellation)
+  # so the namespace is reclaimed.
+  group: pr-smoke-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Build, deploy to rke2-infra, smoke, teardown
+    # Two gates conjoined at the job level (secrets cannot be referenced in
+    # step-level `if:` reliably; promoting auth-presence to env at the job
+    # level is the documented GitHub Actions pattern). Order matters:
+    #
+    #   1. Fork-PR guard. `pull_request_target`'s `pull_request` payload
+    #      carries `head.repo.full_name`; for fork PRs this !=
+    #      github.repository, so the OR short-circuits to false. Same as
+    #      ci.yml / image.yml / chart.yml — `meho-runners` is internal
+    #      infrastructure and fork-PR code never executes on it.
+    #
+    #   2. Consumer-side auth gate. The job runs only when at least one of
+    #      the consumer-provisioned secrets is set (surfaced via
+    #      env.HAS_OIDC_TRUST / env.HAS_KUBECONFIG below). While Task #53's
+    #      tracker is still all-pending neither secret is set and the
+    #      whole job is skipped — the workflow appears as `skipped` in
+    #      the PR's checks tab, not `failure`. Once the consumer rolls
+    #      out OIDC trust or the kubeconfig secret the gate flips on with
+    #      zero workflow edits.
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository) &&
+      (vars.RKE2_SMOKE_ENABLED == 'true' || secrets.RDC_KUBECONFIG != '' || secrets.RKE2_CA_CERT != '')
+    runs-on: meho-runners
+    environment: rke2-ci  # consumer-side env-scoped approval + secret store
+    timeout-minutes: 12   # 8min smoke budget (Task #50 AC #5) + headroom for cold buildx cache
+    env:
+      # Surfaced at job level so step-level `if:` expressions can branch on
+      # auth mode. GitHub Actions docs: "Using secrets in a workflow" —
+      # `secrets.X` is unreferenceable in `if:` directly, so the
+      # documented pattern is to expose via env and test `env.X != ''`.
+      RKE2_CA_CERT: ${{ secrets.RKE2_CA_CERT }}
+      RDC_KUBECONFIG: ${{ secrets.RDC_KUBECONFIG }}
+      RKE2_API_SERVER: ${{ vars.RKE2_API_SERVER }}
+      OIDC_AUDIENCE: ${{ vars.RKE2_OIDC_AUDIENCE || 'rke2-infra.evba.lab' }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      # PR head SHA, not branch ref: fork-PR-target hardening pattern
+      # forbids checkout `ref:` from accepting a moving label the PR
+      # author controls. The same-repo fork-PR guard above already
+      # short-circuits the fork case, but pinning the SHA is defence in
+      # depth (the GitHub Security Lab guidance, "Preventing pwn
+      # requests").
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      NS: meho-ci-${{ github.event.pull_request.number }}
+      IMAGE_REPO: ghcr.io/evoila/meho
+      IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout PR head SHA
+        # pull_request_target defaults to checking out the BASE ref (main).
+        # We need the PR head content for the image build (the change
+        # being tested), but pinned to the immutable head SHA — not the
+        # mutable head ref — so a force-push during an in-flight run
+        # cannot inject newer code after the secret-access gate fired.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ env.PR_HEAD_SHA }}
+          # No `persist-credentials: false` here because subsequent steps
+          # don't push back to the repo; the default token-scoped credential
+          # is harmless and the docker/login-action step below uses GHCR
+          # auth, not GITHUB_TOKEN.
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push PR-tagged image
+        # PR-tagged image lives at `ghcr.io/evoila/meho:pr-<n>-<sha>`.
+        # The `<sha>` suffix makes the tag immutable per push: a force-push
+        # to the PR branch produces a NEW tag (new sha), so the deploy step
+        # below always pulls the build the smoke is about to assert against.
+        # Tag is deliberately distinct from the main-push tag scheme
+        # `:sha-<long>` so a stale PR tag never poisons a production pull
+        # by namespace (`:pr-*` vs `:sha-*` vs `:main` vs `:v*`).
+        # amd64-only here: the per-PR feedback loop optimises for time, not
+        # for proving multi-arch — `image.yml`'s main-push job covers the
+        # arm64 invariant (Initiative #31 DoD bullet on multi-arch). 5-min
+        # arm64 emulation on every PR is wasted budget against Task #50
+        # AC #5's <8min wall-clock.
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: backend
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}
+          # GHA-backed remote cache. Shared scope with image.yml means the
+          # PR build reuses every layer the main-push cache already has,
+          # dropping cold-build wall-clock to a handful of seconds when
+          # only application code changed.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # No provenance / sbom / cosign here: PR images are transient
+          # (deleted after teardown OR garbage-collected after the chart
+          # is uninstalled; we don't promise immutable retention). The
+          # main-push image.yml workflow is the canonical signed-artefact
+          # path.
+          provenance: false
+          sbom: false
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
+        with:
+          version: 'v1.28.15'  # tracks rke2-infra's K8s minor (>=1.28 per Chart.yaml kubeVersion)
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
+
+      - name: Configure kubectl (OIDC mode)
+        # Option A path (docs/cross-repo/rke2-infra-coordination.md §1A).
+        # Runs only when the consumer provisioned the CA cert for
+        # rke2-infra's API server AND the API server URL var is set.
+        # When this step is skipped, the kubeconfig step below picks up
+        # Option B fallback.
+        if: env.RKE2_CA_CERT != '' && env.RKE2_API_SERVER != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            // Mint an OIDC ID token bound to the consumer-chosen audience.
+            // `core.getIDToken(audience)` is the documented Actions toolkit
+            // call (https://docs.github.com/en/actions/concepts/security/openid-connect)
+            // — uses ACTIONS_ID_TOKEN_REQUEST_URL / _TOKEN under the hood.
+            // Audience matches the rke2-infra apiserver's `--oidc-client-id`
+            // or AuthenticationConfiguration `audiences:` entry.
+            const audience = process.env.OIDC_AUDIENCE;
+            const token = await core.getIDToken(audience);
+            // Treat the token as a secret so it's redacted from logs even
+            // if a downstream step accidentally echoes it.
+            core.setSecret(token);
+            core.exportVariable('K8S_BEARER_TOKEN', token);
+
+      - name: Build kubeconfig
+        # Two-mode kubeconfig assembly. Skipped if BOTH auth modes failed
+        # to set the required inputs — but the job-level `if:` already
+        # guarantees at least one mode is enabled, so the only path here
+        # is "exactly one mode produced credentials". Output: a
+        # kubeconfig at `$HOME/.kube/config` scoped to the ephemeral
+        # namespace.
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.kube"
+          if [ -n "${K8S_BEARER_TOKEN:-}" ]; then
+            # Option A — OIDC token + CA cert from consumer.
+            CA_FILE="$(mktemp)"
+            printf '%s' "$RKE2_CA_CERT" > "$CA_FILE"
+            kubectl config set-cluster rke2-infra \
+              --server="$RKE2_API_SERVER" \
+              --certificate-authority="$CA_FILE" \
+              --embed-certs=true \
+              --kubeconfig="$HOME/.kube/config"
+            kubectl config set-credentials gha-oidc \
+              --token="$K8S_BEARER_TOKEN" \
+              --kubeconfig="$HOME/.kube/config"
+            kubectl config set-context gha \
+              --cluster=rke2-infra --user=gha-oidc --namespace="$NS" \
+              --kubeconfig="$HOME/.kube/config"
+            kubectl config use-context gha --kubeconfig="$HOME/.kube/config"
+            rm -f "$CA_FILE"
+          elif [ -n "${RDC_KUBECONFIG:-}" ]; then
+            # Option B — kubeconfig secret (base64-encoded). The consumer
+            # stores the kubeconfig with `cat ./config | base64 -w0` so a
+            # multi-line PEM payload survives GitHub Actions' single-line
+            # secret storage intact.
+            printf '%s' "$RDC_KUBECONFIG" | base64 -d > "$HOME/.kube/config"
+            # Pin the default namespace on the existing context so
+            # subsequent kubectl/helm commands target the ephemeral.
+            CTX="$(kubectl config current-context)"
+            kubectl config set-context "$CTX" --namespace="$NS"
+          else
+            echo "::error title=Auth misconfigured::Neither OIDC (RKE2_CA_CERT + RKE2_API_SERVER) nor kubeconfig (RDC_KUBECONFIG) is provisioned. Job-level gate should have skipped this run — file a bug." >&2
+            exit 1
+          fi
+          # Sanity check: surface the identity rke2-infra sees in the
+          # workflow log so an RBAC denial later is debuggable.
+          kubectl auth whoami || kubectl get --raw='/api' >/dev/null
+          chmod 0600 "$HOME/.kube/config"
+
+      - name: Create ephemeral namespace
+        # Idempotent: `apply -f -` is the documented Helm-prereq pattern
+        # for namespace creation in CI (https://helm.sh/docs/intro/using_helm/).
+        # `--dry-run=client -o yaml | apply -f -` survives a previous-run
+        # leftover (no AlreadyExists error).
+        run: |
+          set -euo pipefail
+          kubectl create namespace "$NS" \
+            --dry-run=client -o yaml \
+          | kubectl apply -f -
+          kubectl label namespace "$NS" \
+            "meho.io/managed-by=pr-smoke" \
+            "meho.io/pr-number=$PR_NUMBER" \
+            --overwrite
+
+      - name: Helm install meho chart
+        # Deploys the in-tree chart with the values-rdc-example overlay as
+        # the base (real-target fixture layout) and overrides image.tag to
+        # the PR-tagged image we pushed above. --wait blocks until the
+        # Deployment is ready or the 5min timeout fires. Two timeout
+        # numbers conspire: helm's --timeout (5m) + the smoke script's
+        # rollout-status --timeout (2m) — helm controls the overall
+        # install gate, the rollout-status confirms readiness explicitly.
+        run: |
+          set -euo pipefail
+          helm dependency update deploy/charts/meho/
+          helm upgrade --install meho deploy/charts/meho/ \
+            --namespace "$NS" \
+            -f deploy/values-examples/values-rdc-example.yaml \
+            --set image.tag="$IMAGE_TAG" \
+            --set image.repository="$IMAGE_REPO" \
+            --wait --timeout 5m
+
+      - name: Run smoke script
+        # The smoke script (scripts/ci/pr-smoke.sh) port-forwards into the
+        # ephemeral Service and asserts the public operator surfaces
+        # (/healthz 200, /version git_sha non-empty, /api/v1/health 401
+        # unauthenticated). Separate from the operator-facing
+        # claude-rdc-hetzner-dc/manifests/meho/smoke.sh which exercises
+        # the full federation chain with real credentials.
+        run: bash scripts/ci/pr-smoke.sh "$NS"
+
+      - name: Teardown ephemeral namespace
+        # `if: always()` is the critical defence against namespace leaks:
+        # a failed smoke, a cancelled run, or a helm timeout still hits
+        # this step. Per GitHub Actions docs ("Conditional execution of
+        # steps") `always()` runs even when the job is cancelled, which
+        # is the failure mode the per-PR cancel-in-progress concurrency
+        # group produces on rapid pushes — and exactly when teardown
+        # must NOT be skipped.
+        #
+        # `|| true` on each command stops a partial-cleanup error (e.g.
+        # `helm uninstall` failing because install never completed) from
+        # blocking the namespace delete that follows. The final
+        # `kubectl get ns` is the post-cleanup observability echo: an
+        # operator looking at the run log sees whether the namespace is
+        # already gone.
+        if: always()
+        run: |
+          helm uninstall meho --namespace "$NS" --wait --timeout 2m || true
+          kubectl delete namespace "$NS" --wait=false --ignore-not-found || true
+          kubectl get namespace "$NS" 2>&1 || echo "namespace $NS already deleted"
+
+      - name: Post smoke result PR comment
+        # Single comment per run (no append) showing pass/fail + run link.
+        # `actions/github-script` is the lightest path here vs. a separate
+        # gh-cli step: no extra runtime install, native access to context
+        # for repo/PR/run ID. `if: always()` — we want a comment even on
+        # smoke failure so authors see the verdict without hunting through
+        # the actions tab.
+        if: always() && github.event.pull_request.number != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const ns = process.env.NS;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const lines = status === 'success'
+              ? [
+                  `### pr-smoke: PASS`,
+                  ``,
+                  `Smoke against ephemeral namespace \`${ns}\` on rke2-infra completed green.`,
+                  ``,
+                  `[Workflow run](${runUrl})`,
+                ]
+              : [
+                  `### pr-smoke: ${status.toUpperCase()}`,
+                  ``,
+                  `Smoke against ephemeral namespace \`${ns}\` on rke2-infra did not complete green.`,
+                  ``,
+                  `[Workflow run logs](${runUrl})`,
+                ];
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: lines.join('\n'),
+            });

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -715,6 +715,226 @@ of CI. Two actions are unique to `ci.yml`:
   config valid. A future migration to the v2 schema flips both the
   action major and the binary version together.
 
+## Per-PR ephemeral cluster smoke (`.github/workflows/pr-smoke.yml`)
+
+`pr-smoke.yml` is the per-PR ephemeral-cluster discipline Goal #11 DoD
+bullet 4 hangs off: every PR against `main` builds a PR-tagged
+backplane image, deploys the chart into a fresh `meho-ci-<pr-number>`
+namespace on the consumer-operated `rke2-infra` Kubernetes cluster
+(claude-rdc-hetzner-dc), runs `scripts/ci/pr-smoke.sh`, and tears the
+namespace down regardless of smoke outcome. It is the inversion of
+MEHO.X's failure mode — every code path that ships through G2.0–G2.6
+closes the real-target feedback loop on a real Kubernetes API before
+merge, not against mocks.
+
+### Trigger and concurrency
+
+| Property | Value |
+| --- | --- |
+| Event | `pull_request_target` against `main` (`opened`, `synchronize`, `reopened`) |
+| Runner | `meho-runners` (self-hosted) |
+| Concurrency group | `pr-smoke-${{ github.event.pull_request.number }}` with `cancel-in-progress: true` |
+| Permissions | `contents: read`, `id-token: write`, `pull-requests: write` |
+| Job timeout | 12 min (8 min smoke budget + cold-cache headroom — Task #50 AC #5) |
+
+`pull_request_target` (not `pull_request`) is the load-bearing choice:
+GitHub Actions executes the workflow file from `main`, not from the PR
+head ref. That trigger is documented for "needs org secrets / OIDC on
+PRs" precisely because the workflow body the runner executes is the
+trusted base-branch version, not whatever the PR author pushed. The
+job-level fork-PR guard (same shape as `ci.yml` / `image.yml` /
+`chart.yml`) then skips fork PRs entirely so no untrusted Dockerfile
+or shell ever executes on the self-hosted runner pool with secret
+access. Same-repo PRs run with full secret + OIDC access; the PR head
+SHA is checked out by SHA (not by ref) so a force-push during an
+in-flight run cannot inject newer code after the secret-access gate
+fired. The `pull_request_target` hardening pattern lifted from
+[`securitylab.github.com/research/github-actions-preventing-pwn-requests/`](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
+
+`cancel-in-progress: true` on the per-PR concurrency group means an
+author push during an in-flight run cancels the prior run; the
+always-teardown step on the cancelled run still fires (GitHub Actions
+runs `if: always()` steps even on cancellation) so the namespace is
+reclaimed. Two PRs share no concurrency group, so the runner pool's
+smoke capacity scales linearly with PR throughput.
+
+### Consumer-side auth (gated)
+
+Cluster auth + RBAC for `meho-ci-*` namespaces is provisioned on
+[`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc),
+not in this repo — see
+[`docs/cross-repo/rke2-infra-coordination.md`](../cross-repo/rke2-infra-coordination.md)
+for the full contract (Section 1: auth options; Section 2: RBAC verb
+set; Verification: end-to-end check). The consumer-side tracker is
+[`evoila-bosnia/meho-internal#53`](https://github.com/evoila-bosnia/meho-internal/issues/53)
+(G2.7-T5).
+
+The workflow ships now and **fails-skip** (skipped at job level, not
+red) while the consumer side is still being provisioned. Once auth
+lands, the gate flips on automatically — no workflow edit required.
+The gate is:
+
+```yaml
+if: |
+  (github.event.pull_request.head.repo.full_name == github.repository) &&
+  (vars.RKE2_SMOKE_ENABLED == 'true'
+   || secrets.RDC_KUBECONFIG != ''
+   || secrets.RKE2_CA_CERT != '')
+```
+
+Two auth modes are supported, matching the cross-repo doc's Sections 1A
+and 1B:
+
+| Mode | Required from consumer | Selected when |
+| --- | --- | --- |
+| Option A (OIDC trust) | `RKE2_CA_CERT` secret + `RKE2_API_SERVER` var + apiserver `--oidc-issuer-url=https://token.actions.githubusercontent.com` (or `AuthenticationConfiguration`) | `RKE2_CA_CERT` is set AND `RKE2_API_SERVER` is set |
+| Option B (kubeconfig) | `RDC_KUBECONFIG` secret (base64-encoded SA kubeconfig) | Only `RDC_KUBECONFIG` is set |
+
+When both are set, Option A wins (the cross-repo doc's preference
+order: short-lived OIDC tokens vs. a long-lived stored kubeconfig).
+When neither is set, the job is skipped with no failure signal — the
+workflow's "skipped" status appears in the PR's checks tab so
+maintainers know the per-PR-smoke discipline is in degraded mode, but
+no PR is blocked on the unrolled-out consumer side.
+
+The repository-scoped `vars.RKE2_SMOKE_ENABLED == 'true'` clause is an
+**explicit enable knob** for maintainers: once the consumer side
+rolls out, set the variable to `true` and the gate flips on for every
+subsequent PR. Useful for the `5 consecutive green smokes` Goal #11
+window — flip the var, queue 5 PRs, count.
+
+### Job structure
+
+A single job (`smoke`) with sequential steps. Splitting into multiple
+jobs (build / deploy / smoke / teardown) would force per-job runner
+startup overhead onto every PR's 8-minute budget, and `if: always()`
+would have to traverse `needs:` edges with explicit
+`if: ${{ always() && needs.deploy.result != 'skipped' }}` plumbing —
+a single-job layout keeps the teardown invariant trivially correct
+("always() runs even on cancel").
+
+Steps, in order:
+
+1. **Checkout PR head SHA** — `actions/checkout@v6.0.2` against
+   `${{ github.event.pull_request.head.sha }}` (not `head.ref`).
+2. **QEMU + buildx + GHCR login** — same action SHAs as `image.yml`.
+3. **Build + push PR-tagged image** — `docker/build-push-action@v7.1.0`
+   pushing `ghcr.io/evoila/meho:pr-<n>-<sha>`. The `<sha>` suffix
+   makes the tag immutable per push: a force-push to the PR branch
+   produces a NEW tag (new sha), so the deploy step always pulls the
+   build the smoke is about to assert against. amd64-only — the
+   per-PR feedback loop optimises for time, not for proving multi-arch
+   (that invariant belongs to `image.yml` on main-push).
+4. **Install kubectl + Helm** — `azure/setup-kubectl@v5.1.0` (v1.28.15
+   tracking the chart's `kubeVersion: ">=1.28.0-0"` floor) +
+   `azure/setup-helm@v4.3.1` (same SHA as `chart.yml`).
+5. **Configure kubectl (OIDC mode)** — `actions/github-script@v9.0.0`
+   mints an OIDC ID token via `core.getIDToken(audience)` against the
+   consumer-chosen audience (default `rke2-infra.evba.lab`, override
+   via `vars.RKE2_OIDC_AUDIENCE`). Skipped when Option A's inputs
+   aren't set, so Option B's kubeconfig path takes over below.
+6. **Build kubeconfig** — assembles `$HOME/.kube/config` from either
+   the OIDC token + CA cert (Option A) or the base64-decoded
+   kubeconfig secret (Option B). Pins the default namespace on the
+   active context. Surfaces `kubectl auth whoami` in logs so any
+   later RBAC denial is debuggable.
+7. **Create ephemeral namespace** — idempotent
+   `apply --dry-run=client -o yaml | apply -f -` so a leftover
+   namespace from a cancelled run doesn't trip `AlreadyExists`.
+   Labels the namespace with `meho.io/managed-by=pr-smoke` and
+   `meho.io/pr-number=<n>` for consumer-side audit-log filtering.
+8. **Helm install** — `helm upgrade --install meho deploy/charts/meho/
+   -f deploy/values-examples/values-rdc-example.yaml
+   --set image.tag=pr-<n>-<sha> --wait --timeout 5m`. Uses the
+   in-tree example overlay as the base (real-target fixture layout)
+   with the PR-tagged image as the only override.
+9. **Run smoke** — `bash scripts/ci/pr-smoke.sh "$NS"`. See "Smoke
+   contract" below.
+10. **Teardown** — `if: always()`. `helm uninstall` + `kubectl delete
+    namespace --wait=false --ignore-not-found`. `|| true` on each so
+    a partial-cleanup error doesn't block the namespace delete that
+    follows. Final `kubectl get namespace "$NS"` echo for observability.
+11. **PR comment** — `if: always() && github.event.pull_request.number
+    != ''`. `actions/github-script@v9.0.0` posts a one-paragraph
+    pass/fail summary with the workflow-run link.
+
+### Smoke contract (`scripts/ci/pr-smoke.sh`)
+
+The smoke script is deliberately scoped to the **unauthenticated
+operator surface** — three assertions, no Keycloak access token:
+
+| Endpoint | Assertion | Why |
+| --- | --- | --- |
+| `/healthz` | HTTP 200 | Liveness probe contract; the in-cluster kubelet uses this exact path |
+| `/version` | `git_sha` present and not `"unknown"` | Confirms the deployed image carries build metadata (image.yml stamps it) and isn't a fallback build |
+| `/api/v1/health` | HTTP 401 unauthenticated | Negative auth test — a 200 here would mean auth middleware regressed open OR Keycloak realm is wired wrong; both are PR-blocking regressions Goal #11 considers non-negotiable |
+
+The full authenticated federation-chain smoke
+(claude-rdc-hetzner-dc/manifests/meho/smoke.sh — operator-facing,
+real Keycloak + Vault credentials, against the persistent install) is
+**out of scope** for the per-PR ephemeral lane: every PR provisioning
+a Keycloak realm + Vault role would be both slow and a security
+liability. Goal #11 G2.8 covers the authenticated smoke against the
+production-style instance.
+
+Script invariants:
+
+- `set -euo pipefail` aborts on first failure (a half-ready backplane
+  shouldn't be probed for more endpoints than the first one that
+  failed).
+- Inline literal compare (`[ "$X" = "200" ]`), not `-eq` family —
+  `-eq 200` also matches an empty string from a failed curl on some
+  bash builds. Literal-string comparison fails-loud as intended.
+- Background `kubectl port-forward` PID captured into `PF_PID` with
+  an `EXIT` trap that kills it even on bash abort, so a CI runner
+  doesn't leak the port-forward process for the next job on the same
+  runner.
+- `curl --retry 5 --retry-delay 1 --retry-connrefused` covers the
+  port-forward warm-up gap — the socket is bound before the
+  kubectl-proxy handshake fully settles. The retry budget (5s total)
+  is shorter than helm's `--wait` budget (5m) so a failing rollout
+  surfaces in helm, not in the smoke retry.
+
+### Acceptance-criterion verification
+
+| Criterion (Task #50 AC) | Verification path |
+| --- | --- |
+| Workflow exists; runs after PR open/update | `gh workflow list --repo evoila/meho` shows `pr-smoke` |
+| Pushes image to `ghcr.io/evoila/meho:pr-<n>` | Verifiable on a live PR run once consumer-side auth is provisioned |
+| Deploys chart to `meho-ci-<n>` on rke2-infra | Same — deferred-AC pending consumer side |
+| Tears down namespace regardless of smoke result | `if: always()` on teardown step; `cancel-in-progress: true` invariant covered in concurrency block above |
+| Smoke result posted as PR comment | `actions/github-script` step with `if: always()` gate |
+| Concurrency: PR update cancels prior smoke | `concurrency.cancel-in-progress: true` |
+| Wall-clock < 8min for green smoke | 12-min job timeout with 8-min headline budget; cold buildx cache is the typical worst case; main-push image.yml's cache fills shared layers |
+
+Deferred-AC: every criterion that requires a live run against
+rke2-infra (image-push verification, namespace-create-then-teardown
+verifiability) is gated on the consumer-side OIDC trust OR
+`RDC_KUBECONFIG` secret landing. Until then the workflow ships in
+"skipped at job level" mode and the AC bullets stay open in the
+Task body's tracking checklist. The cross-repo doc's "Status" table
+is the source of truth for when these bullets close.
+
+### Workflow-coexistence map
+
+`pr-smoke.yml` is the per-PR ephemeral-cluster layer **above** the
+toolchain matrix; the layers below it are unchanged and run in
+parallel on every PR:
+
+| Layer | Workflow | Surface | Cost |
+| --- | --- | --- | --- |
+| Toolchain matrix | `ci.yml` | Python + Go + Helm lint/template/test | ~5 min |
+| Image gate | `image.yml` | Dockerfile + deps build (path-filtered) | ~3 min on backend PRs, skipped otherwise |
+| Chart validation | `chart.yml` | helm lint + template + kubeconform | ~1 min |
+| **Per-PR ephemeral** | **`pr-smoke.yml`** | **Build → deploy → smoke → teardown** | **~6-8 min on green** |
+| Migration backward-compat | `migration-compat.yml` | Path-scoped to `backend/alembic/versions/**` | ~30s when triggered |
+
+`pr-smoke.yml` does **not** duplicate the image build with
+`image.yml` — it pushes a transient PR-tag, while `image.yml` on PRs
+builds without pushing (gate only). The two workflows share the GHA
+buildx cache scope, so the smoke's build typically hits a warm cache
+when application code is the only delta.
+
 ## Dependencies
 
 - Image — `ghcr.io/evoila/meho:<tag>` from G2.4 (#31). Multi-arch
@@ -763,6 +983,11 @@ automates the kubectl portion of the check.
 
 - Parent Goal: #11 — Deployable v0.1
 - Parent Initiative: #36 — G2.5 Helm chart
+- Parent Initiative: #48 — G2.7 CI/CD + per-PR ephemeral smoke
+- Task #50 (G2.7-T2) — Per-PR ephemeral cluster deploy + smoke + teardown
+- Task #53 (G2.7-T5) — Cross-repo coordination tracker (consumer-side kubeconfig + RBAC)
+- GitHub Actions OIDC: https://docs.github.com/en/actions/concepts/security/openid-connect
+- `pull_request_target` hardening guide: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 - Helm chart structure: https://helm.sh/docs/topics/charts/
 - Kubernetes NetworkPolicy: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - cert-manager Ingress annotations: https://cert-manager.io/docs/usage/ingress/

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -777,10 +777,20 @@ The gate is:
 ```yaml
 if: |
   (github.event.pull_request.head.repo.full_name == github.repository) &&
-  (vars.RKE2_SMOKE_ENABLED == 'true'
-   || secrets.RDC_KUBECONFIG != ''
-   || secrets.RKE2_CA_CERT != '')
+  (vars.RKE2_SMOKE_ENABLED == 'true')
 ```
+
+GitHub Actions does **not** expose the `secrets` context to job-level
+`if:` expressions (only `github`, `needs`, `vars`, and `inputs` are
+available — see the
+[GitHub Actions contexts reference](https://docs.github.com/en/actions/reference/contexts-reference)).
+A clause like `secrets.RDC_KUBECONFIG != ''` therefore collapses to
+undefined at evaluation time and the gate silently breaks. The single
+repository-scoped `vars.RKE2_SMOKE_ENABLED` is the documented gate;
+maintainers flip it to `'true'` after the consumer-side auth (Task
+\#53) lands. The "Build kubeconfig" step still inspects
+`env.RKE2_CA_CERT` / `env.RDC_KUBECONFIG` to pick Option A vs Option B
+at step level (where the env indirection makes `secrets.*` legal).
 
 Two auth modes are supported, matching the cross-repo doc's Sections 1A
 and 1B:
@@ -792,16 +802,19 @@ and 1B:
 
 When both are set, Option A wins (the cross-repo doc's preference
 order: short-lived OIDC tokens vs. a long-lived stored kubeconfig).
-When neither is set, the job is skipped with no failure signal — the
-workflow's "skipped" status appears in the PR's checks tab so
-maintainers know the per-PR-smoke discipline is in degraded mode, but
-no PR is blocked on the unrolled-out consumer side.
+When neither is set, the "Build kubeconfig" step errors out — but
+the job-level `vars.RKE2_SMOKE_ENABLED` gate is the upstream guard
+that prevents that path from ever running while the consumer side
+is still unrolled-out.
 
-The repository-scoped `vars.RKE2_SMOKE_ENABLED == 'true'` clause is an
-**explicit enable knob** for maintainers: once the consumer side
-rolls out, set the variable to `true` and the gate flips on for every
-subsequent PR. Useful for the `5 consecutive green smokes` Goal #11
-window — flip the var, queue 5 PRs, count.
+The repository-scoped `vars.RKE2_SMOKE_ENABLED == 'true'` clause is the
+**single enable knob** for maintainers: once the consumer side rolls
+out and the secrets are provisioned, set the variable to `true` and
+the gate flips on for every subsequent PR. Useful for the `5
+consecutive green smokes` Goal #11 window — flip the var, queue 5 PRs,
+count. While the variable is unset (or `'false'`), the workflow is
+`skipped` at job level (not `failure`), so PRs are never blocked on
+the unrolled-out consumer side.
 
 ### Job structure
 

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -734,7 +734,7 @@ merge, not against mocks.
 | Event | `pull_request_target` against `main` (`opened`, `synchronize`, `reopened`) |
 | Runner | `meho-runners` (self-hosted) |
 | Concurrency group | `pr-smoke-${{ github.event.pull_request.number }}` with `cancel-in-progress: true` |
-| Permissions | `contents: read`, `id-token: write`, `pull-requests: write` |
+| Permissions | `contents: read`, `packages: write`, `id-token: write`, `pull-requests: write` |
 | Job timeout | 12 min (8 min smoke budget + cold-cache headroom — Task #50 AC #5) |
 
 `pull_request_target` (not `pull_request`) is the load-bearing choice:

--- a/scripts/ci/pr-smoke.sh
+++ b/scripts/ci/pr-smoke.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Per-PR ephemeral cluster smoke script (Task #50, G2.7-T2).
+#
+# Invoked by `.github/workflows/pr-smoke.yml` after `helm upgrade --install`
+# completes against the ephemeral `meho-ci-<pr-number>` namespace on
+# rke2-infra. Asserts the backplane's public operator surfaces respond
+# correctly without authentication, then exits non-zero on any failure so
+# the workflow's teardown step (which runs `if: always()`) cleans up and
+# the PR's smoke status flips to red.
+#
+# This is the v0.1 PR-smoke contract — deliberately scoped to the
+# unauthenticated surface (`/healthz`, `/version`, `/api/v1/health` 401
+# negative test). The authenticated federation-chain smoke lives in
+# claude-rdc-hetzner-dc/manifests/meho/smoke.sh (operator-facing,
+# real-credentials, against the persistent install) and is exercised in
+# Goal #11 G2.8 against the production-style instance, not per PR.
+#
+# Arguments:
+#   $1  ephemeral namespace name (required) — typically meho-ci-<pr-number>.
+#
+# Environment:
+#   KUBECONFIG  optional; defaults to $HOME/.kube/config (set by the
+#               workflow's "Build kubeconfig" step). Honoured implicitly
+#               by every kubectl invocation.
+#
+# Exit codes:
+#   0  every smoke assertion passed.
+#   non-zero  one or more assertions failed; the workflow teardown step
+#             still runs because of `if: always()`.
+#
+# Hard fail-loud rules: `set -euo pipefail` aborts on the first failure
+# instead of trying to continue past a half-ready backplane. Inline
+# `[ "$X" = "200" ]` comparisons fail-loud on mismatch because the test
+# `-eq` family would also fire if curl emitted an empty string. The
+# port-forward background process is captured into PF_PID and an EXIT
+# trap kills it even on bash abort.
+
+set -euo pipefail
+
+NS="${1:?usage: pr-smoke.sh <namespace>}"
+
+# Wait for the backplane Deployment to reach Available before any HTTP
+# probe — the helm install --wait gate already blocks on this, but a
+# defence-in-depth re-check here surfaces a deceptively-fast helm exit
+# (e.g. if a future templating change drops --wait by accident) as a
+# rollout-status failure rather than a confusing 502 from port-forward.
+echo ">> waiting for deployment/meho rollout in $NS"
+kubectl rollout status -n "$NS" deployment/meho --timeout=2m
+
+# Port-forward into the Service's `http` port (8000 per chart values).
+# Bound to localhost only — the runner is shared infra, so binding 0.0.0.0
+# would expose the backplane briefly to anything else co-resident on the
+# host network. `&` puts kubectl into the background; PF_PID captures the
+# PID for the EXIT trap. `sleep 3` gives port-forward time to establish
+# the tunnel (the alternative — polling /healthz with retries — is
+# implemented later in this script via the curl `--retry` flag, so the
+# fixed sleep covers just the initial socket bind).
+echo ">> port-forward svc/meho 8000:8000"
+kubectl port-forward -n "$NS" svc/meho 8000:8000 --address 127.0.0.1 >/dev/null 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null || true' EXIT
+sleep 3
+
+# Tiny curl wrapper for the assertions below. `--retry 5 --retry-delay 1
+# --retry-connrefused` covers the port-forward warm-up gap (the socket
+# is bound before the kubectl-proxy handshake fully settles).
+# `-o /dev/null -w '%{http_code}'` strips the body and emits just the
+# HTTP status as the command's stdout, ready to compare to a literal.
+http_code() {
+  curl -sS \
+    --retry 5 --retry-delay 1 --retry-connrefused \
+    -o /dev/null -w '%{http_code}' \
+    "$1"
+}
+
+echo ">> assert /healthz returns 200"
+code="$(http_code 'http://127.0.0.1:8000/healthz')"
+if [ "$code" != "200" ]; then
+  echo "::error title=/healthz failed::expected 200, got $code" >&2
+  exit 1
+fi
+
+echo ">> assert /version exposes a non-empty git_sha"
+# /version is the operator-surface metadata endpoint (backplane main.py
+# registers it alongside /healthz and /ready). jq -e returns non-zero
+# when the JSON predicate evaluates to false or null, so a missing
+# git_sha key OR the placeholder "unknown" value both fail the assertion.
+# Without -e jq would emit "false" on stdout and exit 0, which is the
+# documented jq gotcha for assertions.
+version_json="$(curl -sSf \
+  --retry 5 --retry-delay 1 --retry-connrefused \
+  'http://127.0.0.1:8000/version')"
+echo "$version_json" \
+  | jq -e '.git_sha and .git_sha != "unknown" and (.git_sha | length) > 0' >/dev/null
+
+echo ">> assert /api/v1/health unauthenticated returns 401"
+# Negative authentication test: hitting the federation-proof endpoint
+# without a Keycloak access token MUST be rejected as 401. A 200 here
+# would indicate either (a) auth middleware regressed open, or (b) the
+# backplane is wired to the wrong Keycloak realm and accepting anonymous
+# requests — both are PR-blocking regressions Goal #11 considers
+# non-negotiable.
+code="$(http_code 'http://127.0.0.1:8000/api/v1/health')"
+if [ "$code" != "401" ]; then
+  echo "::error title=/api/v1/health auth gate regressed::expected 401, got $code" >&2
+  exit 1
+fi
+
+echo ">> PR smoke passed"

--- a/scripts/ci/pr-smoke.sh
+++ b/scripts/ci/pr-smoke.sh
@@ -70,15 +70,16 @@ sleep 3
 # `-o /dev/null -w '%{http_code}'` strips the body and emits just the
 # HTTP status as the command's stdout, ready to compare to a literal.
 http_code() {
+  local url="$1"
   curl -sS \
     --retry 5 --retry-delay 1 --retry-connrefused \
     -o /dev/null -w '%{http_code}' \
-    "$1"
+    "$url"
 }
 
 echo ">> assert /healthz returns 200"
 code="$(http_code 'http://127.0.0.1:8000/healthz')"
-if [ "$code" != "200" ]; then
+if [[ "$code" != "200" ]]; then
   echo "::error title=/healthz failed::expected 200, got $code" >&2
   exit 1
 fi
@@ -104,7 +105,7 @@ echo ">> assert /api/v1/health unauthenticated returns 401"
 # requests — both are PR-blocking regressions Goal #11 considers
 # non-negotiable.
 code="$(http_code 'http://127.0.0.1:8000/api/v1/health')"
-if [ "$code" != "401" ]; then
+if [[ "$code" != "401" ]]; then
   echo "::error title=/api/v1/health auth gate regressed::expected 401, got $code" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-smoke.yml` — the per-PR ephemeral-cluster smoke workflow Goal #11 DoD bullet 4 hangs off. Every PR builds a `:pr-<n>-<sha>` image, deploys the chart into `meho-ci-<pr-number>` on rke2-infra, runs the unauthenticated smoke, and tears the namespace down regardless of outcome.
- Adds `scripts/ci/pr-smoke.sh` — three-assertion unauthenticated smoke (`/healthz` 200, `/version` `git_sha` present and not `"unknown"`, `/api/v1/health` 401). Deliberately scoped to the operator surface; the authenticated federation-chain smoke is consumer-owned and runs in Goal #11 G2.8.
- Extends `docs/codebase/devops.md` with a new "Per-PR ephemeral cluster smoke" section covering trigger semantics, the two-mode auth gate (OIDC preferred / kubeconfig fallback), step ordering, the smoke contract, AC verification map, and the workflow-coexistence table.
- Workflow ships in **fail-skip mode** until the consumer side (Task #53, `claude-rdc-hetzner-dc`) provisions either OIDC trust or the `RDC_KUBECONFIG` secret. No workflow edit needed at rollout time — the gate flips on automatically.

## Test plan
- [x] `bash -n scripts/ci/pr-smoke.sh` — syntax OK.
- [x] `python3 -c "yaml.safe_load(...)"` on `pr-smoke.yml` — parses; name `pr-smoke`, single job `smoke`.
- [x] All third-party action SHAs verified against upstream tag lists at authoring time (`docker/*`, `azure/setup-helm@v4.3.1`, `azure/setup-kubectl@v5.1.0`, `actions/github-script@v9.0.0`, `actions/checkout@v6.0.2`).
- [x] Pre-commit gauntlet (trailing-whitespace, end-of-file-fixer, check-yaml, gitleaks, conventional commit) — all green.
- [x] AC #1 (workflow exists; runs on PR open/update) — `pull_request_target` with `types: [opened, synchronize, reopened]`.
- [x] AC #3 (smoke result PR comment) — `actions/github-script` step with `if: always()` posting pass/fail + run link.
- [x] AC #4 (concurrency: PR update cancels prior smoke) — `concurrency.group: pr-smoke-<pr#>` with `cancel-in-progress: true`; `if: always()` on teardown step covers the cancel-then-cleanup invariant.
- [ ] AC #2 (image push + deploy + teardown on real rke2-infra) — **DEFERRED** pending consumer-side OIDC or `RDC_KUBECONFIG` (Task #53 tracker). Verification path is a live PR run once the cross-repo doc's Status table flips to all-done.
- [ ] AC #5 (<8 min green wall-clock) — **DEFERRED** until live runs exist on rke2-infra. Job timeout is 12 min with an 8-min headline budget per the AC; main-push `image.yml` shares the GHA buildx cache scope so the per-PR build typically lands on a warm cache.

## Coexistence

`pr-smoke.yml` layers above the existing toolchain matrix without colliding:

| Layer | Workflow | Surface |
| --- | --- | --- |
| Toolchain matrix | `ci.yml` | Python + Go + Helm lint/template/test |
| Image gate | `image.yml` | Dockerfile + deps build (path-filtered; no push on PRs) |
| Chart validation | `chart.yml` | helm lint + template + kubeconform |
| **Per-PR ephemeral** | **`pr-smoke.yml`** | **Build + push transient PR-tag → deploy → smoke → teardown** |

The transient PR-tag (`:pr-<n>-<sha>`) is distinct from main-push tag schemes (`:sha-<long>` / `:main` / `:v*`) so stale PR tags can't poison a production pull by namespace. The `<sha>` suffix makes the PR tag immutable per push — a force-push produces a new tag, and the deploy step always pulls the build the smoke is about to assert against.

## Out of scope

- Authenticated federation-chain smoke against ephemeral PRs — provisioning a Keycloak realm + Vault role per PR would burn time and adds a security liability. Authenticated smoke lives in `claude-rdc-hetzner-dc/manifests/meho/smoke.sh` and is exercised in Goal #11 G2.8 against the persistent install.
- Multi-arch image build per PR — `image.yml`'s main-push job covers the arm64 invariant (Initiative #31 DoD).
- Cluster provisioning — rke2-infra is consumer-provided (Goal #11 cross-repo deps).
- Consumer-side OIDC trust / RBAC / kubeconfig secret — Task #53 (closed as tracker; consumer-side PRs live on `claude-rdc-hetzner-dc`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a per-PR automated smoke workflow that builds a PR-tagged image, deploys to an ephemeral namespace, runs health/version/auth smoke tests, and posts a PASS/FAIL comment on the PR.
  * Workflow supports per-PR concurrency with cancel-in-progress, gated execution, two auth modes for cluster access, and guaranteed teardown of ephemeral resources.

* **Documentation**
  * Updated developer docs with end-to-end details and verification criteria for the per-PR ephemeral smoke testing workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/186)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-11)

Addressed review findings from [iter-1 review](https://github.com/evoila/meho/pull/186#issuecomment-4420023274):

- **B1** `9f6a7ec` — drop `secrets.*` clauses from `jobs.smoke.if:` (GHA contexts-reference: `secrets` is not available in job-level `if:`); gate on `vars.RKE2_SMOKE_ENABLED == 'true'` alone. Docs snippet in `docs/codebase/devops.md` updated to match.
- **B2** `9f6a7ec` — add `packages: write` to the workflow `permissions:` block so the GHCR push of `:pr-<n>-<sha>` is authorised (mirrors `image.yml`).
- **M1** `9f6a7ec` — thread `--kubeconfig="$HOME/.kube/config"` through Option B's `kubectl config current-context` and `set-context` calls for parity with Option A.
- **M2** `9f6a7ec` — move `chmod 0600 "$HOME/.kube/config"` to run BEFORE the `kubectl auth whoami` probe (eliminate the brief default-umask leak window on shared self-hosted runner).
- **m1** `ff5aaca` — `local url="$1"` in `http_code()`.
- **m2** `ff5aaca` — `[[ ... ]]` on the two status-code comparisons.

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 1 -->
