### PR TITLE
ci(license-check): ignore MarkupSafe pending PEP 639 support in pip-licenses

### DIFF
--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -69,8 +69,18 @@ jobs:
         # AGPL inbound is forbidden (would flip combined work to AGPL).
         # Multiple identifier forms covered because pip-licenses falls back
         # from PEP 639 License-Expression to Classifier to raw License field.
+        #
+        # --ignore-packages "MarkupSafe": MarkupSafe 3.x ships its license
+        # via PEP 639 `License-Expression: BSD-3-Clause` only — no Classifier,
+        # no legacy `License` field. pip-licenses 5.0.0 does not yet read PEP
+        # 639 expressions, so it reports MarkupSafe's license as UNKNOWN and
+        # fails the allow-only gate. BSD-3-Clause is already in the allowlist
+        # below; the package is widely vetted (Pallets); skipping the line-item
+        # check for this one package is safer than broadening the allowlist to
+        # include UNKNOWN. Remove this exception once pip-licenses gains PEP
+        # 639 support upstream.
         run: >
-          pip-licenses --format=plain --allow-only="
+          pip-licenses --format=plain --ignore-packages "MarkupSafe" --allow-only="
           Apache Software License;
           Apache-2.0;
           Apache 2.0;


### PR DESCRIPTION
## Summary

- Add `--ignore-packages \"MarkupSafe\"` to the `pip-licenses` invocation in `Python License Check`.
- Why: MarkupSafe 3.x publishes its license **only** via PEP 639 `License-Expression: BSD-3-Clause`. pip-licenses 5.0.0 doesn't read PEP 639 yet, so it falls back to `UNKNOWN` and fails the allow-only gate.
- Effect: backend Dependabot PRs that pull MarkupSafe transitively (sqlalchemy / pydantic / mypy / uvicorn — observed today on #200–#203) stop being blocked by a false-positive.

## Why now

Today's branch-protection update (`required_status_checks` = DCO + Python (ruff+mypy+pytest) + Go (golangci-lint+go test) + Helm (lint+template+kubeconform) + Semgrep SAST + TruffleHog Secret Scan) **does not** include `Python License Check` — precisely because the License Check is silently red on every backend dep bump. Closing this PR unblocks the next step: adding `Python License Check` + `NPM License Check` to `required_status_checks.contexts` so every dep bump goes through a real license gate too.

## Discipline preserved

The file-level comment in `dependency-license-check.yml` already says:

> When the dependency graph reveals license identifiers not in the allow-list (e.g. `Apache Software License` vs `Apache-2.0` — pip emits various forms), expand the allow-list specifically rather than broadening it.

`--ignore-packages \"MarkupSafe\"` is the *narrowest* possible response — it touches one package by name, not the allowlist. BSD-3-Clause is already accepted; this only papers over pip-licenses' missing PEP 639 reader. The exception is reversible: drop the flag the moment pip-licenses ships a version that reads PEP 639 `License-Expression`.

## Test plan

- [ ] CI shows `Python License Check` = success on this PR.
- [ ] No other backend deps regress (no new UNKNOWN-license failures surface).
- [ ] After merge, retry one of the backend Dependabot PRs that previously failed License Check to confirm the fix sticks under typical update flow.

## Refs

- PEP 639 — https://peps.python.org/pep-0639/
- pip-licenses 5.0.0 release notes (no PEP 639 support yet)
- Blocked PRs that motivated this fix: #200 #201 #202 #203 (now merged through the gap; closing the gap going forward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency license verification to ensure compatibility with project requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/204)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->