### PR TITLE
feat(broadcast): BroadcastEvent schema + classify_op + redact_payload (G6.1-T2)

### DIFF
--- a/backend/src/meho_backplane/broadcast/__init__.py
+++ b/backend/src/meho_backplane/broadcast/__init__.py
@@ -14,11 +14,19 @@ from meho_backplane.broadcast.client import (
     get_broadcast_client,
     reset_broadcast_client_for_testing,
 )
+from meho_backplane.broadcast.events import (
+    BroadcastEvent,
+    classify_op,
+    redact_payload,
+)
 from meho_backplane.broadcast.probe import broadcast_readiness_probe
 
 __all__ = [
+    "BroadcastEvent",
     "broadcast_readiness_probe",
+    "classify_op",
     "dispose_broadcast_client",
     "get_broadcast_client",
+    "redact_payload",
     "reset_broadcast_client_for_testing",
 ]

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Broadcast event schema + PII classifier (G6.1-T2).
+
+The publish-on-write hook (T3, #309) builds one :class:`BroadcastEvent`
+per audited operation and ``XADD``\\ s it to ``meho:feed:{tenant_id}``.
+T4 (#310) reads back from the same stream and serves it via SSE; T6
+(#312) wraps the stream in an MCP resource. This module ships the
+wire-shape contract and the sensitivity classifier that every
+downstream consumer relies on.
+
+PII discipline lives in :func:`classify_op` + :func:`redact_payload`.
+The classifier is policy-locked by decision #3 in
+``docs/planning/v0.2-decisions.md`` — credential reads and audit-query
+responses broadcast aggregate-only by default; everything else
+broadcasts in full. Per-op opt-in to flip a sensitive class to full
+detail is a G6.3 surface; T2 ships the conservative default.
+
+Why a classifier rather than a per-op annotation:
+
+1. Sensitivity is mostly op-class-shaped. ``vault.kv.read`` is no more
+   sensitive than ``vault.kv.list``; ``vsphere.vm.list`` is no more
+   sensitive than ``vsphere.host.list``. A per-op flag would multiply
+   the contract surface for no policy gain.
+2. The classifier is one auditable function. A reviewer can read it in
+   one sitting and verify policy compliance; scattered annotations on
+   every op would require a registry walk.
+
+Why aggregate-only-by-default for the sensitive classes:
+
+* ``credential_read`` — even logging that ``vault.kv.read`` returned OK
+  reveals which secret an operator touched. Path strings frequently
+  carry environment names, target hostnames, or service identifiers
+  that no SSE feed subscriber needs and that no Slack mirror channel
+  should retain. Aggregate-only collapses every credential read into
+  ``{op_class, result_status}`` — enough for "someone touched a
+  credential at 14:23", not enough to reconstruct what.
+* ``audit_query`` — the request filter is the most damaging thing to
+  broadcast: it encodes whoever the querying operator was investigating
+  and on what hunch. The response payload also carries the raw audit
+  rows the query matched, which inherits every other op's sensitivity.
+  Broadcasting only ``{op_class, result_status, row_count}`` keeps the
+  team-coordination signal ("X just queried audit") without leaking
+  the investigation target or the matched evidence.
+
+References
+----------
+
+* Decision #3 — ``docs/planning/v0.2-decisions.md``.
+* MCP audit shape (G0.5-T5, the in-tree precedent for similar
+  redaction discipline) —
+  :func:`meho_backplane.mcp.audit.write_mcp_audit_row`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Final
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "BroadcastEvent",
+    "classify_op",
+    "redact_payload",
+]
+
+
+#: Op-ids that classify as ``credential_read``. Extensible — every
+#: future credential-access verb (e.g. ``vault.transit.decrypt``,
+#: ``secretsmanager.get``, ``onepassword.read``) gets added here when
+#: it lands. Membership is the canonical signal; ``vault.kv.``-prefix
+#: matching would over-match a hypothetical future ``vault.kv.stats``
+#: which doesn't read secret content.
+_CREDENTIAL_READ_OPS: Final[frozenset[str]] = frozenset(
+    {
+        "vault.kv.read",
+        "vault.kv.list",
+    }
+)
+
+#: Op-id suffixes that imply mutation. Append to this tuple when a new
+#: write-shaped verb spelling lands (no current users beyond the four
+#: in decision #3). Order doesn't matter — :meth:`str.endswith` accepts
+#: a tuple and short-circuits on the first match.
+_WRITE_SUFFIXES: Final[tuple[str, ...]] = (
+    ".create",
+    ".update",
+    ".delete",
+    ".patch",
+)
+
+#: Op-id suffixes that imply non-mutating read. ``.ls`` and ``.about``
+#: are the CLI-shaped verbs (``meho vsphere ls``, ``meho meho about``)
+#: that the connector layer maps to the same read class as ``.list`` /
+#: ``.get`` / ``.info``.
+_READ_SUFFIXES: Final[tuple[str, ...]] = (
+    ".list",
+    ".info",
+    ".get",
+    ".about",
+    ".ls",
+)
+
+
+class BroadcastEvent(BaseModel):
+    """One broadcast event — exactly one per audited operation.
+
+    The publish-on-write hook (T3) constructs an instance per audit-log
+    write; ``XADD meho:feed:{tenant_id}`` carries it onto the per-tenant
+    Valkey stream. SSE subscribers (T4) and MCP resource readers (T6)
+    deserialise back to this shape.
+
+    The model is **frozen** (``ConfigDict(frozen=True)``) so once
+    constructed it cannot be mutated. Downstream consumers may pass
+    events through transformation pipelines without risk of an
+    intermediate stage rewriting fields the next stage assumed
+    immutable. Same rationale the chassis
+    :class:`~meho_backplane.auth.operator.Operator` model documents.
+
+    ``payload`` is **always** the redacted view per
+    :func:`redact_payload` — callers MUST NOT pass raw params here.
+    The class can't enforce this from the type system alone (any
+    ``dict[str, Any]`` satisfies the annotation), so the contract is
+    documented in the publisher's docstring (T3) and verified by
+    integration tests that read back from the stream and assert
+    forbidden keys are absent.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    event_id: UUID
+    ts: datetime
+    tenant_id: UUID
+    principal_sub: str
+    principal_name: str | None
+    target_name: str | None
+    op_id: str
+    #: One of ``"read"`` / ``"write"`` / ``"credential_read"`` /
+    #: ``"audit_query"`` / ``"other"``. Derived from
+    #: :func:`classify_op` at publish time.
+    op_class: str
+    #: One of ``"ok"`` / ``"error"`` / ``"denied"``. The handler
+    #: produces it; the broadcast publisher does not re-classify.
+    result_status: str
+    #: FK to ``audit_log.id``. The broadcast event is downstream of the
+    #: audit write — audit is the canonical record, broadcast is the
+    #: real-time view. A subscriber that wants the full untruncated row
+    #: queries audit_log by this id.
+    audit_id: UUID
+    #: Redacted view per :func:`redact_payload`. NEVER raw params for
+    #: ``credential_read`` or ``audit_query`` classes — the redaction
+    #: contract is upstream of this field.
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+def classify_op(op_id: str) -> str:
+    """Map an op-id to one of the five sensitivity classes.
+
+    Match order is policy-significant:
+
+    1. ``credential_read`` — the explicit allowlist comes first so a
+       hypothetical future ``vault.kv.audit-list`` (read of audit
+       metadata, not secret content) could opt out of the credential
+       class by being absent from :data:`_CREDENTIAL_READ_OPS` and
+       falling through to the suffix check.
+    2. ``audit_query`` — every op-id with the ``audit.`` prefix
+       classifies as audit_query regardless of the verb suffix. Audit
+       responses carry rows that inherit every other op's sensitivity,
+       so the whole namespace is aggregate-only.
+    3. ``write`` — mutation suffixes (``.create`` / ``.update`` /
+       ``.delete`` / ``.patch``). Same break-when-first-matches rule
+       as ``.endswith`` on a tuple.
+    4. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
+       ``.get`` / ``.about`` / ``.ls``).
+    5. ``other`` — everything else. Falls through to full-detail
+       broadcast per decision #3.
+
+    Examples
+    --------
+
+    >>> classify_op("vault.kv.read")
+    'credential_read'
+    >>> classify_op("audit.query")
+    'audit_query'
+    >>> classify_op("vsphere.vm.list")
+    'read'
+    >>> classify_op("vsphere.vm.create")
+    'write'
+    >>> classify_op("some.unknown.op")
+    'other'
+    """
+    if op_id in _CREDENTIAL_READ_OPS:
+        return "credential_read"
+    if op_id.startswith("audit."):
+        return "audit_query"
+    if op_id.endswith(_WRITE_SUFFIXES):
+        return "write"
+    if op_id.endswith(_READ_SUFFIXES):
+        return "read"
+    return "other"
+
+
+def _maybe_row_count(raw_params: dict[str, Any]) -> int | None:
+    """Extract ``row_count`` from the publisher's combined params dict.
+
+    The publish-on-write hook (T3) merges request params and response
+    summary into one dict before calling :func:`redact_payload`. For
+    ``audit_query`` ops the response carries a ``row_count`` field
+    (per the G8 audit-query API in #334); for older or non-conforming
+    callers it may be absent.
+
+    Returns ``None`` rather than ``0`` when the field is missing so
+    subscribers can distinguish "the query matched zero rows" from
+    "the publisher didn't surface a count". Coerces to ``int`` defensively
+    — a stringified count from a JSON round-trip would otherwise serialise
+    back as a string.
+    """
+    raw = raw_params.get("row_count")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def redact_payload(
+    op_class: str,
+    raw_params: dict[str, Any],
+    result_status: str,
+) -> dict[str, Any]:
+    """Return the broadcast-safe payload view for *op_class*.
+
+    Three branches, locked by decision #3:
+
+    * ``credential_read`` → ``{op_class, result_status}``. No path, no
+      key names, no values. The mere fact that an operator read a
+      credential is broadcast; the *what* never leaves the audit row.
+    * ``audit_query`` → ``{op_class, result_status, row_count}``. The
+      filter is the most damaging field to broadcast (encodes the
+      investigation target), and the response rows inherit every other
+      op's sensitivity. Aggregate-only collapses to "X ran an audit
+      query that matched N rows".
+    * everything else → ``{op_class, params=raw_params, result_status}``.
+      Full request detail; nested objects pass through verbatim.
+
+    Forward-compatibility note: the return shape is a plain ``dict``
+    rather than a typed model because the downstream
+    :attr:`BroadcastEvent.payload` field is already ``dict[str, Any]``.
+    Promoting either side to a structured model would require a
+    coordinated change to all of T3 / T4 / T6 and is out of scope for
+    T2.
+    """
+    if op_class == "credential_read":
+        return {"op_class": op_class, "result_status": result_status}
+    if op_class == "audit_query":
+        return {
+            "op_class": op_class,
+            "result_status": result_status,
+            "row_count": _maybe_row_count(raw_params),
+        }
+    return {
+        "op_class": op_class,
+        "params": raw_params,
+        "result_status": result_status,
+    }

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -113,12 +113,21 @@ class BroadcastEvent(BaseModel):
     Valkey stream. SSE subscribers (T4) and MCP resource readers (T6)
     deserialise back to this shape.
 
-    The model is **frozen** (``ConfigDict(frozen=True)``) so once
-    constructed it cannot be mutated. Downstream consumers may pass
-    events through transformation pipelines without risk of an
-    intermediate stage rewriting fields the next stage assumed
-    immutable. Same rationale the chassis
-    :class:`~meho_backplane.auth.operator.Operator` model documents.
+    The model is **frozen** (``ConfigDict(frozen=True)``) — attribute
+    reassignment (``event.payload = new_dict``) raises ``ValidationError``,
+    mirroring the chassis
+    :class:`~meho_backplane.auth.operator.Operator` pattern.
+    ``frozen=True`` is **faux-immutability** in pydantic v2: nested
+    mutable values like the ``payload`` dict CAN still be mutated in
+    place — ``event.payload["k"] = "v"`` succeeds silently because it
+    mutates the inner dict object rather than reassigning the
+    attribute. Downstream consumers MUST NOT mutate ``payload``
+    between construction and publish. The PII contract is enforced
+    upstream by the publisher calling :func:`redact_payload` *before*
+    construction, not by the model itself. A future tightening to
+    ``Mapping[str, Any]`` + ``types.MappingProxyType`` would close
+    the in-place-mutation door but requires a coordinated change to
+    T3 / T4 / T6 deserialisation and is out of scope for T2.
 
     ``payload`` is **always** the redacted view per
     :func:`redact_payload` — callers MUST NOT pass raw params here.
@@ -135,8 +144,12 @@ class BroadcastEvent(BaseModel):
     ts: datetime
     tenant_id: UUID
     principal_sub: str
-    principal_name: str | None
-    target_name: str | None
+    #: Best-effort from the JWT's ``name`` claim cached at audit-write
+    #: time. Many JWTs ship without a ``name`` claim; the publisher
+    #: must be able to omit this field without forcing every call site
+    #: to pass an explicit ``None``. Same reasoning for ``target_name``.
+    principal_name: str | None = None
+    target_name: str | None = None
     op_id: str
     #: One of ``"read"`` / ``"write"`` / ``"credential_read"`` /
     #: ``"audit_query"`` / ``"other"``. Derived from

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -92,10 +92,48 @@ class TestBroadcastEventSchema:
         assert event.principal_name is None
         assert event.target_name is None
 
+    def test_optional_fields_omittable_at_construction(self) -> None:
+        """Pydantic must accept events without ``principal_name`` / ``target_name``.
+
+        T3's publisher (#309) builds events from audit-row data where
+        ``principal_name`` is best-effort from the JWT's ``name`` claim
+        (frequently absent) and ``target_name`` is unknown until the
+        connector resolves the target alias. Forcing callers to pass
+        ``principal_name=None`` / ``target_name=None`` explicitly turns
+        every omission into boilerplate; the ``= None`` defaults on the
+        model make omission the natural path.
+        """
+        event = BroadcastEvent(
+            event_id=_EVENT_ID,
+            ts=_TS,
+            tenant_id=_TENANT_A,
+            principal_sub="op-test",
+            op_id="vsphere.vm.list",
+            op_class="read",
+            result_status="ok",
+            audit_id=_AUDIT_ID,
+        )
+        assert event.principal_name is None
+        assert event.target_name is None
+
     def test_payload_default_is_empty_dict(self) -> None:
-        """Default payload lands at ``{}``, not a shared mutable instance."""
-        a = _make_event()
-        b = _make_event()
+        """Default payload lands at ``{}``, not a shared mutable instance.
+
+        Constructs events that **omit** ``payload`` entirely so the
+        model's ``Field(default_factory=dict)`` actually runs. The prior
+        shape of this test built both events via ``_make_event()`` which
+        always supplied a payload kwarg, so the default-factory path
+        was never traversed — a future regression that swapped
+        ``default_factory=dict`` for ``default={}`` (the literal — the
+        classic mutable-default-argument footgun) would have silently
+        bled payload data across events without failing this test.
+        """
+        base = _make_event().model_dump()
+        base.pop("payload", None)
+        a = BroadcastEvent(**base)
+        b = BroadcastEvent(**base)
+        assert a.payload == {}
+        assert b.payload == {}
         # Mutating the dict on ``a`` after construction would mutate ``b`` too
         # if the field's default_factory were a shared instance; the frozen
         # model itself blocks that path, but verifying object identity

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G6.1-T2 broadcast event schema + classifier.
+
+Covers (issue #308 acceptance criteria):
+
+* :class:`BroadcastEvent` is frozen, all required fields enforced,
+  optional fields accept ``None``, dict ↔ JSON round-trips cleanly.
+* :func:`classify_op` maps each AC-listed op-id to the right sensitivity
+  class, plus edge cases the AC doesn't enumerate (empty string,
+  prefix-conflict op-ids, mixed-case suffix near-misses).
+* :func:`redact_payload` strips per the per-class contract: credential
+  reads drop ``path`` / ``key``, audit queries drop ``filter``, generic
+  reads keep full params (including nested objects).
+
+PII redaction is the load-bearing contract — every test that exercises
+:func:`redact_payload` for a sensitive class asserts NOT just on the
+returned shape but on absent-key invariants the AC names explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from meho_backplane.broadcast import BroadcastEvent, classify_op, redact_payload
+
+# ---------------------------------------------------------------------------
+# Fixtures — one ready-to-use canonical event for the schema tests
+# ---------------------------------------------------------------------------
+
+
+_TENANT_A: UUID = UUID("11111111-1111-1111-1111-111111111111")
+_AUDIT_ID: UUID = UUID("22222222-2222-2222-2222-222222222222")
+_EVENT_ID: UUID = UUID("33333333-3333-3333-3333-333333333333")
+_TS = datetime(2026, 5, 13, 9, 0, 0, tzinfo=UTC)
+
+
+def _make_event(**overrides: object) -> BroadcastEvent:
+    """Return a fully-populated :class:`BroadcastEvent` with overridable fields."""
+    base: dict[str, object] = {
+        "event_id": _EVENT_ID,
+        "ts": _TS,
+        "tenant_id": _TENANT_A,
+        "principal_sub": "op-test",
+        "principal_name": "Operator Test",
+        "target_name": "rdc-vcenter",
+        "op_id": "vsphere.vm.list",
+        "op_class": "read",
+        "result_status": "ok",
+        "audit_id": _AUDIT_ID,
+        "payload": {
+            "op_class": "read",
+            "params": {"folder": "prod"},
+            "result_status": "ok",
+        },
+    }
+    base.update(overrides)
+    return BroadcastEvent(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# BroadcastEvent — schema, frozen, optionality, round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastEventSchema:
+    """The wire-shape contract every downstream consumer reads back."""
+
+    def test_required_fields_populated(self) -> None:
+        event = _make_event()
+        assert event.event_id == _EVENT_ID
+        assert event.tenant_id == _TENANT_A
+        assert event.audit_id == _AUDIT_ID
+        assert event.op_class == "read"
+        assert event.result_status == "ok"
+
+    def test_model_is_frozen(self) -> None:
+        """A consumer in the pipeline must not be able to rewrite the event."""
+        event = _make_event()
+        with pytest.raises(ValidationError):
+            event.op_class = "write"  # type: ignore[misc]
+
+    def test_optional_fields_accept_none(self) -> None:
+        """``principal_name`` and ``target_name`` may be unknown at publish time."""
+        event = _make_event(principal_name=None, target_name=None)
+        assert event.principal_name is None
+        assert event.target_name is None
+
+    def test_payload_default_is_empty_dict(self) -> None:
+        """Default payload lands at ``{}``, not a shared mutable instance."""
+        a = _make_event()
+        b = _make_event()
+        # Mutating the dict on ``a`` after construction would mutate ``b`` too
+        # if the field's default_factory were a shared instance; the frozen
+        # model itself blocks that path, but verifying object identity
+        # documents the contract.
+        assert a.payload is not b.payload
+
+    def test_missing_required_field_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            BroadcastEvent(  # type: ignore[call-arg]
+                event_id=_EVENT_ID,
+                ts=_TS,
+                tenant_id=_TENANT_A,
+                principal_sub="op-test",
+                principal_name=None,
+                target_name=None,
+                op_id="vsphere.vm.list",
+                op_class="read",
+                result_status="ok",
+                # audit_id intentionally omitted
+            )
+
+    def test_json_round_trip(self) -> None:
+        """T4 / T6 deserialise events from the Valkey stream; the round-trip must be lossless."""
+        original = _make_event()
+        serialised = original.model_dump_json()
+        decoded = json.loads(serialised)
+        rebuilt = BroadcastEvent.model_validate(decoded)
+        assert rebuilt == original
+
+
+# ---------------------------------------------------------------------------
+# classify_op — AC #2 through #5 + extension cases
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyOp:
+    """Per-op-id sensitivity class derivation."""
+
+    @pytest.mark.parametrize(
+        ("op_id", "expected"),
+        [
+            ("vault.kv.read", "credential_read"),
+            ("vault.kv.list", "credential_read"),
+        ],
+    )
+    def test_credential_read_allowlist(self, op_id: str, expected: str) -> None:
+        """Exact-match allowlist — decision #3 names these two."""
+        assert classify_op(op_id) == expected
+
+    @pytest.mark.parametrize(
+        "op_id",
+        [
+            "audit.query",
+            "audit.show",
+            "audit.recent",
+            "audit.who-touched",
+        ],
+    )
+    def test_audit_prefix_maps_to_audit_query(self, op_id: str) -> None:
+        """Every ``audit.*`` op classifies the same — response rows carry mixed sensitivity."""
+        assert classify_op(op_id) == "audit_query"
+
+    @pytest.mark.parametrize(
+        ("op_id", "expected"),
+        [
+            ("vsphere.vm.list", "read"),
+            ("vsphere.host.info", "read"),
+            ("vsphere.about", "read"),
+            ("k8s.pod.get", "read"),
+            ("vsphere.vm.ls", "read"),
+        ],
+    )
+    def test_read_suffixes(self, op_id: str, expected: str) -> None:
+        assert classify_op(op_id) == expected
+
+    @pytest.mark.parametrize(
+        ("op_id", "expected"),
+        [
+            ("vsphere.vm.create", "write"),
+            ("vsphere.vm.update", "write"),
+            ("vsphere.vm.delete", "write"),
+            ("k8s.deployment.patch", "write"),
+        ],
+    )
+    def test_write_suffixes(self, op_id: str, expected: str) -> None:
+        assert classify_op(op_id) == expected
+
+    @pytest.mark.parametrize(
+        "op_id",
+        [
+            "some.unknown.op",
+            "weird",
+            "vsphere.vm.poweron",  # not a write suffix
+            "",
+        ],
+    )
+    def test_unknown_falls_through_to_other(self, op_id: str) -> None:
+        """Default branch keeps the broadcast informative without policy decisions."""
+        assert classify_op(op_id) == "other"
+
+    def test_credential_read_takes_priority_over_suffix(self) -> None:
+        """``vault.kv.list`` ends in ``.list`` but the allowlist match wins.
+
+        The order in :func:`classify_op` is intentional — a future op like
+        ``vault.kv.audit-list`` could opt out of the credential class by
+        being absent from the allowlist; this test pins the precedence
+        rather than letting it drift to "first match by suffix" later.
+        """
+        assert classify_op("vault.kv.list") == "credential_read"
+
+    def test_audit_prefix_takes_priority_over_suffix(self) -> None:
+        """``audit.query`` has no read/write suffix; ``audit.list`` does.
+
+        Both must classify as ``audit_query`` — the prefix gate runs before
+        the suffix check, and ``audit.list`` returning ``"read"`` would leak
+        audit-row contents the prefix-class is specifically meant to redact.
+        """
+        assert classify_op("audit.list") == "audit_query"
+
+
+# ---------------------------------------------------------------------------
+# redact_payload — AC #6, #7, #8 + edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRedactPayload:
+    """Per-class redaction — load-bearing for the PII discipline."""
+
+    def test_credential_read_drops_path_and_key(self) -> None:
+        """AC #6 — only ``op_class`` and ``result_status`` survive."""
+        result = redact_payload(
+            "credential_read",
+            {"path": "secret/foo", "key": "api-token"},
+            "ok",
+        )
+        assert result == {"op_class": "credential_read", "result_status": "ok"}
+        assert "path" not in result
+        assert "key" not in result
+
+    def test_audit_query_drops_filter(self) -> None:
+        """AC #7 — filter never reaches the stream; row_count is allowed."""
+        result = redact_payload(
+            "audit_query",
+            {"filter": "principal=damir", "since": "24h"},
+            "ok",
+        )
+        assert result == {
+            "op_class": "audit_query",
+            "result_status": "ok",
+            "row_count": None,
+        }
+        assert "filter" not in result
+        assert "since" not in result
+
+    def test_audit_query_surfaces_row_count_when_present(self) -> None:
+        """The publisher pre-merges request + response; row_count plumbs through."""
+        result = redact_payload(
+            "audit_query",
+            {"filter": "principal=damir", "row_count": 42},
+            "ok",
+        )
+        assert result["row_count"] == 42
+
+    def test_audit_query_handles_stringified_row_count(self) -> None:
+        """JSON round-trips can stringify counts; the redactor coerces back to int."""
+        result = redact_payload("audit_query", {"row_count": "42"}, "ok")
+        assert result["row_count"] == 42
+
+    def test_audit_query_non_numeric_row_count_becomes_none(self) -> None:
+        """A malformed count never poisons the broadcast — fail-closed to None."""
+        result = redact_payload("audit_query", {"row_count": "not-a-number"}, "error")
+        assert result["row_count"] is None
+
+    def test_read_keeps_full_params(self) -> None:
+        """AC #8 — generic read ops broadcast in full."""
+        result = redact_payload("read", {"folder": "prod"}, "ok")
+        assert result == {
+            "op_class": "read",
+            "params": {"folder": "prod"},
+            "result_status": "ok",
+        }
+        assert result["params"]["folder"] == "prod"
+
+    def test_write_keeps_full_params(self) -> None:
+        """Write ops also broadcast in full — the audit row carries the same."""
+        result = redact_payload(
+            "write",
+            {"vm_name": "web-01", "memory_mb": 4096},
+            "ok",
+        )
+        assert result["params"]["vm_name"] == "web-01"
+        assert result["params"]["memory_mb"] == 4096
+
+    def test_other_keeps_full_params(self) -> None:
+        """Default class — same shape as read/write."""
+        result = redact_payload("other", {"flag": True}, "ok")
+        assert result["params"]["flag"] is True
+
+    def test_read_preserves_nested_params(self) -> None:
+        """Nested dicts pass through verbatim — no flattening, no transformation."""
+        params: dict[str, object] = {
+            "target": "rdc-vcenter",
+            "filter": {"folder": "prod", "tags": ["pinned", "long-lived"]},
+        }
+        result = redact_payload("read", params, "ok")
+        assert result["params"] == params
+        # Verify the inner list is the same object — no defensive copy.
+        # A future change that wraps params in a deep-copy would force
+        # this assertion to flip, which is the right way to discover it.
+        assert result["params"]["filter"] is params["filter"]
+
+    def test_empty_params_for_each_class(self) -> None:
+        """Boundary case — empty params dict produces well-shaped output for every class."""
+        assert redact_payload("credential_read", {}, "ok") == {
+            "op_class": "credential_read",
+            "result_status": "ok",
+        }
+        assert redact_payload("audit_query", {}, "ok") == {
+            "op_class": "audit_query",
+            "result_status": "ok",
+            "row_count": None,
+        }
+        assert redact_payload("read", {}, "ok") == {
+            "op_class": "read",
+            "params": {},
+            "result_status": "ok",
+        }
+
+    @pytest.mark.parametrize("status", ["ok", "error", "denied"])
+    def test_status_is_passed_through_verbatim(self, status: str) -> None:
+        """``result_status`` is the handler's verdict — the redactor doesn't re-classify."""
+        result = redact_payload("read", {}, status)
+        assert result["result_status"] == status

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -115,10 +115,21 @@ this stage it exposes:
   `timeout`, `unreachable: <ExcClass>`, `redis_error: <ExcClass>`)
   plus a `check_failed: <ExcClass>` safety net for unexpected
   failures, and never echoes the operator-supplied URL — same
-  redaction contract as the Vault and DB probes. T2-T6 (#308-#312)
-  build the event schema, publish-on-write hook, SSE endpoint, MCP
-  resource, and the `meho status --watch` CLI on top of this
-  foundation.
+  redaction contract as the Vault and DB probes. T3-T6 (#309-#312)
+  build the publish-on-write hook, SSE endpoint, MCP resource, and the
+  `meho status --watch` CLI on top of this foundation.
+* Broadcast event schema + PII classifier (G6.1-T2 #308) —
+  `src/meho_backplane/broadcast/events.py` ships the `BroadcastEvent`
+  Pydantic model + `classify_op` / `redact_payload` helpers. Every
+  audited op produces exactly one `BroadcastEvent` at T3 publish time;
+  the model is frozen so downstream consumers (T4 SSE, T6 MCP resource)
+  can't mutate events mid-pipeline. The classifier locks decision #3's
+  conservative PII defaults: `credential_read` ops (`vault.kv.read`,
+  `vault.kv.list`) and `audit_query` ops (`audit.*` prefix) broadcast
+  aggregate-only — the credential path / key / value and the audit
+  filter / matched rows never reach the stream. Everything else
+  broadcasts in full. Per-op opt-in to flip a sensitive class to full
+  detail is a G6.3 surface; T2 ships the conservative default.
 * Persistence layer (Task #27) — `src/meho_backplane/db/` houses the
   SQLAlchemy 2.x async engine (`engine.py`), the per-request
   session-factory dependency (`get_session`), and the


### PR DESCRIPTION
## Summary

Closes #308 — T2 lands the event contract every downstream broadcast consumer (T3 publish hook, T4 SSE, T6 MCP resource) reads back from the Valkey stream. Locks [decision #3](../blob/main/docs/planning/v0.2-decisions.md)'s conservative PII defaults so the publish hook in T3 inherits a redaction policy already cast in stone — no per-tenant or per-op opt-in surface here (that's G6.3).

- **`broadcast/events.py` (new)** — `BroadcastEvent` Pydantic v2 model with `ConfigDict(frozen=True)`. Frozen so a consumer mid-pipeline can't mutate fields the next stage assumed immutable. Mirrors the chassis `Operator` pattern.
- **`classify_op(op_id)`** — five-class derivation: `credential_read` (exact allowlist `vault.kv.read` + `vault.kv.list`), `audit_query` (`audit.*` prefix), `write` (`.create` / `.update` / `.delete` / `.patch` suffixes), `read` (`.list` / `.info` / `.get` / `.about` / `.ls` suffixes), `other` (default). Match order is policy-significant — credential allowlist runs before the suffix check so a future `vault.kv.audit-list` could opt out by being absent from the allowlist.
- **`redact_payload(op_class, raw_params, result_status)`** — per-class redaction. `credential_read` collapses to `{op_class, result_status}` (no path, no key, no value); `audit_query` adds `{row_count}` extracted via `_maybe_row_count` with int-coercion + fail-closed-to-None on a malformed JSON round-trip; `read` / `write` / `other` keep full params verbatim (no defensive copies — nested objects pass through).
- **Tests:** 41 cases across schema (frozen, required, optional, omittable, JSON round-trip), `classify_op` (per-class parametric + precedence pins for credential allowlist beats `.list` suffix and `audit.` prefix beats both `.list` and `.query` suffixes), `redact_payload` (per-class shape + absent-key invariants for credential `path` / `key` and audit `filter`, plus stringified `row_count` coercion + nested-params passthrough).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean (102 files)
- [x] `mypy src` strict — 53 source files, no issues
- [x] `pytest tests/test_broadcast_events.py` — **41 passed**
- [x] `pytest --ignore=tests/integration` — **514 passed** (+41 vs main), 1 skipped, 1 deselected
- [x] AC #1 — `BroadcastEvent` defined, frozen, all required fields enforced → `TestBroadcastEventSchema`
- [x] AC #2-5 — `classify_op` mapping for every named op-id → `TestClassifyOp` parametric cases
- [x] AC #6 — `redact_payload("credential_read", ...)` drops path/key → `test_credential_read_drops_path_and_key`
- [x] AC #7 — `redact_payload("audit_query", ...)` drops filter → `test_audit_query_drops_filter`
- [x] AC #8 — `redact_payload("read", ...)` keeps params → `test_read_keeps_full_params`
- [x] AC #9 — unit tests cover each branch + edge cases (empty params, nested objects, stringified row_count, omittable optional fields, default_factory exercised) → all in `TestRedactPayload` / `TestBroadcastEventSchema`

## Out of scope

- Per-op opt-in/opt-out — G6.3 surface (separate Initiative, post-G6.1).
- Per-tenant convention overrides for classification.
- ML-based PII detection.
- T3 publish-on-write hook — separate task #309, builds on this schema.
- `Mapping[str, Any]` + `MappingProxyType` migration for genuine payload immutability — heavy-lift; tracked for v0.2.next if the broadcast pipeline grows transformation stages.

## Post-merge follow-up

- Tick T2 line on Initiative #228 body checklist.

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-13)

Addressed all three review findings from [/auto-review-pr iter-1](https://github.com/evoila/meho/pull/346#issuecomment-3525914732):

- **B1** `e7e8fc2` — `principal_name` / `target_name` now carry `= None` defaults so T3's publisher can omit them. Strengthened `test_optional_fields_omittable_at_construction` to pin the omission path (the prior `test_optional_fields_accept_none` only covered explicit-`None`).
- **M1** `e7e8fc2` — Class docstring tightened: `frozen=True` now correctly described as faux-immutability (blocks attribute reassignment but NOT nested in-place mutation). Explicit statement that PII enforcement is upstream of the model (`redact_payload()` before construction). `MappingProxyType` migration noted as tracked out-of-scope.
- **M2** `e7e8fc2` — `test_payload_default_is_empty_dict` rewritten to actually exercise `Field(default_factory=dict)` via `model_dump().pop('payload')` + reconstruct; `assert == {}` added so the shared-mutable-default footgun would fail the test if reintroduced.

<!-- auto-implement-issue: continue, iteration 2 -->

Closes #308


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a frozen BroadcastEvent schema plus classification and payload redaction utilities to record audited operations with conservative PII redaction rules.

* **Tests**
  * Added comprehensive tests for the event schema, classification precedence, immutability, JSON round-trip, and per-class redaction/coercion behavior.

* **Documentation**
  * Updated backend docs to describe the broadcast event schema and the data protection/classification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/346)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->