### PR TITLE
feat(connectors): SshConnector adapter — asyncssh + key/password auth + per-target connection caching (G0.2-T4)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "fastembed>=0.7,<1.0",
     "kubernetes-asyncio>=32,<33",
     "tenacity>=9.0",
+    "asyncssh>=2.18,<3.0",
 ]
 
 [dependency-groups]
@@ -199,6 +200,14 @@ ignore_missing_imports = true
 # override scope stays narrow.
 [[tool.mypy.overrides]]
 module = ["testcontainers.k3s"]
+ignore_missing_imports = true
+
+# asyncssh (G0.2-T4) ships no ``py.typed`` marker as of 2.18. The SSH
+# connector adapter (:mod:`meho_backplane.connectors.adapters.ssh`)
+# localises the untyped surface to one module. Drop this override if
+# upstream ships stubs.
+[[tool.mypy.overrides]]
+module = ["asyncssh.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/backend/src/meho_backplane/connectors/adapters/__init__.py
+++ b/backend/src/meho_backplane/connectors/adapters/__init__.py
@@ -7,8 +7,12 @@ Current adapters:
 * :class:`~meho_backplane.connectors.adapters.http.HttpConnector` — abstract
   HTTP-API connector with httpx.AsyncClient pooling, retry/timeout, and
   auth-bearer plumbing (G0.2-T3).
+* :class:`~meho_backplane.connectors.adapters.ssh.SshConnector` — abstract
+  SSH connector with asyncssh connection pooling and key/password auth
+  (G0.2-T4).
 """
 
 from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.adapters.ssh import SshConnector
 
-__all__ = ["HttpConnector"]
+__all__ = ["HttpConnector", "SshConnector"]

--- a/backend/src/meho_backplane/connectors/adapters/ssh.py
+++ b/backend/src/meho_backplane/connectors/adapters/ssh.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Abstract SSH-transport connector with asyncssh plumbing.
+
+Every SSH-based connector (bind9, pfsense, Holodeck, etc.) inherits
+:class:`SshConnector` and overrides ``fingerprint``, ``probe``, and
+``execute``. Auth is centralised — vendor connectors do not override
+``_auth_config``.
+
+**Auth flavours.** ``_auth_config`` reads ``target.secret_ref``:
+
+* **Key auth (preferred):** ``secret_ref`` carries a ``ssh_private_key``
+  field (PEM-encoded text) plus ``username``; the key is parsed via
+  ``asyncssh.import_private_key`` and passed as ``client_keys``.
+* **Password auth (fallback):** ``secret_ref`` carries ``username`` and
+  ``password``; used when ``ssh_private_key`` is absent.
+
+**Per-target connection caching.** Each :class:`SshConnector` instance
+owns a dict of live ``asyncssh.SSHClientConnection`` objects keyed by
+``target.name``. The connection is created on first use and reused until
+closed or evicted. SSH key exchange is expensive — pooling matters more
+here than for HTTP.
+
+**Host key checking.** ``known_hosts=None`` disables host-key verification
+for v0.2; pinning is deferred to v0.2.next once a Vault-managed key store
+is in place.
+
+**Timeouts.** ``_run_command`` wraps ``conn.run()`` in
+``asyncio.wait_for``; expiry raises :exc:`asyncio.TimeoutError`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import asyncssh
+import structlog
+
+from meho_backplane.connectors.base import Connector
+
+logger = structlog.get_logger()
+
+# Forward declaration — replaced with `from meho_backplane.targets import Target`
+# once G0.3 lands the Target model.
+type Target = Any
+
+
+class SshConnector(Connector):
+    """Abstract SSH-transport connector.
+
+    Subclasses MUST override ``fingerprint``, ``probe``, and ``execute``.
+    Auth plumbing and connection pooling are provided here.
+    """
+
+    def __init__(self) -> None:
+        self._connections: dict[str, asyncssh.SSHClientConnection] = {}
+        self._lock = asyncio.Lock()
+
+    async def _auth_config(self, target: Target) -> dict[str, Any]:
+        """Extract auth kwargs from ``target.secret_ref``.
+
+        Returns ``{username, client_keys=[key]}`` for key auth, or
+        ``{username, password}`` for password auth (fallback).
+
+        T5 (VaultConnector) will replace the direct dict access with a
+        Vault fetch once it lands; the auth-selection logic stays here.
+        """
+        secret: dict[str, Any] = getattr(target, "secret_ref", {}) or {}
+        username: str = secret.get("username", "root")
+        private_key_text: str | None = secret.get("ssh_private_key")
+        if private_key_text:
+            key = asyncssh.import_private_key(private_key_text)
+            return {"username": username, "client_keys": [key]}
+        return {"username": username, "password": secret.get("password")}
+
+    async def _connect(self, target: Target, raw_jwt: str) -> asyncssh.SSHClientConnection:
+        """Return the cached SSH connection for *target*, creating it if needed."""
+        async with self._lock:
+            existing = self._connections.get(target.name)
+            if existing is not None and not existing.is_closed():
+                return existing
+
+            auth_kwargs = await self._auth_config(target)
+            conn = await asyncssh.connect(
+                target.host,
+                port=target.port or 22,
+                username=auth_kwargs["username"],
+                client_keys=auth_kwargs.get("client_keys"),
+                password=auth_kwargs.get("password"),
+                known_hosts=None,
+            )
+            self._connections[target.name] = conn
+            logger.info("ssh_connected", target=target.name, host=target.host)
+            return conn
+
+    async def _run_command(
+        self,
+        target: Target,
+        cmd: str,
+        *,
+        raw_jwt: str,
+        timeout: float = 30.0,
+    ) -> asyncssh.SSHCompletedProcess:
+        """Run *cmd* on *target* via the pooled SSH connection.
+
+        Raises :exc:`asyncio.TimeoutError` when *timeout* is exceeded.
+        """
+        conn = await self._connect(target, raw_jwt)
+        result = await asyncio.wait_for(conn.run(cmd, check=False), timeout=timeout)
+        logger.info(
+            "ssh_command_executed",
+            target=target.name,
+            cmd=cmd,
+            exit_code=result.exit_status,
+        )
+        return result
+
+    async def aclose(self) -> None:
+        """Close all pooled connections. Called by lifespan or cleanup."""
+        async with self._lock:
+            for conn in self._connections.values():
+                if not conn.is_closed():
+                    conn.close()
+                    await conn.wait_closed()
+            self._connections.clear()

--- a/backend/src/meho_backplane/connectors/adapters/ssh.py
+++ b/backend/src/meho_backplane/connectors/adapters/ssh.py
@@ -15,12 +15,16 @@ Every SSH-based connector (bind9, pfsense, Holodeck, etc.) inherits
   ``asyncssh.import_private_key`` and passed as ``client_keys``.
 * **Password auth (fallback):** ``secret_ref`` carries ``username`` and
   ``password``; used when ``ssh_private_key`` is absent.
+* **Missing credentials:** raises :exc:`ValueError` immediately so callers
+  fail fast rather than hitting an opaque asyncssh auth error.
 
-**Per-target connection caching.** Each :class:`SshConnector` instance
-owns a dict of live ``asyncssh.SSHClientConnection`` objects keyed by
-``target.name``. The connection is created on first use and reused until
-closed or evicted. SSH key exchange is expensive — pooling matters more
-here than for HTTP.
+**Per-target connection pool.** Each :class:`SshConnector` instance
+maintains a per-target pool of live ``asyncssh.SSHClientConnection``
+objects. Connections are cached on first use and reused until closed or
+idle past ``_POOL_TTL_S`` (default 5 min). A per-target lock lets
+concurrent requests to distinct targets proceed in parallel; only requests
+to the *same* target serialize during the SSH handshake. SSH key exchange
+is expensive — pooling matters more here than for HTTP.
 
 **Host key checking.** ``known_hosts=None`` disables host-key verification
 for v0.2; pinning is deferred to v0.2.next once a Vault-managed key store
@@ -33,6 +37,7 @@ is in place.
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 import asyncssh
@@ -46,6 +51,8 @@ logger = structlog.get_logger()
 # once G0.3 lands the Target model.
 type Target = Any
 
+_POOL_TTL_S: float = 300.0  # 5-minute idle eviction window
+
 
 class SshConnector(Connector):
     """Abstract SSH-transport connector.
@@ -55,14 +62,19 @@ class SshConnector(Connector):
     """
 
     def __init__(self) -> None:
-        self._connections: dict[str, asyncssh.SSHClientConnection] = {}
-        self._lock = asyncio.Lock()
+        # Maps target.name → (SSHClientConnection, last_used monotonic timestamp).
+        self._connections: dict[str, tuple[asyncssh.SSHClientConnection, float]] = {}
+        # Short-lived lock protecting only _connections and _connect_locks dicts.
+        self._pool_lock = asyncio.Lock()
+        # Per-target connect locks — SSH handshakes for distinct targets run in parallel.
+        self._connect_locks: dict[str, asyncio.Lock] = {}
 
     async def _auth_config(self, target: Target) -> dict[str, Any]:
         """Extract auth kwargs from ``target.secret_ref``.
 
         Returns ``{username, client_keys=[key]}`` for key auth, or
-        ``{username, password}`` for password auth (fallback).
+        ``{username, password}`` for password auth. Raises :exc:`ValueError`
+        when neither ``ssh_private_key`` nor ``password`` is present.
 
         T5 (VaultConnector) will replace the direct dict access with a
         Vault fetch once it lands; the auth-selection logic stays here.
@@ -73,14 +85,49 @@ class SshConnector(Connector):
         if private_key_text:
             key = asyncssh.import_private_key(private_key_text)
             return {"username": username, "client_keys": [key]}
-        return {"username": username, "password": secret.get("password")}
+        password: str | None = secret.get("password")
+        if password:
+            return {"username": username, "password": password}
+        raise ValueError(
+            f"target '{target.name}': secret_ref must include ssh_private_key or password"
+        )
 
     async def _connect(self, target: Target, raw_jwt: str) -> asyncssh.SSHClientConnection:
-        """Return the cached SSH connection for *target*, creating it if needed."""
-        async with self._lock:
-            existing = self._connections.get(target.name)
-            if existing is not None and not existing.is_closed():
-                return existing
+        """Return a live SSH connection for *target*.
+
+        Fast path (no lock): returns the cached connection when it is open
+        and within the idle TTL. Slow path: acquires the per-target connect
+        lock, evicts stale/closed entries, and opens a fresh connection.
+        """
+        # Fast path: check without acquiring any lock.
+        entry = self._connections.get(target.name)
+        if entry is not None:
+            conn, last_used = entry
+            now = time.monotonic()
+            if not conn.is_closed() and (now - last_used) <= _POOL_TTL_S:
+                self._connections[target.name] = (conn, now)
+                return conn
+
+        # Get or create the per-target connect lock.
+        async with self._pool_lock:
+            if target.name not in self._connect_locks:
+                self._connect_locks[target.name] = asyncio.Lock()
+            t_lock = self._connect_locks[target.name]
+
+        async with t_lock:
+            # Double-check under per-target lock.
+            now = time.monotonic()
+            entry = self._connections.get(target.name)
+            if entry is not None:
+                conn, last_used = entry
+                if not conn.is_closed() and (now - last_used) <= _POOL_TTL_S:
+                    self._connections[target.name] = (conn, now)
+                    return conn
+                # Evict closed or idle-expired entry.
+                if not conn.is_closed():
+                    conn.close()
+                    await conn.wait_closed()
+                del self._connections[target.name]
 
             auth_kwargs = await self._auth_config(target)
             conn = await asyncssh.connect(
@@ -91,7 +138,7 @@ class SshConnector(Connector):
                 password=auth_kwargs.get("password"),
                 known_hosts=None,
             )
-            self._connections[target.name] = conn
+            self._connections[target.name] = (conn, time.monotonic())
             logger.info("ssh_connected", target=target.name, host=target.host)
             return conn
 
@@ -112,16 +159,18 @@ class SshConnector(Connector):
         logger.info(
             "ssh_command_executed",
             target=target.name,
-            cmd=cmd,
+            cmd_len=len(cmd),
             exit_code=result.exit_status,
         )
         return result
 
     async def aclose(self) -> None:
         """Close all pooled connections. Called by lifespan or cleanup."""
-        async with self._lock:
-            for conn in self._connections.values():
-                if not conn.is_closed():
-                    conn.close()
-                    await conn.wait_closed()
+        async with self._pool_lock:
+            to_close = list(self._connections.values())
             self._connections.clear()
+            self._connect_locks.clear()
+        for conn, _ in to_close:
+            if not conn.is_closed():
+                conn.close()
+                await conn.wait_closed()

--- a/backend/tests/test_connectors_ssh_adapter.py
+++ b/backend/tests/test_connectors_ssh_adapter.py
@@ -54,7 +54,7 @@ from meho_backplane.connectors.schemas import (
 _SERVER_KEY = asyncssh.generate_private_key("ssh-ed25519")
 _CLIENT_KEY = asyncssh.generate_private_key("ssh-ed25519")
 _CLIENT_PUB = _CLIENT_KEY.convert_to_public()
-_PASSWORD = "test-secret"
+_PASSWORD = "test-secret"  # NOSONAR — in-process asyncssh test server only, no real system
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_ssh_adapter.py
+++ b/backend/tests/test_connectors_ssh_adapter.py
@@ -3,7 +3,7 @@
 
 """Tests for SshConnector adapter (G0.2-T4).
 
-Coverage matrix (per Task #243 acceptance criteria):
+Coverage matrix (per Task #243 acceptance criteria + review findings):
 
 * ``SshConnector`` class exists and is importable from the adapters package.
 * Abstract class cannot be instantiated directly (ABC enforcement).
@@ -11,10 +11,13 @@ Coverage matrix (per Task #243 acceptance criteria):
   commands against an in-process asyncssh server.
 * Per-target connection pool: same ``target.name`` reuses the same
   connection object; different names get distinct connections.
+* Idle TTL eviction: connection idle past ``_POOL_TTL_S`` is replaced on
+  next ``_connect`` call.
 * Key auth path: ``target.secret_ref`` with ``ssh_private_key`` uses the
   private key for authentication.
 * Password auth path: ``target.secret_ref`` with ``password`` (no
   ``ssh_private_key``) uses password authentication as fallback.
+* Missing credentials: ``_auth_config`` raises ``ValueError`` immediately.
 * Connection failure (wrong host / refused port) surfaces as a
   connect-time error from ``_connect``, not a command-time error.
 * Command timeout: ``_run_command(..., timeout=N)`` raises
@@ -27,6 +30,7 @@ Coverage matrix (per Task #243 acceptance criteria):
 from __future__ import annotations
 
 import asyncio
+import time
 import types
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -35,6 +39,7 @@ import asyncssh
 import pytest
 
 from meho_backplane.connectors.adapters import SshConnector
+from meho_backplane.connectors.adapters.ssh import _POOL_TTL_S
 from meho_backplane.connectors.adapters.ssh import SshConnector as _SshConnectorDirect
 from meho_backplane.connectors.schemas import (
     FingerprintResult,
@@ -337,7 +342,7 @@ async def test_run_command_timeout_raises_asyncio_timeout_error() -> None:
         port=22,
         secret_ref={"username": "u", "password": "p"},
     )
-    conn._connections["timeout-target"] = mock_conn
+    conn._connections["timeout-target"] = (mock_conn, time.monotonic())
 
     with pytest.raises(asyncio.TimeoutError):
         await conn._run_command(target, "sleep 60", raw_jwt="jwt", timeout=0.05)
@@ -445,3 +450,41 @@ async def test_auth_config_defaults_username_to_root() -> None:
     cfg = await conn._auth_config(target)
 
     assert cfg["username"] == "root"
+
+
+@pytest.mark.asyncio
+async def test_auth_config_raises_when_no_credentials() -> None:
+    """_auth_config raises ValueError immediately when neither key nor password is present."""
+    conn = _ConcreteSshConnector()
+    target = types.SimpleNamespace(
+        name="no-creds",
+        host="h",
+        port=22,
+        secret_ref={"username": "alice"},
+    )
+
+    with pytest.raises(ValueError, match="ssh_private_key or password"):
+        await conn._auth_config(target)
+
+
+# ---------------------------------------------------------------------------
+# Idle TTL eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idle_ttl_evicts_stale_connection(ssh_server: Any) -> None:
+    """Connection idle past _POOL_TTL_S is evicted and replaced on next _connect."""
+    conn = _ConcreteSshConnector()
+    target = _password_target(name="ttl-test", host=ssh_server.host, port=ssh_server.port)
+
+    ssh_first = await conn._connect(target, "jwt")
+
+    # Backdate last_used to simulate idle expiry.
+    conn._connections["ttl-test"] = (ssh_first, time.monotonic() - _POOL_TTL_S - 1.0)
+
+    ssh_second = await conn._connect(target, "jwt")
+
+    assert ssh_second is not ssh_first
+    assert not ssh_second.is_closed()
+    await conn.aclose()

--- a/backend/tests/test_connectors_ssh_adapter.py
+++ b/backend/tests/test_connectors_ssh_adapter.py
@@ -302,7 +302,7 @@ async def test_connect_failure_raises_at_connect_time() -> None:
         name="bad-host",
         host="unreachable.internal",
         port=22,
-        secret_ref={"username": "u", "password": "p"},
+        secret_ref={"username": "u", "password": "p"},  # NOSONAR
     )
 
     # asyncssh.connect raises OSError on TCP failure; mock it so the test
@@ -340,7 +340,7 @@ async def test_run_command_timeout_raises_asyncio_timeout_error() -> None:
         name="timeout-target",
         host="127.0.0.1",
         port=22,
-        secret_ref={"username": "u", "password": "p"},
+        secret_ref={"username": "u", "password": "p"},  # NOSONAR
     )
     conn._connections["timeout-target"] = (mock_conn, time.monotonic())
 
@@ -426,13 +426,13 @@ async def test_auth_config_password_auth_fallback() -> None:
         name="pwd-cfg",
         host="h",
         port=22,
-        secret_ref={"username": "bob", "password": "hunter2"},
+        secret_ref={"username": "bob", "password": _PASSWORD},
     )
 
     cfg = await conn._auth_config(target)
 
     assert cfg["username"] == "bob"
-    assert cfg.get("password") == "hunter2"
+    assert cfg.get("password") == _PASSWORD
     assert "client_keys" not in cfg
 
 
@@ -444,7 +444,7 @@ async def test_auth_config_defaults_username_to_root() -> None:
         name="no-user",
         host="h",
         port=22,
-        secret_ref={"password": "pw"},
+        secret_ref={"password": _PASSWORD},
     )
 
     cfg = await conn._auth_config(target)

--- a/backend/tests/test_connectors_ssh_adapter.py
+++ b/backend/tests/test_connectors_ssh_adapter.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for SshConnector adapter (G0.2-T4).
+
+Coverage matrix (per Task #243 acceptance criteria):
+
+* ``SshConnector`` class exists and is importable from the adapters package.
+* Abstract class cannot be instantiated directly (ABC enforcement).
+* A concrete subclass with all three ABC methods can connect and execute
+  commands against an in-process asyncssh server.
+* Per-target connection pool: same ``target.name`` reuses the same
+  connection object; different names get distinct connections.
+* Key auth path: ``target.secret_ref`` with ``ssh_private_key`` uses the
+  private key for authentication.
+* Password auth path: ``target.secret_ref`` with ``password`` (no
+  ``ssh_private_key``) uses password authentication as fallback.
+* Connection failure (wrong host / refused port) surfaces as a
+  connect-time error from ``_connect``, not a command-time error.
+* Command timeout: ``_run_command(..., timeout=N)`` raises
+  :exc:`asyncio.TimeoutError` when the command exceeds *N* seconds.
+* ``aclose()`` closes all pooled connections and empties the pool dict.
+* ``aclose()`` is idempotent on a fresh connector with no pooled
+  connections.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import asyncssh
+import pytest
+
+from meho_backplane.connectors.adapters import SshConnector
+from meho_backplane.connectors.adapters.ssh import SshConnector as _SshConnectorDirect
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+# ---------------------------------------------------------------------------
+# Shared key material (generated once per test session)
+# ---------------------------------------------------------------------------
+
+_SERVER_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_PUB = _CLIENT_KEY.convert_to_public()
+_PASSWORD = "test-secret"
+
+
+# ---------------------------------------------------------------------------
+# In-process SSH server fixture
+# ---------------------------------------------------------------------------
+
+
+class _TestSSHServer(asyncssh.SSHServer):
+    """Minimal in-process server accepting both auth flavours."""
+
+    def password_auth_supported(self) -> bool:
+        return True
+
+    def validate_password(self, username: str, password: str) -> bool:
+        return password == _PASSWORD
+
+    def public_key_auth_supported(self) -> bool:
+        return True
+
+    def validate_public_key(self, username: str, key: Any) -> bool:
+        return key == _CLIENT_PUB
+
+
+async def _handle_process(process: Any) -> None:
+    """Simple command handler for test server."""
+    cmd: str = process.command or ""
+    if cmd == "echo ok":
+        process.stdout.write("ok\n")
+        process.exit(0)
+    elif cmd.startswith("sleep "):
+        await asyncio.sleep(float(cmd.split()[1]))
+        process.exit(0)
+    else:
+        process.stdout.write(f"{cmd}\n")
+        process.exit(0)
+
+
+@pytest.fixture
+async def ssh_server() -> Any:
+    """Yield a running in-process asyncssh server; shut it down after the test."""
+    server = await asyncssh.create_server(
+        _TestSSHServer,
+        "127.0.0.1",
+        0,
+        server_host_keys=[_SERVER_KEY],
+        process_factory=_handle_process,
+    )
+    port: int = server.sockets[0].getsockname()[1]
+
+    yield types.SimpleNamespace(host="127.0.0.1", port=port)
+
+    server.close()
+    await server.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Target builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _password_target(
+    name: str = "srv-01",
+    *,
+    host: str = "127.0.0.1",
+    port: int = 22,
+    username: str = "test",
+) -> Any:
+    return types.SimpleNamespace(
+        name=name,
+        host=host,
+        port=port,
+        secret_ref={"username": username, "password": _PASSWORD},
+    )
+
+
+def _key_target(
+    name: str = "srv-02",
+    *,
+    host: str = "127.0.0.1",
+    port: int = 22,
+    username: str = "test",
+) -> Any:
+    private_key_pem = _CLIENT_KEY.export_private_key("pkcs8-pem").decode()
+    return types.SimpleNamespace(
+        name=name,
+        host=host,
+        port=port,
+        secret_ref={"username": username, "ssh_private_key": private_key_pem},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Concrete subclass for testing
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteSshConnector(SshConnector):
+    """Minimal concrete subclass — all ABC methods raise NotImplementedError."""
+
+    product = "test-ssh"
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        result = await self._run_command(target, "echo ok", raw_jwt="jwt")
+        from datetime import UTC, datetime
+
+        return ProbeResult(
+            ok=result.exit_status == 0,
+            latency_ms=0.0,
+            probed_at=datetime.now(UTC),
+        )
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Import / instantiation
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_connector_importable_from_adapters_package() -> None:
+    assert SshConnector is _SshConnectorDirect
+
+
+def test_ssh_connector_abstract_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError):
+        SshConnector()  # type: ignore[abstract]
+
+
+def test_concrete_subclass_instantiates() -> None:
+    conn = _ConcreteSshConnector()
+    assert conn.product == "test-ssh"
+    assert conn._connections == {}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end against in-process server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_password_auth_connects_and_runs_command(ssh_server: Any) -> None:
+    """Password auth path: secret_ref with username+password."""
+    conn = _ConcreteSshConnector()
+    target = _password_target(host=ssh_server.host, port=ssh_server.port)
+
+    result = await conn._run_command(target, "echo ok", raw_jwt="jwt")
+
+    assert result.exit_status == 0
+    assert result.stdout is not None
+    assert "ok" in result.stdout
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_key_auth_connects_and_runs_command(ssh_server: Any) -> None:
+    """Key auth path: secret_ref with ssh_private_key uses key authentication."""
+    conn = _ConcreteSshConnector()
+    target = _key_target(host=ssh_server.host, port=ssh_server.port)
+
+    result = await conn._run_command(target, "echo ok", raw_jwt="jwt")
+
+    assert result.exit_status == 0
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_via_echo_ok(ssh_server: Any) -> None:
+    """Concrete subclass: probe() works via _run_command('echo ok')."""
+    conn = _ConcreteSshConnector()
+    target = _password_target(host=ssh_server.host, port=ssh_server.port)
+
+    probe_result = await conn.probe(target)
+
+    assert probe_result.ok is True
+    await conn.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Per-target connection pooling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_same_target_reuses_connection(ssh_server: Any) -> None:
+    """Two _connect calls for the same target return the identical connection object."""
+    conn = _ConcreteSshConnector()
+    target = _password_target(name="pool-test", host=ssh_server.host, port=ssh_server.port)
+
+    ssh_a = await conn._connect(target, "jwt")
+    ssh_b = await conn._connect(target, "jwt")
+
+    assert ssh_a is ssh_b
+    assert len(conn._connections) == 1
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_different_targets_get_different_connections(ssh_server: Any) -> None:
+    """Each distinct target.name gets its own SSHClientConnection."""
+    conn = _ConcreteSshConnector()
+    target_a = _password_target(name="srv-a", host=ssh_server.host, port=ssh_server.port)
+    target_b = _password_target(name="srv-b", host=ssh_server.host, port=ssh_server.port)
+
+    ssh_a = await conn._connect(target_a, "jwt")
+    ssh_b = await conn._connect(target_b, "jwt")
+
+    assert ssh_a is not ssh_b
+    assert "srv-a" in conn._connections
+    assert "srv-b" in conn._connections
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_closed_connection_triggers_reconnect(ssh_server: Any) -> None:
+    """A closed cached connection is replaced on next _connect call."""
+    conn = _ConcreteSshConnector()
+    target = _password_target(name="reconnect-test", host=ssh_server.host, port=ssh_server.port)
+
+    ssh_first = await conn._connect(target, "jwt")
+    ssh_first.close()
+    await ssh_first.wait_closed()
+
+    assert ssh_first.is_closed()
+
+    ssh_second = await conn._connect(target, "jwt")
+    assert ssh_second is not ssh_first
+    assert not ssh_second.is_closed()
+    await conn.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Connection failure — surfaces at connect time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_raises_at_connect_time() -> None:
+    """Connection failure raises from _connect, not from a later conn.run() call."""
+    conn = _ConcreteSshConnector()
+    target = types.SimpleNamespace(
+        name="bad-host",
+        host="unreachable.internal",
+        port=22,
+        secret_ref={"username": "u", "password": "p"},
+    )
+
+    # asyncssh.connect raises OSError on TCP failure; mock it so the test
+    # doesn't depend on network behaviour or firewall rules on the test host.
+    async def _refuse(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("Connection refused")
+
+    with patch("asyncssh.connect", side_effect=_refuse), pytest.raises(OSError):
+        await conn._connect(target, "jwt")
+
+    # _run_command calls _connect; the error must surface before run() is called.
+    with patch("asyncssh.connect", side_effect=_refuse), pytest.raises(OSError):
+        await conn._run_command(target, "echo ok", raw_jwt="jwt")
+
+
+# ---------------------------------------------------------------------------
+# Command timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_command_timeout_raises_asyncio_timeout_error() -> None:
+    """_run_command with a short timeout raises asyncio.TimeoutError."""
+    conn = _ConcreteSshConnector()
+
+    mock_conn = MagicMock()
+    mock_conn.is_closed.return_value = False
+
+    async def _never_finishes(*_args: Any, **_kwargs: Any) -> None:
+        await asyncio.sleep(60)
+
+    mock_conn.run = _never_finishes
+
+    target = types.SimpleNamespace(
+        name="timeout-target",
+        host="127.0.0.1",
+        port=22,
+        secret_ref={"username": "u", "password": "p"},
+    )
+    conn._connections["timeout-target"] = mock_conn
+
+    with pytest.raises(asyncio.TimeoutError):
+        await conn._run_command(target, "sleep 60", raw_jwt="jwt", timeout=0.05)
+
+
+# ---------------------------------------------------------------------------
+# aclose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_all_connections_and_empties_pool(ssh_server: Any) -> None:
+    """aclose() calls close()+wait_closed() on every pooled connection."""
+    conn = _ConcreteSshConnector()
+    target_a = _password_target(name="ac-a", host=ssh_server.host, port=ssh_server.port)
+    target_b = _password_target(name="ac-b", host=ssh_server.host, port=ssh_server.port)
+
+    await conn._connect(target_a, "jwt")
+    await conn._connect(target_b, "jwt")
+    assert len(conn._connections) == 2
+
+    await conn.aclose()
+
+    assert conn._connections == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_idempotent_on_empty_pool() -> None:
+    """aclose() on a fresh connector is a no-op."""
+    conn = _ConcreteSshConnector()
+    await conn.aclose()
+    assert conn._connections == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_skips_already_closed_connections(ssh_server: Any) -> None:
+    """aclose() does not call wait_closed() on connections that are already closed."""
+    conn = _ConcreteSshConnector()
+    target = _password_target(name="pre-closed", host=ssh_server.host, port=ssh_server.port)
+
+    ssh = await conn._connect(target, "jwt")
+    # Close manually before aclose()
+    ssh.close()
+    await ssh.wait_closed()
+
+    # aclose() should not raise even though the connection is already closed
+    await conn.aclose()
+    assert conn._connections == {}
+
+
+# ---------------------------------------------------------------------------
+# Auth config unit tests (no real server needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_config_key_auth_returns_client_keys() -> None:
+    """_auth_config picks key auth when ssh_private_key is present."""
+    conn = _ConcreteSshConnector()
+    private_pem = _CLIENT_KEY.export_private_key("pkcs8-pem").decode()
+    target = types.SimpleNamespace(
+        name="key-cfg",
+        host="h",
+        port=22,
+        secret_ref={"username": "alice", "ssh_private_key": private_pem},
+    )
+
+    cfg = await conn._auth_config(target)
+
+    assert cfg["username"] == "alice"
+    assert "client_keys" in cfg
+    assert len(cfg["client_keys"]) == 1
+    assert "password" not in cfg
+
+
+@pytest.mark.asyncio
+async def test_auth_config_password_auth_fallback() -> None:
+    """_auth_config falls back to password when ssh_private_key is absent."""
+    conn = _ConcreteSshConnector()
+    target = types.SimpleNamespace(
+        name="pwd-cfg",
+        host="h",
+        port=22,
+        secret_ref={"username": "bob", "password": "hunter2"},
+    )
+
+    cfg = await conn._auth_config(target)
+
+    assert cfg["username"] == "bob"
+    assert cfg.get("password") == "hunter2"
+    assert "client_keys" not in cfg
+
+
+@pytest.mark.asyncio
+async def test_auth_config_defaults_username_to_root() -> None:
+    """_auth_config defaults username to 'root' when not set in secret_ref."""
+    conn = _ConcreteSshConnector()
+    target = types.SimpleNamespace(
+        name="no-user",
+        host="h",
+        port=22,
+        secret_ref={"password": "pw"},
+    )
+
+    cfg = await conn._auth_config(target)
+
+    assert cfg["username"] == "root"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -248,6 +248,19 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncssh"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/fd/c34fe7e30838b4b9cc91903da26a62c6d33b673c731b3d951fcd70ab1889/asyncssh-2.23.0.tar.gz", hash = "sha256:8c54760953c1f2cf282591bcba5c8c70efc48d645bbf26bd2307a9c66a0ed1a7", size = 542154, upload-time = "2026-05-09T03:15:01.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/b5/b1a3979f4840d1271ca8e0978dbccfb18ad2d33b4ece85cf77122fb46e5f/asyncssh-2.23.0-py3-none-any.whl", hash = "sha256:14108bfdaae17457f0c1841e883ad934271bbfdd46458aa4c4d0973451940ad0", size = 375687, upload-time = "2026-05-09T03:15:00.221Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1181,6 +1194,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "asyncssh" },
     { name = "authlib" },
     { name = "fastapi" },
     { name = "fastembed" },
@@ -1215,6 +1229,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "asyncpg", specifier = ">=0.29" },
+    { name = "asyncssh", specifier = ">=2.18,<3.0" },
     { name = "authlib", specifier = ">=1.3" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "fastembed", specifier = ">=0.7,<1.0" },

--- a/docs/architecture/connectors.md
+++ b/docs/architecture/connectors.md
@@ -91,35 +91,35 @@ class AuthModel(StrEnum):
 
 Stored on every `Target` row (G0.3); read by the connector at `execute()` time.
 
-## Adapter shapes (planned: G0.2-T3 / T4)
+## Adapter shapes (G0.2-T3 / T4)
 
-> **Status:** None of the subclasses below exist yet. G0.2-T1 (ABC + result models) has landed; G0.2-T3 (HTTP adapter), G0.2-T4 (SSH adapter), and G0.2-T5 (`VaultConnector` reference refactor) are still open. The tree is the target hierarchy each vendor Initiative under [G3 (#214)](https://github.com/evoila/meho/issues/214) will register against once the adapters land.
+> **Status:** G0.2-T1 (ABC + result models), G0.2-T2 (registry), G0.2-T3 (HTTP adapter), and G0.2-T4 (SSH adapter) have landed. G0.2-T5 (`VaultConnector` reference refactor) is still open. The tree is the target hierarchy each vendor Initiative under [G3 (#214)](https://github.com/evoila/meho/issues/214) will register against.
 
 ```text
 Connector (ABC)                                      ← G0.2-T1 (shipped)
-├── HttpConnector       — httpx.AsyncClient pool, tenacity retry, SSL_CERT_FILE   ← G0.2-T3 (planned)
+├── HttpConnector       — httpx.AsyncClient pool, tenacity retry, SSL_CERT_FILE   ← G0.2-T3 (shipped)
 │   ├── VaultConnector  — refactor of auth/vault.py (G0.2-T5; reference impl)     ← G0.2-T5 (planned)
 │   ├── VSphereConnector — vSphere REST API (G3.1)
 │   ├── NSXConnector
 │   ├── HarborConnector
 │   └── ... (HTTP-API vendors)
-└── SshConnector         — asyncssh, key+password, per-target connection pool     ← G0.2-T4 (planned)
+└── SshConnector         — asyncssh, key+password, per-target connection pool     ← G0.2-T4 (shipped)
     ├── Bind9Connector
     ├── PfsenseConnector
     └── HolodeckConnector
 ```
 
-**HTTP adapter** (T3, planned): shared `httpx.AsyncClient` per target with retry on idempotent verbs only, `SSL_CERT_FILE` honored natively for the trust-bundle wiring from PR #212.
+**HTTP adapter** (T3, shipped): shared `httpx.AsyncClient` per target with retry on idempotent verbs only, `SSL_CERT_FILE` honored natively for the trust-bundle wiring from PR #212.
 
-**SSH adapter** (T4, planned): asyncssh (async-native, no thread offload — beats paramiko for the event loop). Per-target connection cached; closed on lifespan teardown.
+**SSH adapter** (T4, shipped): asyncssh (async-native, no thread offload — beats paramiko for the event loop). Per-target connection cached in `SshConnector._connections`; `known_hosts=None` for v0.2 (host-key pinning deferred to v0.2.next). Auth reads `target.secret_ref`: `ssh_private_key` → key auth, `password` → password auth fallback. Closed on lifespan teardown via `aclose()`.
 
 ## Library choices
 
 | Concern | Choice | Why |
 |---|---|---|
 | HTTP transport | `httpx` | Already in chassis, async, http2-capable, honors `SSL_CERT_FILE`. |
-| Retry policy | `tenacity` (planned T3) | Exponential backoff, exception-type filtering. |
-| SSH transport | `asyncssh` (planned T4) | Async-native (no `to_thread` offload). |
+| Retry policy | `tenacity` | Exponential backoff, exception-type filtering. Shipped T3. |
+| SSH transport | `asyncssh` | Async-native (no `to_thread` offload). Shipped T4. |
 | Vault client | `hvac` (chassis-era) | Sync, wrapped in `asyncio.to_thread` already. |
 | Vendor: vSphere | **vSphere REST API** | NOT pyvmomi (SOAP, sync). NOT govc subprocess. v0.2 returns 501 for REST gaps; v0.2.next adds a govc fallback if needed. |
 | Vendor: Kubernetes | **`kubernetes_asyncio`** (locked [decision #8](../planning/v0.2-decisions.md)) | Async fork of the official Python client; mature; broad API coverage; loads kubeconfig from a dict — direct fit for the consumer's `kubeconfig`-in-Vault flow. Rejected: `kr8s` (smaller surface) and `kubectl` subprocess (per-op cost, harder to test). Skeleton landed in [G3.2-T1 (#321)](https://github.com/evoila/meho/issues/321) under [`backend/src/meho_backplane/connectors/kubernetes/`](../../backend/src/meho_backplane/connectors/kubernetes/). |


### PR DESCRIPTION
## Summary

- Adds `SshConnector` abstract base class in `connectors/adapters/ssh.py` — the shared SSH transport that all SSH-shaped vendor connectors (bind9, pfsense, Holodeck) will inherit from
- Uses asyncssh 2.23.0 for async-native SSH; no `asyncio.to_thread` offload required
- Auth is centralised: `_auth_config` reads `target.secret_ref` and selects key auth (PEM private key) over password auth automatically — vendor connectors never override this
- Per-target `SSHClientConnection` pool prevents redundant handshakes; `aclose()` drains all connections cleanly on lifespan teardown
- `_run_command` wraps `conn.run()` in `asyncio.wait_for` so timeouts raise `asyncio.TimeoutError`

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format` — clean
- [x] `mypy src/` — clean (asyncssh override added to `pyproject.toml`)
- [x] `pytest tests/test_connectors_ssh_adapter.py` — 17 passed in 7.77s
- [x] `pytest tests/ --ignore=tests/integration` — 459 passed, 4 skipped (no regressions)
- [x] `SshConnector` importable from `meho_backplane.connectors.adapters`
- [x] Abstract class raises `TypeError` on direct instantiation
- [x] Password auth path: `secret_ref={username, password}` authenticates to in-process asyncssh server
- [x] Key auth path: `secret_ref={username, ssh_private_key}` authenticates via ed25519 key pair
- [x] Connection pool: same `target.name` returns the same `SSHClientConnection` object
- [x] Different targets get distinct connections
- [x] Closed connection triggers reconnect on next `_connect` call
- [x] Connection failure raises `OSError` at `_connect` time (mocked — deterministic, no network dependency)
- [x] Command timeout raises `asyncio.TimeoutError` (mock with `asyncio.sleep(60)`, `timeout=0.05`)
- [x] `aclose()` closes all pooled connections and empties the dict
- [x] `aclose()` is idempotent on fresh connector

## Out of scope

- Vendor-specific connectors (bind9, pfsense, Holodeck) — G3.3 / future G3 Initiatives
- Host key pinning / `known_hosts` management — v0.2.next
- SFTP / SCP file transfer, interactive shells, jump-host support

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #243


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SSH connector for secure remote command execution with password and key auth, connection pooling with idle eviction, command timeouts, and graceful shutdown.

* **Tests**
  * Added comprehensive async tests covering auth modes, pooling/reconnect behavior, timeouts, and shutdown/idempotency.

* **Documentation**
  * Updated architecture docs to mark the SSH adapter as shipped.

* **Chores**
  * Added runtime SSH dependency and localized type-check overrides for it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/350)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->