### PR TITLE
test(observability): skip Linux-only /proc metrics on non-Linux

### DIFF
--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -130,7 +130,8 @@ def test_metrics_endpoint_returns_prometheus_text_format(
 @pytest.mark.skipif(
     platform.system() != "Linux",
     reason=(
-        "prometheus_client.ProcessCollector reads /proc/<pid>/; not available on Darwin or Windows"
+        "prometheus_client.ProcessCollector reads /proc/<pid>/; "
+        "not available on non-Linux platforms"
     ),
 )
 def test_metrics_endpoint_exposes_process_metrics_on_linux(
@@ -140,9 +141,16 @@ def test_metrics_endpoint_exposes_process_metrics_on_linux(
     promised operators. ``prometheus_client.ProcessCollector`` derives these
     from ``/proc/<pid>/`` files and emits no samples on non-Linux platforms,
     so the assertion is scoped to Linux (which is the CI runner pool's OS).
+
+    Repeats the basic ``/metrics`` response asserts from the portable test
+    so a broken endpoint on Linux surfaces as a clear status / content-type
+    failure rather than a confusing missing-substring error.
     """
     client.get("/")
     response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/plain; version=0.0.4; charset=utf-8"
     body = response.text
 
     assert "process_resident_memory_bytes" in body

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import platform
 import re
 from collections.abc import Iterator
 from uuid import UUID
@@ -120,15 +121,32 @@ def test_metrics_endpoint_returns_prometheus_text_format(
     assert response.headers["content-type"] == "text/plain; version=0.0.4; charset=utf-8"
     body = response.text
 
-    # Default process collector metrics — the runtime fingerprint
-    # Goal #11 promised operators.
-    assert "process_resident_memory_bytes" in body
-    assert "process_open_fds" in body
-
     # The application counter, with all three labels populated.
     assert 'http_requests_total{method="GET"' in body
     assert 'path="/"' in body
     assert 'status="200"' in body
+
+
+@pytest.mark.skipif(
+    platform.system() != "Linux",
+    reason=(
+        "prometheus_client.ProcessCollector reads /proc/<pid>/; not available on Darwin or Windows"
+    ),
+)
+def test_metrics_endpoint_exposes_process_metrics_on_linux(
+    client: TestClient,
+) -> None:
+    """Default process-collector metrics — the runtime fingerprint Goal #11
+    promised operators. ``prometheus_client.ProcessCollector`` derives these
+    from ``/proc/<pid>/`` files and emits no samples on non-Linux platforms,
+    so the assertion is scoped to Linux (which is the CI runner pool's OS).
+    """
+    client.get("/")
+    response = client.get("/metrics")
+    body = response.text
+
+    assert "process_resident_memory_bytes" in body
+    assert "process_open_fds" in body
 
 
 def test_metrics_endpoint_does_not_increment_for_itself_during_render(


### PR DESCRIPTION
## Summary

`prometheus_client.ProcessCollector` reads `/proc/<pid>/` files and emits **zero samples** on Darwin / Windows. The existing `test_metrics_endpoint_returns_prometheus_text_format` asserts `process_resident_memory_bytes` and `process_open_fds` are in the `/metrics` body — works on the `meho-runners` Linux pool, fails on macOS developer machines.

This PR splits the over-broad assertion: the existing test keeps its portable assertions (status, content-type, `http_requests_total` label shape); the two `/proc`-only assertions move into a new `pytest.mark.skipif(platform.system() != "Linux", ...)` test. Linux CI keeps full coverage; non-Linux developers stop seeing the spurious failure.

## Test plan

- [x] `ruff check src/ tests/` — clean.
- [x] `ruff format --check src/ tests/` — 109 files already formatted.
- [x] `mypy src/` — no issues in 56 source files.
- [x] `pytest tests/test_observability.py` on Darwin — 10 passed, 1 skipped (the new Linux-only test correctly skips).
- [x] Acceptance criterion: `test_metrics_endpoint_returns_prometheus_text_format` passes on Darwin without any platform skip — verified by re-running the previously-failing test in PR #354's worktree.
- [x] Acceptance criterion: `test_metrics_endpoint_exposes_process_metrics_on_linux` exists, marked `skipif(not Linux)`, asserts the two `/proc`-derived metrics.
- [x] No other observability tests touched (verified by `git diff --stat`).
- [ ] **CI assertion** (verifies on PR build): Linux meho-runners pool runs both tests; the Linux-only one passes there (not skipped).

## Out of scope

- Replacing `ProcessCollector` with a portable alternative (`psutil.Process()` works but adds a runtime dep for a test-only fix; not worth it).
- Changing the `/metrics` endpoint behaviour. `ProcessCollector` correctly returns no samples on non-Linux — that's the right runtime behaviour; the test just over-asserted.

Closes #357


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced metrics endpoint tests to better validate application HTTP request metrics (method, path, status).
  * Added Linux-only test coverage to assert process-level Prometheus metrics (memory usage and open file descriptors) are exposed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/359)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->