### PR TITLE
docs(planning): ground decisions #9-#11 with research evidence

### DIFF
--- a/docs/planning/v0.2-decisions.md
+++ b/docs/planning/v0.2-decisions.md
@@ -122,6 +122,77 @@ The Kubernetes connector (G3.2, filed against #214) uses **`kubernetes_asyncio`*
 
 **Why:** Kubernetes is quasi-tier-1 by usage frequency in the consumer's wrapper inventory (`kubectl-vcf.sh` is the most-used wrapper); needs its own G3 Initiative + library choice locked before Phase 1 K8s work starts. Helm is explicitly out of v0.2 K8s connector scope; future `HelmConnector` is a separate consideration.
 
+### 9. Frontend stack — **HTMX 2 + Jinja2 + Tailwind 4 + DaisyUI 5 + Alpine.js (+ Cytoscape.js island for topology)**
+
+Goal G10 (Operator web UI, [#336](https://github.com/evoila/meho/issues/336)) ships as a server-rendered hypermedia application served by the existing FastAPI backplane. No SPA framework, no Node toolchain in CI, no separate frontend deploy artifact.
+
+- **HTMX 2** for partial-page swaps over the wire. GA Jun 2024; 2.x supported in perpetuity per [htmx.org/posts/2024-06-17-htmx-2-0-0-is-released](https://htmx.org/posts/2024-06-17-htmx-2-0-0-is-released/). Operator-driven actions (e.g., `meho vsphere vm.list`) render a Jinja2 template fragment that HTMX swaps into the page; no full-page reload.
+- **Jinja2** for HTML templates — already FastAPI's recommended templating. One template tree per surface (broadcast feed, topology, KB search, memory, audit, connectors).
+- **Tailwind CSS 4** for styling. [v4.0 GA 22 Jan 2025](https://tailwindcss.com/blog/tailwindcss-v4); CSS-first config via `@theme`; oklch palette; ~5× faster builds than v3 (Lightning CSS engine). Built once at backend-image build time via the standalone CLI binary — no `node_modules` enters CI or the image.
+- **DaisyUI 5** for component primitives (cards, tables, drawers, dialogs, toasts, alerts). 50+ MIT-licensed themes; zero runtime deps; configured via `@plugin "daisyui";` directly in the main CSS file (no `tailwind.config.js`). Tailwind-4-native.
+- **Alpine.js** for the modest interactive-state surfaces HTMX alone can't carry (e.g., the multi-state Memory scope-promotion modal, or the topology-table ↔ graph-selection sync flag). Imported as a single `<script>` tag; no build step.
+- **Cytoscape.js** for the topology graph viz (Goal G9 / G10.5). Vendor-agnostic vanilla JS; embeds equally well as a server-rendered island on a Jinja2 page or inside any future React rewrite. Handles 1k+ node graphs.
+
+**Rejected alternatives:**
+
+- **React 19 + Vite 7 + TypeScript + TanStack Query/Router + shadcn/ui** — what the closed [PR #343](https://github.com/evoila/meho/pull/343) initially drafted (all of these are GA and production-ready as of May 2026). Honest pros: higher ceiling on visual polish via shadcn primitives; better mental model for a future frontend specialist; cleaner state machines for highly-interactive surfaces. Decisive cons: adds a 4th parallel CI job (Node toolchain + `package-lock.json` drift + new SHA-pin churn); the 4-person team has no frontend specialist today (`team_v0.2.md`); React → HTMX migration later is a wholesale rewrite, whereas HTMX → React is page-by-page; browser-side PKCE + sessionStorage tokens (the public-client SPA shape) is at odds with current OAuth BCP guidance (see decision #11).
+- **Next.js / Remix / Svelte / Solid / Vue** — smaller ecosystems for the governance/admin UI shape than React; none change the team-fit or no-undoables calculus relative to plain React, and Next.js specifically adds a Node runtime in the chart we don't otherwise need.
+- **HTML over raw FastAPI without HTMX** — every interaction full-page-reload is below the "should look very nicely" bar.
+
+**Why:** Each of the operator's stated G10 constraints maps to HTMX over React:
+
+1. **"Ship cleanly with backend; CI/CD must not break or become brittle."** HTMX adds **zero** new toolchains. The Tailwind 4 standalone CLI is a single `RUN` step in [`image.yml`](../../.github/workflows/image.yml); no parallel CI job; no `package-lock.json` to drift; no Node version pin to maintain. The three-job parallel pipeline in [`ci.yml`](../../.github/workflows/ci.yml) (`python-lint-test` ∥ `go-lint-test` ∥ `helm-lint-template`) stays as-is.
+2. **"No undoables later."** HTMX → React migration is per-page incremental (one surface at a time can flip if there's ever a reason). React → HTMX would be the same scope as building from scratch. HTMX preserves optionality.
+3. **"Not too complicated or fancy. Simplicity bias."** FastAPI + Jinja2 + HTMX is a mature 2025 production pattern for governance/admin UIs (e.g. `fasthx-admin`, server-rendered ML dashboards, IoT admin panels). React + TanStack Router + Query + state-machine glue ships substantially more concept count for the same surfaces.
+4. **"Should look very nicely."** DaisyUI 5's ceiling clears the bar for a governance tool (polished tables/dialogs/cards/themes out of the box, all Tailwind-customizable). Vercel/Linear-grade polish is a designer-driven ceiling, not a framework-driven one — neither React+shadcn nor HTMX+DaisyUI gets there without a designer.
+5. **"Reference visual cues from MEHO.X."** MEHO.X has no frontend (verified — `gh api /repos/evoila-bosnia/MEHO.X/contents/` shows no `frontend/` / `ui/` / `web/`). Both stacks start from a blank slate; team-fit becomes the deciding factor.
+
+Also load-bearing: decision #11 below picks the Backend-for-Frontend auth pattern, which is a natural fit for a server-rendered stack (the FastAPI backplane *is* the BFF). Browser-side PKCE + sessionStorage tokens runs against current OWASP and the in-progress OAuth Browser-Based-Apps BCP.
+
+### 10. Frontend deploy shape — **server-rendered from the existing FastAPI backplane at `/ui/*`; tiny static CSS+JS bundle at `/ui/static/*`**
+
+The web UI is part of the backplane process. No separate deploy artifact, no separate ingress, no separate TLS cert, no SPA bundle.
+
+- **Routes** at `/ui/*` resolve to FastAPI handlers that render Jinja2 templates and return HTML. HTMX partial swaps target the same surface.
+- **Static assets** (one compiled `tailwind.css`, vendored `htmx.min.js`, `alpine.min.js`, `cytoscape.min.js`, logos) live under `backend/src/meho_backplane/ui/static/` and are served by FastAPI's `StaticFiles` mount at `/ui/static/*` ([FastAPI tutorial/static-files](https://fastapi.tiangolo.com/tutorial/static-files/)).
+- **Build step** at backend-image build time: one `tailwindcss` CLI invocation against `backend/src/meho_backplane/ui/templates/**`. Tailwind 4's automatic content detection picks up the template tree without an explicit `content` array. Output is `tailwind.css`. No `node_modules`, no `npm`, no second image stage — the standalone Tailwind binary is downloaded with a pinned SHA256 in the Dockerfile, mirroring the kubeconform install discipline in [`ci.yml`](../../.github/workflows/ci.yml).
+- **No CI changes.** Jinja2 + Tailwind output get covered by the existing `python-lint-test` job in `ci.yml`. Template linting via `djlint` is an optional follow-up via pre-commit if it pays for itself; not blocking. Backend image rebuild on FE template changes is desirable here (single deploy lifecycle, never a skew).
+- **Helm chart unchanged.** [`deploy/charts/meho/`](../../deploy/charts/meho/) already terminates TLS at the backplane Service; the `/ui/*` paths are just additional FastAPI routes. No new subchart, no separate Service/Ingress/cert.
+
+**Rejected alternatives:**
+
+- **React static bundle served by FastAPI at `/ui/*`** (the cf4cf14 draft). Decision #9 picks server-rendered HTMX, which obviates the bundle.
+- **Separate nginx subchart for the FE** — added pod, added cert/ingress/Service, independent release cadence the team doesn't yet need. Reconsider in v0.3+ if independent FE release cadence ever becomes a real constraint.
+
+**Why:** Single deploy lifecycle (the UI always matches the backplane version it talks to — no skew); one TLS termination + one ingress + one cert; one auth boundary (the session cookie scope covers the entire app); zero new CI infrastructure. The "ship cleanly with the backend" constraint becomes literal — there's nothing else to ship.
+
+### 11. Frontend auth — **Backend-for-Frontend (BFF) with httpOnly session cookie; backend holds all OAuth tokens**
+
+The web UI uses the **BFF pattern**: the FastAPI backplane runs the full OAuth 2.1 Authorization Code + PKCE flow as a **confidential** client and stores all tokens server-side. The browser only ever holds a single `HttpOnly; Secure; SameSite=Strict` session cookie that binds to a server-side session record. **No JWT or refresh token ever enters the browser.**
+
+- **Confidential OAuth client:** Keycloak registers `meho-web` as a confidential client (with secret). The secret lives in Vault under the existing CLI-client / MCP-client pattern. (`meho-cli` device-code stays unchanged; `meho-mcp` resource-server stays unchanged.)
+- **Login flow:** `GET /ui/auth/login` → backplane builds an Authorization Code + PKCE request to Keycloak's `/protocol/openid-connect/auth` with `resource=<backplane-url>/api` ([RFC 8707](https://datatracker.ietf.org/doc/rfc8707/) audience binding) and redirects the browser. Keycloak callback hits `/ui/auth/callback`; backplane exchanges code+verifier for the access+refresh tokens, stores them server-side keyed by a new session ID, sets the `meho_session` cookie (`HttpOnly; Secure; SameSite=Strict; Path=/`), redirects to the originally-requested page.
+- **Session storage** is server-side, Postgres-backed for restart durability (the same DB the backplane already uses). Sessions evict on logout or refresh-token rotation failure.
+- **Outbound API calls** from a `/ui/*` route pull the access token from the session and forward it through the existing `verify_jwt` chain (decision #7 / G0.1). JWT validation, tenant binding, and audit-row emission are unchanged.
+- **Refresh token rotation** per [RFC 9700](https://datatracker.ietf.org/doc/rfc9700/) (BCP 240, *Best Current Practice for OAuth 2.0 Security*, Jan 2025): refresh tokens are one-time-use; every exchange returns a new refresh token; replay of a used refresh token revokes the session.
+- **CSRF protection:** double-submit cookie pattern on state-changing routes (POST/PATCH/DELETE). SameSite=Strict already blocks the cross-site vector; the cookie-bound CSRF token is belt-and-braces against malicious same-site sub-domains.
+- **MCP auth stays separate** (decision #7). `meho-mcp` clients still authenticate against the `<backplane-url>/mcp` audience as resource server; the `/ui/*` BFF surface authenticates against `<backplane-url>/api`. The JWT `aud` claim discriminates which surface a token is for.
+
+**Rejected alternatives:**
+
+- **Browser-side public-client PKCE with sessionStorage tokens** (the cf4cf14 draft). Directly contradicted by current OWASP guidance — *"Do not store authentication tokens, session IDs, JWTs, refresh tokens, or any credential in localStorage or sessionStorage"* ([Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)) — and ranked **least secure** of three architectures in the [OAuth 2.0 for Browser-Based Apps BCP draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps), which states *"This architecture [BFF] is strongly recommended for business applications, sensitive applications, and applications that handle personal data"* — MEHO is exactly this profile.
+- **Token-Mediating Backend** (the middle architecture in the BBA BCP) — backend handles OAuth but forwards the access token to the browser for direct API calls. Cleaner than browser-side PKCE; less clean than BFF because the token still enters the browser. No reason to pick the middle option when BFF is the same FastAPI app we're already running.
+- **Implicit flow / hybrid flow** — removed in OAuth 2.1; not considered.
+- **localStorage tokens** — same XSS exfiltration risk as sessionStorage; rejected for the same reason.
+
+**Why:**
+
+- **Security-correctness.** RFC 9700 (Jan 2025) is the canonical OAuth 2.0 security BCP for any new design in 2026. The OAuth Browser-Based-Apps BCP explicitly recommends BFF for sensitive applications. MEHO governs production infrastructure (Vault, Kubernetes, vCenter) — it is exactly the threat profile the BCP names.
+- **Zero new attack surface in the browser.** No JWT in memory, no refresh token in memory, no silent-refresh iframe trick, no PKCE round-trip code-path to audit. XSS in the UI cannot exfiltrate a credential (cookie is `HttpOnly`).
+- **Architectural fit.** Decision #9 picks server-rendered HTMX, so every navigation already involves the backend on every request — the BFF "extra hop" the pattern's critics call out doesn't exist here.
+- **Future-proof against a React rewrite.** If decision #9 ever flips to React (per-page or wholesale), the BFF stays: the React SPA hits the same `/ui/auth/login` flow, holds the same `meho_session` cookie, and the backend keeps holding the tokens. The auth model is independent of the FE framework choice.
+- **Reuses existing infrastructure.** Vault for the client secret; Postgres for session storage; the existing JWT chain for downstream calls. No new components to operate.
+
 ---
 
 ## Sequencing summary


### PR DESCRIPTION
## Summary

Replaces the un-grounded draft of decisions #9-#11 (closed [PR #343](https://github.com/evoila/meho/pull/343) / commit `cf4cf14`) with versions sourced from current real-world evidence: [RFC 9700](https://datatracker.ietf.org/doc/rfc9700/) (OAuth Security BCP, Jan 2025), the [OAuth Browser-Based-Apps BCP draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps), current [OWASP guidance](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html), and version-pinned library state as of May 2026.

The grounded conclusions honestly diverge from the draft on two of three decisions:

- **#9 — Frontend stack** flipped from React + Vite + TanStack to **HTMX 2 + Jinja2 + Tailwind 4 + DaisyUI 5 + Alpine.js** (+ Cytoscape.js island for topology). Driven by team-fit (4 backend engineers, no FE specialist), CI/CD blast-radius (zero new toolchains vs a 4th parallel job + Node lockfile drift), and the no-undoables constraint (HTMX → React is per-page incremental; React → HTMX is a wholesale rewrite).
- **#10 — Deploy shape** stays single-lifecycle but drops the static React bundle. Server-rendered Jinja2 + tiny static CSS/JS bundle at `/ui/static/*`, served by the existing FastAPI backplane. No CI changes; helm chart at `deploy/charts/meho/` unchanged.
- **#11 — Auth** flipped from browser-side public-client PKCE + sessionStorage tokens to **Backend-for-Frontend (BFF)** with `HttpOnly; Secure; SameSite=Strict` session cookie. The draft's sessionStorage choice was directly contradicted by current OWASP guidance (*"Do not store authentication tokens, session IDs, JWTs, refresh tokens, or any credential in localStorage or sessionStorage"*) and ranked least-secure of three architectures in the OAuth Browser-Based-Apps BCP for MEHO's "sensitive application" threat profile.

## Test plan

- [x] `ruff check src/ tests/` — clean.
- [x] `ruff format --check src/ tests/` — 87 files already formatted.
- [x] `mypy src/` — no issues found in 44 source files.
- [x] `pytest tests/` — 319 passed, 1 pre-existing Darwin-only failure (`test_observability.py::test_metrics_endpoint_returns_prometheus_text_format` asserts `process_resident_memory_bytes` in `/metrics`; `prometheus_client.ProcessCollector` is Linux-only via `/proc/<pid>/`. Will pass on the `meho-runners` Linux pool. Unrelated to a docs-only change.).
- [x] Acceptance criterion *"Decisions #9 / #10 / #11 in v0.2-decisions.md are rewritten with evidence (not just opinion)"* — each decision cites RFC numbers (9700, 8707, draft-ietf-oauth-browser-based-apps), version-pinned library release dates (HTMX 2.0 GA Jun 2024, Tailwind 4.0 GA Jan 22 2025), OWASP cheat sheets, and live repo paths.

## Out of scope (per agreed scope-down)

The original #344 body listed seven AC items. After offline discussion the scope was narrowed to "grounded decisions only — no prototypes, no reports". Deferred items:

- Research write-up doc (`docs/planning/frontend-stack-research.md`) — not produced.
- HTMX + React prototypes (`docs/planning/frontend-spike/{htmx,react}/`) — not produced.
- `docs/architecture/frontend.md` — not produced.
- Goal [#336](https://github.com/evoila/meho/issues/336) + Initiative bodies [#337](https://github.com/evoila/meho/issues/337)-[#342](https://github.com/evoila/meho/issues/342) rewrite — **needs a follow-up** (see below).
- Team-fit interview workstream — human-only.
- Visual-identity grounding — design judgment work.

## Known follow-ups

- **Goal [#336](https://github.com/evoila/meho/issues/336) + Initiatives [#337](https://github.com/evoila/meho/issues/337)-[#342](https://github.com/evoila/meho/issues/342) bodies** still describe a React + TanStack stack. They need a sweep to match the locked HTMX + BFF decisions. File as a follow-up Task under #337.
- **`test_observability.py` Darwin gap** — `process_resident_memory_bytes` assertion should grow a `platform.system() == "Linux"` skip-marker (or assert on a metric that's portable). Adjacent finding, not blocking this PR.
- **Local branch cleanup** — `docs/v0.2-decisions-frontend` (the closed-PR-#343 source branch) can be `git branch -D`'d once this merges.

Closes #344


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added v0.2 architectural decisions documenting frontend technology stack (HTMX 2, Jinja2, Tailwind CSS 4, DaisyUI 5, Alpine.js, Cytoscape.js), UI deployment through FastAPI, and Backend-for-Frontend OAuth 2.1 authentication with secure session management and token rotation strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/354)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->