### PR TITLE
refactor + docs: async readiness probes + Vault provisioning spec

### DIFF
--- a/backend/src/meho_backplane/auth/jwt.py
+++ b/backend/src/meho_backplane/auth/jwt.py
@@ -367,24 +367,7 @@ async def verify_jwt(authorization: str | None = Header(default=None)) -> Operat
     return _operator_from_claims(claims, token)
 
 
-def _http_get_json_sync(url: str) -> dict[str, Any]:
-    """Synchronous twin of :func:`_http_get_json` for the readiness probe.
-
-    The probe registry from Task #19 expects a synchronous callable, so
-    a sync HTTP client lives here. We don't share the async cache —
-    readiness is "Keycloak reachable *now*", not "we last reached it
-    inside some request".
-    """
-    with httpx.Client(timeout=_HTTP_TIMEOUT_SECONDS) as client:
-        response = client.get(url)
-        response.raise_for_status()
-        data: Any = response.json()
-        if not isinstance(data, dict):
-            raise httpx.HTTPError(f"expected JSON object from {url}, got {type(data).__name__}")
-        return data
-
-
-def keycloak_readiness_probe() -> ProbeResult:
+async def keycloak_readiness_probe() -> ProbeResult:
     """Readiness probe: confirm Keycloak's JWKS endpoint is fetchable.
 
     Registered with :mod:`meho_backplane.health` at app startup.
@@ -395,6 +378,15 @@ def keycloak_readiness_probe() -> ProbeResult:
     contract (Task #19), and Keycloak's JWKS endpoint is a single
     HTTP GET against a CDN-able JSON document — a few hundred
     milliseconds in the worst case.
+
+    Async because the JWKS fetch goes through :func:`_http_get_json`'s
+    :class:`httpx.AsyncClient`. The previous sync twin
+    (``_http_get_json_sync``) blocked the FastAPI event loop on every
+    ``/ready`` poll — on a busy worker that's enough to starve request
+    handling while the discovery + JWKS round-trips complete. Sharing
+    the async client path with the request hot path also keeps a
+    single transport configured the same way (timeouts, retries when
+    they land in v0.2).
 
     Failure detail surfaces the exception class name (not its
     message) so the probe payload never leaks issuer URLs or other
@@ -413,7 +405,7 @@ def keycloak_readiness_probe() -> ProbeResult:
     discovery_url = f"{issuer}/.well-known/openid-configuration"
 
     try:
-        discovery = _http_get_json_sync(discovery_url)
+        discovery = await _http_get_json(discovery_url)
         jwks_uri = discovery.get("jwks_uri")
         if not isinstance(jwks_uri, str) or not jwks_uri:
             return ProbeResult(
@@ -421,7 +413,7 @@ def keycloak_readiness_probe() -> ProbeResult:
                 ok=False,
                 detail="jwks_uri_missing",
             )
-        jwks = _http_get_json_sync(jwks_uri)
+        jwks = await _http_get_json(jwks_uri)
         if not isinstance(jwks.get("keys"), list):
             return ProbeResult(
                 name="keycloak",

--- a/backend/src/meho_backplane/auth/vault.py
+++ b/backend/src/meho_backplane/auth/vault.py
@@ -172,6 +172,29 @@ async def _to_thread_revoke_self(client: hvac.Client) -> None:
     await asyncio.to_thread(_do_revoke_self, client)
 
 
+def _do_read_health(client: hvac.Client) -> Any:
+    """Synchronously call ``client.sys.read_health_status(method="GET")``.
+
+    Factored out of :func:`vault_readiness_probe` so the blocking call
+    can be offloaded to a worker thread via :func:`_to_thread_read_health`
+    without inlining ``asyncio.to_thread(...)`` boilerplate at the probe
+    call site. The seam is also what tests substitute when validating
+    the probe's exception-mapping branches.
+
+    ``method="GET"`` returns the JSON body when status is 200 and a
+    :class:`requests.Response` (with a readable status code) when Vault
+    is sealed / uninitialised / standby. The HEAD default returns no
+    body — fine for a load balancer but loses the ``sealed`` flag we
+    surface in :attr:`ProbeResult.detail`.
+    """
+    return client.sys.read_health_status(method="GET")
+
+
+async def _to_thread_read_health(client: hvac.Client) -> Any:
+    """Run :func:`_do_read_health` off the event loop."""
+    return await asyncio.to_thread(_do_read_health, client)
+
+
 @asynccontextmanager
 async def vault_client_for_operator(operator: Operator) -> AsyncIterator[hvac.Client]:
     """Yield an authenticated :class:`hvac.Client` bound to *operator*.
@@ -272,12 +295,18 @@ def _classify_health_response(payload: Any) -> tuple[bool, str]:
     return False, f"unexpected_status: {status_code}"
 
 
-def vault_readiness_probe() -> ProbeResult:
+async def vault_readiness_probe() -> ProbeResult:
     """Readiness probe — confirm Vault's ``/sys/health`` is reachable.
 
     Registered with :mod:`meho_backplane.health` at app startup. Hits
     Vault on every call (no caching); ``/sys/health`` is unauthenticated
     and explicitly designed to be cheap by HashiCorp's own contract.
+
+    Async because hvac (the only seam to Vault we have) is synchronous
+    and would block the FastAPI event loop on every ``/ready`` poll if
+    called inline. The actual HTTP call is offloaded to a worker thread
+    via :func:`_to_thread_read_health`, mirroring the same pattern the
+    per-request login uses (:func:`_to_thread_jwt_login`).
 
     The probe distinguishes three failure shapes in ``detail``:
 
@@ -303,12 +332,7 @@ def vault_readiness_probe() -> ProbeResult:
 
     client = _build_client(settings)
     try:
-        # ``method='GET'`` so we get the JSON body when status is 200,
-        # and a ``requests.Response`` (with a status code we can read)
-        # when Vault is sealed / uninitialized / standby. The HEAD
-        # default returns no body, which is fine for a load balancer
-        # but loses the ``sealed`` flag we want to surface in detail.
-        payload = client.sys.read_health_status(method="GET")
+        payload = await _to_thread_read_health(client)
     except (
         requests.exceptions.ConnectionError,
         requests.exceptions.Timeout,

--- a/backend/tests/test_auth_jwt.py
+++ b/backend/tests/test_auth_jwt.py
@@ -454,21 +454,21 @@ def test_jwks_unreachable_returns_401() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_readiness_probe_passes_when_jwks_fetchable() -> None:
+async def test_readiness_probe_passes_when_jwks_fetchable() -> None:
     key = _make_rsa_keypair("kid-A")
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
-        result = keycloak_readiness_probe()
+        result = await keycloak_readiness_probe()
 
     assert result.name == "keycloak"
     assert result.ok is True
     assert result.detail == "jwks_fetched"
 
 
-def test_readiness_probe_fails_when_discovery_unreachable() -> None:
+async def test_readiness_probe_fails_when_discovery_unreachable() -> None:
     with respx.mock as mock_router:
         mock_router.get(_DISCOVERY_URL).mock(return_value=httpx.Response(503))
-        result = keycloak_readiness_probe()
+        result = await keycloak_readiness_probe()
 
     assert result.name == "keycloak"
     assert result.ok is False
@@ -476,7 +476,7 @@ def test_readiness_probe_fails_when_discovery_unreachable() -> None:
     assert result.detail.startswith("jwks_fetch_failed:")
 
 
-def test_readiness_probe_fails_when_jwks_malformed() -> None:
+async def test_readiness_probe_fails_when_jwks_malformed() -> None:
     with respx.mock as mock_router:
         mock_router.get(_DISCOVERY_URL).mock(
             return_value=httpx.Response(
@@ -487,7 +487,7 @@ def test_readiness_probe_fails_when_jwks_malformed() -> None:
         mock_router.get(_JWKS_URL).mock(
             return_value=httpx.Response(200, json={"unexpected": "shape"}),
         )
-        result = keycloak_readiness_probe()
+        result = await keycloak_readiness_probe()
 
     assert result.ok is False
     assert result.detail == "jwks_malformed"

--- a/backend/tests/test_auth_vault.py
+++ b/backend/tests/test_auth_vault.py
@@ -427,7 +427,7 @@ async def test_vault_other_error_wraps_to_client_error(
 # ---------------------------------------------------------------------------
 
 
-def test_readiness_probe_passes_on_unsealed_active_vault(
+async def test_readiness_probe_passes_on_unsealed_active_vault(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake = _install_fake_client(
@@ -439,7 +439,7 @@ def test_readiness_probe_passes_on_unsealed_active_vault(
             "version": "1.18.0",
         },
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.name == "vault"
     assert result.ok is True
@@ -447,7 +447,7 @@ def test_readiness_probe_passes_on_unsealed_active_vault(
     assert fake.sys.read_calls == [{"method": "GET"}]
 
 
-def test_readiness_probe_fails_on_sealed_vault(
+async def test_readiness_probe_fails_on_sealed_vault(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Sealed Vault answers ``/sys/health`` but cannot honour OIDC logins."""
@@ -455,26 +455,26 @@ def test_readiness_probe_fails_on_sealed_vault(
         monkeypatch,
         health_payload={"initialized": True, "sealed": True},
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail == "sealed"
 
 
-def test_readiness_probe_fails_on_uninitialized_vault(
+async def test_readiness_probe_fails_on_uninitialized_vault(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_client(
         monkeypatch,
         health_payload={"initialized": False, "sealed": False},
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail == "uninitialized"
 
 
-def test_readiness_probe_passes_on_standby_node(
+async def test_readiness_probe_passes_on_standby_node(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Standby Vault returns 429; hvac returns the raw Response.
@@ -487,13 +487,13 @@ def test_readiness_probe_passes_on_standby_node(
         status_code = 429
 
     _install_fake_client(monkeypatch, health_payload=_FakeResponse())
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is True
     assert result.detail == "http_429"
 
 
-def test_readiness_probe_reports_unexpected_status(
+async def test_readiness_probe_reports_unexpected_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A status code outside the documented matrix surfaces verbatim."""
@@ -502,28 +502,28 @@ def test_readiness_probe_reports_unexpected_status(
         status_code = 418
 
     _install_fake_client(monkeypatch, health_payload=_FakeResponse())
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail is not None
     assert "418" in result.detail
 
 
-def test_readiness_probe_fails_when_vault_unreachable(
+async def test_readiness_probe_fails_when_vault_unreachable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_client(
         monkeypatch,
         health_exc=requests.exceptions.ConnectionError("dns failure"),
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail is not None
     assert result.detail.startswith("unreachable: ConnectionError")
 
 
-def test_readiness_probe_handles_settings_failure(
+async def test_readiness_probe_handles_settings_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A missing required env var on probe call yields ``settings_unavailable``.
@@ -539,7 +539,7 @@ def test_readiness_probe_handles_settings_failure(
     monkeypatch.delenv("VAULT_ADDR", raising=False)
     get_settings.cache_clear()
 
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail is not None

--- a/backend/tests/test_vault_failures.py
+++ b/backend/tests/test_vault_failures.py
@@ -379,7 +379,7 @@ async def test_vault_login_failure_skips_body_and_skips_revoke(
 # ---------------------------------------------------------------------------
 
 
-def test_readiness_probe_reports_unreachable_on_dns_failure(
+async def test_readiness_probe_reports_unreachable_on_dns_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``/sys/health`` raising ``ConnectionError`` surfaces as
@@ -389,7 +389,7 @@ def test_readiness_probe_reports_unreachable_on_dns_failure(
         monkeypatch,
         health_exc=requests.exceptions.ConnectionError("nx domain"),
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.name == "vault"
     assert result.ok is False
@@ -399,7 +399,7 @@ def test_readiness_probe_reports_unreachable_on_dns_failure(
     assert "nx domain" not in result.detail
 
 
-def test_readiness_probe_reports_unreachable_on_timeout(
+async def test_readiness_probe_reports_unreachable_on_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A read timeout against ``/sys/health`` reports ``unreachable: Timeout``.
@@ -411,14 +411,14 @@ def test_readiness_probe_reports_unreachable_on_timeout(
         monkeypatch,
         health_exc=requests.exceptions.Timeout("upstream timeout"),
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail is not None
     assert result.detail.startswith("unreachable: Timeout")
 
 
-def test_readiness_probe_reports_sealed_on_503_response(
+async def test_readiness_probe_reports_sealed_on_503_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``/sys/health`` returning a 503 response object → ``detail="sealed"``.
@@ -431,13 +431,13 @@ def test_readiness_probe_reports_sealed_on_503_response(
         status_code = 503
 
     _install_fake_client(monkeypatch, health_payload=_FakeResponse())
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail == "sealed"
 
 
-def test_readiness_probe_reports_uninitialized_on_501_response(
+async def test_readiness_probe_reports_uninitialized_on_501_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``/sys/health`` returning 501 → ``detail="uninitialized"``."""
@@ -446,13 +446,13 @@ def test_readiness_probe_reports_uninitialized_on_501_response(
         status_code = 501
 
     _install_fake_client(monkeypatch, health_payload=_FakeResponse())
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail == "uninitialized"
 
 
-def test_readiness_probe_passes_on_dr_secondary_472(
+async def test_readiness_probe_passes_on_dr_secondary_472(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``/sys/health`` returning 472 (DR secondary) → ``ok=true`` with
@@ -463,13 +463,13 @@ def test_readiness_probe_passes_on_dr_secondary_472(
         status_code = 472
 
     _install_fake_client(monkeypatch, health_payload=_FakeResponse())
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is True
     assert result.detail == "http_472"
 
 
-def test_readiness_probe_passes_on_perf_standby_473(
+async def test_readiness_probe_passes_on_perf_standby_473(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``/sys/health`` returning 473 (performance standby) → ``ok=true``."""
@@ -478,13 +478,13 @@ def test_readiness_probe_passes_on_perf_standby_473(
         status_code = 473
 
     _install_fake_client(monkeypatch, health_payload=_FakeResponse())
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is True
     assert result.detail == "http_473"
 
 
-def test_readiness_probe_reports_unexpected_status_for_unknown_code(
+async def test_readiness_probe_reports_unexpected_status_for_unknown_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An undocumented status code surfaces verbatim as
@@ -494,14 +494,14 @@ def test_readiness_probe_reports_unexpected_status_for_unknown_code(
         status_code = 599
 
     _install_fake_client(monkeypatch, health_payload=_FakeResponse())
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail is not None
     assert "599" in result.detail
 
 
-def test_readiness_probe_reports_sealed_when_dict_payload_says_sealed(
+async def test_readiness_probe_reports_sealed_when_dict_payload_says_sealed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Dict payload with ``sealed: true`` (HTTP 200 path) →
@@ -514,13 +514,13 @@ def test_readiness_probe_reports_sealed_when_dict_payload_says_sealed(
         monkeypatch,
         health_payload={"initialized": True, "sealed": True},
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail == "sealed"
 
 
-def test_readiness_probe_reports_uninitialized_when_dict_payload_says_so(
+async def test_readiness_probe_reports_uninitialized_when_dict_payload_says_so(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Dict payload with ``initialized: false`` → ``uninitialized``."""
@@ -528,13 +528,13 @@ def test_readiness_probe_reports_uninitialized_when_dict_payload_says_so(
         monkeypatch,
         health_payload={"initialized": False, "sealed": False},
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail == "uninitialized"
 
 
-def test_readiness_probe_reports_vault_error_for_unclassifiable_response(
+async def test_readiness_probe_reports_vault_error_for_unclassifiable_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A :class:`hvac.exceptions.VaultError` from ``read_health_status``
@@ -547,7 +547,7 @@ def test_readiness_probe_reports_vault_error_for_unclassifiable_response(
         monkeypatch,
         health_exc=hvac.exceptions.VaultError("malformed response"),
     )
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail is not None
@@ -556,7 +556,7 @@ def test_readiness_probe_reports_vault_error_for_unclassifiable_response(
     assert "malformed response" not in result.detail
 
 
-def test_readiness_probe_handles_settings_failure(
+async def test_readiness_probe_handles_settings_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Missing required env vars on probe call → ``settings_unavailable: <Cls>``.
@@ -566,7 +566,7 @@ def test_readiness_probe_handles_settings_failure(
     monkeypatch.delenv("VAULT_ADDR", raising=False)
     get_settings.cache_clear()
 
-    result = vault_readiness_probe()
+    result = await vault_readiness_probe()
 
     assert result.ok is False
     assert result.detail is not None

--- a/docs/cross-repo/README.md
+++ b/docs/cross-repo/README.md
@@ -22,6 +22,7 @@ prove the handshake works end-to-end.
 | --- | --- | --- |
 | [`rke2-infra-coordination.md`](./rke2-infra-coordination.md) | [`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc) | Per-PR ephemeral-cluster smoke + `repository_dispatch` deploy trigger; cluster auth (OIDC > kubeconfig); namespace-scoped RBAC for `meho-ci-*` |
 | [`targets-yaml.md`](./targets-yaml.md) | [`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc) | `targets.yaml` `rdc-meho` entry — schema, worked example, and health-probe contract for the consumer's connector chassis to manage MEHO as a target (Goal #11 DoD bullet 5) |
+| [`vault-provisioning.md`](./vault-provisioning.md) | [`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc) | Vault auth method + role + policy + KV mount + **federation-proof test KV path** (`secret/meho/test/federation`) the backplane reads on every authenticated `/api/v1/health` call. The fifth surface is the one most easily missed during provisioning — its absence breaks smoke leg #4 with a misleading "chain broken" diagnostic |
 
 The consumer-side ticket body the maintainer files when shipping
 the consumer-side half of Task #58 is drafted at

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -1,0 +1,195 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Vault provisioning — consumer-side requirements
+
+> Producer-side spec for what an operator's Vault deployment must
+> provide before the MEHO backplane can run its federation chain
+> against it. The actual provisioning lives on the consumer side
+> ([`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)
+> in the dogfood case); this doc is the contract the consumer reads
+> to know what to build, and the verification commands either side
+> can run to prove the handshake works.
+
+## Why this lives in `evoila/meho`
+
+The federation chain is wired in `backend/src/meho_backplane/auth/vault.py`
+and exercised on every authenticated request to `/api/v1/health`.
+When the chassis changes the shape of "what Vault must accept" — a
+new audience, a new mount path, a new KV layout — this document
+changes in lock-step with the code; the consumer's provisioning
+runbook doesn't need to know about chassis-side renames as long as
+the contract on this page holds.
+
+## What the backplane needs
+
+Five distinct Vault surfaces. The first four ship via Goal #11's
+cross-repo deps (consumer commitment #5 — see
+[`#261`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/261)
+in the consumer repo). The fifth — the federation-proof test KV
+path — is the surface most easily missed during provisioning.
+
+### 1. JWT/OIDC auth method
+
+Mount at `auth/oidc/` (the default Vault convention; configurable
+via `VAULT_OIDC_MOUNT_PATH` if a non-default mount is operationally
+necessary).
+
+```bash
+vault auth enable oidc
+vault write auth/oidc/config \
+  oidc_discovery_url=https://<keycloak-host>/realms/<realm> \
+  oidc_client_id=<keycloak-client-id> \
+  oidc_client_secret=@<(...) \
+  default_role=meho-mcp
+```
+
+The discovery URL must match `KEYCLOAK_ISSUER_URL` in the backplane's
+ConfigMap exactly. Trailing slashes are normalised on the producer
+side.
+
+### 2. Role `meho-mcp`
+
+Bound to the Keycloak realm and to the backplane's audience.
+Default role name `meho-mcp` per
+[`backend/src/meho_backplane/settings.py`](../../backend/src/meho_backplane/settings.py)'s
+`VAULT_OIDC_ROLE`; configurable via env var if a different name fits
+the operator's Vault conventions.
+
+```bash
+vault write auth/oidc/role/meho-mcp \
+  user_claim=sub \
+  bound_audiences=<keycloak-audience> \
+  role_type=jwt \
+  policies=meho-mcp \
+  ttl=1h
+```
+
+The `bound_audiences` value must match `KEYCLOAK_AUDIENCE` in the
+backplane's ConfigMap.
+
+### 3. Policy `meho-mcp`
+
+Grants the role the read paths the backplane exercises. v0.1 needs
+**read** on the entire `secret/meho/*` subtree because operators
+delegate per-secret authorisation to their Keycloak group
+membership (groups → Vault external-group bindings → richer
+policies) rather than per-path Vault policy:
+
+```hcl
+path "secret/data/meho/*" {
+  capabilities = ["read"]
+}
+path "secret/metadata/meho/*" {
+  capabilities = ["read"]
+}
+```
+
+Both paths are required: KV v2 splits the secret value (`/data/`)
+from its metadata (`/metadata/`); the backplane reads `/data/`
+through hvac's `secrets.kv.v2.read_secret_version`, and the read
+also touches `/metadata/` to honour `raise_on_deleted_version`.
+
+### 4. KV v2 mount at `secret/`
+
+The default Vault convention. Configurable via `vault.paths.kv` in
+the chart (default `secret/meho`); the backplane reads under that
+prefix.
+
+```bash
+vault secrets enable -path=secret -version=2 kv  # if not already
+```
+
+Existing labs that already have `secret/` mounted as KV v2 (the
+default in fresh Vault installs) don't need to do this; the policy
+above will Just Work.
+
+### 5. Federation-proof test KV path `secret/meho/test/federation`
+
+**This is the surface most easily missed.** The producer-side
+`/api/v1/health` handler reads `secret/meho/test/federation` on
+every authenticated call to prove the federation chain works
+end-to-end (Keycloak JWT → Vault OIDC login → KV read). The
+producer-side path is hard-coded at
+[`backend/src/meho_backplane/api/v1/health.py:68`](../../backend/src/meho_backplane/api/v1/health.py#L68)
+and intentionally not configurable in v0.1 — per-route customisation
+of which secret to read lands with the first connector post-Goal-2.
+
+The data at this exact path **must exist** when smoke leg #4
+("Vault federation works") is run, otherwise the read fails with
+`vault.read_ok=false` + `detail="read_failed: InvalidPath"` and the
+smoke verifier exits 1 even though the entire rest of the
+federation chain (auth, login, role binding, policy) is healthy.
+The diagnostic is misleading because the failure looks like a chain
+break when it's actually a missing fixture.
+
+Provisioning command (one-time, value content immaterial):
+
+```bash
+vault kv put secret/meho/test/federation \
+  purpose="MEHO v0.1 federation-proof fixture" \
+  note="Read by /api/v1/health; absence breaks smoke.sh leg #4"
+```
+
+The value's *content* is never read by the backplane — only the
+presence of the path is asserted (via hvac's KV v2 metadata
+read returning a non-error response with a `version` field). Any
+non-empty key set works; the two keys above are a self-documenting
+default the lab admin can grep for during incident response.
+
+## Verification
+
+Run from any host with the operator's Vault token (`vault login`
+against the operator's Keycloak identity, OR a service-account
+JWT bound to the same role).
+
+```bash
+# 1. Auth method exists with correct discovery URL
+vault read -format=json auth/oidc/config \
+  | jq '{oidc_discovery_url, default_role}'
+
+# 2. Role exists with correct audience binding
+vault read -format=json auth/oidc/role/meho-mcp \
+  | jq '{bound_audiences, user_claim, role_type, policies}'
+
+# 3. Policy grants meho/* read
+vault policy read meho-mcp
+
+# 4. KV mount is v2 at the expected prefix
+vault secrets list -format=json \
+  | jq '."secret/" | {type, options}'
+# Expect: type="kv", options.version="2"
+
+# 5. Federation-proof fixture exists
+vault kv get -format=json secret/meho/test/federation \
+  | jq '.data.metadata.version'
+# Expect: a positive integer (the KV-v2 version number).
+# A "No value found at secret/data/meho/test/federation" error is
+# the smoking gun for missing surface #5.
+```
+
+When commands 1-5 all return non-error output and the JSON
+extractions are populated, the backplane's federation chain has
+everything it needs from Vault.
+
+## Failure modes the consumer should expect
+
+| Failure | Diagnostic on the producer side | Consumer-side fix |
+| --- | --- | --- |
+| `/api/v1/health` returns `vault.reachable=false`, `detail="login_failed: VaultUnreachableError"` | TCP / TLS / timeout to `VAULT_ADDR`. The readiness probe `/ready` also reports `vault` as unhealthy. | Verify `VAULT_ADDR` resolves and is reachable from the backplane Pod's network policy (egress to Vault is in the chart's NetworkPolicy by default — check `networkPolicy.vaultCIDR`) |
+| `/api/v1/health` returns `vault.reachable=false`, `detail="login_failed: VaultRoleDeniedError"` | Vault accepted the connection but rejected the JWT for the configured role. | Verify surface 2 (role binding). Most often: `bound_audiences` doesn't match the audience the backplane is forwarding (cross-check `KEYCLOAK_AUDIENCE` env var against `vault read auth/oidc/role/meho-mcp`) |
+| `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: InvalidPath"` | **Missing surface 5** — federation-proof KV path doesn't exist. | Run the provisioning command from surface 5 above |
+| `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: Forbidden"` | **Missing surface 3** — policy doesn't grant read on `secret/meho/*`. | Verify surface 3 (`vault policy read meho-mcp`); the policy must include both `secret/data/meho/*` and `secret/metadata/meho/*` |
+| `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: KeyError"` or `read_failed: TypeError` | Vault returned an unexpected payload shape — KV-v1 mount instead of v2, proxy mangling the response, etc. | Verify surface 4 (KV v2 mount); the mount must be type `kv` with `options.version="2"` |
+
+## References
+
+- Producer-side handler: [`backend/src/meho_backplane/api/v1/health.py`](../../backend/src/meho_backplane/api/v1/health.py)
+- Producer-side Vault client: [`backend/src/meho_backplane/auth/vault.py`](../../backend/src/meho_backplane/auth/vault.py)
+- Backplane settings (env-var contract): [`backend/src/meho_backplane/settings.py`](../../backend/src/meho_backplane/settings.py)
+- Cross-repo handshake (cluster-side): [`./rke2-infra-coordination.md`](./rke2-infra-coordination.md)
+- Smoke leg #4 contract: [`../acceptance/smoke.md`](../acceptance/smoke.md)
+- Consumer-side parent ticket: [`evoila-bosnia/claude-rdc-hetzner-dc#293`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/293) — Vault OIDC federation to Keycloak (surfaces 1-4)
+- Vault OIDC docs: <https://developer.hashicorp.com/vault/docs/auth/jwt>


### PR DESCRIPTION
## Summary

Tackles the two observations from the [pre-flight runtime audit](https://github.com/evoila/meho/pull/207#issuecomment-... ): one code change (async probes), one doc addition (Vault provisioning spec). Two distinct commits for clean review; nothing in this PR blocks the cold-deploy on #327 — both are forward-looking improvements that surfaced during the audit.

## Commit 1 — `refactor(probes)`: convert readiness probes to async

The Keycloak and Vault readiness probes were registered with the readiness-probe registry as **synchronous** callables. The registry already supports async probes (`run_probes_async` dispatches via `inspect.iscoroutinefunction`), but the sync versions were calling blocking I/O (`httpx.Client.get` for the JWKS fetch, `hvac.Client.sys.read_health_status` for Vault's `/sys/health`) inline. That blocked the FastAPI event loop on every kubelet `/ready` poll for ~200-500ms (Keycloak round-trip) + ~50-100ms (Vault round-trip).

For v0.1 dogfood single-operator load the block was effectively invisible. The fix becomes load-bearing the moment concurrent operators land — which is exactly the v0.1 → v0.2 transition that triggers connector expansion.

**Changes:**
- `auth/jwt.py`: convert `keycloak_readiness_probe` to `async def`, use the existing `_http_get_json` (`httpx.AsyncClient`) instead of the sync twin. Delete `_http_get_json_sync` (dead after the conversion).
- `auth/vault.py`: add `_do_read_health` + `_to_thread_read_health` helpers (mirrors the existing `_do_jwt_login` / `_to_thread_jwt_login` pair, and finally makes the module docstring's promise of *three* `_to_thread_*` helpers accurate). Convert `vault_readiness_probe` to `async def`, use `await _to_thread_read_health(client)` for the blocking call.
- Tests (3 files, 21 functions): mechanical `def test_readiness_probe_*` → `async def test_readiness_probe_*` + `result = X()` → `result = await X()`.

**Validation:**
- All 83 health-area tests pass (3 + 7 + 11 probe tests + 62 sibling tests sharing the same fixtures).
- Ruff / Ruff format / mypy clean on touched source + test files.
- No production callers needed updating — `register_probe()` and `run_probes_async()` already handle both shapes.

## Commit 2 — `docs(cross-repo)`: producer-side spec for consumer-side Vault provisioning

The federation chain has five distinct Vault surfaces the consumer must provision before the backplane can run smoke leg #4 against the deployed instance. Surfaces 1-4 (auth method, role, policy, KV mount) are covered by consumer-side ticket [#293](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/293). **Surface 5** — a fixture at the *specific path* `secret/meho/test/federation` the backplane reads on every authenticated `/api/v1/health` call — is **not** explicitly enumerated in #293's acceptance.

#293's policy grants `secret/meho/*` read, so the *access* works. But the *data* at the producer's exact path may not exist. If not, smoke leg #4 would fail with:

```
vault.reachable=true, vault.read_ok=false, detail="read_failed: InvalidPath"
```

— a misleading diagnostic that looks like a chain break when it's actually a missing fixture.

**Changes:**
- `docs/cross-repo/vault-provisioning.md` (new, 195 lines): producer-side spec enumerating all 5 surfaces with vault-CLI commands, a 5-step verification recipe, and a failure-modes table mapping `/api/v1/health` response shapes back to the consumer-side surface that needs fixing. Surface #5 is called out explicitly as "the surface most easily missed" with its `vault kv put` command inline.
- `docs/cross-repo/README.md`: adds a row to the "Current handshakes" table referencing the new doc, with the surface-#5 call-out so README scanners find it.

## Test plan

- [x] CI passes (8 required checks).
- [x] All 83 health-area tests pass under pytest.
- [x] Ruff / format / mypy clean on touched files.
- [ ] After merge, lab admin (or a future operator) reads `vault-provisioning.md` and verifies surface #5 exists at `secret/meho/test/federation` before re-running smoke leg #4. If absent, the doc's provisioning command fixes it in one `vault kv put`.

## What this is NOT

- Not a fix for #205 — that landed as #207.
- Not blocking on #327 — both changes are forward-looking. The producer-side spec doc is consumed by future operators; the async probe refactor is anticipatory work for the v0.1 → v0.2 load transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Vault provisioning consumer requirements documentation detailing required authentication methods, role configurations, access policies, KV mounts, and federation test fixtures for backplane health verification.
  * Included step-by-step verification commands and troubleshooting guidance for authentication and authorization failures.

* **Tests**
  * Updated health check test suites across multiple test modules.

* **Refactor**
  * Modified authentication health check implementations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/208)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->