### PR TITLE
ci(go): bump CI Go version 1.22 -> 1.23 to match cli/go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,11 @@ jobs:
         # the tree today.
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          go-version: '1.22'
+          # Tracks `cli/go.mod`'s `go 1.23.0` directive. golangci-lint
+          # invokes `go/packages` which honors the go.mod-required Go
+          # version; running an older Go than go.mod requires fails with
+          # `go.mod requires go >= X` (CI run 25680051917).
+          go-version: '1.23'
           cache-dependency-path: cli/go.sum
 
       - name: golangci-lint

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -98,13 +98,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          # Matches `cli/go.mod`'s `go 1.22` directive. GoReleaser
+          # Matches `cli/go.mod`'s `go 1.23.0` directive. GoReleaser
           # builds with this toolchain; bumping requires an aligned
           # `cli/go.mod` edit so we hardcode the version explicitly
           # rather than reading it from go.mod via `go-version-file:`
           # (which would silently follow a future bump without a CI
           # rebuild signal).
-          go-version: '1.22'
+          go-version: '1.23'
           # Cache go modules across runs; speeds up the cold checkout
           # by 10-20s on the self-hosted runner pool's pre-warmed
           # filesystem. Keyed by cli/go.sum (the only Go module in


### PR DESCRIPTION
## What's still red after #190 merged

After #190 unblocked \`chart\` (cosign auth) and the Python \`CI\` matrix slot (Docker Hub rate limit), the **Go** matrix slot is the last remaining failure:

\`\`\`
level=error msg="Running error: context loading failed:
  failed to load packages: failed to load with go/packages:
  err: exit status 1: stderr: go: go.mod requires go >= 1.23.0
  (running go 1.22.12; GOTOOLCHAIN=local)"
##[error]golangci-lint exit with code 3
\`\`\`

## Root cause

[cli/go.mod:3](cli/go.mod#L3) declares \`go 1.23.0\`, but both [ci.yml:178](.github/workflows/ci.yml#L178) and [cli-release.yml:107](.github/workflows/cli-release.yml#L107) were still pinning \`go-version: '1.22'\`. \`golangci-lint\` shells out to \`go/packages\` which honors go.mod's required Go version, so an older toolchain fails fast.

The version drift already existed; it surfaced now because dependabot bumped \`golangci-lint-action\` (#193) to a newer point version that's stricter about the toolchain.

## What this PR does

- [ci.yml:178](.github/workflows/ci.yml#L178): \`go-version: '1.22'\` → \`'1.23'\`. Added a comment pointing at the go.mod requirement and the failing CI run.
- [cli-release.yml:107](.github/workflows/cli-release.yml#L107): same bump. Also updated the inline comment which still referenced the stale \`go 1.22\` directive.
- Both stay on a major-only pin (\`'1.23'\`, not \`'1.23.0'\`) so setup-go fetches the latest 1.23.x patch — same shape as the original 1.22 pin.

## Other CI jobs

Confirmed from CI run 25680051917 (the failing main run):

| Job | Status |
|---|---|
| Python (ruff + mypy + pytest) | ✅ 1m17s (mirror.gcr.io fix from #190 worked) |
| Helm (lint + template + kubeconform) | ✅ 10s |
| Go (golangci-lint + go test) | ❌ — fixed here |
| chart | ✅ (cosign auth fix from #190 worked) |
| image | ✅ |
| Secret Scan | ✅ |
| Security Scan | ✅ |
| Quality Gate (Sonar) | skipped (gated on CI success — will run after merge) |

## Test plan
- [ ] PR's own Go job: \`golangci-lint\` runs end-to-end (no \`requires go >= 1.23.0\` error)
- [ ] PR's own Go job: \`go build ./...\` + \`go test\` succeed under 1.23
- [ ] After merge, full main CI matrix is green and SonarCloud Quality Gate runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipelines to use Go version 1.23.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/196)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->