### PR TITLE
feat(mcp): reference tool meho.status + reference resource meho://tenant/<id>/info (G0.5-T4)

### DIFF
--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -57,7 +57,7 @@ from meho_backplane.auth.vault import (
 from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.middleware import verify_jwt_and_bind
 
-__all__ = ["router"]
+__all__ = ["build_health_response", "router"]
 
 #: Hardcoded path inside the Vault KV v2 mount used to prove the
 #: federation chain. The path is provisioned by the consumer (see
@@ -225,17 +225,17 @@ async def _probe_vault_federation(
         )
 
 
-@router.get("/health", response_model=HealthResponse)
-async def authenticated_health(
-    operator: Operator = Depends(verify_jwt_and_bind),
-) -> HealthResponse:
-    """Federation-proof authenticated health check.
+async def build_health_response(operator: Operator) -> HealthResponse:
+    """Assemble the :class:`HealthResponse` for a validated operator.
 
-    See module docstring for the four-step chain this exercises. The
-    ``Depends(verify_jwt_and_bind)`` annotation is what guarantees the
-    JWT is validated *and* ``operator_sub`` is bound into structlog
-    contextvars before this body runs — every log line emitted from
-    here downstream carries operator identity automatically.
+    Lifted out of :func:`authenticated_health` so the MCP reference tool
+    ``meho.status`` (G0.5-T4) can return the same federation-proof status
+    bundle without re-implementing the Vault + DB probe chain. The route
+    handler is now a thin wrapper around this helper plus the
+    :class:`Operator` dependency the FastAPI router supplies; the MCP
+    tool handler at :mod:`meho_backplane.mcp.tools.meho_status` calls
+    this directly with the :class:`Operator` the MCP dispatcher already
+    resolved.
     """
     log = structlog.get_logger()
     vault_status = await _probe_vault_federation(operator, log)
@@ -249,3 +249,18 @@ async def authenticated_health(
         vault=vault_status,
         db=DbStatus(migrated=db_probe_result.ok),
     )
+
+
+@router.get("/health", response_model=HealthResponse)
+async def authenticated_health(
+    operator: Operator = Depends(verify_jwt_and_bind),
+) -> HealthResponse:
+    """Federation-proof authenticated health check.
+
+    See module docstring for the four-step chain this exercises. The
+    ``Depends(verify_jwt_and_bind)`` annotation is what guarantees the
+    JWT is validated *and* ``operator_sub`` is bound into structlog
+    contextvars before this body runs — every log line emitted from
+    here downstream carries operator identity automatically.
+    """
+    return await build_health_response(operator)

--- a/backend/src/meho_backplane/mcp/resources/__init__.py
+++ b/backend/src/meho_backplane/mcp/resources/__init__.py
@@ -12,7 +12,9 @@ invoked from the FastAPI ``lifespan`` (see
 ``pkgutil.iter_modules`` so the registrations land before the first
 ``resources/templates/list`` request arrives.
 
-T3 (#248) ships the registry shell; this subpackage stays empty until
-T4 (#249) lands the reference ``meho://tenant/{tenant_id}/info``
-resource.
+T4 (#249) lands the first resource template:
+``meho://tenant/{tenant_id}/info`` at
+:mod:`meho_backplane.mcp.resources.tenant_info` — the reference impl
+that establishes the tenant-boundary enforcement pattern every
+downstream G3-G9 resource copies.
 """

--- a/backend/src/meho_backplane/mcp/resources/tenant_info.py
+++ b/backend/src/meho_backplane/mcp/resources/tenant_info.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho://tenant/{tenant_id}/info`` — the reference MCP resource (G0.5-T4).
+
+The simplest universally-useful resource: an identity bundle every MCP
+client can fetch at session start to confirm which tenant it's operating
+on. Establishes the ``meho://`` URI scheme convention every downstream
+G3-G9 resource will follow.
+
+Tenant-boundary enforcement is the load-bearing pattern
+=======================================================
+
+The handler validates that the ``tenant_id`` bound from the URI
+template matches the operator's ``tenant_id`` from the JWT — cross-
+tenant reads are rejected at the resource layer, not just at the
+JWT-validation layer. The MCP dispatcher's call-time RBAC re-check
+already gates *role*, but it doesn't gate *tenant scope* (an
+``operator``-role operator in tenant A can absolutely read
+``meho://tenant/<A>/info``; what's forbidden is reading
+``meho://tenant/<B>/info`` from inside tenant A's session).
+
+Downstream resources (G4 ``meho://kb/{slug}``, G5
+``meho://target/{tenant_id}/{target_slug}``, …) copy this pattern: bind
+the tenant variable from the URI template, validate it equals
+``operator.tenant_id``, reject otherwise. Adding the check at the
+registry handler rather than relying on a global middleware keeps the
+contract obvious at the call site and avoids a forgotten check
+escalating into a tenant-boundary CVE.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Tenant
+from meho_backplane.mcp.registry import (
+    ResourceTemplateDefinition,
+    register_mcp_resource,
+)
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+
+async def _tenant_info_handler(
+    operator: Operator,
+    bound: dict[str, str],
+) -> dict[str, Any]:
+    """Return the operator's tenant identity bundle.
+
+    Three rejection arms, all mapped onto the dispatcher's
+    :class:`~meho_backplane.mcp.server.McpInvalidParamsError`
+    (``-32602``) — the JSON-RPC transport doesn't carry HTTP-status
+    semantics; ``-32602`` plus a structured ``message`` is the
+    spec-correct shape for any input-validation failure in this layer:
+
+    * **Malformed ``tenant_id``** — the URI bound a non-UUID string.
+      Equivalent to AC #8's ``400`` on a bad tenant_id.
+    * **Cross-tenant read** — bound tenant differs from the operator's
+      JWT tenant. Equivalent to AC #7's ``403``. The check runs *before*
+      the DB query so a probe attempt against an arbitrary UUID can't
+      learn whether that tenant exists.
+    * **Tenant not found** — the operator's own tenant_id has no row
+      in the ``tenant`` table. Only reachable if the JWT's
+      ``tenant_id`` claim was minted before the tenant row was seeded;
+      treated as INVALID_PARAMS rather than INTERNAL_ERROR because the
+      operator can act on the message (re-seed / re-mint), and -32603
+      would hide a configuration error inside a generic-error envelope.
+    """
+    raw_id = bound["tenant_id"]
+    try:
+        bound_uuid = UUID(raw_id)
+    except ValueError as exc:
+        raise McpInvalidParamsError(
+            f"tenant_info: invalid tenant_id (not a UUID): {raw_id!r}",
+        ) from exc
+
+    if bound_uuid != operator.tenant_id:
+        raise McpInvalidParamsError(
+            "tenant_info: cross-tenant access denied — bound "
+            f"tenant_id {raw_id!r} does not match the operator's tenant",
+        )
+
+    async with get_sessionmaker()() as session:
+        tenant = (
+            await session.execute(select(Tenant).where(Tenant.id == bound_uuid))
+        ).scalar_one_or_none()
+    if tenant is None:
+        raise McpInvalidParamsError(
+            f"tenant_info: tenant row not found for id {raw_id!r}",
+        )
+
+    return {
+        "id": str(tenant.id),
+        "slug": tenant.slug,
+        "name": tenant.name,
+        "operator_role": operator.tenant_role.value,
+    }
+
+
+register_mcp_resource(
+    definition=ResourceTemplateDefinition(
+        uriTemplate="meho://tenant/{tenant_id}/info",
+        name="Tenant identity",
+        description=(
+            "Identity bundle for the operator's tenant: id, slug, name, "
+            "and the operator's role within that tenant. Cross-tenant "
+            "reads return INVALID_PARAMS — the bound tenant_id must match "
+            "the operator's JWT tenant claim."
+        ),
+        mimeType="application/json",
+        required_role=TenantRole.READ_ONLY,
+    ),
+    handler=_tenant_info_handler,
+)

--- a/backend/src/meho_backplane/mcp/tools/__init__.py
+++ b/backend/src/meho_backplane/mcp/tools/__init__.py
@@ -12,6 +12,7 @@ invoked from the FastAPI ``lifespan`` (see
 ``pkgutil.iter_modules`` so the registrations land before the first
 ``tools/list`` request arrives.
 
-T3 (#248) ships the registry shell; this subpackage stays empty until
-T4 (#249) lands the reference ``meho.status`` tool.
+T4 (#249) lands the first tool: ``meho.status`` at
+:mod:`meho_backplane.mcp.tools.meho_status` — the reference impl
+downstream G3-G9 connector tools copy.
 """

--- a/backend/src/meho_backplane/mcp/tools/meho_status.py
+++ b/backend/src/meho_backplane/mcp/tools/meho_status.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho.status`` — the reference MCP tool (G0.5-T4).
+
+Mirrors :func:`~meho_backplane.api.v1.health.authenticated_health` onto
+the MCP transport. A call to ``tools/call`` with
+``name="meho.status"`` returns the same operator-identity +
+Vault-federation + DB-migration bundle the chassis ``GET /api/v1/health``
+route returns, scoped to the operator the MCP dispatcher already
+authenticated.
+
+Why this is the *reference* tool
+================================
+
+If the four-step chain ``GET /api/v1/health`` exercises (JWT validation
+→ Vault JWT/OIDC login → KV v2 read of ``meho/test/federation`` → DB
+migration probe) works end-to-end for the MCP transport, every other
+downstream tool (G3 cluster, G4 knowledge, G5 memory, G6 broadcast, G7
+conventions, G8 targets) inherits a working auth + dispatch baseline.
+A failure surfaces here loudly *before* any product tool would.
+
+The tool description matters
+============================
+
+Per AI-engineering best-practices, the ``description`` field is the
+agent's prompt for *when to call this tool*. Imprecise descriptions
+get tools called incorrectly, miss-routed, or never invoked at all. The
+description below names what the tool does, when an agent should call
+it (session start / connectivity check), and that there are no
+arguments — copy-paste good for downstream connector tools.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.api.v1.health import build_health_response
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+
+
+async def _meho_status_handler(
+    operator: Operator,
+    _arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the chassis ``/api/v1/health`` payload wire-identical.
+
+    The MCP dispatcher already validated ``arguments`` against the
+    tool's ``inputSchema`` (``{additionalProperties: false}``) before
+    reaching this handler, so the body unconditionally builds the
+    health bundle. ``model_dump(mode="json")`` serialises the
+    :class:`HealthResponse` to a JSON-safe dict that the dispatcher
+    wraps in the MCP ``content`` array.
+    """
+    response = await build_health_response(operator)
+    return response.model_dump(mode="json")
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.status",
+        description=(
+            "Returns the operator's identity (sub, name, email) plus the "
+            "MEHO backplane's dependency status: Vault federation chain "
+            "(reachable + KV read OK?) and DB migration state. Call at "
+            "MCP session start to verify the operator can reach all "
+            "subsystems before issuing product calls. No arguments."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.READ_ONLY,
+        op_class="read",
+    ),
+    handler=_meho_status_handler,
+)

--- a/backend/tests/test_mcp_resource_tenant_info.py
+++ b/backend/tests/test_mcp_resource_tenant_info.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``meho://tenant/{tenant_id}/info`` reference MCP resource (G0.5-T4, #249).
+
+Covers acceptance criteria 5-8 on issue #249:
+
+* ``resources/templates/list`` returns the tenant-info template entry.
+  (The AC text says ``resources/list``, but per T3's spec-correctness
+  decision templated resources surface via ``resources/templates/list``;
+  concrete ``resources/list`` is empty in v0.2.)
+* ``resources/read`` with the operator's own tenant_id returns
+  ``{id, slug, name, operator_role}``.
+* ``resources/read`` with a *different* tenant's id returns
+  ``INVALID_PARAMS`` (-32602). The AC text says HTTP 403, but the JSON-
+  RPC transport carries error codes, not HTTP statuses — every input-
+  validation failure including tenant-boundary breach maps to -32602.
+* ``resources/read`` with a non-UUID id returns INVALID_PARAMS (-32602).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Tenant
+from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.registry import clear_registries
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.settings import get_settings
+
+_OPERATOR_TENANT_ID = UUID("00000000-0000-0000-0000-00000000a0a0")
+
+
+def _operator(role: TenantRole = TenantRole.READ_ONLY) -> Operator:
+    return Operator(
+        sub="op-test",
+        name="Test",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=_OPERATOR_TENANT_ID,
+        tenant_role=role,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry_with_production_resource() -> Iterator[None]:
+    """Reset the registry then re-register the production ``tenant_info`` resource.
+
+    Same rationale as :mod:`tests.test_mcp_tool_meho_status` — Python's
+    import cache prevents the lifespan's
+    :func:`eager_import_mcp_modules` from re-running top-level
+    registrations after the first test. :func:`importlib.reload` forces
+    the module body to re-execute so each test starts from a known
+    state regardless of cross-file ordering.
+    """
+    from meho_backplane.mcp.resources import tenant_info
+
+    clear_registries()
+    importlib.reload(tenant_info)
+    yield
+    clear_registries()
+
+
+@pytest.fixture
+def client_with_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[TestClient, Operator]]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    get_settings.cache_clear()
+
+    op = _operator(TenantRole.READ_ONLY)
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+async def seeded_operator_tenant() -> None:
+    """Insert a :class:`Tenant` row matching the fixture operator's ``tenant_id``.
+
+    The conftest autouse fixture runs ``alembic upgrade head`` to materialise
+    the ``tenant`` table; this fixture populates the operator's row so the
+    handler's ``session.execute(select(Tenant).where(...))`` returns a real
+    record rather than ``None``.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            Tenant(
+                id=_OPERATOR_TENANT_ID,
+                slug="op-test-tenant",
+                name="Operator Test Tenant",
+            ),
+        )
+
+
+def _post_mcp(client: TestClient, body: Any) -> Any:
+    return client.post("/mcp", json=body)
+
+
+def test_resources_templates_list_exposes_tenant_info(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #5: ``resources/templates/list`` returns the registered template."""
+    client, _op = client_with_operator
+
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "resources/templates/list"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    templates = body["result"]["resourceTemplates"]
+    tenant_info = [t for t in templates if t["uriTemplate"] == "meho://tenant/{tenant_id}/info"]
+    assert len(tenant_info) == 1
+    assert tenant_info[0]["mimeType"] == "application/json"
+    # MEHO-internal RBAC field stripped from the wire shape.
+    assert "required_role" not in tenant_info[0]
+
+
+@pytest.mark.asyncio
+async def test_resources_read_own_tenant_returns_identity_bundle(
+    client_with_operator: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,
+) -> None:
+    """AC #6: reading the operator's own tenant returns {id, slug, name, role}."""
+    client, op = client_with_operator
+    uri = f"meho://tenant/{op.tenant_id}/info"
+
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "resources/read",
+            "params": {"uri": uri},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    contents = body["result"]["contents"]
+    assert contents[0]["uri"] == uri
+    assert contents[0]["mimeType"] == "application/json"
+
+    bundle = json.loads(contents[0]["text"])
+    assert bundle["id"] == str(op.tenant_id)
+    assert bundle["slug"] == "op-test-tenant"
+    assert bundle["name"] == "Operator Test Tenant"
+    assert bundle["operator_role"] == TenantRole.READ_ONLY.value
+
+
+def test_resources_read_cross_tenant_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #7: a URI bound to a different tenant rejects with -32602.
+
+    The tenant-boundary check runs *before* the DB query, so the test
+    doesn't need to seed the foreign tenant — the rejection happens
+    purely from the operator vs. URI mismatch.
+    """
+    client, _op = client_with_operator
+    foreign_tenant = uuid4()
+    uri = f"meho://tenant/{foreign_tenant}/info"
+
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "resources/read",
+            "params": {"uri": uri},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "cross-tenant" in body["error"]["message"].lower()
+
+
+def test_resources_read_invalid_uuid_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #8: a non-UUID bound to {tenant_id} rejects with -32602."""
+    client, _op = client_with_operator
+    # The URI must still match the template's path shape for the matcher
+    # to bind `tenant_id`; the bound value is then validated as a UUID
+    # inside the handler.
+    uri = "meho://tenant/not-a-uuid/info"
+
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "resources/read",
+            "params": {"uri": uri},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "not a uuid" in body["error"]["message"].lower()

--- a/backend/tests/test_mcp_tool_meho_status.py
+++ b/backend/tests/test_mcp_tool_meho_status.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``meho.status`` reference MCP tool (G0.5-T4, #249).
+
+Covers acceptance criteria 1-4 on issue #249:
+
+* ``tools/list`` exposes ``meho.status`` with a well-formed JSON Schema
+  2020-12 ``inputSchema``.
+* ``tools/call`` with no arguments returns the operator identity + Vault
+  + DB-migration bundle wire-identical to ``GET /api/v1/health`` (modulo
+  the MCP ``content`` wrapper).
+* ``tools/call`` with an extra argument violates the
+  ``additionalProperties: false`` constraint and surfaces as
+  ``INVALID_PARAMS`` (-32602).
+
+AC #4 (sub-``read_only`` role rejection) is satisfied by the registry's
+call-time RBAC re-check — already tested in
+:mod:`tests.test_mcp_registry`'s
+``test_tools_call_forbidden_for_under_privileged_operator`` — plus the
+``required_role=READ_ONLY`` on this tool's definition. The AC itself
+notes "which doesn't exist in v0.2, but the check is defensive";
+adding a duplicate end-to-end test here would only re-exercise registry
+machinery T3 already proved.
+
+Vault + DB notes
+================
+
+The lifespan startup that triggers ``eager_import_mcp_modules`` also
+exercises the chassis env (DB engine, settings). The handler under
+test calls
+:func:`~meho_backplane.api.v1.health.build_health_response`, which in
+turn probes Vault. Tests don't mock Vault: the probe is designed to
+return :class:`VaultStatus(reachable=False, …)` on a failed login, and
+the AC wants *wire-shape identity* with the chassis route, which holds
+regardless of the probe outcome.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.registry import clear_registries
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.settings import get_settings
+
+
+def _operator(role: TenantRole = TenantRole.READ_ONLY) -> Operator:
+    return Operator(
+        sub="op-test",
+        name="Test",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=role,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry_with_production_tool() -> Iterator[None]:
+    """Reset the registry then re-register the production ``meho.status`` tool.
+
+    ``clear_registries()`` between tests is needed for isolation, but
+    Python's import cache means the lifespan's
+    :func:`eager_import_mcp_modules` is a no-op on the 2nd+ call within
+    the same process — the top-level ``register_mcp_tool(...)`` call in
+    :mod:`meho_backplane.mcp.tools.meho_status` only runs at first
+    import. :func:`importlib.reload` forces the module body to re-execute
+    so the production registration lands fresh in every test, regardless
+    of which test file ran first.
+    """
+    from meho_backplane.mcp.tools import meho_status
+
+    clear_registries()
+    importlib.reload(meho_status)
+    yield
+    clear_registries()
+
+
+@pytest.fixture
+def client_with_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[TestClient, Operator]]:
+    """Same shape as :mod:`tests.test_mcp_registry`'s fixture, pinned to READ_ONLY.
+
+    The tool requires ``required_role=READ_ONLY`` so all happy-path
+    cases run as ``read_only``; tests that need a different role
+    parametrise indirectly.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    get_settings.cache_clear()
+
+    op = _operator(TenantRole.READ_ONLY)
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+        get_settings.cache_clear()
+
+
+def _post_mcp(client: TestClient, body: Any) -> Any:
+    return client.post("/mcp", json=body)
+
+
+def test_tools_list_exposes_meho_status_with_well_formed_input_schema(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #1: ``tools/list`` surfaces ``meho.status`` with a 2020-12 schema."""
+    client, _op = client_with_operator
+
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    tools = body["result"]["tools"]
+    statuses = [t for t in tools if t["name"] == "meho.status"]
+    assert len(statuses) == 1
+    schema = statuses[0]["inputSchema"]
+    assert schema["type"] == "object"
+    assert schema["properties"] == {}
+    assert schema["additionalProperties"] is False
+    # MEHO-internal fields stripped from the wire shape.
+    assert "required_role" not in statuses[0]
+    assert "op_class" not in statuses[0]
+
+
+def test_tools_call_meho_status_returns_health_response_shape(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #2: ``tools/call meho.status`` wire-matches ``GET /api/v1/health``.
+
+    The MCP envelope wraps the response in ``content[0].text`` carrying
+    a JSON-serialised dict. Decoding that dict and asserting against the
+    chassis :class:`HealthResponse` model is the canonical "wire-shape
+    identical (modulo wrapper)" check.
+    """
+    client, op = client_with_operator
+
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "meho.status", "arguments": {}},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+
+    # Operator identity matches the fixture operator.
+    assert payload["operator"]["sub"] == op.sub
+    assert payload["operator"]["name"] == op.name
+    assert payload["operator"]["email"] is None
+
+    # Vault federation status is structurally present. The test environment
+    # has no real Vault — the probe is designed to fail closed, returning
+    # ``reachable=False`` with a structured detail.
+    assert "reachable" in payload["vault"]
+    assert "read_ok" in payload["vault"]
+    assert payload["vault"]["reachable"] is False
+
+    # DB-migration probe runs against the test SQLite (set up by the autouse
+    # ``_default_database_url`` fixture in conftest). The probe should
+    # report healthy because conftest ran ``alembic upgrade head``.
+    assert payload["db"]["migrated"] is True
+
+
+def test_tools_call_meho_status_rejects_extra_arguments(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #3: extra args fail the ``additionalProperties: false`` schema → -32602."""
+    client, _op = client_with_operator
+
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "meho.status", "arguments": {"foo": "bar"}},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "inputschema" in body["error"]["message"].lower()

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -266,6 +266,33 @@ this stage it exposes:
   `operator_sub`) with a fail-closed MCP-specific audit path on
   `tools/call` + `resources/read`.
 
+* MCP reference tool + resource (Task #249, G0.5-T4) — the two
+  reference implementations downstream G3-G9 connector tools and
+  resources copy. `backend/src/meho_backplane/mcp/tools/meho_status.py`
+  registers `meho.status` — a no-arg tool whose handler calls
+  `meho_backplane.api.v1.health.build_health_response()` (the same
+  helper the chassis `GET /api/v1/health` route uses post-T4) so the
+  MCP transport returns wire-identical operator-identity + Vault +
+  DB-migration data. The tool's `inputSchema` uses
+  `additionalProperties: false` to reject extra arguments, and its
+  `description` field is written to AI-engineering best-practice
+  standards (precise about what / when / no-args). The companion
+  `backend/src/meho_backplane/mcp/resources/tenant_info.py` registers
+  `meho://tenant/{tenant_id}/info` as a `ResourceTemplateDefinition`
+  whose handler binds `tenant_id` from the URI, validates it as a UUID,
+  enforces tenant-boundary by checking the bound value equals
+  `operator.tenant_id`, then queries the `tenant` table via
+  `get_sessionmaker()` and returns `{id, slug, name, operator_role}`.
+  Cross-tenant reads / invalid UUIDs / missing rows all surface as
+  `McpInvalidParamsError` (-32602) — the JSON-RPC transport carries
+  error codes, not HTTP statuses, so every input-validation failure at
+  this layer maps to INVALID_PARAMS. The tenant-boundary check runs
+  *before* the DB query so a probe attempt against an arbitrary UUID
+  cannot learn whether that tenant exists. `build_health_response()`
+  was extracted from `authenticated_health()` in `api/v1/health.py`
+  during T4 so the chassis route and the MCP tool share the same
+  federation-proof probe chain rather than diverging.
+
 * MCP tool + resource registries (Task #248, G0.5-T3) — the substrate
   every G3–G9 verb registers against. `backend/src/meho_backplane/mcp/registry.py`
   exposes `register_mcp_tool(definition, handler)` /


### PR DESCRIPTION
## Summary

T4 ships the two reference implementations downstream G3-G9 connector tools and resources will copy as templates:

- **`meho.status` (tool)** — the MCP transport equivalent of `GET /api/v1/health`. `mcp/tools/meho_status.py` registers it against T3's registry; the handler calls `meho_backplane.api.v1.health.build_health_response()` (extracted during T4) so the chassis route and the MCP tool share the same federation-proof probe chain rather than diverging. `inputSchema` uses `additionalProperties: false` so extra args fail validation under the `Draft202012Validator` pinned in T3.
- **`meho://tenant/{tenant_id}/info` (resource)** — establishes the `meho://` URI scheme and the tenant-boundary enforcement pattern every downstream resource will follow. The handler validates the bound `tenant_id` as a UUID, checks it matches `operator.tenant_id` *before* hitting the DB (so a probe can't learn whether an arbitrary tenant exists), queries `Tenant`, and returns `{id, slug, name, operator_role}`.
- **Error code shape.** Cross-tenant reads, invalid UUIDs, and missing rows all surface as `McpInvalidParamsError` (-32602) — the JSON-RPC transport carries error codes, not HTTP statuses, so the issue body's mention of "400" / "403" maps onto INVALID_PARAMS at this layer.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — 75 files formatted
- [x] `mypy src/ --ignore-missing-imports` — 38 source files (was 36 pre-T4), no issues
- [x] `pytest tests/ -q --deselect …test_metrics_endpoint…` — **345 passed** (+7 vs main: the 7 new T4 tests), 1 deselected (pre-existing macOS-only flake on `process_resident_memory_bytes`, file unchanged on this branch)

### AC coverage

- [x] `tools/list` returns `meho.status` with well-formed Draft 2020-12 `inputSchema` — `test_tools_list_exposes_meho_status_with_well_formed_input_schema`
- [x] `tools/call meho.status` returns wire-identical health bundle — `test_tools_call_meho_status_returns_health_response_shape`
- [x] `tools/call` with `arguments={"foo": "bar"}` → -32602 (extra prop fails `additionalProperties: false`) — `test_tools_call_meho_status_rejects_extra_arguments`
- [x] Sub-`read_only` role rejection — delegated to T3's `test_tools_call_forbidden_for_under_privileged_operator` plus `required_role=READ_ONLY` on the def. The AC notes "which doesn't exist in v0.2, but the check is defensive"; the existing registry RBAC re-check activates on this tool's gate.
- [x] `resources/templates/list` returns the tenant-info template — `test_resources_templates_list_exposes_tenant_info`. The AC text said `resources/list`, but T3's spec-correctness decision (MCP 2025-06-18) routes templated resources through `resources/templates/list`; the concrete `resources/list` returns empty in v0.2.
- [x] `resources/read meho://tenant/<own-id>/info` returns `{id, slug, name, operator_role}` — `test_resources_read_own_tenant_returns_identity_bundle`
- [x] Cross-tenant `resources/read` → -32602 (AC's "403" maps to INVALID_PARAMS) — `test_resources_read_cross_tenant_returns_invalid_params`
- [x] Invalid-UUID `resources/read` → -32602 (AC's "400" maps to INVALID_PARAMS) — `test_resources_read_invalid_uuid_returns_invalid_params`

## Test isolation note

`test_mcp_tool_meho_status.py` and `test_mcp_resource_tenant_info.py` use `importlib.reload()` in their autouse fixtures to re-execute the production registration modules before each test. Without that, Python's import cache makes the lifespan's `eager_import_mcp_modules()` a no-op on the 2nd+ test (top-level `register_mcp_*` calls only run on first import), and `clear_registries()` between tests would leave subsequent tests with empty registries. This is a real interaction with the m1 fix on PR 294 (TestClient lifespan now runs) — surfaced as the first downstream test file pattern that needs it.

## Out of scope

- **T5 (#250)** — MCP-specific audit row on `tools/call` + `resources/read`. T4 registers the tool and resource; T5 wires the audit-log writes around the dispatcher.
- **T6 (#251)** — End-to-end MCP Inspector acceptance test + `docs/architecture/mcp.md`. T6 exercises everything T1-T5 ship from a real MCP client.
- **`structuredContent` field on `tools/call` results.** v0.2 ships unstructured-only (the JSON-serialised handler return as a text block).
- **`outputSchema` validation on tool handler return values.** Plumbed through `ToolDefinition` (T3) but not yet validated by `handle_tools_call`; lands when a downstream tool actually needs it.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `meho.status` MCP tool providing system health status and authentication connectivity verification
  * Added `meho://tenant/{tenant_id}/info` MCP resource for retrieving tenant details with automatic cross-tenant boundary enforcement

* **Documentation**
  * Updated backend documentation describing the new MCP tool and resource with implementation examples

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/297)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->