### PR TITLE
docs(acceptance): smoke.sh federation chain contract + verifier (G2.8-T2)

### DIFF
--- a/docs/acceptance/README.md
+++ b/docs/acceptance/README.md
@@ -20,12 +20,11 @@ Copyright (c) 2026 evoila Group
 | File | Goal #11 DoD bullet | Initiative G2.8 task |
 | --- | --- | --- |
 | [`install.md`](./install.md) | bullet 1 — `install.sh` cold-deploy → working MEHO at meho.evba.lab in <5 min | [#55](https://github.com/evoila-bosnia/meho-internal/issues/55) |
+| [`smoke.md`](./smoke.md) | bullet 2 — `smoke.sh` passes (login + status + audit-row + Vault + DB-migration state) | [#56](https://github.com/evoila-bosnia/meho-internal/issues/56) |
 | [`rollback.md`](./rollback.md) | bullet 3 — `helm rollback meho` verified end-to-end with a non-trivial schema diff | [#57](https://github.com/evoila-bosnia/meho-internal/issues/57) |
 
 Siblings to be added by their respective G2.8 tasks as they land:
 
-- [Task #56](https://github.com/evoila-bosnia/meho-internal/issues/56) —
-  `smoke.sh` federation-chain proof (DoD bullet 2)
 - [Task #58](https://github.com/evoila-bosnia/meho-internal/issues/58) —
   5-consecutive-merged-PR green-smoke counter + `targets.yaml` entry
   (DoD bullets 4 + 5)

--- a/docs/acceptance/smoke.md
+++ b/docs/acceptance/smoke.md
@@ -1,0 +1,340 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# `smoke.sh` federation chain — acceptance contract
+
+> The producer-side specification of Goal #11 DoD bullet 2:
+>
+> > `smoke.sh` passes (login + status + audit-row + Vault +
+> > DB-migration state) — the full federation chain works for a real
+> > operator with a real Keycloak token against the deployed
+> > backplane.
+>
+> This document codifies **what "passing" looks like** for the
+> federation-chain end-to-end smoke. The actual smoke run executes on
+> the consumer side
+> ([`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc));
+> the producer (this repo) owns the acceptance bar + the verifier the
+> consumer's wrapper invokes as its last step.
+
+## Tracking issue
+
+This contract closes
+[`evoila-bosnia/meho-internal#56`](https://github.com/evoila-bosnia/meho-internal/issues/56)
+(parent Initiative
+[#54](https://github.com/evoila-bosnia/meho-internal/issues/54),
+parent Goal
+[#11](https://github.com/evoila-bosnia/meho-internal/issues/11)).
+
+## Why this lives in `evoila/meho`
+
+The CLI (`meho login`, `meho status`), the authenticated
+`/api/v1/health` endpoint, the audit middleware, and the DB-migration
+runner are all produced here. When any of those surfaces changes the
+shape of "federation-chain proof", this document — and the verifier
+it points at — change in lock-step, without the consumer's `smoke.sh`
+wrapper needing to know. Same producer-owns-the-contract /
+consumer-owns-the-wrapper split as
+[`install.md`](./install.md) and [`rollback.md`](./rollback.md).
+
+## What the five legs prove
+
+The Goal #11 DoD bullet 2 phrasing — "login + status + audit-row +
+Vault + DB-migration state" — maps to five discrete legs the verifier
+asserts in order. Each leg corresponds to a load-bearing Initiative
+the federation chain depends on:
+
+| # | Leg | What it proves end-to-end | Predecessor task |
+| --- | --- | --- | --- |
+| 1 | **login** | `meho login <backplane>` (device-code flow) succeeds; the resulting access token is persisted in the OS keyring (or a 0600-mode file on headless hosts) and is usable by subsequent CLI calls. Verifies the Keycloak → CLI → token-store chain. | [`#44`](https://github.com/evoila-bosnia/meho-internal/issues/44) — `meho login` (G2.6-T2) / [`#42`](https://github.com/evoila-bosnia/meho-internal/issues/42) — CLI binary (G2.6) |
+| 2 | **status** | `meho status --json` (or the equivalent `curl -H "Authorization: Bearer ..." /api/v1/health`) returns 200 and the JSON response carries `operator.sub`, `vault.reachable=true`, `vault.read_ok=true`, `db.migrated=true`. Verifies the Status API + JWT middleware + the federation summary surface. | [`#45`](https://github.com/evoila-bosnia/meho-internal/issues/45) — `meho status` (G2.6-T3) |
+| 3 | **audit-row** | An authenticated `GET /api/v1/health` writes a synchronous row to `audit_log` (operator_sub, method=GET, path=/api/v1/health, status_code=200) before the response returns. Verifies the audit middleware's "row-before-response" contract end-to-end. | [`#28`](https://github.com/evoila-bosnia/meho-internal/issues/28) — audit middleware (G2.3-T2) |
+| 4 | **Vault** | The same `/api/v1/health` call exercises a Vault JWT/OIDC round-trip — the backplane forwards the operator's JWT to Vault, Vault verifies against the configured Keycloak trust, returns a Vault token bound to the operator, and the backplane reads `secret/meho/test/federation` under that token. Verifies the federation chain. | [`#25`](https://github.com/evoila-bosnia/meho-internal/issues/25) — Vault JWT federation (G2.2) |
+| 5 | **DB-migration state** | The chassis's `db_migration_probe()` reports `alembic_version == head`. Optional cluster-side cross-check: `kubectl get job -l app.kubernetes.io/component=migrate,app.kubernetes.io/instance=<release>` shows `succeeded=1`, OR the helm release status is `deployed` (when the Job was GC'd by the hook-succeeded delete-policy). Verifies the migration-runner contract. | [`#29`](https://github.com/evoila-bosnia/meho-internal/issues/29) — migration runner + CI guard (G2.3-T3) |
+
+The five legs share **one** authenticated `/api/v1/health` request —
+legs #2, #3, #4, and #5 all parse fields off the response of that
+single request. This is deliberate: each smoke run writes exactly one
+audit row, keeping the closing-comment artefact small and the
+audit-log signal-to-noise ratio high. The cluster-side cross-check
+in leg #5 is the only leg that makes a second probe (a kubectl /
+helm call), and that probe is read-only.
+
+## What "passing" means
+
+The deployed system has **passed** the smoke when every required leg
+above passes. The producer-side verifier
+[`scripts/acceptance/smoke.sh`](../../scripts/acceptance/smoke.sh)
+encodes every one of them as a discrete check.
+
+### Required (verifier-asserted) — runs every smoke run
+
+| # | Assertion | How it's checked | Why |
+| --- | --- | --- | --- |
+| 1 | A bearer token is available to the verifier — either via `MEHO_ACCESS_TOKEN` env var (preferred; exported by the consumer's wrapper after `meho login`) or via the `meho` CLI's keyring lookup | The verifier asserts the precondition; the actual proof of "login produced a working token" is leg #2 (a stored token that doesn't authenticate is a failed login, not a passed one) | The verifier is non-interactive (no TTY). The interactive `meho login` runs in the consumer's wrapper BEFORE the verifier; the verifier just confirms the wrapper produced a usable token |
+| 2 | `GET https://<backplane>/api/v1/health` with `Authorization: Bearer <token>` returns 200 AND the response JSON contains a non-empty `.operator.sub` | `curl -sSf` + `jq -e '.operator.sub != null and .operator.sub != ""'` | Federation chain works for at least one operator — JWKS cached, signature verified, audience matched, Vault OIDC role exchange succeeded, operator identity bound into the response body |
+| 3 | The authenticated probe writes an `audit_log` row matching the operator's `sub`, `method='GET'`, `path='/api/v1/health'`, `status_code=200`, `occurred_at` within the last minute | `psql "$DATABASE_URL"` against the live DB with a parameterised query; **deferred to operator-side** when `DATABASE_URL` is unset | Audit middleware is synchronous (row written before response yielded). Verifies the v0.1 audit-on-every-authenticated-call contract end-to-end. Scoping by `operator_sub` + `path` + recent timestamp avoids false positives from concurrent operator activity on the same backplane |
+| 4 | Same `/api/v1/health` response carries `.vault.reachable=true` AND `.vault.read_ok=true` | `jq -r '.vault.reachable'` + `jq -r '.vault.read_ok'` on the leg #2 response | The federation chain to Vault (JWT/OIDC login + `secret/meho/test/federation` KV read) succeeded. `.vault.detail` carries the KV version on success, the exception class name on failure — never a free-form message (per the v0.2 sensitive-data discipline in `backend/src/meho_backplane/api/v1/health.py`) |
+| 5 | Same `/api/v1/health` response carries `.db.migrated=true` | `jq -r '.db.migrated'` on the leg #2 response | The chassis's `db_migration_probe()` reports `alembic_version == head` (per `backend/src/meho_backplane/db/migrations.py`). Verifies the migration-runner contract: the backplane is talking to a DB whose schema matches the deployed image's expected revision |
+
+### Optional (verifier-asserted when context is available)
+
+| # | Assertion | When it runs | Why |
+| --- | --- | --- | --- |
+| 5b | The migrate Job's status is `succeeded=1`, OR (when the Job has been GC'd by the hook-succeeded delete-policy) the helm release status is `deployed` | When `kubectl` (and optionally `helm`) is on the verifier's PATH. Skipped on operator workstations that probe the public ingress without cluster access | Cross-checks the chassis-side `.db.migrated` flag against the cluster-side migration-Job state. Catches a subtle case where `db_migration_probe()` lies — e.g. the probe reports `migrated=true` because the schema happens to be at head, but the migration Job for the *current* upgrade never ran (someone stamped manually) |
+| 6 | Wall-clock duration from wrapper start to verifier exit ≤ 60 seconds | When `SMOKE_START_TS` is set (consumer's wrapper records it as the first action) | Federation chain on a warm cluster is sub-second per leg; bursting past 60s indicates a Vault / Keycloak / PG latency regression worth investigating even when the legs themselves pass. Under `--enforce-budget` this is a hard failure; without it, a warning |
+
+### Deferred-to-operator-side — leg #3 fallback
+
+Leg #3 requires `psql` access to the live database. When the verifier
+runs from a host that does not have `DATABASE_URL` set (operator
+workstation without DB credentials), leg #3 becomes a `[note]` line
+emitting the exact `psql` command the operator should run, and the
+result is recorded in the closing-comment artefact on issue #56
+instead of in the verifier's exit code. Same posture as
+`install-verify.sh`'s authenticated audit-row check (#9) and
+`rollback-verify.sh`'s schema check (#2).
+
+## What "60s" means
+
+The 60-second budget is **wall-clock for the verifier itself** — the
+five legs against a warm, deployed backplane. Stopwatch semantics:
+
+| Boundary | Event |
+| --- | --- |
+| **Start** | The consumer's `smoke.sh` wrapper's first instruction. Implementation: `START_TS=$(date -u +%s); export SMOKE_START_TS="$START_TS"` on line 1 (after `set -euo pipefail`). |
+| **Stop** | The verifier prints `[ok] federation chain verified end-to-end` and exits 0. |
+
+The budget covers **everything in between**:
+
+- Token retrieval (either CLI keyring lookup or `MEHO_ACCESS_TOKEN`
+  env var read)
+- One authenticated `GET /api/v1/health` round-trip (legs #2 + #4 +
+  #5 parse this single response)
+- Optional `psql` round-trip for leg #3 (the actual SELECT against
+  `audit_log` is sub-millisecond against a warm PG; the latency floor
+  is the TCP+TLS+auth handshake)
+- Optional `kubectl` + `helm` round-trips for leg #5b
+
+The budget does **not** cover:
+
+- Interactive `meho login` (device-code flow) — that runs in the
+  consumer's wrapper before the verifier is invoked. Operator
+  approval in the browser is unbounded.
+- Initial chart install / upgrade (covered by Task #55's
+  install-verify.sh's 5-minute budget)
+
+### Why 60 seconds is the right bar
+
+The federation chain on a warm cluster is sub-second per leg:
+
+- `curl https://<backplane>/api/v1/health` over the lab's ingress
+  controller: ~50ms TLS + ~20-200ms backplane response (JWKS cached,
+  Vault token cached or re-issued)
+- `psql` against the namespace-scoped PG: ~10ms connect + ~5ms
+  parameterised SELECT
+- `kubectl get job`: ~50ms against the API server
+
+A budget of 60s allows for one transient retry on each leg without
+bursting. If the smoke ever exceeds 60s on a warm cluster without a
+known correlate (Vault unsealed during the run, Keycloak realm
+reload, PG vacuum-induced lock contention), the regression is in the
+federation chain itself, **not** the budget. The fix lands in the
+chart / image / Vault role config — not in this document.
+
+## What failure looks like
+
+The verifier exits non-zero on the first failed required leg and
+prints a diagnostic line. Common failure modes:
+
+| Failure | Surface | First debug step |
+| --- | --- | --- |
+| Leg #1 fails — no token and no CLI | `[FAIL] login: no MEHO_ACCESS_TOKEN and meho CLI not on PATH` | The consumer's wrapper didn't run `meho login` or didn't export `MEHO_ACCESS_TOKEN`. Rerun the wrapper, OR run `meho login <backplane>` manually in the same shell |
+| Leg #2 fails — 401 | `[FAIL] status: GET .../api/v1/health failed` | Token is expired, the audience in the JWT doesn't match the backplane's configured audience, or the JWKS cache went stale and rejected a valid signature. Rerun `meho login <backplane>` to get a fresh token; if that still 401s, inspect `kubectl logs -n <ns> deployment/<release>` for JWT-validation errors |
+| Leg #2 fails — `operator.sub` missing | `[FAIL] status: response missing operator.sub` | The JWT validated but `verify_jwt_and_bind` didn't bind the sub into structlog — middleware regression. Inspect the route handler at `backend/src/meho_backplane/api/v1/health.py` |
+| Leg #3 fails — psql returns 0 rows | `[FAIL] audit-row: psql returned 0 rows` | Audit middleware did not write a row, OR the row didn't match the WHERE clause. Most often: path normalisation diverged (trailing slash, query string), the audit middleware's contextvar binding broke (operator_sub null in the row), or the request flow short-circuited before the middleware ran (e.g. a 401 from JWT validation — but then leg #2 would have failed first) |
+| Leg #4 fails — `vault.reachable=false` | `[FAIL] vault: not reachable from backplane` | Vault role JWKS URL drift (Keycloak realm renamed?), audience mismatch on the Vault role, network policy blocks egress to Vault, or Vault is sealed. `detail` field carries the exception class name |
+| Leg #4 fails — `vault.read_ok=false` | `[FAIL] vault: reachable but read failed` | JWT/OIDC login to Vault succeeded but the subsequent secret read failed. Either the operator's Vault policy doesn't permit reads on `secret/meho/test/federation`, OR the KV mount / path doesn't exist (consumer-side provisioning gap) |
+| Leg #5 fails — `db.migrated=false` | `[FAIL] db-migration: chassis reports .db.migrated=false` | DB unreachable from backplane, `alembic_version` table missing, or `alembic_version.version_num != head`. Inspect `kubectl logs -n <ns> deployment/<release>` for connection errors, or run `kubectl exec -n <ns> deployment/<release> -- python -m meho_backplane.db.migrations --check` (when the migration runner contract from Task #29 ships this entry-point) |
+| Budget exceeded under `--enforce-budget` | `[FAIL] wall-clock Xs > budget 60s` | Inspect `kubectl get events -n <ns> --sort-by=.lastTimestamp` for slow legs. Most often: a Vault re-seal during the smoke window, a PG vacuum causing lock contention, or a Keycloak realm export running concurrently |
+
+The verifier never hides a failure behind a green check. Each
+assertion fails-loud with the exact mismatch (e.g. `expected
+operator.sub, got null`).
+
+## Who runs the test
+
+| Role | Action | Cadence |
+| --- | --- | --- |
+| **RDC operator** | Runs the consumer's `smoke.sh` wrapper from the operator workstation (with VPN + Vault session + a completed `meho login` in the same shell). Captures stdout + stderr + the optional `psql` output (when run from a host with DB access). | Per Goal #11 closing-criteria — once for the acceptance milestone; on every cold-deploy from then on |
+| **`evoila/meho` maintainer** | Reviews the captured run on issue #56 (or the linked artefact), confirms legs #1-#5 are green and (when the operator has DB access) the audit-row was found, ticks the DoD bullet on Goal #11 | Once per Goal-closing review |
+| **CI (per-PR ephemeral smoke)** | Runs the unauthenticated subset of `install-verify.sh` against the per-PR `meho-ci-<n>` namespace via [`scripts/ci/pr-smoke.sh`](../../scripts/ci/pr-smoke.sh). The PR smoke does **not** run `smoke.sh` — it has no Keycloak token (the device-code flow needs a real browser). The federation chain smoke is a Goal-closing exercise, not a per-PR gate. | Federation-chain smoke does NOT run per-PR; per-PR smoke covers the unauthenticated surface only |
+
+The per-PR smoke and the closing-criteria federation smoke intentionally
+do not overlap: the per-PR smoke catches regressions in the
+unauthenticated surface fast; this contract closes the federation
+chain's behaviour against a real operator + real Vault + real PG at
+the closing milestone. Together they're the two sides of the
+"every code path closes the real-target feedback loop" discipline
+Goal #11 makes non-negotiable.
+
+## What the consumer-side `smoke.sh` wrapper needs to do
+
+For the producer-side verifier to be invocable end-to-end, the
+consumer's wrapper (lives at
+`evoila-bosnia/claude-rdc-hetzner-dc/manifests/meho/smoke.sh` per
+Goal #11 cross-repo deps) MUST:
+
+1. **Record the start timestamp** as the first action:
+
+   ```bash
+   START_TS=$(date -u +%s)
+   export SMOKE_START_TS="$START_TS"
+   ```
+
+2. **Run `meho login` interactively**:
+
+   ```bash
+   meho login https://meho.evba.lab
+   ```
+
+   The operator completes the device-code flow in their browser. On
+   success the CLI persists the token to the keyring (or 0600 file).
+
+3. **Export the access token** for the verifier:
+
+   ```bash
+   export MEHO_ACCESS_TOKEN="$(meho token)"
+   ```
+
+   When `meho token` is not yet implemented (v0.2 surface), the
+   wrapper falls back to extracting the token from the CLI's
+   credentials file or asking the operator to paste it.
+
+4. **Invoke the verifier** as the last step:
+
+   ```bash
+   export DATABASE_URL='postgresql://meho:...@.../meho'   # optional
+   bash scripts/acceptance/smoke.sh \
+     --backplane https://meho.evba.lab \
+     --namespace meho \
+     --release meho \
+     --enforce-budget
+   ```
+
+   (or fetch the verifier via `curl -sSf
+   https://raw.githubusercontent.com/evoila/meho/main/scripts/acceptance/smoke.sh`
+   if the consumer prefers not to pin a producer commit).
+
+5. **Propagate the verifier's exit code** as the wrapper's exit code.
+   Either the smoke passed wholesale (every required leg green +
+   budget met) or it did not.
+
+The verifier's `--skip-login` flag exists for the case where the
+operator has already completed `meho login` in a prior shell — the
+verifier then trusts the keyring-stored token without re-running
+the interactive flow.
+
+## Sensitive-data discipline (Goal #11 / Task #25)
+
+The verifier holds itself to the same JWT-handling discipline the
+backplane enforces:
+
+- **Bearer tokens are never echoed.** `curl`'s
+  `-H "Authorization: Bearer ..."` is constructed inline; the token
+  never lands in any log line, never in `set -x` output (the verifier
+  doesn't enable `set -x`), and never in `ps`-visible argv (the
+  header travels as a `curl` argument, but the verifier's banner
+  prints the host + namespace + release only, never the headers).
+- **Operator `sub` is echoed.** The audit-row check needs `sub` for
+  the WHERE clause and the closing-comment artefact records it as
+  proof of which operator wrote the row. `sub` is a Keycloak-issued
+  UUID — not PII in the v0.1 model. `name` and `email` are
+  deliberately excluded from any verifier output.
+- **`vault.detail`** carries only structured strings the route
+  handler constructs (`read_failed: KeyError`, `login_failed:
+  VaultClientError`) — never operator-controllable URL substrings
+  or exception messages. Same shape per
+  `backend/src/meho_backplane/api/v1/health.py`.
+- **`psql` query parameters** are passed via `-v sub="$operator_sub"`
+  + `:'sub'`, which inlines the value as a single-quoted SQL literal.
+  Even though `sub` is a Keycloak UUID (no quotes possible), the
+  parameterisation is defensive — a future change of `operator_sub`
+  shape can't open a SQL injection path through this verifier.
+
+The verifier's stdout / stderr is safe to capture verbatim into the
+closing-comment artefact on issue #56.
+
+## Acceptance-criteria status
+
+The full set of acceptance criteria on
+[issue #56](https://github.com/evoila-bosnia/meho-internal/issues/56)
+and where each lands:
+
+| AC | Status at PR-time | Evidence path |
+| --- | --- | --- |
+| AC1 — `meho login https://meho.evba.lab` succeeds; token stored; `meho status` no longer 401s | **deferred-to-consumer-side** | Interactive login requires a real Keycloak realm and a real browser. The producer-side verifier confirms a usable token is available (leg #1) and proves it works (leg #2) but cannot drive the device-code flow itself. Consumer's wrapper drives the login; verifier consumes the resulting token |
+| AC2 — `meho status --json` returns JSON with `.operator.sub`, `.operator.email`, `.vault.reachable=true`, `.vault.read_ok=true`, `.db.migrated=true` | **verifier-asserted** (leg #2 + leg #4 + leg #5) | `jq -e` on each field of the `/api/v1/health` response. `.operator.email` is NOT asserted by the verifier (email is PII the verifier deliberately doesn't echo); the consumer's wrapper can run `meho status --json \| jq .operator.email` separately if needed |
+| AC3 — PG audit-row check: query against the lab's PG returns a row matching the `meho status` call | **verifier-asserted** (leg #3, when `DATABASE_URL` set) / **deferred-to-operator-side** (otherwise) | `psql` with the parameterised query above. When `DATABASE_URL` is unset on the verifier host, the verifier emits the exact `psql` command for the operator to run, and the operator pastes the output into the closing comment |
+| AC4 — Vault audit log shows successful OIDC login + secret read attributed to the operator's identity | **deferred-to-consumer-side** | The producer-side verifier asserts the federation chain WORKED (leg #4) but does not have access to Vault's own audit log (consumer-side Vault deployment; the operator inspects Vault's audit log per the consumer's runbook). Recorded in the closing-comment artefact on #56 |
+| AC5 — Test run captured with timestamps, command transcripts, and assertion results | **deferred-to-consumer-side** | The captured artefact lands in the closing comment on #56. The verifier's `[ok]` / `[FAIL]` / `[note]` lines are stable and grep-able for inclusion |
+| AC6 — No JWT bytes appear in any captured output (sensitive-data discipline) | **verifier-asserted (by construction)** | The verifier never echoes the token — see "Sensitive-data discipline" above. The captured artefact from the verifier's stdout/stderr is safe to publish verbatim |
+
+The "deferred-to-consumer-side" status is **expected and correct** —
+the producer-side worker for #56 cannot drive the interactive
+`meho login` (no real Keycloak realm, no operator browser), cannot
+inspect Vault's own audit log (consumer-side deployment), and cannot
+run the smoke against the live lab (no VPN, no kubeconfig, no DB
+credentials). The producer ships the contract + the verifier + the
+acceptance bar; the consumer runs the smoke + writes the closing
+artefact.
+
+## Static checks the producer side CAN run at PR time
+
+Even though the deployed-system smoke is deferred to the
+consumer-side runbook, the producer side asserts at PR time that the
+verifier itself is well-formed:
+
+| Check | How | What it proves |
+| --- | --- | --- |
+| Bash syntax | `bash -n scripts/acceptance/smoke.sh` | The verifier parses without errors |
+| `--help` exits 0 | `bash scripts/acceptance/smoke.sh --help` | The self-contained help text renders without breaking on the heredoc |
+| Unknown-flag exit 2 | `bash scripts/acceptance/smoke.sh --bogus` returns exit code 2 | The CLI-usage-error path works (matches `install-verify.sh` / `rollback-verify.sh`) |
+| Missing-token failure mode | `bash scripts/acceptance/smoke.sh --enforce-budget` (with no token, no DB, no cluster) exits 1 with `[FAIL] login: ...` | Fail-loud on the precondition; budget hard-fail on missing `SMOKE_START_TS` |
+
+These checks run inside the PR's CI on the linter / shell-static-check
+job (`scripts/ci/check-scripts.sh` or the equivalent — TBD as part of
+Task #29's CI guard expansion). They do **not** prove the smoke
+passes against the live deployment; they prove the verifier won't
+explode under the operator's hand.
+
+## References
+
+- Parent Goal:
+  [#11 — Deployable v0.1](https://github.com/evoila-bosnia/meho-internal/issues/11)
+  (DoD bullet 2)
+- Parent Initiative:
+  [#54 — G2.8 Acceptance / dogfood proof](https://github.com/evoila-bosnia/meho-internal/issues/54)
+- This task:
+  [#56 — `smoke.sh` passes (login + status + audit-row + Vault + DB-migration state)](https://github.com/evoila-bosnia/meho-internal/issues/56)
+- Predecessors:
+  - [Task #42](https://github.com/evoila-bosnia/meho-internal/issues/42) — CLI binary (G2.6)
+  - [Task #44](https://github.com/evoila-bosnia/meho-internal/issues/44) — `meho login` device-code flow (G2.6-T2)
+  - [Task #45](https://github.com/evoila-bosnia/meho-internal/issues/45) — `meho status` (G2.6-T3)
+  - [Task #25](https://github.com/evoila-bosnia/meho-internal/issues/25) — Vault JWT federation (G2.2)
+  - [Task #28](https://github.com/evoila-bosnia/meho-internal/issues/28) — audit middleware (G2.3-T2)
+  - [Task #29](https://github.com/evoila-bosnia/meho-internal/issues/29) — migration runner entrypoint (G2.3-T3)
+  - [Task #55](https://github.com/evoila-bosnia/meho-internal/issues/55) (closed) — `install.sh` cold-deploy contract
+- Sibling acceptance tasks:
+  [#55](https://github.com/evoila-bosnia/meho-internal/issues/55) (closed),
+  [#57](https://github.com/evoila-bosnia/meho-internal/issues/57) (closed),
+  [#58](https://github.com/evoila-bosnia/meho-internal/issues/58)
+- Producer artefacts the smoke uses:
+  - CLI: [`https://github.com/evoila/meho/releases`](https://github.com/evoila/meho/releases) (`meho login`, `meho status`)
+  - Authenticated health: [`backend/src/meho_backplane/api/v1/health.py`](../../backend/src/meho_backplane/api/v1/health.py)
+  - Audit middleware: [`backend/src/meho_backplane/audit.py`](../../backend/src/meho_backplane/audit.py)
+  - DB-migration probe: [`backend/src/meho_backplane/db/migrations.py`](../../backend/src/meho_backplane/db/migrations.py)
+- Cross-repo handshake: [`docs/cross-repo/rke2-infra-coordination.md`](../cross-repo/rke2-infra-coordination.md)
+- Deploy surface deep-dive: [`docs/codebase/devops.md`](../codebase/devops.md)

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -1006,6 +1006,7 @@ companion verifier shell under
 | DoD bullet | Contract | Verifier |
 | --- | --- | --- |
 | 1 — `install.sh` cold-deploy → working MEHO in <5 min | [`docs/acceptance/install.md`](../acceptance/install.md) | [`scripts/acceptance/install-verify.sh`](../../scripts/acceptance/install-verify.sh) |
+| 2 — `smoke.sh` passes (login + status + audit-row + Vault + DB-migration state) — federation chain end-to-end | [`docs/acceptance/smoke.md`](../acceptance/smoke.md) | [`scripts/acceptance/smoke.sh`](../../scripts/acceptance/smoke.sh) |
 | 3 — `helm rollback meho` end-to-end with a non-trivial schema diff (cluster-level forward-compat proof) | [`docs/acceptance/rollback.md`](../acceptance/rollback.md) | [`scripts/acceptance/rollback-verify.sh`](../../scripts/acceptance/rollback-verify.sh) (sample N+1 migration at [`scripts/acceptance/synthetic-n-plus-1.sql`](../../scripts/acceptance/synthetic-n-plus-1.sql)) |
 
 The split between producer-owned contracts + verifiers and
@@ -1034,6 +1035,7 @@ real `helm rollback` against the lab (slow, Goal-closing milestone).
 - Task #50 (G2.7-T2) — Per-PR ephemeral cluster deploy + smoke + teardown
 - Task #53 (G2.7-T5) — Cross-repo coordination tracker (consumer-side kubeconfig + RBAC)
 - Task #55 (G2.8-T1) — `install.sh` cold-deploy acceptance contract + verifier (`docs/acceptance/install.md`, `scripts/acceptance/install-verify.sh`)
+- Task #56 (G2.8-T2) — `smoke.sh` federation-chain acceptance contract + verifier (`docs/acceptance/smoke.md`, `scripts/acceptance/smoke.sh`)
 - Task #57 (G2.8-T3) — `helm rollback` end-to-end acceptance contract + verifier (`docs/acceptance/rollback.md`, `scripts/acceptance/rollback-verify.sh`, `scripts/acceptance/synthetic-n-plus-1.sql`)
 - Task #30 (G2.3-T4) — unit-level forward-compat regression test (`backend/tests/test_migration_rollback.py`)
 - Helm `helm rollback` reference: https://helm.sh/docs/helm/helm_rollback/

--- a/scripts/acceptance/smoke.sh
+++ b/scripts/acceptance/smoke.sh
@@ -1,0 +1,639 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# smoke.sh — producer-side federation-chain acceptance verifier
+# (Task #56, Goal #11 DoD bullet 2).
+#
+# The five-leg end-to-end proof that a deployed MEHO works for a real
+# operator with a real Keycloak token against a real Vault and a real
+# Postgres. Companion to install-verify.sh (Task #55) and
+# rollback-verify.sh (Task #57): same producer-owns-the-contract /
+# consumer-runs-the-exercise split, same `[ok]` / `[FAIL]` / `[WARN]`
+# vocabulary, same exit-code shape.
+#
+# The five legs codify Goal #11 DoD bullet 2:
+#
+#   `smoke.sh` passes (login + status + audit-row + Vault +
+#   DB-migration state).
+#
+#   1. login              — meho login <backplane> succeeds; a bearer
+#                           token is stored in the keyring / 0600 file.
+#                           Verifies the device-code chain end-to-end
+#                           (Keycloak → CLI → token store) — Task #44.
+#   2. status             — meho status (or meho status --json | jq)
+#                           returns 0. Verifies the Status API + auth +
+#                           federation summary surface — Task #45.
+#   3. audit-row          — issue an authenticated GET /api/v1/health,
+#                           then assert a corresponding row landed in
+#                           audit_log (operator_sub, method=GET,
+#                           path=/api/v1/health, status_code=200).
+#                           Verifies G2.3 audit middleware contract
+#                           end-to-end — Task #28.
+#   4. vault              — assert the federation-proof Vault round-trip
+#                           ran. The chassis-side proof is the same
+#                           authenticated /api/v1/health probe — the
+#                           response carries vault.reachable=true +
+#                           vault.read_ok=true when the Vault chain
+#                           worked. Verifies G2.2 federation —
+#                           Task #25.
+#   5. db-migration state — assert alembic head == current. The
+#                           chassis-side proof is db.migrated=true on
+#                           the same /api/v1/health response (DB
+#                           migration probe, Task #29). Optional
+#                           cluster-side cross-check via `kubectl exec`
+#                           against the migrate Job's image when
+#                           kubectl context is available.
+#
+# Exit codes mirror install-verify.sh / rollback-verify.sh:
+#
+#   0  → every required leg passed (federation chain works end-to-end).
+#   1  → at least one required leg failed (smoke did NOT pass; see
+#        [FAIL] lines above).
+#   2  → CLI usage error (missing args, curl/jq/meho not on PATH).
+#
+# Usage (called from the consumer's smoke.sh wrapper on
+# `claude-rdc-hetzner-dc/manifests/meho/smoke.sh`, or directly by the
+# operator):
+#
+#   bash scripts/acceptance/smoke.sh \
+#     --backplane https://meho.evba.lab \
+#     --namespace meho \
+#     --release meho
+#
+# The wrapper is responsible for completing the interactive
+# device-code login BEFORE invoking this script — the verifier itself
+# is non-interactive (no TTY assumed). The recommended consumer-side
+# pattern is:
+#
+#   meho login https://meho.evba.lab           # interactive (browser)
+#   bash scripts/acceptance/smoke.sh ...       # non-interactive
+#
+# Flags:
+#   --backplane <url>             Backplane base URL (default:
+#                                 https://meho.evba.lab). The five legs
+#                                 run against this host.
+#   --namespace <ns>              Kubernetes namespace the chart was
+#                                 installed into (default: meho). Used
+#                                 by the optional cluster-side
+#                                 cross-checks.
+#   --release <name>              Helm release name (default: meho).
+#   --cacert <path>               CA bundle for the ingress TLS verify
+#                                 (default: system trust store).
+#   --skip-login                  Skip leg #1 (login). Useful when the
+#                                 operator already ran `meho login` in
+#                                 a prior shell and the token is in the
+#                                 keyring — the verifier only needs to
+#                                 confirm the token works (covered by
+#                                 leg #2). Default: leg #1 runs and
+#                                 fails when no stored token is found.
+#   --enforce-budget              Treat the optional 60s wall-clock
+#                                 budget check as a hard failure (the
+#                                 federation chain end-to-end on a warm
+#                                 cluster is sub-second per leg; the
+#                                 budget catches a Vault / Keycloak /
+#                                 PG latency regression that would
+#                                 otherwise pass silently). Under
+#                                 --enforce-budget the verifier ALSO
+#                                 hard-fails when SMOKE_START_TS is
+#                                 unset or non-numeric — same
+#                                 contract-input discipline as
+#                                 install-verify.sh's --enforce-budget.
+#                                 Goal #11 closing-criteria runs MUST
+#                                 pass --enforce-budget.
+#   -h | --help                   Print this help and exit 0.
+#
+# Environment:
+#   MEHO_ACCESS_TOKEN     A Keycloak access token for the operator.
+#                         REQUIRED for legs #2, #3, #4. The wrapper
+#                         typically obtains this from `meho login` (the
+#                         CLI stores it in the keyring; the wrapper
+#                         exports it via `meho token`) or from a
+#                         service-account grant in CI.
+#   DATABASE_URL          PostgreSQL connection string (psql shape).
+#                         When set, leg #3 (audit-row) runs against the
+#                         live DB. When unset, leg #3 is a [note] line
+#                         deferred to the consumer-side runbook
+#                         (operator runs the psql query manually and
+#                         pastes the output into the closing-comment
+#                         artefact on #56).
+#   KUBECONFIG            Honoured by the optional cluster-side
+#                         cross-checks (leg #5's alembic-current probe).
+#   SMOKE_START_TS        Unix timestamp (seconds, UTC) — set by the
+#                         consumer's smoke.sh wrapper as the FIRST
+#                         action. Enables the optional 60s wall-clock
+#                         budget check. Omit only for standalone
+#                         debugging runs.
+#
+# Sensitive-data discipline (per Goal #11 / Task #25):
+#
+# - The bearer token is NEVER echoed. `curl`'s `-H "Authorization:
+#   Bearer ..."` is constructed inline and not interpolated into any
+#   log line. The verifier's stdout / stderr is safe to capture
+#   verbatim into the closing-comment artefact.
+# - The operator's `sub` IS echoed (it's the identifier the audit row
+#   asserts against), but neither `name` nor `email` is. The
+#   audit-row check elides PII before printing.
+# - `meho login` runs in a child shell — no JWT bytes flow back through
+#   shared file descriptors. The CLI persists tokens via the keyring /
+#   0600 file fallback; smoke.sh reads tokens only through that channel
+#   (or via the operator-provided MEHO_ACCESS_TOKEN env var).
+#
+# Notes on the defensive shape (mirrors install-verify.sh /
+# rollback-verify.sh):
+#
+# - `set -Eeuo pipefail` aborts on first failed command. The verifier
+#   never modifies cluster state (no `apply`, no `delete`, no `psql`
+#   INSERT/UPDATE). Safe to run repeatedly against the same release.
+# - `[ "$X" = "<literal>" ]` literal-string compares — `-eq` family
+#   would match an empty curl response on some bash builds.
+# - `curl --retry` covers ingress-controller warm-up and Vault /
+#   Keycloak transient blips. Bounded budget so a real outage surfaces
+#   within the smoke window.
+
+set -Eeuo pipefail
+
+# --- Help text ---------------------------------------------------------
+# Self-contained --help output. Same rationale as install-verify.sh:
+# a heredoc decouples the operator-facing surface from this script's
+# physical line numbering, so reordering the header comments cannot
+# silently truncate help mid-flag.
+usage() {
+    cat <<'HELP'
+smoke.sh — producer-side federation-chain acceptance verifier
+(Task #56, Goal #11 DoD bullet 2).
+
+Runs the five legs documented in docs/acceptance/smoke.md against a
+deployed MEHO instance. The verifier's exit code IS the smoke run's
+exit code:
+
+  0  every required leg passed (federation chain works end-to-end)
+  1  at least one required leg failed
+  2  CLI usage error (missing args, curl/jq/meho not found)
+
+Usage:
+  bash scripts/acceptance/smoke.sh \
+    --backplane https://meho.evba.lab \
+    --namespace meho \
+    --release meho
+
+The wrapper completes `meho login` interactively before invoking this
+script. Subsequent legs read the bearer token from MEHO_ACCESS_TOKEN
+(set by the wrapper) or from the CLI's keyring / 0600 file fallback.
+
+Flags:
+  --backplane <url>             Backplane base URL
+                                (default: https://meho.evba.lab).
+  --namespace <ns>              Kubernetes namespace (default: meho).
+  --release <name>              Helm release name (default: meho).
+  --cacert <path>               CA bundle for ingress TLS verify
+                                (default: system trust store).
+  --skip-login                  Skip leg #1 (login). Use when the
+                                operator already ran `meho login` in a
+                                prior shell.
+  --enforce-budget              Treat the 60s wall-clock budget check
+                                as a hard failure. Also hard-fails when
+                                SMOKE_START_TS is unset or non-numeric.
+                                Goal #11 closing-criteria runs MUST
+                                pass this flag.
+  -h | --help                   Print this help and exit 0.
+
+Environment:
+  MEHO_ACCESS_TOKEN     Keycloak access token. Required for legs #2-#4.
+  DATABASE_URL          psql connection string. Enables leg #3 audit-row
+                        assertion when set.
+  KUBECONFIG            Honoured by optional cluster-side cross-checks
+                        (leg #5 alembic-current probe).
+  SMOKE_START_TS        Unix epoch seconds (UTC), captured by the
+                        consumer's smoke.sh wrapper as its first
+                        action. Required under --enforce-budget.
+
+See docs/acceptance/smoke.md for the full contract.
+HELP
+}
+
+# --- Defaults ----------------------------------------------------------
+BACKPLANE="https://meho.evba.lab"
+NAMESPACE="meho"
+RELEASE="meho"
+CACERT=""
+SKIP_LOGIN=0
+ENFORCE_BUDGET=0
+BUDGET_SECONDS=60 # Federation chain is sub-second per leg on a warm cluster.
+
+# --- CLI parse ---------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --backplane=*) BACKPLANE="${1#*=}"; shift ;;
+        --backplane)
+            [[ $# -ge 2 && -n "${2:-}" ]] || { echo "smoke.sh: --backplane requires a value" >&2; exit 2; }
+            BACKPLANE="$2"; shift 2 ;;
+        --namespace=*) NAMESPACE="${1#*=}"; shift ;;
+        --namespace)
+            [[ $# -ge 2 && -n "${2:-}" ]] || { echo "smoke.sh: --namespace requires a value" >&2; exit 2; }
+            NAMESPACE="$2"; shift 2 ;;
+        --release=*) RELEASE="${1#*=}"; shift ;;
+        --release)
+            [[ $# -ge 2 && -n "${2:-}" ]] || { echo "smoke.sh: --release requires a value" >&2; exit 2; }
+            RELEASE="$2"; shift 2 ;;
+        --cacert=*) CACERT="${1#*=}"; shift ;;
+        --cacert)
+            [[ $# -ge 2 && -n "${2:-}" ]] || { echo "smoke.sh: --cacert requires a value" >&2; exit 2; }
+            CACERT="$2"; shift 2 ;;
+        --skip-login) SKIP_LOGIN=1; shift ;;
+        --enforce-budget) ENFORCE_BUDGET=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "smoke.sh: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Normalise: strip any trailing slash from the backplane URL so the
+# curl invocations below don't double up on `//api/...`.
+BACKPLANE="${BACKPLANE%/}"
+
+# --- Tooling pre-flight ------------------------------------------------
+need_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "smoke.sh: required tool '$1' not on PATH" >&2
+        exit 2
+    fi
+}
+need_tool curl
+need_tool jq
+
+# --- Counters + helpers ------------------------------------------------
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+
+check_ok()   { PASS_COUNT=$((PASS_COUNT + 1)); printf '[ok]   %s\n' "$1"; }
+check_fail() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    printf '[FAIL] %s\n' "$1" >&2
+    [[ -n "${2:-}" ]] && printf '       %s\n' "$2" >&2
+}
+check_warn() {
+    WARN_COUNT=$((WARN_COUNT + 1))
+    printf '[WARN] %s\n' "$1" >&2
+    [[ -n "${2:-}" ]] && printf '       %s\n' "$2" >&2
+}
+check_note() { printf '[note] %s\n' "$1"; }
+
+# Curl retry args — same shape as install-verify.sh /
+# rollback-verify.sh. `--retry-all-errors` is only included when the
+# installed curl actually accepts it (gates on Ubuntu 22.04's 7.81+
+# vs older base images).
+CURL_RETRY_ARGS=(--retry 5 --retry-delay 2 --retry-connrefused)
+if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+    CURL_RETRY_ARGS+=(--retry-all-errors)
+fi
+
+# Common curl invocation. Token (if any) is appended by the caller via
+# additional `-H "Authorization: Bearer $TOKEN"` so this helper never
+# sees the bearer; the token also never lands in the function's
+# argv (each leg constructs its own `-H` arg inline).
+curl_body() {
+    local url="$1"
+    shift
+    local cacert_args=()
+    [[ -n "$CACERT" ]] && cacert_args=("--cacert" "$CACERT")
+    curl -sSf "${cacert_args[@]}" \
+        "${CURL_RETRY_ARGS[@]}" \
+        --max-time 10 \
+        "$@" "$url"
+}
+
+# --- Banner ------------------------------------------------------------
+echo "smoke.sh: producer-side federation-chain acceptance check (Task #56)"
+echo "  backplane:         $BACKPLANE"
+echo "  namespace:         $NAMESPACE"
+echo "  release:           $RELEASE"
+[[ -n "$CACERT" ]] && echo "  CA bundle:         $CACERT"
+[[ "$SKIP_LOGIN" -eq 1 ]] && echo "  login leg:         SKIPPED (--skip-login)"
+[[ "$ENFORCE_BUDGET" -eq 1 ]] && echo "  budget enforce:    HARD"
+echo
+
+# --- Leg #1: login -----------------------------------------------------
+# The login leg proves the device-code chain end-to-end:
+#
+#   operator → CLI → Keycloak realm → access token → CLI token store.
+#
+# `meho login` is the CLI surface shipped by Task #44 (CLI #42). It
+# requires an interactive browser session (the device-code flow's
+# user_code is verified on the operator's workstation). The verifier
+# itself is non-interactive — by the time smoke.sh runs, the consumer-
+# side wrapper has either:
+#
+#   (a) already invoked `meho login` interactively and the token is in
+#       the keyring → SKIP_LOGIN=1 and we skip the explicit login call;
+#   (b) exported MEHO_ACCESS_TOKEN from a prior `meho login` →
+#       SKIP_LOGIN=1 and we use that token directly.
+#
+# The verifier still ASSERTS leg #1 even with --skip-login by checking
+# the auth chain works (a stored token that doesn't authenticate is a
+# failed login, not a passed one). The actual assertion is delegated
+# to leg #2 (`meho status` won't return 0 against an invalid token),
+# and leg #1 here records that login produced a usable token.
+if [[ "$SKIP_LOGIN" -eq 1 ]]; then
+    if [[ -n "${MEHO_ACCESS_TOKEN:-}" ]]; then
+        check_ok "login: MEHO_ACCESS_TOKEN provided by wrapper (skipped interactive login)"
+    else
+        # No token in env AND --skip-login — the operator is relying on
+        # the CLI keyring's stored token. The verifier can't probe the
+        # keyring directly without the CLI binary, so the trust falls
+        # to leg #2.
+        if command -v meho >/dev/null 2>&1; then
+            check_note 'login: --skip-login set with no MEHO_ACCESS_TOKEN; relying on the meho CLI keyring lookup in leg #2'
+            check_ok "login: deferred to leg #2 (CLI keyring lookup)"
+        else
+            check_fail "login: --skip-login set, no MEHO_ACCESS_TOKEN, and meho CLI not on PATH" \
+                'either run "meho login <backplane>" from this shell, OR export MEHO_ACCESS_TOKEN, OR install the meho CLI'
+        fi
+    fi
+else
+    # Interactive login — the verifier itself does NOT invoke `meho
+    # login` (no TTY assumed; the wrapper does it). Instead the verifier
+    # checks that either MEHO_ACCESS_TOKEN is set OR the CLI is on PATH
+    # (the latter implies the wrapper ran login and the token's in the
+    # keyring). This is the producer-side surrogate; the consumer's
+    # wrapper documents the full interactive flow.
+    if [[ -n "${MEHO_ACCESS_TOKEN:-}" ]]; then
+        check_ok 'login: MEHO_ACCESS_TOKEN provided (assumed produced by prior "meho login")'
+    elif command -v meho >/dev/null 2>&1; then
+        check_note 'login: no MEHO_ACCESS_TOKEN env var; relying on the meho CLI keyring lookup in leg #2'
+        check_ok "login: meho CLI present (deferred to leg #2 for token validity proof)"
+    else
+        check_fail "login: no MEHO_ACCESS_TOKEN and meho CLI not on PATH" \
+            "run \"meho login $BACKPLANE\" first, OR export MEHO_ACCESS_TOKEN"
+    fi
+fi
+
+# --- Leg #2: status ----------------------------------------------------
+# The status leg proves the Status API + auth + federation summary
+# surface (Task #45). Two equivalent assertion shapes — the verifier
+# prefers MEHO_ACCESS_TOKEN over the CLI when both are available
+# because the curl path is hermetic (no dependency on the CLI version
+# the operator happens to have installed) and the response JSON is
+# what every downstream check (legs #3, #4, #5) consumes.
+#
+# `meho status --json` (when invoked directly) emits the same JSON
+# shape, so a wrapper that prefers the CLI is equivalent. We pick the
+# curl path here so the verifier can run from any host with curl + jq
+# + a token, not only from a host with the meho binary installed.
+if [[ -z "${MEHO_ACCESS_TOKEN:-}" ]]; then
+    # No token → try the CLI directly. The CLI reads the keyring and
+    # constructs the same /api/v1/health request internally.
+    if command -v meho >/dev/null 2>&1; then
+        if status_json="$(meho status --json --backplane "$BACKPLANE" 2>/dev/null)"; then
+            check_ok "status: \`meho status --json\` returns 0 (keyring-mediated)"
+        else
+            check_fail "status: \`meho status --json\` failed" \
+                "the stored token is missing or rejected; rerun \`meho login $BACKPLANE\`"
+            status_json=""
+        fi
+    else
+        check_fail "status: no MEHO_ACCESS_TOKEN and meho CLI not on PATH" \
+            "cannot probe /api/v1/health without either a token or the CLI"
+        status_json=""
+    fi
+else
+    # Token path — curl directly. `curl -sSf` exits non-zero on >=400
+    # so a 401 here means the token expired between login and now (or
+    # the wrapper exported a stale token).
+    if status_json="$(curl_body "$BACKPLANE/api/v1/health" \
+        -H "Authorization: Bearer $MEHO_ACCESS_TOKEN" 2>/dev/null)"; then
+        check_ok "status: GET $BACKPLANE/api/v1/health (authenticated) returns 200"
+    else
+        check_fail "status: GET $BACKPLANE/api/v1/health failed" \
+            "MEHO_ACCESS_TOKEN missing / expired / Vault role denied; rerun \`meho login $BACKPLANE\`"
+        status_json=""
+    fi
+fi
+
+# Parse the response shape regardless of how we got it — the assertion
+# bar (operator.sub present + vault healthy + db.migrated true) is the
+# same. `jq -e` exits non-zero on a false / null match, so the verifier
+# can chain it directly into check_ok / check_fail without parsing
+# stderr.
+operator_sub=""
+if [[ -n "${status_json:-}" ]]; then
+    if echo "$status_json" | jq -e '.operator.sub != null and .operator.sub != ""' >/dev/null 2>&1; then
+        operator_sub="$(echo "$status_json" | jq -r '.operator.sub')"
+        check_ok "status: response carries operator.sub (federation chain produced an identity)"
+    else
+        check_fail "status: response missing operator.sub" \
+            "expected JWT validation to bind operator identity; got: $(echo "$status_json" | jq -c '.operator // {}')"
+    fi
+fi
+
+# --- Leg #4: vault -----------------------------------------------------
+# Asserted BEFORE leg #3 because the audit-row check needs the
+# operator_sub to query psql, and we want to fail-fast on a broken
+# federation chain (a missing Vault round-trip means audit_log writes
+# may also be broken, and leg #3's psql output would be misleading).
+#
+# The chassis-side proof of Vault is the .vault.reachable=true +
+# .vault.read_ok=true pair on the /api/v1/health response. This is
+# the SAME response leg #2 already parsed — no second request needed
+# (the audit-row check in leg #3 would write a SECOND row otherwise,
+# polluting the closing-comment artefact).
+if [[ -n "${status_json:-}" ]]; then
+    vault_reachable="$(echo "$status_json" | jq -r '.vault.reachable // false')"
+    vault_read_ok="$(echo "$status_json" | jq -r '.vault.read_ok // false')"
+    vault_detail="$(echo "$status_json" | jq -r '.vault.detail // ""')"
+    if [[ "$vault_reachable" == "true" && "$vault_read_ok" == "true" ]]; then
+        # detail carries the KV version on success — useful in the
+        # closing-comment artefact.
+        check_ok "vault: federation chain operational (reachable=true, read_ok=true, detail='$vault_detail')"
+    elif [[ "$vault_reachable" == "true" && "$vault_read_ok" != "true" ]]; then
+        check_fail "vault: reachable but read failed" \
+            "JWT/OIDC login succeeded but secret read against meho/test/federation failed; detail='$vault_detail'. Vault role / policy / KV mount misconfigured?"
+    else
+        check_fail "vault: not reachable from backplane" \
+            "JWT/OIDC login to Vault failed; detail='$vault_detail'. Common causes: Vault role JWKS URL drift, audience mismatch, network policy blocks egress, Vault sealed"
+    fi
+fi
+
+# --- Leg #3: audit-row -------------------------------------------------
+# The audit middleware writes synchronously BEFORE the response is
+# returned (per backend/src/meho_backplane/audit.py): by the time leg
+# #2's curl returns 200, the audit_log row already exists. The query
+# below scopes by operator_sub + recent timestamp + path to avoid
+# false positives from concurrent operator activity.
+#
+# DATABASE_URL is the operator-cost path. The verifier needs psql +
+# DB read credentials to inspect audit_log. When DATABASE_URL is
+# unset, the check becomes a [note] line emitting the exact psql
+# command the operator should run, and the result is recorded in the
+# closing-comment artefact on issue #56 — same pattern as
+# rollback-verify.sh's schema check.
+if [[ -n "${DATABASE_URL:-}" && -n "$operator_sub" ]]; then
+    need_tool psql
+    # Bind the sub via a psql variable. `-v` + `:'name'` inlines the
+    # value as a single-quoted SQL literal, so an operator_sub
+    # containing a quote (it shouldn't — Keycloak sub is a UUID — but
+    # defensive coding wins here) can't break out of the literal.
+    audit_query="SELECT operator_sub, method, path, status_code
+                   FROM audit_log
+                  WHERE operator_sub = :'sub'
+                    AND path = '/api/v1/health'
+                    AND method = 'GET'
+                    AND status_code = 200
+                    AND occurred_at > NOW() - INTERVAL '1 minute'
+                  ORDER BY occurred_at DESC LIMIT 1;"
+    if audit_row="$(psql "$DATABASE_URL" -tA -v sub="$operator_sub" -c "$audit_query" 2>/dev/null)"; then
+        if [[ -n "$audit_row" ]]; then
+            # `-tA` returns tuples-only, unaligned, pipe-delimited. The
+            # row is `<sub>|GET|/api/v1/health|200`; we don't echo the
+            # sub itself (PII) but confirm the row landed.
+            check_ok "audit-row: psql found a matching row for the /api/v1/health call (method=GET, path=/api/v1/health, status_code=200)"
+        else
+            check_fail "audit-row: psql returned 0 rows for the /api/v1/health call" \
+                "audit middleware did not write a row, OR the row didn't match (operator_sub mismatch, path normalisation diverged, status_code regressed). Capture: psql \"\$DATABASE_URL\" -c \"SELECT operator_sub, method, path, status_code, occurred_at FROM audit_log ORDER BY occurred_at DESC LIMIT 5;\""
+        fi
+    else
+        check_fail "audit-row: psql query against \$DATABASE_URL failed" \
+            "verify DATABASE_URL is set + reachable + has SELECT on audit_log; query was the standard audit-row probe (see docs/acceptance/smoke.md)"
+    fi
+elif [[ -z "${DATABASE_URL:-}" ]]; then
+    check_note "audit-row: deferred — \$DATABASE_URL unset"
+    check_note "  operator: run the following on a host with PG SELECT access on audit_log:"
+    check_note "    psql \"\$DATABASE_URL\" -c \\"
+    check_note "      \"SELECT operator_sub, method, path, status_code, occurred_at\""
+    check_note "      \"  FROM audit_log\""
+    check_note "      \" WHERE path = '/api/v1/health'\""
+    check_note "      \"   AND occurred_at > NOW() - INTERVAL '1 minute'\""
+    check_note "      \" ORDER BY occurred_at DESC LIMIT 5;\""
+    check_note "  expected: at least one row matching the operator's sub, method=GET, path=/api/v1/health, status_code=200"
+    check_note "  paste the output into the closing comment on issue #56"
+elif [[ -z "$operator_sub" ]]; then
+    # DATABASE_URL set but leg #2 didn't yield a sub → leg #2 already
+    # failed; downgrade this to a [WARN] so the operator sees the
+    # cascade and doesn't get a flood of [FAIL] lines pointing at the
+    # same root cause.
+    check_warn "audit-row: skipped because leg #2 did not yield operator.sub" \
+        "fix leg #2 (status) first, then re-run; the audit middleware row exists iff the /api/v1/health call returned 200"
+fi
+
+# --- Leg #5: db-migration state ---------------------------------------
+# The chassis-side proof of DB-migration state is .db.migrated=true on
+# the /api/v1/health response. The chassis runs db_migration_probe()
+# under the hood (backend/src/meho_backplane/db/migrations.py — Task
+# #29's runner contract): connect to DB, read alembic_version table,
+# compare to head() from ScriptDirectory.
+#
+# Optional cluster-side cross-check: `alembic current` via the
+# migrate Job's image. When kubectl context + KUBECONFIG are set on
+# the verifier host, the verifier asserts the migrate Job's last
+# completed run shows revision == head. The Job's hook-succeeded
+# delete-policy GC's the Pod after success, so the fallback is the
+# helm release status (deployed) — same pattern as install-verify.sh's
+# check #2.
+if [[ -n "${status_json:-}" ]]; then
+    db_migrated="$(echo "$status_json" | jq -r '.db.migrated // null')"
+    if [[ "$db_migrated" == "true" ]]; then
+        check_ok "db-migration: chassis reports .db.migrated=true (alembic_version == head)"
+    else
+        check_fail "db-migration: chassis reports .db.migrated=$db_migrated (expected true)" \
+            "either DB unreachable from backplane, alembic_version table missing, or current revision != head. Inspect: kubectl logs -n $NAMESPACE deployment/$RELEASE"
+    fi
+fi
+
+# Optional cluster-side cross-check.
+if command -v kubectl >/dev/null 2>&1; then
+    # The migrate Job is named via the chart's `meho.fullname` helper
+    # (release-name-dependent). The same label selector
+    # install-verify.sh uses is invariant across release rename:
+    job_name="$(kubectl get job -n "$NAMESPACE" \
+        -l "app.kubernetes.io/component=migrate,app.kubernetes.io/instance=${RELEASE}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [[ -n "$job_name" ]]; then
+        # Job still present (post-install/upgrade window before hook
+        # GC, or chart configured without hook-succeeded deletion).
+        # Assert succeeded=1.
+        job_status="$(kubectl get job -n "$NAMESPACE" "$job_name" \
+            -o jsonpath='{.status.succeeded}' 2>/dev/null || true)"
+        if [[ "$job_status" == "1" ]]; then
+            check_ok "db-migration: cluster cross-check — migrate Job $job_name succeeded=1"
+        else
+            check_warn "db-migration: cluster cross-check inconclusive" \
+                "migrate Job $job_name status.succeeded='$job_status'; chassis-side .db.migrated is the authoritative signal"
+        fi
+    elif command -v helm >/dev/null 2>&1; then
+        # Job GC'd; fall back to helm release status.
+        helm_status="$(helm status -n "$NAMESPACE" "$RELEASE" -o json 2>/dev/null \
+            | jq -r '.info.status // "unknown"' 2>/dev/null || echo "unknown")"
+        if [[ "$helm_status" == "deployed" ]]; then
+            check_ok "db-migration: cluster cross-check — migrate Job GC'd by hook-succeeded; helm release status=deployed"
+        else
+            check_warn "db-migration: cluster cross-check inconclusive" \
+                "Job not present and helm release status='$helm_status'; chassis-side .db.migrated is the authoritative signal"
+        fi
+    else
+        # No Job, no helm — the chassis-side signal is the only one
+        # left, and it already passed (or failed) above. Note the gap
+        # so the operator knows what's missing for a fuller proof.
+        check_note "db-migration: cluster cross-check skipped — migrate Job GC'd and \`helm\` not on PATH"
+    fi
+else
+    check_note "db-migration: cluster cross-check skipped — \`kubectl\` not on PATH"
+fi
+
+# --- Optional: wall-clock budget ---------------------------------------
+# Same matrix as install-verify.sh's check #7:
+#
+#   ENFORCE_BUDGET  SMOKE_START_TS     outcome
+#   0 (warn-only)   unset              [note] skipped — debugging mode
+#   0               non-numeric        [WARN] invalid value
+#   0               numeric            [ok]/[WARN] depending on elapsed
+#   1 (hard-fail)   unset              [FAIL] — Goal #11 closing runs
+#   1               non-numeric        [FAIL] — same
+#   1               numeric            [ok]/[FAIL] depending on elapsed
+#
+# The 60s budget reflects that the federation chain on a warm cluster
+# is sub-second per leg; bursting past 60s indicates a Vault /
+# Keycloak / PG latency regression worth investigating even when the
+# legs themselves pass.
+echo
+if [[ -z "${SMOKE_START_TS:-}" ]]; then
+    if [[ "$ENFORCE_BUDGET" -eq 1 ]]; then
+        check_fail "SMOKE_START_TS is unset under --enforce-budget" \
+            "Goal #11 closing-criteria runs require a numeric start timestamp; the consumer's smoke.sh wrapper sets START_TS=\$(date -u +%s) as its first action"
+    else
+        check_note "wall-clock budget check skipped — SMOKE_START_TS unset"
+    fi
+elif ! [[ "$SMOKE_START_TS" =~ ^[0-9]+$ ]]; then
+    if [[ "$ENFORCE_BUDGET" -eq 1 ]]; then
+        check_fail "SMOKE_START_TS is not a unix timestamp under --enforce-budget" \
+            "got '$SMOKE_START_TS'; the wrapper should set START_TS=\$(date -u +%s)"
+    else
+        check_warn "SMOKE_START_TS is not a unix timestamp" \
+            "got '$SMOKE_START_TS'; the wrapper should set START_TS=\$(date -u +%s)"
+    fi
+else
+    NOW_TS="$(date -u +%s)"
+    ELAPSED=$((NOW_TS - SMOKE_START_TS))
+    if [[ "$ELAPSED" -le "$BUDGET_SECONDS" ]]; then
+        check_ok "wall-clock ${ELAPSED}s <= budget ${BUDGET_SECONDS}s"
+    else
+        msg="wall-clock ${ELAPSED}s > budget ${BUDGET_SECONDS}s"
+        if [[ "$ENFORCE_BUDGET" -eq 1 ]]; then
+            check_fail "$msg" "Goal #11 closing-criteria run; see docs/acceptance/smoke.md 'What \"60s\" means'"
+        else
+            check_warn "$msg" "non-closing run; rerun with --enforce-budget for hard-fail behaviour"
+        fi
+    fi
+fi
+
+# --- Summary -----------------------------------------------------------
+echo
+printf 'smoke.sh: %d passed, %d failed, %d warned\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$WARN_COUNT"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    echo "smoke.sh: federation chain DID NOT pass acceptance — see [FAIL] lines above" >&2
+    exit 1
+fi
+
+echo "[ok]   federation chain verified end-to-end (login + status + audit-row + Vault + DB-migration state)"
+exit 0


### PR DESCRIPTION
## Summary

- Producer-side acceptance bar for Goal #11 DoD bullet 2 — smoke.sh
  passes (login + status + audit-row + Vault + DB-migration state).
- Ships `docs/acceptance/smoke.md` (contract) + `scripts/acceptance/smoke.sh`
  (verifier) mirroring the pattern of #55 (install) and #57 (rollback):
  same `[ok]/[FAIL]/[WARN]` vocabulary, same 0/1/2 exit-code shape,
  same `--enforce-budget` with `SMOKE_START_TS` validation.
- Five legs assert the federation chain end-to-end against a SINGLE
  authenticated `GET /api/v1/health` — one request, one audit row,
  four parsed fields plus optional psql audit-row probe and optional
  kubectl/helm migration-Job cross-check.
- Updates `docs/acceptance/README.md` index + `docs/codebase/devops.md`
  Acceptance contracts table with the smoke row.

## Five legs and their predecessors

| # | Leg | Verifies | Predecessor |
| --- | --- | --- | --- |
| 1 | login | Keycloak → CLI → token store chain | #44 / #42 |
| 2 | status | Status API + JWT middleware + federation summary | #45 |
| 3 | audit-row | Audit middleware row-before-response contract | #28 |
| 4 | Vault | JWT/OIDC round-trip + secret read | #25 |
| 5 | DB-migration state | alembic_version == head + optional cluster cross-check | #29 |

## Test plan

- [x] `bash -n scripts/acceptance/smoke.sh` — clean parse
- [x] `shellcheck scripts/acceptance/smoke.sh` — no warnings
- [x] `bash scripts/acceptance/smoke.sh --help` — renders heredoc, exits 0
- [x] `bash scripts/acceptance/smoke.sh --bogus` — exits 2 (CLI usage error)
- [x] `bash scripts/acceptance/smoke.sh --enforce-budget` (no token,
  no `SMOKE_START_TS`) — fail-loud with `[FAIL] login: ...` AND
  `[FAIL] SMOKE_START_TS is unset` (matches install-verify.sh's
  contract-input discipline)
- [x] `MEHO_ACCESS_TOKEN=fake bash scripts/acceptance/smoke.sh --backplane
  https://nonexistent.invalid` — exits 1 with `[FAIL] status: GET
  failed` and downstream legs gracefully skip on missing
  `status_json` (no cascading [FAIL] noise; audit-row downgrades to
  `[WARN] ... skipped because leg #2 did not yield operator.sub`
  when DATABASE_URL was also set)
- [x] Pre-commit hooks (trailing whitespace, EOF, large-files,
  merge-conflicts, private-key, mixed-line-ending, gitleaks,
  conventional-commit) — all green

## Producer-side static-check scope (deferred to consumer for the live run)

The deployed-system smoke is **expected** to be deferred-to-consumer-side:

- AC1 (interactive `meho login`) requires a real browser + Keycloak realm
- AC4 (Vault's own audit log) requires consumer-side Vault access
- AC5 (test run captured) is a closing-comment artefact

The verifier itself ships in this PR; the producer side asserts only
that the verifier is well-formed (the four static checks above). The
actual smoke run against `meho.evba.lab` lands as the closing-comment
artefact on issue #56 after the consumer-side wrapper on
`claude-rdc-hetzner-dc/manifests/meho/smoke.sh` is wired up. See
`docs/acceptance/smoke.md` "Acceptance-criteria status" for the
full PR-time vs deployed-time split.

## Sensitive-data discipline (Goal #11 / Task #25)

- Bearer token never echoed (constructed inline in `curl -H "Authorization:
  Bearer $MEHO_ACCESS_TOKEN"`; never in `set -x` output; never in `ps`-visible
  argv beyond the curl header)
- Operator `sub` echoed (Keycloak UUID, needed for the audit-row WHERE
  clause + closing-comment proof); `name` and `email` deliberately
  excluded
- `vault.detail` carries only exception class names per
  `backend/src/meho_backplane/api/v1/health.py` discipline
- `psql` query parameterised via `psql -v sub='...'` — defensive even
  though Keycloak sub is a UUID

## Out of scope

- Sibling: #58 — 5-consecutive-merged-PR green-smoke counter + targets.yaml
- Sibling: #54 closing (orchestrator decision after all four
  G2.8 tasks land)
- Consumer-side `smoke.sh` wrapper on `claude-rdc-hetzner-dc` — driven
  by the consumer per Goal #11 cross-repo deps; this PR ships the
  contract + producer-side verifier the wrapper invokes

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed acceptance contract documentation for federation-chain verification, including requirements, success criteria, failure modes, and debugging guidance.
  * Updated acceptance contracts index and Definition of Done to include federation-chain smoke test specifications.

* **New Features**
  * Introduced end-to-end federation-chain verification tool featuring automated checks, standardized status reporting, and budget enforcement.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/194)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->