### PR TITLE
docs(acceptance): three small pre-flight nits

### DIFF
--- a/deploy/values-examples/values-kind.yaml
+++ b/deploy/values-examples/values-kind.yaml
@@ -74,8 +74,13 @@
 # even for local development.
 image:
   # MUST be overridden — pass `--set image.tag=sha-<git-sha>` at install
-  # time, or set it here before applying. The schema rejects an empty tag.
-  tag: ""
+  # time, or set it here before applying. The schema's pattern check
+  # rejects this `<REPLACE: ...>` literal AND an empty string equally,
+  # but the placeholder form keeps the failure message human-readable
+  # ("does not match pattern: <REPLACE: ...>") and stays consistent with
+  # `values-rdc-example.yaml`'s placeholder convention. A forgotten
+  # substitution fails-loud at `helm install` time, never silently.
+  tag: "<REPLACE: sha-<40-char-git-sha> or v0.1.0>"
 
 # Ingress is disabled on kind by default — kind ships no IngressClass and
 # the chart's port-forward flow (`kubectl port-forward`) is sufficient

--- a/deploy/values-examples/values-rdc-example.yaml
+++ b/deploy/values-examples/values-rdc-example.yaml
@@ -15,6 +15,15 @@
 # See `deploy/values-examples/README.md` for the substitution recipe
 # and the External Secrets Operator (ESO) sync patterns the chart
 # expects the consumer to provision before install.
+#
+# Top-level fields not shown in this example (e.g. `broadcast`,
+# `migrationJob`, `securityContext`, `affinity`, `tolerations`) are
+# satisfied by chart defaults in `deploy/charts/meho/values.yaml` —
+# override here only when the site requires non-default sizing,
+# retention, Redis/Valkey config, scheduling, or pod-security
+# context. The schema marks `broadcast` and `migrationJob` as
+# required at the top level; Helm's values-merge supplies the chart
+# defaults so the example doesn't need to redeclare them.
 
 replicaCount: 1
 

--- a/docs/acceptance/smoke.md
+++ b/docs/acceptance/smoke.md
@@ -62,6 +62,18 @@ audit-log signal-to-noise ratio high. The cluster-side cross-check
 in leg #5 is the only leg that makes a second probe (a kubectl /
 helm call), and that probe is read-only.
 
+**Note on script-side leg ordering.** The numbered legs above are the
+*contract* order — the narrative order an operator reads. The
+verifier (`scripts/acceptance/smoke.sh`) asserts them in a different
+order for fail-fast reasons: **#2 status → #4 Vault → #3 audit-row →
+#5 db-migration**. Leg #4 is asserted before leg #3 because the
+audit-row check needs the `operator_sub` from leg #2's response AND
+because a broken Vault chain often correlates with broken audit
+writes; failing fast on Vault avoids a flood of misleading audit-row
+`[FAIL]` lines that all point at the same root cause. The pass/fail
+verdict is identical either way — only the order of the lines in the
+verifier's output changes.
+
 ## What "passing" means
 
 The deployed system has **passed** the smoke when every required leg


### PR DESCRIPTION
## Summary

Three small doc / comment improvements surfaced during a producer-side pre-flight audit of the acceptance artefacts before #327 (consumer-side `manifests/meho/`) lands and the real cold-deploy is exercised.

**None block the deploy.** Addressing them now removes minor noise from the closing-comment artefacts on issues #55-#57.

## Changes

1. **`docs/acceptance/smoke.md`** — document the script-side leg-ordering inversion. The contract numbers legs `1 → 5` in narrative order (login → status → audit-row → Vault → db-migration), but `smoke.sh` asserts them as `#2 → #4 → #3 → #5` for fail-fast reasons. Reviewers comparing the contract to the verifier output shouldn't have to reverse-engineer the choice.

2. **`deploy/values-examples/values-rdc-example.yaml`** — header note that the schema's required top-level fields `broadcast` and `migrationJob` (plus optional `securityContext`, `affinity`, `tolerations`) are satisfied by chart defaults. The example doesn't need to redeclare them; without this note a reviewer might think the example is incomplete.

3. **`deploy/values-examples/values-kind.yaml`** — switch \`image.tag: \"\"\` to the \`<REPLACE: ...>\` placeholder convention used in \`values-rdc-example.yaml\`. The schema rejects both equally, but the placeholder form keeps the helm lint failure message human-readable.

All three are doc / comment changes only. No chart template, no verifier script, no schema modification. \`helm lint\` with valid stand-in values still passes.

## Test plan

- [ ] CI passes (6 required checks).
- [ ] \`helm lint deploy/charts/meho/ -f deploy/values-examples/values-rdc-example.yaml -f /tmp/override-rdc.yaml\` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying notes to example Helm values documentation explaining which chart fields are satisfied by defaults.
  * Added note to acceptance tests documenting the order of federation-chain verification.

* **Chores**
  * Updated example configuration placeholder to clearly indicate required overrides.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->