### PR TITLE
feat(cli): targets list/describe/probe verbs with --json + alias resolution (G0.3-T5)

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -50,6 +50,12 @@ type AuthedClient struct {
 	store   auth.TokenStore
 	service string
 	user    string
+
+	// backplaneURL and httpClient are stored for the hand-written
+	// targets/retrieve methods (doGet / doPost) that are not yet
+	// covered by the oapi-codegen generated surface.
+	backplaneURL string
+	httpClient   *http.Client
 }
 
 // AuthedClientOptions configures NewAuthedClient. Every field has a
@@ -141,6 +147,8 @@ func NewAuthedClient(_ context.Context, backplaneURL string, opts AuthedClientOp
 		store:               store,
 		service:             service,
 		user:                user,
+		backplaneURL:        backplaneURL,
+		httpClient:          httpClient,
 	}
 	box.onRefresh = authed.persistRefresh
 	return authed, nil

--- a/cli/internal/api/targets.go
+++ b/cli/internal/api/targets.go
@@ -24,21 +24,23 @@ type TargetSummary struct {
 
 // Target is the full read shape returned by GET /api/v1/targets/{name}.
 type Target struct {
-	ID          string         `json:"id"`
-	TenantID    string         `json:"tenant_id"`
-	Name        string         `json:"name"`
-	Aliases     []string       `json:"aliases"`
-	Product     string         `json:"product"`
-	Host        string         `json:"host"`
-	Port        *int           `json:"port"`
-	FQDN        *string        `json:"fqdn"`
-	SecretRef   *string        `json:"secret_ref"`
-	AuthModel   string         `json:"auth_model"`
-	VPNRequired bool           `json:"vpn_required"`
-	Extras      map[string]any `json:"extras"`
-	Notes       *string        `json:"notes"`
-	CreatedAt   string         `json:"created_at"`
-	UpdatedAt   string         `json:"updated_at"`
+	ID              string         `json:"id"`
+	TenantID        string         `json:"tenant_id"`
+	Name            string         `json:"name"`
+	Aliases         []string       `json:"aliases"`
+	Product         string         `json:"product"`
+	Host            string         `json:"host"`
+	Port            *int           `json:"port"`
+	FQDN            *string        `json:"fqdn"`
+	SecretRef       *string        `json:"secret_ref"`
+	AuthModel       string         `json:"auth_model"`
+	VPNRequired     bool           `json:"vpn_required"`
+	Extras          map[string]any `json:"extras"`
+	Notes           *string        `json:"notes"`
+	Fingerprint     map[string]any `json:"fingerprint,omitempty"`
+	PreferredImplID *string        `json:"preferred_impl_id,omitempty"`
+	CreatedAt       string         `json:"created_at"`
+	UpdatedAt       string         `json:"updated_at"`
 }
 
 // ProbeResult is the shape returned by POST /api/v1/targets/{name}/probe.
@@ -123,21 +125,30 @@ func (c *AuthedClient) DescribeTarget(ctx context.Context, name string) (*Target
 }
 
 // ProbeTarget calls POST /api/v1/targets/{name}/probe with a one-shot 401-retry.
-func (c *AuthedClient) ProbeTarget(ctx context.Context, name string) (*ProbeResult, int, error) {
+// On 404 / 409, the structured near-miss detail is returned alongside the error.
+func (c *AuthedClient) ProbeTarget(ctx context.Context, name string) (*ProbeResult, int, *TargetErrorDetail, error) {
 	resp, err := c.doPost(ctx, "/api/v1/targets/"+url.PathEscape(name)+"/probe", nil)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode == http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK:
 		var pr ProbeResult
 		if jerr := json.Unmarshal(body, &pr); jerr != nil {
-			return nil, resp.StatusCode, fmt.Errorf("meho: decode probe result: %w", jerr)
+			return nil, resp.StatusCode, nil, fmt.Errorf("meho: decode probe result: %w", jerr)
 		}
-		return &pr, resp.StatusCode, nil
+		return &pr, resp.StatusCode, nil, nil
+	case http.StatusNotFound, http.StatusConflict:
+		var envelope struct {
+			Detail TargetErrorDetail `json:"detail"`
+		}
+		_ = json.Unmarshal(body, &envelope)
+		return nil, resp.StatusCode, &envelope.Detail, errFromBody(body, resp.StatusCode)
+	default:
+		return nil, resp.StatusCode, nil, errFromBody(body, resp.StatusCode)
 	}
-	return nil, resp.StatusCode, errFromBody(body, resp.StatusCode)
 }
 
 // doGet makes an authenticated GET to backplaneURL+path with optional query

--- a/cli/internal/api/targets.go
+++ b/cli/internal/api/targets.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// TargetSummary is the short list shape returned by GET /api/v1/targets.
+type TargetSummary struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Aliases []string `json:"aliases"`
+	Product string   `json:"product"`
+	Host    string   `json:"host"`
+}
+
+// Target is the full read shape returned by GET /api/v1/targets/{name}.
+type Target struct {
+	ID          string         `json:"id"`
+	TenantID    string         `json:"tenant_id"`
+	Name        string         `json:"name"`
+	Aliases     []string       `json:"aliases"`
+	Product     string         `json:"product"`
+	Host        string         `json:"host"`
+	Port        *int           `json:"port"`
+	FQDN        *string        `json:"fqdn"`
+	SecretRef   *string        `json:"secret_ref"`
+	AuthModel   string         `json:"auth_model"`
+	VPNRequired bool           `json:"vpn_required"`
+	Extras      map[string]any `json:"extras"`
+	Notes       *string        `json:"notes"`
+	CreatedAt   string         `json:"created_at"`
+	UpdatedAt   string         `json:"updated_at"`
+}
+
+// ProbeResult is the shape returned by POST /api/v1/targets/{name}/probe.
+type ProbeResult struct {
+	OK        bool     `json:"ok"`
+	Reason    *string  `json:"reason"`
+	LatencyMs *float64 `json:"latency_ms"`
+	ProbedAt  string   `json:"probed_at"`
+}
+
+// TargetErrorDetail is the structured 404/409 detail shape from the backplane.
+type TargetErrorDetail struct {
+	Error   string          `json:"error"`
+	Query   string          `json:"query"`
+	Matches []TargetSummary `json:"matches"`
+}
+
+// ListTargetsParams holds the optional filters for GET /api/v1/targets.
+type ListTargetsParams struct {
+	Product *string
+	Limit   *int
+	Cursor  *string
+}
+
+// ListTargets calls GET /api/v1/targets with a one-shot 401-retry.
+// Returns the typed slice on success. On error the response body is
+// parsed for a structured error detail where possible; otherwise
+// the raw status is surfaced.
+func (c *AuthedClient) ListTargets(ctx context.Context, params *ListTargetsParams) ([]TargetSummary, int, error) {
+	q := url.Values{}
+	if params != nil {
+		if params.Product != nil && *params.Product != "" {
+			q.Set("product", *params.Product)
+		}
+		if params.Cursor != nil {
+			q.Set("cursor", *params.Cursor)
+		}
+	}
+	resp, err := c.doGet(ctx, "/api/v1/targets", q)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusOK {
+		var targets []TargetSummary
+		if jerr := json.Unmarshal(body, &targets); jerr != nil {
+			return nil, resp.StatusCode, fmt.Errorf("meho: decode targets list: %w", jerr)
+		}
+		return targets, resp.StatusCode, nil
+	}
+	return nil, resp.StatusCode, errFromBody(body, resp.StatusCode)
+}
+
+// DescribeTarget calls GET /api/v1/targets/{name} with a one-shot 401-retry.
+// Returns (target, statusCode, error). On 404 / 409, error wraps the
+// structured detail from the backplane.
+func (c *AuthedClient) DescribeTarget(ctx context.Context, name string) (*Target, int, *TargetErrorDetail, error) {
+	resp, err := c.doGet(ctx, "/api/v1/targets/"+url.PathEscape(name), nil)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var t Target
+		if jerr := json.Unmarshal(body, &t); jerr != nil {
+			return nil, resp.StatusCode, nil, fmt.Errorf("meho: decode target: %w", jerr)
+		}
+		return &t, resp.StatusCode, nil, nil
+	case http.StatusNotFound, http.StatusConflict:
+		// FastAPI wraps structured HTTPException detail in {"detail": {...}}.
+		var envelope struct {
+			Detail TargetErrorDetail `json:"detail"`
+		}
+		_ = json.Unmarshal(body, &envelope)
+		return nil, resp.StatusCode, &envelope.Detail, errFromBody(body, resp.StatusCode)
+	default:
+		return nil, resp.StatusCode, nil, errFromBody(body, resp.StatusCode)
+	}
+}
+
+// ProbeTarget calls POST /api/v1/targets/{name}/probe with a one-shot 401-retry.
+func (c *AuthedClient) ProbeTarget(ctx context.Context, name string) (*ProbeResult, int, error) {
+	resp, err := c.doPost(ctx, "/api/v1/targets/"+url.PathEscape(name)+"/probe", nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusOK {
+		var pr ProbeResult
+		if jerr := json.Unmarshal(body, &pr); jerr != nil {
+			return nil, resp.StatusCode, fmt.Errorf("meho: decode probe result: %w", jerr)
+		}
+		return &pr, resp.StatusCode, nil
+	}
+	return nil, resp.StatusCode, errFromBody(body, resp.StatusCode)
+}
+
+// doGet makes an authenticated GET to backplaneURL+path with optional query
+// parameters, retrying once with a refreshed token on 401.
+func (c *AuthedClient) doGet(ctx context.Context, path string, query url.Values) (*http.Response, error) {
+	return c.doRequest(ctx, http.MethodGet, path, query)
+}
+
+// doPost makes an authenticated POST to backplaneURL+path (empty body).
+func (c *AuthedClient) doPost(ctx context.Context, path string, query url.Values) (*http.Response, error) {
+	return c.doRequest(ctx, http.MethodPost, path, query)
+}
+
+func (c *AuthedClient) doRequest(ctx context.Context, method, path string, query url.Values) (*http.Response, error) {
+	resp, err := c.rawRequest(ctx, method, path, query)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	// 401: close the body we can't use, try a token refresh, then retry.
+	_ = resp.Body.Close()
+	if rerr := c.box.refresh(ctx); rerr != nil {
+		return nil, rerr
+	}
+	return c.rawRequest(ctx, method, path, query)
+}
+
+func (c *AuthedClient) rawRequest(ctx context.Context, method, path string, query url.Values) (*http.Response, error) {
+	rawURL := strings.TrimRight(c.backplaneURL, "/") + path
+	if len(query) > 0 {
+		rawURL += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("meho: build request: %w", err)
+	}
+	bearer := c.box.snapshot()
+	if bearer != "" {
+		req.Header.Set("Authorization", authorizationHeader(bearer))
+	}
+	req.Header.Set("Accept", "application/json")
+	return c.httpClient.Do(req)
+}
+
+// errFromBody constructs a simple error from the HTTP status and response body.
+// FastAPI wraps string details in {"detail": "..."} and dict details in
+// {"detail": {...}}. We extract the string form if present; otherwise fall
+// back to the raw status code.
+func errFromBody(body []byte, status int) error {
+	trimmed := strings.TrimSpace(string(body))
+	if len(trimmed) == 0 || len(trimmed) > 512 {
+		return fmt.Errorf("meho: HTTP %d", status)
+	}
+	// Try string detail first (most 401/403/501 responses).
+	var envelope struct {
+		Detail string `json:"detail"`
+	}
+	if jerr := json.Unmarshal(body, &envelope); jerr == nil && envelope.Detail != "" {
+		return fmt.Errorf("meho: HTTP %d: %s", status, envelope.Detail)
+	}
+	return fmt.Errorf("meho: HTTP %d", status)
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/cmd/targets"
 	"github.com/evoila/meho/cli/internal/discovery"
 )
 
@@ -74,6 +75,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newLoginCmd())
 	root.AddCommand(newStatusCmd())
+	root.AddCommand(targets.NewCommand())
 
 	// G0.2-T6 (#245) — static connector dispatch commands for the
 	// known product set. v0.2 ships vault only; v0.2.next replaces

--- a/cli/internal/cmd/targets/describe.go
+++ b/cli/internal/cmd/targets/describe.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+func newDescribeCmd() *cobra.Command {
+	var (
+		jsonOut   bool
+		backplane string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "describe <name|alias>",
+		Short: "Describe a target by name or alias",
+		Long: "describe calls GET /api/v1/targets/{name} using alias-aware " +
+			"resolution.\n\n" +
+			"Pass the canonical name or any registered alias. On 404, " +
+			"near-miss suggestions are printed to stderr.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			backplaneURL, err := resolveURL(backplane)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), jsonOut)
+			}
+			client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
+			if err != nil {
+				if api.IsTokenNotFound(err) {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
+						jsonOut)
+				}
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("build client: %v", err)),
+					jsonOut)
+			}
+
+			target, status, detail, err := client.DescribeTarget(cmd.Context(), name)
+			if err != nil {
+				if api.IsNoRefreshToken(err) {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("token expired; run `meho login %s`", backplaneURL)),
+						jsonOut)
+				}
+				switch status {
+				case http.StatusUnauthorized:
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("backplane rejected stored credentials; run `meho login %s`", backplaneURL)),
+						jsonOut)
+				case http.StatusForbidden:
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected("insufficient role: operator role required"),
+						jsonOut)
+				case http.StatusNotFound:
+					if detail != nil {
+						output.PrintTargetNearMisses(cmd.ErrOrStderr(), name, detail.Matches)
+					} else {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Target %q not found.\n", name)
+					}
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected(fmt.Sprintf("target %q not found", name)),
+						jsonOut)
+				case http.StatusConflict:
+					if detail != nil {
+						output.PrintAmbiguousTarget(cmd.ErrOrStderr(), name, detail.Matches)
+					}
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected(fmt.Sprintf("ambiguous query %q: use the canonical name", name)),
+						jsonOut)
+				default:
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+						jsonOut)
+				}
+			}
+
+			if jsonOut {
+				return output.PrintJSON(cmd.OutOrStdout(), target)
+			}
+			return output.PrintTarget(cmd.OutOrStdout(), target)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw JSON on stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplane, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by `meho login`)")
+	return cmd
+}

--- a/cli/internal/cmd/targets/describe.go
+++ b/cli/internal/cmd/targets/describe.go
@@ -31,20 +31,9 @@ func newDescribeCmd() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-			backplaneURL, err := resolveURL(backplane)
+			client, backplaneURL, err := buildClient(cmd, backplane, jsonOut)
 			if err != nil {
-				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), jsonOut)
-			}
-			client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
-			if err != nil {
-				if api.IsTokenNotFound(err) {
-					return output.RenderError(cmd.ErrOrStderr(),
-						output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
-						jsonOut)
-				}
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.Unexpected(fmt.Sprintf("build client: %v", err)),
-					jsonOut)
+				return err
 			}
 
 			target, status, detail, err := client.DescribeTarget(cmd.Context(), name)

--- a/cli/internal/cmd/targets/describe_test.go
+++ b/cli/internal/cmd/targets/describe_test.go
@@ -6,7 +6,6 @@ package targets
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -26,7 +25,6 @@ func fullTargetBody(name string) []byte {
 }
 
 func notFoundBody(query string) []byte {
-	// FastAPI HTTPException with dict detail wraps in {"detail": {...}}.
 	envelope := map[string]any{
 		"detail": map[string]any{
 			"error": "no_target",
@@ -42,15 +40,7 @@ func notFoundBody(query string) []byte {
 
 func fakeDescribeServer(t *testing.T, name string, body []byte, status int) string {
 	t.Helper()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/targets/"+name, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		_, _ = w.Write(body)
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return srv.URL
+	return fakeServer(t, "/api/v1/targets/"+name, jsonHandler(body, status))
 }
 
 func TestDescribe_HumanHappyPath(t *testing.T) {

--- a/cli/internal/cmd/targets/describe_test.go
+++ b/cli/internal/cmd/targets/describe_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func fullTargetBody(name string) []byte {
+	t := map[string]any{
+		"id": "aaa", "tenant_id": "ttt",
+		"name": name, "aliases": []string{"a-alias"},
+		"product": "rke2", "host": "10.0.0.1",
+		"auth_model": "shared_service_account",
+		"vpn_required": false, "extras": map[string]any{},
+		"created_at": "2026-01-01T00:00:00Z",
+		"updated_at": "2026-01-01T00:00:00Z",
+	}
+	b, _ := json.Marshal(t)
+	return b
+}
+
+func notFoundBody(query string) []byte {
+	// FastAPI HTTPException with dict detail wraps in {"detail": {...}}.
+	envelope := map[string]any{
+		"detail": map[string]any{
+			"error": "no_target",
+			"query": query,
+			"matches": []map[string]any{
+				{"id": "xx", "name": "alpha-prod", "aliases": []string{}, "product": "rke2", "host": "10.0.0.1"},
+			},
+		},
+	}
+	b, _ := json.Marshal(envelope)
+	return b
+}
+
+func fakeDescribeServer(t *testing.T, name string, body []byte, status int) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/"+name, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestDescribe_HumanHappyPath(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeDescribeServer(t, "alpha", fullTargetBody("alpha"), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, stderr, err := runCobraCmd(t, newDescribeCmd(), "alpha")
+	if err != nil {
+		t.Fatalf("describe returned error: %v\nstderr:\n%s", err, stderr)
+	}
+	out := stdout.String()
+	for _, want := range []string{"Name:", "alpha", "Product:", "rke2", "Host:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, jwtMarker) {
+		t.Errorf("JWT marker leaked into stdout:\n%s", out)
+	}
+}
+
+func TestDescribe_JSONOutput(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeDescribeServer(t, "alpha", fullTargetBody("alpha"), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, _, err := runCobraCmd(t, newDescribeCmd(), "alpha", "--json")
+	if err != nil {
+		t.Fatalf("describe --json returned error: %v", err)
+	}
+	var decoded map[string]any
+	if jerr := json.Unmarshal([]byte(strings.TrimSpace(stdout.String())), &decoded); jerr != nil {
+		t.Fatalf("not valid JSON: %v\n%s", jerr, stdout)
+	}
+	if decoded["name"] != "alpha" {
+		t.Errorf("expected name=alpha, got %v", decoded["name"])
+	}
+}
+
+func TestDescribe_NotFound_ShowsNearMisses(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeDescribeServer(t, "alph", notFoundBody("alph"), http.StatusNotFound)
+	seedCreds(t, xdg, url)
+
+	_, stderr, err := runCobraCmd(t, newDescribeCmd(), "alph")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	se := stderr.String()
+	if !strings.Contains(se, "not found") {
+		t.Errorf("expected 'not found' in stderr, got: %q", se)
+	}
+	if !strings.Contains(se, "alpha-prod") {
+		t.Errorf("expected near-miss 'alpha-prod' in stderr, got: %q", se)
+	}
+}
+
+func TestDescribe_AliasResolution_WorksTransparently(t *testing.T) {
+	xdg := withTempXDG(t)
+	// The resolver on the backplane handles alias → canonical name;
+	// the CLI just passes the arg verbatim in the URL path.
+	url := fakeDescribeServer(t, "a-alias", fullTargetBody("alpha"), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, _, err := runCobraCmd(t, newDescribeCmd(), "a-alias")
+	if err != nil {
+		t.Fatalf("describe via alias returned error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "alpha") {
+		t.Errorf("expected alpha in output, got:\n%s", stdout)
+	}
+}
+
+func TestDescribe_NoCreds(t *testing.T) {
+	_ = withTempXDG(t)
+	_, stderr, err := runCobraCmd(t, newDescribeCmd(), "alpha")
+	if err == nil {
+		t.Fatal("expected error for no-creds path")
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected `meho login` hint, got: %q", stderr)
+	}
+}

--- a/cli/internal/cmd/targets/helpers.go
+++ b/cli/internal/cmd/targets/helpers.go
@@ -9,7 +9,11 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
 )
 
 // resolveURL resolves the backplane URL from the --backplane flag or
@@ -28,6 +32,28 @@ func resolveURL(override string) (string, error) {
 		return "", err
 	}
 	return normalizeURL(cfg.BackplaneURL)
+}
+
+// buildClient resolves the backplane URL and builds an AuthedClient, rendering
+// a structured error for the well-known failure modes (no config, no creds,
+// generic build failure). The returned URL is always valid when error is nil.
+func buildClient(cmd *cobra.Command, override string, jsonOut bool) (*api.AuthedClient, string, error) {
+	backplaneURL, err := resolveURL(override)
+	if err != nil {
+		return nil, "", output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), jsonOut)
+	}
+	client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		if api.IsTokenNotFound(err) {
+			return nil, backplaneURL, output.RenderError(cmd.ErrOrStderr(),
+				output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
+				jsonOut)
+		}
+		return nil, backplaneURL, output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("build client: %v", err)),
+			jsonOut)
+	}
+	return client, backplaneURL, nil
 }
 
 func normalizeURL(s string) (string, error) {

--- a/cli/internal/cmd/targets/helpers.go
+++ b/cli/internal/cmd/targets/helpers.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// resolveURL resolves the backplane URL from the --backplane flag or
+// from the persisted config written by `meho login`. Mirrors the logic
+// in cmd.resolveBackplaneURL; duplicated here to avoid the package-
+// internal function being accessible from outside the cmd package.
+func resolveURL(override string) (string, error) {
+	if override != "" {
+		return normalizeURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", errors.New("no backplane URL configured; run `meho login <url>` first or pass --backplane <url>")
+		}
+		return "", err
+	}
+	return normalizeURL(cfg.BackplaneURL)
+}
+
+func normalizeURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}

--- a/cli/internal/cmd/targets/helpers_test.go
+++ b/cli/internal/cmd/targets/helpers_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// jwtMarker is the base64-URL prefix every JWT carries. Tests use it
+// as a sentinel to verify no bearer value leaks into output.
+const jwtMarker = "eyJ.TEST-DUMMY-TOKEN-TARGETS"
+
+// withTempXDG redirects XDG_CONFIG_HOME + MEHO_KEYRING_DISABLE so the
+// test exercises the file-backed token store in an isolated tmpdir.
+func withTempXDG(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	return dir
+}
+
+// seedCreds persists a stored token + config at the supplied XDG dir.
+func seedCreds(t *testing.T, xdg, backplaneURL string) {
+	t.Helper()
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  jwtMarker,
+		Expiry:       time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(filepath.Join(xdg, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL}); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+}
+
+// runCobraCmd executes a cobra command with the given argv.
+// Returns captured stdout, stderr, and the RunE error (if any).
+func runCobraCmd(t *testing.T, cmd *cobra.Command, argv ...string) (stdout, stderr *bytes.Buffer, err error) {
+	t.Helper()
+	stdout = &bytes.Buffer{}
+	stderr = &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs(argv)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd.SetContext(ctx)
+	err = cmd.Execute()
+	return
+}

--- a/cli/internal/cmd/targets/helpers_test.go
+++ b/cli/internal/cmd/targets/helpers_test.go
@@ -6,6 +6,8 @@ package targets
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
@@ -47,6 +49,27 @@ func seedCreds(t *testing.T, xdg, backplaneURL string) {
 	if err := auth.SaveConfigAt(filepath.Join(xdg, "meho", "config.json"),
 		auth.Config{BackplaneURL: backplaneURL}); err != nil {
 		t.Fatalf("SaveConfigAt: %v", err)
+	}
+}
+
+// fakeServer starts an httptest.Server that mounts handler at pattern.
+// The server is closed automatically when t finishes.
+func fakeServer(t *testing.T, pattern string, handler http.HandlerFunc) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(pattern, handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// jsonHandler returns a HandlerFunc that writes body with the given status and
+// Content-Type: application/json.
+func jsonHandler(body []byte, status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
 	}
 }
 

--- a/cli/internal/cmd/targets/list.go
+++ b/cli/internal/cmd/targets/list.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+func newListCmd() *cobra.Command {
+	var (
+		product  string
+		jsonOut  bool
+		backplane string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List targets in your tenant",
+		Long: "list calls GET /api/v1/targets and renders the results as a " +
+			"table.\n\n" +
+			"Pass --product to filter by product slug (exact match). " +
+			"Pass --json to emit the raw JSON array — useful for jq pipelines.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			backplaneURL, err := resolveURL(backplane)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), jsonOut)
+			}
+			client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
+			if err != nil {
+				if api.IsTokenNotFound(err) {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
+						jsonOut)
+				}
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("build client: %v", err)),
+					jsonOut)
+			}
+
+			params := &api.ListTargetsParams{}
+			if product != "" {
+				params.Product = &product
+			}
+			targets, status, err := client.ListTargets(cmd.Context(), params)
+			if err != nil {
+				if api.IsNoRefreshToken(err) {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("token expired; run `meho login %s`", backplaneURL)),
+						jsonOut)
+				}
+				if status == http.StatusUnauthorized {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("backplane rejected stored credentials; run `meho login %s`", backplaneURL)),
+						jsonOut)
+				}
+				if status == http.StatusForbidden {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected("insufficient role: operator role required for targets list"),
+						jsonOut)
+				}
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+					jsonOut)
+			}
+
+			if jsonOut {
+				return output.PrintJSON(cmd.OutOrStdout(), targets)
+			}
+			return output.PrintTargetsTable(cmd.OutOrStdout(), targets)
+		},
+	}
+
+	cmd.Flags().StringVarP(&product, "product", "p", "", "filter by product slug (exact match)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a JSON array on stdout instead of the human table")
+	cmd.Flags().StringVar(&backplane, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by `meho login`)")
+	return cmd
+}

--- a/cli/internal/cmd/targets/list.go
+++ b/cli/internal/cmd/targets/list.go
@@ -31,20 +31,9 @@ func newListCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			backplaneURL, err := resolveURL(backplane)
+			client, backplaneURL, err := buildClient(cmd, backplane, jsonOut)
 			if err != nil {
-				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), jsonOut)
-			}
-			client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
-			if err != nil {
-				if api.IsTokenNotFound(err) {
-					return output.RenderError(cmd.ErrOrStderr(),
-						output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
-						jsonOut)
-				}
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.Unexpected(fmt.Sprintf("build client: %v", err)),
-					jsonOut)
+				return err
 			}
 
 			params := &api.ListTargetsParams{}

--- a/cli/internal/cmd/targets/list_test.go
+++ b/cli/internal/cmd/targets/list_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -17,15 +16,7 @@ import (
 
 func fakeListServer(t *testing.T, body []byte, status int) string {
 	t.Helper()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		_, _ = w.Write(body)
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return srv.URL
+	return fakeServer(t, "/api/v1/targets", jsonHandler(body, status))
 }
 
 func twoTargetsBody() []byte {

--- a/cli/internal/cmd/targets/list_test.go
+++ b/cli/internal/cmd/targets/list_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+func fakeListServer(t *testing.T, body []byte, status int) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func twoTargetsBody() []byte {
+	targets := []map[string]any{
+		{"id": "aaa", "name": "alpha", "aliases": []string{"a"}, "product": "rke2", "host": "10.0.0.1"},
+		{"id": "bbb", "name": "beta", "aliases": []string{}, "product": "vcenter", "host": "10.0.0.2"},
+	}
+	b, _ := json.Marshal(targets)
+	return b
+}
+
+func TestList_HumanHappyPath(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeListServer(t, twoTargetsBody(), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, stderr, err := runCobraCmd(t, newListCmd())
+	if err != nil {
+		t.Fatalf("list returned error: %v\nstderr:\n%s", err, stderr)
+	}
+	out := stdout.String()
+	for _, want := range []string{"alpha", "beta", "rke2", "vcenter", "10.0.0.1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, jwtMarker) {
+		t.Errorf("JWT marker leaked into stdout:\n%s", out)
+	}
+}
+
+func TestList_JSONOutput(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeListServer(t, twoTargetsBody(), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, _, err := runCobraCmd(t, newListCmd(), "--json")
+	if err != nil {
+		t.Fatalf("list --json returned error: %v", err)
+	}
+	var decoded []map[string]any
+	if jerr := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &decoded); jerr != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", jerr, stdout)
+	}
+	if len(decoded) != 2 {
+		t.Errorf("expected 2 targets, got %d", len(decoded))
+	}
+}
+
+func TestList_ProductFilter_SentAsQueryParam(t *testing.T) {
+	xdg := withTempXDG(t)
+	var gotProduct string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+		gotProduct = r.URL.Query().Get("product")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	seedCreds(t, xdg, srv.URL)
+
+	_, _, err := runCobraCmd(t, newListCmd(), "--product", "vcenter")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotProduct != "vcenter" {
+		t.Errorf("expected product=vcenter in query, got %q", gotProduct)
+	}
+}
+
+func TestList_EmptyTenant(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeListServer(t, []byte("[]"), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, _, err := runCobraCmd(t, newListCmd())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No targets") {
+		t.Errorf("expected empty-list message, got:\n%s", stdout)
+	}
+}
+
+func TestList_NoCreds(t *testing.T) {
+	_ = withTempXDG(t) // no seeded creds
+
+	_, stderr, err := runCobraCmd(t, newListCmd())
+	if err == nil {
+		t.Fatal("expected error for no-creds path")
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected `meho login` hint, got: %q", stderr)
+	}
+}
+
+func TestList_BackplaneOverride(t *testing.T) {
+	xdg := withTempXDG(t)
+	live := fakeListServer(t, []byte("[]"), http.StatusOK)
+	deadURL := "http://192.0.2.1:1"
+	seedCreds(t, xdg, deadURL)
+	// Also seed creds for the live server.
+	store, _ := auth.NewFileStore()
+	svc, user := auth.KeyForBackplane(live)
+	_ = store.Save(svc, user, auth.StoredToken{
+		BackplaneURL: live,
+		AccessToken:  jwtMarker,
+		Expiry:       time.Now().Add(time.Hour),
+	})
+
+	_, _, err := runCobraCmd(t, newListCmd(), "--backplane", live)
+	if err != nil {
+		t.Fatalf("override path returned error: %v", err)
+	}
+}

--- a/cli/internal/cmd/targets/list_test.go
+++ b/cli/internal/cmd/targets/list_test.go
@@ -69,16 +69,13 @@ func TestList_JSONOutput(t *testing.T) {
 func TestList_ProductFilter_SentAsQueryParam(t *testing.T) {
 	xdg := withTempXDG(t)
 	var gotProduct string
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+	url := fakeServer(t, "/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
 		gotProduct = r.URL.Query().Get("product")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("[]"))
 	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	seedCreds(t, xdg, srv.URL)
+	seedCreds(t, xdg, url)
 
 	_, _, err := runCobraCmd(t, newListCmd(), "--product", "vcenter")
 	if err != nil {

--- a/cli/internal/cmd/targets/probe.go
+++ b/cli/internal/cmd/targets/probe.go
@@ -32,23 +32,12 @@ func newProbeCmd() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-			backplaneURL, err := resolveURL(backplane)
+			client, backplaneURL, err := buildClient(cmd, backplane, jsonOut)
 			if err != nil {
-				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), jsonOut)
-			}
-			client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
-			if err != nil {
-				if api.IsTokenNotFound(err) {
-					return output.RenderError(cmd.ErrOrStderr(),
-						output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
-						jsonOut)
-				}
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.Unexpected(fmt.Sprintf("build client: %v", err)),
-					jsonOut)
+				return err
 			}
 
-			pr, status, err := client.ProbeTarget(cmd.Context(), name)
+			pr, status, detail, err := client.ProbeTarget(cmd.Context(), name)
 			if err != nil {
 				if api.IsNoRefreshToken(err) {
 					return output.RenderError(cmd.ErrOrStderr(),
@@ -65,8 +54,20 @@ func newProbeCmd() *cobra.Command {
 						output.Unexpected("insufficient role: operator role required"),
 						jsonOut)
 				case http.StatusNotFound:
+					if detail != nil {
+						output.PrintTargetNearMisses(cmd.ErrOrStderr(), name, detail.Matches)
+					} else {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Target %q not found.\n", name)
+					}
 					return output.RenderError(cmd.ErrOrStderr(),
 						output.Unexpected(fmt.Sprintf("target %q not found", name)),
+						jsonOut)
+				case http.StatusConflict:
+					if detail != nil {
+						output.PrintAmbiguousTarget(cmd.ErrOrStderr(), name, detail.Matches)
+					}
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected(fmt.Sprintf("ambiguous query %q: use the canonical name", name)),
 						jsonOut)
 				case http.StatusNotImplemented:
 					// 501: no connector registered yet for this product — friendly message.

--- a/cli/internal/cmd/targets/probe.go
+++ b/cli/internal/cmd/targets/probe.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+func newProbeCmd() *cobra.Command {
+	var (
+		jsonOut   bool
+		backplane string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "probe <name|alias>",
+		Short: "Invoke the connector probe for a target",
+		Long: "probe calls POST /api/v1/targets/{name}/probe, which invokes " +
+			"the registered connector's probe method.\n\n" +
+			"A 501 response means no connector is registered yet for the " +
+			"target's product — this is expected before the G3 connector " +
+			"for that product lands.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			backplaneURL, err := resolveURL(backplane)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), jsonOut)
+			}
+			client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
+			if err != nil {
+				if api.IsTokenNotFound(err) {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
+						jsonOut)
+				}
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("build client: %v", err)),
+					jsonOut)
+			}
+
+			pr, status, err := client.ProbeTarget(cmd.Context(), name)
+			if err != nil {
+				if api.IsNoRefreshToken(err) {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("token expired; run `meho login %s`", backplaneURL)),
+						jsonOut)
+				}
+				switch status {
+				case http.StatusUnauthorized:
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("backplane rejected stored credentials; run `meho login %s`", backplaneURL)),
+						jsonOut)
+				case http.StatusForbidden:
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected("insufficient role: operator role required"),
+						jsonOut)
+				case http.StatusNotFound:
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected(fmt.Sprintf("target %q not found", name)),
+						jsonOut)
+				case http.StatusNotImplemented:
+					// 501: no connector registered yet for this product — friendly message.
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"No connector registered yet for target %q.\n"+
+							"The connector for this product lands in G3 — check the initiative tracker.\n",
+						name)
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected(fmt.Sprintf("no connector registered for target %q", name)),
+						jsonOut)
+				default:
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+						jsonOut)
+				}
+			}
+
+			if jsonOut {
+				return output.PrintJSON(cmd.OutOrStdout(), pr)
+			}
+			return output.PrintProbeResult(cmd.OutOrStdout(), pr)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw JSON on stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplane, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by `meho login`)")
+	return cmd
+}

--- a/cli/internal/cmd/targets/probe_test.go
+++ b/cli/internal/cmd/targets/probe_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func probeOKBody() []byte {
+	b, _ := json.Marshal(map[string]any{
+		"ok":         true,
+		"reason":     nil,
+		"latency_ms": 12.5,
+		"probed_at":  "2026-01-01T00:00:00Z",
+	})
+	return b
+}
+
+func probeFailedBody() []byte {
+	b, _ := json.Marshal(map[string]any{
+		"ok":         false,
+		"reason":     "connection refused",
+		"latency_ms": nil,
+		"probed_at":  "2026-01-01T00:00:00Z",
+	})
+	return b
+}
+
+func fakeProbeServer(t *testing.T, name string, body []byte, status int) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/"+name+"/probe", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestProbe_HumanHappyPath(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeProbeServer(t, "alpha", probeOKBody(), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, stderr, err := runCobraCmd(t, newProbeCmd(), "alpha")
+	if err != nil {
+		t.Fatalf("probe returned error: %v\nstderr:\n%s", err, stderr)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "ok") {
+		t.Errorf("expected 'ok' in output, got:\n%s", out)
+	}
+	if strings.Contains(out, jwtMarker) {
+		t.Errorf("JWT marker leaked into stdout:\n%s", out)
+	}
+}
+
+func TestProbe_JSONOutput(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeProbeServer(t, "alpha", probeOKBody(), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, _, err := runCobraCmd(t, newProbeCmd(), "alpha", "--json")
+	if err != nil {
+		t.Fatalf("probe --json returned error: %v", err)
+	}
+	var decoded map[string]any
+	if jerr := json.Unmarshal([]byte(strings.TrimSpace(stdout.String())), &decoded); jerr != nil {
+		t.Fatalf("not valid JSON: %v\n%s", jerr, stdout)
+	}
+	if decoded["ok"] != true {
+		t.Errorf("expected ok=true, got %v", decoded["ok"])
+	}
+}
+
+func TestProbe_FailedProbe_StillReturnsOK(t *testing.T) {
+	// A failed probe (ok=false) is a 200 response; the connector
+	// reported the target is unreachable, not that the route failed.
+	xdg := withTempXDG(t)
+	url := fakeProbeServer(t, "alpha", probeFailedBody(), http.StatusOK)
+	seedCreds(t, xdg, url)
+
+	stdout, _, err := runCobraCmd(t, newProbeCmd(), "alpha")
+	if err != nil {
+		t.Fatalf("probe returned error on failed probe: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "failed") {
+		t.Errorf("expected 'failed' status in output, got:\n%s", stdout)
+	}
+}
+
+func TestProbe_501_PrintsFriendlyMessage(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeProbeServer(t, "alpha",
+		[]byte(`{"detail":"no connector registered for product=\"rke2\""}`),
+		http.StatusNotImplemented)
+	seedCreds(t, xdg, url)
+
+	_, stderr, err := runCobraCmd(t, newProbeCmd(), "alpha")
+	if err == nil {
+		t.Fatal("expected error on 501")
+	}
+	se := stderr.String()
+	if !strings.Contains(se, "connector") {
+		t.Errorf("expected connector message in stderr, got: %q", se)
+	}
+	if !strings.Contains(se, "G3") {
+		t.Errorf("expected G3 reference in stderr, got: %q", se)
+	}
+}
+
+func TestProbe_NotFound(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeProbeServer(t, "no-such",
+		[]byte(`{"detail":"no_target"}`),
+		http.StatusNotFound)
+	seedCreds(t, xdg, url)
+
+	_, _, err := runCobraCmd(t, newProbeCmd(), "no-such")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+}
+
+func TestProbe_NoCreds(t *testing.T) {
+	_ = withTempXDG(t)
+	_, stderr, err := runCobraCmd(t, newProbeCmd(), "alpha")
+	if err == nil {
+		t.Fatal("expected error for no-creds path")
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected `meho login` hint, got: %q", stderr)
+	}
+}

--- a/cli/internal/cmd/targets/probe_test.go
+++ b/cli/internal/cmd/targets/probe_test.go
@@ -6,7 +6,6 @@ package targets
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -33,19 +32,13 @@ func probeFailedBody() []byte {
 
 func fakeProbeServer(t *testing.T, name string, body []byte, status int) string {
 	t.Helper()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/targets/"+name+"/probe", func(w http.ResponseWriter, r *http.Request) {
+	return fakeServer(t, "/api/v1/targets/"+name+"/probe", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		_, _ = w.Write(body)
+		jsonHandler(body, status)(w, r)
 	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return srv.URL
 }
 
 func TestProbe_HumanHappyPath(t *testing.T) {

--- a/cli/internal/cmd/targets/probe_test.go
+++ b/cli/internal/cmd/targets/probe_test.go
@@ -126,6 +126,29 @@ func TestProbe_NotFound(t *testing.T) {
 	}
 }
 
+func TestProbe_NotFound_ShowsNearMisses(t *testing.T) {
+	xdg := withTempXDG(t)
+	body, _ := json.Marshal(map[string]any{
+		"detail": map[string]any{
+			"error": "no_target",
+			"query": "alph",
+			"matches": []map[string]any{
+				{"id": "aaa", "name": "alpha", "aliases": []string{}, "product": "rke2", "host": "10.0.0.1"},
+			},
+		},
+	})
+	url := fakeProbeServer(t, "alph", body, http.StatusNotFound)
+	seedCreds(t, xdg, url)
+
+	_, stderr, err := runCobraCmd(t, newProbeCmd(), "alph")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(stderr.String(), "alpha") {
+		t.Errorf("expected near-miss 'alpha' in stderr, got: %q", stderr)
+	}
+}
+
 func TestProbe_NoCreds(t *testing.T) {
 	_ = withTempXDG(t)
 	_, stderr, err := runCobraCmd(t, newProbeCmd(), "alpha")

--- a/cli/internal/cmd/targets/targets.go
+++ b/cli/internal/cmd/targets/targets.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package targets implements the `meho targets` subcommand tree.
+//
+// Three verbs:
+//
+//   - meho targets list [--product P] [--json]
+//   - meho targets describe <name|alias> [--json]
+//   - meho targets probe <name|alias>
+//
+// All verbs are read-only (operator role). Write verbs (create / update /
+// delete) are deferred to v0.2 per the T5 out-of-scope list.
+package targets
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns the `meho targets` parent command.
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "targets",
+		Short: "Operate the MEHO targets registry",
+		Long: "List, describe, and probe targets registered in the operator's " +
+			"tenant.\n\n" +
+			"All verbs are read-only in v0.2; write operations (create, update, " +
+			"delete) are available via the REST API at /api/v1/targets.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newDescribeCmd())
+	cmd.AddCommand(newProbeCmd())
+	return cmd
+}

--- a/cli/internal/output/targets.go
+++ b/cli/internal/output/targets.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package output
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// PrintTargetsTable renders a list of TargetSummary rows as a tabwriter table.
+// Columns: NAME, ALIASES, PRODUCT, HOST.
+func PrintTargetsTable(w io.Writer, targets []api.TargetSummary) error {
+	if len(targets) == 0 {
+		fmt.Fprintln(w, "No targets found.")
+		return nil
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tALIASES\tPRODUCT\tHOST")
+	for _, t := range targets {
+		aliases := strings.Join(t.Aliases, ",")
+		if aliases == "" {
+			aliases = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", t.Name, aliases, t.Product, t.Host)
+	}
+	return tw.Flush()
+}
+
+// PrintTarget renders a full Target as a key-value summary.
+func PrintTarget(w io.Writer, t *api.Target) error {
+	fmt.Fprintf(w, "Name:        %s\n", t.Name)
+	if len(t.Aliases) > 0 {
+		fmt.Fprintf(w, "Aliases:     %s\n", strings.Join(t.Aliases, ", "))
+	}
+	fmt.Fprintf(w, "Product:     %s\n", t.Product)
+	fmt.Fprintf(w, "Host:        %s\n", t.Host)
+	if t.Port != nil {
+		fmt.Fprintf(w, "Port:        %d\n", *t.Port)
+	}
+	if t.FQDN != nil {
+		fmt.Fprintf(w, "FQDN:        %s\n", *t.FQDN)
+	}
+	fmt.Fprintf(w, "Auth model:  %s\n", t.AuthModel)
+	fmt.Fprintf(w, "VPN:         %v\n", t.VPNRequired)
+	if t.Notes != nil && *t.Notes != "" {
+		fmt.Fprintf(w, "Notes:       %s\n", *t.Notes)
+	}
+	fmt.Fprintf(w, "ID:          %s\n", t.ID)
+	fmt.Fprintf(w, "Tenant:      %s\n", t.TenantID)
+	fmt.Fprintf(w, "Created:     %s\n", t.CreatedAt)
+	fmt.Fprintf(w, "Updated:     %s\n", t.UpdatedAt)
+	return nil
+}
+
+// PrintProbeResult renders a ProbeResult for human consumption.
+func PrintProbeResult(w io.Writer, pr *api.ProbeResult) error {
+	status := "ok"
+	if !pr.OK {
+		status = "failed"
+	}
+	fmt.Fprintf(w, "Probe:     %s\n", status)
+	if pr.Reason != nil && *pr.Reason != "" {
+		fmt.Fprintf(w, "Reason:    %s\n", *pr.Reason)
+	}
+	if pr.LatencyMs != nil {
+		fmt.Fprintf(w, "Latency:   %.1f ms\n", *pr.LatencyMs)
+	}
+	fmt.Fprintf(w, "Probed at: %s\n", pr.ProbedAt)
+	return nil
+}
+
+// PrintTargetNearMisses renders the near-miss suggestions from a 404 detail.
+func PrintTargetNearMisses(w io.Writer, query string, matches []api.TargetSummary) {
+	fmt.Fprintf(w, "Target %q not found.\n", query)
+	if len(matches) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Did you mean one of:")
+	for _, m := range matches {
+		if len(m.Aliases) > 0 {
+			fmt.Fprintf(w, "  %s  (aliases: %s)\n", m.Name, strings.Join(m.Aliases, ", "))
+		} else {
+			fmt.Fprintf(w, "  %s\n", m.Name)
+		}
+	}
+}
+
+// PrintAmbiguousTarget renders the ambiguous-alias matches from a 409 detail.
+func PrintAmbiguousTarget(w io.Writer, query string, matches []api.TargetSummary) {
+	fmt.Fprintf(w, "Ambiguous query %q matched multiple targets:\n", query)
+	for _, m := range matches {
+		fmt.Fprintf(w, "  %s  (product: %s, host: %s)\n", m.Name, m.Product, m.Host)
+	}
+	fmt.Fprintln(w, "Use the canonical target name instead of the alias.")
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -58,13 +58,24 @@ cli/
     │   ├── login.go           # `meho login` subcommand + auth-config discovery + config persistence.
     │   ├── login_test.go      # override-resolution + help-flag tests.
     │   ├── status.go          # `meho status` subcommand + --json + URL resolver.
-    │   └── status_test.go     # happy/JSON/no-creds/unreachable/401/redaction tests.
+    │   ├── status_test.go     # happy/JSON/no-creds/unreachable/401/redaction tests.
+    │   └── targets/           # `meho targets` subcommand tree (G0.3-T5 #256).
+    │       ├── targets.go     # parent command (NewCommand).
+    │       ├── helpers.go     # resolveURL / normalizeURL shared by verbs.
+    │       ├── list.go        # `meho targets list [--product P] [--json]`.
+    │       ├── describe.go    # `meho targets describe <name|alias> [--json]`.
+    │       ├── probe.go       # `meho targets probe <name|alias> [--json]`.
+    │       ├── helpers_test.go # withTempXDG / seedCreds / runCobraCmd shared test helpers.
+    │       ├── list_test.go   # human/JSON/product-filter/empty/no-creds/override tests.
+    │       ├── describe_test.go # human/JSON/404-near-miss/alias/no-creds tests.
+    │       └── probe_test.go  # ok/failed/501-friendly/404/no-creds tests.
     ├── discovery/
     │   ├── discovery.go       # /api/v1/commands manifest fetch + cobra graft.
     │   └── discovery_test.go  # 200/404/transport/decode + collision tests.
     ├── output/
     │   ├── format.go          # human + JSON formatters + structured exit codes.
-    │   └── format_test.go     # human/JSON/exit-code pinning.
+    │   ├── format_test.go     # human/JSON/exit-code pinning.
+    │   └── targets.go         # PrintTargetsTable / PrintTarget / PrintProbeResult (G0.3-T5 #256).
     └── version/
         └── version.go         # build-time identity (Version/Commit/Date).
 ```


### PR DESCRIPTION
## Summary

- **`api/targets.go`**: `Target`, `TargetSummary`, `ProbeResult` types; `ListTargets`, `DescribeTarget`, `ProbeTarget` methods on `AuthedClient`. Generic `doGet`/`doPost` helper with one-shot 401-retry matching `GetHealth`'s pattern. FastAPI error envelope (`{"detail": {...}}`) is unwrapped on 404/409 so near-miss and ambiguous-target detail surfaces to the CLI.
- **`api/client.go`**: stores `backplaneURL` + `httpClient` on `AuthedClient` so hand-written methods can build raw HTTP requests without type-asserting into generated internals.
- **`output/targets.go`**: `PrintTargetsTable` (tabwriter, NAME/ALIASES/PRODUCT/HOST), `PrintTarget` (key-value), `PrintProbeResult`, `PrintTargetNearMisses`, `PrintAmbiguousTarget`.
- **`cmd/targets/`**: parent command + `list`/`describe`/`probe` verbs. 501 on probe prints a friendly "no connector yet — check G3 tracker" message. 404 on describe renders near-miss suggestions. All verbs support `--json` + `--backplane` override.
- **`cmd/root.go`**: registers `targets.NewCommand()` on the cobra root.
- 17 tests in `list_test.go` / `describe_test.go` / `probe_test.go` covering happy-paths, JSON output, product-filter query param, empty tenant, no-creds, backplane override, 404/501 error paths.

> **Note:** Go is not installed on the author's machine; `go vet` + `go test` will be verified by CI.

## Test plan

- [ ] `go vet ./...` — CI gate
- [ ] `go test ./cli/internal/cmd/targets/...` — 17 tests
- [ ] `go test ./cli/internal/api/...` — existing api tests + new type compilation
- [ ] `go test ./cli/internal/output/...` — existing output tests still pass

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)