### PR TITLE
feat(mcp): JSON-RPC 2.0 dispatch + initialize handshake (G0.5-T1)

### DIFF
--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -20,6 +20,14 @@ Gunicorn / k8s probes. v0.1 ships:
   one row to ``audit_log`` per authenticated request *before* the
   response yields back to the ASGI send chain. Fail-closed on
   insert error: an unaudited request is converted to HTTP 500.
+
+v0.2 adds:
+
+* The MCP Streamable HTTP transport entrypoint at ``/mcp`` (G0.5-T1,
+  #246) — JSON-RPC 2.0 dispatch with built-in ``initialize`` / ``ping``
+  / ``notifications/initialized`` handlers. Bearer-token auth on this
+  route lands in G0.5-T2 (#247); the tool + resource registries land
+  in G0.5-T3 (#248).
 """
 
 import os
@@ -40,6 +48,7 @@ from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.health import register_probe
 from meho_backplane.health import router as health_router
 from meho_backplane.logging import configure_logging
+from meho_backplane.mcp import router as mcp_router
 from meho_backplane.metrics import render_metrics
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.settings import parse_bool_env
@@ -127,6 +136,14 @@ app.include_router(health_router)
 app.include_router(version_router)
 app.include_router(api_v1_auth_config_router)
 app.include_router(api_v1_health_router)
+# MCP Streamable HTTP transport entrypoint (G0.5-T1, #246). The router
+# inherits the same RequestContextMiddleware + AuditMiddleware chain as
+# every HTTP route; T1 has no Bearer-token auth on /mcp yet, so
+# AuditMiddleware's "no operator_sub bound" skip rule passes /mcp
+# requests through unchanged. T2 (#247) layers OAuth-RS auth on top;
+# T5 (#250) replaces the implicit audit pass-through with a fail-closed
+# MCP-specific audit path on tools/call + resources/read.
+app.include_router(mcp_router)
 
 # Opt-in stub routes for end-to-end verification of
 # :func:`~meho_backplane.auth.rbac.require_role`. Disabled by default

--- a/backend/src/meho_backplane/mcp/__init__.py
+++ b/backend/src/meho_backplane/mcp/__init__.py
@@ -34,6 +34,6 @@ chain. Origin-header validation per the MCP transport security warning
 ``MCP_ALLOWED_ORIGINS`` setting T2 introduces.
 """
 
-from meho_backplane.mcp.server import register_method, router
+from meho_backplane.mcp.server import McpInvalidParamsError, register_method, router
 
-__all__ = ["register_method", "router"]
+__all__ = ["McpInvalidParamsError", "register_method", "router"]

--- a/backend/src/meho_backplane/mcp/__init__.py
+++ b/backend/src/meho_backplane/mcp/__init__.py
@@ -24,14 +24,21 @@ T1 (this Task #246) ships the **transport + dispatch skeleton**:
   universal — ``initialize``, ``notifications/initialized``, and
   ``ping``.
 
-**No Bearer-token auth in T1.** Every well-formed JSON-RPC request
-currently succeeds. T2 (#247) adds the OAuth 2.1 resource-server
-chain: ``/.well-known/oauth-protected-resource``, the
-``WWW-Authenticate`` header on 401s, audience validation per RFC 8707,
-and reuse of the existing :func:`~meho_backplane.auth.jwt.verify_jwt`
-chain. Origin-header validation per the MCP transport security warning
-(DNS rebinding defence) is also deferred to T2 — it requires the
-``MCP_ALLOWED_ORIGINS`` setting T2 introduces.
+**No Bearer-token auth in T1.** No ``Authorization`` header is required;
+no ``operator_sub`` is bound. Well-formed JSON-RPC requests reach the
+handler without an identity check. The transport layer still enforces
+two spec MUSTs that can reject before the handler runs: the
+``MCP-Protocol-Version`` header validation (HTTP 400 on an unsupported
+revision per spec §"Protocol Version Header", waived for the
+``initialize`` call itself) and the JSON-RPC envelope parse / validate
+pipeline (HTTP 200 + JSON-RPC error envelope on parse error / invalid
+request). T2 (#247) adds the OAuth 2.1 resource-server chain on top:
+``/.well-known/oauth-protected-resource``, the ``WWW-Authenticate``
+header on 401s, audience validation per RFC 8707, and reuse of the
+existing :func:`~meho_backplane.auth.jwt.verify_jwt` chain. Origin-
+header validation per the MCP transport security warning (DNS rebinding
+defence) is also deferred to T2 — it requires the ``MCP_ALLOWED_ORIGINS``
+setting T2 introduces.
 """
 
 from meho_backplane.mcp.server import McpInvalidParamsError, register_method, router

--- a/backend/src/meho_backplane/mcp/__init__.py
+++ b/backend/src/meho_backplane/mcp/__init__.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Model Context Protocol (MCP) server module.
+
+This package implements the MEHO MCP server surface per
+[MCP spec revision 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18).
+Hosted servers use the Streamable HTTP transport (POST to a single MCP
+endpoint with JSON-RPC 2.0 envelopes); stdio is for local-subprocess
+servers and is explicitly out of scope for MEHO.
+
+T1 (this Task #246) ships the **transport + dispatch skeleton**:
+
+* :data:`~meho_backplane.mcp.server.router` — FastAPI ``APIRouter``
+  mounted at ``/mcp`` by :mod:`meho_backplane.main`. Accepts JSON-RPC
+  2.0 POST bodies, parses + dispatches them, and returns either a
+  single-shot JSON response (for *requests*) or HTTP 202 Accepted (for
+  *notifications*) per the Streamable HTTP transport spec.
+* :func:`~meho_backplane.mcp.server.register_method` — module-level
+  dispatch registration mirroring the
+  :func:`~meho_backplane.health.register_probe` pattern. T3 (#248) layers
+  the tool / resource registries on top of this.
+* Built-in handlers for the lifecycle primitives the spec defines as
+  universal — ``initialize``, ``notifications/initialized``, and
+  ``ping``.
+
+**No Bearer-token auth in T1.** Every well-formed JSON-RPC request
+currently succeeds. T2 (#247) adds the OAuth 2.1 resource-server
+chain: ``/.well-known/oauth-protected-resource``, the
+``WWW-Authenticate`` header on 401s, audience validation per RFC 8707,
+and reuse of the existing :func:`~meho_backplane.auth.jwt.verify_jwt`
+chain. Origin-header validation per the MCP transport security warning
+(DNS rebinding defence) is also deferred to T2 — it requires the
+``MCP_ALLOWED_ORIGINS`` setting T2 introduces.
+"""
+
+from meho_backplane.mcp.server import register_method, router
+
+__all__ = ["register_method", "router"]

--- a/backend/src/meho_backplane/mcp/schemas.py
+++ b/backend/src/meho_backplane/mcp/schemas.py
@@ -166,15 +166,18 @@ class InitializeRequest(BaseModel):
 class ServerCapabilities(BaseModel):
     """Server-side capability declaration returned on ``initialize``.
 
-    T1 advertises ``tools`` and ``resources`` envelopes (with
-    ``listChanged: false``) so the negotiated capability namespace is
-    already reachable when T3 (#248) wires the registries. ``prompts``
-    / ``roots`` / ``sampling`` / ``completions`` are out of scope for
-    v0.2 and stay absent — clients that probe for them must treat the
-    omission as "not supported" per spec §Capability Negotiation.
-
-    ``logging`` is reserved for a future server-emit-log capability;
-    leaving it ``None`` here makes the upgrade additive.
+    T1 advertises an **empty** capabilities envelope — ``tools`` /
+    ``resources`` / ``logging`` all stay :data:`None`, which the
+    hand-rolled wire serializer drops. Advertising a capability ahead
+    of the dispatch table being able to honor it would tell a
+    spec-conforming client it can call ``tools/list`` / ``resources/list``
+    immediately after the handshake, which would then ``-32601`` and
+    likely cause the client to disconnect per spec §Capability
+    Negotiation ("Only use capabilities that were successfully
+    negotiated"). T3 (#248) is where ``tools`` and ``resources`` flip
+    back on, paired with the dispatch-table additions. ``prompts`` /
+    ``roots`` / ``sampling`` / ``completions`` are out of scope for
+    v0.2 and stay absent.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/backend/src/meho_backplane/mcp/schemas.py
+++ b/backend/src/meho_backplane/mcp/schemas.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""JSON-RPC 2.0 + MCP 2025-06-18 wire-shape models.
+
+Pydantic v2 envelopes for the MCP server entrypoint (G0.5-T1). T1 covers
+only the lifecycle surface: ``initialize`` / ``ping`` /
+``notifications/initialized``. The tool + resource registries (T3, #248)
+and the OAuth-RS metadata document (T2, #247) layer their own request /
+response models on top of these JSON-RPC envelopes.
+
+The wire forms here follow two specs that the MCP 2025-06-18 revision
+chains together:
+
+* JSON-RPC 2.0 — https://www.jsonrpc.org/specification — the envelope,
+  the request / response / error shapes, and the notification rule
+  (request without an ``id`` member; server MUST NOT reply).
+* MCP 2025-06-18 lifecycle —
+  https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
+  — the ``initialize`` request / result and ``serverInfo`` /
+  ``capabilities`` payloads.
+
+Field names that the wire defines as camelCase (``protocolVersion``,
+``clientInfo``, ``serverInfo``) keep that shape on the Python side too;
+the ``# noqa: N815`` markers exist because pep8-naming would otherwise
+push them to snake_case, breaking interop with every MCP client in the
+wild.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = [
+    "INTERNAL_ERROR",
+    "INVALID_PARAMS",
+    "INVALID_REQUEST",
+    "METHOD_NOT_FOUND",
+    "PARSE_ERROR",
+    "PROTOCOL_VERSION",
+    "InitializeRequest",
+    "InitializeResponse",
+    "JsonRpcError",
+    "JsonRpcId",
+    "JsonRpcRequest",
+    "JsonRpcResponse",
+    "ServerCapabilities",
+]
+
+
+#: The MCP spec revision this server implements. Returned verbatim in
+#: ``InitializeResponse.protocolVersion`` when the client requests this
+#: version; otherwise the server responds with the same value anyway and
+#: the client decides whether to disconnect (spec §Version Negotiation).
+PROTOCOL_VERSION: str = "2025-06-18"
+
+
+#: A JSON-RPC 2.0 id is "a String, Number, or NULL value if included"
+#: (spec §4.1). A request *without* an id is a notification (§4.1.2);
+#: the absent / explicit-null distinction is normatively discouraged on
+#: the request side, so this server treats both as the same shape.
+JsonRpcId = int | str | None
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC 2.0 envelopes
+# ---------------------------------------------------------------------------
+
+
+class JsonRpcRequest(BaseModel):
+    """Inbound JSON-RPC 2.0 request envelope.
+
+    Notifications carry no ``id`` (spec §4.1.2). Because Pydantic v2 cannot
+    distinguish "field absent" from "field present and ``null``" once a
+    default is supplied, the dispatcher consults the raw ``payload`` dict
+    for the ``"id"`` key when deciding whether to emit a response — see
+    :func:`~meho_backplane.mcp.server.mcp_dispatch`.
+
+    ``extra="allow"`` lets the model accept MCP-spec extensions that
+    revision 2025-06-18 doesn't itself surface (the spec is intentionally
+    forward-extensible at the envelope layer); the dispatcher only reads
+    the four canonical fields.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="allow")
+
+    jsonrpc: Literal["2.0"]
+    id: JsonRpcId = None
+    method: str
+    params: dict[str, Any] | None = None
+
+
+class JsonRpcError(BaseModel):
+    """JSON-RPC 2.0 error object (the ``response.error`` payload).
+
+    ``data`` is optional per spec §5.1 and is omitted on the wire when
+    unset; callers that need to attach structured context (e.g. an
+    "unsupported protocol version" body with ``supported`` + ``requested``
+    keys) pass it through here.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    code: int
+    message: str
+    data: dict[str, Any] | None = None
+
+
+class JsonRpcResponse(BaseModel):
+    """Outbound JSON-RPC 2.0 response envelope.
+
+    Spec §5: "Either the result member or error member MUST be included,
+    but both members MUST NOT be included." The
+    :meth:`_exactly_one_of_result_or_error` validator enforces this
+    invariant on construction so a misbehaving handler can't emit a
+    wire-broken response that some clients accept and others reject.
+
+    Serialization to the wire goes through
+    :func:`~meho_backplane.mcp.server._serialize_response`, which drops
+    the unset half of ``result`` / ``error`` (Pydantic's ``exclude_none``
+    would also strip ``id`` when it's the spec-mandated ``null`` on a
+    parse-error response — see spec §5).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    jsonrpc: Literal["2.0"] = "2.0"
+    id: JsonRpcId
+    result: dict[str, Any] | None = None
+    error: JsonRpcError | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one_of_result_or_error(self) -> JsonRpcResponse:
+        if (self.result is None) == (self.error is None):
+            raise ValueError(
+                "JsonRpcResponse must have exactly one of `result` or `error`",
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# MCP 2025-06-18 lifecycle payloads
+# ---------------------------------------------------------------------------
+
+
+class InitializeRequest(BaseModel):
+    """``initialize`` request params per MCP 2025-06-18 §Initialization.
+
+    The spec example body carries ``protocolVersion``, ``capabilities``,
+    and ``clientInfo`` as required keys; defensively, ``capabilities``
+    and ``clientInfo`` are tolerated as missing (default to empty dict)
+    because some client SDKs omit empty objects. Missing
+    ``protocolVersion`` is the only required-field shape that hits
+    the ``INVALID_PARAMS`` path.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="allow")
+
+    protocolVersion: str  # noqa: N815 — wire field is camelCase per MCP spec
+    capabilities: dict[str, Any] = Field(default_factory=dict)
+    clientInfo: dict[str, Any] = Field(default_factory=dict)  # noqa: N815
+
+
+class ServerCapabilities(BaseModel):
+    """Server-side capability declaration returned on ``initialize``.
+
+    T1 advertises ``tools`` and ``resources`` envelopes (with
+    ``listChanged: false``) so the negotiated capability namespace is
+    already reachable when T3 (#248) wires the registries. ``prompts``
+    / ``roots`` / ``sampling`` / ``completions`` are out of scope for
+    v0.2 and stay absent — clients that probe for them must treat the
+    omission as "not supported" per spec §Capability Negotiation.
+
+    ``logging`` is reserved for a future server-emit-log capability;
+    leaving it ``None`` here makes the upgrade additive.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tools: dict[str, Any] | None = None
+    resources: dict[str, Any] | None = None
+    logging: dict[str, Any] | None = None
+
+
+class InitializeResponse(BaseModel):
+    """``initialize`` result per MCP 2025-06-18 §Initialization.
+
+    ``instructions`` stays ``None`` in T1; G7.1 will populate it with
+    the assembled tenant-aware session preamble once tenancy lands.
+    Until then the field is serialized as omitted (the wire view drops
+    ``None``-valued ``instructions``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    protocolVersion: str = PROTOCOL_VERSION  # noqa: N815
+    capabilities: ServerCapabilities
+    serverInfo: dict[str, str]  # noqa: N815
+    instructions: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Standard JSON-RPC error codes (spec §5.1)
+# ---------------------------------------------------------------------------
+
+#: "Invalid JSON was received by the server." (spec §5.1)
+PARSE_ERROR: int = -32700
+
+#: "The JSON sent is not a valid Request object." (spec §5.1)
+INVALID_REQUEST: int = -32600
+
+#: "The method does not exist / is not available." (spec §5.1)
+METHOD_NOT_FOUND: int = -32601
+
+#: "Invalid method parameter(s)." (spec §5.1)
+INVALID_PARAMS: int = -32602
+
+#: "Internal JSON-RPC error." (spec §5.1)
+INTERNAL_ERROR: int = -32603

--- a/backend/src/meho_backplane/mcp/schemas.py
+++ b/backend/src/meho_backplane/mcp/schemas.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 __all__ = [
     "INTERNAL_ERROR",
@@ -90,6 +90,27 @@ class JsonRpcRequest(BaseModel):
     id: JsonRpcId = None
     method: str
     params: dict[str, Any] | None = None
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def _reject_bool_id(cls, value: Any) -> Any:
+        """Reject ``bool`` ids before Pydantic coerces them to int.
+
+        ``bool`` is a subclass of ``int`` in Python, so the ``int | str |
+        None`` annotation accepts ``True`` / ``False`` and silently
+        coerces them to ``1`` / ``0``. JSON-RPC 2.0 §4.1.2 restricts the
+        id to "a String, Number, or NULL value if included" — and the
+        wire contract on the response side requires the response id to
+        equal the request id. Echoing ``1`` when the client sent ``true``
+        breaks that contract. The ``mode="before"`` hook runs ahead of
+        type coercion so the ValidationError surfaces ``True`` /
+        ``False`` rather than ``1`` / ``0`` in the error context.
+        """
+        if isinstance(value, bool):
+            raise ValueError(
+                "JSON-RPC id must be String, Number, or NULL — not bool",
+            )
+        return value
 
 
 class JsonRpcError(BaseModel):

--- a/backend/src/meho_backplane/mcp/schemas.py
+++ b/backend/src/meho_backplane/mcp/schemas.py
@@ -59,8 +59,14 @@ PROTOCOL_VERSION: str = "2025-06-18"
 
 #: A JSON-RPC 2.0 id is "a String, Number, or NULL value if included"
 #: (spec §4.1). A request *without* an id is a notification (§4.1.2);
-#: the absent / explicit-null distinction is normatively discouraged on
-#: the request side, so this server treats both as the same shape.
+#: the dispatcher honors the absent / explicit-null distinction by
+#: inspecting the raw payload dict (``"id" not in payload``) — absent
+#: ids fall into the notification path (HTTP 202, no response body),
+#: while ``"id": null`` is treated as a discouraged-but-valid request
+#: with a null id (the response echoes ``id: null`` per spec §5). On
+#: the response side ``bool`` is rejected explicitly because ``bool``
+#: subclasses ``int``; see
+#: :meth:`JsonRpcRequest._reject_bool_id` for the validator.
 JsonRpcId = int | str | None
 
 

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -40,8 +40,12 @@ Per the Streamable HTTP §"Sending Messages to the Server":
 
 A JSON-RPC-level error (parse error, invalid request, method not found,
 invalid params, internal error) is encoded as a 200 envelope with the
-``error`` member populated; only transport-level failures (in T1: none)
-flip the HTTP status away from 200 / 202.
+``error`` member populated. **Transport-level failures** flip the HTTP
+status away from 200 / 202; T1 has one such case: an unsupported
+``MCP-Protocol-Version`` header on a non-``initialize`` call returns
+HTTP 400 with a JSON-RPC error envelope in the body (spec §"Protocol
+Version Header" MUST). T2 (#247) adds the OAuth 401 / 403 cases when
+the Bearer chain lands.
 
 The single-shot JSON shape is also what the AC list on #246 codifies:
 no streaming, no chunked responses, no SSE. The transport spec's GET

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -280,8 +280,16 @@ def _coerce_request_id(payload: dict[str, Any]) -> JsonRpcId:
     parseable (helps clients correlate failures). When the raw value
     isn't a String / Number / NULL, fall back to ``None`` per spec §5
     ("If there was an error in detecting the id ... it MUST be Null").
+
+    ``bool`` is short-circuited explicitly because it subclasses ``int``
+    in Python — without this check ``True`` / ``False`` would slip
+    through the ``isinstance(raw, (int, str))`` arm and echo as ``1`` /
+    ``0`` in the error response, which the client cannot correlate
+    against its original ``true`` / ``false`` request id.
     """
     raw = payload.get("id")
+    if isinstance(raw, bool):
+        return None
     if isinstance(raw, (int, str)) or raw is None:
         return raw
     return None

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -323,110 +323,136 @@ def _coerce_request_id(payload: dict[str, Any]) -> JsonRpcId:
     return None
 
 
-@router.post("")
-async def mcp_dispatch(request: Request) -> Response:
-    """Dispatch a single JSON-RPC 2.0 request or notification.
+def _parse_request_body(raw_body: bytes) -> dict[str, Any] | JSONResponse:
+    """Decode ``raw_body`` to a JSON-RPC envelope dict or an HTTP error response.
 
-    The Streamable HTTP body contract (§"Sending Messages to the Server"):
+    Three rejection arms map onto the spec-prescribed error codes:
 
-    * Input is a JSON object — batch arrays are unsupported in T1.
-    * On a *request* (id present): return 200 + single JSON envelope.
-    * On a *notification* (id absent, or method prefix
-      ``notifications/``): return 202 with no body, regardless of
-      whether the handler errored — JSON-RPC §4.1.2 forbids replying.
+    * Empty body → PARSE_ERROR (clearer message than ``json.loads(b"")``'s
+      "Expecting value").
+    * :class:`json.JSONDecodeError` → PARSE_ERROR with the parser's message.
+    * Non-dict payload (array or scalar) → INVALID_REQUEST. JSON-RPC §6
+      allows batch arrays at the protocol layer but the MCP Streamable
+      HTTP transport mandates a single envelope per POST.
 
-    GET requests on this path automatically return HTTP 405 (FastAPI's
-    default for an unmatched method) which satisfies the spec's
-    fallback when the server does not implement the GET-opens-SSE
-    branch of the Streamable HTTP transport.
+    On success returns the parsed ``dict``; on failure returns the
+    :class:`JSONResponse` that the dispatcher should hand back to the
+    client. The union return is the idiomatic "or-error-response" shape
+    that lets the caller narrow with :func:`isinstance`.
     """
-    raw_body = await request.body()
     if not raw_body:
         return _error_response(None, PARSE_ERROR, "parse error: empty body")
-
     try:
         payload = json.loads(raw_body)
     except json.JSONDecodeError as exc:
         _log.warning("mcp_parse_error", error=exc.msg)
         return _error_response(None, PARSE_ERROR, f"parse error: {exc.msg}")
-
     if not isinstance(payload, dict):
-        # Batch (array) bodies are spec-allowed at the JSON-RPC layer
-        # (§6) but the MCP Streamable HTTP transport accepts only a
-        # single request / notification / response per POST. Reject
-        # arrays so the contract is unambiguous.
         return _error_response(
             None,
             INVALID_REQUEST,
             "invalid request: expected JSON object, not array or scalar",
         )
+    return payload
 
-    try:
-        jrpc = JsonRpcRequest.model_validate(payload)
-    except ValidationError as exc:
+
+def _validate_protocol_version_header(
+    request: Request,
+    method: str,
+    payload: dict[str, Any],
+) -> JSONResponse | None:
+    """Enforce MCP 2025-06-18 §"Protocol Version Header" on non-initialize calls.
+
+    Per spec, clients MUST send ``MCP-Protocol-Version`` on every post-
+    ``initialize`` request, and the server MUST respond with HTTP 400
+    when the value is invalid or unsupported. ``initialize`` is exempted
+    because clients don't know which version to send until the handshake
+    completes. Absent header on a non-initialize call is accepted as
+    transitional lenience: spec SHOULD-assume-2025-03-26 doesn't help —
+    v0.2 doesn't support that revision — and tightening this in T1
+    would break clients that don't yet emit the header. T6 (#251)
+    acceptance tests will pin the strict-mode contract.
+
+    Returns ``None`` on the OK path; a :class:`JSONResponse` (HTTP 400
+    + JSON-RPC error envelope) on rejection so the caller can early-
+    return it.
+    """
+    if method == "initialize":
+        return None
+    protocol_header = request.headers.get("mcp-protocol-version")
+    if protocol_header is None or protocol_header == PROTOCOL_VERSION:
+        return None
+    _log.warning(
+        "mcp_unsupported_protocol_version",
+        method=method,
+        header=protocol_header,
+        supported=PROTOCOL_VERSION,
+    )
+    return _error_response(
+        _coerce_request_id(payload),
+        INVALID_REQUEST,
+        (
+            f"unsupported MCP-Protocol-Version: {protocol_header!r} "
+            f"(server supports {PROTOCOL_VERSION!r})"
+        ),
+        status_code=400,
+    )
+
+
+def _build_success_response(
+    request_id: JsonRpcId,
+    result: _McpHandlerResult,
+) -> Response:
+    """Wrap a successful handler result in the JSON-RPC response envelope.
+
+    Three handler return shapes are accepted: a :class:`BaseModel` (dumped
+    with ``exclude_none=True`` so optional MCP fields like
+    ``InitializeResponse.instructions`` are omitted), a plain ``dict``
+    (used verbatim), and any other shape — which is treated as a handler
+    bug and converted to INTERNAL_ERROR. The else-arm is load-bearing
+    for the non-notification contract: returning ``None`` from a
+    request-shaped handler would otherwise emit a wire-broken envelope
+    that fails the spec's exactly-one-of(result, error) invariant.
+    """
+    if isinstance(result, BaseModel):
+        result_body: dict[str, Any] = result.model_dump(mode="json", exclude_none=True)
+    elif isinstance(result, dict):
+        result_body = result
+    else:
         return _error_response(
-            _coerce_request_id(payload),
-            INVALID_REQUEST,
-            f"invalid request: {exc.error_count()} validation error(s)",
+            request_id,
+            INTERNAL_ERROR,
+            "handler returned no result for a non-notification request",
         )
+    response = JsonRpcResponse(id=request_id, result=result_body)
+    return JSONResponse(content=_serialize_response(response))
 
-    # MCP-Protocol-Version header validation per spec §"Protocol Version
-    # Header". Clients MUST send the header on every post-initialize
-    # request; if the value is invalid or unsupported the server MUST
-    # respond with HTTP 400 Bad Request. The header is exempted on the
-    # `initialize` call itself because clients don't know which version
-    # to send until the handshake completes. Absent header on non-
-    # initialize methods is accepted as a transitional lenience: spec
-    # SHOULD-assume-2025-03-26 doesn't help since v0.2 doesn't support
-    # that revision, and tightening this in T1 would break clients that
-    # don't yet emit the header. T6 (#251) acceptance tests will pin
-    # the strict-mode contract.
-    if jrpc.method != "initialize":
-        protocol_header = request.headers.get("mcp-protocol-version")
-        if protocol_header is not None and protocol_header != PROTOCOL_VERSION:
-            _log.warning(
-                "mcp_unsupported_protocol_version",
-                method=jrpc.method,
-                header=protocol_header,
-                supported=PROTOCOL_VERSION,
-            )
-            return _error_response(
-                _coerce_request_id(payload),
-                INVALID_REQUEST,
-                (
-                    f"unsupported MCP-Protocol-Version: {protocol_header!r} "
-                    f"(server supports {PROTOCOL_VERSION!r})"
-                ),
-                status_code=400,
-            )
 
-    # Notification detection: JSON-RPC §4.1.2 says a notification is a
-    # request without an ``id`` member. Pydantic-side, ``jrpc.id``
-    # collapses absent and explicit-null to ``None`` (spec discourages
-    # the latter); the raw dict tells us which form arrived. The
-    # method-prefix relaxation handles buggy clients that send a
-    # ``notifications/*`` method with an id — the method semantics
-    # are spec-defined as notification-only, so the server treats it
-    # as such regardless of the envelope's id field.
-    is_notification = "id" not in payload or jrpc.method.startswith("notifications/")
+async def _dispatch_to_handler(
+    jrpc: JsonRpcRequest,
+    is_notification: bool,
+) -> Response:
+    """Look up and run the handler; map handler outcomes to wire responses.
 
-    # The MCP transport spec at §"Sending Messages to the Server"
-    # splits the notification response shape: "If the server accepts
-    # the input, the server MUST return HTTP status code 202" vs. "If
-    # the server cannot accept the input, it MUST return an HTTP error
-    # status code." The phrase "cannot accept" is intentionally narrow
-    # — it refers to *transport-level* rejection (malformed envelope,
-    # bad JSON, batch arrays), not "the handler's logic couldn't
-    # process this notification." Spec language treats application-
-    # level failures of a notification as the server's problem to log,
-    # not the client's to fix (the client cannot retry a notification
-    # without violating §4.1.2). T1 therefore returns 202 for every
-    # post-envelope notification path — unknown method, invalid params,
-    # internal error — and logs the failure for operator triage. The
-    # transport-level rejections (parse error, invalid request, batch
-    # arrays, unsupported protocol version) above already flip to
-    # HTTP 4xx because they happen *before* the notification/request
-    # split.
+    The MCP transport spec at §"Sending Messages to the Server" splits
+    the notification response shape: "If the server accepts the input,
+    the server MUST return HTTP status code 202" vs. "If the server
+    cannot accept the input, it MUST return an HTTP error status code."
+    The phrase "cannot accept" is intentionally narrow — it refers to
+    *transport-level* rejection (malformed envelope, bad JSON, batch
+    arrays, unsupported protocol version), not "the handler's logic
+    couldn't process this notification." Spec language treats
+    application-level failures of a notification as the server's problem
+    to log, not the client's to fix (the client cannot retry a
+    notification without violating §4.1.2). Every post-envelope
+    notification arm here therefore returns HTTP 202 and logs the
+    failure for operator triage — the transport-level rejections in
+    :func:`_parse_request_body`,
+    :class:`JsonRpcRequest.model_validate`, and
+    :func:`_validate_protocol_version_header` already flip the status
+    to HTTP 4xx because they run *before* the notification/request
+    split.
+    """
     handler = _DISPATCH.get(jrpc.method)
     if handler is None:
         if is_notification:
@@ -461,20 +487,65 @@ async def mcp_dispatch(request: Request) -> Response:
 
     if is_notification:
         return Response(status_code=202)
+    return _build_success_response(jrpc.id, result)
 
-    if isinstance(result, BaseModel):
-        result_body: dict[str, Any] = result.model_dump(mode="json", exclude_none=True)
-    elif isinstance(result, dict):
-        result_body = result
-    else:
-        # Handler returned None (or a non-dict scalar) for a request-
-        # shaped invocation. That's a handler bug; surface as
-        # INTERNAL_ERROR rather than emitting a wire-broken envelope.
+
+@router.post("")
+async def mcp_dispatch(request: Request) -> Response:
+    """Dispatch a single JSON-RPC 2.0 request or notification.
+
+    The Streamable HTTP body contract (§"Sending Messages to the Server"):
+
+    * Input is a JSON object — batch arrays are unsupported in T1.
+    * On a *request* (id present): return 200 + single JSON envelope.
+    * On a *notification* (id absent, or method prefix
+      ``notifications/``): return 202 with no body, regardless of
+      whether the handler errored — JSON-RPC §4.1.2 forbids replying.
+
+    The function is the orchestrator only; each phase of the dispatch
+    pipeline lives in its own helper so the per-phase contract is grep-
+    able and the cognitive complexity stays under the project's
+    SonarCloud threshold:
+
+    * :func:`_parse_request_body` — body → ``dict`` or transport error.
+    * :func:`JsonRpcRequest.model_validate` + :func:`_coerce_request_id`
+      — envelope shape validation.
+    * :func:`_validate_protocol_version_header` — spec §"Protocol
+      Version Header" enforcement.
+    * :func:`_dispatch_to_handler` — handler lookup + execution + error
+      mapping.
+
+    GET requests on this path automatically return HTTP 405 (FastAPI's
+    default for an unmatched method) which satisfies the spec's
+    fallback when the server does not implement the GET-opens-SSE
+    branch of the Streamable HTTP transport.
+    """
+    raw_body = await request.body()
+    parsed = _parse_request_body(raw_body)
+    if isinstance(parsed, JSONResponse):
+        return parsed
+    payload = parsed
+
+    try:
+        jrpc = JsonRpcRequest.model_validate(payload)
+    except ValidationError as exc:
         return _error_response(
-            jrpc.id,
-            INTERNAL_ERROR,
-            "handler returned no result for a non-notification request",
+            _coerce_request_id(payload),
+            INVALID_REQUEST,
+            f"invalid request: {exc.error_count()} validation error(s)",
         )
 
-    response = JsonRpcResponse(id=jrpc.id, result=result_body)
-    return JSONResponse(content=_serialize_response(response))
+    protocol_error = _validate_protocol_version_header(request, jrpc.method, payload)
+    if protocol_error is not None:
+        return protocol_error
+
+    # Notification detection: JSON-RPC §4.1.2 says a notification is a
+    # request without an ``id`` member. Pydantic-side, ``jrpc.id``
+    # collapses absent and explicit-null to ``None`` (spec discourages
+    # the latter); the raw dict tells us which form arrived. The
+    # method-prefix relaxation handles buggy clients that send a
+    # ``notifications/*`` method with an id — the method semantics
+    # are spec-defined as notification-only, so the server treats it
+    # as such regardless of the envelope's id field.
+    is_notification = "id" not in payload or jrpc.method.startswith("notifications/")
+    return await _dispatch_to_handler(jrpc, is_notification)

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -97,7 +97,7 @@ from meho_backplane.mcp.schemas import (
     ServerCapabilities,
 )
 
-__all__ = ["register_method", "router"]
+__all__ = ["McpInvalidParamsError", "register_method", "router"]
 
 
 #: Stable ``serverInfo.name`` returned on every ``initialize``. Matches
@@ -141,7 +141,7 @@ def register_method(name: str, handler: _McpHandler) -> None:
     _DISPATCH[name] = handler
 
 
-class _McpInvalidParamsError(Exception):
+class McpInvalidParamsError(Exception):
     """Handler-side sentinel mapped to JSON-RPC ``INVALID_PARAMS``.
 
     Raised by a handler when its params fail validation (e.g.
@@ -149,6 +149,10 @@ class _McpInvalidParamsError(Exception):
     raises :class:`pydantic.ValidationError`). The dispatcher catches
     this distinctly from a generic :class:`Exception` so the wire
     response carries code ``-32602`` rather than ``-32603``.
+
+    Re-exported from :mod:`meho_backplane.mcp` so T3 (#248) tool
+    handlers — and any future MCP method handler — can raise it
+    without reaching into a dunder-private symbol.
     """
 
 
@@ -176,7 +180,7 @@ async def _initialize(params: dict[str, Any] | None) -> InitializeResponse:
     try:
         InitializeRequest.model_validate(params or {})
     except ValidationError as exc:
-        raise _McpInvalidParamsError(
+        raise McpInvalidParamsError(
             f"initialize: {exc.error_count()} validation error(s)",
         ) from exc
 
@@ -415,7 +419,7 @@ async def mcp_dispatch(request: Request) -> Response:
 
     try:
         result = await handler(jrpc.params)
-    except _McpInvalidParamsError as exc:
+    except McpInvalidParamsError as exc:
         if is_notification:
             _log.warning(
                 "mcp_notification_invalid_params",

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -173,11 +173,17 @@ async def _initialize(params: dict[str, Any] | None) -> InitializeResponse:
             f"initialize: {exc.error_count()} validation error(s)",
         ) from exc
 
+    # T1 advertises an **empty** capabilities envelope. Advertising
+    # ``tools`` / ``resources`` here ahead of T3 (#248) registering the
+    # corresponding methods would tell a spec-conforming client it can
+    # call ``tools/list`` (and friends) — which would then ``-32601``
+    # and may disconnect the client per the MCP 2025-06-18 §Capability
+    # Negotiation contract ("Only use capabilities that were
+    # successfully negotiated"). T3 flips the ``tools`` / ``resources``
+    # capability envelopes back on once the dispatch table can honor
+    # the negotiated methods.
     return InitializeResponse(
-        capabilities=ServerCapabilities(
-            tools={"listChanged": False},
-            resources={"listChanged": False, "subscribe": False},
-        ),
+        capabilities=ServerCapabilities(),
         serverInfo={"name": _SERVER_NAME, "version": __version__},
     )
 

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -406,6 +406,23 @@ async def mcp_dispatch(request: Request) -> Response:
     # as such regardless of the envelope's id field.
     is_notification = "id" not in payload or jrpc.method.startswith("notifications/")
 
+    # The MCP transport spec at §"Sending Messages to the Server"
+    # splits the notification response shape: "If the server accepts
+    # the input, the server MUST return HTTP status code 202" vs. "If
+    # the server cannot accept the input, it MUST return an HTTP error
+    # status code." The phrase "cannot accept" is intentionally narrow
+    # — it refers to *transport-level* rejection (malformed envelope,
+    # bad JSON, batch arrays), not "the handler's logic couldn't
+    # process this notification." Spec language treats application-
+    # level failures of a notification as the server's problem to log,
+    # not the client's to fix (the client cannot retry a notification
+    # without violating §4.1.2). T1 therefore returns 202 for every
+    # post-envelope notification path — unknown method, invalid params,
+    # internal error — and logs the failure for operator triage. The
+    # transport-level rejections (parse error, invalid request, batch
+    # arrays, unsupported protocol version) above already flip to
+    # HTTP 4xx because they happen *before* the notification/request
+    # split.
     handler = _DISPATCH.get(jrpc.method)
     if handler is None:
         if is_notification:

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -167,6 +167,12 @@ async def _initialize(params: dict[str, Any] | None) -> InitializeResponse:
     Negotiation past v0.2 (e.g. supporting an older revision for
     legacy clients) is a v0.3 concern.
     """
+    # ``params or {}`` deliberately collapses ``None`` and ``{}``. Spec-
+    # aligned: a missing ``params`` field on the JSON-RPC request and an
+    # explicit empty params object are both equivalent to "no required
+    # fields supplied" for our purposes — :class:`InitializeRequest`'s
+    # validator will then surface a clean INVALID_PARAMS for the
+    # required-but-missing ``protocolVersion``.
     try:
         InitializeRequest.model_validate(params or {})
     except ValidationError as exc:

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``POST /mcp`` — MCP Streamable HTTP transport entrypoint.
+
+This module is the MCP server's front door: a FastAPI ``APIRouter``
+mounted at ``/mcp`` by :mod:`meho_backplane.main` and a module-level
+method-dispatch table that mirrors the
+:func:`~meho_backplane.health.register_probe` registry pattern. The
+route accepts JSON-RPC 2.0 envelopes per the
+[2025-06-18 Streamable HTTP spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports)
+and routes each ``method`` to a registered handler.
+
+Auth in T1
+==========
+
+There is **no Bearer-token validation on this route in T1**. Every
+well-formed JSON-RPC request currently succeeds, regardless of who
+calls it. This is by design — T2 (#247) layers the OAuth 2.1
+resource-server chain on top: ``/.well-known/oauth-protected-resource``,
+``WWW-Authenticate`` headers on 401s, audience validation per RFC 8707,
+and reuse of :func:`~meho_backplane.auth.jwt.verify_jwt`. Origin-header
+validation per the MCP transport spec's DNS-rebinding security warning
+is also a T2 concern (it depends on the ``MCP_ALLOWED_ORIGINS`` setting
+T2 introduces).
+
+Response shapes
+===============
+
+Per the Streamable HTTP §"Sending Messages to the Server":
+
+* If the input is a JSON-RPC **request** (has an ``id``): the server
+  returns HTTP 200 with ``Content-Type: application/json`` and a single
+  JSON-RPC response envelope in the body. SSE (``text/event-stream``)
+  for long-running tools is **out of scope** for v0.2.
+* If the input is a JSON-RPC **notification** (no ``id``): the server
+  returns HTTP 202 Accepted with an empty body. The MCP spec is strict
+  on this — 204 is not a substitute even though both communicate
+  "nothing to send back".
+
+A JSON-RPC-level error (parse error, invalid request, method not found,
+invalid params, internal error) is encoded as a 200 envelope with the
+``error`` member populated; only transport-level failures (in T1: none)
+flip the HTTP status away from 200 / 202.
+
+The single-shot JSON shape is also what the AC list on #246 codifies:
+no streaming, no chunked responses, no SSE. The transport spec's GET
+support (clients opening an SSE stream pre-request) is unimplemented;
+FastAPI auto-replies HTTP 405 to GET on this path because the route
+only declares POST.
+
+Audit + middleware interaction
+==============================
+
+The chassis-stage :class:`~meho_backplane.audit.AuditMiddleware` and
+:class:`~meho_backplane.middleware.RequestContextMiddleware` wrap every
+HTTP request, including ``/mcp``. Without Bearer auth in T1, no
+``operator_sub`` is bound into structlog contextvars, so
+``AuditMiddleware`` short-circuits its skip rule and forwards the
+buffered response unchanged — there's no fail-closed 500 from an audit
+write because no audit write is attempted. T5 (#250) replaces this
+implicit pass-through with a fail-closed MCP-specific audit path that
+runs on ``tools/call`` + ``resources/read``.
+
+References
+----------
+* JSON-RPC 2.0 — https://www.jsonrpc.org/specification
+* MCP 2025-06-18 lifecycle — https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
+* MCP 2025-06-18 transport — https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, ValidationError
+
+from meho_backplane import __version__
+from meho_backplane.mcp.schemas import (
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    INVALID_REQUEST,
+    METHOD_NOT_FOUND,
+    PARSE_ERROR,
+    InitializeRequest,
+    InitializeResponse,
+    JsonRpcError,
+    JsonRpcId,
+    JsonRpcRequest,
+    JsonRpcResponse,
+    ServerCapabilities,
+)
+
+__all__ = ["register_method", "router"]
+
+
+#: Stable ``serverInfo.name`` returned on every ``initialize``. Matches
+#: the FastAPI app title in :mod:`meho_backplane.main` so MCP clients
+#: and the HTTP API's OpenAPI document agree on the server's identity.
+_SERVER_NAME: str = "meho-backplane"
+
+
+# A handler receives the parsed JSON-RPC ``params`` (``None`` when the
+# request omits the field) and returns one of:
+# * a :class:`pydantic.BaseModel` instance — serialized via
+#   :meth:`~pydantic.BaseModel.model_dump` into the response's ``result``;
+# * a plain ``dict`` — used verbatim as the ``result`` body;
+# * ``None`` — sentinel meaning "no result body", which is only
+#   meaningful for handlers registered against ``notifications/*``
+#   methods. For request-shaped methods, a ``None`` return is treated as
+#   :data:`INTERNAL_ERROR` (a handler bug).
+_McpHandlerResult = BaseModel | dict[str, Any] | None
+_McpHandler = Callable[[dict[str, Any] | None], Awaitable[_McpHandlerResult]]
+
+
+_DISPATCH: dict[str, _McpHandler] = {}
+
+
+def register_method(name: str, handler: _McpHandler) -> None:
+    """Register a JSON-RPC method handler against the dispatch table.
+
+    Mirrors the :func:`~meho_backplane.health.register_probe` registry
+    pattern. T3 (#248) builds the per-tool registry on top of this:
+    ``register_mcp_tool`` registers handlers under ``tools/*`` method
+    names and supplies its own RBAC / scope filter; T4 (#249) populates
+    the table with the first reference tool ``meho.status``.
+
+    Raises :class:`RuntimeError` on duplicate name — handlers should be
+    registered exactly once per process, at import time. The error
+    surface is a programmer-error class rather than a 4xx because the
+    registry is configured at module load, not via a network call.
+    """
+    if name in _DISPATCH:
+        raise RuntimeError(f"MCP method {name!r} already registered")
+    _DISPATCH[name] = handler
+
+
+class _McpInvalidParamsError(Exception):
+    """Handler-side sentinel mapped to JSON-RPC ``INVALID_PARAMS``.
+
+    Raised by a handler when its params fail validation (e.g.
+    :class:`~meho_backplane.mcp.schemas.InitializeRequest.model_validate`
+    raises :class:`pydantic.ValidationError`). The dispatcher catches
+    this distinctly from a generic :class:`Exception` so the wire
+    response carries code ``-32602`` rather than ``-32603``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Built-in lifecycle handlers
+# ---------------------------------------------------------------------------
+
+
+async def _initialize(params: dict[str, Any] | None) -> InitializeResponse:
+    """Handle the ``initialize`` method per MCP 2025-06-18 §Initialization.
+
+    Returns a server-info + capabilities envelope. The spec requires the
+    server to echo the client's ``protocolVersion`` when it supports it,
+    or respond with another supported version otherwise; T1 supports
+    only :data:`PROTOCOL_VERSION` and always responds with that.
+    Negotiation past v0.2 (e.g. supporting an older revision for
+    legacy clients) is a v0.3 concern.
+    """
+    try:
+        InitializeRequest.model_validate(params or {})
+    except ValidationError as exc:
+        raise _McpInvalidParamsError(
+            f"initialize: {exc.error_count()} validation error(s)",
+        ) from exc
+
+    return InitializeResponse(
+        capabilities=ServerCapabilities(
+            tools={"listChanged": False},
+            resources={"listChanged": False, "subscribe": False},
+        ),
+        serverInfo={"name": _SERVER_NAME, "version": __version__},
+    )
+
+
+async def _ping(_params: dict[str, Any] | None) -> dict[str, Any]:
+    """Handle the ``ping`` utility method.
+
+    Defined in MCP 2025-06-18 §Utilities/Ping as the canonical liveness
+    probe between client and server. The response body is an empty
+    object — the operator-facing signal is the success itself, not
+    anything inside it.
+    """
+    return {}
+
+
+async def _initialized_notification(_params: dict[str, Any] | None) -> None:
+    """Acknowledge ``notifications/initialized`` — no response body.
+
+    The MCP lifecycle requires the client to send this notification
+    after the ``initialize`` request resolves successfully (§Initialization).
+    Per JSON-RPC §4.1.2, notifications carry no ``id`` and the server
+    MUST NOT reply with a response envelope; the Streamable HTTP
+    transport encodes that contract as HTTP 202 Accepted with no body.
+    The handler runs for side-effect signalling only — future revisions
+    may flip a per-session "initialized" flag here.
+    """
+    return None
+
+
+register_method("initialize", _initialize)
+register_method("notifications/initialized", _initialized_notification)
+register_method("ping", _ping)
+
+
+# ---------------------------------------------------------------------------
+# Wire serialization
+# ---------------------------------------------------------------------------
+
+
+def _serialize_response(resp: JsonRpcResponse) -> dict[str, Any]:
+    """Serialize a :class:`JsonRpcResponse` to a wire-shape dict.
+
+    JSON-RPC §5: the response carries either ``result`` or ``error``
+    but never both, and the unset half MUST be omitted from the wire
+    (not serialized as ``null``). Pydantic's ``exclude_none=True`` is
+    too coarse — it would also strip the ``id`` field on parse-error
+    responses, which spec §5 mandates is ``null`` and present. So the
+    serialization is hand-rolled: ``id`` always serialized; exactly one
+    of ``result`` / ``error`` serialized based on which is set.
+    """
+    out: dict[str, Any] = {"jsonrpc": resp.jsonrpc, "id": resp.id}
+    if resp.error is not None:
+        out["error"] = resp.error.model_dump(mode="json", exclude_none=True)
+    else:
+        # Result is guaranteed non-None by JsonRpcResponse's model validator.
+        out["result"] = resp.result
+    return out
+
+
+def _error_response(
+    request_id: JsonRpcId,
+    code: int,
+    message: str,
+) -> JSONResponse:
+    """Build a JSON-RPC error envelope wrapped in HTTP 200.
+
+    JSON-RPC-level errors are always HTTP 200 with the failure encoded
+    in the envelope; the HTTP status only changes for transport-level
+    issues (none in T1). See MCP transport §"Sending Messages to the
+    Server".
+    """
+    body = JsonRpcResponse(
+        id=request_id,
+        error=JsonRpcError(code=code, message=message),
+    )
+    return JSONResponse(content=_serialize_response(body))
+
+
+# ---------------------------------------------------------------------------
+# Router + dispatch
+# ---------------------------------------------------------------------------
+
+
+router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+_log = structlog.get_logger()
+
+
+def _coerce_request_id(payload: dict[str, Any]) -> JsonRpcId:
+    """Best-effort extract the ``id`` from a malformed request payload.
+
+    Used on the JSON-RPC validation-error path so an INVALID_REQUEST
+    response can still echo the client's id when one was syntactically
+    parseable (helps clients correlate failures). When the raw value
+    isn't a String / Number / NULL, fall back to ``None`` per spec §5
+    ("If there was an error in detecting the id ... it MUST be Null").
+    """
+    raw = payload.get("id")
+    if isinstance(raw, (int, str)) or raw is None:
+        return raw
+    return None
+
+
+@router.post("")
+async def mcp_dispatch(request: Request) -> Response:
+    """Dispatch a single JSON-RPC 2.0 request or notification.
+
+    The Streamable HTTP body contract (§"Sending Messages to the Server"):
+
+    * Input is a JSON object — batch arrays are unsupported in T1.
+    * On a *request* (id present): return 200 + single JSON envelope.
+    * On a *notification* (id absent, or method prefix
+      ``notifications/``): return 202 with no body, regardless of
+      whether the handler errored — JSON-RPC §4.1.2 forbids replying.
+
+    GET requests on this path automatically return HTTP 405 (FastAPI's
+    default for an unmatched method) which satisfies the spec's
+    fallback when the server does not implement the GET-opens-SSE
+    branch of the Streamable HTTP transport.
+    """
+    raw_body = await request.body()
+    if not raw_body:
+        return _error_response(None, PARSE_ERROR, "parse error: empty body")
+
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError as exc:
+        _log.warning("mcp_parse_error", error=exc.msg)
+        return _error_response(None, PARSE_ERROR, f"parse error: {exc.msg}")
+
+    if not isinstance(payload, dict):
+        # Batch (array) bodies are spec-allowed at the JSON-RPC layer
+        # (§6) but the MCP Streamable HTTP transport accepts only a
+        # single request / notification / response per POST. Reject
+        # arrays so the contract is unambiguous.
+        return _error_response(
+            None,
+            INVALID_REQUEST,
+            "invalid request: expected JSON object, not array or scalar",
+        )
+
+    try:
+        jrpc = JsonRpcRequest.model_validate(payload)
+    except ValidationError as exc:
+        return _error_response(
+            _coerce_request_id(payload),
+            INVALID_REQUEST,
+            f"invalid request: {exc.error_count()} validation error(s)",
+        )
+
+    # Notification detection: JSON-RPC §4.1.2 says a notification is a
+    # request without an ``id`` member. Pydantic-side, ``jrpc.id``
+    # collapses absent and explicit-null to ``None`` (spec discourages
+    # the latter); the raw dict tells us which form arrived. The
+    # method-prefix relaxation handles buggy clients that send a
+    # ``notifications/*`` method with an id — the method semantics
+    # are spec-defined as notification-only, so the server treats it
+    # as such regardless of the envelope's id field.
+    is_notification = "id" not in payload or jrpc.method.startswith("notifications/")
+
+    handler = _DISPATCH.get(jrpc.method)
+    if handler is None:
+        if is_notification:
+            _log.warning("mcp_unknown_notification", method=jrpc.method)
+            return Response(status_code=202)
+        return _error_response(
+            jrpc.id,
+            METHOD_NOT_FOUND,
+            f"method not found: {jrpc.method}",
+        )
+
+    try:
+        result = await handler(jrpc.params)
+    except _McpInvalidParamsError as exc:
+        if is_notification:
+            _log.warning(
+                "mcp_notification_invalid_params",
+                method=jrpc.method,
+                error=str(exc),
+            )
+            return Response(status_code=202)
+        return _error_response(jrpc.id, INVALID_PARAMS, str(exc))
+    except Exception as exc:
+        _log.exception("mcp_handler_error", method=jrpc.method)
+        if is_notification:
+            return Response(status_code=202)
+        return _error_response(
+            jrpc.id,
+            INTERNAL_ERROR,
+            f"internal error: {type(exc).__name__}",
+        )
+
+    if is_notification:
+        return Response(status_code=202)
+
+    if isinstance(result, BaseModel):
+        result_body: dict[str, Any] = result.model_dump(mode="json", exclude_none=True)
+    elif isinstance(result, dict):
+        result_body = result
+    else:
+        # Handler returned None (or a non-dict scalar) for a request-
+        # shaped invocation. That's a handler bug; surface as
+        # INTERNAL_ERROR rather than emitting a wire-broken envelope.
+        return _error_response(
+            jrpc.id,
+            INTERNAL_ERROR,
+            "handler returned no result for a non-notification request",
+        )
+
+    response = JsonRpcResponse(id=jrpc.id, result=result_body)
+    return JSONResponse(content=_serialize_response(response))

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -87,6 +87,7 @@ from meho_backplane.mcp.schemas import (
     INVALID_REQUEST,
     METHOD_NOT_FOUND,
     PARSE_ERROR,
+    PROTOCOL_VERSION,
     InitializeRequest,
     InitializeResponse,
     JsonRpcError,
@@ -247,19 +248,32 @@ def _error_response(
     request_id: JsonRpcId,
     code: int,
     message: str,
+    *,
+    status_code: int = 200,
 ) -> JSONResponse:
-    """Build a JSON-RPC error envelope wrapped in HTTP 200.
+    """Build a JSON-RPC error envelope wrapped in the chosen HTTP status.
 
-    JSON-RPC-level errors are always HTTP 200 with the failure encoded
-    in the envelope; the HTTP status only changes for transport-level
-    issues (none in T1). See MCP transport §"Sending Messages to the
-    Server".
+    JSON-RPC-level errors (parse, invalid request, method-not-found,
+    invalid params, internal error) default to HTTP 200 with the failure
+    encoded in the envelope. ``status_code`` overrides this for the
+    narrow set of transport-level failures that MCP Streamable HTTP
+    mandates flip the HTTP status:
+
+    * The ``MCP-Protocol-Version`` validation arm sets ``status_code=400``
+      per spec §"Protocol Version Header" — "If the server receives a
+      request with an invalid or unsupported `MCP-Protocol-Version`, it
+      MUST respond with `400 Bad Request`."
+
+    The body still carries a JSON-RPC envelope because the MCP transport
+    spec at §"Sending Messages to the Server" allows it ("The HTTP
+    response body MAY comprise a JSON-RPC error response that has no
+    id") and it gives the client a structured failure to render.
     """
     body = JsonRpcResponse(
         id=request_id,
         error=JsonRpcError(code=code, message=message),
     )
-    return JSONResponse(content=_serialize_response(body))
+    return JSONResponse(content=_serialize_response(body), status_code=status_code)
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +355,36 @@ async def mcp_dispatch(request: Request) -> Response:
             INVALID_REQUEST,
             f"invalid request: {exc.error_count()} validation error(s)",
         )
+
+    # MCP-Protocol-Version header validation per spec §"Protocol Version
+    # Header". Clients MUST send the header on every post-initialize
+    # request; if the value is invalid or unsupported the server MUST
+    # respond with HTTP 400 Bad Request. The header is exempted on the
+    # `initialize` call itself because clients don't know which version
+    # to send until the handshake completes. Absent header on non-
+    # initialize methods is accepted as a transitional lenience: spec
+    # SHOULD-assume-2025-03-26 doesn't help since v0.2 doesn't support
+    # that revision, and tightening this in T1 would break clients that
+    # don't yet emit the header. T6 (#251) acceptance tests will pin
+    # the strict-mode contract.
+    if jrpc.method != "initialize":
+        protocol_header = request.headers.get("mcp-protocol-version")
+        if protocol_header is not None and protocol_header != PROTOCOL_VERSION:
+            _log.warning(
+                "mcp_unsupported_protocol_version",
+                method=jrpc.method,
+                header=protocol_header,
+                supported=PROTOCOL_VERSION,
+            )
+            return _error_response(
+                _coerce_request_id(payload),
+                INVALID_REQUEST,
+                (
+                    f"unsupported MCP-Protocol-Version: {protocol_header!r} "
+                    f"(server supports {PROTOCOL_VERSION!r})"
+                ),
+                status_code=400,
+            )
 
     # Notification detection: JSON-RPC §4.1.2 says a notification is a
     # request without an ``id`` member. Pydantic-side, ``jrpc.id``

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -288,6 +288,32 @@ def test_request_missing_method_returns_invalid_request(client: TestClient) -> N
     assert body["error"]["code"] == INVALID_REQUEST
 
 
+@pytest.mark.parametrize("bad_id", [True, False])
+def test_bool_id_is_rejected_as_invalid_request(
+    client: TestClient,
+    bad_id: bool,
+) -> None:
+    """``bool`` ids violate JSON-RPC §4.1.2 (Number/String/NULL only).
+
+    ``bool`` subclasses ``int`` in Python, so without an explicit reject
+    Pydantic would coerce ``True`` → ``1`` / ``False`` → ``0`` and echo
+    that integer in the response, breaking the client's id correlation.
+    The field validator on :class:`JsonRpcRequest.id` and the bool-
+    short-circuit in :func:`_coerce_request_id` both gate this.
+    """
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": bad_id, "method": "ping"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    # The error response carries id=null because the raw id was not a
+    # valid JSON-RPC id; echoing the bool would propagate the bug.
+    assert body["id"] is None
+    assert body["error"]["code"] == INVALID_REQUEST
+
+
 # ---------------------------------------------------------------------------
 # ping utility
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the MCP Streamable HTTP transport entrypoint (G0.5-T1, #246).
+
+Covers the acceptance criteria on issue #246:
+
+* ``/mcp`` accepts JSON-RPC 2.0 POST bodies.
+* ``initialize`` returns ``protocolVersion=2025-06-18``, capabilities,
+  and a ``serverInfo`` payload pinned to the running app's version.
+* ``initialize`` with missing ``protocolVersion`` returns
+  :data:`~meho_backplane.mcp.schemas.INVALID_PARAMS` (``-32602``).
+* ``notifications/initialized`` is acknowledged with HTTP 202 and no
+  body, per MCP Streamable HTTP §"Sending Messages to the Server".
+* Unknown methods return :data:`~meho_backplane.mcp.schemas.METHOD_NOT_FOUND`
+  (``-32601``) for requests, and 202 (silently dropped) for notifications.
+* Parse errors return :data:`~meho_backplane.mcp.schemas.PARSE_ERROR`
+  (``-32700``) with ``id: null`` per JSON-RPC spec §5.
+* Wrong ``jsonrpc`` envelope returns
+  :data:`~meho_backplane.mcp.schemas.INVALID_REQUEST` (``-32600``).
+* ``ping`` returns ``result: {}``.
+* Bearer-auth-free calls succeed (T1 has no auth; T2 adds it).
+
+Note on AC #3 wording
+=====================
+
+The issue body's AC list says ``notifications/initialized`` "returns 204
+no content". The MCP Streamable HTTP spec requires HTTP **202** Accepted
+for notifications (§"Sending Messages to the Server", "the server MUST
+return HTTP status code 202 Accepted with no body"). The spec MUST
+overrides the AC's HTTP-code detail — the intent ("acknowledge with no
+body") is met either way; the wire code follows the spec.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane import __version__
+from meho_backplane.main import app
+from meho_backplane.mcp.schemas import (
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    INVALID_REQUEST,
+    METHOD_NOT_FOUND,
+    PARSE_ERROR,
+    PROTOCOL_VERSION,
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Plain :class:`TestClient` for the running app.
+
+    The shared :mod:`conftest` autouse fixture supplies a per-test
+    SQLite ``DATABASE_URL`` with the schema migrated, so the app's
+    lifespan and middleware chain boot cleanly under
+    :class:`fastapi.testclient.TestClient` without any per-test
+    plumbing here.
+    """
+    return TestClient(app)
+
+
+def _post_mcp(client: TestClient, body: Any) -> Any:
+    """POST *body* (JSON) to ``/mcp`` and return the response object."""
+    return client.post("/mcp", json=body)
+
+
+# ---------------------------------------------------------------------------
+# initialize handshake
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_returns_protocol_version_capabilities_and_serverinfo(
+    client: TestClient,
+) -> None:
+    """A well-formed ``initialize`` returns the spec-mandated payload."""
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "0.0.1"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == 1
+    assert "error" not in body
+
+    result = body["result"]
+    assert result["protocolVersion"] == PROTOCOL_VERSION
+    assert result["serverInfo"] == {"name": "meho-backplane", "version": __version__}
+    # Both registries land later (T3/#248); T1 advertises their envelopes
+    # so the negotiated capability namespace is reachable, with
+    # listChanged: false matching the v0.2 out-of-scope notes.
+    assert result["capabilities"]["tools"] == {"listChanged": False}
+    assert result["capabilities"]["resources"] == {
+        "listChanged": False,
+        "subscribe": False,
+    }
+
+
+def test_initialize_without_protocol_version_returns_invalid_params(
+    client: TestClient,
+) -> None:
+    """``initialize`` missing required ``protocolVersion`` → -32602."""
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "initialize",
+            "params": {"capabilities": {}},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 2
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "result" not in body
+
+
+# ---------------------------------------------------------------------------
+# notifications/initialized
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_initialized_returns_202_with_empty_body(
+    client: TestClient,
+) -> None:
+    """The post-initialize notification: 202 Accepted, no body."""
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+
+    assert response.status_code == 202
+    assert response.content == b""
+
+
+def test_notifications_initialized_with_extraneous_id_still_returns_202(
+    client: TestClient,
+) -> None:
+    """Buggy clients that include an id on a ``notifications/*`` method
+    still get 202 — the method semantics are spec-defined as
+    notification-only regardless of the envelope's id field.
+    """
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "notifications/initialized",
+        },
+    )
+
+    assert response.status_code == 202
+    assert response.content == b""
+
+
+# ---------------------------------------------------------------------------
+# Unknown method routing
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_method_returns_method_not_found_for_request(
+    client: TestClient,
+) -> None:
+    """A request-shaped call to an unregistered method → -32601."""
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/list",  # T3 (#248) registers; not yet present
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 3
+    assert body["error"]["code"] == METHOD_NOT_FOUND
+    assert "tools/list" in body["error"]["message"]
+
+
+def test_unknown_notification_returns_202(client: TestClient) -> None:
+    """Notification (no id) to an unregistered method → 202, dropped."""
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "method": "completely_unknown_method"},
+    )
+
+    assert response.status_code == 202
+    assert response.content == b""
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC envelope errors
+# ---------------------------------------------------------------------------
+
+
+def test_parse_error_on_invalid_json(client: TestClient) -> None:
+    """Non-JSON body → -32700, id=null per JSON-RPC §5."""
+    response = client.post(
+        "/mcp",
+        content=b"this is not json",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] is None
+    assert body["error"]["code"] == PARSE_ERROR
+
+
+def test_empty_body_returns_parse_error(client: TestClient) -> None:
+    """Empty body → -32700 with an explicit "empty body" message.
+
+    Caught explicitly so the error message is informative rather than
+    the default "Expecting value" from :func:`json.loads`.
+    """
+    response = client.post(
+        "/mcp",
+        content=b"",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] is None
+    assert body["error"]["code"] == PARSE_ERROR
+    assert "empty" in body["error"]["message"]
+
+
+def test_array_body_returns_invalid_request(client: TestClient) -> None:
+    """JSON-RPC batch arrays are unsupported in T1 → -32600."""
+    response = _post_mcp(
+        client,
+        [{"jsonrpc": "2.0", "id": 1, "method": "ping"}],
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] is None
+    assert body["error"]["code"] == INVALID_REQUEST
+
+
+def test_wrong_jsonrpc_version_returns_invalid_request(client: TestClient) -> None:
+    """Envelope with ``jsonrpc`` != "2.0" → -32600.
+
+    The id can be echoed back when it's syntactically parseable; the
+    dispatcher's best-effort id extractor preserves it so the client
+    can correlate the failure with the in-flight request.
+    """
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "1.0", "id": 4, "method": "ping"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 4
+    assert body["error"]["code"] == INVALID_REQUEST
+
+
+def test_request_missing_method_returns_invalid_request(client: TestClient) -> None:
+    """Envelope without a ``method`` field → -32600."""
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 5},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 5
+    assert body["error"]["code"] == INVALID_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# ping utility
+# ---------------------------------------------------------------------------
+
+
+def test_ping_returns_empty_result(client: TestClient) -> None:
+    """``ping`` returns ``result: {}``."""
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 7, "method": "ping"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == 7
+    assert body["result"] == {}
+    assert "error" not in body
+
+
+# ---------------------------------------------------------------------------
+# T1 auth contract — no Bearer required
+# ---------------------------------------------------------------------------
+
+
+def test_t1_has_no_auth_unauthenticated_call_succeeds(client: TestClient) -> None:
+    """AC: "T1 has NO auth yet — every request currently succeeds."
+
+    Calling ``/mcp`` with no ``Authorization`` header must still
+    succeed in T1. T2 (#247) is what adds the OAuth-RS chain on top.
+    """
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 8, "method": "ping"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Wire shape: result and error are mutually exclusive on the wire
+# ---------------------------------------------------------------------------
+
+
+def test_success_response_omits_error_member(client: TestClient) -> None:
+    """Per JSON-RPC §5, a successful response MUST NOT include ``error``."""
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 9, "method": "ping"},
+    )
+
+    body = response.json()
+    assert "result" in body
+    assert "error" not in body
+
+
+def test_error_response_omits_result_member(client: TestClient) -> None:
+    """Per JSON-RPC §5, an error response MUST NOT include ``result``."""
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 10, "method": "no_such_method"},
+    )
+
+    body = response.json()
+    assert "error" in body
+    assert "result" not in body
+
+
+# ---------------------------------------------------------------------------
+# Method-not-allowed for non-POST verbs (transport contract)
+# ---------------------------------------------------------------------------
+
+
+def test_get_on_mcp_endpoint_returns_405(client: TestClient) -> None:
+    """The Streamable HTTP transport allows clients to GET ``/mcp`` to
+    open an SSE stream (§"Listening for Messages from the Server").
+    T1 doesn't implement the SSE branch; FastAPI auto-replies 405 to GET
+    on a POST-only route, which is the spec's allowed fallback ("the
+    server ... return HTTP 405 Method Not Allowed").
+    """
+    response = client.get("/mcp")
+    assert response.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# register_method duplicate-registration guard
+# ---------------------------------------------------------------------------
+
+
+def test_register_method_rejects_duplicate_registration() -> None:
+    """``register_method`` is a programmer-error gate, not a network one."""
+    from meho_backplane.mcp.server import register_method
+
+    async def _dummy(_params: dict[str, Any] | None) -> dict[str, Any]:
+        return {}
+
+    with pytest.raises(RuntimeError, match="already registered"):
+        register_method("initialize", _dummy)
+
+
+# ---------------------------------------------------------------------------
+# Internal error path
+# ---------------------------------------------------------------------------
+
+
+def test_handler_exception_becomes_internal_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A handler that raises an unexpected exception → -32603.
+
+    Exercises the generic ``except Exception`` arm of the dispatcher.
+    Registers a one-shot handler via ``monkeypatch`` on the module-level
+    ``_DISPATCH`` dict so the test doesn't pollute the global registry.
+    """
+    from meho_backplane.mcp import server as server_module
+
+    async def _boom(_params: dict[str, Any] | None) -> dict[str, Any]:
+        raise ValueError("boom")
+
+    monkeypatch.setitem(server_module._DISPATCH, "test_boom", _boom)
+
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 11, "method": "test_boom"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 11
+    assert body["error"]["code"] == INTERNAL_ERROR

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -495,7 +495,13 @@ def test_get_on_mcp_endpoint_returns_405(client: TestClient) -> None:
 
 
 def test_register_method_rejects_duplicate_registration() -> None:
-    """``register_method`` is a programmer-error gate, not a network one."""
+    """``register_method`` is a programmer-error gate, not a network one.
+
+    Test isolation: ``register_method`` raises *before* mutating
+    ``_DISPATCH`` (the duplicate check runs ahead of the dict
+    assignment), so a passing run leaves no residue in the module-
+    level registry. No fixture-level cleanup is needed.
+    """
     from meho_backplane.mcp.server import register_method
 
     async def _dummy(_params: dict[str, Any] | None) -> dict[str, Any]:
@@ -536,3 +542,38 @@ def test_handler_exception_becomes_internal_error(
     body = response.json()
     assert body["id"] == 11
     assert body["error"]["code"] == INTERNAL_ERROR
+
+
+def test_handler_returning_non_dict_scalar_becomes_internal_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A handler that returns a non-dict / non-BaseModel value → -32603.
+
+    This is the load-bearing handler-bug guard at the end of
+    ``mcp_dispatch``: if a handler returns a list, string, int, or any
+    other shape that isn't a JSON-RPC ``result`` body, the dispatcher
+    must convert that to INTERNAL_ERROR rather than emit a wire-broken
+    envelope. ``test_handler_exception_becomes_internal_error`` covers
+    the ``except Exception`` arm; this case is the "handler returned
+    successfully but with the wrong shape" arm.
+    """
+    from meho_backplane.mcp import server as server_module
+
+    async def _list_returner(_params: dict[str, Any] | None) -> list[int]:
+        # Plausible handler bug: forgetting to wrap the items in a
+        # ``{"items": [...]}`` dict before returning.
+        return [1, 2, 3]
+
+    monkeypatch.setitem(server_module._DISPATCH, "test_bad_shape", _list_returner)
+
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 12, "method": "test_bad_shape"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 12
+    assert body["error"]["code"] == INTERNAL_ERROR
+    assert "result" in body["error"]["message"].lower()

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -101,14 +101,13 @@ def test_initialize_returns_protocol_version_capabilities_and_serverinfo(
     result = body["result"]
     assert result["protocolVersion"] == PROTOCOL_VERSION
     assert result["serverInfo"] == {"name": "meho-backplane", "version": __version__}
-    # Both registries land later (T3/#248); T1 advertises their envelopes
-    # so the negotiated capability namespace is reachable, with
-    # listChanged: false matching the v0.2 out-of-scope notes.
-    assert result["capabilities"]["tools"] == {"listChanged": False}
-    assert result["capabilities"]["resources"] == {
-        "listChanged": False,
-        "subscribe": False,
-    }
+    # T1 advertises an **empty** capabilities envelope — see
+    # `ServerCapabilities` docstring + `_initialize` for rationale.
+    # Advertising `tools` / `resources` ahead of T3 (#248) registering
+    # the corresponding handlers would tell a spec-conforming client
+    # it can call `tools/list`, which would then `-32601`. T3 flips the
+    # envelopes back on paired with the dispatch-table additions.
+    assert result["capabilities"] == {}
 
 
 def test_initialize_without_protocol_version_returns_invalid_params(

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -385,6 +385,95 @@ def test_error_response_omits_result_member(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# MCP-Protocol-Version header validation
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_version_header_matching_supported_is_accepted(
+    client: TestClient,
+) -> None:
+    """Header present + matching ``PROTOCOL_VERSION`` → request proceeds normally."""
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 100, "method": "ping"},
+        headers={"MCP-Protocol-Version": PROTOCOL_VERSION},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 100
+    assert body["result"] == {}
+
+
+def test_protocol_version_header_unsupported_returns_400(
+    client: TestClient,
+) -> None:
+    """Header present + unsupported value → HTTP 400 per spec MUST.
+
+    MCP 2025-06-18 §Protocol Version Header: "If the server receives a
+    request with an invalid or unsupported `MCP-Protocol-Version`, it
+    MUST respond with `400 Bad Request`."
+    """
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 101, "method": "ping"},
+        headers={"MCP-Protocol-Version": "1999-01-01"},
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["id"] == 101
+    assert body["error"]["code"] == INVALID_REQUEST
+    assert "1999-01-01" in body["error"]["message"]
+
+
+def test_protocol_version_header_absent_is_accepted_transitionally(
+    client: TestClient,
+) -> None:
+    """Header absent on non-initialize → accepted (transitional lenience).
+
+    Spec SHOULD-assume-2025-03-26 doesn't help us — v0.2 doesn't support
+    that revision. T1 accepts header-absent so clients that don't yet
+    emit it aren't broken. T6 (#251) will pin the strict-mode contract.
+    """
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 102, "method": "ping"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == 102
+
+
+def test_initialize_does_not_require_protocol_version_header(
+    client: TestClient,
+) -> None:
+    """``initialize`` is exempt — clients don't know the version yet.
+
+    Per spec, the header is required on "all subsequent requests" after
+    initialize. The initialize call itself happens before negotiation,
+    so any header value (or its absence) is accepted on that call.
+    """
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 103,
+            "method": "initialize",
+            "params": {"protocolVersion": PROTOCOL_VERSION},
+        },
+        # Deliberately wrong header — would normally trigger 400 but
+        # initialize is exempt.
+        headers={"MCP-Protocol-Version": "1999-01-01"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 103
+    assert body["result"]["protocolVersion"] == PROTOCOL_VERSION
+
+
+# ---------------------------------------------------------------------------
 # Method-not-allowed for non-POST verbs (transport contract)
 # ---------------------------------------------------------------------------
 

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -239,6 +239,38 @@ this stage it exposes:
   `RequestContextMiddleware`'s `X-Request-Id` response header so the
   operator has a correlation crumb on the failure path.
 
+* MCP Streamable HTTP transport entrypoint (Task #246, G0.5-T1) —
+  `backend/src/meho_backplane/mcp/` is the new module hosting MEHO's
+  Model Context Protocol server front. `mcp/schemas.py` defines the
+  JSON-RPC 2.0 envelopes (`JsonRpcRequest`, `JsonRpcResponse`,
+  `JsonRpcError`) plus the MCP 2025-06-18 lifecycle payloads
+  (`InitializeRequest`, `InitializeResponse`, `ServerCapabilities`) as
+  frozen Pydantic v2 models; `mcp/server.py` mounts the `APIRouter` at
+  `POST /mcp`, exposes the module-level `register_method(name, handler)`
+  dispatch-table API (mirroring `register_probe`'s shape), and ships
+  three built-in handlers — `initialize`, `notifications/initialized`,
+  and `ping`. The route follows the Streamable HTTP transport's
+  single-response shape (no SSE in v0.2): requests get HTTP 200 with a
+  single JSON-RPC envelope; notifications get HTTP 202 Accepted with
+  no body per spec §"Sending Messages to the Server". JSON-RPC-level
+  errors (parse, invalid request, method-not-found, invalid params,
+  internal error) are encoded as 200 envelopes with the `error` member
+  populated — only transport-level failures flip the HTTP code. T1 has
+  **no Bearer-token auth** on `/mcp` yet; every well-formed request
+  succeeds. T2 (#247) adds the OAuth 2.1 resource-server chain
+  (`/.well-known/oauth-protected-resource`, `WWW-Authenticate` headers,
+  audience validation per RFC 8707, reuse of `verify_jwt`); Origin-
+  header validation per the MCP transport DNS-rebinding warning is
+  also deferred to T2 because it depends on the `MCP_ALLOWED_ORIGINS`
+  setting T2 introduces. T3 (#248) layers the tool + resource
+  registries (`register_mcp_tool`, `register_mcp_resource`); T4 (#249)
+  populates them with the reference `meho.status` tool and
+  `meho://tenant/<id>/info` resource; T5 (#250) replaces the implicit
+  AuditMiddleware pass-through (which currently fires its
+  "no operator_sub bound" skip rule on every `/mcp` call because T1
+  doesn't bind one) with a fail-closed MCP-specific audit path on
+  `tools/call` + `resources/read`.
+
 Database persistence lands progressively in subsequent G2.3 Tasks. The stack (FastAPI, Pydantic v2,
 SQLAlchemy 2.x async, Alembic, structlog, prometheus_client, authlib
 for JOSE) is locked by


### PR DESCRIPTION
## Summary

- Stands up the MCP server entrypoint at `POST /mcp` per **MCP spec revision 2025-06-18** — JSON-RPC 2.0 dispatch + Streamable HTTP transport (single-response shape; SSE is out of scope for v0.2).
- New `backend/src/meho_backplane/mcp/` module with `schemas.py` (frozen Pydantic v2 envelopes for JSON-RPC + MCP lifecycle payloads) and `server.py` (FastAPI router + `register_method` dispatch-table API that mirrors `register_probe`, so #248 can layer the tool / resource registries on top).
- Built-in handlers for the lifecycle primitives the spec defines as universal — `initialize`, `notifications/initialized`, `ping`. Unknown methods on requests return JSON-RPC `-32601`; on notifications they're silently 202-accepted per JSON-RPC §4.1.2.
- No Bearer-token auth on this route yet — T2 (#247) layers the OAuth-RS chain on top. Origin-header validation per the MCP transport DNS-rebinding warning is also deferred to T2 (it depends on the `MCP_ALLOWED_ORIGINS` setting T2 introduces).

## Deviation from the issue's AC #3

The AC list on #246 says `notifications/initialized` "returns **204** no content". The MCP Streamable HTTP spec ("Sending Messages to the Server") requires HTTP **202 Accepted** for notifications, not 204. The AC's *intent* ("acknowledge with no body") is met either way; the wire code follows the spec MUST. Tests assert 202.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — 45 files formatted
- [x] `mypy src/` (strict mode) — 27 source files, no issues
- [x] `pytest tests/` — **246 passed**, 1 deselected (the pre-existing `process_resident_memory_bytes` test that fails on macOS too — also fails on `main`, this PR doesn't touch it)
- [x] New `tests/test_mcp_server.py` — **18 cases**, one per acceptance criterion plus the JSON-RPC edge paths (parse error, batch arrays, missing method, wrong jsonrpc version, internal error path, GET → 405, duplicate-registration guard, unauthenticated success). Walks every JSON-RPC error code in the dispatch.

### AC coverage

- [x] `/mcp` accepts JSON-RPC 2.0 POSTs
- [x] `initialize` returns `serverInfo` (name/version) + capabilities + `protocolVersion=2025-06-18`
- [x] `notifications/initialized` accepted with no body (202 per spec; see deviation note above)
- [x] Unknown method returns `-32601`
- [x] Parse error returns `-32700` with `id: null`
- [x] Invalid params (`initialize` without `protocolVersion`) returns `-32602`
- [x] `ping` returns `result: {}`
- [x] T1 has **no auth** — every well-formed request currently succeeds (docstrings + dedicated test)
- [x] CI green: ruff + mypy + pytest

## Out of scope

- **OAuth-RS auth** — G0.5-T2 (#247): `/.well-known/oauth-protected-resource`, `WWW-Authenticate` headers, audience validation per RFC 8707, reuse of `verify_jwt`.
- **Origin-header validation** (transport-MUST per MCP spec, deferred because it requires `MCP_ALLOWED_ORIGINS` from T2).
- **Tool + resource registries + `tools/list` / `tools/call` / `resources/list` / `resources/read`** — G0.5-T3 (#248).
- **Reference tool `meho.status` + reference resource `meho://tenant/<id>/info`** — G0.5-T4 (#249).
- **MCP-specific audit integration** (path-exclusion from chassis `AuditMiddleware`; fail-closed audit row on `tools/call`/`resources/read`) — G0.5-T5 (#250).
- **End-to-end MCP Inspector acceptance test** + `docs/architecture/mcp.md` — G0.5-T6 (#251).
- **SSE response shape** (`Content-Type: text/event-stream` for long-running tools) — out of v0.2 scope entirely.
- **Batch JSON-RPC arrays** — spec §6 allows them at the JSON-RPC layer but the MCP Streamable HTTP transport accepts only single envelopes per POST; the dispatcher rejects arrays with `-32600`.

Closes #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /mcp Streamable HTTP JSON-RPC transport with protocol-version handling and built-in lifecycle handlers (initialize, notifications/initialized, ping). Requests return JSON-RPC envelopes (200); notifications return HTTP 202 Accepted.

* **Behavior / Error Handling**
  * Strict envelope validation; boolean ids rejected; initialize exempt from protocol-header enforcement; unsupported versions return JSON-RPC INVALID_REQUEST; non-object or parse failures and handler errors map to appropriate JSON-RPC errors.

* **Tests**
  * Expanded acceptance tests covering header rules, id validation, notification vs request semantics, handler-return and error-path conversions.

* **Documentation**
  * New docs describing the MCP transport, JSON-RPC schemas, and handler registration API.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/266)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-12)

Addressed review feedback from the three CHANGES_REQUESTED / COMMENTED reviews on iteration 1 (CodeRabbit, ilhan-karic, /review-pr-slim).

**Fixed:**

- **B1** `a92aa59` — Stop advertising `tools` / `resources` capabilities ahead of T3. `ServerCapabilities()` now ships every field `None`; the wire serializer drops them. Prevents spec-conforming clients from disconnecting when their follow-up `tools/list` call hits `-32601`.
- **M1** `094019f` — Reject `bool` ids in JSON-RPC envelopes. `bool` subclasses `int` in Python, so `True` / `False` were coercing to `1` / `0` on the wire — a JSON-RPC §4.1.2 wire-contract violation. Added a `mode="before"` `field_validator` on `JsonRpcRequest.id` and a `isinstance(raw, bool)` short-circuit in `_coerce_request_id`. Parametrized test covers both gates.
- **M2** `a10b0c4` — `MCP-Protocol-Version` header now validated per spec §"Protocol Version Header" MUST. If header present and unsupported → HTTP 400 + JSON-RPC error envelope. `initialize` exempted (clients don't know the version pre-handshake). Header absent is accepted as transitional lenience (spec's SHOULD-assume-2025-03-26 doesn't help — v0.2 doesn't support that revision). Four tests pin the contract.
- **Mi1 + Mi7** `ea2595f` — `JsonRpcId` docstring corrected to describe the dispatcher's actual absent/null distinction. Comment on `InitializeRequest.model_validate(params or {})` explaining the deliberate `None` / `{}` collapse.
- **Mi4** `433e8f9` — `_McpInvalidParamsError` → `McpInvalidParamsError`; re-exported from `meho_backplane.mcp` so T3 (#248) tool handlers can raise it without reaching into a dunder-private symbol.
- **Mi2 + Mi8** `24c210e` — Added `test_handler_returning_non_dict_scalar_becomes_internal_error` to cover the load-bearing handler-bug guard (success-with-wrong-shape arm). Annotated `test_register_method_rejects_duplicate_registration` to note it raises before mutating, so no fixture cleanup is needed.

**Disputed (with inline reply):**

- **Q1** `adb6440` — Notifications return HTTP 202 even when the handler errors (unknown method, invalid params, internal error). Spec §"Sending Messages to the Server" splits "accepts → 202" from "cannot accept → 4xx", but "cannot accept" is intentionally narrow — it refers to transport-level rejection (malformed envelope, batch arrays, bad JSON, unsupported `MCP-Protocol-Version`). Transport-level rejections already flip to HTTP 4xx; post-envelope arms stay at 202 because (1) JSON-RPC §4.1.2 says the server MUST NOT reply to a notification, (2) clients cannot retry on 4xx without violating §4.1.2, and (3) most MCP servers in the wild treat unknown notifications as silently-dropped for forward-compat. Comment in `mcp_dispatch` now spells this out. See inline reply on the original comment.

- **Mi6** (ilhan-karic) — `_serialize_response`'s hand-rolled "drop the unset half" logic vs `model_dump(exclude_none=True)` + manual id override. **Keeping the hand-roll.** Pydantic's `exclude_none=True` would also strip the `id` field on parse-error responses, where spec §5 mandates the id be **null** and **present**. The hand-roll makes that load-bearing distinction grep-able and pins the spec citation right where the serializer lives; the alternative is a model_dump + post-process that buries the rationale one indirection away. The reviewer framed this as "Fine, but..." — not blocking.

**Deferred to follow-up (recorded for orchestrator):**

- **Mi3** — Unbounded `request.body()` read; DOS risk. Belongs with the rest of `/mcp` transport hardening (Origin-header validation, content-type 415 enforcement, body-size cap), all gated on the `MCP_ALLOWED_ORIGINS` / size-cap settings T2 (#247) introduces. Both reviewers agreed this is T2 scope.
- **Mi5** (ilhan-karic) — Strict content-type check (415 on non-`application/json`). Spec-aligned at the moment (the spec doesn't forbid lenience); a hardening item that fits naturally with Mi3's transport-hardening cluster. Will land alongside Mi3 in T2.
- **CR1** (CodeRabbit) — `mcp_dispatch` cognitive complexity 18 vs SonarCloud threshold 15. CodeRabbit's own note framed this as "purely optional cleanup". The function is single-responsibility (envelope → dispatch → wire-shape mapping) and splitting into three helpers would fragment that cohesion. Will revisit if T3's registry-aware dispatch pushes complexity higher.

**Verification (re-run after fixes):**

- `ruff check src/ tests/` — clean
- `ruff format --check` — 52 files formatted
- `mypy src/` (strict) — 27 source files, no issues
- `pytest tests/` — **253 passed**, 1 deselected (pre-existing macOS-only test, still fails on `main`)
- `tests/test_mcp_server.py` — **25 cases** (up from 18): 7 new tests cover bool-id rejection (×2 parametrized), protocol-version header validation (×4), and the missing handler-bug-guard arm (×1)

<!-- auto-implement-issue: continue, iteration 2 -->



---

## Follow-up (auto-implement-issue, iteration 3, 2026-05-12)

CodeRabbit's iteration-2 review flagged 3 new actionable items, all direct fallout from iteration-2's M2 protocol-version fix:

**Fixed:**

- **CR2 + CR3** `a9d9931` — Two docstring claims went stale when M2 introduced the HTTP 400 path for unsupported `MCP-Protocol-Version`. `mcp/__init__.py:29` said "Every well-formed JSON-RPC request currently succeeds" — no longer true. `mcp/server.py` module docstring said "transport-level failures (in T1: none) flip the HTTP status" — M2 added exactly that case. Both rewritten to enumerate the actual T1 transport-failure surface and point at T2 for the OAuth 401/403 cases.

- **CR4** `8262277` — `mcp_dispatch` cognitive complexity 22 vs SonarCloud threshold 15 (iteration-1 was 18; M2 pushed it higher). Refactored into four focused helpers, each with its load-bearing spec citation:

  - `_parse_request_body(raw_body)` — bytes → envelope dict or transport error.
  - `_validate_protocol_version_header(request, method, payload)` — spec §"Protocol Version Header" enforcement.
  - `_build_success_response(request_id, result)` — JSON-RPC envelope serialization.
  - `_dispatch_to_handler(jrpc, is_notification)` — handler lookup, execution, error mapping. The Q1 "cannot accept" comment lives here now since the notification/202 split is local to handler execution.

  `mcp_dispatch` becomes a thin orchestrator. Behavior preserved end-to-end — same 25 test cases pass unchanged.

**Verification (re-run after iter-3 fixes):**

- `ruff check src/ tests/` — clean
- `ruff format --check` — 52 files formatted
- `mypy src/` (strict) — 27 source files, no issues
- `pytest tests/` — **253 passed**, 1 deselected (pre-existing macOS test)
- SonarCloud quality gate — passed on iter-2 (was already passing); iter-3 should bring `mcp_dispatch`'s complexity below the threshold

<!-- auto-implement-issue: continue, iteration 3 -->
