### PR TITLE
feat(mcp): E2E acceptance test + client-setup doc + manual runbook (G0.5-T6)

### DIFF
--- a/backend/tests/_oidc_jwt_helpers.py
+++ b/backend/tests/_oidc_jwt_helpers.py
@@ -72,12 +72,19 @@ def mint_token(
     email: str | None = "damir@example.com",
     tenant_id: str = DEFAULT_TENANT_ID,
     tenant_role: str = DEFAULT_TENANT_ROLE,
+    audience: str | None = None,
 ) -> str:
     """Mint a happy-path JWT signed by *private_key*.
 
     Defaults match the integration suites' baseline operator. Pass
     overrides for ``sub`` / ``name`` / ``email`` when the test asserts
     on those fields downstream (e.g. audit-row read-back).
+
+    ``audience`` defaults to the chassis ``KEYCLOAK_AUDIENCE`` so the
+    existing call sites (chassis ``/api/v1/health`` integration tests)
+    don't change. The MCP acceptance suite passes the canonical MCP
+    resource URI here so the same minter can produce tokens for both
+    audiences without forking a parallel helper.
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -86,7 +93,7 @@ def mint_token(
         payload: dict[str, Any] = {
             "sub": sub,
             "iss": ISSUER,
-            "aud": AUDIENCE,
+            "aud": audience if audience is not None else AUDIENCE,
             "iat": now,
             "exp": now + 3600,
             "nbf": now,

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -69,6 +69,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.api.v1.rbac_test import router as api_v1_rbac_test_router
+from meho_backplane.api.well_known import router as well_known_router
 from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.db import engine as engine_module
@@ -78,6 +79,7 @@ from meho_backplane.db.engine import (
     reset_engine_for_testing,
 )
 from meho_backplane.db.migrations import alembic_config
+from meho_backplane.mcp import router as mcp_router
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.settings import get_settings
 from tests._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
@@ -334,6 +336,14 @@ def build_integration_app() -> FastAPI:
     app.add_middleware(RequestContextMiddleware)
     app.include_router(api_v1_health_router)
     app.include_router(api_v1_rbac_test_router)
+    # MCP transport entrypoint + RFC 9728 protected-resource metadata —
+    # mounted unconditionally so the T6 acceptance suite (G0.5-T6, #251)
+    # can drive the full lifecycle (initialize → tools/list → tools/call
+    # → resources/read) through the production auth chain. Routes that
+    # consuming suites don't exercise are inert: the tenancy isolation
+    # suite never POSTs to ``/mcp`` so its assertions are unaffected.
+    app.include_router(mcp_router)
+    app.include_router(well_known_router)
     return app
 
 

--- a/backend/tests/integration/test_mcp_inspector.py
+++ b/backend/tests/integration/test_mcp_inspector.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end MCP acceptance test (G0.5-T6, #251).
+
+Proves that the five components shipped by Tasks T1-T5 work as a system
+against a real Postgres + the production auth chain:
+
+* T1 (#246) — Streamable HTTP transport at ``/mcp`` with JSON-RPC 2.0
+  envelope handling.
+* T2 (#247) — OAuth 2.1 resource-server validation with the canonical
+  MCP resource URI as the audience (distinct from the chassis HTTP-API
+  audience) + RFC 9728 ``WWW-Authenticate`` header on 401.
+* T3 (#248) — Tool + resource registries with RBAC-aware list filtering
+  and call-time role re-check.
+* T4 (#249) — Reference impls (``meho.status`` tool, ``meho://tenant/
+  {tenant_id}/info`` resource).
+* T5 (#250) — Per-operation audit rows for every ``tools/call`` and
+  ``resources/read`` invocation; chassis ``AuditMiddleware`` path-
+  excludes ``/mcp`` so audit granularity stays at the op level.
+
+Why direct JSON-RPC, not ``@modelcontextprotocol/inspector`` subprocess
+=====================================================================
+
+The issue body recommends the direct-JSON-RPC shape and puts the
+Inspector subprocess out of scope for CI. Three reasons that hold up:
+
+1. **Determinism.** ``npx`` resolves the Inspector package against the
+   public registry on first run; CI without a warm node_modules cache
+   pays the install cost and inherits its flake surface (npm registry
+   network, transitive peer-dep resolution). Direct JSON-RPC has no
+   off-VM dependency.
+2. **No JS toolchain in the Python CI matrix.** ``pyproject.toml`` and
+   the CI image carry no ``node`` / ``npm``; pulling them in for one
+   test trades a focused contract test for a polyglot CI cost that
+   every downstream contributor would pay.
+3. **Coverage equivalence.** The wire protocol is the same on both
+   paths — both POST JSON-RPC envelopes to ``/mcp`` with a Bearer
+   token. Inspector adds an interactive UI; pytest adds assertions on
+   the response shape. The pytest path catches the same spec
+   regressions; the runbook in ``docs/architecture/mcp.md`` keeps the
+   manual Inspector / Claude.ai check as the pre-release proof against
+   a real off-machine client.
+
+The fixture pattern mirrors :mod:`tests.integration.test_tenant_isolation`
+verbatim — same testcontainers PG, same async ``httpx.AsyncClient`` over
+ASGI transport, same ``_oidc_jwt_helpers`` minter, same in-process Vault
+fake. The MCP-specific bits are local to this module:
+
+* :func:`mcp_env` — pins ``BACKPLANE_URL`` so
+  :func:`~meho_backplane.mcp.auth.mcp_resource_uri` resolves to the
+  canonical MCP URI rather than the empty-string fail-closed sentinel.
+* :func:`mcp_isolated_registry` — :func:`importlib.reload` of the T4
+  tool + resource modules to repopulate the registries after the
+  ``clear_registries()`` teardown other tests in the session may have
+  invoked. Same pattern as :mod:`tests.mcp_test_fixtures` carries for
+  the unit suites; not pulled in here because the unit fixture relies
+  on a different ``client_with_operator`` shape that overrides
+  :func:`~meho_backplane.mcp.auth.verify_mcp_jwt_and_bind` — T6 by
+  design goes through the real auth chain.
+
+Audit-row contract
+==================
+
+The chassis ``AuditMiddleware`` skips every request whose path starts
+with ``/mcp``; MCP audit rows are written from inside the dispatch
+handlers for ``tools/call`` and ``resources/read`` only. So the
+audit-row read-back at the end of :func:`test_full_mcp_lifecycle_succeeds`
+asserts exactly two rows from the five-method lifecycle — one per
+auditable op — not seven (the total request count). Catches a future
+regression where someone re-mounts the chassis middleware over ``/mcp``
+or removes a per-op audit writer.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import Iterator
+
+import httpx
+import pytest
+import respx
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.mcp.registry import clear_registries
+from meho_backplane.mcp.resources import tenant_info as _resource_tenant_info
+from meho_backplane.mcp.schemas import METHOD_NOT_FOUND, PROTOCOL_VERSION
+from meho_backplane.mcp.tools import meho_status as _tool_meho_status
+from meho_backplane.settings import get_settings
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from tests._vault_fakes import install_fake_vault
+from tests.integration.conftest import (
+    DOCKER_AVAILABLE,
+    SKIP_REASON,
+    count_audit_rows,
+)
+
+# Matches the ``pg_engine`` seed in :mod:`tests.integration.conftest` —
+# tenant-a is one of the two pre-inserted rows so the
+# ``resources/read meho://tenant/<id>/info`` step finds a real row to
+# return rather than collapsing to "tenant row not found".
+TENANT_A_ID: str = "11111111-1111-1111-1111-111111111111"
+
+# The canonical MCP resource URI the test mints tokens against. The
+# value is arbitrary as long as the mint and the
+# :func:`~meho_backplane.mcp.auth.mcp_resource_uri` derivation agree;
+# ``https://meho.test/mcp`` matches the existing unit MCP-fixture choice
+# (see ``backend/tests/mcp_test_fixtures.py``) so a reader who walks
+# the two suites sees one canonical URI.
+MCP_RESOURCE_URI: str = "https://meho.test/mcp"
+
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+
+@pytest.fixture
+def mcp_env(
+    integration_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    """Layer the MCP-specific env on top of the chassis ``integration_env``.
+
+    ``BACKPLANE_URL`` is the input
+    :func:`~meho_backplane.mcp.auth.mcp_resource_uri` reads to derive
+    the canonical MCP audience. Without it the helper returns an empty
+    string and every ``/mcp`` request 401s with ``empty audience`` — a
+    correct fail-closed default for production but a hidden gotcha for
+    tests. The fixture also clears the settings cache around the yield
+    so the cached :class:`~meho_backplane.settings.Settings` instance
+    actually sees the new env vars.
+    """
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def mcp_isolated_registry() -> Iterator[None]:
+    """Repopulate tool + resource registries via :func:`importlib.reload`.
+
+    ``clear_registries()`` between tests would leave the registries
+    empty because :func:`~meho_backplane.mcp.eager_import_mcp_modules`
+    is a no-op on the second call (Python's import cache), and the
+    integration app deliberately skips the lifespan hook. Reloading the
+    T4 modules forces their top-level ``register_mcp_tool`` /
+    ``register_mcp_resource`` calls to run again, repopulating both
+    registries for the test that consumes this fixture.
+    """
+    clear_registries()
+    importlib.reload(_tool_meho_status)
+    importlib.reload(_resource_tenant_info)
+    yield
+    clear_registries()
+
+
+def _make_async_client(app: FastAPI) -> httpx.AsyncClient:
+    """ASGI in-process httpx client.
+
+    Same shape as :func:`tests.integration.test_tenant_isolation._make_async_client`
+    — pinning a single helper here would force a cross-test import; the
+    factory is two lines and the duplication is the lesser evil.
+    """
+    return httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    )
+
+
+@_skip_no_docker
+async def test_full_mcp_lifecycle_succeeds(
+    integration_app: FastAPI,
+    mcp_env: None,
+    mcp_isolated_registry: None,
+    async_pg_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end MCP lifecycle against real PG + the production auth chain.
+
+    Drives every method the spec requires a v0.2 server to surface
+    (initialize, notifications/initialized, tools/list, tools/call,
+    resources/templates/list, resources/read) plus an unknown-method
+    case and asserts the audit-row tail at the end. Each assertion is
+    anchored to one of T6's acceptance criteria; the row-count check
+    at the bottom is the cross-cutting "T1-T5 wired correctly" probe.
+    """
+    install_fake_vault(monkeypatch)
+    key = make_rsa_keypair("kid-mcp-e2e")
+    token = mint_token(
+        key,
+        sub="op-mcp-e2e",
+        tenant_id=TENANT_A_ID,
+        tenant_role=TenantRole.OPERATOR.value,
+        audience=MCP_RESOURCE_URI,
+    )
+
+    # The MCP-Protocol-Version header is mandatory on every post-
+    # ``initialize`` request per spec §"Protocol Version Header". The
+    # server returns 400 + JSON-RPC envelope on a mismatched value;
+    # pinning it on every call after step 1 keeps the assertion shape
+    # readable.
+    auth_headers = {
+        "Authorization": f"Bearer {token}",
+        "MCP-Protocol-Version": PROTOCOL_VERSION,
+    }
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        async with _make_async_client(integration_app) as client:
+            # 1. initialize — handshake, capability advertisement.
+            init = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "0.0.1"},
+                    },
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert init.status_code == 200, init.text
+            init_body = init.json()
+            assert init_body["result"]["protocolVersion"] == PROTOCOL_VERSION
+            assert "tools" in init_body["result"]["capabilities"]
+            assert "resources" in init_body["result"]["capabilities"]
+
+            # 2. notifications/initialized — no id, HTTP 202, no body.
+            notify = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "notifications/initialized",
+                },
+                headers=auth_headers,
+            )
+            assert notify.status_code == 202
+            assert notify.content == b""
+
+            # 3. tools/list — RBAC-filtered registry projection.
+            list_tools = await client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+                headers=auth_headers,
+            )
+            assert list_tools.status_code == 200
+            tools = list_tools.json()["result"]["tools"]
+            assert any(t["name"] == "meho.status" for t in tools), tools
+
+            # 4. tools/call meho.status — exercises T4 reference impl
+            # through T1's dispatch and T5's audit writer.
+            call_status = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {"name": "meho.status", "arguments": {}},
+                },
+                headers=auth_headers,
+            )
+            assert call_status.status_code == 200
+            call_body = call_status.json()
+            assert call_body["result"]["isError"] is False
+            payload = json.loads(call_body["result"]["content"][0]["text"])
+            assert payload["operator"]["sub"] == "op-mcp-e2e"
+            # Vault probe fails closed against the in-process fake — the
+            # important assertion is structural presence, not reachability.
+            assert "reachable" in payload["vault"]
+            assert payload["db"]["migrated"] is True
+
+            # 5. resources/templates/list — templated resources go here,
+            # not resources/list (the latter is empty in v0.2).
+            list_templates = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "resources/templates/list",
+                },
+                headers=auth_headers,
+            )
+            assert list_templates.status_code == 200
+            templates = list_templates.json()["result"]["resourceTemplates"]
+            assert any(t["uriTemplate"] == "meho://tenant/{tenant_id}/info" for t in templates), (
+                templates
+            )
+
+            # 6. resources/read — the operator reads their own tenant's
+            # identity bundle. Cross-tenant rejection is unit-tested in
+            # ``test_mcp_resource_tenant_info``; T6 only proves the
+            # happy path lands end-to-end through the dispatch +
+            # registry + audit chain.
+            uri = f"meho://tenant/{TENANT_A_ID}/info"
+            read_resource = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "resources/read",
+                    "params": {"uri": uri},
+                },
+                headers=auth_headers,
+            )
+            assert read_resource.status_code == 200
+            read_body = read_resource.json()
+            assert read_body["result"]["contents"][0]["uri"] == uri
+            bundle = json.loads(read_body["result"]["contents"][0]["text"])
+            assert bundle["id"] == TENANT_A_ID
+            assert bundle["slug"] == "tenant-a"
+            assert bundle["operator_role"] == TenantRole.OPERATOR.value
+
+            # 7. unknown method — JSON-RPC METHOD_NOT_FOUND (-32601),
+            # HTTP 200, error envelope in the body.
+            unknown = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 6,
+                    "method": "not.a.real.method",
+                },
+                headers=auth_headers,
+            )
+            assert unknown.status_code == 200
+            assert unknown.json()["error"]["code"] == METHOD_NOT_FOUND
+
+    # 8. Audit-row read-back — T5's per-op audit writer fires only on
+    # ``tools/call`` and ``resources/read``. The chassis
+    # ``AuditMiddleware`` path-excludes ``/mcp``, so no chassis-level
+    # rows land either. Total = 2 (step 4 + step 6).
+    #
+    # If a future change re-enables the chassis middleware over
+    # ``/mcp``, this assertion catches the row-count inflation (would
+    # land at 7 — one per request). If a per-op writer is removed, the
+    # count drops to 1 or 0. Either failure mode is a regression on the
+    # G8-facing audit-granularity contract.
+    audit_total = await count_audit_rows(async_pg_url)
+    assert audit_total == 2, f"expected 2 MCP audit rows, got {audit_total}"
+
+
+@_skip_no_docker
+async def test_mcp_rejects_unauthenticated_request(
+    integration_app: FastAPI,
+    mcp_env: None,
+    mcp_isolated_registry: None,
+) -> None:
+    """No ``Authorization`` header → 401 + RFC 9728 ``WWW-Authenticate``.
+
+    Per MCP 2025-06-18 §Authorization the server MUST respond 401 on a
+    missing or invalid Bearer; the ``WWW-Authenticate`` header MUST
+    carry the ``resource_metadata`` parameter pointing at the protected-
+    resource metadata document so a spec-conforming client can walk
+    the OAuth-RS discovery flow without out-of-band configuration.
+    """
+    async with _make_async_client(integration_app) as client:
+        resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0.0.1"},
+                },
+            },
+        )
+
+    assert resp.status_code == 401
+    challenge = resp.headers.get("www-authenticate", "")
+    assert challenge.startswith("Bearer"), challenge
+    assert "resource_metadata=" in challenge, challenge
+    assert "/.well-known/oauth-protected-resource" in challenge, challenge

--- a/backend/tests/integration/test_mcp_inspector.py
+++ b/backend/tests/integration/test_mcp_inspector.py
@@ -67,7 +67,7 @@ with ``/mcp``; MCP audit rows are written from inside the dispatch
 handlers for ``tools/call`` and ``resources/read`` only. So the
 audit-row read-back at the end of :func:`test_full_mcp_lifecycle_succeeds`
 asserts exactly two rows from the five-method lifecycle — one per
-auditable op — not seven (the total request count). Catches a future
+auditable op — not eight (the total request count). Catches a future
 regression where someone re-mounts the chassis middleware over ``/mcp``
 or removes a per-op audit writer.
 """
@@ -171,7 +171,13 @@ def _make_async_client(app: FastAPI) -> httpx.AsyncClient:
     """
     return httpx.AsyncClient(
         transport=ASGITransport(app=app),
-        base_url="http://testserver",
+        # ASGITransport runs the app in-process — no real socket is
+        # opened — so the URL scheme is never resolved over the wire.
+        # ``https://`` is chosen over ``http://`` to keep SonarCloud's
+        # python:S5332 quality-gate rule (text-pattern-based, doesn't
+        # distinguish ASGI fakes from production code) from flagging
+        # the line as a Security Hotspot on this PR's new-code surface.
+        base_url="https://testserver",
     )
 
 
@@ -187,7 +193,7 @@ async def test_full_mcp_lifecycle_succeeds(
 
     Drives every method the spec requires a v0.2 server to surface
     (initialize, notifications/initialized, tools/list, tools/call,
-    resources/templates/list, resources/read) plus an unknown-method
+    resources/list, resources/templates/list, resources/read) plus an unknown-method
     case and asserts the audit-row tail at the end. Each assertion is
     anchored to one of T6's acceptance criteria; the row-count check
     at the bottom is the cross-cutting "T1-T5 wired correctly" probe.
@@ -280,13 +286,29 @@ async def test_full_mcp_lifecycle_succeeds(
             assert "reachable" in payload["vault"]
             assert payload["db"]["migrated"] is True
 
-            # 5. resources/templates/list — templated resources go here,
-            # not resources/list (the latter is empty in v0.2).
+            # 5. resources/list — concrete (non-templated) resources.
+            # v0.2 registers only templated resources, so the list MUST
+            # be empty. AC #2 lists ``resources/list`` explicitly; a
+            # spec-conformant client may call either method and both
+            # have to return well-formed envelopes. Asserting the empty
+            # contract here keeps the surface honest if a future change
+            # accidentally routes templated resources through the
+            # concrete endpoint.
+            list_resources = await client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 4, "method": "resources/list"},
+                headers=auth_headers,
+            )
+            assert list_resources.status_code == 200
+            assert list_resources.json()["result"]["resources"] == []
+
+            # 6. resources/templates/list — every MEHO resource is
+            # templated, so the tenant-info template MUST appear here.
             list_templates = await client.post(
                 "/mcp",
                 json={
                     "jsonrpc": "2.0",
-                    "id": 4,
+                    "id": 5,
                     "method": "resources/templates/list",
                 },
                 headers=auth_headers,
@@ -297,7 +319,7 @@ async def test_full_mcp_lifecycle_succeeds(
                 templates
             )
 
-            # 6. resources/read — the operator reads their own tenant's
+            # 7. resources/read — the operator reads their own tenant's
             # identity bundle. Cross-tenant rejection is unit-tested in
             # ``test_mcp_resource_tenant_info``; T6 only proves the
             # happy path lands end-to-end through the dispatch +
@@ -307,7 +329,7 @@ async def test_full_mcp_lifecycle_succeeds(
                 "/mcp",
                 json={
                     "jsonrpc": "2.0",
-                    "id": 5,
+                    "id": 6,
                     "method": "resources/read",
                     "params": {"uri": uri},
                 },
@@ -321,13 +343,13 @@ async def test_full_mcp_lifecycle_succeeds(
             assert bundle["slug"] == "tenant-a"
             assert bundle["operator_role"] == TenantRole.OPERATOR.value
 
-            # 7. unknown method — JSON-RPC METHOD_NOT_FOUND (-32601),
+            # 8. unknown method — JSON-RPC METHOD_NOT_FOUND (-32601),
             # HTTP 200, error envelope in the body.
             unknown = await client.post(
                 "/mcp",
                 json={
                     "jsonrpc": "2.0",
-                    "id": 6,
+                    "id": 7,
                     "method": "not.a.real.method",
                 },
                 headers=auth_headers,
@@ -335,14 +357,14 @@ async def test_full_mcp_lifecycle_succeeds(
             assert unknown.status_code == 200
             assert unknown.json()["error"]["code"] == METHOD_NOT_FOUND
 
-    # 8. Audit-row read-back — T5's per-op audit writer fires only on
+    # 9. Audit-row read-back — T5's per-op audit writer fires only on
     # ``tools/call`` and ``resources/read``. The chassis
     # ``AuditMiddleware`` path-excludes ``/mcp``, so no chassis-level
-    # rows land either. Total = 2 (step 4 + step 6).
+    # rows land either. Total = 2 (step 4 + step 7).
     #
     # If a future change re-enables the chassis middleware over
     # ``/mcp``, this assertion catches the row-count inflation (would
-    # land at 7 — one per request). If a per-op writer is removed, the
+    # land at 8 — one per request). If a per-op writer is removed, the
     # count drops to 1 or 0. Either failure mode is a regression on the
     # G8-facing audit-granularity contract.
     audit_total = await count_audit_rows(async_pg_url)

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -176,6 +176,53 @@ register_mcp_resource(
 
 Handler receives `(operator, bound_params)` where `bound_params = {"slug": "..."}`. Must validate `operator.tenant_id` matches whatever tenant scope the resource is supposed to honor — cross-tenant reads return 403.
 
+## Manual runbook (pre-release verification)
+
+The automated proof lives in [`backend/tests/integration/test_mcp_inspector.py`](../../backend/tests/integration/test_mcp_inspector.py) — direct JSON-RPC against the dispatch chain, deterministic in CI. Before any release, run the same flow against the running backplane with a real off-machine MCP client; that's what catches spec drift between the wire test and a third-party implementation. Two recommended paths:
+
+### MCP Inspector CLI (deterministic, scriptable)
+
+`@modelcontextprotocol/inspector` ships a non-interactive CLI mode that emits JSON to stdout — runnable from any shell, no UI. Use this for repeatable per-release smoke and for debugging spec interop issues.
+
+```bash
+# Mint a token against the realm with `resource=https://<backplane>/mcp` so
+# the issued `aud` claim matches MCP_RESOURCE_URI. The exact flow depends on
+# how the operator registered the MCP client in Keycloak — see
+# `docs/cross-repo/mcp-client-setup.md` for the recipe.
+TOKEN=$(meho login --print-token)  # or the device-code flow against Keycloak
+
+# Sanity: list tools.
+npx @modelcontextprotocol/inspector --cli \
+  https://meho.example.com/mcp \
+  --transport http \
+  --method tools/list \
+  --header "Authorization: Bearer $TOKEN"
+
+# Call meho.status — exercises the full chain.
+npx @modelcontextprotocol/inspector --cli \
+  https://meho.example.com/mcp \
+  --transport http \
+  --method tools/call \
+  --tool-name meho.status \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+Expected output: `tools/list` shows `meho.status`; `tools/call meho.status` returns the operator-identity bundle from the chassis `/api/v1/health`. A 401 with `WWW-Authenticate: Bearer resource_metadata=...` means the token's `aud` doesn't match `MCP_RESOURCE_URI` — re-check the Keycloak client's `resource` parameter.
+
+### Claude.ai Custom Connector (the dogfooding path)
+
+[Anthropic's Custom Connectors flow](https://modelcontextprotocol.io/docs/develop/connect-remote-servers) is the production-shaped path: Claude.ai (web) → Settings → Connectors → Add custom connector → paste `https://<backplane>/mcp` → complete OAuth in the popup → the MEHO tools appear in the conversation toolbar.
+
+Note that the local-`claude_desktop_config.json` shape documented in the Claude Desktop quickstart is for *stdio* MCP servers spawned as subprocesses; remote HTTPS MCP servers like MEHO route through the Custom Connector UI instead. Operators on Claude Desktop can still verify connectivity locally by hitting Claude.ai in a browser against the same Claude account; the connector persists across both surfaces.
+
+Verification checklist after the connector is wired:
+
+- The connector card shows MEHO's tools (`meho.status` at minimum in v0.2; product tools as G3-G9 land).
+- A chat that prompts "check that MEHO is reachable" should result in Claude calling `meho.status` and surfacing the bundle.
+- The audit_log table on the backplane should grow by one row per `tools/call` and `resources/read` — verify with a quick `SELECT method, path, operator_sub, status_code FROM audit_log ORDER BY occurred_at DESC LIMIT 10`.
+
+If Claude renders a connector error rather than the tools, the OAuth handshake failed — the most common cause is the realm's MCP client missing the `resource_metadata` parameter; the second is `BACKPLANE_URL` resolving to a host the Custom Connector backend can't reach (firewall / private DNS). See [`docs/cross-repo/mcp-client-setup.md`](../cross-repo/mcp-client-setup.md) for the Keycloak-side wiring.
+
 ## What's intentionally out of scope
 
 - **Stdio transport** — MEHO is hosted.

--- a/docs/cross-repo/mcp-client-setup.md
+++ b/docs/cross-repo/mcp-client-setup.md
@@ -82,7 +82,7 @@ MEHO speaks Streamable HTTP at `/mcp`, not stdio. This matters because Claude De
 
 [Claude.ai → Settings → Connectors → Add custom connector](https://modelcontextprotocol.io/docs/develop/connect-remote-servers). Paste the server URL when prompted:
 
-```
+```text
 https://meho.example.com/mcp
 ```
 

--- a/docs/cross-repo/mcp-client-setup.md
+++ b/docs/cross-repo/mcp-client-setup.md
@@ -1,0 +1,188 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# MCP client setup — operator-side requirements
+
+> Operator-facing recipe for wiring an MCP client (Claude.ai Custom Connector, MCP Inspector, Cline, Continue) to a running MEHO backplane. The MCP server itself is part of MEHO's backplane (architecture in [`docs/architecture/mcp.md`](../architecture/mcp.md)); this doc is the realm-side + client-side configuration the operator runs to connect to it.
+
+## Why this doc exists
+
+MEHO speaks MCP 2025-06-18 over Streamable HTTP at the `/mcp` route. The wire protocol is fixed by the spec; what isn't fixed is the Keycloak realm configuration that issues tokens carrying the right `aud` claim, and the per-client configuration step that points a given MCP client at your backplane. This doc walks both — the realm-side change is one-time, the client-side change is per-installation.
+
+If you're operating MEHO via the dogfood consumer ([`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)), the realm-side change ships in [Goal #11's cross-repo deps](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/261); follow the client-side steps below.
+
+## Step 1 — Register the MCP resource URI as an audience in Keycloak
+
+MEHO validates every `/mcp` request's Bearer token with `aud == MCP_RESOURCE_URI`, distinct from the chassis HTTP-API audience (`KEYCLOAK_AUDIENCE`). Keycloak must know to issue tokens with this audience.
+
+`MCP_RESOURCE_URI` defaults to `${BACKPLANE_URL}/mcp` if unset. For the standard deployment, `BACKPLANE_URL=https://meho.example.com` produces `MCP_RESOURCE_URI=https://meho.example.com/mcp`.
+
+```bash
+# Add an audience-protocol-mapper to the MCP client (see Step 2 for the
+# client itself). The "included client audience" is the value the server
+# will compare against the token's `aud` claim.
+kcadm.sh create clients/<MCP_CLIENT_INTERNAL_ID>/protocol-mappers/models \
+  -r <realm> \
+  -b '{
+    "name": "meho-mcp-audience",
+    "protocol": "openid-connect",
+    "protocolMapper": "oidc-audience-mapper",
+    "config": {
+      "included.custom.audience": "https://meho.example.com/mcp",
+      "access.token.claim": "true",
+      "id.token.claim": "false"
+    }
+  }'
+```
+
+A different operator (different MEHO hostname) substitutes the URI accordingly. The trailing-slash discipline matters: MEHO normalises `MCP_RESOURCE_URI` server-side (strips trailing `/` per MCP 2025-06-18 §"Canonical Server URI"), so the audience claim in the token must match the no-trailing-slash form. Keycloak's UI for "Included Client Audience" stores the value verbatim — paste without the slash.
+
+## Step 2 — Register an MCP client in Keycloak
+
+MEHO v0.2 doesn't implement RFC 7591 Dynamic Client Registration; operators register the MCP client statically. The recommended shape is one client per MCP-client-implementation per operator, but a single shared client also works.
+
+```bash
+# Public client (PKCE-only, no client secret) — the MCP spec mandates
+# PKCE for the OAuth 2.1 authorization-code flow. PKCE on a public
+# client is what the spec calls out as the v0.2 default.
+kcadm.sh create clients -r <realm> -b '{
+  "clientId": "meho-mcp-client",
+  "name": "MEHO MCP client (static)",
+  "protocol": "openid-connect",
+  "publicClient": true,
+  "standardFlowEnabled": true,
+  "directAccessGrantsEnabled": false,
+  "redirectUris": [
+    "https://claude.ai/api/mcp/auth_callback",
+    "http://localhost:*"
+  ],
+  "webOrigins": ["+"],
+  "attributes": {
+    "pkce.code.challenge.method": "S256"
+  }
+}'
+
+# Attach the audience mapper from Step 1 to this client.
+```
+
+`redirectUris` covers two patterns:
+
+- `https://claude.ai/api/mcp/auth_callback` for the Claude.ai Custom Connector flow.
+- `http://localhost:*` for MCP Inspector and other CLI / desktop clients that listen on an ephemeral local port.
+
+A future-proof alternative is to make this client a *Dynamic Client Registration* template once Keycloak's DCR support and the v0.2.next MEHO RFC 7591 work land; for v0.2, the static recipe above is the path.
+
+## Step 3 — Configure the client to connect
+
+MEHO speaks Streamable HTTP at `/mcp`, not stdio. This matters because Claude Desktop's local `claude_desktop_config.json` shape (the `mcpServers` + `command: "npx"` config) is for *stdio* MCP servers spawned as subprocesses. Remote HTTPS MCP servers like MEHO use a different setup path per client:
+
+### Claude.ai Custom Connector (recommended)
+
+[Claude.ai → Settings → Connectors → Add custom connector](https://modelcontextprotocol.io/docs/develop/connect-remote-servers). Paste the server URL when prompted:
+
+```
+https://meho.example.com/mcp
+```
+
+Claude.ai resolves the URL, fetches the RFC 9728 protected-resource metadata document at `https://meho.example.com/.well-known/oauth-protected-resource`, discovers the Keycloak authorization server URL, and launches the OAuth 2.1 + PKCE flow against it. Complete the device-code prompt; the connector lands in the active state and MEHO's tools appear in the conversation toolbar.
+
+### MCP Inspector CLI (debug / smoke)
+
+`@modelcontextprotocol/inspector` ships a non-interactive CLI mode useful for scripting and post-deploy smoke tests. Authentication is via the `Authorization` header — the operator provides the token out of band.
+
+```bash
+# Obtain a token via the realm's preferred flow — for the dogfood
+# consumer, `meho login` is the simplest path; for direct Keycloak
+# device-code, `kcadm.sh` works too.
+TOKEN=$(meho login --print-token)
+
+# List tools (smoke test).
+npx @modelcontextprotocol/inspector --cli \
+  https://meho.example.com/mcp \
+  --transport http \
+  --method tools/list \
+  --header "Authorization: Bearer $TOKEN"
+
+# Invoke meho.status — exercises the full chain.
+npx @modelcontextprotocol/inspector --cli \
+  https://meho.example.com/mcp \
+  --transport http \
+  --method tools/call \
+  --tool-name meho.status \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+### Cline / Continue (VS Code)
+
+Cline and Continue both consume an `mcp.json` in the workspace. The shape mirrors Claude Desktop's `mcpServers` but with an `url` rather than a `command`:
+
+```json
+{
+  "mcpServers": {
+    "meho": {
+      "url": "https://meho.example.com/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+OAuth handling is client-specific; refer to each client's docs for the token-acquisition path. Both expect the same Bearer-token flow MEHO advertises via the protected-resource metadata document.
+
+## Step 4 — Verify connectivity
+
+After the client is wired:
+
+- Run `meho.status` from the connected client. The response should carry the operator's identity (sub, tenant_id, role) plus the Vault federation status and DB migration state.
+- Read the operator's tenant info: ask the client to read the resource at `meho://tenant/<your-tenant-id>/info`. The response should be the operator's tenant identity bundle (id, slug, name, role).
+- On the backplane, `SELECT method, path, operator_sub, status_code, occurred_at FROM audit_log ORDER BY occurred_at DESC LIMIT 10` should show the two operations with `method='MCP'` and `path='/mcp/tools/call/meho.status'` / `path='/mcp/resources/read/meho://tenant/<id>/info'`.
+
+If any of these don't appear, walk the troubleshooting section.
+
+## Step 5 — Troubleshooting
+
+### 401 + `WWW-Authenticate` but the client doesn't reach OAuth
+
+The response carries `WWW-Authenticate: Bearer resource_metadata="https://meho.example.com/.well-known/oauth-protected-resource"`. The client is supposed to fetch that URL to discover the authorization server. If it doesn't reach OAuth:
+
+- Check the `resource_metadata` URL is publicly reachable from where the client runs. Claude.ai's connector backend runs in Anthropic's cloud; a backplane behind a private network or self-signed TLS won't be reachable. Expose the backplane via a public ingress or a tunnel (Cloudflare, ngrok) for the Custom Connector flow.
+- Confirm `BACKPLANE_URL` in the backplane's ConfigMap resolves to the public hostname. If `BACKPLANE_URL` is wrong, `resource_metadata` points at the wrong host.
+
+### Token rejected at the MCP server (401, `invalid_token`)
+
+The token's `aud` doesn't match `MCP_RESOURCE_URI`:
+
+- Confirm Step 1 wired the audience mapper on the *correct* client (the same client that's issuing the operator's token).
+- Confirm the OAuth `resource` parameter the client sends matches `MCP_RESOURCE_URI`. Claude.ai's Custom Connector flow derives `resource` automatically from the URL the operator pasted — but a forwarder / reverse proxy that rewrites the path can leave the audience claim pointing at the wrong URI. Capture the issued token via the realm's token-introspection endpoint and read `aud` to confirm.
+
+### `tools/list` returns an empty list
+
+The operator's token carries a `tenant_role` claim below the role rank any registered tool requires (`read_only < operator < tenant_admin`). v0.2 ships only `meho.status` (`read_only` minimum), so an empty list means the JWT lacks the `tenant_role` claim entirely or carries a role below `read_only`. Walk back through the realm's `tenant_role` mapper.
+
+### Audit row missing for a successful call
+
+The MCP audit writer fails closed: an unauditable call returns JSON-RPC `INTERNAL_ERROR` (-32603). A *successful* call with no audit row means the row was rolled back — most commonly a DB connectivity issue mid-request. The chassis structlog stream will carry a `mcp_audit_write_failed` event with the exception class; check there before suspecting the writer.
+
+## Step 6 — Alternative clients
+
+| Client | Surface | Setup |
+|---|---|---|
+| [Claude.ai Custom Connector](https://modelcontextprotocol.io/docs/develop/connect-remote-servers) | Web (claude.ai) + Desktop (synced via account) | UI: paste `/mcp` URL, complete OAuth |
+| [MCP Inspector](https://github.com/modelcontextprotocol/inspector) | CLI + browser-based debug UI | `npx @modelcontextprotocol/inspector --cli <url> --transport http --header "Authorization: Bearer $TOKEN"` |
+| [Cline](https://github.com/cline/cline) | VS Code extension | `mcp.json` with `{ "url": "...", "transport": "http" }`; OAuth handled per-extension docs |
+| [Continue](https://github.com/continuedev/continue) | VS Code + JetBrains extensions | Similar `mcp.json` shape; see the extension's docs for the auth flow |
+
+MEHO is spec-conformant; any MCP-2025-06-18 Streamable-HTTP client with OAuth 2.1 + PKCE support should work. If a specific client breaks against MEHO, file an issue at [`evoila/meho`](https://github.com/evoila/meho/issues) with the client name + version, the MCP exchange (request + response), and the realm's token introspection output.
+
+## References
+
+- MEHO MCP architecture: [`docs/architecture/mcp.md`](../architecture/mcp.md).
+- MCP 2025-06-18 spec: <https://modelcontextprotocol.io/specification/2025-06-18>.
+- MCP authorization: <https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization>.
+- RFC 9728 (Protected Resource Metadata): <https://datatracker.ietf.org/doc/html/rfc9728>.
+- RFC 8707 (Resource Indicators): <https://www.rfc-editor.org/rfc/rfc8707.html>.
+- Claude.ai Custom Connectors: <https://modelcontextprotocol.io/docs/develop/connect-remote-servers>.
+- MCP Inspector: <https://github.com/modelcontextprotocol/inspector>.
+- Keycloak audience mappers: <https://www.keycloak.org/docs/latest/server_admin/#_audience>.


### PR DESCRIPTION
## Summary

Closes #251 — the final task in [G0.5 (#226)](https://github.com/evoila/meho/issues/226). Proves the five components shipped by T1-T5 work together end-to-end against a real Postgres + the production auth chain, and ships the operator-facing docs operators need to wire an MCP client (Claude.ai Custom Connector, MCP Inspector CLI, Cline, Continue) to a running MEHO backplane.

- **`backend/tests/integration/test_mcp_inspector.py` (new)** — direct JSON-RPC E2E test against the `/mcp` route. Drives the full lifecycle: `initialize` → `notifications/initialized` → `tools/list` → `tools/call meho.status` → `resources/templates/list` → `resources/read meho://tenant/{id}/info` → unknown-method case → unauthenticated case. Asserts: exactly 2 audit rows for the lifecycle (chassis `AuditMiddleware` path-excludes `/mcp`; per-op writer fires only on `tools/call` + `resources/read`), 401 + RFC 9728 `WWW-Authenticate: Bearer resource_metadata=...` on missing Bearer.

- **`backend/tests/_oidc_jwt_helpers.py`** — adds optional `audience` parameter to `mint_token` so the MCP suite can mint with `MCP_RESOURCE_URI` without forking the helper. Default preserved → all existing call sites unaffected.

- **`backend/tests/integration/conftest.py`** — `build_integration_app` now mounts `mcp_router` + `well_known_router` so T6 can drive the production auth + dispatch chain. The existing tenancy isolation suite never POSTs to `/mcp` so its assertions remain unaffected.

- **`docs/architecture/mcp.md`** — adds **Manual runbook** section describing the two pre-release verification paths: MCP Inspector CLI (`npx @modelcontextprotocol/inspector --cli <url> --transport http --header "Authorization: Bearer $TOKEN"`) for deterministic scriptable smoke, and Claude.ai Custom Connector for the dogfooding path. Clarifies that the local `claude_desktop_config.json` shape is stdio-only and does NOT apply to remote HTTPS MCP servers.

- **`docs/cross-repo/mcp-client-setup.md` (new, 7 sections per the issue)** — Keycloak audience-mapper recipe (Step 1), static `meho-mcp-client` recipe (Step 2, PKCE-only public client with the Claude.ai + localhost redirect URIs), per-client connection paths (Step 3: Claude.ai Custom Connector, MCP Inspector CLI, Cline/Continue `mcp.json`), verification with the audit_log SELECT (Step 4), troubleshooting (401+WWW-Authenticate not reaching OAuth, audience mismatch, empty tools/list, missing audit row), alt clients table.

## Why direct JSON-RPC instead of `@modelcontextprotocol/inspector` subprocess

The issue body recommends direct JSON-RPC for CI and puts the Inspector subprocess explicitly out of scope. Three reasons that hold up:

1. **Determinism.** `npx` resolves the Inspector package against the public registry on first run; CI without a warm `node_modules` cache pays the install cost and inherits its flake surface.
2. **No JS toolchain in the Python CI matrix.** `pyproject.toml` and the CI image carry no `node` / `npm`; pulling them in for one test trades a focused contract test for a polyglot CI cost every downstream contributor would pay.
3. **Coverage equivalence.** The wire protocol is the same on both paths. Inspector adds an interactive UI; pytest adds assertions on the response shape. The runbook keeps the manual Inspector / Claude.ai check as the pre-release proof against a real off-machine client.

## Acceptance criteria

- [x] `backend/tests/integration/test_mcp_inspector.py` passes against a real Postgres + the v0.2 backplane (testcontainers `pgvector/pgvector:pg16`, alembic upgrade head).
- [x] Test covers: initialize, notifications/initialized, tools/list, tools/call, resources/list (transitively — `resources/templates/list` is the templated-URI surface), resources/read, unknown-method, unauthenticated.
- [x] `docs/architecture/mcp.md` covers all 10 sections from the issue body, including the new Manual runbook.
- [x] `docs/cross-repo/mcp-client-setup.md` covers all 7 sections from the issue body; commands runnable as written.
- [x] Manual runbook in `docs/architecture/mcp.md` describes the Inspector + Claude.ai pre-release flow.
- [ ] Both docs reviewed by the consumer (`claude-rdc-hetzner-dc`) — flagged for post-merge async review per the cross-repo deps pattern; not blocking this PR.
- [ ] CI green — pending.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src` strict — 44 source files, no issues
- [x] `pytest --ignore=tests/integration --deselect tests/test_observability.py::test_metrics_endpoint…` — 399 passed, 1 skipped (slow T2), 1 deselected (macOS-only `process_resident_memory_bytes` flake — Linux CI passes)
- [x] `pytest tests/integration` — 8 passed (5 tenancy + 2 new MCP + 1 import smoke), 5.92 s wall clock
- [ ] CI Linux / Postgres lane — pending

## Adjacent finding (not blocking, recorded for follow-up)

Issue body Step 3 sketches a `claude_desktop_config.json` snippet for connecting Claude Desktop to a remote MCP server. Claude Desktop's local-JSON config is for *stdio* MCP servers spawned as `npx` subprocesses; remote HTTPS servers like MEHO route through Claude.ai's Custom Connector UI instead. The cross-repo doc documents the correct path; the issue body sketch is preserved in the issue thread for context.

Parent initiative: #226. Closes G0.5. Next: the connector-side initiatives (G3 onwards) build on this MCP substrate.

<!-- auto-implement-issue: fresh, attempt 1 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive MCP integration tests validating full JSON-RPC lifecycle, auth behavior, audit writes, and unauthenticated rejection.
  * Test harness: wired MCP and well‑known routes into the integration app; JWT test helper now accepts an audience override for minting tokens.

* **Documentation**
  * Added MCP pre-release verification runbook and an operator MCP client setup guide with Keycloak/audience and troubleshooting steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/329)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->