### PR TITLE
fix(ci): pin golangci-lint-action to v6.5.2 — v9 break since #198

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,17 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # golangci-lint-action v7+ refuses to install golangci-lint v1.x
+      # binaries; the in-tree cli/.golangci.yml is still on the v1
+      # config schema. Until the schema migration ships as a separate
+      # follow-up, major bumps of this action would break CI (and
+      # already did once via PR #198). Minor / patch bumps within v6
+      # still come through. See the long comment in .github/workflows/
+      # ci.yml's golangci-lint step for context.
+      - dependency-name: "golangci/golangci-lint-action"
+        update-types:
+          - "version-update:semver-major"
 
   # Backend Python deps live at backend/pyproject.toml + backend/uv.lock.
   # Without this block, Dependabot security updates default to `/` and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,15 +183,22 @@ jobs:
           cache-dependency-path: cli/go.sum
 
       - name: golangci-lint
-        # v6 (NOT v7+ / v8+) because the in-tree cli/.golangci.yml is
-        # written in the golangci-lint v1 config schema (disable-all +
+        # v6 (NOT v7+ / v8+ / v9+) because the in-tree cli/.golangci.yml
+        # is written in the golangci-lint v1 config schema (disable-all +
         # explicit enable list, v1 linter names like `gosimple` /
-        # `errcheck`). golangci-lint-action v7.x+ defaults to the v2
-        # binary which rejects v1 configs. Pinning the binary to
-        # v1.64.8 keeps the existing config valid; a future migration
-        # to the v2 schema can flip both the action major and the
-        # binary version together.
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
+        # `errcheck`). golangci-lint-action v7.x+ refuses to install any
+        # v1.x binary at all — fails with `invalid version string
+        # 'v1.64.8', golangci-lint v1 is not supported`. PR #198
+        # (Dependabot) attempted the major bump from v6.5.2 -> v9.2.0
+        # without the corresponding v2 config migration and broke every
+        # Go CI run on main between #198's merge and this revert. To
+        # prevent the same problem recurring, the action's major-version
+        # bumps are now in Dependabot's ignore list (see
+        # `.github/dependabot.yml`); minor / patch bumps within v6 still
+        # come through normally. Migrating cli/.golangci.yml to the v2
+        # schema is tracked as a separate follow-up — when that lands,
+        # the action major and the binary version flip together.
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84  # v6.5.2
         with:
           version: v1.64.8
           working-directory: cli


### PR DESCRIPTION
## Summary

[#198](https://github.com/evoila/meho/pull/198) (Dependabot) bumped `golangci/golangci-lint-action` from v6.5.2 to **v9.2.0**. The action major flipped without the corresponding `golangci-lint` v1 → v2 config migration. v7+ of the action refuses to install any v1.x binary at all:

\`\`\`
Failed to run: Error: invalid version string 'v1.64.8',
golangci-lint v1 is not supported by golangci-lint-action >= v7.
\`\`\`

That broke the \`Go (golangci-lint + go test)\` job on **every push to main** since #198 merged. Required-check enforcement on branch protection (just added this morning) means downstream PRs either ride red or wait for a fix; this PR unblocks them.

## Changes

1. **\`.github/workflows/ci.yml\`** — revert the action SHA from \`1e7e51e771...\` (v9.2.0) back to \`55c2c1448f...\` (v6.5.2, the SHA at HEAD just before #198 merged). Binary version \`v1.64.8\` stays. The comment at the lint step is extended to spell out exactly why the major is pinned, where the migration is tracked, and that #198 attempted the bump without the config migration — so a future reader doesn't repeat the mistake.

2. **\`.github/dependabot.yml\`** — add an \`ignore\` rule for \`golangci/golangci-lint-action\` major-version bumps under the \`github-actions\` ecosystem block. Minor and patch updates still flow normally (v6.5.3, v6.6.0, etc.), so the action stays reasonably current within v6 without Dependabot re-proposing the same broken bump every Monday.

## Why pin + ignore instead of migrating to v2 in this PR

The v2 migration is real work, not a one-line schema patch:

- \`gosimple\` was folded into \`staticcheck\` in v2 — needs removal from the enable list.
- The v2 config schema requires a top-level \`version: \"2\"\` key, a reorganised \`linters:\` block (\`disable-all: true\` → \`default: none\`), and per-section moves for \`linters-settings\` and \`issues\`.
- The v2 linter defaults catch things v1 didn't — the existing 5470 lines of CLI code may surface new lint findings that need fixes before CI goes green.
- \`golangci-lint\` isn't installed on the dev machine I used, so the migration couldn't be validated locally; pushing blind would mean iterating against CI for each new finding the v2 default catches.

A separate follow-up ticket is the right shape for the migration: single PR, careful schema work, local validation, fix-or-suppress each v2 finding individually. This PR's job is to stop the bleeding.

## Validation

- \`helm lint\` unaffected (no chart touch).
- Branch protection's \`required_status_checks.contexts\` still includes \`Go (golangci-lint + go test)\` (just verified via \`gh api\`). Once this lands and the next CI run completes, the check will go SUCCESS and PRs can merge again.

## Test plan

- [x] Workflow YAML is valid (the action SHA is the well-known v6.5.2 pin from before #198).
- [x] Dependabot config syntactically valid (\`ignore\` block with \`dependency-name\` + \`update-types\`).
- [ ] After merge: confirm \`Go (golangci-lint + go test)\` goes SUCCESS on the merge commit's CI run.

## Follow-up

A separate \`/new-ticket\` should track the v1 → v2 golangci-lint migration. Scope: bump action to current v9.x (or whatever's latest at migration time), migrate \`cli/.golangci.yml\` to v2 schema, drop \`gosimple\` from enable list (folded into staticcheck), fix or suppress any new v2-default findings, validate locally with \`golangci-lint v2.x.x run\` before pushing.

Refs: #198 (the breaking bump), #193 (the last good v6.5.2 SHA pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations and dependency management settings to enhance internal CI/CD processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/210)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->