### PR TITLE
feat(mcp): OAuth 2.1 resource-server protection on /mcp (G0.5-T2)

### DIFF
--- a/backend/src/meho_backplane/api/well_known.py
+++ b/backend/src/meho_backplane/api/well_known.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/.well-known/*`` discovery surfaces — unauthenticated metadata documents.
+
+This module hosts the discovery routes a third-party MCP client hits
+*before* it has a token to present. By construction these endpoints
+MUST be reachable without authentication; that's the bootstrap step
+that lets the client learn which authorisation server to talk to in
+order to obtain the access token the protected ``/mcp`` route demands.
+
+v0.2 ships one route here: ``/.well-known/oauth-protected-resource``
+per RFC 9728 §3. It describes the backplane's MCP server resource so
+spec-conforming MCP clients (Claude Desktop, MCP Inspector, custom SDK
+consumers) can:
+
+1. POST to ``/mcp`` without a token → server returns 401 +
+   ``WWW-Authenticate: Bearer resource_metadata="<metadata-url>"``
+   (per :mod:`meho_backplane.mcp.auth`).
+2. GET ``<metadata-url>`` → returns this route's JSON body.
+3. Extract ``authorization_servers[0]`` and fetch its own metadata
+   (``/.well-known/oauth-authorization-server`` per RFC 8414, owned by
+   Keycloak).
+4. Run the OAuth 2.1 + PKCE handshake against Keycloak with the
+   ``resource`` parameter set to ``resource`` from this document.
+5. Re-POST to ``/mcp`` with the issued access token in
+   ``Authorization: Bearer ...``.
+
+The chassis HTTP API has its own discovery surface for the CLI
+(``/api/v1/auth-config``); that endpoint is the CLI's bootstrap path
+and reads ``KEYCLOAK_AUDIENCE`` rather than the MCP resource URI. The
+two coexist because the chassis and MCP surfaces have **distinct
+audiences** — see :mod:`meho_backplane.mcp.auth`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+from meho_backplane.mcp.auth import mcp_resource_uri
+from meho_backplane.settings import get_settings
+
+__all__ = ["router"]
+
+
+router = APIRouter(prefix="/.well-known", tags=["discovery"])
+
+
+@router.get("/oauth-protected-resource")
+async def protected_resource_metadata() -> dict[str, Any]:
+    """Return the RFC 9728 protected-resource metadata document.
+
+    Fields per RFC 9728 §3:
+
+    * ``resource`` (REQUIRED) — the canonical MCP server URI clients
+      pass as the ``resource`` parameter in OAuth requests per RFC 8707.
+      Resolved via :func:`~meho_backplane.mcp.auth.mcp_resource_uri`,
+      which prefers an explicit ``MCP_RESOURCE_URI`` setting and falls
+      back to ``f"{backplane_url}/mcp"``.
+    * ``authorization_servers`` — the Keycloak issuer URL. MCP 2025-06-18
+      §Authorization Server Discovery requires this to be non-empty.
+    * ``scopes_supported`` — v0.2 ships two scopes that downstream
+      Tasks (T3 RBAC filter, T4 reference tool, T5 audit) consume.
+      Conservative: clients that request only ``mcp:read`` can list /
+      inspect but not invoke side-effecting tools.
+    * ``bearer_methods_supported`` — ``["header"]`` only. MCP transport
+      forbids tokens in the URI query (see §"Access Token Usage").
+
+    No authentication is enforced on this endpoint by design: RFC 9728
+    discovery is the bootstrap step that lets unauthenticated clients
+    learn how to obtain a token. The chassis middleware chain still
+    runs — the request_id stays bound for log correlation, and
+    AuditMiddleware skips the row because no ``operator_sub`` is bound
+    (the standard unauthenticated-route path).
+    """
+    settings = get_settings()
+    return {
+        "resource": mcp_resource_uri(settings),
+        "authorization_servers": [
+            str(settings.keycloak_issuer_url).rstrip("/"),
+        ],
+        "scopes_supported": ["mcp:read", "mcp:execute"],
+        "bearer_methods_supported": ["header"],
+    }

--- a/backend/src/meho_backplane/auth/jwt.py
+++ b/backend/src/meho_backplane/auth/jwt.py
@@ -100,6 +100,7 @@ __all__ = [
     "clear_jwks_cache",
     "keycloak_readiness_probe",
     "verify_jwt",
+    "verify_jwt_for_audience",
 ]
 
 #: HTTP timeout for both the OIDC discovery hit and the JWKS hit. Keep
@@ -211,12 +212,23 @@ async def _fetch_jwks(*, force_refresh: bool = False) -> dict[str, Any]:
         return jwks
 
 
-def _decode_with_jwks(token: str, jwks: dict[str, Any], settings: Settings) -> Any:
+def _decode_with_jwks(
+    token: str,
+    jwks: dict[str, Any],
+    settings: Settings,
+    *,
+    expected_audience: str,
+) -> Any:
     """Verify *token* against *jwks* and return the validated claims.
 
     Wrapped behind the ``warnings.catch_warnings`` block to suppress the
     authlib-jose deprecation noise on every request — the deprecation is
     a v0.2 migration item, not a per-request signal.
+
+    ``expected_audience`` is passed by the caller so MCP routes (G0.5-T2)
+    can validate against the MCP canonical URI rather than the chassis
+    ``KEYCLOAK_AUDIENCE``. The chassis ``verify_jwt`` passes
+    ``settings.keycloak_audience`` to preserve existing behaviour.
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -232,7 +244,7 @@ def _decode_with_jwks(token: str, jwks: dict[str, Any], settings: Settings) -> A
                 },
                 "aud": {
                     "essential": True,
-                    "value": settings.keycloak_audience,
+                    "value": expected_audience,
                 },
             },
         )
@@ -286,7 +298,12 @@ def _extract_bearer_token(authorization: str | None) -> str:
     return token
 
 
-async def _decode_with_kid_rotation(token: str, settings: Settings) -> Any:
+async def _decode_with_kid_rotation(
+    token: str,
+    settings: Settings,
+    *,
+    expected_audience: str,
+) -> Any:
     """Decode *token* against the cached JWKS, refreshing once on a kid miss.
 
     The first ``_fetch_jwks`` call serves the cached keyset (or fetches
@@ -301,6 +318,10 @@ async def _decode_with_kid_rotation(token: str, settings: Settings) -> Any:
     The retry budget is exactly one — a second ``ValueError`` after the
     forced JWKS refresh is treated as a hard 401, preventing an
     infinite-refresh loop on a token whose ``kid`` truly does not exist.
+
+    ``expected_audience`` is forwarded to :func:`_decode_with_jwks` so
+    callers (chassis ``verify_jwt`` vs MCP ``verify_mcp_jwt``) can
+    enforce different audiences against the same JWKS + issuer pair.
     """
     try:
         jwks = await _fetch_jwks()
@@ -311,7 +332,7 @@ async def _decode_with_kid_rotation(token: str, settings: Settings) -> Any:
         raise _http_401("jwks_unavailable") from None
 
     try:
-        return _decode_with_jwks(token, jwks, settings)
+        return _decode_with_jwks(token, jwks, settings, expected_audience=expected_audience)
     except ValueError:
         # Treat *any* ValueError as a kid-miss signal — the message
         # ("Key not found") is authlib-internal and not part of any
@@ -327,7 +348,7 @@ async def _decode_with_kid_rotation(token: str, settings: Settings) -> Any:
         raise _http_401("jwks_unavailable") from None
 
     try:
-        return _decode_with_jwks(token, jwks, settings)
+        return _decode_with_jwks(token, jwks, settings, expected_audience=expected_audience)
     except _DECODE_ERRORS_WITH_VALUEERROR as retry_exc:
         raise _http_401("invalid_token") from retry_exc
 
@@ -432,6 +453,39 @@ def _operator_from_claims(claims: Any, raw_jwt: str, settings: Settings) -> Oper
         raise _http_401("invalid_token") from exc
 
 
+async def verify_jwt_for_audience(
+    authorization: str | None,
+    *,
+    expected_audience: str,
+) -> Operator:
+    """Validate a Bearer token against an explicit ``aud`` claim value.
+
+    The full JWT-validation chain (Bearer extraction → JWKS fetch +
+    kid-rotation retry → signature/claims/structure validation →
+    Operator projection) parametrised by audience. This is the public
+    seam the chassis :func:`verify_jwt` dependency uses with
+    ``settings.keycloak_audience``; MCP routes (G0.5-T2) use the same
+    seam with the MCP canonical URI per RFC 8707 §2 / RFC 9728 §7.4
+    audience-binding semantics. Keeping both surfaces on a single chain
+    avoids drift between "what the chassis validates" and "what MCP
+    validates" — issuer / kid-rotation / signature handling stays
+    identical; only the audience differs.
+
+    Raises 401 on every failure mode the chassis chain raises.
+    Failures-with-audience-mismatch surface as ``invalid_token``
+    because that's how authlib's ``InvalidClaimError`` maps in the
+    centralised handler.
+    """
+    token = _extract_bearer_token(authorization)
+    settings = get_settings()
+    claims = await _decode_with_kid_rotation(
+        token,
+        settings,
+        expected_audience=expected_audience,
+    )
+    return _operator_from_claims(claims, token, settings)
+
+
 async def verify_jwt(authorization: str | None = Header(default=None)) -> Operator:
     """FastAPI dependency: validate the Bearer token and return an Operator.
 
@@ -447,10 +501,11 @@ async def verify_jwt(authorization: str | None = Header(default=None)) -> Operat
     cache is refreshed exactly once and the verify is retried. A
     second miss is a hard 401 ``invalid_token``.
     """
-    token = _extract_bearer_token(authorization)
     settings = get_settings()
-    claims = await _decode_with_kid_rotation(token, settings)
-    return _operator_from_claims(claims, token, settings)
+    return await verify_jwt_for_audience(
+        authorization,
+        expected_audience=settings.keycloak_audience,
+    )
 
 
 async def keycloak_readiness_probe() -> ProbeResult:

--- a/backend/src/meho_backplane/auth/jwt.py
+++ b/backend/src/meho_backplane/auth/jwt.py
@@ -475,7 +475,19 @@ async def verify_jwt_for_audience(
     Failures-with-audience-mismatch surface as ``invalid_token``
     because that's how authlib's ``InvalidClaimError`` maps in the
     centralised handler.
+
+    Defence in depth: an empty or whitespace-only ``expected_audience``
+    short-circuits to ``audience_not_configured`` 401. The MCP route
+    derives the audience from ``MCP_RESOURCE_URI`` / ``BACKPLANE_URL``
+    and returns an empty string when neither is set; without this
+    guard the fail-closed property would rely on the *issuer* never
+    emitting a token with an empty ``aud`` claim — a true assumption
+    against any real Keycloak deployment but one external invariant
+    away from a bypass. Failing the check locally to the verifier
+    makes the property auditable in one place.
     """
+    if not expected_audience or not expected_audience.strip():
+        raise _http_401("audience_not_configured")
     token = _extract_bearer_token(authorization)
     settings = get_settings()
     claims = await _decode_with_kid_rotation(

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -25,9 +25,13 @@ v0.2 adds:
 
 * The MCP Streamable HTTP transport entrypoint at ``/mcp`` (G0.5-T1,
   #246) — JSON-RPC 2.0 dispatch with built-in ``initialize`` / ``ping``
-  / ``notifications/initialized`` handlers. Bearer-token auth on this
-  route lands in G0.5-T2 (#247); the tool + resource registries land
-  in G0.5-T3 (#248).
+  / ``notifications/initialized`` handlers.
+* OAuth 2.1 resource-server protection on ``/mcp`` (G0.5-T2, #247) —
+  Bearer-token validation with the MCP canonical URI as the audience
+  per RFC 8707 §2, plus the RFC 9728 ``/.well-known/oauth-protected-resource``
+  metadata document and the ``WWW-Authenticate: Bearer
+  resource_metadata=...`` header on 401. The tool + resource
+  registries (T3) and reference tool (T4) land next.
 """
 
 import os
@@ -40,6 +44,7 @@ from fastapi import FastAPI, Response
 from meho_backplane import __version__
 from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
+from meho_backplane.api.well_known import router as well_known_router
 from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.jwt import keycloak_readiness_probe
 from meho_backplane.auth.vault import vault_readiness_probe
@@ -136,13 +141,23 @@ app.include_router(health_router)
 app.include_router(version_router)
 app.include_router(api_v1_auth_config_router)
 app.include_router(api_v1_health_router)
-# MCP Streamable HTTP transport entrypoint (G0.5-T1, #246). The router
-# inherits the same RequestContextMiddleware + AuditMiddleware chain as
-# every HTTP route; T1 has no Bearer-token auth on /mcp yet, so
-# AuditMiddleware's "no operator_sub bound" skip rule passes /mcp
-# requests through unchanged. T2 (#247) layers OAuth-RS auth on top;
-# T5 (#250) replaces the implicit audit pass-through with a fail-closed
-# MCP-specific audit path on tools/call + resources/read.
+# MCP Streamable HTTP transport entrypoint (G0.5-T1, #246) and the
+# RFC 9728 protected-resource metadata document (G0.5-T2, #247).
+#
+# Auth posture per route:
+# * ``/.well-known/oauth-protected-resource`` — unauthenticated by
+#   design. Spec-conforming MCP clients hit this *before* they have a
+#   token, to discover the authorisation server. AuditMiddleware's
+#   skip rule (no ``operator_sub`` bound) means the route also doesn't
+#   write audit rows, which is the intended behaviour for a discovery
+#   endpoint.
+# * ``/mcp`` — requires a Bearer token whose ``aud`` matches the MCP
+#   canonical URI (G0.5-T2). The
+#   :func:`~meho_backplane.mcp.auth.verify_mcp_jwt_and_bind` dependency
+#   binds ``operator_sub`` + ``tenant_id`` so AuditMiddleware writes a
+#   row per request. G0.5-T5 (#250) layers MCP-specific audit
+#   semantics on top.
+app.include_router(well_known_router)
 app.include_router(mcp_router)
 
 # Opt-in stub routes for end-to-end verification of

--- a/backend/src/meho_backplane/mcp/__init__.py
+++ b/backend/src/meho_backplane/mcp/__init__.py
@@ -9,13 +9,16 @@ Hosted servers use the Streamable HTTP transport (POST to a single MCP
 endpoint with JSON-RPC 2.0 envelopes); stdio is for local-subprocess
 servers and is explicitly out of scope for MEHO.
 
-T1 (this Task #246) ships the **transport + dispatch skeleton**:
+T1 (#246) shipped the **transport + dispatch skeleton**; T2 (this
+Task #247) layers the **OAuth 2.1 resource-server** chain on top.
+Together they expose:
 
 * :data:`~meho_backplane.mcp.server.router` — FastAPI ``APIRouter``
   mounted at ``/mcp`` by :mod:`meho_backplane.main`. Accepts JSON-RPC
-  2.0 POST bodies, parses + dispatches them, and returns either a
-  single-shot JSON response (for *requests*) or HTTP 202 Accepted (for
-  *notifications*) per the Streamable HTTP transport spec.
+  2.0 POST bodies (Streamable HTTP single-response shape) and routes
+  each method to a registered handler. Every request runs through
+  :func:`~meho_backplane.mcp.auth.verify_mcp_jwt_and_bind` before the
+  body is parsed.
 * :func:`~meho_backplane.mcp.server.register_method` — module-level
   dispatch registration mirroring the
   :func:`~meho_backplane.health.register_probe` pattern. T3 (#248) layers
@@ -23,24 +26,48 @@ T1 (this Task #246) ships the **transport + dispatch skeleton**:
 * Built-in handlers for the lifecycle primitives the spec defines as
   universal — ``initialize``, ``notifications/initialized``, and
   ``ping``.
+* :func:`~meho_backplane.mcp.auth.verify_mcp_jwt` /
+  :func:`~meho_backplane.mcp.auth.verify_mcp_jwt_and_bind` — the OAuth-RS
+  dependency that validates the Bearer token against the chassis JWKS
+  and the **MCP canonical URI** (RFC 8707 §2 audience binding). On 401
+  it attaches the RFC 9728 §5.1 ``WWW-Authenticate: Bearer
+  resource_metadata=...`` header so spec-conforming clients can
+  discover the metadata document. The chassis HTTP API keeps its own
+  audience (``KEYCLOAK_AUDIENCE``) so a token issued for one surface
+  is never replayable on the other.
+* :func:`~meho_backplane.mcp.auth.mcp_resource_uri` /
+  :func:`~meho_backplane.mcp.auth.www_authenticate_header` — helpers
+  that resolve the canonical URI from ``MCP_RESOURCE_URI`` /
+  ``BACKPLANE_URL`` and build the discovery-header value. Re-exported
+  so T3 / T6 can reuse them without reaching into the auth module.
 
-**No Bearer-token auth in T1.** No ``Authorization`` header is required;
-no ``operator_sub`` is bound. Well-formed JSON-RPC requests reach the
-handler without an identity check. The transport layer still enforces
-two spec MUSTs that can reject before the handler runs: the
-``MCP-Protocol-Version`` header validation (HTTP 400 on an unsupported
-revision per spec §"Protocol Version Header", waived for the
-``initialize`` call itself) and the JSON-RPC envelope parse / validate
-pipeline (HTTP 200 + JSON-RPC error envelope on parse error / invalid
-request). T2 (#247) adds the OAuth 2.1 resource-server chain on top:
-``/.well-known/oauth-protected-resource``, the ``WWW-Authenticate``
-header on 401s, audience validation per RFC 8707, and reuse of the
-existing :func:`~meho_backplane.auth.jwt.verify_jwt` chain. Origin-
-header validation per the MCP transport security warning (DNS rebinding
-defence) is also deferred to T2 — it requires the ``MCP_ALLOWED_ORIGINS``
-setting T2 introduces.
+The unauthenticated metadata document at
+``/.well-known/oauth-protected-resource`` lives in
+:mod:`meho_backplane.api.well_known`. That router is what an MCP client
+fetches *before* it has a token, to discover the authorisation server.
+
+**Out of scope for T2** (deferred to a later transport-hardening
+task): Origin-header validation per the MCP transport DNS-rebinding
+warning, content-type 415 strict enforcement, and request-body size
+caps. These need ``MCP_ALLOWED_ORIGINS`` / size-cap settings that
+haven't been added yet; bundling them with T2 would over-scope the
+OAuth-RS work.
 """
 
+from meho_backplane.mcp.auth import (
+    mcp_resource_uri,
+    verify_mcp_jwt,
+    verify_mcp_jwt_and_bind,
+    www_authenticate_header,
+)
 from meho_backplane.mcp.server import McpInvalidParamsError, register_method, router
 
-__all__ = ["McpInvalidParamsError", "register_method", "router"]
+__all__ = [
+    "McpInvalidParamsError",
+    "mcp_resource_uri",
+    "register_method",
+    "router",
+    "verify_mcp_jwt",
+    "verify_mcp_jwt_and_bind",
+    "www_authenticate_header",
+]

--- a/backend/src/meho_backplane/mcp/auth.py
+++ b/backend/src/meho_backplane/mcp/auth.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""OAuth 2.1 resource-server chain for the ``/mcp`` route.
+
+This module is the MCP-side of the auth boundary: it consumes the same
+Keycloak JWTs the chassis accepts but enforces a **different audience**
+— the canonical MCP resource URI per RFC 8707 §2 — and emits the
+RFC 9728 §5.1 ``WWW-Authenticate`` header on 401 so spec-conforming
+MCP clients can discover the protected-resource metadata document and
+follow the OAuth 2.1 + PKCE handshake. The chassis ``verify_jwt`` keeps
+its existing ``KEYCLOAK_AUDIENCE`` audience for HTTP API routes; MCP
+gets its own audience binding so a token issued for the HTTP API can't
+be replayed at the MCP endpoint and vice-versa.
+
+Reused chassis infrastructure
+=============================
+
+* :func:`~meho_backplane.auth.jwt.verify_jwt_for_audience` — the
+  parameterised seam (signature + claims + kid-rotation + Operator
+  projection). MCP simply passes its own ``expected_audience``.
+* :class:`~meho_backplane.auth.operator.Operator` — same identity
+  shape (sub / name / email / tenant_id / tenant_role / raw_jwt). MCP
+  routes receive the operator by injection just like chassis routes.
+* :func:`~meho_backplane.middleware.verify_jwt_and_bind` is **not**
+  reused: this module ships its own :func:`verify_mcp_jwt_and_bind`
+  that mirrors the binding contract (operator_sub + tenant_id into
+  structlog contextvars) but layers WWW-Authenticate header injection
+  on the 401 path.
+
+Spec citations
+==============
+
+* MCP 2025-06-18 §Authorization —
+  https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+  ("MCP servers MUST validate that tokens presented to them were
+  specifically issued for them as the intended audience, according to
+  RFC 8707 §2. Invalid or expired tokens MUST receive a HTTP 401
+  response.")
+* RFC 9728 §5.1 — Bearer-scheme WWW-Authenticate response containing
+  the ``resource_metadata`` parameter pointing at the protected-
+  resource metadata document.
+* RFC 8707 — Resource Indicators. The ``resource`` parameter sent at
+  the OAuth-AS during authorisation must equal the canonical MCP URI;
+  the issued token's ``aud`` claim then binds to that resource.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import Depends, Header, HTTPException
+
+from meho_backplane.auth.jwt import verify_jwt_for_audience
+from meho_backplane.auth.operator import Operator
+from meho_backplane.settings import Settings, get_settings
+
+__all__ = [
+    "mcp_resource_uri",
+    "verify_mcp_jwt",
+    "verify_mcp_jwt_and_bind",
+    "www_authenticate_header",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+def mcp_resource_uri(settings: Settings | None = None) -> str:
+    """Return the canonical MCP server URI for audience binding.
+
+    Resolves in priority order:
+
+    1. ``Settings.mcp_resource_uri`` when explicitly set — operators
+       with non-default MCP mount points (e.g. ``/api/mcp``) override
+       per environment.
+    2. ``f"{settings.backplane_url}/mcp"`` derived at use time.
+    3. Empty string when neither is set — fail-closed for MCP: no JWT
+       can have an empty audience claim, so every ``/mcp`` request 401s
+       until an operator wires ``BACKPLANE_URL`` (or ``MCP_RESOURCE_URI``).
+
+    Per MCP 2025-06-18 §Resource Parameter Implementation, the canonical
+    form is lowercase scheme + host with no trailing slash; the helper
+    strips any trailing slash on ``backplane_url`` before concatenating
+    to enforce that convention.
+    """
+    settings = settings or get_settings()
+    if settings.mcp_resource_uri:
+        return settings.mcp_resource_uri
+    if not settings.backplane_url:
+        return ""
+    return f"{settings.backplane_url.rstrip('/')}/mcp"
+
+
+def www_authenticate_header(settings: Settings | None = None) -> str:
+    """Build the RFC 9728 §5.1 ``WWW-Authenticate`` header value.
+
+    Shape per spec example::
+
+        Bearer resource_metadata="https://meho.example/.well-known/oauth-protected-resource"
+
+    The metadata URL is rooted at ``backplane_url`` because RFC 9728
+    §3 hosts the document at ``/.well-known/oauth-protected-resource``
+    *on the resource server's origin*, not on the authorisation
+    server. When ``backplane_url`` is empty (chassis-only deployment),
+    the helper returns the bare ``Bearer`` challenge with no
+    ``resource_metadata`` parameter — a degraded but spec-legal
+    response that doesn't leak a malformed URL.
+    """
+    settings = settings or get_settings()
+    base = settings.backplane_url.rstrip("/")
+    if not base:
+        return "Bearer"
+    metadata_url = f"{base}/.well-known/oauth-protected-resource"
+    return f'Bearer resource_metadata="{metadata_url}"'
+
+
+async def verify_mcp_jwt(
+    authorization: str | None = Header(default=None),
+) -> Operator:
+    """FastAPI dependency: validate the Bearer token for the MCP audience.
+
+    Reuses :func:`~meho_backplane.auth.jwt.verify_jwt_for_audience` with
+    :func:`mcp_resource_uri` as the ``expected_audience``. The chassis
+    chain raises :class:`fastapi.HTTPException` with status 401 on
+    every failure mode (missing header, malformed Authorization, JWKS
+    unreachable, signature mismatch, expired token, audience mismatch,
+    issuer mismatch, malformed JWT, malformed tenant claims). On any of
+    those, this wrapper re-raises the same exception with the
+    RFC 9728 §5.1 ``WWW-Authenticate`` header attached so MCP clients
+    can discover the resource-metadata URL and walk the OAuth-RS
+    discovery flow.
+
+    A 401 is preserved verbatim — same detail token, same status code.
+    Non-401 status codes from the chassis chain (none today, reserved
+    for future cases) propagate without the header injection.
+    """
+    settings = get_settings()
+    expected_audience = mcp_resource_uri(settings)
+    try:
+        return await verify_jwt_for_audience(
+            authorization,
+            expected_audience=expected_audience,
+        )
+    except HTTPException as exc:
+        if exc.status_code != 401:
+            raise
+        headers = dict(exc.headers or {})
+        headers["WWW-Authenticate"] = www_authenticate_header(settings)
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=exc.detail,
+            headers=headers,
+        ) from exc
+
+
+async def verify_mcp_jwt_and_bind(
+    operator: Operator = Depends(verify_mcp_jwt),
+) -> Operator:
+    """Validate the Bearer token *and* bind operator identity into contextvars.
+
+    Mirrors the chassis :func:`~meho_backplane.middleware.verify_jwt_and_bind`
+    pattern: every authenticated MCP route handler declares
+    ``Depends(verify_mcp_jwt_and_bind)`` so the
+    ``operator_sub`` and ``tenant_id`` slots end up in structlog's
+    contextvars before the handler runs. The chassis
+    :class:`~meho_backplane.audit.AuditMiddleware` reads ``operator_sub``
+    to decide whether to write an audit row; without this binding the
+    middleware would skip the row and the operator-action trail would
+    have an `/mcp` shaped hole. G0.5-T5 (#250) layers MCP-specific
+    audit semantics on top of this implicit chassis trail.
+
+    ``tenant_id`` is bound as ``str(operator.tenant_id)`` for the same
+    JSON-renderer reason the chassis wrapper documents — see
+    :func:`~meho_backplane.middleware.verify_jwt_and_bind`.
+    """
+    structlog.contextvars.bind_contextvars(
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+    )
+    return operator

--- a/backend/src/meho_backplane/mcp/auth.py
+++ b/backend/src/meho_backplane/mcp/auth.py
@@ -154,6 +154,16 @@ async def verify_mcp_jwt(
     except HTTPException as exc:
         if exc.status_code != 401:
             raise
+        # Structured-log the MCP-side auth failure with a grep-able event
+        # name. The chassis `verify_jwt` deliberately doesn't log auth
+        # failures (the 401 surface is already on every chassis route);
+        # /mcp is a new surface where operators want to distinguish MCP
+        # 401 spikes from chassis 401 spikes. ``detail`` is the chassis
+        # chain's failure-mode token (`missing_token` / `invalid_token`
+        # / `jwks_unavailable` / `missing_tenant_claim` / etc.) — never
+        # an operator-controllable string, so logging it verbatim is
+        # safe (see auth/jwt.py docstring).
+        _log.warning("mcp_auth_failed", detail=exc.detail)
         headers = dict(exc.headers or {})
         headers["WWW-Authenticate"] = www_authenticate_header(settings)
         raise HTTPException(

--- a/backend/src/meho_backplane/mcp/auth.py
+++ b/backend/src/meho_backplane/mcp/auth.py
@@ -71,11 +71,22 @@ def mcp_resource_uri(settings: Settings | None = None) -> str:
 
     1. ``Settings.mcp_resource_uri`` when explicitly set — operators
        with non-default MCP mount points (e.g. ``/api/mcp``) override
-       per environment.
+       per environment. The value is normalised (``.strip()`` +
+       ``.rstrip('/')``) so an operator who pastes the URI from a
+       browser bar with a trailing slash, or leaves a stray newline in
+       the env var, doesn't cause an ``aud`` mismatch against tokens
+       whose ``resource`` parameter Keycloak emitted in canonical
+       form. MCP 2025-06-18 §"Canonical Server URI" mandates the no-
+       trailing-slash form for interop, so the normalisation also
+       enforces the spec contract.
     2. ``f"{settings.backplane_url}/mcp"`` derived at use time.
     3. Empty string when neither is set — fail-closed for MCP: no JWT
        can have an empty audience claim, so every ``/mcp`` request 401s
        until an operator wires ``BACKPLANE_URL`` (or ``MCP_RESOURCE_URI``).
+       Defence in depth: :func:`~meho_backplane.auth.jwt.verify_jwt_for_audience`
+       short-circuits an empty expected_audience to a 401 explicitly so
+       the fail-closed property is local to the verifier and doesn't
+       depend on any honest-issuer assumption.
 
     Per MCP 2025-06-18 §Resource Parameter Implementation, the canonical
     form is lowercase scheme + host with no trailing slash; the helper
@@ -84,7 +95,7 @@ def mcp_resource_uri(settings: Settings | None = None) -> str:
     """
     settings = settings or get_settings()
     if settings.mcp_resource_uri:
-        return settings.mcp_resource_uri
+        return settings.mcp_resource_uri.strip().rstrip("/")
     if not settings.backplane_url:
         return ""
     return f"{settings.backplane_url.rstrip('/')}/mcp"

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -80,11 +80,13 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, ValidationError
 
 from meho_backplane import __version__
+from meho_backplane.auth.operator import Operator
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
 from meho_backplane.mcp.schemas import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
@@ -491,7 +493,10 @@ async def _dispatch_to_handler(
 
 
 @router.post("")
-async def mcp_dispatch(request: Request) -> Response:
+async def mcp_dispatch(
+    request: Request,
+    operator: Operator = Depends(verify_mcp_jwt_and_bind),
+) -> Response:
     """Dispatch a single JSON-RPC 2.0 request or notification.
 
     The Streamable HTTP body contract (§"Sending Messages to the Server"):
@@ -501,6 +506,17 @@ async def mcp_dispatch(request: Request) -> Response:
     * On a *notification* (id absent, or method prefix
       ``notifications/``): return 202 with no body, regardless of
       whether the handler errored — JSON-RPC §4.1.2 forbids replying.
+
+    Authentication (G0.5-T2, #247): every request to this route MUST
+    carry a Bearer token whose ``aud`` claim equals the canonical MCP
+    resource URI per RFC 8707 §2. Validation runs as a FastAPI
+    dependency before the body is parsed, so a missing or invalid
+    token short-circuits to 401 + ``WWW-Authenticate: Bearer
+    resource_metadata=...`` per RFC 9728 §5.1 — the dispatch pipeline
+    never sees an unauthenticated request. The :class:`Operator` is
+    injected into this handler for downstream use even though T2
+    itself doesn't consume the identity beyond the contextvar binding
+    side effect; T3 / T4 / T5 will pull tenant / role data off it.
 
     The function is the orchestrator only; each phase of the dispatch
     pipeline lives in its own helper so the per-phase contract is grep-
@@ -520,6 +536,10 @@ async def mcp_dispatch(request: Request) -> Response:
     fallback when the server does not implement the GET-opens-SSE
     branch of the Streamable HTTP transport.
     """
+    # ``operator`` is unused beyond the dependency-injection side
+    # effects (JWT validation + contextvar binding). Downstream Tasks
+    # (T3 RBAC filter, T4 reference tool, T5 audit) will read it.
+    del operator
     raw_body = await request.body()
     parsed = _parse_request_body(raw_body)
     if isinstance(parsed, JSONResponse):

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -172,6 +172,29 @@ class Settings(BaseModel):
         The flag is read at FastAPI app construction time; flipping it
         after import has no effect — every test that needs the routes
         builds its own :class:`~fastapi.FastAPI` with the flag set.
+    backplane_url:
+        Canonical externally-visible URL of this backplane, e.g.
+        ``https://meho.evba.lab``. Used to construct the MCP server's
+        canonical URI (G0.5-T2) and the absolute URL the RFC 9728
+        ``WWW-Authenticate: resource_metadata=...`` header points at.
+        Default ``""`` is fail-closed for MCP: a request to ``/mcp``
+        with the default value cannot validate (token audience can
+        never equal the empty derived URI), and the
+        ``/.well-known/oauth-protected-resource`` metadata document
+        will surface an empty ``resource`` field that fails RFC 9728
+        validation on the client side. Operators MUST set this before
+        enabling MCP traffic. Leaving it empty in dev / chassis-only
+        deployments keeps the chassis routes operational.
+    mcp_resource_uri:
+        The canonical URI of this backplane's MCP server, sent as the
+        ``resource`` parameter on OAuth 2.1 authorisation / token
+        requests per RFC 8707 and returned in the RFC 9728 ``resource``
+        field. JWTs presented at ``/mcp`` MUST carry this value in
+        their ``aud`` claim. Default ``""`` falls back to
+        ``f"{backplane_url}/mcp"`` at use time; operators with non-
+        standard MCP mounts (e.g. ``/api/mcp``) override per
+        environment. Per the MCP 2025-06-18 spec's canonical-URI
+        guidance, prefer the no-trailing-slash form.
     """
 
     keycloak_issuer_url: HttpUrl
@@ -181,6 +204,8 @@ class Settings(BaseModel):
     jwt_tenant_claim_name: str = Field(default="tenant_id", min_length=1)
     jwt_tenant_role_claim_name: str = Field(default="tenant_role", min_length=1)
     enable_rbac_test_route: bool = False
+    backplane_url: str = ""
+    mcp_resource_uri: str = ""
     vault_addr: HttpUrl
     vault_oidc_role: str = Field(default="meho-mcp", min_length=1)
     vault_oidc_mount_path: str = Field(default="jwt", min_length=1)
@@ -246,6 +271,8 @@ def get_settings() -> Settings:
         enable_rbac_test_route=parse_bool_env(
             os.environ.get("MEHO_ENABLE_RBAC_TEST_ROUTE"),
         ),
+        backplane_url=os.environ.get("BACKPLANE_URL", ""),
+        mcp_resource_uri=os.environ.get("MCP_RESOURCE_URI", ""),
         vault_addr=os.environ["VAULT_ADDR"],  # type: ignore[arg-type]
         vault_oidc_role=os.environ.get("VAULT_OIDC_ROLE", "meho-mcp"),
         vault_oidc_mount_path=os.environ.get("VAULT_OIDC_MOUNT_PATH", "jwt"),

--- a/backend/tests/test_auth_jwt.py
+++ b/backend/tests/test_auth_jwt.py
@@ -599,13 +599,19 @@ def test_value_error_key_not_found_triggers_jwks_refresh(
     real_decode = jwt_module._decode_with_jwks
     call_count = {"n": 0}
 
-    def fake_decode(tok: str, ks: dict[str, Any], settings: Any) -> Any:
+    def fake_decode(
+        tok: str,
+        ks: dict[str, Any],
+        settings: Any,
+        *,
+        expected_audience: str,
+    ) -> Any:
         call_count["n"] += 1
         if call_count["n"] == 1:
             # Message intentionally unrelated to "Key not found" — the
             # fix must refresh on *any* ValueError.
             raise ValueError("some opaque authlib internal message")
-        return real_decode(tok, ks, settings)
+        return real_decode(tok, ks, settings, expected_audience=expected_audience)
 
     monkeypatch.setattr(jwt_module, "_decode_with_jwks", fake_decode)
 

--- a/backend/tests/test_mcp_auth.py
+++ b/backend/tests/test_mcp_auth.py
@@ -350,6 +350,45 @@ def test_jwks_unreachable_returns_401(
 
 
 # ---------------------------------------------------------------------------
+# Defence in depth: empty audience setting fail-closes locally to the verifier
+# ---------------------------------------------------------------------------
+
+
+def test_empty_audience_setting_returns_401(
+    keypair: Any,
+    jwks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``BACKPLANE_URL=""`` + ``MCP_RESOURCE_URI=""`` → every request 401s.
+
+    Without this guard the fail-closed property would rely on the
+    issuer never minting a token with an empty ``aud`` claim. The
+    verifier now refuses upfront with ``audience_not_configured`` so
+    the failure mode is local to the verifier rather than depending on
+    an honest-issuer invariant.
+    """
+    monkeypatch.setenv("BACKPLANE_URL", "")
+    monkeypatch.setenv("MCP_RESOURCE_URI", "")
+    get_settings.cache_clear()
+    try:
+        client = TestClient(app)
+        with respx.mock as router:
+            _mock_discovery_and_jwks(router, jwks)
+            # Even a token whose `aud` matches the empty derived audience
+            # (i.e. `aud=""`) is rejected because the verifier refuses
+            # to run at all on an empty expected_audience.
+            token = _mint_mcp_token(keypair, audience="")
+            response = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 100, "method": "ping"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 401
+    finally:
+        get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
 # Settings resolution: explicit MCP_RESOURCE_URI overrides the BACKPLANE_URL derivation
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_mcp_auth.py
+++ b/backend/tests/test_mcp_auth.py
@@ -211,6 +211,36 @@ def test_token_for_chassis_audience_is_rejected_at_mcp(
     assert "Bearer" in response.headers.get("www-authenticate", "")
 
 
+def test_token_for_arbitrary_audience_is_rejected_at_mcp(
+    client: TestClient,
+    keypair: Any,
+    jwks: dict[str, Any],
+) -> None:
+    """*Any* non-matching ``aud`` claim 401s — not just the chassis audience.
+
+    Pins the contract that the audience check is value-based: a token
+    minted for an arbitrary third party (e.g. another internal service
+    that happens to share the same Keycloak realm) cannot reach
+    ``/mcp`` no matter what its `aud` is. authlib's check is exact-
+    string match, so this test would catch a regression that loosens
+    audience handling to "any value not in a denylist" or similar.
+    """
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, jwks)
+        foreign_token = _mint_mcp_token(
+            keypair,
+            audience="https://some-other-service.evba.lab/api",
+        )
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 11, "method": "ping"},
+            headers={"Authorization": f"Bearer {foreign_token}"},
+        )
+
+    assert response.status_code == 401
+    assert "Bearer" in response.headers.get("www-authenticate", "")
+
+
 def test_token_with_mcp_audience_is_accepted(
     client: TestClient,
     keypair: Any,

--- a/backend/tests/test_mcp_auth.py
+++ b/backend/tests/test_mcp_auth.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the OAuth 2.1 resource-server chain on ``/mcp`` (G0.5-T2, #247).
+
+Covers the auth-side acceptance criteria on issue #247:
+
+* Missing ``Authorization`` header → 401 + RFC 9728 §5.1 ``WWW-Authenticate``
+  header pointing at ``/.well-known/oauth-protected-resource``.
+* JWT with the chassis audience (``KEYCLOAK_AUDIENCE``, not the MCP
+  resource URI) → 401: audience binding per RFC 8707 §2 is enforced
+  distinct from the HTTP API.
+* JWT with the MCP resource URI in ``aud`` → 200 + a valid JSON-RPC
+  response (``ping`` round-trips).
+* Malformed ``Authorization`` shape (``Basic …`` instead of
+  ``Bearer …``) → 401 + WWW-Authenticate.
+* The ``WWW-Authenticate`` value uses the exact RFC 9728 shape:
+  ``Bearer resource_metadata="<absolute-url>"``.
+
+Test strategy mirrors :mod:`tests.test_api_v1_health` — RSA keypair
+fixture, JWKS document, ``respx`` mocks of the OIDC discovery + JWKS
+endpoints. The bearer tokens are signed locally with the fixture key
+and the JWKS document is served from the same key, so the chassis
+verify chain accepts them as if they came from a real Keycloak realm.
+"""
+
+from __future__ import annotations
+
+import time
+import warnings
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from authlib.jose import JsonWebToken
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import DEFAULT_TENANT_ID, DEFAULT_TENANT_ROLE
+from ._oidc_jwt_helpers import ISSUER as _CHASSIS_ISSUER
+from ._oidc_jwt_helpers import JWKS_URL as _JWKS_URL
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+_BACKPLANE_URL: str = "https://meho.test"
+_MCP_RESOURCE_URI: str = f"{_BACKPLANE_URL}/mcp"
+_CHASSIS_AUDIENCE: str = "meho-backplane"
+
+
+def _mint_mcp_token(
+    private_key: Any,
+    *,
+    audience: str = _MCP_RESOURCE_URI,
+    sub: str = "mcp-op-42",
+    tenant_id: str = DEFAULT_TENANT_ID,
+    tenant_role: str = DEFAULT_TENANT_ROLE,
+) -> str:
+    """Mint a JWT signed by *private_key* with the given audience.
+
+    Local-only helper because the shared :func:`mint_token` in
+    :mod:`_oidc_jwt_helpers` hard-codes the chassis audience. Adding an
+    ``audience`` knob there would land in :mod:`test_api_v1_health`'s
+    helper module; keeping a local mint helper here keeps the change
+    contained to the MCP test suite.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        jwt = JsonWebToken(["RS256"])
+        now = int(time.time())
+        payload: dict[str, Any] = {
+            "sub": sub,
+            "iss": _CHASSIS_ISSUER,
+            "aud": audience,
+            "iat": now,
+            "exp": now + 3600,
+            "nbf": now,
+            "tenant_id": tenant_id,
+            "tenant_role": tenant_role,
+            "name": "MCP Test",
+            "email": "mcp-test@example.com",
+        }
+        header = {"alg": "RS256", "kid": private_key.as_dict()["kid"], "typ": "JWT"}
+        token: bytes | str = jwt.encode(header, payload, private_key)
+        return token.decode("ascii") if isinstance(token, bytes) else token
+
+
+@pytest.fixture(autouse=True)
+def _mcp_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the MCP-relevant env vars around every test in this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _CHASSIS_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _CHASSIS_AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("MCP_RESOURCE_URI", "")  # exercise the fallback derivation
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    """Empty the module-level JWKS cache around every test.
+
+    Without this guard a token from one test could be accepted by
+    another via stale-cache hits, which would mask the audience-
+    rejection assertions.
+    """
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def keypair() -> Any:
+    """RSA-2048 keypair used to sign every token in this module."""
+    return _make_rsa_keypair(kid="mcp-auth-test-kid")
+
+
+@pytest.fixture
+def jwks(keypair: Any) -> dict[str, Any]:
+    """JWKS document containing the public half of :func:`keypair`."""
+    return _public_jwks(keypair)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Plain :class:`TestClient` — no dependency overrides in this module.
+
+    The full auth chain runs end-to-end against the respx-mocked
+    Keycloak. That is the whole point of this test file.
+    """
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# 401 contract: missing or malformed Bearer credential
+# ---------------------------------------------------------------------------
+
+
+def test_missing_authorization_returns_401_with_www_authenticate(
+    client: TestClient,
+) -> None:
+    """No ``Authorization`` header → 401 + RFC 9728 §5.1 header.
+
+    The ``resource_metadata`` parameter MUST be the absolute URL of the
+    backplane's RFC 9728 metadata document so the client can fetch it
+    and learn the authorisation server.
+    """
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    )
+
+    assert response.status_code == 401
+    www_auth = response.headers.get("www-authenticate", "")
+    assert www_auth.startswith("Bearer")
+    assert f'resource_metadata="{_BACKPLANE_URL}/.well-known/oauth-protected-resource"' in www_auth
+
+
+def test_basic_auth_scheme_returns_401_with_www_authenticate(
+    client: TestClient,
+) -> None:
+    """An ``Authorization: Basic …`` shape is rejected as missing-Bearer."""
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 2, "method": "ping"},
+        headers={"Authorization": "Basic dXNlcjpwYXNz"},
+    )
+
+    assert response.status_code == 401
+    assert "Bearer" in response.headers.get("www-authenticate", "")
+
+
+# ---------------------------------------------------------------------------
+# Audience binding (RFC 8707 §2)
+# ---------------------------------------------------------------------------
+
+
+def test_token_for_chassis_audience_is_rejected_at_mcp(
+    client: TestClient,
+    keypair: Any,
+    jwks: dict[str, Any],
+) -> None:
+    """A JWT issued for ``KEYCLOAK_AUDIENCE`` does not grant ``/mcp`` access.
+
+    The chassis HTTP API and the MCP route have distinct audiences per
+    RFC 8707 §2; replaying a chassis token at ``/mcp`` is the canonical
+    confused-deputy attack the binding rule defends against.
+    """
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, jwks)
+        chassis_token = _mint_mcp_token(keypair, audience=_CHASSIS_AUDIENCE)
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 3, "method": "ping"},
+            headers={"Authorization": f"Bearer {chassis_token}"},
+        )
+
+    assert response.status_code == 401
+    assert "Bearer" in response.headers.get("www-authenticate", "")
+
+
+def test_token_with_mcp_audience_is_accepted(
+    client: TestClient,
+    keypair: Any,
+    jwks: dict[str, Any],
+) -> None:
+    """A JWT with ``aud == MCP_RESOURCE_URI`` traverses the chain to the dispatcher.
+
+    End-to-end happy path: token validated, ``ping`` dispatched, JSON-RPC
+    response returned with the correct id and an empty ``result`` body.
+    """
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, jwks)
+        token = _mint_mcp_token(keypair)
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 4, "method": "ping"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == 4
+    assert body["result"] == {}
+
+
+# ---------------------------------------------------------------------------
+# WWW-Authenticate header shape (RFC 9728 §5.1)
+# ---------------------------------------------------------------------------
+
+
+def test_www_authenticate_header_has_rfc9728_shape(client: TestClient) -> None:
+    """Header value is exactly ``Bearer resource_metadata="<url>"``.
+
+    The MCP client parses this header to discover the metadata URL; a
+    syntactically different shape (missing quotes, wrong parameter
+    name) breaks the spec-conforming discovery flow.
+    """
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 5, "method": "ping"},
+    )
+
+    www_auth = response.headers["www-authenticate"]
+    # Format: `Bearer resource_metadata="<url>"`. Quote the URL so clients
+    # tolerate parameters with `/` and `:` (RFC 9728 §5.1 example).
+    expected = f'Bearer resource_metadata="{_BACKPLANE_URL}/.well-known/oauth-protected-resource"'
+    assert www_auth == expected
+
+
+# ---------------------------------------------------------------------------
+# Expiry handling — token validation chain end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_expired_token_returns_401(
+    client: TestClient,
+    keypair: Any,
+    jwks: dict[str, Any],
+) -> None:
+    """Expired ``exp`` claim → 401, regardless of audience correctness.
+
+    Mints a token with ``exp`` 10 seconds in the past (well outside the
+    configured 30-second leeway). The chassis chain raises
+    :class:`authlib.jose.errors.ExpiredTokenError`, which maps to
+    ``invalid_token`` and 401 — and the MCP wrapper adds the
+    ``WWW-Authenticate`` header.
+    """
+    with respx.mock as router:
+        _mock_discovery_and_jwks(router, jwks)
+        # Hand-mint an expired token (the helper assumes 1h validity).
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            jwt = JsonWebToken(["RS256"])
+            now = int(time.time())
+            payload: dict[str, Any] = {
+                "sub": "expired-op",
+                "iss": _CHASSIS_ISSUER,
+                "aud": _MCP_RESOURCE_URI,
+                "iat": now - 7200,
+                "exp": now - 60,  # expired
+                "nbf": now - 7200,
+                "tenant_id": DEFAULT_TENANT_ID,
+                "tenant_role": DEFAULT_TENANT_ROLE,
+            }
+            header = {
+                "alg": "RS256",
+                "kid": keypair.as_dict()["kid"],
+                "typ": "JWT",
+            }
+            token_b: bytes | str = jwt.encode(header, payload, keypair)
+            token = token_b.decode("ascii") if isinstance(token_b, bytes) else token_b
+
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 6, "method": "ping"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 401
+    assert "Bearer" in response.headers.get("www-authenticate", "")
+
+
+# ---------------------------------------------------------------------------
+# JWKS unreachable — 401 (degrades gracefully, not 5xx)
+# ---------------------------------------------------------------------------
+
+
+def test_jwks_unreachable_returns_401(
+    client: TestClient,
+    keypair: Any,
+) -> None:
+    """A Keycloak JWKS endpoint that times out / 5xxs surfaces as 401.
+
+    The chassis chain maps ``httpx.HTTPError`` from the JWKS fetch to
+    ``_http_401("jwks_unavailable")``. The MCP wrapper then adds the
+    WWW-Authenticate header — a client retrying after rediscovery is
+    the correct UX even when the failure mode is server-side.
+    """
+    with respx.mock as router:
+        # Mount the discovery endpoint but fail the JWKS hit.
+        router.get(f"{_CHASSIS_ISSUER}/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(
+                200,
+                json={"issuer": _CHASSIS_ISSUER, "jwks_uri": _JWKS_URL},
+            ),
+        )
+        router.get(_JWKS_URL).mock(return_value=httpx.Response(503))
+        token = _mint_mcp_token(keypair)
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 7, "method": "ping"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 401
+    assert "Bearer" in response.headers.get("www-authenticate", "")
+
+
+# ---------------------------------------------------------------------------
+# Settings resolution: explicit MCP_RESOURCE_URI overrides the BACKPLANE_URL derivation
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_mcp_resource_uri_is_the_required_audience(
+    keypair: Any,
+    jwks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``MCP_RESOURCE_URI`` overrides the ``{BACKPLANE_URL}/mcp`` default.
+
+    Operators with non-default MCP mounts set this explicitly; the
+    audience-binding rule then expects tokens to carry the explicit
+    value in their ``aud`` claim. A token minted against the
+    *derived* default URI is rejected.
+    """
+    monkeypatch.setenv("MCP_RESOURCE_URI", "https://meho.test/api/mcp")
+    get_settings.cache_clear()
+    try:
+        client = TestClient(app)
+        with respx.mock as router:
+            _mock_discovery_and_jwks(router, jwks)
+            # Token minted against the *derived* default URI — should be
+            # rejected because the operator has overridden to /api/mcp.
+            stale_token = _mint_mcp_token(keypair, audience=_MCP_RESOURCE_URI)
+            response = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 8, "method": "ping"},
+                headers={"Authorization": f"Bearer {stale_token}"},
+            )
+            assert response.status_code == 401
+
+            # Token minted against the explicit override — accepted.
+            clear_jwks_cache()
+            ok_token = _mint_mcp_token(
+                keypair,
+                audience="https://meho.test/api/mcp",
+            )
+            ok_response = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 9, "method": "ping"},
+                headers={"Authorization": f"Bearer {ok_token}"},
+            )
+            assert ok_response.status_code == 200
+            assert ok_response.json()["result"] == {}
+    finally:
+        get_settings.cache_clear()

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -34,13 +34,17 @@ body") is met either way; the wire code follows the spec.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
+from uuid import UUID
 
 import pytest
 from fastapi.testclient import TestClient
 
 from meho_backplane import __version__
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
 from meho_backplane.mcp.schemas import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
@@ -50,18 +54,47 @@ from meho_backplane.mcp.schemas import (
     PROTOCOL_VERSION,
 )
 
+_DISPATCH_TEST_OPERATOR: Operator = Operator(
+    sub="dispatcher-test-operator",
+    name="Dispatcher Test",
+    email=None,
+    raw_jwt="fixture-jwt-not-real",
+    tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+    tenant_role=TenantRole.OPERATOR,
+)
+
+
+async def _fixture_verify_mcp_jwt_and_bind() -> Operator:
+    """Dependency override used by every dispatcher unit test.
+
+    The real :func:`~meho_backplane.mcp.auth.verify_mcp_jwt_and_bind`
+    validates the Bearer token against Keycloak's JWKS and the MCP
+    canonical URI. End-to-end coverage of that chain lives in
+    :mod:`tests.test_mcp_auth`; here we only care about the JSON-RPC
+    dispatch + transport semantics, so overriding the dependency with
+    a fixture :class:`Operator` keeps these tests independent of the
+    full OAuth-RS round trip.
+    """
+    return _DISPATCH_TEST_OPERATOR
+
 
 @pytest.fixture
-def client() -> TestClient:
-    """Plain :class:`TestClient` for the running app.
+def client() -> Iterator[TestClient]:
+    """:class:`TestClient` with ``verify_mcp_jwt_and_bind`` overridden.
 
     The shared :mod:`conftest` autouse fixture supplies a per-test
     SQLite ``DATABASE_URL`` with the schema migrated, so the app's
     lifespan and middleware chain boot cleanly under
     :class:`fastapi.testclient.TestClient` without any per-test
-    plumbing here.
+    plumbing here. The dependency override skips the full Bearer-token
+    chain (covered in :mod:`tests.test_mcp_auth`) so each test in this
+    file can focus on JSON-RPC dispatch semantics.
     """
-    return TestClient(app)
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fixture_verify_mcp_jwt_and_bind
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
 
 
 def _post_mcp(client: TestClient, body: Any) -> Any:
@@ -332,27 +365,6 @@ def test_ping_returns_empty_result(client: TestClient) -> None:
     assert body["id"] == 7
     assert body["result"] == {}
     assert "error" not in body
-
-
-# ---------------------------------------------------------------------------
-# T1 auth contract — no Bearer required
-# ---------------------------------------------------------------------------
-
-
-def test_t1_has_no_auth_unauthenticated_call_succeeds(client: TestClient) -> None:
-    """AC: "T1 has NO auth yet — every request currently succeeds."
-
-    Calling ``/mcp`` with no ``Authorization`` header must still
-    succeed in T1. T2 (#247) is what adds the OAuth-RS chain on top.
-    """
-    response = _post_mcp(
-        client,
-        {"jsonrpc": "2.0", "id": 8, "method": "ping"},
-    )
-
-    assert response.status_code == 200
-    body = response.json()
-    assert body["result"] == {}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_well_known.py
+++ b/backend/tests/test_well_known.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``/.well-known/oauth-protected-resource`` metadata route.
+
+Covers G0.5-T2 (#247) acceptance criteria for the discovery surface:
+
+* The metadata document is unauthenticated (no Bearer required).
+* The ``resource`` field matches the canonical MCP URI derived from
+  ``MCP_RESOURCE_URI`` or, falling back, from ``BACKPLANE_URL``.
+* ``authorization_servers`` contains the configured Keycloak issuer
+  with no trailing slash.
+* ``scopes_supported`` advertises the v0.2 scope namespace.
+* ``bearer_methods_supported`` advertises only ``["header"]`` per the
+  MCP transport spec's ban on URI-query tokens.
+
+The auth-chain tests for ``/mcp`` itself live in :mod:`tests.test_mcp_auth`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """``TestClient`` with the MCP settings pinned for the well-known route.
+
+    The metadata document reads ``BACKPLANE_URL`` /
+    ``MCP_RESOURCE_URI`` / ``KEYCLOAK_ISSUER_URL`` at request time.
+    The shared conftest sets KEYCLOAK_* defaults; the MCP-specific
+    pieces are pinned here per-test so the asserts below can verify
+    the wire shape against known values.
+    """
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    monkeypatch.setenv("MCP_RESOURCE_URI", "")
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield TestClient(app)
+    get_settings.cache_clear()
+
+
+def test_well_known_returns_required_rfc9728_fields(client: TestClient) -> None:
+    """The metadata document carries every field RFC 9728 requires or recommends."""
+    response = client.get("/.well-known/oauth-protected-resource")
+
+    assert response.status_code == 200
+    body = response.json()
+
+    # RFC 9728 §3 required.
+    assert body["resource"] == "https://meho.test/mcp"
+
+    # MCP 2025-06-18 §Authorization Server Discovery: authorization_servers
+    # MUST contain at least one issuer identifier.
+    assert body["authorization_servers"] == ["https://keycloak.test/realms/meho"]
+
+    # RFC 9728 §3 recommended.
+    assert body["scopes_supported"] == ["mcp:read", "mcp:execute"]
+
+    # MCP transport §Access Token Usage: "Access tokens MUST NOT be included
+    # in the URI query string" — only header-bound tokens are accepted.
+    assert body["bearer_methods_supported"] == ["header"]
+
+
+def test_well_known_does_not_require_authentication(client: TestClient) -> None:
+    """RFC 9728 discovery is the bootstrap step; it MUST be unauthenticated.
+
+    A request without ``Authorization`` returns 200, not 401 — otherwise
+    a fresh MCP client could never reach the metadata document to learn
+    where to obtain a token.
+    """
+    response = client.get("/.well-known/oauth-protected-resource")
+    assert response.status_code == 200
+
+
+def test_well_known_honors_explicit_mcp_resource_uri_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``MCP_RESOURCE_URI`` setting overrides the derived URI.
+
+    Operators with non-default MCP mounts (e.g. ``/api/mcp``) set
+    ``MCP_RESOURCE_URI`` explicitly; the metadata document echoes it
+    verbatim per RFC 9728 §3 / MCP §"Resource Parameter Implementation".
+    """
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    monkeypatch.setenv("MCP_RESOURCE_URI", "https://meho.test/api/mcp")
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    try:
+        client = TestClient(app)
+        response = client.get("/.well-known/oauth-protected-resource")
+        assert response.status_code == 200
+        assert response.json()["resource"] == "https://meho.test/api/mcp"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_well_known_strips_trailing_slash_on_backplane_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The canonical URI form is no-trailing-slash per MCP spec.
+
+    MCP 2025-06-18 §"Canonical Server URI" notes both
+    ``https://mcp.example.com/`` and ``https://mcp.example.com`` are
+    valid absolute URIs but implementations SHOULD use the no-slash
+    form. The helper strips a trailing slash on ``BACKPLANE_URL``
+    before concatenating ``/mcp`` so a mis-set env var doesn't produce
+    a double-slash ``https://meho.test//mcp``.
+    """
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test/")
+    monkeypatch.setenv("MCP_RESOURCE_URI", "")
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    try:
+        client = TestClient(app)
+        response = client.get("/.well-known/oauth-protected-resource")
+        assert response.json()["resource"] == "https://meho.test/mcp"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_well_known_keycloak_issuer_url_has_no_trailing_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``authorization_servers`` entries strip trailing slashes.
+
+    Pydantic's ``HttpUrl`` appends a trailing slash to URLs without a
+    path component; the metadata document strips it so downstream
+    clients can use the value verbatim as the issuer identifier when
+    constructing AS-metadata URLs per RFC 8414.
+    """
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    monkeypatch.setenv("MCP_RESOURCE_URI", "")
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    try:
+        client = TestClient(app)
+        body = client.get("/.well-known/oauth-protected-resource").json()
+        for server in body["authorization_servers"]:
+            assert not server.endswith("/")
+    finally:
+        get_settings.cache_clear()

--- a/backend/tests/test_well_known.py
+++ b/backend/tests/test_well_known.py
@@ -140,17 +140,26 @@ def test_well_known_keycloak_issuer_url_has_no_trailing_slash(
     path component; the metadata document strips it so downstream
     clients can use the value verbatim as the issuer identifier when
     constructing AS-metadata URLs per RFC 8414.
+
+    The env var is deliberately set **with** a trailing slash so the
+    test actually exercises the strip — a previous version of this
+    test set the value without a trailing slash, which made the
+    ``not server.endswith("/")`` assertion pass trivially regardless
+    of whether the strip logic ran.
     """
     monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
     monkeypatch.setenv("MCP_RESOURCE_URI", "")
-    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho/")
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
     get_settings.cache_clear()
     try:
         client = TestClient(app)
         body = client.get("/.well-known/oauth-protected-resource").json()
-        for server in body["authorization_servers"]:
-            assert not server.endswith("/")
+        # Exact equality, not just "doesn't end with /" — pins the
+        # canonical form against future regressions.
+        assert body["authorization_servers"] == [
+            "https://keycloak.test/realms/meho",
+        ]
     finally:
         get_settings.cache_clear()

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -255,21 +255,45 @@ this stage it exposes:
   no body per spec §"Sending Messages to the Server". JSON-RPC-level
   errors (parse, invalid request, method-not-found, invalid params,
   internal error) are encoded as 200 envelopes with the `error` member
-  populated — only transport-level failures flip the HTTP code. T1 has
-  **no Bearer-token auth** on `/mcp` yet; every well-formed request
-  succeeds. T2 (#247) adds the OAuth 2.1 resource-server chain
-  (`/.well-known/oauth-protected-resource`, `WWW-Authenticate` headers,
-  audience validation per RFC 8707, reuse of `verify_jwt`); Origin-
-  header validation per the MCP transport DNS-rebinding warning is
-  also deferred to T2 because it depends on the `MCP_ALLOWED_ORIGINS`
-  setting T2 introduces. T3 (#248) layers the tool + resource
-  registries (`register_mcp_tool`, `register_mcp_resource`); T4 (#249)
-  populates them with the reference `meho.status` tool and
-  `meho://tenant/<id>/info` resource; T5 (#250) replaces the implicit
-  AuditMiddleware pass-through (which currently fires its
-  "no operator_sub bound" skip rule on every `/mcp` call because T1
-  doesn't bind one) with a fail-closed MCP-specific audit path on
+  populated; transport-level failures flip the HTTP code (an
+  unsupported `MCP-Protocol-Version` header → 400; missing or
+  invalid Bearer → 401 — see Task #247 below). T3 (#248) layers the
+  tool + resource registries (`register_mcp_tool`,
+  `register_mcp_resource`); T4 (#249) populates them with the
+  reference `meho.status` tool and `meho://tenant/<id>/info` resource;
+  T5 (#250) replaces the chassis AuditMiddleware row (which now fires
+  on every authenticated `/mcp` call thanks to T2 binding
+  `operator_sub`) with a fail-closed MCP-specific audit path on
   `tools/call` + `resources/read`.
+
+* MCP OAuth 2.1 resource-server protection (Task #247, G0.5-T2) —
+  layers spec-conforming auth on top of the T1 dispatcher.
+  `backend/src/meho_backplane/mcp/auth.py` houses the
+  `verify_mcp_jwt` / `verify_mcp_jwt_and_bind` FastAPI dependencies,
+  which reuse the chassis JWKS chain through the new
+  `verify_jwt_for_audience` seam in `auth/jwt.py` but validate against
+  the **MCP canonical URI** instead of the chassis `KEYCLOAK_AUDIENCE`
+  — RFC 8707 §2 audience binding, so a token issued for the HTTP API
+  surface cannot be replayed at `/mcp` and vice versa. On every 401
+  the wrapper attaches the RFC 9728 §5.1
+  `WWW-Authenticate: Bearer resource_metadata="<url>"` header so MCP
+  clients can discover the resource-metadata document and walk the
+  OAuth 2.1 + PKCE handshake against Keycloak. The unauthenticated
+  metadata document lives at `/.well-known/oauth-protected-resource`
+  in `backend/src/meho_backplane/api/well_known.py` — required fields
+  per RFC 9728 §3 (`resource`, `authorization_servers`,
+  `scopes_supported`, `bearer_methods_supported`) populated from the
+  new `BACKPLANE_URL` + `MCP_RESOURCE_URI` settings. The dispatcher's
+  `Depends(verify_mcp_jwt_and_bind)` runs before envelope parsing, so
+  the request never reaches the JSON-RPC pipeline when auth fails;
+  the binding side effect (`operator_sub` + `tenant_id` into structlog
+  contextvars) is what makes `AuditMiddleware` write a row per `/mcp`
+  request, replacing T1's implicit pass-through. T5 (#250) will layer
+  MCP-specific audit semantics on `tools/call` / `resources/read`.
+  Origin-header validation per the MCP transport DNS-rebinding warning
+  is deferred to a later transport-hardening task — it needs
+  `MCP_ALLOWED_ORIGINS` infrastructure that doesn't exist yet, and
+  bundling it with T2 would over-scope the OAuth-RS work.
 
 Database persistence lands progressively in subsequent G2.3 Tasks. The stack (FastAPI, Pydantic v2,
 SQLAlchemy 2.x async, Alembic, structlog, prometheus_client, authlib


### PR DESCRIPTION
## Summary

- Layers spec-conforming **OAuth 2.1 resource-server** protection on `POST /mcp` per MCP 2025-06-18 §Authorization (RFC 9728 + RFC 8707). T1's dispatcher gains a `Depends(verify_mcp_jwt_and_bind)` security gate that runs before envelope parsing.
- New `mcp/auth.py` validates Bearer tokens against the **MCP canonical URI** (not the chassis `KEYCLOAK_AUDIENCE`) via the new `verify_jwt_for_audience` seam in `auth/jwt.py`. RFC 8707 §2 audience binding: a token issued for the HTTP API surface cannot be replayed at `/mcp` and vice versa.
- On 401 the wrapper attaches the RFC 9728 §5.1 `WWW-Authenticate: Bearer resource_metadata="<url>"` header so spec-conforming MCP clients can discover the metadata document.
- New unauthenticated GET `/.well-known/oauth-protected-resource` (`api/well_known.py`) returns the RFC 9728 §3 metadata document — `resource`, `authorization_servers` (Keycloak issuer), `scopes_supported`, `bearer_methods_supported`.
- Two new env vars (`BACKPLANE_URL`, `MCP_RESOURCE_URI`); both default to empty (fail-closed for MCP without breaking chassis-only deployments).

## How the audience binding works

```
Client (no token) ──POST /mcp──►  Server
                                  401 + WWW-Authenticate: Bearer resource_metadata="https://meho.test/.well-known/oauth-protected-resource"

Client ──GET /.well-known/oauth-protected-resource──►  Server
                                                       { "resource": "https://meho.test/mcp",
                                                         "authorization_servers": ["https://keycloak.test/realms/meho"],
                                                         "scopes_supported": ["mcp:read", "mcp:execute"],
                                                         "bearer_methods_supported": ["header"] }

Client ──OAuth 2.1 + PKCE w/ resource=https://meho.test/mcp──►  Keycloak
                                                                ►  access_token (aud = "https://meho.test/mcp")

Client ──POST /mcp + Authorization: Bearer <token>──►  Server
                                                       ►  validates aud == MCP canonical URI
                                                       ►  200 + JSON-RPC envelope
```

A token whose `aud` is `meho-backplane` (the chassis audience) is **rejected** at `/mcp` even with a valid signature — that's the RFC 8707 §2 confused-deputy defence.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — 61 files formatted
- [x] `mypy src/` (strict) — 29 source files, no issues
- [x] `pytest tests/` — **276 passed**, 1 deselected (pre-existing macOS-only flake from T1 era)

### AC coverage

- [x] `/.well-known/oauth-protected-resource` returns RFC 9728-compliant JSON — `test_well_known_returns_required_rfc9728_fields`.
- [x] Unauthenticated POST `/mcp` → 401 + `WWW-Authenticate: Bearer resource_metadata="..."` per RFC 9728 §5.1 — `test_missing_authorization_returns_401_with_www_authenticate` + `test_www_authenticate_header_has_rfc9728_shape`.
- [x] JWT with chassis audience is rejected at `/mcp` with 401 — `test_token_for_chassis_audience_is_rejected_at_mcp`.
- [x] JWT with `aud == MCP_RESOURCE_URI` accepted; `verify_mcp_jwt` returns `Operator` — `test_token_with_mcp_audience_is_accepted`.
- [x] Malformed `Authorization` (Basic …) → 401 — `test_basic_auth_scheme_returns_401_with_www_authenticate`.
- [x] Expired token → 401 — `test_expired_token_returns_401`.
- [x] Settings expose `MCP_RESOURCE_URI` + `BACKPLANE_URL`; defaults documented — `test_well_known_honors_explicit_mcp_resource_uri_override` + `test_explicit_mcp_resource_uri_is_the_required_audience`.
- [x] CI green: ruff + mypy + pytest.

### Bonus coverage (beyond AC)

- [x] WWW-Authenticate header shape exact match (RFC 9728 §5.1 example) — `test_www_authenticate_header_has_rfc9728_shape`.
- [x] JWKS unreachable → 401 (not 5xx), still carries WWW-Authenticate — `test_jwks_unreachable_returns_401`.
- [x] Trailing-slash stripping on `BACKPLANE_URL` and Keycloak issuer.
- [x] Discovery endpoint is unauthenticated — `test_well_known_does_not_require_authentication`.

### Dispatcher tests preserved

- [x] All 25 JSON-RPC dispatch tests from T1 still pass. The `client` fixture now overrides `verify_mcp_jwt_and_bind` with a stub returning a fixture `Operator`, so each dispatcher test stays independent of the full OAuth-RS chain (which is covered separately in `test_mcp_auth.py`).

## Out of scope

- **Origin-header validation** (MCP transport DNS-rebinding warning) — needs `MCP_ALLOWED_ORIGINS` infrastructure that doesn't exist yet. Belongs with a transport-hardening cluster (Origin + body-size cap + content-type 415) as a fast-follow.
- **`MCP_ENABLED` boolean flag** (Initiative #226 DoD line) — T2 doesn't need it for auth.
- **Token revocation cache, Dynamic Client Registration (RFC 7591), scope-based RBAC inside MCP** — all explicit "Out of scope" items on #247.
- **G0.5-T3 (#248)** — tool + resource registries (`register_mcp_tool`, `register_mcp_resource`).
- **G0.5-T4 (#249)** — reference `meho.status` tool + `meho://tenant/<id>/info` resource.
- **G0.5-T5 (#250)** — MCP-specific audit integration on `tools/call` + `resources/read`. T2 currently writes a chassis `audit_log` row per `/mcp` request via the existing `AuditMiddleware` because the new dependency binds `operator_sub`; T5 will replace this with the fail-closed MCP-specific path.
- **G0.5-T6 (#251)** — end-to-end MCP Inspector acceptance test + `docs/architecture/mcp.md` + `docs/cross-repo/mcp-client-setup.md`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP endpoints now enforce OAuth 2.1 Bearer-token protection.
  * Added RFC 9728 OAuth protected-resource discovery at /.well-known/oauth-protected-resource.

* **Security**
  * Enforced JWT audience validation for MCP access.
  * Returns RFC 9728-style WWW-Authenticate challenges on 401s.

* **Tests**
  * Comprehensive end-to-end tests for MCP auth and discovery added.

* **Documentation**
  * Backend docs updated with OAuth/resource-server and auth behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/290)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-12)

Addressed review feedback from CodeRabbit's inline nitpick and @ikaric's review body.

**Fixed:**

- **CR-A** `2c83a19` — Normalize explicit `MCP_RESOURCE_URI` (strip whitespace + rstrip slash) before returning from `mcp_resource_uri()`. A stray trailing slash or newline in the env var no longer causes opaque `aud` mismatches.
- **R-2** `7b629ce` — Empty-audience guard in `verify_jwt_for_audience`. The fail-closed property is now local to the verifier (`audience_not_configured` 401) rather than dependent on the issuer never minting a token with `aud=""`. New test `test_empty_audience_setting_returns_401` asserts a token with `aud=""` still 401s even when the derived audience is also `""`.
- **R-1** `9c3c6eb` — Use the previously-unused `_log` to emit `mcp_auth_failed` in the 401 branch of `verify_mcp_jwt`, carrying the chassis failure-mode token (`missing_token` / `invalid_token` / `jwks_unavailable` / etc.) as `detail`. Gives on-call a grep-able event to distinguish MCP-side 401 spikes from chassis-side ones.
- **CR-B + R-4** `1f928e0` — Strengthen `test_well_known_keycloak_issuer_url_has_no_trailing_slash` to actually exercise the strip: set `KEYCLOAK_ISSUER_URL` **with** a trailing slash and assert exact-equality against the canonical (no-slash) form. The previous shape (no trailing slash in input + `not endswith("/")` assertion) passed trivially.
- **R-5** `7a3db92` — Add `test_token_for_arbitrary_audience_is_rejected_at_mcp` pinning the value-based audience-check contract: a token minted for an arbitrary third party (not just the chassis audience) also 401s.

**Disputed:**

- **R-3** (`del operator` style smell) — Keeping the parameter form `operator: Operator = Depends(verify_mcp_jwt_and_bind)` over the `dependencies=[Depends(...)]` form for forward compat with T3 (#248). T3's `tools/call` handler will read tenant / role data off the `Operator` parameter; flipping to the parameter form *now* lets T3 add behaviour without touching the route signature. The reviewer already framed this as "defensible forward-compat", so keeping as-is and accepting the minor `del operator` cleanup as the cost of that compat. The `del` makes the unused-by-T2 intent explicit; mypy strict otherwise flags the parameter as unused.

**DCO compliance:**

The first commit on this branch (`d2e9c64`, the T2 main feature commit) lacks the `Signed-off-by:` trailer that the DCO bot requires. Hard rules in `/auto-implement-issue` (Phase 8: "Never `--amend`. Never force-push.") block the standard `git rebase --signoff main && git push --force-with-lease` remediation. Every commit landed in this iteration (`2c83a19`, `7b629ce`, `9c3c6eb`, `1f928e0`, `7a3db92`) is `git commit -s` signed, so DCO compliance is in place from this commit forward. The pre-existing commit needs either:
1. An `--admin` merge bypass (precedent: PR #181 / G2.7-T6, 2026-05-11 — same incident).
2. A manual rebase + force-push outside this skill's guardrails.

Flagging for human-merge decision.

**Verification (re-run after iter-2 fixes):**

- `ruff check src/ tests/` — clean
- `ruff format --check` — 61 files formatted
- `mypy src/` (strict) — 29 source files, no issues
- `pytest tests/` — **278 passed**, 1 deselected (pre-existing macOS flake)
- MCP-focused tests grew to **39 cases** (25 dispatcher + 8 auth chain + 6 well-known) from 37 in iteration 1.

<!-- auto-implement-issue: continue, iteration 2 -->



---

## Follow-up (auto-implement-issue, iteration 3, 2026-05-12)

PR now **APPROVED** by @damir-topic (review `4273271769`). One non-blocking inline finding addressed by dispute; no code changes this iteration.

**Disputed (with inline reply):**

- **Thread on `mcp/auth.py:176`** (`async` without `await`) — Both CodeRabbit and @damir-topic flagged that `verify_mcp_jwt_and_bind` is `async def` with no `await` in the body. The reviewer explicitly noted "I'd lean toward keeping it async on consistency grounds — the two are used as a pair and reading them with matching shapes is worth the few ns. Author's call; not blocking." Keeping `async` for shape consistency with **both** the sibling `verify_mcp_jwt` (which IS async because it awaits `verify_jwt_for_audience`) and the chassis parallel `verify_jwt_and_bind` in `middleware.py` (also `async def` + only calls `bind_contextvars`). Coroutine-creation overhead is a few ns per request; the cohort cost (consistency, grep-ability of the dependency family) beats the per-call cost. If the chassis sibling ever flips to plain `def`, this flips with it — same commit, same rationale. Inline reply posted + thread resolved.

**Thread state:** all 4 threads resolved. `reviewDecision = APPROVED`.

**DCO status (carried over from iter-2 note):** the first commit `d2e9c64` still lacks `Signed-off-by`. Every commit from iter-2 onward is `-s` signed. Per Hard rule 8 (no `--amend`, no force-push) the standard `rebase --signoff` remediation is blocked from inside the skill. Options remain: `--admin` merge bypass (precedent: PR #181 / G2.7-T6) or a manual force-push outside the skill's guardrails.

<!-- auto-implement-issue: continue, iteration 3 -->
