### PR TITLE
fix(#209): chart trust-bundle injection — extraVolumes/extraVolumeMounts/extraEnv

### DIFF
--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -65,6 +65,14 @@ spec:
             # Other operator-supplied secrets (Keycloak client secret, Vault
             # role bindings) come via ESO-synced Kubernetes Secrets; G2.6
             # wires the references when each surface lands.
+            {{- with .Values.extraEnv }}
+            # Operator-supplied extra env vars (full EnvVar shape — accepts
+            # `value` or `valueFrom`). Most common use: pointing
+            # `SSL_CERT_FILE` at a trust-manager-distributed bundle path so
+            # the Python ssl context trusts internal-CA-signed Vault /
+            # Keycloak endpoints (Issue #209).
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           # Probes target the backplane's chassis health endpoints (Task #19,
           # `backend/src/meho_backplane/health.py`): `/healthz` for liveness
           # (returns 200 unconditionally; failure → pod restart) and `/ready`
@@ -85,9 +93,23 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            # Operator-supplied extra VolumeMounts. Paired with
+            # `extraVolumes` below — see Issue #209 for the trust-bundle
+            # use case (mount a trust-manager ConfigMap into the Pod so
+            # `SSL_CERT_FILE` resolves to a real path).
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        # Operator-supplied extra Volumes (full Volume shape). Most common
+        # use: mounting a trust-manager-distributed CA bundle ConfigMap
+        # so the backplane can connect to internal-CA-signed Vault and
+        # Keycloak (Issue #209). Paired with `extraVolumeMounts` above.
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/meho/templates/migration-job.yaml
+++ b/deploy/charts/meho/templates/migration-job.yaml
@@ -94,6 +94,14 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.postgres.credentialsSecret }}
                   key: url
+            {{- with .Values.extraEnv }}
+            # Operator-supplied extra env vars (full EnvVar shape).
+            # Shared with the backplane Deployment so e.g. `SSL_CERT_FILE`
+            # points at the same trust-bundle path. Postgres with internal
+            # CA-signed TLS is the typical reason the migration Job needs
+            # this too (Issue #209).
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.migrationJob.resources | nindent 12 }}
           securityContext:
@@ -104,9 +112,23 @@ spec:
             # emptyDir keeps readOnlyRootFilesystem: true valid.
             - name: tmp
               mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            # Operator-supplied extra VolumeMounts. Shared with the
+            # backplane Deployment so the migration Pod sees the same
+            # trust bundle / sidecar config / additional secret mounts
+            # (Issue #209).
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        # Operator-supplied extra Volumes. Shared with the backplane
+        # Deployment; see Issue #209 for the trust-bundle use case
+        # (internal-CA-signed Postgres often demands the same mount the
+        # backplane needs for Vault / Keycloak).
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -540,6 +540,21 @@
       "type": "object",
       "description": "Kubernetes Affinity surface — wide and version-dependent; schema permits arbitrary shape.",
       "additionalProperties": true
+    },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Extra Kubernetes Volume objects to attach to the backplane Pod AND the migration Job Pod. Each item is a full Volume shape; the chart renders the list verbatim. Loose `items: object` rather than enumerating every Volume source type because Kubernetes adds new ones over time and the API server validates downstream. Most common use: trust-manager CA bundle ConfigMaps (Issue #209).",
+      "items": { "type": "object" }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Extra Kubernetes VolumeMount objects for the backplane container AND the migration Job container. Pair each entry with an `extraVolumes` item of matching name — a mount with no matching Volume fails Pod admission.",
+      "items": { "type": "object" }
+    },
+    "extraEnv": {
+      "type": "array",
+      "description": "Extra Kubernetes EnvVar objects (value or valueFrom) appended to the backplane container env AND the migration Job container env. Most common use: pointing `SSL_CERT_FILE` at a mounted trust-bundle path so Python's default ssl context trusts internal-CA-signed Vault / Keycloak / Postgres endpoints (Issue #209). Don't collide with the chart's own keys (DATABASE_URL, REDIS_URL).",
+      "items": { "type": "object" }
     }
   },
   "definitions": {

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -371,3 +371,29 @@ nodeSelector: {}
 tolerations: []
 # -- Affinity rules applied to the Pod template.
 affinity: {}
+
+# -- Extra Volumes to attach to the backplane Pod AND the migration Job
+# Pod. Items are Kubernetes Volume objects rendered into the Pod spec
+# verbatim. Most common use: mounting a trust-manager-distributed CA
+# bundle ConfigMap so the backplane trusts internal-CA-signed Vault /
+# Keycloak / Postgres endpoints. See `deploy/values-examples/README.md`
+# for the SSL_CERT_FILE pattern (Issue #209). Default empty — no extra
+# volumes are mounted; clusters using only public CAs need nothing here.
+extraVolumes: []
+
+# -- Extra VolumeMounts attached to the backplane container AND the
+# migration Job container. Items are Kubernetes VolumeMount objects
+# rendered into the container spec verbatim. Pair with `extraVolumes`
+# above (a mount with no matching Volume name fails Pod admission).
+extraVolumeMounts: []
+
+# -- Extra environment variables for the backplane container AND the
+# migration Job container. Items are full Kubernetes EnvVar objects
+# (accepts `value` OR `valueFrom`). Most common use: `SSL_CERT_FILE`
+# pointing at a mounted trust bundle's path, so Python's default ssl
+# context honours internal CAs. The list is appended after the chart's
+# own env (DATABASE_URL, REDIS_URL); operator values win on collisions
+# only if Kubernetes' duplicate-EnvVar resolution rule (last-write-wins)
+# applies to your runtime. Don't rely on overrides — pick a name that
+# doesn't clash.
+extraEnv: []

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -173,6 +173,87 @@ Two resources combine to materialise a Secret the chart can consume:
 The `secret/meho` base is configurable via `vault.paths.kv` — adjust the
 KV paths above accordingly if you remount Vault elsewhere.
 
+## Internal-CA trust bundle (`extraVolumes` / `extraEnv`)
+
+The backplane connects to **Vault**, **Keycloak**, and **PostgreSQL**
+over TLS. Any lab whose Vault / Keycloak / PG ingress is signed by an
+**internal CA** (the realistic posture for every regulated lab) needs
+to inject that CA into the backplane Pod, otherwise the readiness probes
+fail with `SSLError` / `ConnectError` and `/ready` returns 503 even
+though `/healthz` is green. The `--atomic --wait` install path rolls
+back the release. This is Issue [#209](https://github.com/evoila/meho/issues/209).
+
+The chart exposes three top-level knobs — `extraVolumes`,
+`extraVolumeMounts`, `extraEnv` — that flow into both the backplane
+Deployment AND the migration Job (Postgres' internal-CA-signed TLS is
+the typical reason the migration Job needs the bundle too).
+
+### Recommended pattern: trust-manager + `SSL_CERT_FILE`
+
+In v0.1 the recommended path is [trust-manager](https://cert-manager.io/docs/trust/trust-manager/)
+(jetstack/trust-manager). The lab admin creates one `Bundle` resource
+cluster-wide; trust-manager distributes a `ConfigMap` containing
+`ca.crt` into every namespace flagged via
+`trust.cert-manager.io/include` (or a NamespaceSelector). The chart
+mounts that ConfigMap and points Python's ssl module at it via
+`SSL_CERT_FILE`:
+
+```yaml
+extraVolumes:
+  - name: trust-bundle
+    configMap:
+      name: internal-ca-bundle       # the ConfigMap trust-manager renders
+      optional: false                # fail-loud if it's missing
+
+extraVolumeMounts:
+  - name: trust-bundle
+    mountPath: /etc/ssl/extra-certs
+    readOnly: true
+
+extraEnv:
+  - name: SSL_CERT_FILE
+    value: /etc/ssl/extra-certs/ca.crt
+```
+
+`SSL_CERT_FILE` is CPython's standard env var
+([`ssl.get_default_verify_paths`](https://docs.python.org/3/library/ssl.html#ssl.get_default_verify_paths))
+— httpx, hvac, asyncpg, and SQLAlchemy all honour it without code
+changes. Mounting read-only keeps the discipline (the bundle is owned
+by trust-manager, not by anything inside the Pod).
+
+### Alternatives if trust-manager isn't deployed
+
+- **Direct ConfigMap.** Skip trust-manager; create the ConfigMap by hand
+  in the `meho` namespace. `extraVolumes[0].configMap.name` points at
+  it. Rotation is now the operator's job.
+- **Secret instead of ConfigMap.** Same `extraVolumes` shape with
+  `secret:` instead of `configMap:`. Useful if the bundle itself is
+  sensitive (uncommon — CA certificates are public-by-design).
+- **Pre-baked image.** Add the CA to the runtime image's
+  `/etc/ssl/certs/`. Rejected for v0.1 because it puts environment-
+  specific state into a public OSS artefact; the chart-side approach
+  keeps the image generic.
+
+### Verification
+
+After `helm install`:
+
+```bash
+# The mount is present
+kubectl exec -n meho deployment/meho -- ls -l /etc/ssl/extra-certs/ca.crt
+# SSL_CERT_FILE resolves to it
+kubectl exec -n meho deployment/meho -- printenv SSL_CERT_FILE
+# Python sees it
+kubectl exec -n meho deployment/meho -- python -c "import ssl; print(ssl.get_default_verify_paths().cafile)"
+# /ready turns green for vault + keycloak
+kubectl exec -n meho deployment/meho -- wget -qO- http://localhost:8000/ready | jq '.checks'
+```
+
+If `/ready` still reports `ssl_error` after the mount lands, check the
+**migration Job's** Pod logs — that Job uses the same bundle. A
+common drift cause: a typo'd ConfigMap name (the mount succeeds but
+the file is empty / wrong).
+
 ## End-to-end install flow
 
 The order matters because the chart's migration Job runs as a

--- a/deploy/values-examples/values-rdc-example.yaml
+++ b/deploy/values-examples/values-rdc-example.yaml
@@ -193,3 +193,44 @@ networkPolicy:
 # itself; see deploy/values-examples/README.md for the contract.
 eso:
   enabled: false
+
+# Trust bundle for internal-CA-signed Vault + Keycloak + Postgres.
+# The RDC lab uses trust-manager (jetstack/trust-manager) to distribute
+# an internal-CA-bundle ConfigMap (key `ca.crt`) into every namespace
+# that has the `trust.cert-manager.io/include` annotation. The chart
+# below mounts that ConfigMap into the backplane Pod AND the migration
+# Job Pod, then sets `SSL_CERT_FILE` so Python's default ssl context
+# honours it. Without this, the readiness probes' httpx calls to
+# Keycloak and the hvac calls to Vault both fail with `SSLError` and
+# `/ready` returns 503 even though `/healthz` is green — see Issue #209.
+#
+# The ConfigMap name (`internal-ca-bundle` here) is whatever the
+# trust-manager `Bundle` resource targets in this cluster; check
+# `kubectl get cm -n meho` to see the name your lab admin chose.
+extraVolumes:
+  - name: trust-bundle
+    configMap:
+      name: internal-ca-bundle
+      # `optional: false` (the default) fails Pod admission if the
+      # ConfigMap is missing — fails-loud, matching the chart-wide
+      # "no silent misconfig" discipline. trust-manager creates it
+      # before any Pod can mount it, so this is rare in practice.
+      optional: false
+
+extraVolumeMounts:
+  - name: trust-bundle
+    # `/etc/ssl/extra-certs/` is a convention; nothing else mounts
+    # here. `SSL_CERT_FILE` below points at the specific key. The
+    # mount is read-only — the bundle is owned by trust-manager, not
+    # by anything inside the Pod.
+    mountPath: /etc/ssl/extra-certs
+    readOnly: true
+
+extraEnv:
+  - name: SSL_CERT_FILE
+    # Python's `ssl` module honours `SSL_CERT_FILE` as a CA bundle
+    # path (see CPython `ssl.get_default_verify_paths()`). This routes
+    # httpx (Keycloak readiness probe, JWKS fetch) and hvac (Vault
+    # OIDC login, `/sys/health` poll) through the internal CA without
+    # the chart having to mutate the OS trust store.
+    value: /etc/ssl/extra-certs/ca.crt


### PR DESCRIPTION
## Summary

Fixes [#209](https://github.com/evoila/meho/issues/209) — the second-stage cold-deploy blocker that surfaced once #205 + #207 unblocked the migration Job. The backplane Pod's readiness probes fail with `SSLError` / `ConnectError` against internal-CA-signed Vault + Keycloak endpoints; `helm install --atomic --wait` rolls back the release.

The fix adds three new top-level chart knobs — \`extraVolumes\`, \`extraVolumeMounts\`, \`extraEnv\` — that flow into both the backplane Deployment AND the migration Job. The recommended pattern is trust-manager + \`SSL_CERT_FILE\`, which CPython's ssl module honours by default (no backend code change needed).

## Changes

### Chart templates

- **\`deploy/charts/meho/templates/deployment.yaml\`** — render \`extraEnv\` into the backplane container's env list (after \`DATABASE_URL\` and \`REDIS_URL\`), \`extraVolumeMounts\` into its volumeMounts (after \`tmp\` emptyDir), and \`extraVolumes\` into the Pod spec's volumes.
- **\`deploy/charts/meho/templates/migration-job.yaml\`** — same three additions, scoped to the migrate container. Postgres' internal-CA-signed TLS is the typical reason the migration Job needs the bundle too; without it the Job hits the same \`--atomic --wait\` rollback at the pre-install hook.

### Values + schema

- **\`deploy/charts/meho/values.yaml\`** — three new top-level keys, each defaulting to empty list. Long-form comments documenting the SSL_CERT_FILE pattern and the rendering contract (append after chart's own values; don't collide with DATABASE_URL / REDIS_URL).
- **\`deploy/charts/meho/values.schema.json\`** — three new top-level properties at the right indentation level (I caught one wrong-place edit during development; final lands at the top \`properties\` object). \`items: object\` is loose by design — Kubernetes adds new Volume source types over time and the API server validates the actual shape downstream.

### Examples + docs

- **\`deploy/values-examples/values-rdc-example.yaml\`** — worked example using trust-manager to distribute an \`internal-ca-bundle\` ConfigMap, mounted at \`/etc/ssl/extra-certs\`, with \`SSL_CERT_FILE\` pointing at the bundle.
- **\`deploy/values-examples/README.md\`** — new section \"Internal-CA trust bundle (\`extraVolumes\` / \`extraEnv\`)\" covering the trust-manager pattern, alternatives (direct ConfigMap, Secret, pre-baked image — rejected), and a 4-command verification recipe.

## Why \`SSL_CERT_FILE\` and not OS trust store patching

The chart could in principle patch \`/etc/ssl/certs/ca-certificates.crt\` via an initContainer running \`update-ca-certificates\`. Rejected because:

1. It requires \`privileged: true\` or a CAP_FOWNER addition, which conflicts with \`readOnlyRootFilesystem: true\` + \`allowPrivilegeEscalation: false\` discipline.
2. \`SSL_CERT_FILE\` is a single env var with the same effect for every Python TLS client in the Pod.
3. httpx / hvac / asyncpg / SQLAlchemy / etc. all honour \`SSL_CERT_FILE\` without code changes.

## Validation

- \`helm lint\` passes with both empty extras (default) and the trust-bundle-populated rdc example.
- \`helm template\` renders SSL_CERT_FILE + trust-bundle mount + trust-bundle volume in BOTH the Deployment AND the migration Job (12 grep hits in the rendered output for the populated values; 0 for empty values).
- Without extras, the chart renders identically to pre-change — the \`{{- with .Values.extraX }}\` guards no-op when the list is empty.
- Schema's \`additionalProperties: false\` at the top level still rejects typos like \`extraVoumes\` but accepts the three new properly-named keys.

## Test plan (post-merge, the actual cold-deploy)

- [ ] The new chart version publishes via \`chart.yml\` workflow.
- [ ] Lab admin updates \`claude-rdc-hetzner-dc/manifests/meho/values-rdc.yaml\` with the trust-bundle \`extraVolumes\` block from the example (pointing at whatever the lab's trust-manager Bundle ConfigMap is named).
- [ ] Re-run \`install.sh\`. Pod readiness should now flip green for \`vault\` and \`keycloak\` checks within the 5-minute budget.
- [ ] Smoke leg #4 (Vault federation) and leg #5 (DB migration) should both pass on the deployed instance.

Closes #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for injecting custom environment variables (`extraEnv`) and volume mounts (`extraVolumeMounts` and `extraVolumes`) into backplane and migration Job pods through Helm configuration.

* **Documentation**
  * Added comprehensive guide and example configurations for setting up internal CA trust bundles for TLS endpoint validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->