### PR TITLE
ci(chart): use apt python3-yaml — runner has no pip

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -277,16 +277,19 @@ jobs:
           echo "Chart version: ${VERSION}"
 
       - name: Ensure PyYAML — chart-stamp dep on ARC runners
-        # The actions-runner-controller scale-set image is minimal and
-        # doesn't ship PyYAML; github-hosted ubuntu-latest does. The next
-        # step's `python3 - <<PY ... import yaml ... PY` exit-1s with
-        # ModuleNotFoundError otherwise. --user keeps the install in
-        # ~/.local with no sudo dependency; the no-op shortcut is
-        # forward-compat for when the runner image grows PyYAML.
+        # The actions-runner-controller scale-set image is minimal: it
+        # ships python3 but not pip (so `pip install pyyaml` exits with
+        # "No module named pip") and not PyYAML itself. Use the apt
+        # package `python3-yaml` — same shape as the envsubst install
+        # in image.yml / chart.yml / cli-release.yml.
         shell: bash
         run: |
           python3 -c "import yaml" 2>/dev/null && exit 0
-          python3 -m pip install --user --quiet pyyaml
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -q && sudo apt-get install -y --no-install-recommends python3-yaml
+          else
+            apt-get update -q && apt-get install -y --no-install-recommends python3-yaml
+          fi
 
       - name: Stamp Chart.yaml with version + appVersion
         # `helm package` reads `name`, `version`, and `appVersion` from


### PR DESCRIPTION
## Fix-of-the-fix for #187

#187's "Ensure PyYAML" step used \`python3 -m pip install --user pyyaml\`, but the ARC scale-set runner image is more minimal than I assumed: it has \`python3\` but not pip. The step failed with:

\`\`\`
Ensure PyYAML — chart-stamp dep on ARC runners:
  /usr/bin/python3: No module named pip
  ##[error]Process completed with exit code 1.
\`\`\`

Switching to \`apt-get install python3-yaml\` — same shape as the envsubst install in #183:

\`\`\`yaml
- name: Ensure PyYAML — chart-stamp dep on ARC runners
  shell: bash
  run: |
    python3 -c "import yaml" 2>/dev/null && exit 0
    if command -v sudo >/dev/null 2>&1; then
      sudo apt-get update -q && sudo apt-get install -y --no-install-recommends python3-yaml
    else
      apt-get update -q && apt-get install -y --no-install-recommends python3-yaml
    fi
\`\`\`

Why apt over pip:
- The runner image ships Python without pip, so \`pip install\` requires bootstrapping pip first (`apt install python3-pip`) — pulling in a much larger surface just to install one dep.
- The envsubst install in #183 already uses this exact shape successfully; consistency means one less branch in operator mental model.

Verified with actionlint locally (exit 0).

## Test plan
- [ ] PR's own \`chart\` job goes past the "Ensure PyYAML" step and into the actual stamp + helm package + cosign sign steps
- [ ] After merge, the next push to main shows \`chart\` green

## Lesson logged
Adding to my memory of this repo: ARC scale-set runner image is **very** minimal — assume nothing beyond bash + python3 + apt. Anything else needs an inline install step (or, properly, baking into the runner image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow dependency management to improve build system reliability and consistency across deployment environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/188)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->