### PR TITLE
docs(planning): capture v0.2 strategic decisions

### DIFF
--- a/docs/planning/v0.2-decisions.md
+++ b/docs/planning/v0.2-decisions.md
@@ -1,0 +1,152 @@
+# v0.2 Strategic Decisions
+
+Captured during the v0.2 planning pass on 2026-05-12. These decisions are
+load-bearing for every Initiative under Goals [#214](https://github.com/evoila/meho/issues/214) (G3 connector parity), [#215](https://github.com/evoila/meho/issues/215) (G4 knowledge), [#216](https://github.com/evoila/meho/issues/216) (G5 memory), [#217](https://github.com/evoila/meho/issues/217) (G6 broadcast), [#218](https://github.com/evoila/meho/issues/218) (G7 conventions), [#219](https://github.com/evoila/meho/issues/219) (G8 audit query), [#220](https://github.com/evoila/meho/issues/220) (G9 topology + targets), and the foundational [#221](https://github.com/evoila/meho/issues/221) (G0 substrate).
+
+Decisions stay live until contradicted by a new captured decision; do not
+re-litigate without surfacing a `## Reopening discussion` block here first.
+
+---
+
+## Decision context: the hidden Goal #221 (G0)
+
+Before any v0.2 feature work, four (then five) structural gaps in the v0.1 chassis must close:
+
+- **No tenancy** in JWT validation or audit_log scoping.
+- **No connector base** — Vault + Keycloak are bespoke modules with no shared ABC.
+- **No targets-as-data** — consumer's `targets.yaml` is file-on-disk, client-resolved.
+- **No retrieval substrate** — pgvector + fastembed for G4 (kb) and G5 (memory) share one pipeline.
+- **No MCP server front** — added late after decision #6 below flipped MCP from "deferred" to "in-scope for v0.2".
+
+Filed as Goal [#221](https://github.com/evoila/meho/issues/221) with 5 Initiatives: [#222](https://github.com/evoila/meho/issues/222) (tenant), [#223](https://github.com/evoila/meho/issues/223) (connector base), [#224](https://github.com/evoila/meho/issues/224) (targets-as-data), [#225](https://github.com/evoila/meho/issues/225) (retrieval substrate), [#226](https://github.com/evoila/meho/issues/226) (MCP bootstrap).
+
+---
+
+## Locked decisions
+
+### 1. Track count — **3 parallel tracks after G0**
+
+After G0 (#221) ships, three producer-side tracks run in parallel:
+
+- **Track A:** G3 (#214) — connectors, starting with G3.1 vSphere (#227)
+- **Track B:** G6 (#217) — activity broadcast, starting with G6.1 SSE feed (#228)
+- **Track C:** G7 (#218) — tenant conventions + Layer 2 starter (#229)
+
+Phase 2 (G4 / G5 / G8 + G3 tier-2/3) and Phase 3 (G3 tier-4 + G9 full topology) fan in once Phase-1 tracks are in flight. Estimated **~12-15 weeks** to v0.2 ship at 3 effective tracks.
+
+**Why:** Damir chose the most aggressive option (~30 weeks at 1 track vs ~12 weeks at 3 tracks). Requires 3 effective parallel agent/human capacity. Coordination risk acknowledged in the G0.1 (#222) Initiative body — single migration includes all the columns G3 / G6 / G7 will need so migrations don't conflict during parallel Phase 1.
+
+### 2. G4 knowledge migration — **one-shot import + 1-month overlap**
+
+MEHO ingests the consumer's `kb/` directory once. The repo's `kb/` and `docs/` stay live as fallback for ≥1 month. Operators retire the in-repo path only once `meho kb search` is in daily use for ≥1 month and the team agrees.
+
+**Why:** Consumer-needs.md §G4 L121 explicitly leans this way. Single source of truth converges; the 1-month overlap absorbs migration-issue risk; dual-read-forever was rejected because it never converges. Locked in G4 Goal body (#215) DoD.
+
+### 3. G6 broadcast PII defaults — **conservative aggregate-only for sensitive ops**
+
+Sensitivity classifier on op_id:
+
+- `credential_read` (initially `vault.kv.read`, `vault.kv.list`) — broadcast as `{op_id, target, result_status}`. No path, no key names, no values.
+- `audit_query` (G8 verbs) — broadcast as `{op_id, result_status, row_count}`. No filter contents.
+- Everything else — full request params + structured response summary.
+
+Per-op opt-in to flip credential_read / audit_query to full detail is a G6.3 surface (separate Initiative, post-G6.1). Operator-side opt-out for a normally-full-detail op is also G6.3 territory.
+
+**Why:** Consumer-needs.md L368 lean. Aggregate-only-by-default-for-everything kills the team-coordination UX that's G6's whole point; full-detail-by-default leaks credentials when an operator forgets to mark a read as sensitive. The classifier-on-op_id middle ground gets safe defaults with explicit per-op overrides.
+
+### 4. G7 server-side partition — **operational rules only**
+
+Migrated to `rdc-internal` tenant conventions (Layer 1, server-side database-backed):
+- "Vault is canonical; 1Password is bootstrap-residual"
+- Naming rule — no `claude` / AI-tool names in operator-visible identifiers
+- Secret-handling discipline (never paste into chat, never commit secrets)
+- CLI-wrapper fallback discipline during MEHO transition
+- Sensitive-lab-specifics-stay-private (no real hostnames/IPs in public repo)
+
+NOT migrated (stay in repo CLAUDE.md):
+- /work-ticket flow + ticket+PR discipline
+- Markdown-sidecar convention for OpenAPI specs
+- PR cadence rules
+- Repo-internal naming for branches / commits
+
+**Why:** Operational rules bind ANY session against the tenant regardless of where it runs (Slack agent, MCP client, CLI on a different machine). Repo-internal rules apply only to repo work and have a filesystem of their own.
+
+### 5. G7 Layer 2 starter — **ship `docs/examples/consumer-onboarding/CLAUDE.md` + onboarding guide**
+
+MEHO ships a starter CLAUDE.md template in `docs/examples/consumer-onboarding/`. Consumer repos (today: `claude-rdc-hetzner-dc`; future: any external customer) copy it into their root or merge with an existing CLAUDE.md. The template teaches local Claude sessions to:
+
+- Prefer `meho kb search` over `grep kb/`
+- Prefer `meho <connector> <op>` over local `./scripts/*.sh` wrappers
+- Write memories through `meho remember`, not local files
+- Resolve targets through `meho targets describe`, not by reading `targets.yaml` directly
+
+Filed as part of G7.1's scope (#229), not a separate Initiative.
+
+**Why:** This addresses the layer the original G7 framing missed. Server-side conventions (Layer 1) bind agents connecting *through* MEHO; they don't help the operator's local Claude Code session in their cloned repo. The Layer 2 template provides consistent local-agent UX across consumer repos without per-operator divergence.
+
+### 6. G9 topology curation — **auto-discovery + curated cross-system edges in v0.2**
+
+G9 ships full ~100% topology in v0.2:
+
+- **Auto-discovery (~70%):** Probes derive obvious edges (k8s cluster → nodes, vCenter → VMs, NSX → portgroups).
+- **Curated cross-system edges (~30%):** Tenant-admin annotation flow + typed edges (`authenticates-via`, `routes-through`, `mounts`, `runs-on`, `depends-on`, etc.) + per-edge audit + edit conflict handling.
+
+The edge-type vocabulary is the load-bearing modeling decision; locked early in G9 (filed when we approach Phase 3 Initiative drafting).
+
+**Why:** Damir chose the aggressive option (full ~100% v0.2 vs auto-discovery-only). Adds ~1 Initiative to G9's original 2-Initiative scope, but unlocks topology-aware policy in v0.2.next without a deferred-curation re-litigation. Risk: cross-system edge modeling is wildcard LoE; if it slides, the auto-discovery half can still ship as v0.2.
+
+### 7. MCP server front — **ship in v0.2 alongside CLI**
+
+MEHO speaks MCP from v0.2 day 1. Bootstrap filed as G0.5 (#226). Every G3–G9 Initiative gains a parallel **MCP-tool-parity Task** alongside its CLI verb work.
+
+**Spec target:** MCP revision **2025-06-18** (current stable). Pinned in `docs/architecture/mcp.md` (to be created by G0.5).
+
+**Auth pattern:** MEHO acts as OAuth 2.1 resource server per RFC 9728 (Protected Resource Metadata) + RFC 8707 (audience binding). Keycloak (already integrated) is the authorization server. Re-uses the existing `verify_jwt` chain.
+
+**Transport:** Streamable HTTP. Stdio explicitly NOT supported (MEHO is hosted, not a local subprocess).
+
+**Why:** Damir chose the aggressive option (ship-in-v0.2 vs defer-to-v0.2.next). Doubles surface area per verb (every CLI command gets an MCP tool definition) but collapses the timeline to external pilot. Risk: MCP spec is still iterating; pin to 2025-06-18 and document upgrade discipline.
+
+---
+
+## Sequencing summary
+
+| Phase | Duration | Tracks | Initiatives shipping |
+|---|---|---|---|
+| Phase 0 | ~4 weeks | sequential (G0.1 first; then 4 parallel) | #222 → #223 + #224 + #225 + #226 |
+| Phase 1 | ~6-8 weeks | 3 parallel | #227 (G3.1) ∥ #228 (G6.1) ∥ #229 (G7.1) |
+| Phase 2 | ~3-4 weeks | fan-in | G3.2/3 + G4.1 + G5.1 + G8.1 (Initiatives to be filed when approaching) |
+| Phase 3 | ~2-3 weeks | fan-in | G3 tier-3/4 + G9 full topology (Initiatives to be filed when approaching) |
+
+**Total: ~28 Initiatives across 8 Goals → ~130-160 Tasks for v0.2.** Adjusted up from a ~100-150 Task estimate based on three aggressive decisions (3 tracks, full G9, MCP-in-v0.2).
+
+---
+
+## Filed under G0 (foundational substrate)
+
+- [#221](https://github.com/evoila/meho/issues/221) Goal G0 — foundational substrate
+- [#222](https://github.com/evoila/meho/issues/222) Initiative G0.1 — Tenant model (effort: medium)
+- [#223](https://github.com/evoila/meho/issues/223) Initiative G0.2 — Connector base + registry (effort: large)
+- [#224](https://github.com/evoila/meho/issues/224) Initiative G0.3 — Targets-as-data (effort: medium)
+- [#225](https://github.com/evoila/meho/issues/225) Initiative G0.4 — Retrieval substrate (effort: medium)
+- [#226](https://github.com/evoila/meho/issues/226) Initiative G0.5 — MCP server bootstrap (effort: large)
+
+## Filed under Phase-1 tracks
+
+- [#227](https://github.com/evoila/meho/issues/227) Initiative G3.1 — vSphere tier-1 connector (Track A; effort: large)
+- [#228](https://github.com/evoila/meho/issues/228) Initiative G6.1 — SSE feed core (Track B; effort: medium)
+- [#229](https://github.com/evoila/meho/issues/229) Initiative G7.1 — Tenant conventions + Layer 2 starter (Track C; effort: medium)
+
+## Not yet filed (drafted when each Phase approaches)
+
+Phase 2 candidates: G3.2 Vault op surface, G3.3 bind9, G3.4 tier-2 batch (NSX + SDDC + Harbor greenfield), G4.1 kb migration, G4.2 docs sidecars, G4.3 migration tooling, G5.1 memory storage + verbs, G5.2 auto-expiry + tenant-promotion, G5.3 laptop-local migration UX, G8.1 audit query core, G8.2 audit replay, G6.2 Slack mirror, G7.2 session preamble assembler polish, G6.3 PII opt-in/opt-out, plus MCP-tool-parity Tasks under each.
+
+Phase 3 candidates: G3.5/6 tier-3 (VCF mgmt plane + standalone), G3.7 tier-4 Holodeck, G9.1 graph schema + auto-discovery + 3 verbs, G9.2 curated cross-system edges + annotation flow, G9.3 discovery audit log → graph history.
+
+---
+
+## Reopening discussion
+
+(empty)
+
+When reopening a locked decision, add an entry here with: (1) which decision number, (2) what changed, (3) which Initiatives need re-evaluation, (4) date.


### PR DESCRIPTION
## Summary

- Locks the 6 strategic decisions made during v0.2 planning across Goals #214–#220 + #221
- Captures track count (3 parallel), kb migration shape (one-shot + 1mo overlap), PII broadcast defaults (conservative aggregate), G7 partition (operational rules only), Layer-2 starter (ship CLAUDE.md template), G9 curation (full ~100% v0.2), MCP server (alongside CLI in v0.2)
- Lists the 9 Initiatives filed so far (5 G0 + 3 Phase-1) and the not-yet-filed candidates for Phases 2 and 3
- "Reopening discussion" section is the harness for revisiting any decision later

## Test plan

- [x] Markdown rendered cleanly (relative repo links, GitHub issue links)
- [x] No code change — docs-only addition under `docs/planning/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v0.2 strategic decisions documentation, including foundational architectural choices, operational guidelines, decision protocols, and phase sequencing information for the upcoming release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/230)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->