### PR TITLE
feat(broadcast): SSE feed endpoint at GET /api/v1/feed (G6.1-T4)

### DIFF
--- a/backend/src/meho_backplane/api/v1/feed.py
+++ b/backend/src/meho_backplane/api/v1/feed.py
@@ -94,7 +94,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Final
 
 import structlog
@@ -223,6 +223,59 @@ def _resolve_cursor(
     return _LIVE_TAIL_CURSOR
 
 
+def _process_entries(
+    items: list[tuple[str, dict[str, str]]],
+    *,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+    stream_key: str,
+) -> Iterator[tuple[str, str]]:
+    """Yield ``(entry_id, sse_frame)`` for every entry that passes the filter.
+
+    Handles three skip paths inline:
+
+    * Unknown field shape (entry XADD'd without an ``event`` field) —
+      log + skip. T3's publisher is currently the only writer; this
+      branch is the safety net against a future Slack-mirror /
+      downstream tool writing alternate field shapes onto the same
+      stream key.
+    * Malformed JSON in the ``event`` field — log + skip rather than
+      tearing the subscriber down. A T3 bug or stream-key collision
+      with a foreign writer surfaces here as a logged warning, not a
+      500.
+    * Filter rejection — silently drop (the operator's filter is
+      working as intended).
+
+    Lifted out of :func:`_feed_generator` so the main loop's
+    cognitive complexity stays under the SonarCloud S3776 ceiling.
+    The helper itself is a single ``for``-loop with three
+    ``continue`` arms.
+    """
+    for entry_id, fields in items:
+        raw_event_json = fields.get("event")
+        if not isinstance(raw_event_json, str):
+            _log.warning(
+                "feed_skipped_unknown_field_shape",
+                stream_key=stream_key,
+                entry_id=entry_id,
+                fields=list(fields.keys()),
+            )
+            continue
+        try:
+            event = BroadcastEvent.model_validate_json(raw_event_json)
+        except ValidationError:
+            _log.warning(
+                "feed_skipped_malformed_event",
+                stream_key=stream_key,
+                entry_id=entry_id,
+            )
+            continue
+        if not _passes_filter(event, op_class, principal, target):
+            continue
+        yield entry_id, _format_event(entry_id, raw_event_json)
+
+
 async def _feed_generator(
     operator: Operator,
     cursor: str,
@@ -230,14 +283,28 @@ async def _feed_generator(
     principal: str | None,
     target: str | None,
 ) -> AsyncIterator[str]:
-    """SSE generator: BLOCK on XREAD, filter, format, heartbeat.
+    """SSE generator: BLOCK on XREAD, delegate parsing, heartbeat-on-silence.
 
-    Cancelled cleanly on client disconnect (Starlette raises
-    :class:`asyncio.CancelledError` into the await point). The
-    ``except`` arm returns silently rather than propagating so the
-    surrounding StreamingResponse doesn't synthesise a 500-shaped
-    audit row at session end — a normal SSE close lands as a clean
-    200.
+    Heartbeat semantics — ``last_heartbeat`` tracks the wall-clock of
+    the **last outbound yield** (event frame or heartbeat), NOT the
+    last inbound XREAD result. A noisy tenant where every event is
+    filtered out for this subscriber still produces zero outbound
+    bytes; without this guarantee the connection would idle-timeout
+    at the nginx / ALB / CloudFront layer. The "all entries filtered
+    out" path therefore emits an inline heartbeat when the idle
+    window has elapsed — both quiet and busy-but-filtered tenants
+    keep the connection alive.
+
+    On client disconnect Starlette raises
+    :class:`asyncio.CancelledError` into the pending ``xread`` await;
+    the handler logs and re-raises per the asyncio cancellation
+    contract (Sonar S7497 — swallowing CancelledError breaks the task
+    tree's unwind invariants and Python 3.13+ asyncio internals re-
+    issue cancellation when it goes unpropagated). The audit row at
+    session end still records a clean 200 close because
+    ``http.response.start`` was sent on the first yield (before any
+    cancellation point), so AuditMiddleware's buffered status_code
+    is already locked at 200.
     """
     client = get_broadcast_client()
     stream_key = _stream_key(operator)
@@ -251,6 +318,7 @@ async def _feed_generator(
                 count=_XREAD_COUNT,
             )
             now = time.monotonic()
+            emitted_any = False
             if entries:
                 # redis-py returns ``[[stream_key, [(entry_id, fields), ...]], ...]``
                 # — one outer tuple per stream queried. We always
@@ -258,58 +326,32 @@ async def _feed_generator(
                 # feed), so ``entries[0][1]`` is the list of
                 # ``(entry_id, fields_dict)`` tuples.
                 _key, items = entries[0]
-                for entry_id, fields in items:
+                for entry_id, frame in _process_entries(
+                    items,
+                    op_class=op_class,
+                    principal=principal,
+                    target=target,
+                    stream_key=stream_key,
+                ):
                     cursor = entry_id
-                    raw_event_json = fields.get("event")
-                    if not isinstance(raw_event_json, str):
-                        # A producer that XADD'd a field other than
-                        # ``event`` would land here. T3's publisher
-                        # is the only writer; this branch is the
-                        # safety net against a future Slack-mirror /
-                        # downstream tool writing alternate field
-                        # shapes onto the same stream key.
-                        _log.warning(
-                            "feed_skipped_unknown_field_shape",
-                            stream_key=stream_key,
-                            entry_id=entry_id,
-                            fields=list(fields.keys()),
-                        )
-                        continue
-                    try:
-                        event = BroadcastEvent.model_validate_json(raw_event_json)
-                    except ValidationError:
-                        # A malformed event on the stream is a T3
-                        # bug or a stream-key collision with a
-                        # foreign writer. Log + skip rather than
-                        # tearing down every subscriber.
-                        _log.warning(
-                            "feed_skipped_malformed_event",
-                            stream_key=stream_key,
-                            entry_id=entry_id,
-                        )
-                        continue
-                    if not _passes_filter(event, op_class, principal, target):
-                        continue
-                    yield _format_event(entry_id, raw_event_json)
+                    yield frame
+                    emitted_any = True
+            if emitted_any:
                 last_heartbeat = now
-                continue
-            # XREAD returned no entries within the block window.
-            # Emit a heartbeat if the wall-clock idle window has
-            # elapsed (it always has, since BLOCK = HEARTBEAT_INTERVAL
-            # by construction — but the explicit check keeps the
-            # contract honest if either constant later changes).
-            if now - last_heartbeat >= _HEARTBEAT_INTERVAL_SECONDS:
+            elif now - last_heartbeat >= _HEARTBEAT_INTERVAL_SECONDS:
                 yield ": heartbeat\n\n"
                 last_heartbeat = now
     except asyncio.CancelledError:
-        # Client disconnect. Suppress propagation so the audit row at
-        # session end reflects a clean 200 close.
+        # Client disconnect. Log the structured event for operator
+        # triage, then re-raise so the task tree unwinds per asyncio's
+        # cancellation contract — Sonar S7497, Python 3.13+ asyncio
+        # internals (re-issue cancellation if it goes unpropagated).
         _log.info(
             "feed_subscriber_disconnected",
             stream_key=stream_key,
             operator_sub=operator.sub,
         )
-        return
+        raise
 
 
 @router.get("/feed")

--- a/backend/src/meho_backplane/api/v1/feed.py
+++ b/backend/src/meho_backplane/api/v1/feed.py
@@ -66,10 +66,23 @@ Heartbeat
 =========
 
 The generator emits ``: heartbeat\\n\\n`` (SSE comment line) every
-``_HEARTBEAT_INTERVAL_SECONDS`` of inactivity to keep intermediaries
-from idle-timing-out the connection. The heartbeat fires when the
-``XREAD BLOCK`` call returns no entries within the block window —
-the natural quiet-time signal Valkey gives the loop.
+``_HEARTBEAT_INTERVAL_SECONDS`` of **outbound silence** (no event
+frame yielded to the subscriber) to keep intermediaries from
+idle-timing-out the connection. Two scenarios trigger the heartbeat:
+
+1. **Valkey-quiet** — ``XREAD BLOCK`` returns no entries within the
+   block window. The natural quiet-time signal Valkey gives the loop.
+2. **Subscriber-filtered** — ``XREAD BLOCK`` returns entries but they
+   all fail the operator's ``op_class`` / ``principal`` / ``target``
+   filter, so the generator yields nothing outbound. Without this
+   second path a noisy tenant with a narrow-filtered subscriber
+   would emit zero outbound bytes (events filtered, no heartbeat
+   either) and the nginx / ALB / CloudFront ~60 s idle timeout would
+   drop the connection.
+
+``last_heartbeat`` tracks the wall-clock of the last outbound yield
+(event frame or heartbeat); inbound XREAD activity that doesn't
+produce an outbound frame does NOT reset it.
 
 Disconnect handling
 ===================
@@ -100,12 +113,13 @@ References
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from collections.abc import AsyncIterator, Iterator
 from typing import Final
 
 import structlog
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError
 
@@ -155,6 +169,50 @@ _XREAD_COUNT: Final[int] = 20
 #: a fresh connection without ``Last-Event-Id`` / ``since`` gets the
 #: live tail, not a backlog.
 _LIVE_TAIL_CURSOR: Final[str] = "$"
+
+#: Valkey stream entry id shape — ``<ms-timestamp>`` or
+#: ``<ms-timestamp>-<sequence>``. Accepts both forms because the
+#: bare-timestamp form is legal (Valkey auto-assigns sequence 0) even
+#: though XADD-emitted ids always include the sequence suffix.
+#: Used by :func:`_validate_cursor_or_400` at the route boundary to
+#: reject malformed ``Last-Event-Id`` / ``since`` values before they
+#: reach XREAD and trigger an SSE reconnect loop.
+_VALKEY_STREAM_ID_RE: Final[re.Pattern[str]] = re.compile(r"^\d+(?:-\d+)?$")
+
+
+def _validate_cursor_or_400(cursor: str) -> str:
+    """Validate the SSE replay cursor; raise HTTP 400 on bad input.
+
+    Cursor sources are operator-controlled (``Last-Event-Id`` header,
+    ``since`` query parameter). Without this gate, a malformed cursor
+    propagates verbatim into the ``XREAD`` call and Valkey rejects it
+    with a ``redis.ResponseError`` mid-stream — the SSE response was
+    already sent ``http.response.start``, so the failure surfaces as a
+    connection drop. The browser ``EventSource`` auto-reconnects per
+    the WHATWG spec with the SAME bad cursor and tightens into a
+    reconnect loop.
+
+    Returning HTTP 400 at the route boundary (before any streaming)
+    flips the SSE state machine to ``readyState=CLOSED`` (the spec
+    aborts auto-reconnect on 4xx-class responses), giving the client
+    a recoverable error rather than a hot-loop.
+
+    Accepts:
+
+    * ``"$"`` — Valkey's "live tail" anchor.
+    * ``"<int>"`` or ``"<int>-<int>"`` — Valkey stream id forms.
+
+    Rejects everything else with ``HTTPException(400)``. The detail
+    string deliberately doesn't echo the input — operator-controlled
+    cursors could carry log-injection payloads if reflected verbatim
+    into structured log shippers.
+    """
+    if cursor == _LIVE_TAIL_CURSOR or _VALKEY_STREAM_ID_RE.fullmatch(cursor):
+        return cursor
+    raise HTTPException(
+        status_code=400,
+        detail="invalid_cursor: expected Valkey stream id (e.g. '1715600000000-0') or '$'",
+    )
 
 
 def _stream_key(operator: Operator) -> str:
@@ -405,9 +463,11 @@ async def feed_endpoint(
         the stream into a single response (nginx default behaviour
         would otherwise stall every event behind its buffer flush).
     """
-    cursor = _resolve_cursor(
-        last_event_id_header=request.headers.get("Last-Event-Id"),
-        since=since,
+    cursor = _validate_cursor_or_400(
+        _resolve_cursor(
+            last_event_id_header=request.headers.get("Last-Event-Id"),
+            since=since,
+        )
     )
     generator = _feed_generator(
         operator=operator,

--- a/backend/src/meho_backplane/api/v1/feed.py
+++ b/backend/src/meho_backplane/api/v1/feed.py
@@ -76,10 +76,17 @@ Disconnect handling
 
 Client disconnect propagates as :class:`asyncio.CancelledError` into
 the generator (Starlette cancels the request task on
-``http.disconnect``). The ``except`` arm returns cleanly without
-re-raising so the audit row at session end records the normal exit
-rather than a synthetic 500 — and Valkey's BLOCKing XREAD releases
-the connection from the pool the next event-loop tick.
+``http.disconnect``). The ``except`` arm logs the structured
+``feed_subscriber_disconnected`` event for operator triage, then
+re-raises so the cancellation unwinds the task tree per asyncio's
+contract (Sonar S7497; Python 3.13+ asyncio re-issues cancellation
+if it goes unpropagated). The audit row at session end still records
+a clean 200 close because ``http.response.start`` was sent on the
+first yield — before any cancellation point — so
+:class:`~meho_backplane.audit.AuditMiddleware`'s buffered
+``status_code`` is already locked at 200 by the time the cancellation
+propagates. Valkey's BLOCKing XREAD releases the connection from the
+pool the next event-loop tick.
 
 References
 ----------
@@ -326,14 +333,32 @@ async def _feed_generator(
                 # feed), so ``entries[0][1]`` is the list of
                 # ``(entry_id, fields_dict)`` tuples.
                 _key, items = entries[0]
-                for entry_id, frame in _process_entries(
+                if items:
+                    # Advance the cursor past EVERY consumed entry,
+                    # not only the ones that survive the filter. The
+                    # M2 refactor moved skip-paths (filter mismatch,
+                    # malformed JSON, unknown field shape) inside
+                    # ``_process_entries``; the helper consumes those
+                    # entries without yielding, so a ``cursor =
+                    # entry_id`` placed inside the post-helper
+                    # ``for ... yield`` loop never advances past them.
+                    # Under explicit-cursor replay (``since=<id>`` or
+                    # ``Last-Event-Id``) a tenant where every entry is
+                    # filtered out would otherwise re-read the same
+                    # batch forever: XREAD with cursor=id_N returns
+                    # IDs > id_N, helper drops them, cursor stays at
+                    # id_N, next XREAD returns the same set. Set the
+                    # cursor here, BEFORE the yield loop, so the next
+                    # XREAD reads strictly past this batch regardless
+                    # of whether anything yielded out the other side.
+                    cursor = items[-1][0]
+                for _entry_id, frame in _process_entries(
                     items,
                     op_class=op_class,
                     principal=principal,
                     target=target,
                     stream_key=stream_key,
                 ):
-                    cursor = entry_id
                     yield frame
                     emitted_any = True
             if emitted_any:

--- a/backend/src/meho_backplane/api/v1/feed.py
+++ b/backend/src/meho_backplane/api/v1/feed.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /api/v1/feed`` — Server-Sent Events feed for broadcast events (G6.1-T4).
+
+Per-tenant SSE endpoint that streams :class:`BroadcastEvent` records
+``XADD``\\ ed by T3's publish-on-write hook onto
+``meho:feed:{tenant_id}``. Subscribers — `meho status --watch` (T5,
+#311), the future Slack mirror (G6.2 #333), and any third-party
+operator dashboard — open one HTTP connection per session and
+receive events as soon as they're published.
+
+Transport
+=========
+
+Standard SSE per the WHATWG ``EventSource`` spec. Each event is
+emitted as::
+
+    event: broadcast
+    data: <model_dump_json of BroadcastEvent>
+    id: <Valkey stream entry id, e.g. 1715600000000-0>
+
+Clients reconnecting with ``Last-Event-Id: <id>`` receive replay from
+that point. The ``id:`` field carries the Valkey entry id verbatim so
+the reconnect handshake is server-stateless — the Valkey stream IS the
+session state.
+
+Filtering
+=========
+
+Three optional query parameters apply **after** the XREAD pull:
+
+* ``op_class`` — exact-match filter on
+  :attr:`BroadcastEvent.op_class` (e.g. ``read``, ``write``,
+  ``credential_read``).
+* ``principal`` — exact-match filter on
+  :attr:`BroadcastEvent.principal_sub` (the JWT ``sub`` claim, not the
+  human ``name``).
+* ``target`` — exact-match filter on
+  :attr:`BroadcastEvent.target_name`.
+
+All three default to "no filter" — an unfiltered feed yields every
+event the operator's tenant produces.
+
+Replay
+======
+
+Either of the two replay knobs may be set; ``Last-Event-Id`` header
+takes precedence over the ``since`` query parameter when both are
+present. The default cursor is ``$`` (Valkey's "from now" anchor), so
+a fresh connection yields only events ``XADD``\\ ed after the SSE
+handshake completes.
+
+Tenant scoping
+==============
+
+The stream key is ``meho:feed:{operator.tenant_id}`` derived from the
+validated JWT; the client cannot subscribe to a different tenant's
+stream by passing a tenant_id in the query string — there is no such
+parameter. RBAC requires ``operator`` role minimum (read_only → 403);
+the rationale matches the retrieval route's gate: read-only operators
+have lower-friction surfaces (``meho status``, kb search) that don't
+need real-time feed.
+
+Heartbeat
+=========
+
+The generator emits ``: heartbeat\\n\\n`` (SSE comment line) every
+``_HEARTBEAT_INTERVAL_SECONDS`` of inactivity to keep intermediaries
+from idle-timing-out the connection. The heartbeat fires when the
+``XREAD BLOCK`` call returns no entries within the block window —
+the natural quiet-time signal Valkey gives the loop.
+
+Disconnect handling
+===================
+
+Client disconnect propagates as :class:`asyncio.CancelledError` into
+the generator (Starlette cancels the request task on
+``http.disconnect``). The ``except`` arm returns cleanly without
+re-raising so the audit row at session end records the normal exit
+rather than a synthetic 500 — and Valkey's BLOCKing XREAD releases
+the connection from the pool the next event-loop tick.
+
+References
+----------
+
+* SSE / EventSource: https://html.spec.whatwg.org/multipage/server-sent-events.html
+* Valkey ``XREAD``: https://valkey.io/commands/xread/
+* FastAPI ``StreamingResponse``:
+  https://fastapi.tiangolo.com/advanced/custom-response/#streamingresponse
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+from typing import Final
+
+import structlog
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import ValidationError
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.broadcast import BroadcastEvent, get_broadcast_client
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1", tags=["feed"])
+
+_log = structlog.get_logger(__name__)
+
+#: Operator-minimum gate, factored to module scope so B008 (the
+#: "no function call in default" lint rule) doesn't trip on
+#: ``Depends(require_role(...))`` inside the handler's argument list.
+#: Mirrors the in-repo pattern in :mod:`meho_backplane.api.v1.retrieve`.
+_REQUIRE_OPERATOR = Depends(require_role(TenantRole.OPERATOR))
+
+
+#: XREAD ``BLOCK`` window in milliseconds. The generator yields a
+#: heartbeat once per quiet window of this length; the value also
+#: bounds how long a client-disconnect-cancel takes to land in the
+#: generator (the BLOCK call has to time out or return entries before
+#: the surrounding loop can observe the cancelled context).
+#:
+#: 30 seconds matches the issue body's spec and the common SSE
+#: intermediary keep-alive window (nginx default proxy_read_timeout
+#: is 60s; AWS ALB idle timeout 60s).
+_XREAD_BLOCK_MS: Final[int] = 30_000
+
+#: Wall-clock idle interval after which the generator emits a
+#: heartbeat. Same value as the XREAD block window so a quiet period
+#: produces exactly one heartbeat per cycle — bypasses the "BLOCK 30s
+#: returned empty, did the connection drop?" ambiguity for both the
+#: client and any HTTP intermediaries.
+_HEARTBEAT_INTERVAL_SECONDS: Final[float] = 30.0
+
+#: Upper bound on entries pulled per XREAD call. Bounded to keep the
+#: generator's tick latency-aware: a burst of N events still trickles
+#: out to the client in chunks of up to this size rather than blocking
+#: the event-loop tick on a 1000-event ``model_validate_json`` sweep.
+_XREAD_COUNT: Final[int] = 20
+
+#: Initial cursor when the client doesn't provide one. Valkey's ``$``
+#: anchor means "only entries XADD'd after this XREAD call started" —
+#: a fresh connection without ``Last-Event-Id`` / ``since`` gets the
+#: live tail, not a backlog.
+_LIVE_TAIL_CURSOR: Final[str] = "$"
+
+
+def _stream_key(operator: Operator) -> str:
+    """Build the per-tenant stream key from the JWT-derived tenant id.
+
+    Centralised here so a future tenancy-isolation tightening (e.g. a
+    per-environment prefix) lands in one place. Mirrors the same
+    helper in :mod:`meho_backplane.broadcast.publisher`.
+    """
+    return f"meho:feed:{operator.tenant_id}"
+
+
+def _format_event(entry_id: str, raw_event_json: str) -> str:
+    """Format one Valkey entry as an SSE ``event: broadcast`` frame.
+
+    The ``data:`` field carries the JSON verbatim — no
+    pretty-printing or re-serialisation. Subscribers parse this back
+    into a :class:`BroadcastEvent` on their side, so a re-dump here
+    would only churn newlines (and SSE forbids embedded newlines in
+    ``data:`` fields unless explicitly split into multiple ``data:``
+    lines — easier to enforce by passing the canonical single-line
+    JSON straight through from
+    :meth:`BroadcastEvent.model_dump_json`).
+
+    The ``id:`` line is the Valkey stream entry id verbatim;
+    clients use it as the next ``Last-Event-Id`` value.
+    """
+    return f"event: broadcast\ndata: {raw_event_json}\nid: {entry_id}\n\n"
+
+
+def _passes_filter(
+    event: BroadcastEvent,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+) -> bool:
+    """Return ``True`` iff the event matches every non-None filter.
+
+    None means "no filter on this field". Exact-match semantics — no
+    substring or pattern matching today; G6.3 may revisit if operator
+    feedback flags the gap. ``target_name`` is nullable on
+    :class:`BroadcastEvent`; an event with ``target_name=None`` and
+    a non-None *target* filter never passes (the operator asked for
+    a specific target; an event with no target attribution doesn't
+    qualify).
+    """
+    if op_class is not None and event.op_class != op_class:
+        return False
+    if principal is not None and event.principal_sub != principal:
+        return False
+    return not (target is not None and event.target_name != target)
+
+
+def _resolve_cursor(
+    last_event_id_header: str | None,
+    since: str | None,
+) -> str:
+    """Pick the XREAD cursor per the ``Last-Event-Id`` > ``since`` > ``$`` order.
+
+    Per the SSE spec, ``Last-Event-Id`` is the canonical reconnect
+    mechanism — clients automatically resend it after a connection
+    drop. The ``since`` query parameter exists for callers that need
+    explicit replay control without relying on the SSE auto-reconnect
+    machinery (e.g. server-side bridges that consume the feed via
+    plain HTTP). When both are present the header wins because it
+    encodes "I'm continuing a session I already had"; the query
+    parameter is the explicit override.
+    """
+    if last_event_id_header:
+        return last_event_id_header
+    if since:
+        return since
+    return _LIVE_TAIL_CURSOR
+
+
+async def _feed_generator(
+    operator: Operator,
+    cursor: str,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+) -> AsyncIterator[str]:
+    """SSE generator: BLOCK on XREAD, filter, format, heartbeat.
+
+    Cancelled cleanly on client disconnect (Starlette raises
+    :class:`asyncio.CancelledError` into the await point). The
+    ``except`` arm returns silently rather than propagating so the
+    surrounding StreamingResponse doesn't synthesise a 500-shaped
+    audit row at session end — a normal SSE close lands as a clean
+    200.
+    """
+    client = get_broadcast_client()
+    stream_key = _stream_key(operator)
+    last_heartbeat = time.monotonic()
+
+    try:
+        while True:
+            entries = await client.xread(
+                {stream_key: cursor},
+                block=_XREAD_BLOCK_MS,
+                count=_XREAD_COUNT,
+            )
+            now = time.monotonic()
+            if entries:
+                # redis-py returns ``[[stream_key, [(entry_id, fields), ...]], ...]``
+                # — one outer tuple per stream queried. We always
+                # query exactly one stream (the operator's tenant
+                # feed), so ``entries[0][1]`` is the list of
+                # ``(entry_id, fields_dict)`` tuples.
+                _key, items = entries[0]
+                for entry_id, fields in items:
+                    cursor = entry_id
+                    raw_event_json = fields.get("event")
+                    if not isinstance(raw_event_json, str):
+                        # A producer that XADD'd a field other than
+                        # ``event`` would land here. T3's publisher
+                        # is the only writer; this branch is the
+                        # safety net against a future Slack-mirror /
+                        # downstream tool writing alternate field
+                        # shapes onto the same stream key.
+                        _log.warning(
+                            "feed_skipped_unknown_field_shape",
+                            stream_key=stream_key,
+                            entry_id=entry_id,
+                            fields=list(fields.keys()),
+                        )
+                        continue
+                    try:
+                        event = BroadcastEvent.model_validate_json(raw_event_json)
+                    except ValidationError:
+                        # A malformed event on the stream is a T3
+                        # bug or a stream-key collision with a
+                        # foreign writer. Log + skip rather than
+                        # tearing down every subscriber.
+                        _log.warning(
+                            "feed_skipped_malformed_event",
+                            stream_key=stream_key,
+                            entry_id=entry_id,
+                        )
+                        continue
+                    if not _passes_filter(event, op_class, principal, target):
+                        continue
+                    yield _format_event(entry_id, raw_event_json)
+                last_heartbeat = now
+                continue
+            # XREAD returned no entries within the block window.
+            # Emit a heartbeat if the wall-clock idle window has
+            # elapsed (it always has, since BLOCK = HEARTBEAT_INTERVAL
+            # by construction — but the explicit check keeps the
+            # contract honest if either constant later changes).
+            if now - last_heartbeat >= _HEARTBEAT_INTERVAL_SECONDS:
+                yield ": heartbeat\n\n"
+                last_heartbeat = now
+    except asyncio.CancelledError:
+        # Client disconnect. Suppress propagation so the audit row at
+        # session end reflects a clean 200 close.
+        _log.info(
+            "feed_subscriber_disconnected",
+            stream_key=stream_key,
+            operator_sub=operator.sub,
+        )
+        return
+
+
+@router.get("/feed")
+async def feed_endpoint(
+    request: Request,
+    op_class: str | None = Query(default=None, description="Filter by event op_class."),
+    principal: str | None = Query(default=None, description="Filter by principal_sub."),
+    target: str | None = Query(default=None, description="Filter by target_name."),
+    since: str | None = Query(
+        default=None,
+        description="Explicit replay cursor; superseded by Last-Event-Id when present.",
+    ),
+    operator: Operator = _REQUIRE_OPERATOR,
+) -> StreamingResponse:
+    """Stream broadcast events for the operator's tenant as Server-Sent Events.
+
+    Headers:
+        ``Last-Event-Id``: optional SSE reconnect cursor. Takes
+        precedence over the ``since`` query parameter when both are
+        present.
+
+    Returns:
+        :class:`StreamingResponse` with ``media_type=text/event-stream``.
+        ``Cache-Control: no-cache, no-store, must-revalidate`` and
+        ``X-Accel-Buffering: no`` keep intermediaries from buffering
+        the stream into a single response (nginx default behaviour
+        would otherwise stall every event behind its buffer flush).
+    """
+    cursor = _resolve_cursor(
+        last_event_id_header=request.headers.get("Last-Event-Id"),
+        since=since,
+    )
+    generator = _feed_generator(
+        operator=operator,
+        cursor=cursor,
+        op_class=op_class,
+        principal=principal,
+        target=target,
+    )
+    return StreamingResponse(
+        generator,
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -48,6 +48,7 @@ from fastapi import FastAPI, Response
 
 from meho_backplane import __version__
 from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_router
+from meho_backplane.api.v1.feed import router as api_v1_feed_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.api.v1.retrieve import router as api_v1_retrieve_router
 from meho_backplane.api.well_known import router as well_known_router
@@ -234,6 +235,13 @@ app.include_router(api_v1_health_router)
 # privacy-preserving query_hash payload (the raw query is never
 # persisted -- per v0.2 sensitivity defaults).
 app.include_router(api_v1_retrieve_router)
+# G6.1-T4 (#310) -- Server-Sent Events feed at `GET /api/v1/feed`.
+# Streams events XADD'd by T3's publish-on-write hook onto
+# `meho:feed:{tenant_id}`. Same RBAC gate as /api/v1/retrieve
+# (operator role minimum); tenant scoping derives the stream key
+# from the JWT's tenant_id claim so cross-tenant subscription is
+# impossible by construction.
+app.include_router(api_v1_feed_router)
 # MCP Streamable HTTP transport entrypoint (G0.5-T1, #246) and the
 # RFC 9728 protected-resource metadata document (G0.5-T2, #247).
 #

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -256,18 +256,22 @@ async def _collect_n_frames(
 # ---------------------------------------------------------------------------
 
 
-def _mint_authenticated_token(
+async def _request_feed_authenticated(
     monkeypatch: pytest.MonkeyPatch,
     *,
     kid: str,
     sub: str,
     role: TenantRole,
-) -> tuple[str, object]:
-    """Bundle ``install_fake_vault`` + ``make_rsa_keypair`` + ``mint_token``.
+    extra_headers: dict[str, str] | None = None,
+    params: dict[str, str] | None = None,
+) -> httpx.Response:
+    """One-call HTTP-edge scaffold: vault + key + JWT + respx + client.
 
-    Returns ``(token, key)`` ready to wire into a ``respx.mock`` block.
-    Extracted so HTTP-edge tests can share the JWT-minting boilerplate
-    without tripping SonarCloud's duplication-on-new-code threshold.
+    Collapses the install_fake_vault / make_rsa_keypair / mint_token /
+    respx.mock / _make_client chain that every authenticated-edge test
+    needs into a single helper. Extracted so the three /api/v1/feed
+    edge cases share one body shape instead of three lookalike
+    scaffolds (SonarCloud duplication-on-new-code threshold).
     """
     from tests._vault_fakes import install_fake_vault
 
@@ -279,7 +283,12 @@ def _mint_authenticated_token(
         tenant_id=str(_TENANT_A),
         tenant_role=role.value,
     )
-    return token, key
+    headers = {"Authorization": f"Bearer {token}", **(extra_headers or {})}
+    app = _build_app()
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        async with _make_client(app) as client:
+            return await client.get("/api/v1/feed", headers=headers, params=params)
 
 
 class TestFeedEndpoint:
@@ -297,20 +306,12 @@ class TestFeedEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """``read_only`` operators can't subscribe; ``operator`` minimum required."""
-        token, key = _mint_authenticated_token(
+        response = await _request_feed_authenticated(
             monkeypatch,
             kid="kid-feed-read-only",
             sub="op-readonly",
             role=TenantRole.READ_ONLY,
         )
-        app = _build_app()
-        with respx.mock as mock_router:
-            mock_discovery_and_jwks(mock_router, public_jwks(key))
-            async with _make_client(app) as client:
-                response = await client.get(
-                    "/api/v1/feed",
-                    headers={"Authorization": f"Bearer {token}"},
-                )
         assert response.status_code == 403
         assert response.json() == {"detail": "insufficient_role"}
 
@@ -334,23 +335,13 @@ class TestFeedEndpoint:
         ``EventSource.readyState=CLOSED`` per the spec — browsers stop
         auto-reconnecting on 4xx-class responses.
         """
-        token, key = _mint_authenticated_token(
+        response = await _request_feed_authenticated(
             monkeypatch,
             kid="kid-feed-bad-cursor",
             sub="op-bad-cursor",
             role=TenantRole.OPERATOR,
+            extra_headers={"Last-Event-Id": "abc-not-a-valkey-id"},
         )
-        app = _build_app()
-        with respx.mock as mock_router:
-            mock_discovery_and_jwks(mock_router, public_jwks(key))
-            async with _make_client(app) as client:
-                response = await client.get(
-                    "/api/v1/feed",
-                    headers={
-                        "Authorization": f"Bearer {token}",
-                        "Last-Event-Id": "abc-not-a-valkey-id",
-                    },
-                )
         assert response.status_code == 400
         assert response.json()["detail"].startswith("invalid_cursor")
 
@@ -360,23 +351,16 @@ class TestFeedEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Malformed ``since`` query parameter → 400 (same gate as the header)."""
-        token, key = _mint_authenticated_token(
+        response = await _request_feed_authenticated(
             monkeypatch,
             kid="kid-feed-bad-since",
             sub="op-bad-since",
             role=TenantRole.OPERATOR,
+            params={"since": "drop-table;"},
         )
-        app = _build_app()
-        with respx.mock as mock_router:
-            mock_discovery_and_jwks(mock_router, public_jwks(key))
-            async with _make_client(app) as client:
-                response = await client.get(
-                    "/api/v1/feed",
-                    params={"since": "drop-table;"},
-                    headers={"Authorization": f"Bearer {token}"},
-                )
         assert response.status_code == 400
         assert response.json()["detail"].startswith("invalid_cursor")
+
 
 # ---------------------------------------------------------------------------
 # Generator — every body-shaping AC

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -227,6 +227,17 @@ async def _collect_n_frames(
     ``TimeoutError`` on its way out of the context.
     """
     frames: list[str] = []
+    if n <= 0:
+        # Early-return for cursor-pass-through tests that only need
+        # the helper to drive the generator's first ``xread`` call
+        # without consuming any frames. The post-``async for``
+        # ``aclose`` is still required so the generator's
+        # ``CancelledError`` cleanup path runs (and the structured
+        # disconnect log fires); without ``aclose`` the generator
+        # would be garbage-collected and asyncio 3.13+ would emit
+        # ``Task was destroyed but it is pending`` warnings.
+        await gen.aclose()
+        return frames
     try:
         async with asyncio.timeout(timeout):
             async for chunk in gen:
@@ -245,6 +256,32 @@ async def _collect_n_frames(
 # ---------------------------------------------------------------------------
 
 
+def _mint_authenticated_token(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    kid: str,
+    sub: str,
+    role: TenantRole,
+) -> tuple[str, object]:
+    """Bundle ``install_fake_vault`` + ``make_rsa_keypair`` + ``mint_token``.
+
+    Returns ``(token, key)`` ready to wire into a ``respx.mock`` block.
+    Extracted so HTTP-edge tests can share the JWT-minting boilerplate
+    without tripping SonarCloud's duplication-on-new-code threshold.
+    """
+    from tests._vault_fakes import install_fake_vault
+
+    install_fake_vault(monkeypatch)
+    key = make_rsa_keypair(kid)
+    token = mint_token(
+        key,
+        sub=sub,
+        tenant_id=str(_TENANT_A),
+        tenant_role=role.value,
+    )
+    return token, key
+
+
 class TestFeedEndpoint:
     """Authn/authz layer + the 200 + ``text/event-stream`` happy header."""
 
@@ -260,15 +297,11 @@ class TestFeedEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """``read_only`` operators can't subscribe; ``operator`` minimum required."""
-        from tests._vault_fakes import install_fake_vault
-
-        install_fake_vault(monkeypatch)
-        key = make_rsa_keypair("kid-feed-read-only")
-        token = mint_token(
-            key,
+        token, key = _mint_authenticated_token(
+            monkeypatch,
+            kid="kid-feed-read-only",
             sub="op-readonly",
-            tenant_id=str(_TENANT_A),
-            tenant_role=TenantRole.READ_ONLY.value,
+            role=TenantRole.READ_ONLY,
         )
         app = _build_app()
         with respx.mock as mock_router:
@@ -281,6 +314,69 @@ class TestFeedEndpoint:
         assert response.status_code == 403
         assert response.json() == {"detail": "insufficient_role"}
 
+    async def test_invalid_last_event_id_returns_400(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Malformed ``Last-Event-Id`` cursor → 400, no SSE reconnect loop.
+
+        The bug class this test pins (iter-3 B1): without route-boundary
+        validation, garbage cursors propagate to ``XREAD`` and Valkey
+        raises ``redis.ResponseError`` mid-stream. ``http.response.start``
+        was already sent, so the failure surfaces as a connection drop.
+        Per the WHATWG SSE spec, browser ``EventSource`` auto-reconnects
+        on stream drop with the SAME ``Last-Event-Id`` — and the bad
+        cursor came FROM the client side. Tight reconnect loop with no
+        recovery.
+
+        Post-fix contract: an HTTP 400 at the route boundary flips
+        ``EventSource.readyState=CLOSED`` per the spec — browsers stop
+        auto-reconnecting on 4xx-class responses.
+        """
+        token, key = _mint_authenticated_token(
+            monkeypatch,
+            kid="kid-feed-bad-cursor",
+            sub="op-bad-cursor",
+            role=TenantRole.OPERATOR,
+        )
+        app = _build_app()
+        with respx.mock as mock_router:
+            mock_discovery_and_jwks(mock_router, public_jwks(key))
+            async with _make_client(app) as client:
+                response = await client.get(
+                    "/api/v1/feed",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Last-Event-Id": "abc-not-a-valkey-id",
+                    },
+                )
+        assert response.status_code == 400
+        assert response.json()["detail"].startswith("invalid_cursor")
+
+    async def test_invalid_since_query_param_returns_400(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Malformed ``since`` query parameter → 400 (same gate as the header)."""
+        token, key = _mint_authenticated_token(
+            monkeypatch,
+            kid="kid-feed-bad-since",
+            sub="op-bad-since",
+            role=TenantRole.OPERATOR,
+        )
+        app = _build_app()
+        with respx.mock as mock_router:
+            mock_discovery_and_jwks(mock_router, public_jwks(key))
+            async with _make_client(app) as client:
+                response = await client.get(
+                    "/api/v1/feed",
+                    params={"since": "drop-table;"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert response.status_code == 400
+        assert response.json()["detail"].startswith("invalid_cursor")
 
 # ---------------------------------------------------------------------------
 # Generator — every body-shaping AC
@@ -544,7 +640,8 @@ class TestFeedGenerator:
     async def test_cursor_passes_through_to_xread(self, _feed_env: None) -> None:
         """The cursor argument (already resolved by the handler) is what xread sees."""
         broadcast_client = get_broadcast_client()
-        mock = _xread_returning([])
+        event = _make_event(tenant_id=_TENANT_A)
+        mock = _xread_returning([event])
         with patch.object(broadcast_client, "xread", new=mock):
             gen = _feed_generator(
                 operator=_make_operator(tenant_id=_TENANT_A),
@@ -553,7 +650,7 @@ class TestFeedGenerator:
                 principal=None,
                 target=None,
             )
-            await _collect_n_frames(gen, n=0, timeout=0.2)
+            await _collect_n_frames(gen, n=1, timeout=0.2)
 
         assert mock.await_count >= 1
         cursor_arg = mock.await_args_list[0].args[0]

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -460,6 +460,87 @@ class TestFeedGenerator:
         assert len(frames) == 1
         assert frames[0] == ": heartbeat\n\n"
 
+    async def test_cursor_advances_past_filtered_entries(
+        self,
+        _feed_env: None,
+    ) -> None:
+        """Filtered entries advance the XREAD cursor so the next BLOCK reads past them.
+
+        The bug class this test pins: ``_process_entries`` consumes
+        filtered-out / malformed / unknown-field-shape entries
+        internally without yielding. A naive ``cursor = entry_id``
+        placed inside the main loop's post-helper ``for ... yield``
+        would never observe those entries, leaving the cursor pinned
+        at the previous value. Under explicit-cursor replay
+        (``since=<id>`` or ``Last-Event-Id``) on a busy-but-filtered
+        tenant, the next XREAD would re-read the same batch
+        indefinitely.
+
+        Post-fix contract: the cursor advances to ``items[-1][0]`` for
+        every consumed batch BEFORE the yield loop. The second XREAD
+        call must therefore start *past* the first batch's last entry,
+        not at the original subscriber cursor.
+        """
+        # First batch: two writes (subscriber filters for reads).
+        # Second batch: one read.
+        write_a = _make_event(op_class="write", op_id="vsphere.vm.create")
+        write_b = _make_event(op_class="write", op_id="vsphere.vm.delete")
+        read_c = _make_event(op_class="read", op_id="vsphere.vm.list")
+        broadcast_client = get_broadcast_client()
+        seen_cursors: list[str] = []
+
+        async def _xread_side_effect(
+            streams: dict[str, str],
+            **_kwargs: object,
+        ) -> object:
+            cursor_value = next(iter(streams.values()))
+            seen_cursors.append(cursor_value)
+            if len(seen_cursors) == 1:
+                return [
+                    (
+                        "meho:feed:<irrelevant>",
+                        [
+                            ("1715600000001-0", {"event": write_a.model_dump_json()}),
+                            ("1715600000002-0", {"event": write_b.model_dump_json()}),
+                        ],
+                    ),
+                ]
+            if len(seen_cursors) == 2:
+                return [
+                    (
+                        "meho:feed:<irrelevant>",
+                        [("1715600000003-0", {"event": read_c.model_dump_json()})],
+                    ),
+                ]
+            await asyncio.sleep(0.01)
+            return None
+
+        mock = AsyncMock(side_effect=_xread_side_effect)
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(),
+                cursor="1715600000000-0",
+                op_class="read",
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1)
+
+        # The yielded frame is the read event from the SECOND batch —
+        # the writes in batch one filtered out and produced no
+        # outbound frames.
+        assert len(frames) == 1
+        assert "id: 1715600000003-0" in frames[0]
+
+        # Load-bearing assertion: the second XREAD call's cursor is
+        # the LAST entry id of batch one, NOT the original
+        # subscriber cursor. Without the iter-2 B1 fix, the second
+        # call would resend ``1715600000000-0`` and Valkey would
+        # re-return the filtered writes forever.
+        assert len(seen_cursors) >= 2
+        assert seen_cursors[0] == "1715600000000-0"
+        assert seen_cursors[1] == "1715600000002-0"
+
     async def test_cursor_passes_through_to_xread(self, _feed_env: None) -> None:
         """The cursor argument (already resolved by the handler) is what xread sees."""
         broadcast_client = get_broadcast_client()

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -251,6 +251,43 @@ async def _collect_n_frames(
     return frames
 
 
+async def _drive_generator_with_one_batch(
+    items: list[tuple[str, dict[str, str]]],
+    *,
+    op_class: str | None = None,
+    principal: str | None = None,
+    target: str | None = None,
+) -> list[str]:
+    """Mock xread to return *items* once then idle, drive one frame out, return it.
+
+    Skip-path tests (malformed event, unknown field shape) all share
+    the same scaffold: push one batch through ``_feed_generator`` and
+    assert which entry survives the filter. Bundled here so the
+    per-test bodies stop repeating the AsyncMock / patch.object /
+    _feed_generator scaffold (SonarCloud duplication-on-new-code).
+    """
+    broadcast_client = get_broadcast_client()
+    call_count = {"n": 0}
+
+    async def _xread_side_effect(*_a: object, **_k: object) -> object:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return [("meho:feed:<irrelevant>", items)]
+        await asyncio.sleep(0.01)
+        return None
+
+    mock = AsyncMock(side_effect=_xread_side_effect)
+    with patch.object(broadcast_client, "xread", new=mock):
+        gen = _feed_generator(
+            operator=_make_operator(),
+            cursor="$",
+            op_class=op_class,
+            principal=principal,
+            target=target,
+        )
+        return await _collect_n_frames(gen, n=1)
+
+
 # ---------------------------------------------------------------------------
 # HTTP edge — authn / authz / 200 + content-type
 # ---------------------------------------------------------------------------
@@ -643,62 +680,22 @@ class TestFeedGenerator:
     async def test_malformed_event_skipped(self, _feed_env: None) -> None:
         """A bogus JSON in ``event`` doesn't kill the subscriber."""
         good_event = _make_event(op_id="vsphere.vm.list")
-        broadcast_client = get_broadcast_client()
         items = [
             ("1715600000000-0", {"event": "not-json"}),
             ("1715600000001-0", {"event": good_event.model_dump_json()}),
         ]
-        call_count = {"n": 0}
-
-        async def _xread_side_effect(*_a: object, **_k: object) -> object:
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                return [("meho:feed:<irrelevant>", items)]
-            await asyncio.sleep(0.01)
-            return None
-
-        mock = AsyncMock(side_effect=_xread_side_effect)
-        with patch.object(broadcast_client, "xread", new=mock):
-            gen = _feed_generator(
-                operator=_make_operator(),
-                cursor="$",
-                op_class=None,
-                principal=None,
-                target=None,
-            )
-            frames = await _collect_n_frames(gen, n=1)
-
+        frames = await _drive_generator_with_one_batch(items)
         assert len(frames) == 1
         assert "id: 1715600000001-0" in frames[0]
 
     async def test_unknown_field_shape_skipped(self, _feed_env: None) -> None:
         """An XADD'd entry without an ``event`` field is logged + skipped."""
         good_event = _make_event(op_id="vsphere.host.info")
-        broadcast_client = get_broadcast_client()
         items = [
             ("1715600000000-0", {"unknown": "field"}),
             ("1715600000001-0", {"event": good_event.model_dump_json()}),
         ]
-        call_count = {"n": 0}
-
-        async def _xread_side_effect(*_a: object, **_k: object) -> object:
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                return [("meho:feed:<irrelevant>", items)]
-            await asyncio.sleep(0.01)
-            return None
-
-        mock = AsyncMock(side_effect=_xread_side_effect)
-        with patch.object(broadcast_client, "xread", new=mock):
-            gen = _feed_generator(
-                operator=_make_operator(),
-                cursor="$",
-                op_class=None,
-                principal=None,
-                target=None,
-            )
-            frames = await _collect_n_frames(gen, n=1)
-
+        frames = await _drive_generator_with_one_batch(items)
         assert len(frames) == 1
         assert "id: 1715600000001-0" in frames[0]
 

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -1,0 +1,563 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G6.1-T4 SSE feed endpoint.
+
+Covers (issue #310 acceptance criteria):
+
+* ``GET /api/v1/feed`` with a valid JWT returns 200 +
+  ``text/event-stream``; ``read_only`` role → 403; unauthenticated → 401.
+* Events ``XADD``\\ ed to tenant-A's stream appear on tenant-A's SSE
+  connection (per-tenant scoping — stream key derived from JWT).
+* Filter by ``op_class`` / ``principal`` / ``target`` keeps only
+  matching events.
+* ``Last-Event-Id`` header takes precedence over the ``since`` query
+  parameter; ``since`` is used when only it is present; ``$`` is the
+  default cursor.
+* Heartbeat ``: heartbeat\\n\\n`` is emitted after an idle window.
+* Malformed entries on the stream don't tear down the subscriber.
+
+Test architecture
+=================
+
+Two surfaces, each tested at the layer that fits:
+
+* **HTTP edge (TestFeedEndpoint)** — drives ``/api/v1/feed`` via an
+  async httpx client against an ASGI app. Covers authn / authz / the
+  200 + content-type happy path. Does not attempt to assert on the
+  streamed body — httpx + ASGITransport's cancellation handshake on
+  ``async with response.stream(...)`` exit is racy enough that
+  asserting on stream contents tight-loops the generator (the mock
+  ``xread`` has to ``await asyncio.sleep`` to give cancellation a
+  chance, and even then the cancellation propagation through
+  Starlette is timing-dependent). Stream contents are exercised at
+  the generator layer instead.
+* **Generator (TestFeedGenerator)** — drives :func:`_feed_generator`
+  directly with a mock broadcast client. Async-generator semantics
+  are deterministic: ``aclose()`` synchronously sends
+  :class:`asyncio.CancelledError` into the generator's pending
+  ``await``, so every test cleanly tears down without relying on
+  ASGI's cancellation chain. Every filter / cursor / formatting AC
+  is verified here.
+* **Real Valkey integration (TestFeedIntegration)** — Docker-gated.
+  Publishes via :func:`publish_event` and reads back through the
+  generator (NOT via httpx) for the same cancellation-determinism
+  reason.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from meho_backplane.api.v1.feed import _feed_generator
+from meho_backplane.api.v1.feed import router as feed_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    dispose_broadcast_client,
+    get_broadcast_client,
+    publish_event,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+from tests._oidc_jwt_helpers import (
+    AUDIENCE,
+    ISSUER,
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+
+_TENANT_A: UUID = UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B: UUID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_broadcast_client() -> Iterator[None]:
+    reset_broadcast_client_for_testing()
+    yield
+    reset_broadcast_client_for_testing()
+
+
+@pytest.fixture
+def _feed_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars so ``get_settings`` succeeds + JWT verification works.
+
+    ``DATABASE_URL`` is left to the conftest's autouse
+    ``_default_database_url`` fixture (per-tmp-path SQLite with
+    ``alembic upgrade head`` already run) so the audit middleware's
+    INSERT lands on a migrated DB.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(feed_router)
+    return app
+
+
+def _make_client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="https://testserver",
+    )
+
+
+def _make_operator(
+    *,
+    sub: str = "op-test",
+    tenant_id: UUID = _TENANT_A,
+    role: TenantRole = TenantRole.OPERATOR,
+) -> Operator:
+    """Construct an :class:`Operator` directly — no JWT round-trip.
+
+    The route handler uses ``Depends(require_role(...))`` to produce
+    the operator; the generator (where the SSE body lives) takes the
+    same shape via plain function arguments. Construction here skips
+    the JWT chain and lets generator-level tests pin exactly the
+    fields they care about (``sub``, ``tenant_id``).
+    """
+    return Operator(
+        sub=sub,
+        name=None,
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=tenant_id,
+        tenant_role=role,
+    )
+
+
+def _make_event(
+    *,
+    tenant_id: UUID = _TENANT_A,
+    op_class: str = "read",
+    principal_sub: str = "op-test",
+    target_name: str | None = "rdc-vcenter",
+    op_id: str = "vsphere.vm.list",
+) -> BroadcastEvent:
+    return BroadcastEvent(
+        event_id=uuid4(),
+        ts=datetime(2026, 5, 13, tzinfo=UTC),
+        tenant_id=tenant_id,
+        principal_sub=principal_sub,
+        target_name=target_name,
+        op_id=op_id,
+        op_class=op_class,
+        result_status="ok",
+        audit_id=UUID("33333333-3333-3333-3333-333333333333"),
+        payload={"op_class": op_class, "params": {}, "result_status": "ok"},
+    )
+
+
+def _xread_returning(events: list[BroadcastEvent]) -> AsyncMock:
+    """AsyncMock that returns *events* on the first call, then awaits idle forever.
+
+    Every subsequent call sleeps a tick and returns ``None`` — the
+    BLOCK-timeout-shaped response from redis-py ``xread``. The sleep
+    is what gives the generator's surrounding code a chance to
+    observe :class:`asyncio.CancelledError` when the test calls
+    ``gen.aclose()``.
+    """
+    items = [
+        (f"{1715600000000 + i}-0", {"event": event.model_dump_json()})
+        for i, event in enumerate(events)
+    ]
+    call_count = {"n": 0}
+
+    async def _xread_side_effect(*_args: object, **_kwargs: object) -> object:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return [("meho:feed:<irrelevant>", items)]
+        await asyncio.sleep(0.01)
+        return None
+
+    return AsyncMock(side_effect=_xread_side_effect)
+
+
+async def _collect_n_frames(
+    gen: AsyncIterator[str],
+    *,
+    n: int,
+    timeout: float = 1.0,
+) -> list[str]:
+    """Read up to *n* SSE frames from *gen* and aclose() it cleanly.
+
+    Tests instantiate ``_feed_generator(...)`` directly, drain the
+    first *n* frames, then rely on this helper's
+    :meth:`__aiter__.aclose` to cancel any pending ``xread`` and
+    unwind the generator. Determinism comes from the mocked ``xread``'s
+    ``asyncio.sleep`` yield point above.
+    """
+    frames: list[str] = []
+    try:
+        async with asyncio.timeout(timeout):
+            async for chunk in gen:
+                frames.append(chunk)
+                if len(frames) >= n:
+                    break
+    finally:
+        await gen.aclose()
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# HTTP edge — authn / authz / 200 + content-type
+# ---------------------------------------------------------------------------
+
+
+class TestFeedEndpoint:
+    """Authn/authz layer + the 200 + ``text/event-stream`` happy header."""
+
+    async def test_unauthenticated_returns_401(self, _feed_env: None) -> None:
+        app = _build_app()
+        async with _make_client(app) as client:
+            response = await client.get("/api/v1/feed")
+        assert response.status_code == 401
+
+    async def test_read_only_role_returns_403(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``read_only`` operators can't subscribe; ``operator`` minimum required."""
+        from tests._vault_fakes import install_fake_vault
+
+        install_fake_vault(monkeypatch)
+        key = make_rsa_keypair("kid-feed-read-only")
+        token = mint_token(
+            key,
+            sub="op-readonly",
+            tenant_id=str(_TENANT_A),
+            tenant_role=TenantRole.READ_ONLY.value,
+        )
+        app = _build_app()
+        with respx.mock as mock_router:
+            mock_discovery_and_jwks(mock_router, public_jwks(key))
+            async with _make_client(app) as client:
+                response = await client.get(
+                    "/api/v1/feed",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert response.status_code == 403
+        assert response.json() == {"detail": "insufficient_role"}
+
+
+# ---------------------------------------------------------------------------
+# Generator — every body-shaping AC
+# ---------------------------------------------------------------------------
+
+
+class TestFeedGenerator:
+    """Drives :func:`_feed_generator` directly with a mocked broadcast client."""
+
+    async def test_basic_event_yield_with_tenant_scoping(self, _feed_env: None) -> None:
+        """One event → one well-formed SSE frame; stream key is JWT-derived."""
+        event = _make_event(tenant_id=_TENANT_A)
+        broadcast_client = get_broadcast_client()
+        mock = _xread_returning([event])
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1)
+
+        assert mock.await_count >= 1
+        # Stream key passed to xread is the JWT-derived tenant stream.
+        stream_key_arg = mock.await_args_list[0].args[0]
+        assert stream_key_arg == {f"meho:feed:{_TENANT_A}": "$"}
+
+        assert len(frames) == 1
+        frame = frames[0]
+        assert frame.startswith("event: broadcast\n")
+        assert "data: " in frame
+        assert "id: 1715600000000-0" in frame
+        data_line = next(line for line in frame.split("\n") if line.startswith("data: "))
+        decoded = json.loads(data_line[len("data: ") :])
+        assert decoded["tenant_id"] == str(_TENANT_A)
+        assert decoded["op_id"] == "vsphere.vm.list"
+
+    async def test_filter_by_op_class(self, _feed_env: None) -> None:
+        read_event = _make_event(op_class="read", op_id="vsphere.vm.list")
+        write_event = _make_event(op_class="write", op_id="vsphere.vm.create")
+        broadcast_client = get_broadcast_client()
+        mock = _xread_returning([read_event, write_event])
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(),
+                cursor="$",
+                op_class="read",
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1)
+
+        assert len(frames) == 1
+        decoded = json.loads(
+            next(line for line in frames[0].split("\n") if line.startswith("data: "))[
+                len("data: ") :
+            ]
+        )
+        assert decoded["op_class"] == "read"
+
+    async def test_filter_by_principal(self, _feed_env: None) -> None:
+        a_event = _make_event(principal_sub="alice")
+        b_event = _make_event(principal_sub="bob")
+        broadcast_client = get_broadcast_client()
+        mock = _xread_returning([a_event, b_event])
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(),
+                cursor="$",
+                op_class=None,
+                principal="alice",
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1)
+
+        assert len(frames) == 1
+        decoded = json.loads(
+            next(line for line in frames[0].split("\n") if line.startswith("data: "))[
+                len("data: ") :
+            ]
+        )
+        assert decoded["principal_sub"] == "alice"
+
+    async def test_filter_by_target(self, _feed_env: None) -> None:
+        vcenter_event = _make_event(target_name="rdc-vcenter")
+        k8s_event = _make_event(target_name="rdc-k8s")
+        no_target_event = _make_event(target_name=None)
+        broadcast_client = get_broadcast_client()
+        mock = _xread_returning([vcenter_event, k8s_event, no_target_event])
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target="rdc-vcenter",
+            )
+            frames = await _collect_n_frames(gen, n=1)
+
+        # Only the vCenter event matches; events with target=None are
+        # filtered out when the operator asks for a specific target.
+        assert len(frames) == 1
+        decoded = json.loads(
+            next(line for line in frames[0].split("\n") if line.startswith("data: "))[
+                len("data: ") :
+            ]
+        )
+        assert decoded["target_name"] == "rdc-vcenter"
+
+    async def test_cursor_passes_through_to_xread(self, _feed_env: None) -> None:
+        """The cursor argument (already resolved by the handler) is what xread sees."""
+        broadcast_client = get_broadcast_client()
+        mock = _xread_returning([])
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="1715600000000-0",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            await _collect_n_frames(gen, n=0, timeout=0.2)
+
+        assert mock.await_count >= 1
+        cursor_arg = mock.await_args_list[0].args[0]
+        assert cursor_arg == {f"meho:feed:{_TENANT_A}": "1715600000000-0"}
+
+    async def test_malformed_event_skipped(self, _feed_env: None) -> None:
+        """A bogus JSON in ``event`` doesn't kill the subscriber."""
+        good_event = _make_event(op_id="vsphere.vm.list")
+        broadcast_client = get_broadcast_client()
+        items = [
+            ("1715600000000-0", {"event": "not-json"}),
+            ("1715600000001-0", {"event": good_event.model_dump_json()}),
+        ]
+        call_count = {"n": 0}
+
+        async def _xread_side_effect(*_a: object, **_k: object) -> object:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return [("meho:feed:<irrelevant>", items)]
+            await asyncio.sleep(0.01)
+            return None
+
+        mock = AsyncMock(side_effect=_xread_side_effect)
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1)
+
+        assert len(frames) == 1
+        assert "id: 1715600000001-0" in frames[0]
+
+    async def test_unknown_field_shape_skipped(self, _feed_env: None) -> None:
+        """An XADD'd entry without an ``event`` field is logged + skipped."""
+        good_event = _make_event(op_id="vsphere.host.info")
+        broadcast_client = get_broadcast_client()
+        items = [
+            ("1715600000000-0", {"unknown": "field"}),
+            ("1715600000001-0", {"event": good_event.model_dump_json()}),
+        ]
+        call_count = {"n": 0}
+
+        async def _xread_side_effect(*_a: object, **_k: object) -> object:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return [("meho:feed:<irrelevant>", items)]
+            await asyncio.sleep(0.01)
+            return None
+
+        mock = AsyncMock(side_effect=_xread_side_effect)
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1)
+
+        assert len(frames) == 1
+        assert "id: 1715600000001-0" in frames[0]
+
+
+# ---------------------------------------------------------------------------
+# Cursor resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCursor:
+    """``Last-Event-Id`` > ``since`` > ``$`` precedence."""
+
+    def test_header_takes_precedence_over_since(self) -> None:
+        from meho_backplane.api.v1.feed import _resolve_cursor
+
+        assert _resolve_cursor("from-header", "from-query") == "from-header"
+
+    def test_since_used_when_no_header(self) -> None:
+        from meho_backplane.api.v1.feed import _resolve_cursor
+
+        assert _resolve_cursor(None, "from-query") == "from-query"
+
+    def test_dollar_default_when_neither_set(self) -> None:
+        from meho_backplane.api.v1.feed import _resolve_cursor
+
+        assert _resolve_cursor(None, None) == "$"
+
+    def test_empty_header_falls_through_to_since(self) -> None:
+        from meho_backplane.api.v1.feed import _resolve_cursor
+
+        # An empty Last-Event-Id header is the "no resumption point"
+        # signal — fall through to since rather than passing the
+        # empty string to xread (which would be a redis-py argument
+        # error).
+        assert _resolve_cursor("", "from-query") == "from-query"
+
+
+# ---------------------------------------------------------------------------
+# Real-Valkey integration
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_DOCKER_AVAILABLE = _docker_socket_present()
+_SKIP_REASON = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason=_SKIP_REASON)
+class TestFeedIntegration:
+    """``publish_event`` → ``_feed_generator`` reads it back over real Valkey."""
+
+    @pytest.fixture
+    async def valkey_url(self, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[str]:
+        from testcontainers.redis import RedisContainer
+
+        image = os.environ.get("MEHO_TEST_VALKEY_IMAGE", "valkey/valkey:8")
+        with RedisContainer(image) as container:
+            host = container.get_container_host_ip()
+            port = container.get_exposed_port(6379)
+            url = f"redis://{host}:{port}"
+            monkeypatch.setenv("BROADCAST_REDIS_URL", url)
+            monkeypatch.setenv("KEYCLOAK_ISSUER_URL", ISSUER)
+            monkeypatch.setenv("KEYCLOAK_AUDIENCE", AUDIENCE)
+            monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+            get_settings.cache_clear()
+            reset_broadcast_client_for_testing()
+            try:
+                yield url
+            finally:
+                await dispose_broadcast_client()
+                get_settings.cache_clear()
+
+    async def test_publish_then_generator_read(self, valkey_url: str) -> None:
+        """End-to-end: publish_event into Valkey → generator yields back."""
+        event = _make_event(tenant_id=_TENANT_A)
+
+        # The generator's cursor must be set to "0" (from-beginning)
+        # rather than "$" (live-tail) because the publish happens
+        # before the first xread call here — with $ we'd miss the
+        # entry (xread interprets $ as "the last id at xread-call
+        # time", and the entry was added before that).
+        await publish_event(event)
+
+        gen = _feed_generator(
+            operator=_make_operator(tenant_id=_TENANT_A),
+            cursor="0",
+            op_class=None,
+            principal=None,
+            target=None,
+        )
+        frames = await _collect_n_frames(gen, n=1, timeout=5.0)
+
+        assert len(frames) == 1
+        data_line = next(line for line in frames[0].split("\n") if line.startswith("data: "))
+        decoded = json.loads(data_line[len("data: ") :])
+        rebuilt = BroadcastEvent.model_validate(decoded)
+        assert rebuilt == event

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -217,6 +217,14 @@ async def _collect_n_frames(
     :meth:`__aiter__.aclose` to cancel any pending ``xread`` and
     unwind the generator. Determinism comes from the mocked ``xread``'s
     ``asyncio.sleep`` yield point above.
+
+    ``TimeoutError`` from the ``asyncio.timeout`` wrapper is caught
+    silently because the timeout IS the test's termination mechanism
+    when ``n`` is unreachable (e.g. ``n=0`` for cursor-passes-through
+    cases, or a heartbeat test waiting one cycle past the patched
+    interval). The generator re-raises ``CancelledError`` per its
+    post-M1 contract; ``asyncio.timeout`` converts that to
+    ``TimeoutError`` on its way out of the context.
     """
     frames: list[str] = []
     try:
@@ -225,6 +233,8 @@ async def _collect_n_frames(
                 frames.append(chunk)
                 if len(frames) >= n:
                     break
+    except TimeoutError:
+        pass
     finally:
         await gen.aclose()
     return frames
@@ -381,6 +391,74 @@ class TestFeedGenerator:
             ]
         )
         assert decoded["target_name"] == "rdc-vcenter"
+
+    async def test_heartbeat_emitted_when_all_entries_filter_out(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Busy-but-filtered tenants still receive the keep-alive heartbeat.
+
+        The bug class this test pins (B1 / SonarCloud iter-1): a noisy
+        tenant where every event is rejected by the subscriber's filter
+        would otherwise emit zero outbound bytes but reset
+        ``last_heartbeat`` on every xread cycle — the wall-clock idle
+        check would never fire and intermediaries (nginx 60s, AWS ALB
+        60s, CloudFront 60s) would idle-timeout the connection. The
+        post-fix contract: heartbeats track outbound silence, not
+        inbound stream activity.
+
+        Time is compressed via the ``_HEARTBEAT_INTERVAL_SECONDS``
+        constant patched to a sub-second value rather than letting the
+        test wait the production 30 s. Same approach the SonarCloud
+        S7483 comment about timeout context managers anticipates.
+        """
+        from meho_backplane.api.v1 import feed as feed_module
+
+        monkeypatch.setattr(feed_module, "_HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+        # Every event has op_class=write; the subscriber filters for
+        # op_class=read. xread returns the events on cycle 1; cycle 2+
+        # returns None with a sleep that's long enough for the patched
+        # heartbeat window to elapse.
+        write_event_a = _make_event(op_class="write", op_id="vsphere.vm.create")
+        write_event_b = _make_event(op_class="write", op_id="vsphere.vm.delete")
+        broadcast_client = get_broadcast_client()
+        items = [
+            (f"{1715600000000 + i}-0", {"event": event.model_dump_json()})
+            for i, event in enumerate([write_event_a, write_event_b])
+        ]
+        call_count = {"n": 0}
+
+        async def _xread_side_effect(*_a: object, **_k: object) -> object:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # All entries filter out: subscriber asked for reads,
+                # tenant sent writes.
+                return [("meho:feed:<irrelevant>", items)]
+            # Subsequent cycles sleep past the heartbeat interval so
+            # the next loop iteration emits a heartbeat.
+            await asyncio.sleep(0.1)
+            return None
+
+        mock = AsyncMock(side_effect=_xread_side_effect)
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(),
+                cursor="$",
+                op_class="read",
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1, timeout=2.0)
+
+        # The single emitted frame is the heartbeat — every event was
+        # filtered out, but the contract still required keep-alive
+        # bytes on the wire. ``_collect_n_frames`` appends the raw
+        # yielded chunk verbatim (no \n\n splitting), so the frame
+        # carries the SSE comment-line shape end-to-end.
+        assert len(frames) == 1
+        assert frames[0] == ": heartbeat\n\n"
 
     async def test_cursor_passes_through_to_xread(self, _feed_env: None) -> None:
         """The cursor argument (already resolved by the handler) is what xread sees."""

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -145,8 +145,27 @@ this stage it exposes:
   the broadcast feed is the real-time view, the audit row is the
   record-of-truth, and Valkey unreachability never propagates as a
   request-path 5xx. Subscribers reading the stream get at-most-once
-  delivery; T4 SSE (#310), T5 CLI `--watch` (#311), and T6 MCP
-  resource (#312) all build on this single publisher.
+  delivery; T5 CLI `--watch` (#311) and T6 MCP resource (#312) build
+  on T4's SSE surface.
+* Broadcast SSE feed endpoint (G6.1-T4 #310) —
+  `src/meho_backplane/api/v1/feed.py` exposes
+  `GET /api/v1/feed` as a `text/event-stream` Server-Sent Events
+  endpoint. Subscribers issue `XREAD BLOCK 30000` against
+  `meho:feed:{operator.tenant_id}` (stream key derived from the
+  validated JWT — cross-tenant subscription is impossible by
+  construction), filter events post-stream by optional `op_class` /
+  `principal` / `target` query parameters, and emit SSE frames
+  `event: broadcast\ndata: <json>\nid: <entry-id>\n\n`. Replay is
+  driven by the SSE-standard `Last-Event-Id` header (preferred) or
+  the explicit `since` query parameter; default cursor is Valkey's
+  `$` anchor ("live-tail from now"). The generator emits a comment
+  heartbeat `: heartbeat\n\n` every 30s of inactivity to keep
+  intermediaries from idle-timing-out the connection. RBAC requires
+  `operator` role minimum; `read_only` operators get 403. Client
+  disconnect surfaces as `asyncio.CancelledError` and is swallowed
+  so the audit row at session end records a clean 200 close.
+  Subscribers (T5 CLI watch #311, T6 MCP resource #312, future
+  Slack mirror G6.2) consume the same SSE wire shape.
 * Persistence layer (Task #27) — `src/meho_backplane/db/` houses the
   SQLAlchemy 2.x async engine (`engine.py`), the per-request
   session-factory dependency (`get_session`), and the


### PR DESCRIPTION
## Summary

Closes #310 — T4 ships the operator-facing SSE surface that streams the events T3's publish-on-write hook ``XADD``s onto the per-tenant Valkey stream. Subscribers (T5 CLI ``--watch`` #311, T6 MCP resource #312, future Slack mirror G6.2 #333) open one HTTP connection per session and receive events as they're published.

- **`api/v1/feed.py` (new)** — `GET /api/v1/feed` returns `text/event-stream`. Generator issues `XREAD BLOCK 30000` against `meho:feed:{operator.tenant_id}` (stream key derived from the JWT — cross-tenant subscription impossible by construction), filters post-stream by optional `op_class` / `principal` / `target` query parameters, emits SSE frames `event: broadcast\ndata: <BroadcastEvent JSON>\nid: <Valkey entry id>\n\n`. Replay via SSE-standard `Last-Event-Id` header (preferred) or `since` query parameter; default cursor is `$` (live-tail). Heartbeat `: heartbeat\n\n` every 30s of inactivity. RBAC = operator role minimum.
- **Disconnect handling** — client disconnect surfaces as `asyncio.CancelledError`; the generator catches + returns silently so the audit row at session end records a clean 200 close.
- **Defensive parsing** — entries with malformed JSON or an unknown field shape are logged + skipped rather than tearing down the subscriber.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean (109 files)
- [x] `mypy src` strict — 56 source files, no issues
- [x] `pytest tests/test_api_v1_feed.py` — **14 passed** across three layers
- [x] `pytest --ignore=tests/integration` — **552 passed** (+14 vs T3 baseline), 1 skipped, 1 deselected
- [x] AC #1-2 — 200 + `text/event-stream` for authenticated operator, JWT-derived stream key — TestFeedEndpoint + TestFeedGenerator
- [x] AC #3-5 — Tenant boundary + filter by `op_class` / `principal` / `target` — TestFeedGenerator parametric cases
- [x] AC #6-7 — `Last-Event-Id` > `since` > `$` precedence — TestResolveCursor + TestFeedGenerator
- [x] AC #8 — Heartbeat shape pinned via the generator unit tests; the long-idle window is not exercised in CI (would slow the suite by 30s per case) but documented in the module
- [x] AC #9 — Disconnect cleanup — exercised by every test that drains the generator and calls `aclose()`; the `except asyncio.CancelledError: return` arm is the load-bearing fix
- [x] AC #10-11 — Unauthenticated → 401, read_only → 403 — TestFeedEndpoint

## Test architecture note

Body-shaping ACs (filters, cursors, malformed-entry skip) are tested at the **generator layer** rather than via httpx ASGI streaming. The httpx + ASGITransport cancellation handshake on `async with response.stream(...)` exit is racy enough that asserting on streamed bytes tight-loops the generator (the mocked `xread` has to `await asyncio.sleep` to give cancellation a chance, and even then the chain is timing-dependent). Async-generator `aclose()` is deterministic — the cleanest cancellation point in the system. HTTP-edge tests cover authn / authz / the 200-content-type happy header; everything else lands at the generator layer.

## Out of scope

- WebSocket transport — SSE is the right shape for read-only streams.
- Per-tenant rate limiting on the feed endpoint.
- Subscription pause/resume.

## Post-merge follow-up

- Tick T4 line on Initiative #228 body checklist.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a real-time Server-Sent Events feed: tenant-scoped streams, replay cursors (Last-Event-Id > since, default $), optional filters (op_class, principal, target), heartbeat comment frames, and operator-level RBAC (401/403). Graceful disconnects are logged.

* **Tests**
  * Added unit/generator-level and docker-gated integration tests covering auth, cursor resolution/advancement, filtering, heartbeat, malformed events, and end-to-end publish/read.

* **Documentation**
  * Expanded backend docs with feed behavior, SSE format, cursor semantics, heartbeat, and RBAC.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/353)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->