### PR TITLE
docs(architecture): connector + MCP architecture references

### DIFF
--- a/docs/architecture/connectors.md
+++ b/docs/architecture/connectors.md
@@ -1,0 +1,215 @@
+# Connector architecture
+
+How MEHO talks to the systems it governs. The substrate landed in [G0.2 (#223)](https://github.com/evoila/meho/issues/223); every connector implementation under [G3 (#214)](https://github.com/evoila/meho/issues/214) inherits from this contract.
+
+## Why a connector ABC
+
+The v0.1 chassis had vendor-specific modules ([`auth/jwt.py`](../../backend/src/meho_backplane/auth/jwt.py) for Keycloak, [`auth/vault.py`](../../backend/src/meho_backplane/auth/vault.py) for Vault) with no shared shape. v0.2 generalises so the ~14 connectors planned for v0.2 don't ship as 14 one-offs:
+
+- Same fingerprint contract across every vendor (consumer-needs.md §G3 L94–99).
+- Same probe semantics → reusable in the readiness-probe registry.
+- Same op-id namespace → uniform audit shape, MCP tool registration, broadcast classification.
+- Same per-target identity-model field → operators pick `impersonation` / `shared_service_account` / `per_user` per target.
+
+## The ABC
+
+[`backend/src/meho_backplane/connectors/base.py`](../../backend/src/meho_backplane/connectors/base.py):
+
+```python
+class Connector(ABC):
+    product: str  # subclass sets: "vsphere", "vault", "bind9", ...
+
+    @abstractmethod
+    async def fingerprint(self, target: Target) -> FingerprintResult: ...
+
+    @abstractmethod
+    async def probe(self, target: Target) -> ProbeResult: ...
+
+    @abstractmethod
+    async def execute(
+        self, target: Target, op_id: str, params: dict[str, Any]
+    ) -> OperationResult: ...
+```
+
+Three required methods, all async. **Op-id namespace** is `<product>.<resource>.<verb>` — e.g., `vsphere.vm.list`, `vault.kv.read`, `bind9.zone.create`.
+
+## Result models
+
+[`backend/src/meho_backplane/connectors/schemas.py`](../../backend/src/meho_backplane/connectors/schemas.py) — every model frozen, `extras` wrapped in `MappingProxyType` so in-place mutation also raises.
+
+### `FingerprintResult` (consumer-needs L95 shape)
+
+```python
+class FingerprintResult(BaseModel):
+    vendor: str
+    product: str
+    version: str | None
+    build: str | None
+    edition: str | None
+    reachable: bool
+    probed_at: datetime
+    probe_method: str       # e.g. "GET /api/about" for vSphere REST
+    extras: Mapping[str, Any]
+```
+
+Cached server-side keyed by `target.name`. Used by version-tagged doc/kb shelf lookup, operation-set selection, MCP capability advertisement.
+
+### `ProbeResult`
+
+```python
+class ProbeResult(BaseModel):
+    ok: bool
+    reason: str | None
+    latency_ms: float | None
+    probed_at: datetime
+```
+
+Lightweight reachability + auth-challenge. Reused as a readiness probe in the [chassis registry](../../backend/src/meho_backplane/health.py).
+
+### `OperationResult`
+
+```python
+class OperationResult(BaseModel):
+    status: str            # "ok" | "error" | "denied"
+    op_id: str
+    result: dict | list | None
+    error: str | None
+    duration_ms: float
+    extras: Mapping[str, Any]
+```
+
+Raw response in `result`. JSONFlux result-handle wrapping for large sets is an external concern (set-shaped ops > 20 rows return a handle reference; full set fetched via a follow-up op).
+
+### `AuthModel` (per-target identity model per v0.1-spec L447–454)
+
+```python
+class AuthModel(StrEnum):
+    IMPERSONATION = "impersonation"               # forward operator JWT (vSphere SSO etc.)
+    SHARED_SERVICE_ACCOUNT = "shared_service_account"  # single SA per connector (Vault, bind9, NSX)
+    PER_USER = "per_user"                         # per-operator cred in Vault (Harbor etc.)
+```
+
+Stored on every `Target` row (G0.3); read by the connector at `execute()` time.
+
+## Adapter shapes (G0.2-T3 / T4)
+
+Two abstract intermediates between `Connector` and the vendor implementations:
+
+```
+Connector (ABC)
+├── HttpConnector       — httpx.AsyncClient pool, tenacity retry, SSL_CERT_FILE
+│   ├── VaultConnector  — refactor of auth/vault.py (G0.2-T5; reference impl)
+│   ├── VSphereConnector — vSphere REST API (G3.1)
+│   ├── NSXConnector
+│   ├── HarborConnector
+│   └── ... (HTTP-API vendors)
+└── SshConnector         — asyncssh, key+password, per-target connection pool
+    ├── Bind9Connector
+    ├── PfsenseConnector
+    └── HolodeckConnector
+```
+
+**HTTP adapter** (T3): shared `httpx.AsyncClient` per target with retry on idempotent verbs only, `SSL_CERT_FILE` honored natively for the trust-bundle wiring from PR #212.
+
+**SSH adapter** (T4): asyncssh (async-native, no thread offload — beats paramiko for the event loop). Per-target connection cached; closed on lifespan teardown.
+
+## Library choices
+
+| Concern | Choice | Why |
+|---|---|---|
+| HTTP transport | `httpx` | Already in chassis, async, http2-capable, honors `SSL_CERT_FILE`. |
+| Retry policy | `tenacity` (planned T3) | Exponential backoff, exception-type filtering. |
+| SSH transport | `asyncssh` (planned T4) | Async-native (no `to_thread` offload). |
+| Vault client | `hvac` (chassis-era) | Sync, wrapped in `asyncio.to_thread` already. |
+| Vendor: vSphere | **vSphere REST API** | NOT pyvmomi (SOAP, sync). NOT govc subprocess. v0.2 returns 501 for REST gaps; v0.2.next adds a govc fallback if needed. |
+| Vendor: Kubernetes | **Not yet decided** | `kubernetes_asyncio` is the lean; will be locked when the Kubernetes connector Initiative is filed under G3. |
+
+## The registry
+
+Module-level dict in `connectors/registry.py` (G0.2-T2, PR #295 open). Mirrors the chassis [`register_probe`](../../backend/src/meho_backplane/health.py) pattern:
+
+```python
+register_connector("vsphere", VSphereConnector)
+get_connector("vsphere")  # → VSphereConnector class
+```
+
+Eager-imported at app startup via the FastAPI `lifespan` so module-side `register_connector(...)` calls land before the first request. Duplicate registration raises `RuntimeError` — programmer bug, surfaces at boot, never at request time.
+
+## Op dispatch flow
+
+For a CLI call like `meho vsphere vm.list --target rdc-vcenter`:
+
+1. CLI → `POST /api/v1/connectors/vsphere/vm.list` body `{target: "rdc-vcenter", params: {...}}`
+2. FastAPI handler → `resolve_target(operator.tenant_id, "rdc-vcenter")` (G0.3) → `Target` row.
+3. → `get_connector("vsphere")` → `VSphereConnector` class.
+4. → `connector.execute(target, "vsphere.vm.list", params)`.
+5. Connector looks up `op_id` in its per-product `_op_map`, runs the operation against the vendor.
+6. Returns `OperationResult(status="ok", result=[...], duration_ms=42.3)`.
+7. `AuditMiddleware` writes one row with `tenant_id`, `target_id`, `op_id`, `params_hash`.
+8. G6 broadcast publishes an event (aggregate-only for `credential_read` op-class per decision #3 in [v0.2-decisions.md](../planning/v0.2-decisions.md)).
+9. MCP path mirrors this: `tools/call name="vsphere.vm.list"` dispatches via the same `_op_map`.
+
+## Adding a new connector
+
+Once G0.2 fully lands:
+
+1. **Create the package** at `backend/src/meho_backplane/connectors/<product>/`.
+2. **Implement the subclass** in `connector.py`:
+   ```python
+   class HarborConnector(HttpConnector):
+       product = "harbor"
+
+       async def fingerprint(self, target): ...
+       async def probe(self, target): ...
+       async def execute(self, target, op_id, params): ...
+
+       _op_map = {
+           "harbor.project.list": _harbor_project_list,
+           "harbor.repository.list": _harbor_repository_list,
+       }
+   ```
+3. **Register at module top** in `__init__.py`:
+   ```python
+   from meho_backplane.connectors.registry import register_connector
+   from .connector import HarborConnector
+   register_connector("harbor", HarborConnector)
+   ```
+4. **Register MCP tools** per operation in `mcp/tools/harbor.py` (the registry from G0.5):
+   ```python
+   register_mcp_tool(
+       ToolDefinition(
+           name="harbor.project.list",
+           description="List Harbor projects accessible to the operator. ...",
+           inputSchema={"type": "object", "properties": {...}},
+           required_role=TenantRole.OPERATOR,
+           op_class="read",
+       ),
+       handler=_harbor_project_list_mcp_handler,
+   )
+   ```
+5. **Restart.** Lifespan eager-import picks up both the connector and the MCP tools.
+6. **Operator side:** `meho targets create --product harbor --host harbor.evba.lab ...` (or `meho targets import` from a `targets.yaml` entry).
+7. **Verify:** `meho targets probe harbor-evba` → fingerprint. `meho harbor project.list` → ops.
+
+### As an Initiative
+
+For team workflow:
+
+- File an Initiative under [#214](https://github.com/evoila/meho/issues/214) — `G3.x Initiative: <Product> connector`.
+- ~6 Tasks per connector: probe + fingerprint, auth flow, 4–6 high-frequency operations, MCP tool registrations, vendor-simulator integration test (vcsim for vSphere; SSH container for SSH connectors).
+
+## What's intentionally out of scope
+
+- **Streaming / long-running ops** — v0.2 returns a single `OperationResult`; progress notifications + cancellation are v0.2.next.
+- **Raw command passthrough** (`pyvmomi.call(...)`, `kubectl(args)`) — implementation-coupling + policy-tractability problems. Coverage gaps that auto-derivation + hand-written ops can't fill produce a structured `OperationResult(status="error", error="unsupported_op")` that becomes a backlog ticket.
+- **Runbooks (multi-step composition)** — deferred to v0.2.next as a thin layer above `execute()`.
+- **Custom JSON-Schema-shaped param overrides per operator** — v0.2 ships the param schemas the op_map declares; tenant-specific tweaks are out of scope.
+
+## References
+
+- v0.1-spec §"Versioned connectors + targets" L267–292 — fingerprint cache, target as instance.
+- v0.1-spec §"Operations" L294–311 — three sources (auto-derived OpenAPI primary, hand-written secondary, runbooks tertiary).
+- v0.1-spec §"Per-target identity model" L447–454 — the AuthModel enum origin.
+- Consumer-needs.md §G3 L72–101 — contract requirements + connector tier priority.
+- [docs/planning/v0.2-decisions.md](../planning/v0.2-decisions.md) — locked decisions (track count, library choices, sequencing).
+- [docs/architecture/mcp.md](mcp.md) — the parallel MCP-tool registry every operation also registers against.

--- a/docs/architecture/connectors.md
+++ b/docs/architecture/connectors.md
@@ -91,27 +91,27 @@ class AuthModel(StrEnum):
 
 Stored on every `Target` row (G0.3); read by the connector at `execute()` time.
 
-## Adapter shapes (G0.2-T3 / T4)
+## Adapter shapes (planned: G0.2-T3 / T4)
 
-Two abstract intermediates between `Connector` and the vendor implementations:
+> **Status:** None of the subclasses below exist yet. G0.2-T1 (ABC + result models) has landed; G0.2-T3 (HTTP adapter), G0.2-T4 (SSH adapter), and G0.2-T5 (`VaultConnector` reference refactor) are still open. The tree is the target hierarchy each vendor Initiative under [G3 (#214)](https://github.com/evoila/meho/issues/214) will register against once the adapters land.
 
-```
-Connector (ABC)
-├── HttpConnector       — httpx.AsyncClient pool, tenacity retry, SSL_CERT_FILE
-│   ├── VaultConnector  — refactor of auth/vault.py (G0.2-T5; reference impl)
+```text
+Connector (ABC)                                      ← G0.2-T1 (shipped)
+├── HttpConnector       — httpx.AsyncClient pool, tenacity retry, SSL_CERT_FILE   ← G0.2-T3 (planned)
+│   ├── VaultConnector  — refactor of auth/vault.py (G0.2-T5; reference impl)     ← G0.2-T5 (planned)
 │   ├── VSphereConnector — vSphere REST API (G3.1)
 │   ├── NSXConnector
 │   ├── HarborConnector
 │   └── ... (HTTP-API vendors)
-└── SshConnector         — asyncssh, key+password, per-target connection pool
+└── SshConnector         — asyncssh, key+password, per-target connection pool     ← G0.2-T4 (planned)
     ├── Bind9Connector
     ├── PfsenseConnector
     └── HolodeckConnector
 ```
 
-**HTTP adapter** (T3): shared `httpx.AsyncClient` per target with retry on idempotent verbs only, `SSL_CERT_FILE` honored natively for the trust-bundle wiring from PR #212.
+**HTTP adapter** (T3, planned): shared `httpx.AsyncClient` per target with retry on idempotent verbs only, `SSL_CERT_FILE` honored natively for the trust-bundle wiring from PR #212.
 
-**SSH adapter** (T4): asyncssh (async-native, no thread offload — beats paramiko for the event loop). Per-target connection cached; closed on lifespan teardown.
+**SSH adapter** (T4, planned): asyncssh (async-native, no thread offload — beats paramiko for the event loop). Per-target connection cached; closed on lifespan teardown.
 
 ## Library choices
 
@@ -135,7 +135,9 @@ get_connector("vsphere")  # → VSphereConnector class
 
 Eager-imported at app startup via the FastAPI `lifespan` so module-side `register_connector(...)` calls land before the first request. Duplicate registration raises `RuntimeError` — programmer bug, surfaces at boot, never at request time.
 
-## Op dispatch flow
+## Op dispatch flow (target shape, once G0.2-T2 / G0.3 land)
+
+> **Status:** today's shipped substrate is the ABC + result models. The remaining pieces — connector registry ([G0.2-T2 / PR #295, open](https://github.com/evoila/meho/pull/295)), targets-as-data ([G0.3 / #224, open](https://github.com/evoila/meho/issues/224)), `_op_map` per connector, the `/api/v1/connectors/...` route surface, and the G6 broadcast hook — are not yet wired. The flow below is the **target shape** every Initiative under #214 / #220 / #217 will land against.
 
 For a CLI call like `meho vsphere vm.list --target rdc-vcenter`:
 

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -111,11 +111,11 @@ Every G3–G9 tool registration MUST pass a description review before merge.
 
 ## Audit integration
 
-MCP handlers write their own audit rows per `tools/call` and `resources/read`, **not** via the chassis `AuditMiddleware`. The middleware path-excludes `/mcp/*` requests because the JSON-RPC envelope carries multiple potential ops — one audit row per HTTP request would be wrong granularity.
+Per [G0.5-T5 (#250, PR #300)](https://github.com/evoila/meho/pull/300): MCP handlers write their own audit rows per `tools/call` and `resources/read`, **not** via the chassis `AuditMiddleware`. The middleware path-excludes `/mcp` requests (see `_AUDIT_SKIP_PATH_PREFIXES` in [`audit.py`](../../backend/src/meho_backplane/audit.py)) because the JSON-RPC envelope carries multiple potential ops — one audit row per HTTP request would be wrong granularity for G8's audit queries.
 
-MCP audit row shape (G0.5-T5 spec):
+The per-operation writer is [`mcp/audit.py::write_mcp_audit_row`](../../backend/src/meho_backplane/mcp/audit.py), called from inside [`mcp/handlers.py`](../../backend/src/meho_backplane/mcp/handlers.py) for both `tools/call` and `resources/read`. MCP audit row shape:
 
-```
+```text
 operator_sub  ← from JWT (validated by /mcp auth chain)
 tenant_id     ← operator.tenant_id
 request_id    ← from RequestContextMiddleware (still runs)

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -1,0 +1,198 @@
+# MCP server architecture
+
+How MEHO speaks the Model Context Protocol alongside its HTTP API. The substrate landed in [G0.5 (#226)](https://github.com/evoila/meho/issues/226); every G3–G9 connector Initiative will register MCP tools against this server.
+
+## Why MCP-in-v0.2
+
+The locked decision (#7 in [v0.2-decisions.md](../planning/v0.2-decisions.md)) was to ship MCP alongside the CLI in v0.2 rather than defer to v0.2.next. Two consequences:
+
+- Every G3–G9 verb gains a parallel MCP tool definition.
+- External pilots (the first being a customer beyond `rdc-internal`) get day-1 agent-native access via Claude Desktop, Cline, Continue, or any MCP-spec-conformant client.
+
+## Spec target
+
+**[MCP 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18)**. Pinned in [`mcp/schemas.py`](../../backend/src/meho_backplane/mcp/schemas.py) as `PROTOCOL_VERSION`. Future revisions will need an ADR + a coordinated upgrade.
+
+## Transport
+
+**Streamable HTTP**, not stdio. MEHO is a hosted server, not a local subprocess. The `/mcp` route accepts JSON-RPC 2.0 POST requests with a single envelope per body (batch arrays are unsupported — MCP Streamable HTTP transport mandates single envelopes).
+
+Response shapes per the spec's *Sending Messages to the Server* section:
+
+| Input | Response |
+|---|---|
+| Request (has `id`) | HTTP 200 + JSON-RPC envelope |
+| Notification (no `id`) | HTTP 202 Accepted with no body |
+| Parse error | HTTP 200 + `error: { code: -32700, ... }` |
+| Invalid request | HTTP 200 + `error: { code: -32600, ... }` |
+| Unsupported `MCP-Protocol-Version` | **HTTP 400** + JSON-RPC error envelope (spec MUST) |
+| Missing/invalid Bearer token | HTTP 401 + `WWW-Authenticate: Bearer resource_metadata="..."` |
+| Insufficient scope/role | HTTP 403 |
+| GET on `/mcp` | HTTP 405 (FastAPI default; SSE-on-GET unimplemented in v0.2) |
+
+## OAuth 2.1 resource-server pattern
+
+MEHO acts as an **OAuth 2.1 resource server** per [RFC 9728 (Protected Resource Metadata)](https://datatracker.ietf.org/doc/html/rfc9728) + [RFC 8707 (Resource Indicators)](https://www.rfc-editor.org/rfc/rfc8707.html). The flow:
+
+1. Client sends request without token → server returns **401** + `WWW-Authenticate: Bearer resource_metadata="<backplane>/.well-known/oauth-protected-resource"`.
+2. Client fetches PR metadata at the URL in step 1.
+3. Client follows OAuth 2.1 (PKCE + `resource` parameter) against the discovered Keycloak authorization server.
+4. Client retries with `Authorization: Bearer <token>`. Server validates `aud` matches `MCP_RESOURCE_URI`.
+
+**PR metadata document** at [`/.well-known/oauth-protected-resource`](../../backend/src/meho_backplane/api/well_known.py) returns:
+
+```json
+{
+  "resource": "https://meho.evba.lab/mcp",
+  "authorization_servers": ["https://keycloak.evba.lab/realms/evba"],
+  "scopes_supported": ["mcp:read", "mcp:execute"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+**Critical:** the MCP audience is **distinct** from the chassis HTTP API audience. An HTTP-API JWT (audience = `KEYCLOAK_AUDIENCE`) is rejected at `/mcp` with 401. Clients call MEHO at MCP-shaped or HTTP-shaped endpoints with the appropriate token, not interchangeably.
+
+## Tool registry + Resource registry
+
+Two parallel registries in [`mcp/registry.py`](../../backend/src/meho_backplane/mcp/registry.py):
+
+### `ToolDefinition` + handler
+
+```python
+class ToolDefinition(BaseModel):
+    name: str                # dotted: "meho.status", "vault.kv.read"
+    description: str         # agent-facing — LOAD-BEARING for UX
+    inputSchema: dict        # JSON Schema 2020-12
+    outputSchema: dict | None
+    required_role: TenantRole  # MEHO-internal; dropped from wire shape
+    op_class: str              # "read" | "write" | "credential_read" | "audit_query"
+```
+
+Wire shape (returned via `tools/list`) drops `required_role` and `op_class` — clients shouldn't see server-side policy.
+
+### `ResourceTemplateDefinition` + handler
+
+```python
+class ResourceTemplateDefinition(BaseModel):
+    uriTemplate: str           # RFC 6570: "meho://tenant/{tenant_id}/info"
+    name: str
+    description: str
+    mimeType: str = "application/json"
+    required_role: TenantRole
+```
+
+**Spec correctness note:** v0.2 uses `resources/templates/list`, not `resources/list`. Per the 2025-06-18 spec, concrete-URI resources go through `resources/list`; templated resources go through `resources/templates/list`. Every MEHO resource carries a template, so v0.2's `resources/list` response is always empty.
+
+### Registration discipline
+
+[`mcp/registry.py`](../../backend/src/meho_backplane/mcp/registry.py) enforces three reject-at-boot rules for resources:
+
+- Duplicate placeholder names within one template (e.g., `meho://tenant/{id}/{id}`).
+- Exact-duplicate `uriTemplate` strings.
+- Same-shape collision (e.g., `meho://kb/{slug}` and `meho://kb/{id}` would silently shadow).
+
+Surface failures at boot, never at request time.
+
+## RBAC filtering
+
+Every registered tool/resource carries a `required_role` (one of `read_only` / `operator` / `tenant_admin`). The list methods filter the registry against the calling operator's `tenant_role`; tools/resources above the operator's role rank don't appear in the response. Role rank declared as a pinned tuple in [`mcp/registry.py`](../../backend/src/meho_backplane/mcp/registry.py) — `read_only < operator < tenant_admin`.
+
+Helper `role_at_least(actual, required)` is the single source for the role ordering, used by both list-time filtering and call-time re-checks.
+
+## Tool description quality
+
+Per AI-engineering best-practices: **the description IS the agent's prompt for when to use the tool.** Imprecise descriptions get tools called incorrectly.
+
+Good: "Returns the operator's identity (sub, tenant) plus the MEHO backplane's dependency status (Vault reachable, DB migrated). Use at session start to verify the MCP session can reach all subsystems. No arguments required."
+
+Bad: "Status check tool."
+
+Every G3–G9 tool registration MUST pass a description review before merge.
+
+## Audit integration
+
+MCP handlers write their own audit rows per `tools/call` and `resources/read`, **not** via the chassis `AuditMiddleware`. The middleware path-excludes `/mcp/*` requests because the JSON-RPC envelope carries multiple potential ops — one audit row per HTTP request would be wrong granularity.
+
+MCP audit row shape (G0.5-T5 spec):
+
+```
+operator_sub  ← from JWT (validated by /mcp auth chain)
+tenant_id     ← operator.tenant_id
+request_id    ← from RequestContextMiddleware (still runs)
+method        ← "MCP"
+path          ← "/mcp/tools/call/{tool_name}" or "/mcp/resources/read/{uri}"
+status_code   ← 200 / 400 / 403 / 404 / 500 (derived from JSON-RPC outcome)
+duration_ms   ← time.monotonic() bracket
+payload       ← {op_id, params_hash, op_class}
+```
+
+Fail-closed: audit write failure → MCP call fails with JSON-RPC `INTERNAL_ERROR` (-32603). Compliance-critical.
+
+`params_hash` is SHA256 of canonicalized (sorted-keys JSON) arguments — content-addressable, deterministic, doesn't leak the args.
+
+## Adding an MCP tool
+
+For a new vendor connector op:
+
+1. **Implement the op** in your connector's `_op_map` (per [`connectors.md`](connectors.md)).
+2. **Register an MCP tool** in `backend/src/meho_backplane/mcp/tools/<product>.py`:
+   ```python
+   register_mcp_tool(
+       ToolDefinition(
+           name="vsphere.vm.list",
+           description="List VMs visible to the operator's vSphere session, ...",
+           inputSchema={
+               "type": "object",
+               "properties": {
+                   "target": {"type": "string", "description": "Target name or alias."},
+                   "folder": {"type": "string", "description": "Optional folder filter."},
+               },
+               "required": ["target"],
+               "additionalProperties": False,
+           },
+           required_role=TenantRole.OPERATOR,
+           op_class="read",
+       ),
+       handler=_vsphere_vm_list_handler,
+   )
+   ```
+3. **Lifespan eager-import** picks it up on restart.
+4. **Verify** via `tools/list` then `tools/call` against a running backplane (use `@modelcontextprotocol/inspector`).
+
+## Adding an MCP resource
+
+```python
+register_mcp_resource(
+    ResourceTemplateDefinition(
+        uriTemplate="meho://kb/{slug}",
+        name="Knowledge-base entry",
+        description="One kb entry by slug. Tenant-scoped to the operator's tenant.",
+        mimeType="text/markdown",
+        required_role=TenantRole.OPERATOR,
+    ),
+    handler=_kb_entry_handler,
+)
+```
+
+Handler receives `(operator, bound_params)` where `bound_params = {"slug": "..."}`. Must validate `operator.tenant_id` matches whatever tenant scope the resource is supposed to honor — cross-tenant reads return 403.
+
+## What's intentionally out of scope
+
+- **Stdio transport** — MEHO is hosted.
+- **Dynamic Client Registration (RFC 7591)** — operators register MCP clients manually in Keycloak. v0.2.next polish.
+- **Resource subscriptions** (`resources/subscribe`) — v0.2 advertises `subscribe: false`.
+- **`listChanged` notifications** — v0.2 advertises `listChanged: false` on both tools and resources.
+- **MCP prompts / sampling / roots** — defined in the spec but not load-bearing for v0.2's operator surface.
+- **Server-initiated progress notifications + cancellation** — all v0.2 tools are short-lived.
+- **Inter-server delegation** (MEHO as MCP client to a downstream MCP server) — out of scope; MEHO is the leaf server.
+
+## References
+
+- [MCP 2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18) (the binding contract).
+- [MCP 2025-06-18 Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) — OAuth 2.1 resource-server pattern.
+- [MCP 2025-06-18 Lifecycle](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle) — initialize, notifications/initialized.
+- [MCP 2025-06-18 Tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) — tool definition + invocation.
+- [MCP 2025-06-18 Resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources) — resource definition + templates/list vs list.
+- [RFC 9728 (Protected Resource Metadata)](https://datatracker.ietf.org/doc/html/rfc9728), [RFC 8707 (Resource Indicators)](https://www.rfc-editor.org/rfc/rfc8707.html), [OAuth 2.1 draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13).
+- [docs/planning/v0.2-decisions.md](../planning/v0.2-decisions.md) — decision #7 (ship MCP in v0.2).
+- [docs/architecture/connectors.md](connectors.md) — the parallel connector op registry every MCP tool wraps.


### PR DESCRIPTION
## Summary

Captures the v0.2 connector + MCP architecture for [#221 G0](https://github.com/evoila/meho/issues/221).

What is **shipped** at merge time (substrate):

- Connector ABC + result schemas — [G0.2-T1 / #240](https://github.com/evoila/meho/issues/240) ([base.py](backend/src/meho_backplane/connectors/base.py), [schemas.py](backend/src/meho_backplane/connectors/schemas.py))
- MCP JSON-RPC dispatch + lifecycle — [G0.5-T1 / #246](https://github.com/evoila/meho/issues/246) ([server.py](backend/src/meho_backplane/mcp/server.py), [schemas.py](backend/src/meho_backplane/mcp/schemas.py))
- OAuth 2.1 resource-server chain — [G0.5-T2 / #247](https://github.com/evoila/meho/issues/247) ([mcp/auth.py](backend/src/meho_backplane/mcp/auth.py), [well_known.py](backend/src/meho_backplane/api/well_known.py))
- Tool + resource registries with RBAC + jsonschema — [G0.5-T3 / #248](https://github.com/evoila/meho/issues/248) ([registry.py](backend/src/meho_backplane/mcp/registry.py))
- Reference tool + resource — [G0.5-T4 / #249](https://github.com/evoila/meho/issues/249) ([meho_status.py](backend/src/meho_backplane/mcp/tools/meho_status.py), [tenant_info.py](backend/src/meho_backplane/mcp/resources/tenant_info.py))
- Per-operation MCP audit + chassis `/mcp` path-exclusion — [G0.5-T5 / #250 / PR #300](https://github.com/evoila/meho/pull/300) ([mcp/audit.py](backend/src/meho_backplane/mcp/audit.py), [audit.py](backend/src/meho_backplane/audit.py))

What is **planned and labeled as such** in the docs (target shape, not yet wired):

- Connector registry — [G0.2-T2 / PR #295 open](https://github.com/evoila/meho/pull/295)
- HTTP + SSH adapters and `VaultConnector` reference refactor — [G0.2-T3 / T4 / T5](https://github.com/evoila/meho/issues/223)
- Targets-as-data — [G0.3 / #224 open](https://github.com/evoila/meho/issues/224)
- Backplane `/api/v1/connectors/...` route surface and per-connector `_op_map` — land alongside the adapters above
- G3–G9 vendor Initiatives — all downstream of #214 / #217 / #220 etc.

Files:

- **[docs/architecture/connectors.md](docs/architecture/connectors.md)** — Connector ABC, result models, planned adapter hierarchy, library choices, registry + dispatch flow (target shape), procedure for adding a connector once the adapters land.
- **[docs/architecture/mcp.md](docs/architecture/mcp.md)** — MCP 2025-06-18 spec target, Streamable HTTP transport, OAuth 2.1 resource-server (RFC 9728 + RFC 8707), tool + resource template registries with RBAC, audit integration via T5's `mcp/audit.py`, registration discipline, "how to add" procedures.

Both docs cross-link to [docs/planning/v0.2-decisions.md](docs/planning/v0.2-decisions.md) for the locked strategic decisions.

## Test plan

- [x] Markdown renders cleanly (relative repo links, GitHub issue links, line-anchored file references).
- [x] No code change — docs-only addition under `docs/architecture/`.
- [x] Cross-references to [docs/planning/v0.2-decisions.md](docs/planning/v0.2-decisions.md) (PR #230) for decision context.
- [x] Every code-cited file path exists at the linked location (verified against `backend/src/meho_backplane/`).
- [x] All quoted code shapes match source files (ABC signatures, frozen result models with `MappingProxyType`, `ToolDefinition` / `ResourceTemplateDefinition`, `to_wire()` field stripping, `_ROLE_RANK` tuple, `PROTOCOL_VERSION = "2025-06-18"`).
- [x] Markdownlint MD040 cleared on both files (ASCII blocks tagged `text`).

Refs #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added connector architecture docs describing connector contract, registration/boot behavior, operation dispatch flow, adapter patterns, auth/result shapes, verification steps, and explicit out-of-scope items.
  * Added MCP server architecture docs covering MCP transport and auth, tool/resource registries and registration rules, RBAC filtering, audit behavior, versioning guidance, "how to add" instructions, and out-of-scope clarifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/319)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->