### PR TITLE
feat(backplane): add GET /api/v1/auth-config — public OAuth discovery for meho login

### DIFF
--- a/backend/src/meho_backplane/api/v1/__init__.py
+++ b/backend/src/meho_backplane/api/v1/__init__.py
@@ -3,8 +3,16 @@
 
 """Version 1 of the backplane HTTP API.
 
-v0.1 ships a single authenticated route — :mod:`~meho_backplane.api.v1.health`
-— that exercises the entire federation chain (JWT validation → Vault
-OIDC login → secret read) and returns the operator identity plus
-dependency status to the CLI's ``meho status`` command.
+v0.1 ships two routes:
+
+* :mod:`~meho_backplane.api.v1.auth_config` — public
+  ``GET /api/v1/auth-config`` that returns the Keycloak realm issuer +
+  audience so ``meho login`` can run the device-code flow against the
+  right realm without operator flags. Unauthenticated by design — this
+  is the OAuth metadata the CLI needs *before* it can auth.
+* :mod:`~meho_backplane.api.v1.health` — authenticated
+  ``GET /api/v1/health`` that exercises the entire federation chain
+  (JWT validation → Vault OIDC login → secret read) and returns the
+  operator identity plus dependency status to the CLI's
+  ``meho status`` command.
 """

--- a/backend/src/meho_backplane/api/v1/auth_config.py
+++ b/backend/src/meho_backplane/api/v1/auth_config.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /api/v1/auth-config`` — public OAuth discovery for the CLI.
+
+The CLI's device-code flow (``cli/internal/cmd/login.go``) needs the
+Keycloak realm issuer URL and the audience claim before it can run
+``cfg.DeviceAuth(flowCtx)``. Operators should only have to know one
+URL — the backplane's — so the CLI fetches both values from this
+endpoint at the start of ``meho login``.
+
+Unauthenticated by design:
+
+* This is the OAuth metadata the CLI needs **before** it can auth.
+* The values are public OAuth metadata — the issuer URL appears in
+  every JWT's ``iss`` claim and the audience appears in every JWT's
+  ``aud`` claim. They are not secrets.
+* Adding authentication here would create a chicken-and-egg loop with
+  ``meho login``.
+
+The values are sourced from the running ``Settings`` singleton — the
+same ones :mod:`~meho_backplane.auth.jwt` uses to validate inbound
+JWTs. The endpoint cannot drift from the validation surface because
+both read from the same env-var contract documented in
+:mod:`meho_backplane.settings`.
+
+Response shape locked by the CLI's discovery parser in
+``cli/internal/cmd/login.go`` (search for ``keycloak_issuer`` /
+``audience`` in that file's ``fetchBackplaneAuthConfig``). Field
+renames here are wire-compat breaks for the CLI.
+
+Closes the gap documented in closed Task #44's coordination note
+("add the endpoint to G2.2-T3's ``/api/v1/health`` Task body
+retroactively as a follow-up issue") that was never filed; the CLI
+shipped with the ``--issuer`` / ``--client-id`` fallback flags while
+this surface waited.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel, ConfigDict
+
+from meho_backplane.settings import get_settings
+
+__all__ = ["router"]
+
+
+class AuthConfigResponse(BaseModel):
+    """OAuth discovery surface returned to ``meho login``.
+
+    Field names match the CLI's expected JSON keys (``keycloak_issuer``
+    and ``audience``); renaming either field is a wire-compat break.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    keycloak_issuer: str
+    audience: str
+
+
+router = APIRouter(prefix="/api/v1", tags=["auth"])
+
+
+@router.get("/auth-config", response_model=AuthConfigResponse)
+async def auth_config() -> AuthConfigResponse:
+    """Return Keycloak issuer + audience for the CLI's device-code flow.
+
+    Reads :func:`~meho_backplane.settings.get_settings` so the response
+    cannot drift from the values :mod:`~meho_backplane.auth.jwt` uses
+    when it validates inbound JWTs. The issuer URL is trailing-slash-
+    normalised here — Keycloak's discovery document advertises the
+    canonical form without a trailing slash and the CLI's own URL
+    construction (``<issuer>/.well-known/openid-configuration``) is
+    cleaner against the normalised form.
+    """
+    settings = get_settings()
+    return AuthConfigResponse(
+        keycloak_issuer=str(settings.keycloak_issuer_url).rstrip("/"),
+        audience=settings.keycloak_audience,
+    )

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -29,6 +29,7 @@ from typing import Final
 from fastapi import FastAPI, Response
 
 from meho_backplane import __version__
+from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.jwt import keycloak_readiness_probe
@@ -122,6 +123,7 @@ app.add_middleware(RequestContextMiddleware)
 
 app.include_router(health_router)
 app.include_router(version_router)
+app.include_router(api_v1_auth_config_router)
 app.include_router(api_v1_health_router)
 
 

--- a/backend/tests/test_auth_config.py
+++ b/backend/tests/test_auth_config.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end tests for ``GET /api/v1/auth-config``.
+
+The route is unauthenticated — these tests deliberately verify that
+property by NOT passing an ``Authorization`` header and asserting the
+response is 200 (not 401). The CLI's device-code flow hits this
+endpoint before it has a JWT, so any future regression that adds auth
+would deadlock ``meho login``.
+
+The wire shape is locked to the CLI's parser in
+``cli/internal/cmd/login.go``'s ``fetchBackplaneAuthConfig``: it
+expects exactly ``keycloak_issuer`` and ``audience`` JSON keys. Field
+renames here are wire-compat breaks. The shape assertion below would
+catch that.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def _auth_config_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    """Pin the env vars ``Settings`` reads, then clear the lru_cache.
+
+    The settings singleton is cached at module scope by
+    :func:`functools.lru_cache`. Without the cache clear, a stale
+    instance constructed in an earlier test would survive into this
+    one and return the previous values regardless of the monkeypatched
+    env. The conftest's autouse fixture handles ``DATABASE_URL`` and
+    re-clears the cache around every test; we set the auth-specific
+    keys this route reads.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.evba.lab/realms/evba")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.evba.lab")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_auth_config_returns_keycloak_issuer_and_audience(
+    _auth_config_settings: None,
+) -> None:
+    """Happy path: response carries the values the CLI parses.
+
+    Wire shape locked to the CLI's expectation in
+    ``cli/internal/cmd/login.go``'s ``fetchBackplaneAuthConfig`` —
+    the parser reads ``keycloak_issuer`` and ``audience`` JSON keys.
+    """
+    with TestClient(app) as client:
+        response = client.get("/api/v1/auth-config")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "keycloak_issuer": "https://keycloak.evba.lab/realms/evba",
+        "audience": "meho-backplane",
+    }
+
+
+def test_auth_config_normalises_trailing_slash_on_issuer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Keycloak issuer URL is returned without a trailing slash.
+
+    Keycloak's discovery document advertises the canonical issuer
+    without a trailing slash; the CLI then builds
+    ``<issuer>/.well-known/openid-configuration``. Without
+    normalisation a double slash would appear in the discovery URL.
+    The route's :func:`str.rstrip` should drop trailing slashes
+    regardless of how the operator typed the env var.
+    """
+    monkeypatch.setenv(
+        "KEYCLOAK_ISSUER_URL",
+        "https://keycloak.evba.lab/realms/evba/",
+    )
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.evba.lab")
+    get_settings.cache_clear()
+
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/auth-config")
+    finally:
+        get_settings.cache_clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["keycloak_issuer"] == "https://keycloak.evba.lab/realms/evba"
+    assert not payload["keycloak_issuer"].endswith("/")
+
+
+def test_auth_config_is_unauthenticated(
+    _auth_config_settings: None,
+) -> None:
+    """Calling the route without an ``Authorization`` header returns 200.
+
+    This is the load-bearing security property: the CLI's
+    device-code flow needs this endpoint **before** it has a JWT. If
+    a future change accidentally adds ``Depends(verify_jwt_and_bind)``
+    to the route, this test will start returning 401 and fail loud,
+    preventing a regression that would deadlock ``meho login``.
+    """
+    with TestClient(app) as client:
+        response = client.get("/api/v1/auth-config")
+
+    assert response.status_code == 200
+    # Sanity: a request that DID include an Authorization header
+    # should also succeed (the route ignores it). This catches a
+    # regression that requires auth without rejecting unauthenticated.
+    with TestClient(app) as client:
+        response_with_header = client.get(
+            "/api/v1/auth-config",
+            headers={"Authorization": "Bearer not-actually-validated"},
+        )
+    assert response_with_header.status_code == 200
+
+
+def test_auth_config_route_is_registered_in_main_app() -> None:
+    """The route table contains exactly one ``/api/v1/auth-config`` GET.
+
+    Catches a regression where the router import lands but
+    ``app.include_router(api_v1_auth_config_router)`` is removed from
+    ``meho_backplane.main`` — the module imports fine but the endpoint
+    404s in production. The assertion is path-and-method-specific so a
+    typo in the prefix would surface as a mismatch.
+    """
+    matching_routes = [
+        route
+        for route in app.routes
+        # FastAPI's APIRoute exposes ``path`` + ``methods``; non-APIRoute
+        # entries (Mount, etc.) don't have ``methods`` so guard the
+        # attribute access defensively.
+        if getattr(route, "path", None) == "/api/v1/auth-config"
+        and "GET" in getattr(route, "methods", set())
+    ]
+    assert len(matching_routes) == 1, (
+        f"expected exactly one GET /api/v1/auth-config route, got {len(matching_routes)}"
+    )


### PR DESCRIPTION
## Summary

Closes a gap documented in **closed Task #44**'s coordination note that was never filed as a follow-up issue. The CLI's `meho login` calls `GET <backplane>/api/v1/auth-config` to discover Keycloak issuer + OAuth audience before running the device-code flow — but the endpoint didn't exist on the backplane. Operators had to pass `--issuer` + `--client-id` flags on every login; the `smoke.md` recipe (Step 2 — `meho login https://meho.evba.lab` no-flags) would have 404'd on the next cold-deploy attempt.

This is a one-commit gap-fill — no Task was filed per `/new-ticket` hard rule #5 (one-commit changes shouldn't get ticket hierarchies).

## What's in the PR

| File | Change |
| --- | --- |
| `backend/src/meho_backplane/api/v1/auth_config.py` | New 75-line module: unauthenticated `GET /api/v1/auth-config`, returns `{keycloak_issuer, audience}` from `Settings`. Mirrors the shape of `health.py` minus the federation chain. Issuer URL is trailing-slash-normalised so the CLI builds `<issuer>/.well-known/openid-configuration` cleanly. |
| `backend/src/meho_backplane/main.py` | 2-line addition: import + `app.include_router(api_v1_auth_config_router)`. |
| `backend/src/meho_backplane/api/v1/__init__.py` | Docstring update: v0.1 now ships two routes (auth_config public + health authenticated). |
| `backend/tests/test_auth_config.py` | New 150-line test module, 4 test cases (see below). |

## Tests (4, all asserting load-bearing properties)

1. **Happy path** — response shape exactly matches the CLI's parser (`fetchBackplaneAuthConfig` in login.go).
2. **Trailing-slash normalisation** — `https://kc/realms/evba/` becomes `https://kc/realms/evba` so the CLI's `<issuer>/.well-known/...` URL construction doesn't double-slash.
3. **Unauthenticated by design** — request without `Authorization` returns 200 (not 401). Sanity check: request WITH `Authorization` also returns 200 (route ignores it). **This is the security-property regression guard** — a future change that accidentally adds `Depends(verify_jwt_and_bind)` would deadlock `meho login` (CLI needs the endpoint *before* it has a JWT); this test fails loud on it.
4. **Route registration** — asserts exactly one `GET /api/v1/auth-config` in `app.routes` so a missing `app.include_router(...)` call surfaces immediately.

## Why no settings/chart/env changes

The values come from existing `Settings` fields populated by env vars the chart's ConfigMap already sets (`KEYCLOAK_ISSUER_URL`, `KEYCLOAK_AUDIENCE`). The endpoint is read-only against the running settings singleton — no new state, no new failure modes.

## Validation

- 4 new tests pass; 32 health-area tests total (incl. existing) all pass under pytest.
- Ruff / Ruff format / mypy clean on touched files.
- `helm lint` unaffected — no chart change.
- No new env vars, no `values.schema.json` entries, no ConfigMap keys.

## Test plan (post-merge)

- [ ] New chart will reference an image with this endpoint. Smoke leg #1 (`meho login https://meho.evba.lab` no-flags) should succeed end-to-end against the deployed instance once the lab admin retries the cold-deploy.
- [ ] `curl -sf https://meho.evba.lab/api/v1/auth-config | jq -e '.keycloak_issuer and .audience'` returns 200 + non-empty values.

## What this is NOT

- Not a refresh-token discovery URL (v0.2 once `meho login --refresh` lands).
- Not OAuth scopes discovery (`meho login --scope` accepts CLI flag overrides; default `["openid"]` set on the CLI side).
- Not an audit-log row (public endpoint, no operator identity at request time).
- Not rate-limited or cached — endpoint is cheap, called once per login.

Refs: closed [#44](https://github.com/evoila-bosnia/meho-internal/issues/44) (the meho login Task that documented this gap), closed Initiative [#21](https://github.com/evoila-bosnia/meho-internal/issues/21) (G2.2 — federation-chain Initiative), `cli/internal/cmd/login.go:201-238` (`fetchBackplaneAuthConfig`), `docs/acceptance/smoke.md` Step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public API endpoint (`GET /api/v1/auth-config`) that provides OAuth discovery metadata, including Keycloak issuer and audience information. This endpoint is unauthenticated and supports device-code login flows.

* **Tests**
  * Added comprehensive tests for the new authentication configuration endpoint, verifying proper HTTP responses, payload structure, and correct route registration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->