### PR TITLE
docs(planning): lock decision #8 — K8s connector library = kubernetes_asyncio

### DIFF
--- a/docs/planning/v0.2-decisions.md
+++ b/docs/planning/v0.2-decisions.md
@@ -107,6 +107,21 @@ MEHO speaks MCP from v0.2 day 1. Bootstrap filed as G0.5 (#226). Every G3–G9 I
 
 **Why:** Damir chose the aggressive option (ship-in-v0.2 vs defer-to-v0.2.next). Doubles surface area per verb (every CLI command gets an MCP tool definition) but collapses the timeline to external pilot. Risk: MCP spec is still iterating; pin to 2025-06-18 and document upgrade discipline.
 
+### 8. Kubernetes connector library — **`kubernetes_asyncio`**
+
+The Kubernetes connector (G3.2, filed against #214) uses **`kubernetes_asyncio`** as its API client:
+
+- Async fork of the official Python Kubernetes client. Mature, maintained, broad API coverage (CoreV1 / AppsV1 / NetworkingV1 / etc.).
+- Loads kubeconfig from a dict — direct fit for the `kubeconfig` field in each k8s target's Vault `secret_ref` (per the consumer's `targets.yaml` shape).
+- No thread offload needed (async-native), unlike the official sync `kubernetes` client.
+- Apache-2.0 licensed.
+
+**Rejected alternatives:**
+- **`kr8s`** — newer, async-first, lighter footprint, but smaller community + smaller API surface coverage. Reconsider in v0.2.next if `kubernetes_asyncio` API gaps surface.
+- **`kubectl` subprocess** — matches the consumer's `kubectl-vcf.sh` shape today, but ugly architecturally + subprocess-per-op cost + harder to test.
+
+**Why:** Kubernetes is quasi-tier-1 by usage frequency in the consumer's wrapper inventory (`kubectl-vcf.sh` is the most-used wrapper); needs its own G3 Initiative + library choice locked before Phase 1 K8s work starts. Helm is explicitly out of v0.2 K8s connector scope; future `HelmConnector` is a separate consideration.
+
 ---
 
 ## Sequencing summary


### PR DESCRIPTION
## Summary

- Locks decision #8 in [`docs/planning/v0.2-decisions.md`](docs/planning/v0.2-decisions.md): the Kubernetes connector ([G3.2 / #320](https://github.com/evoila/meho/issues/320)) uses **`kubernetes_asyncio`** as its API client.
- Async fork of the official client, mature, broad API coverage, loads kubeconfig from a dict (direct fit for the consumer's Vault-backed targets.yaml flow), no thread offload.
- Rejected alternatives noted: `kr8s` (smaller community + API surface), `kubectl` subprocess (ugly architecturally + subprocess-per-op cost).
- Helm explicitly out of v0.2 K8s connector scope.

## Context

K8s was flagged earlier in the planning pass as quasi-tier-1 by usage frequency (the consumer's `kubectl-vcf.sh` is their most-used wrapper) but missing from the G3 tier table. Filing the Initiative + locking the library before Phase 1 K8s work starts.

## Test plan

- [x] Markdown rendered cleanly
- [x] Decision body follows the same structure as #1–#7
- [x] Forward link to G3.2 (#320) intact
- [x] No code change — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v0.2 planning documentation with strategic decision records covering technical architecture and key technology choices for the upcoming release
  * Documented evaluated alternative approaches and solutions with detailed implementation rationale to provide transparency, context, and architectural guidance  
  * Established explicit conditions and criteria for future reconsideration of key architectural decisions made during this planning cycle

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->