### PR TITLE
docs(planning): lock decisions #9-#11 — frontend stack, deploy shape, auth flow

### DIFF
--- a/docs/planning/v0.2-decisions.md
+++ b/docs/planning/v0.2-decisions.md
@@ -122,6 +122,54 @@ The Kubernetes connector (G3.2, filed against #214) uses **`kubernetes_asyncio`*
 
 **Why:** Kubernetes is quasi-tier-1 by usage frequency in the consumer's wrapper inventory (`kubectl-vcf.sh` is the most-used wrapper); needs its own G3 Initiative + library choice locked before Phase 1 K8s work starts. Helm is explicitly out of v0.2 K8s connector scope; future `HelmConnector` is a separate consideration.
 
+### 9. Frontend framework — **React 19 + Vite + TypeScript + TanStack stack**
+
+The new web UI Goal (G10 — Operator web UI) uses:
+
+- **React 19** with strict TypeScript. Latest stable, mature ecosystem, broad operator-tooling component coverage.
+- **Vite 7** build tool. Fast HMR, modern ESM bundling.
+- **TanStack Query 5** for server state (caching, invalidation, optimistic updates, SSE/WebSocket integration).
+- **TanStack Router 1** for file-based routing. Type-safe, matches the TanStack Query mental model.
+- **Tailwind CSS 4** for styling — the Dependabot PRs (#11, #12, #59 in chassis era) already pinned this direction.
+- **shadcn/ui** components on Radix UI primitives. Copy-in component library (no runtime dep); operator-facing primitives (Table, Dialog, Tabs, etc.).
+- **Cytoscape.js** for the topology graph (G10.5). Battle-tested node-edge graph viz; handles 1k+ node graphs.
+- **Vitest** for unit tests; **Playwright** for E2E.
+
+**Rejected alternatives:**
+- **Vue / Svelte / Solid** — smaller ecosystems for the complex-dashboard shape; React + TanStack has the most off-the-shelf operator-tool components.
+- **Next.js** — overkill for an SPA admin UI; we don't need SSR. Adds deploy complexity (Node runtime in the chart).
+- **Plain React Router + Redux** — TanStack Router + Query is cleaner for this shape; less boilerplate.
+
+**Why:** Frontend Initiative was added late after Damir requested UI insight into KB / topology / connectors / memory / broadcast (the broadcast surface flagged as priority). The Dependabot PR history hints that the team already started in this direction once before; this locks it.
+
+### 10. Frontend deploy shape — **static bundle served by the backplane FastAPI at `/ui/*`**
+
+The React SPA is built to a static bundle at CI time and **served by FastAPI** via `StaticFiles` mounted at `/ui/*`. The bundle ships inside the backend wheel + container image.
+
+**Why this rather than a separate nginx subchart:**
+- Single deployment lifecycle. The frontend always matches the API version it talks to — no skew.
+- One TLS termination, one ingress, one cert. The chart already terminates at the backplane Service.
+- Simpler CI: frontend build is a step in the existing image pipeline; no separate registry push.
+- One auth boundary. The browser hits `https://meho.evba.lab/ui/...`; OAuth callback at `/ui/auth/callback` reuses the same Keycloak issuer + (different) OAuth client.
+
+**Why not separate subchart:**
+- Couples release cadence (deliberate for v0.2). If we want independent FE release cadence later, split in v0.3+.
+- More resources (separate pod for nginx) for no benefit at v0.2 scale.
+
+**Out of scope:** SSR, ISR, edge-deployed FE. Pure static SPA.
+
+### 11. Frontend auth — **OAuth 2.1 Authorization Code + PKCE, browser-side**
+
+The web UI uses the standard SPA auth flow: **OAuth 2.1 Authorization Code with PKCE** against the same Keycloak authorization server the CLI + MCP use.
+
+- **Separate OAuth client** in Keycloak (`meho-web` vs `meho-cli` vs `meho-mcp`). Each gets its own audience claim in JWTs.
+- **Resource indicator (RFC 8707):** the UI requests `aud=<backplane-url>/api` for HTTP-API access. The MCP audience (`<backplane-url>/mcp`) is distinct (per decision #7).
+- **Token storage:** `sessionStorage` (cleared on tab close, safer than localStorage against XSS). Refresh token never enters browser memory; refresh via silent re-auth using the iframe trick or PKCE refresh flow.
+- **Browser flow constraints:** redirect URIs are exact-match registered with Keycloak (`https://meho.evba.lab/ui/auth/callback`). PKCE code-verifier in `sessionStorage` for the duration of the auth round-trip.
+- **Same `verify_jwt_and_bind` chain** at the backplane validates the UI's JWTs — no new validation surface. Audience-mismatch returns 401 with the standard WWW-Authenticate header.
+
+**Why:** the browser environment doesn't support the device-code flow the CLI uses; PKCE is the spec-blessed SPA equivalent. Reuses the existing Keycloak + JWT chain unchanged.
+
 ---
 
 ## Sequencing summary


### PR DESCRIPTION
## Summary

Adds three locked decisions to [docs/planning/v0.2-decisions.md](docs/planning/v0.2-decisions.md) ahead of [Goal G10 — Operator web UI (#336)](https://github.com/evoila/meho/issues/336):

- **#9 Frontend framework** — React 19 + Vite + TypeScript + TanStack Query/Router + Tailwind + shadcn/ui. Cytoscape.js for the topology graph viz.
- **#10 Frontend deploy shape** — static bundle served by backplane FastAPI at `/ui/*`. Single deploy lifecycle, one TLS termination, no separate nginx subchart.
- **#11 Frontend auth** — OAuth 2.1 Authorization Code + PKCE against the same Keycloak. Separate `meho-web` OAuth client; `sessionStorage` for tokens; RFC 8707 resource indicator binds JWT audience to the backplane HTTP API.

## Context

Damir asked for a web UI surface tonight. The new Goal G10 + 6 Initiatives ([#337-#342](https://github.com/evoila/meho/issues/336)) reference these decisions; locking them in the canonical decisions doc keeps the planning surface coherent.

## Test plan

- [x] Markdown rendered cleanly
- [x] Decision bodies follow the same structure as #1–#8
- [x] Forward links to G10 (#336) + G10.0-G10.5 Initiatives intact
- [x] No code change — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Finalized and documented v0.2 operator UI architectural decisions: the selected frontend framework and development tooling, deployment approach serving the UI as a static bundle packaged within the backend service, and OAuth 2.1-based authentication strategy for secure user access.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/343)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->