### PR TITLE
ci: replace gh api with curl + fix Dependabot uv directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,25 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  # When language manifests land, add per-ecosystem blocks below.
+  # Backend Python deps live at backend/pyproject.toml + backend/uv.lock.
+  # Without this block, Dependabot security updates default to `/` and
+  # fail with `dependency_file_not_found: { "file-path": "/" }` (Dependabot
+  # job 1360360077). The `uv` ecosystem covers the uv.lock format the
+  # project uses (Dependabot supports it natively since 2025).
+  - package-ecosystem: "uv"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # When other language manifests land, add per-ecosystem blocks below.
   # Reference (MEHO.X conventions):
   #
   # - package-ecosystem: "pip"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -373,18 +373,43 @@ jobs:
         # numbers — image digests, tags, and refs are all opaque strings.
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.RDC_DISPATCH_TOKEN != ''
         env:
-          # gh CLI reads GH_TOKEN for auth; the job-level RDC_DISPATCH_TOKEN
-          # is the PAT minted on claude-rdc-hetzner-dc.
-          GH_TOKEN: ${{ env.RDC_DISPATCH_TOKEN }}
+          # `curl` reads the PAT via this var; the job-level
+          # RDC_DISPATCH_TOKEN is the PAT minted on
+          # claude-rdc-hetzner-dc.
+          RDC_TOKEN: ${{ env.RDC_DISPATCH_TOKEN }}
           DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
+        # Implementation note: the original step used `gh api`, but the
+        # gha-runner-scale-set image doesn't ship the `gh` CLI (exit 127:
+        # command not found, CI run 25684872120). curl IS preinstalled
+        # (it's used by the kubeconform install in chart.yml too).
+        # python3's json.dumps does the heavy lifting on payload escaping
+        # so multi-line TAGS (newline-separated tag list from
+        # docker/metadata-action) are encoded as valid JSON strings,
+        # preserving the exact semantics gh provided.
         run: |
-          gh api repos/evoila-bosnia/claude-rdc-hetzner-dc/dispatches \
-            --method POST \
-            --silent \
-            -f event_type=meho-image-pushed \
-            -f client_payload[image]=ghcr.io/evoila/meho \
-            -f client_payload[digest]="${DIGEST}" \
-            -f client_payload[tag]="${TAGS}" \
-            -f client_payload[commit]="${GITHUB_SHA}" \
-            -f client_payload[ref]="${GITHUB_REF}"
+          set -euo pipefail
+          PAYLOAD="$(python3 -c '
+          import json, os
+          print(json.dumps({
+              "event_type": "meho-image-pushed",
+              "client_payload": {
+                  "image": "ghcr.io/evoila/meho",
+                  "digest": os.environ["DIGEST"],
+                  "tag": os.environ["TAGS"],
+                  "commit": os.environ["GITHUB_SHA"],
+                  "ref": os.environ["GITHUB_REF"],
+              },
+          }))
+          ')"
+          # --fail-with-body: non-2xx → non-zero exit AND print response
+          # body so the workflow log shows whatever Fulcio/Rekor/GitHub
+          # said. Mirrors gh's behavior. -sS silences progress but keeps
+          # error output.
+          curl --fail-with-body -sS -X POST \
+            -H "Authorization: Bearer ${RDC_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/json" \
+            -d "${PAYLOAD}" \
+            https://api.github.com/repos/evoila-bosnia/claude-rdc-hetzner-dc/dispatches


### PR DESCRIPTION
## Two leftover noisemakers after #196

CI is now green for the **core** matrix (CI / chart / image / secret / security / Sonar Quality Gate) — confirmed on PR #196's own merge. Two leftover failures kept showing up on every main push and every Dependabot security run:

### 1. \`image\` workflow: \`Notify claude-rdc-hetzner-dc\` exits 127

The cross-repo dispatch step added in #185 calls \`gh api ...\`. The gha-runner-scale-set image doesn't ship the gh CLI:

\`\`\`
/home/runner/.../sh: line N: gh: command not found
##[error]Process completed with exit code 127.
\`\`\`

Same minimal-runner pattern as envsubst (#183), PyYAML (#188), pip-missing (also #188). Rather than add a **fourth** inline install step, **replaced \`gh api\` with \`curl\`** (already on the runner — chart.yml uses it for the kubeconform install).

\`gh api\` is a thin wrapper around \`curl\` + the REST API, so the semantics are identical:
- \`Authorization: Bearer ${RDC_TOKEN}\` + \`Accept\` + \`X-GitHub-Api-Version\` + \`Content-Type\` headers
- \`--fail-with-body\`: non-2xx → non-zero exit AND prints the response body to the log (mirrors gh's behavior, including the fail-loud-on-401/422 design intent already documented in the step's comment block)

Payload construction uses \`python3 -c 'json.dumps(...)'\` so multi-line \`TAGS\` (newline-separated tag list from \`docker/metadata-action\`) are encoded as a valid JSON string. Matches what \`gh\`'s \`-f client_payload[tag]=\` produced.

### 2. Dependabot security updates: \`dependency_file_not_found: "/"\`

Two Dependabot \"uv in /.\" runs failed today:

\`\`\`
dependency_file_not_found: { "file-path": "/" }
\`\`\`

Dependabot tries uv security updates at \`/\` because [\`.github/dependabot.yml\`](.github/dependabot.yml) doesn't have a \`uv\` block telling it where the manifest lives. \`backend/pyproject.toml\` + \`backend/uv.lock\` exist; Dependabot just doesn't know to look in \`/backend\`.

Added a \`uv\` ecosystem block pointing at \`/backend\`. Same shape as the existing \`github-actions\` block (labels, schedule, commit prefix). Dependabot supports the \`uv\` ecosystem natively since 2025.

## Verification

\`\`\`
$ actionlint .github/workflows/image.yml
[exit 0]

$ python3 -c '<the heredoc from the curl step>'
{"event_type":"meho-image-pushed","client_payload":{...,
 "tag":"ghcr.io/evoila/meho:main\nghcr.io/evoila/meho:sha-deadbeef",...}}
[multi-line tag escaped correctly]

$ ruby -ryaml -e "YAML.load_file('.github/dependabot.yml')"
[exit 0]
\`\`\`

## Test plan
- [ ] PR's own \`image\` job goes past \`Notify claude-rdc-hetzner-dc\` (it'll skip on PR, since \`github.event_name == 'push'\` guard is still there)
- [ ] After merge, the next push to main runs the dispatch step successfully — verify the curl receives a 204 (the docs call out 204 No Content as the expected success response for repository_dispatch)
- [ ] After merge, the next scheduled Dependabot run picks up \`backend/uv.lock\` cleanly (no more \`/ not found\` errors)

## Out of scope (long-term)
Same as in prior PRs: bake \`gh\`, \`gettext-base\`, \`python3-yaml\` into the ARC runner image so future workflows don't need any of these workarounds. That's runner-config repo territory, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration for improved dependency management automation
  * Enhanced CI/CD workflow reliability for deployment notifications

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/197)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->