### PR TITLE
fix(#205): unblock cold-deploy — alembic script_location + configmap hook + SA override note

### DIFF
--- a/backend/src/meho_backplane/db/migrations.py
+++ b/backend/src/meho_backplane/db/migrations.py
@@ -128,9 +128,35 @@ def alembic_config(ini_path: Path | None = None) -> Config:
     Config is **not** cached — it is cheap to construct and the
     caller may want to override ``script_location`` for offline /
     test scenarios.
+
+    The on-disk ``alembic.ini`` ships ``script_location = alembic``
+    (relative) for source-tree dev ergonomics — running
+    ``alembic upgrade head`` from ``backend/`` Just Works.  Alembic's
+    ``coerce_resource_to_filename`` only does package-resource
+    resolution for values containing a colon (e.g. ``pkg:path``);
+    plain ``alembic`` is treated as a cwd-relative filename. That
+    breaks the installed-wheel path: the migration Job's container
+    has ``WORKDIR /app`` but the wheel's ``alembic/`` lives under
+    ``site-packages/meho_backplane/alembic/`` — Alembic fails with
+    ``Path doesn't exist: alembic`` (issue #205).
+
+    The convention in every resolution path of :func:`find_alembic_ini`
+    is that ``alembic/`` lives **adjacent to** ``alembic.ini`` (the
+    wheel's ``force-include`` ships them as siblings, the source
+    tree has them as siblings under ``backend/``, the cwd-fallback
+    and env-override patterns are the same). Override
+    ``script_location`` to that absolute path so Alembic finds the
+    scripts regardless of cwd. Guard with ``is_dir()`` so an exotic
+    layout where someone points ``$ALEMBIC_CONFIG`` at an ini-only
+    file falls through to whatever the ini said (caller can still
+    set ``script_location`` themselves; we don't lock it).
     """
     resolved = ini_path or find_alembic_ini()
-    return Config(str(resolved))
+    cfg = Config(str(resolved))
+    script_dir = resolved.parent / "alembic"
+    if script_dir.is_dir():
+        cfg.set_main_option("script_location", str(script_dir))
+    return cfg
 
 
 def _read_current_revision(connection: Connection) -> str | None:

--- a/backend/tests/test_db_engine.py
+++ b/backend/tests/test_db_engine.py
@@ -288,6 +288,64 @@ def test_find_alembic_ini_env_override_missing_raises(
     assert str(missing) in str(exc_info.value)
 
 
+def test_alembic_config_overrides_script_location_to_absolute_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``alembic_config`` overrides ``script_location`` to an absolute path.
+
+    Regression for issue #205: the on-disk ``alembic.ini`` ships
+    ``script_location = alembic`` (relative) for source-tree dev
+    ergonomics. Alembic's ``coerce_resource_to_filename`` only does
+    package-resource resolution for values containing a colon, so the
+    plain ``alembic`` ends up cwd-relative — which breaks the installed
+    -wheel path (the migration Job's WORKDIR is ``/app`` but the wheel
+    ships scripts at ``site-packages/meho_backplane/alembic/``).
+
+    The fix is to override ``script_location`` programmatically to the
+    absolute path of the ``alembic/`` directory adjacent to the
+    resolved ``alembic.ini``. Asserting against a tmp_path fixture is
+    sufficient: every resolution path in :func:`find_alembic_ini`
+    follows the same "scripts live next to ini" convention.
+    """
+    custom_ini = tmp_path / "alembic.ini"
+    custom_ini.write_text("[alembic]\nscript_location = alembic\n")
+    scripts_dir = tmp_path / "alembic"
+    scripts_dir.mkdir()
+    monkeypatch.setenv("ALEMBIC_CONFIG", str(custom_ini))
+
+    cfg = alembic_config()
+
+    resolved_script_location = cfg.get_main_option("script_location")
+    assert resolved_script_location is not None
+    assert Path(resolved_script_location).is_absolute()
+    assert Path(resolved_script_location) == scripts_dir
+
+
+def test_alembic_config_preserves_ini_script_location_when_adjacent_dir_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``alembic_config`` falls through to the ini value when no adjacent dir.
+
+    Defensive: if an operator points ``$ALEMBIC_CONFIG`` at an ini file
+    that *doesn't* sit next to an ``alembic/`` directory (exotic
+    layouts — mounted ConfigMap, partial overlay), don't lock the
+    script_location to a path that doesn't exist. Fall through to
+    whatever the ini said; the caller can still override
+    programmatically. This guard keeps the fix surgical — we add an
+    override only when the conventional adjacent layout is satisfied.
+    """
+    custom_ini = tmp_path / "alembic.ini"
+    custom_ini.write_text("[alembic]\nscript_location = /opt/scripts\n")
+    # Deliberately do NOT create tmp_path / "alembic"/.
+    monkeypatch.setenv("ALEMBIC_CONFIG", str(custom_ini))
+
+    cfg = alembic_config()
+
+    assert cfg.get_main_option("script_location") == "/opt/scripts"
+
+
 # ---------------------------------------------------------------------------
 # Optional testcontainers-PG suite
 # ---------------------------------------------------------------------------

--- a/deploy/charts/meho/templates/configmap.yaml
+++ b/deploy/charts/meho/templates/configmap.yaml
@@ -4,6 +4,32 @@ metadata:
   name: {{ include "meho.fullname" . }}-config
   labels:
     {{- include "meho.labels" . | nindent 4 }}
+  # Pre-install / pre-upgrade hook so the ConfigMap exists before the
+  # migration Job's Pod is created. The migration Job (weight -10)
+  # mounts this ConfigMap via `envFrom`, so without the hook
+  # annotation the Pod hits `Error: configmap "<release>-config" not
+  # found` and the entire `helm install --atomic` rolls back before
+  # the Deployment ever renders (issue #205).
+  #
+  # Weight -20 (lower than the migration Job's -10) sequences the
+  # ConfigMap first within the pre-install phase.
+  # `before-hook-creation` means each upgrade replaces the previous
+  # ConfigMap cleanly; the Pod's envFrom is read at Pod start so the
+  # brief delete-recreate window doesn't affect a running backplane.
+  #
+  # Lifecycle implication: hook resources are not tracked by the
+  # release manifest. `helm get manifest` won't list this ConfigMap,
+  # and `helm uninstall` won't garbage-collect it. The trade-off is
+  # acceptable for v0.1 (the Deployment in the release manifest
+  # references the ConfigMap by name, which exists because the hook
+  # ran; uninstall is rare and `kubectl delete cm <release>-config`
+  # cleans up). v0.2 may split this into two ConfigMaps (a
+  # migration-only hook + a release-tracked one for the Deployment)
+  # if leak-on-uninstall becomes load-bearing.
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-20"
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   # Non-secret env vars consumed by the backplane via `envFrom` in the
   # Deployment. Keys follow `backend/src/meho_backplane/settings.py`'s

--- a/deploy/values-examples/values-rdc-example.yaml
+++ b/deploy/values-examples/values-rdc-example.yaml
@@ -32,7 +32,16 @@ image:
 imagePullSecrets: []
 
 serviceAccount:
-  create: true
+  # The RDC lab pre-provisions a ServiceAccount named `meho-backplane`
+  # via consumer-side ticket #266 (claude-rdc-hetzner-dc). When the lab
+  # admin owns the SA's name + RBAC, set `create: false` and `name:
+  # <existing-sa>` to wire the chart's Deployment to the existing SA.
+  #
+  # Greenfield labs that want the chart to create its own SA can flip
+  # `create: true` and remove `name` — the chart names the SA after the
+  # release (`<release>` — `meho` for the default release name).
+  create: false
+  name: meho-backplane
   # The RDC lab uses ESO + Vault for secret sync, not workload-identity
   # bindings, so the SA carries no IAM/IRSA annotations.
   annotations: {}


### PR DESCRIPTION
## Summary

Three co-dependent fixes for [#205](https://github.com/evoila/meho/issues/205). Together they unblock the cold-deploy path that [`claude-rdc-hetzner-dc/manifests/meho/install.sh` (#327)](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/327) drives. Without all three, `helm install --atomic` rolls back on the pre-install migration Job before the Deployment ever renders.

## What this changes

### (1) `backend/src/meho_backplane/db/migrations.py` — alembic_config() overrides script_location

**Symptom on cold install:**
```
migration_failed: CommandError: Path doesn't exist: alembic.
Please use the 'init' command to create a new scripts folder.
```

**Root cause**: `backend/alembic.ini` ships `script_location = alembic` (relative) for source-tree dev ergonomics. Alembic's `coerce_resource_to_filename` only does package-resource resolution for values containing a colon (`pkg:path`); the plain `alembic` is treated as a cwd-relative filename. That breaks the installed-wheel path: the migration Job's container has `WORKDIR /app` but the wheel's `alembic/` lives under `site-packages/meho_backplane/alembic/`.

**Fix**: override `script_location` programmatically in `alembic_config()` to the absolute path of the `alembic/` directory adjacent to the resolved `alembic.ini`. Works across all four resolution paths of `find_alembic_ini` (env var, wheel package data, cwd, source tree) because `alembic/` is conventionally sibling to `alembic.ini` in every one. Guard with `is_dir()` so exotic ini-only layouts fall through gracefully.

Two new regression tests in `test_db_engine.py` cover the override path and the defensive fall-through.

### (2) `deploy/charts/meho/templates/configmap.yaml` — pre-install hook (weight -20)

**Adjacent symptom**: `Error: configmap "meho-config" not found` — `templates/configmap.yaml` had no hook annotation, so it rendered in the "main" Helm phase AFTER the pre-install migration Job (weight `-10`). The Job's Pod referenced the ConfigMap via `envFrom`, hit "not found", and failed before migrations ran.

**Fix**: annotate ConfigMap as `helm.sh/hook: pre-install,pre-upgrade` with weight `-20` so the ConfigMap renders first within the pre-install phase. `before-hook-creation` lets each upgrade cleanly replace the previous ConfigMap.

Lifecycle implication documented in the template comment: hook resources aren't tracked by `helm get manifest` or cleaned up on `helm uninstall`. Acceptable for v0.1; v0.2 may split into two ConfigMaps (a migration-only hook + a release-tracked one for the Deployment) if leak-on-uninstall becomes load-bearing.

### (3) `deploy/values-examples/values-rdc-example.yaml` — document SA-name override

Not a chart bug. The RDC lab pre-provisions a ServiceAccount named `meho-backplane` via consumer-side [#266](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/266); the chart's default is to create its own SA named `<release>` (so `meho`). Without documentation, the dogfooding consumer hits this drift during install debugging.

Updated the `serviceAccount` block in the example to show the `create: false` + `name: meho-backplane` override pattern, with a comment explaining when greenfield labs should flip back to `create: true`.

## Validation

- [x] `helm lint deploy/charts/meho/ -f deploy/values-examples/values-rdc-example.yaml -f <stand-in-overrides>` — passes.
- [x] `helm template` confirms ConfigMap renders with `hook-weight: \"-20\"` and the migration Job retains `hook-weight: \"-10\"`.
- [x] New + existing `alembic_config` / `find_alembic_ini` tests pass under pytest (5/5).
- [x] Ruff / Ruff format / mypy all clean on touched files.

## Test plan (post-merge, the actual cold-deploy)

- [ ] `helm install meho oci://ghcr.io/evoila/meho-chart --version <ver> --set image.tag=<sha> -f values-rdc.yaml -n meho --wait --timeout 5m --atomic` completes without --rollback-on-failure firing on the migration Job.
- [ ] Cold install reaches healthy Pods + successful migration Job within 5 minutes wall-clock.
- [ ] Idempotent: re-running with the same `--tag` is a no-op past `helm upgrade --install`.

Closes #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database migration script location resolution for installed wheel packages
  * Improved Helm deployment stability by ensuring ConfigMap is created before migrations during install/upgrade cycles, preventing atomic rollback failures

* **Tests**
  * Added tests for database migration configuration behavior under override scenarios

* **Documentation**
  * Updated ServiceAccount configuration example to reference pre-existing accounts with proper RBAC setup

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->