### PR TITLE
ci(chart) + tests: fix cosign-sign auth + Docker Hub rate limit

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -256,6 +256,20 @@ jobs:
           echo "${GHCR_PASS}" | helm registry login ghcr.io \
             --username "${GHCR_USER}" --password-stdin
 
+      - name: Log in to GHCR (Docker config — for cosign sign)
+        # `helm registry login` above writes to ~/.config/helm/registry/config.json,
+        # which `cosign sign` does NOT read. cosign reads ~/.docker/config.json.
+        # Without this step the "Sign chart with cosign" step below fails with
+        #   UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided
+        # even though the helm push above succeeds (helm uses its own auth file).
+        # Mirrors the working pattern in image.yml; same SHA so a single
+        # supply-chain audit covers both pipelines.
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Compute chart version (calver or tag)
         id: ver
         env:

--- a/backend/tests/test_db_engine.py
+++ b/backend/tests/test_db_engine.py
@@ -344,7 +344,12 @@ class TestPostgresIntegration:
         """
         from testcontainers.postgres import PostgresContainer
 
-        with PostgresContainer("postgres:16-alpine") as pg:
+        # Google's public Docker Hub mirror — same image bits, no Docker Hub
+        # anonymous pull rate limit (100/6h per egress IP). The self-hosted
+        # runner pool shares one egress IP across all org CI, which exhausts
+        # the limit quickly. mirror.gcr.io/library/<name> mirrors the Docker
+        # Hub `library/*` namespace 1:1 and requires no auth.
+        with PostgresContainer("mirror.gcr.io/library/postgres:16-alpine") as pg:
             sync_url = pg.get_connection_url()  # postgresql+psycopg2://...
             async_url = sync_url.replace(
                 "postgresql+psycopg2://",

--- a/backend/tests/test_migration_rollback.py
+++ b/backend/tests/test_migration_rollback.py
@@ -415,7 +415,8 @@ class TestForwardCompatRollback:
         token = _mint_token(key, sub=operator_sub)
         _install_fake_vault(monkeypatch)
 
-        with PostgresContainer("postgres:16-alpine") as pg:
+        # mirror.gcr.io: see comment on the matching line in test_db_engine.py.
+        with PostgresContainer("mirror.gcr.io/library/postgres:16-alpine") as pg:
             sync_url = pg.get_connection_url()
             async_url = _async_url_from(sync_url)
 


### PR DESCRIPTION
## What's still red after the runner-image fixes

After #183 (envsubst), #187+#188 (PyYAML), the runner-image gaps are closed. Two further failures remained on main — both **workflow/test design** issues, not runner gaps:

### 1. \`chart\` workflow: \`cosign sign\` → \`UNAUTHORIZED\` to GHCR

\`\`\`
cosign sign --yes ghcr.io/evoila/meho-chart@sha256:9caba2c…
Error: failed to upload layer:
  POST https://ghcr.io/v2/evoila/meho-chart/blobs/uploads/:
  UNAUTHORIZED: unauthenticated:
  User cannot be authenticated with the token provided.
\`\`\`

The chart was packaged + pushed successfully (the digest exists on GHCR) — the failure is **cosign trying to write the signature reference** as a separate manifest. Why?

- [chart.yml:249-257](.github/workflows/chart.yml#L249-L257) does \`helm registry login ghcr.io\`, which writes auth to \`~/.config/helm/registry/config.json\`.
- \`cosign sign\` does **not** read that file. It reads \`~/.docker/config.json\`.
- [image.yml:136-144](.github/workflows/image.yml#L136-L144) does \`docker/login-action\` BEFORE its cosign step, which writes to \`~/.docker/config.json\`. That's why image's identical \`cosign sign\` call is green.

**Fix:** add a second login step in chart.yml right after the helm one — same SHA-pinned \`docker/login-action\` as image.yml, so a single supply-chain audit covers both pipelines.

### 2. \`CI\` (Python pytest): Docker Hub anonymous-pull rate limit

\`\`\`
test_alembic_upgrade_head_against_real_pg
docker.errors.APIError: 500 Server Error … error from registry:
  You have reached your unauthenticated pull rate limit.
\`\`\`

Two test classes (\`test_db_engine.TestPostgresIntegration\` + \`test_migration_rollback.TestForwardCompatPostgres\`) spin up \`postgres:16-alpine\` via testcontainers. Self-hosted runners share **one egress IP across all org CI**, so the 100-pull-per-6h Docker Hub anonymous limit is hit fast.

**Fix:** repoint both \`PostgresContainer(...)\` calls at **\`mirror.gcr.io/library/postgres:16-alpine\`** — Google's public mirror of the Docker Hub \`library/*\` namespace, no auth required, no rate limit. Same image bits, same digest equivalence guaranteed by GCR.

## Verification

\`\`\`
$ actionlint .github/workflows/chart.yml
[exit 0]

$ cd backend && uvx ruff@0.9.6 check tests/test_db_engine.py tests/test_migration_rollback.py
All checks passed!
\`\`\`

## Test plan
- [ ] PR's own \`chart\` job goes past \`Sign chart with cosign\` step (no easy way to test on a PR build since cosign sign is push-only — verify post-merge on main push)
- [ ] PR's own \`CI\` job runs \`TestPostgresIntegration\` and \`TestForwardCompatPostgres\` without Docker Hub rate-limit errors
- [ ] After merge, the next push to main is green across all jobs

## Out of scope (next tickets)

- **Bake \`gettext-base\` + \`python3-yaml\` + \`docker\` into the ARC runner image** so future workflows don't need the inline install steps from #183 and #188. (Runner-controller repo, not this one.)
- **Configure Docker Hub mirror at runner-daemon level** via \`/etc/docker/daemon.json\` \`registry-mirrors\`, which would cover ANY future Docker Hub pull (not just these two tests). My mirror.gcr.io fix here is surgical — fine for the two known calls; a daemon-level mirror is the more general structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD authentication process to enable container registry operations
  * Updated test infrastructure to utilize container image mirror for improved reliability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/190)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->