### PR TITLE
ci(chart): install PyYAML before Chart.yaml stamp step

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -276,6 +276,18 @@ jobs:
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Chart version: ${VERSION}"
 
+      - name: Ensure PyYAML — chart-stamp dep on ARC runners
+        # The actions-runner-controller scale-set image is minimal and
+        # doesn't ship PyYAML; github-hosted ubuntu-latest does. The next
+        # step's `python3 - <<PY ... import yaml ... PY` exit-1s with
+        # ModuleNotFoundError otherwise. --user keeps the install in
+        # ~/.local with no sudo dependency; the no-op shortcut is
+        # forward-compat for when the runner image grows PyYAML.
+        shell: bash
+        run: |
+          python3 -c "import yaml" 2>/dev/null && exit 0
+          python3 -m pip install --user --quiet pyyaml
+
       - name: Stamp Chart.yaml with version + appVersion
         # `helm package` reads `name`, `version`, and `appVersion` from
         # Chart.yaml. We rewrite version (chart calver) and appVersion (git


### PR DESCRIPTION
## Why

After #183 turned `image`, `CI`, `Secret Scan`, `Security Scan` and `Quality Gate` green on main, the **`chart`** workflow is the only remaining red check. Same class of issue as the envsubst gap fixed in #183 — the ARC scale-set runner image is minimal and doesn't ship a tool that github-hosted \`ubuntu-latest\` preinstalls.

Failure log:

\`\`\`
Stamp Chart.yaml with version + appVersion:
  python3 - <<PY
    import yaml   <-- ModuleNotFoundError: No module named 'yaml'
    ...
  ##[error]Process completed with exit code 1.
\`\`\`

The step's own comment says: *"Use python3+pyyaml on the self-hosted runner so we don't pull in an extra `yq` dependency for two field edits."* The assumption that PyYAML was preinstalled held on \`ubuntu-latest\` but not on the ARC image.

## What this PR does

Adds a one-step "Ensure PyYAML" install right before the existing stamp step:

\`\`\`yaml
- name: Ensure PyYAML — chart-stamp dep on ARC runners
  shell: bash
  run: |
    python3 -c "import yaml" 2>/dev/null && exit 0
    python3 -m pip install --user --quiet pyyaml
\`\`\`

Mirrors the envsubst pattern from #183:
- no-op if PyYAML is already present (forward-compat for runner image upgrades)
- \`--user\` install, no sudo dependency
- isolated to its own step so the log shows whether the install was needed

## Test plan
- [ ] \`chart\` job on this PR goes green (the publish job is gated on push/tag, but the workflow's PR-level \`validate\` job should at minimum no longer pre-fail at stamp time)
- [ ] After merge, the next push to main runs the full chart publish path green

## Out of scope (still)

Long-term, both this and #183's envsubst install belong in the ARC runner image, not in every workflow that needs them. Likely candidate list to bake in:
- \`gettext-base\` (envsubst — fixed in #183)
- \`python3-yaml\` (PyYAML — this PR)
- \`jq\`, \`curl\` (probably already there, worth confirming)

Filing on the runner-controller side, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced chart publishing workflow to ensure required dependencies are properly available during the release process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/187)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->