### PR TITLE
feat(cli): targets import verb — bulk-import targets.yaml with --update/--dry-run/--json (G0.3-T6)

### DIFF
--- a/backend/tests/test_api_v1_targets_import.py
+++ b/backend/tests/test_api_v1_targets_import.py
@@ -20,15 +20,10 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterator
-from datetime import UTC, datetime
-from typing import Any
 
 import pytest
 import respx
 from fastapi.testclient import TestClient
-
-from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import Target as TargetORM
 
 from ._oidc_jwt_helpers import (
     DEFAULT_TENANT_ID,
@@ -40,6 +35,7 @@ from ._targets_helpers import (
     _admin_token,
     _build_app,
     _empty_connector_registry,  # noqa: F401
+    _insert_target,
     _isolated_jwks_cache,  # noqa: F401
     _operator_token,
     _settings_env,  # noqa: F401
@@ -53,29 +49,6 @@ from ._targets_helpers import (
 @pytest.fixture
 def client() -> Iterator[TestClient]:
     yield TestClient(_build_app())
-
-
-async def _insert_target(**kwargs: Any) -> TargetORM:
-    defaults: dict[str, Any] = {
-        "id": uuid.uuid4(),
-        "tenant_id": uuid.UUID(DEFAULT_TENANT_ID),
-        "name": "default-target",
-        "product": "ssh",
-        "host": "10.0.0.1",
-        "aliases": [],
-        "vpn_required": False,
-        "auth_model": "shared_service_account",
-        "extras": {},
-        "created_at": datetime.now(UTC),
-        "updated_at": datetime.now(UTC),
-    }
-    defaults.update(kwargs)
-    t = TargetORM(**defaults)
-    sm = get_sessionmaker()
-    async with sm() as session:
-        session.add(t)
-        await session.commit()
-    return t
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_api_v1_targets_import.py
+++ b/backend/tests/test_api_v1_targets_import.py
@@ -25,87 +25,34 @@ from typing import Any
 
 import pytest
 import respx
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from meho_backplane.api.v1.targets import router as targets_router
-from meho_backplane.audit import AuditMiddleware
-from meho_backplane.auth.jwt import clear_jwks_cache
-from meho_backplane.auth.operator import TenantRole
-from meho_backplane.connectors.registry import clear_registry
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Target as TargetORM
-from meho_backplane.middleware import RequestContextMiddleware
-from meho_backplane.settings import get_settings
 
-from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
 from ._oidc_jwt_helpers import (
     DEFAULT_TENANT_ID,
     make_rsa_keypair,
-    mint_token,
     mock_discovery_and_jwks,
     public_jwks,
 )
-from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._targets_helpers import (
+    _admin_token,
+    _build_app,
+    _empty_connector_registry,  # noqa: F401
+    _isolated_jwks_cache,  # noqa: F401
+    _operator_token,
+    _settings_env,  # noqa: F401
+)
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# App + DB fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
-    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
-    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
-    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
-    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
-    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
-    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
-    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
-    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
-    get_settings.cache_clear()
-    yield
-    get_settings.cache_clear()
-
-
-@pytest.fixture(autouse=True)
-def _isolated_jwks_cache() -> Iterator[None]:
-    clear_jwks_cache()
-    yield
-    clear_jwks_cache()
-
-
-@pytest.fixture(autouse=True)
-def _empty_connector_registry() -> Iterator[None]:
-    clear_registry()
-    yield
-    clear_registry()
-
-
-def _build_app() -> FastAPI:
-    app = FastAPI()
-    app.add_middleware(AuditMiddleware)
-    app.add_middleware(RequestContextMiddleware)
-    app.include_router(targets_router)
-    return app
 
 
 @pytest.fixture
 def client() -> Iterator[TestClient]:
     yield TestClient(_build_app())
-
-
-def _admin_token(key: Any, tenant_id: str = DEFAULT_TENANT_ID) -> str:
-    return mint_token(
-        key, sub="admin-1", tenant_role=TenantRole.TENANT_ADMIN.value, tenant_id=tenant_id
-    )
-
-
-def _operator_token(key: Any, tenant_id: str = DEFAULT_TENANT_ID) -> str:
-    return mint_token(
-        key, sub="op-1", tenant_role=TenantRole.OPERATOR.value, tenant_id=tenant_id
-    )
 
 
 async def _insert_target(**kwargs: Any) -> TargetORM:

--- a/backend/tests/test_api_v1_targets_import.py
+++ b/backend/tests/test_api_v1_targets_import.py
@@ -1,0 +1,483 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration tests for the bulk-import flow (G0.3-T6 / Task #257).
+
+These tests drive the backplane API directly (no CLI), verifying that
+POST /api/v1/targets and PATCH /api/v1/targets/{name} behave correctly
+for the operations the import tool performs:
+
+* Create a batch of targets → all appear in list / describe.
+* Re-import without --update → 409 on duplicate names.
+* Re-import with --update (PATCH) → notes and extras updated in place.
+* Round-trip: import entry fields match describe response semantically.
+* Extras (unknown YAML fields) survive the round-trip as JSONB.
+* Missing required fields → 422 from the create endpoint.
+* Cross-tenant isolation — imported targets invisible to other tenants.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from meho_backplane.api.v1.targets import router as targets_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import (
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+@pytest.fixture(autouse=True)
+def _empty_connector_registry() -> Iterator[None]:
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(targets_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def _admin_token(key: Any, tenant_id: str = DEFAULT_TENANT_ID) -> str:
+    return mint_token(
+        key, sub="admin-1", tenant_role=TenantRole.TENANT_ADMIN.value, tenant_id=tenant_id
+    )
+
+
+def _operator_token(key: Any, tenant_id: str = DEFAULT_TENANT_ID) -> str:
+    return mint_token(
+        key, sub="op-1", tenant_role=TenantRole.OPERATOR.value, tenant_id=tenant_id
+    )
+
+
+async def _insert_target(**kwargs: Any) -> TargetORM:
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "tenant_id": uuid.UUID(DEFAULT_TENANT_ID),
+        "name": "default-target",
+        "product": "ssh",
+        "host": "10.0.0.1",
+        "aliases": [],
+        "vpn_required": False,
+        "auth_model": "shared_service_account",
+        "extras": {},
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+    defaults.update(kwargs)
+    t = TargetORM(**defaults)
+    sm = get_sessionmaker()
+    async with sm() as session:
+        session.add(t)
+        await session.commit()
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Create (POST) — import tool's happy path
+# ---------------------------------------------------------------------------
+
+
+def test_import_create_single_target(client: TestClient) -> None:
+    """POST /api/v1/targets with a full import entry returns 201."""
+    key = make_rsa_keypair("kid-A")
+    payload = {
+        "name": "rdc-vcenter",
+        "product": "vcenter",
+        "host": "vc-dc.evba.lab",
+        "port": 443,
+        "aliases": ["rdc", "host-vcenter"],
+        "secret_ref": "secret/rdc/vsphere",
+        "vpn_required": True,
+        "auth_model": "shared_service_account",
+        "extras": {"sso_realm": "evba.lab"},
+        "notes": "Host vCenter for 4 Hetzner hosts.",
+    }
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json=payload,
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "rdc-vcenter"
+    assert data["product"] == "vcenter"
+    assert data["host"] == "vc-dc.evba.lab"
+    assert data["port"] == 443
+    assert set(data["aliases"]) == {"rdc", "host-vcenter"}
+    assert data["secret_ref"] == "secret/rdc/vsphere"
+    assert data["vpn_required"] is True
+    assert data["extras"]["sso_realm"] == "evba.lab"
+    assert data["notes"] == "Host vCenter for 4 Hetzner hosts."
+
+
+def test_import_create_minimal_target(client: TestClient) -> None:
+    """POST with only required fields uses correct defaults."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={"name": "minimal", "product": "ssh", "host": "10.0.0.1",
+                  "aliases": [], "extras": {}, "auth_model": "shared_service_account",
+                  "vpn_required": False},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["auth_model"] == "shared_service_account"
+    assert data["vpn_required"] is False
+    assert data["aliases"] == []
+    assert data["extras"] == {}
+    assert data["port"] is None
+    assert data["notes"] is None
+
+
+async def test_import_batch_creates_all(client: TestClient) -> None:
+    """Sequential POSTs for a batch of targets all land in the list endpoint."""
+    key = make_rsa_keypair("kid-A")
+    targets_to_create = [
+        {"name": f"target-{i}", "product": "rke2", "host": f"10.0.0.{i}",
+         "aliases": [], "extras": {}, "auth_model": "shared_service_account",
+         "vpn_required": False}
+        for i in range(1, 6)
+    ]
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        for payload in targets_to_create:
+            r = client.post(
+                "/api/v1/targets",
+                json=payload,
+                headers={"Authorization": f"Bearer {_admin_token(key)}"},
+            )
+            assert r.status_code == 201, f"failed creating {payload['name']}: {r.text}"
+
+        # Verify all appear in list
+        list_resp = client.get(
+            "/api/v1/targets",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert list_resp.status_code == 200
+    names = {t["name"] for t in list_resp.json()}
+    for i in range(1, 6):
+        assert f"target-{i}" in names
+
+
+# ---------------------------------------------------------------------------
+# Duplicate → 409 (default import mode — no --update)
+# ---------------------------------------------------------------------------
+
+
+def test_import_duplicate_name_returns_409(client: TestClient) -> None:
+    """Re-importing without --update returns 409 on the second POST."""
+    key = make_rsa_keypair("kid-A")
+    payload = {"name": "dup-target", "product": "ssh", "host": "10.0.0.1",
+               "aliases": [], "extras": {}, "auth_model": "shared_service_account",
+               "vpn_required": False}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        r1 = client.post(
+            "/api/v1/targets",
+            json=payload,
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+        r2 = client.post(
+            "/api/v1/targets",
+            json=payload,
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert r1.status_code == 201
+    assert r2.status_code == 409
+    # detail is a plain string from the HTTPException raised in create_target
+    assert "already exists" in r2.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Update (PATCH) — import tool's --update path
+# ---------------------------------------------------------------------------
+
+
+async def test_import_update_patches_notes(client: TestClient) -> None:
+    """PATCH /api/v1/targets/{name} with updated notes persists the change."""
+    await _insert_target(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        name="rdc-vcenter",
+        product="vcenter",
+        host="vc-dc.evba.lab",
+        notes="original notes",
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.patch(
+            "/api/v1/targets/rdc-vcenter",
+            json={"notes": "updated notes from import --update"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["notes"] == "updated notes from import --update"
+
+
+async def test_import_update_patches_extras(client: TestClient) -> None:
+    """PATCH with updated extras replaces the extras JSONB field."""
+    await _insert_target(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        name="rdc-vcenter",
+        product="vcenter",
+        host="vc-dc.evba.lab",
+        extras={"sso_realm": "old-realm"},
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.patch(
+            "/api/v1/targets/rdc-vcenter",
+            json={"extras": {"sso_realm": "evba.lab", "new_field": "value"}},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 200
+    extras = response.json()["extras"]
+    assert extras["sso_realm"] == "evba.lab"
+    assert extras["new_field"] == "value"
+
+
+async def test_import_update_only_supplied_fields(client: TestClient) -> None:
+    """PATCH does not overwrite fields absent from the request body."""
+    await _insert_target(
+        tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+        name="alpha",
+        product="rke2",
+        host="10.0.0.1",
+        port=6443,
+        notes="kept notes",
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        # Only update host; port and notes should survive.
+        response = client.patch(
+            "/api/v1/targets/alpha",
+            json={"host": "10.0.0.2"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["host"] == "10.0.0.2"
+    assert data["port"] == 6443
+    assert data["notes"] == "kept notes"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: import entry → describe → fields match semantically
+# ---------------------------------------------------------------------------
+
+
+async def test_import_round_trip_fields_match(client: TestClient) -> None:
+    """POST a target then GET it — every field from the import entry matches."""
+    key = make_rsa_keypair("kid-A")
+    payload = {
+        "name": "rdc-vault",
+        "product": "vault",
+        "host": "vault.evba.lab",
+        "port": 8200,
+        "aliases": ["vault", "secrets"],
+        "secret_ref": "secret/rdc/vault/token",
+        "vpn_required": True,
+        "auth_model": "shared_service_account",
+        "extras": {"namespace": "admin", "account": "vault-sa"},
+        "notes": "Production Vault cluster.\nVault 1.17.",
+    }
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        create_resp = client.post(
+            "/api/v1/targets",
+            json=payload,
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+        assert create_resp.status_code == 201
+
+        describe_resp = client.get(
+            "/api/v1/targets/rdc-vault",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert describe_resp.status_code == 200
+    data = describe_resp.json()
+
+    assert data["name"] == payload["name"]
+    assert data["product"] == payload["product"]
+    assert data["host"] == payload["host"]
+    assert data["port"] == payload["port"]
+    assert set(data["aliases"]) == set(payload["aliases"])
+    assert data["secret_ref"] == payload["secret_ref"]
+    assert data["vpn_required"] == payload["vpn_required"]
+    assert data["extras"] == payload["extras"]
+    assert data["notes"] == payload["notes"]
+
+
+# ---------------------------------------------------------------------------
+# Extras round-trip — unknown YAML fields survive as JSONB
+# ---------------------------------------------------------------------------
+
+
+async def test_import_extras_preserved_through_patch(client: TestClient) -> None:
+    """Extras set on create are preserved after a PATCH that doesn't touch them."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        client.post(
+            "/api/v1/targets",
+            json={"name": "k8s-prod", "product": "kubernetes", "host": "10.5.50.1",
+                  "aliases": [], "extras": {"kubeconfig_field": "kubeconfig",
+                                            "impersonate_sa": "meho-sa"},
+                  "auth_model": "shared_service_account", "vpn_required": False},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+        # PATCH only notes
+        client.patch(
+            "/api/v1/targets/k8s-prod",
+            json={"notes": "updated"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+        describe = client.get(
+            "/api/v1/targets/k8s-prod",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert describe.status_code == 200
+    extras = describe.json()["extras"]
+    assert extras["kubeconfig_field"] == "kubeconfig"
+    assert extras["impersonate_sa"] == "meho-sa"
+
+
+# ---------------------------------------------------------------------------
+# Missing required fields → 422
+# ---------------------------------------------------------------------------
+
+
+def test_import_missing_name_returns_422(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={"product": "ssh", "host": "10.0.0.1"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 422
+
+
+def test_import_missing_host_returns_422(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={"name": "alpha", "product": "ssh"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_import_cross_tenant_invisible(client: TestClient) -> None:
+    """Targets imported into tenant_a are not visible to tenant_b."""
+    tenant_a = DEFAULT_TENANT_ID
+    tenant_b = str(uuid.uuid4())
+
+    await _insert_target(
+        tenant_id=uuid.UUID(tenant_a),
+        name="tenant-a-target",
+        product="rke2",
+        host="10.0.0.1",
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            "/api/v1/targets",
+            headers={"Authorization": f"Bearer {_operator_token(key, tenant_b)}"},
+        )
+    assert response.status_code == 200
+    names = [t["name"] for t in response.json()]
+    assert "tenant-a-target" not in names
+
+
+# ---------------------------------------------------------------------------
+# Operator role cannot create (only tenant_admin can)
+# ---------------------------------------------------------------------------
+
+
+def test_import_operator_role_cannot_create(client: TestClient) -> None:
+    """POST /api/v1/targets requires tenant_admin; operator gets 403."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={"name": "alpha", "product": "ssh", "host": "10.0.0.1"},
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 403

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.27.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/cli/internal/api/targets.go
+++ b/cli/internal/api/targets.go
@@ -4,12 +4,14 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -65,6 +67,34 @@ type ListTargetsParams struct {
 	Cursor  *string
 }
 
+// TargetCreateRequest is the POST /api/v1/targets body.
+type TargetCreateRequest struct {
+	Name        string         `json:"name"`
+	Aliases     []string       `json:"aliases"`
+	Product     string         `json:"product"`
+	Host        string         `json:"host"`
+	Port        *int           `json:"port,omitempty"`
+	SecretRef   *string        `json:"secret_ref,omitempty"`
+	AuthModel   string         `json:"auth_model"`
+	VPNRequired bool           `json:"vpn_required"`
+	Extras      map[string]any `json:"extras"`
+	Notes       *string        `json:"notes,omitempty"`
+}
+
+// TargetUpdateRequest is the PATCH /api/v1/targets/{name} body.
+// Nil pointer fields serialize as JSON null, which instructs the
+// server to clear that column (Pydantic exclude_unset behaviour).
+type TargetUpdateRequest struct {
+	Aliases     []string       `json:"aliases"`
+	Host        string         `json:"host"`
+	Port        *int           `json:"port"`
+	SecretRef   *string        `json:"secret_ref"`
+	AuthModel   string         `json:"auth_model"`
+	VPNRequired bool           `json:"vpn_required"`
+	Extras      map[string]any `json:"extras"`
+	Notes       *string        `json:"notes"`
+}
+
 // ListTargets calls GET /api/v1/targets with a one-shot 401-retry.
 // Returns the typed slice on success. On error the response body is
 // parsed for a structured error detail where possible; otherwise
@@ -74,6 +104,9 @@ func (c *AuthedClient) ListTargets(ctx context.Context, params *ListTargetsParam
 	if params != nil {
 		if params.Product != nil && *params.Product != "" {
 			q.Set("product", *params.Product)
+		}
+		if params.Limit != nil {
+			q.Set("limit", strconv.Itoa(*params.Limit))
 		}
 		if params.Cursor != nil {
 			q.Set("cursor", *params.Cursor)
@@ -151,6 +184,44 @@ func (c *AuthedClient) ProbeTarget(ctx context.Context, name string) (*ProbeResu
 	}
 }
 
+// CreateTarget calls POST /api/v1/targets with a one-shot 401-retry.
+// Returns the newly created target on 201, or an error on any other status.
+func (c *AuthedClient) CreateTarget(ctx context.Context, req TargetCreateRequest) (*Target, int, error) {
+	resp, err := c.doRequestWithBody(ctx, http.MethodPost, "/api/v1/targets", req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusCreated {
+		var t Target
+		if jerr := json.Unmarshal(body, &t); jerr != nil {
+			return nil, resp.StatusCode, fmt.Errorf("meho: decode created target: %w", jerr)
+		}
+		return &t, resp.StatusCode, nil
+	}
+	return nil, resp.StatusCode, errFromBody(body, resp.StatusCode)
+}
+
+// UpdateTarget calls PATCH /api/v1/targets/{name} with a one-shot 401-retry.
+// Returns the updated target on 200, or an error on any other status.
+func (c *AuthedClient) UpdateTarget(ctx context.Context, name string, req TargetUpdateRequest) (*Target, int, error) {
+	resp, err := c.doRequestWithBody(ctx, http.MethodPatch, "/api/v1/targets/"+url.PathEscape(name), req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusOK {
+		var t Target
+		if jerr := json.Unmarshal(body, &t); jerr != nil {
+			return nil, resp.StatusCode, fmt.Errorf("meho: decode updated target: %w", jerr)
+		}
+		return &t, resp.StatusCode, nil
+	}
+	return nil, resp.StatusCode, errFromBody(body, resp.StatusCode)
+}
+
 // doGet makes an authenticated GET to backplaneURL+path with optional query
 // parameters, retrying once with a refreshed token on 401.
 func (c *AuthedClient) doGet(ctx context.Context, path string, query url.Values) (*http.Response, error) {
@@ -192,6 +263,42 @@ func (c *AuthedClient) rawRequest(ctx context.Context, method, path string, quer
 		req.Header.Set("Authorization", authorizationHeader(bearer))
 	}
 	req.Header.Set("Accept", "application/json")
+	return c.httpClient.Do(req)
+}
+
+// doRequestWithBody sends method+path with a JSON-marshalled body,
+// retrying once on 401 after a token refresh.
+func (c *AuthedClient) doRequestWithBody(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	resp, err := c.rawRequestWithBody(ctx, method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	_ = resp.Body.Close()
+	if rerr := c.box.refresh(ctx); rerr != nil {
+		return nil, rerr
+	}
+	return c.rawRequestWithBody(ctx, method, path, body)
+}
+
+func (c *AuthedClient) rawRequestWithBody(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	rawURL := strings.TrimRight(c.backplaneURL, "/") + path
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("meho: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("meho: build request: %w", err)
+	}
+	bearer := c.box.snapshot()
+	if bearer != "" {
+		req.Header.Set("Authorization", authorizationHeader(bearer))
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 	return c.httpClient.Do(req)
 }
 

--- a/cli/internal/api/targets.go
+++ b/cli/internal/api/targets.go
@@ -81,20 +81,6 @@ type TargetCreateRequest struct {
 	Notes       *string        `json:"notes,omitempty"`
 }
 
-// TargetUpdateRequest is the PATCH /api/v1/targets/{name} body.
-// Nil pointer fields serialize as JSON null, which instructs the
-// server to clear that column (Pydantic exclude_unset behaviour).
-type TargetUpdateRequest struct {
-	Aliases     []string       `json:"aliases"`
-	Host        string         `json:"host"`
-	Port        *int           `json:"port"`
-	SecretRef   *string        `json:"secret_ref"`
-	AuthModel   string         `json:"auth_model"`
-	VPNRequired bool           `json:"vpn_required"`
-	Extras      map[string]any `json:"extras"`
-	Notes       *string        `json:"notes"`
-}
-
 // ListTargets calls GET /api/v1/targets with a one-shot 401-retry.
 // Returns the typed slice on success. On error the response body is
 // parsed for a structured error detail where possible; otherwise
@@ -204,9 +190,11 @@ func (c *AuthedClient) CreateTarget(ctx context.Context, req TargetCreateRequest
 }
 
 // UpdateTarget calls PATCH /api/v1/targets/{name} with a one-shot 401-retry.
+// body is a sparse map — only keys present in the map are sent to the server,
+// so the backend's exclude_unset logic leaves unmentioned fields untouched.
 // Returns the updated target on 200, or an error on any other status.
-func (c *AuthedClient) UpdateTarget(ctx context.Context, name string, req TargetUpdateRequest) (*Target, int, error) {
-	resp, err := c.doRequestWithBody(ctx, http.MethodPatch, "/api/v1/targets/"+url.PathEscape(name), req)
+func (c *AuthedClient) UpdateTarget(ctx context.Context, name string, body map[string]any) (*Target, int, error) {
+	resp, err := c.doRequestWithBody(ctx, http.MethodPatch, "/api/v1/targets/"+url.PathEscape(name), body)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// knownYAMLFields are extracted into dedicated importEntry fields;
+// everything else is spilled into importEntry.Extras.
+var knownYAMLFields = map[string]bool{
+	"name":         true,
+	"aliases":      true,
+	"product":      true,
+	"host":         true,
+	"port":         true,
+	"secret_ref":   true,
+	"vpn_required": true,
+	"notes":        true,
+	"auth_model":   true,
+}
+
+// importEntry is a single target parsed from a targets.yaml file.
+type importEntry struct {
+	Name        string
+	Aliases     []string
+	Product     string
+	Host        string
+	Port        *int
+	SecretRef   *string
+	VPNRequired bool
+	Notes       *string
+	AuthModel   string
+	Extras      map[string]any
+}
+
+// importAction describes what the import will do with a single entry.
+type importAction struct {
+	Action string // "CREATE" or "UPDATE"
+	Entry  importEntry
+}
+
+// importPlan holds the full set of actions resolved before any writes.
+type importPlan struct {
+	Actions   []importAction
+	Conflicts []string // existing names when --update is not set
+}
+
+func newImportCmd() *cobra.Command {
+	var (
+		update    bool
+		dryRun    bool
+		asJSON    bool
+		backplane string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Bulk-import targets from a targets.yaml file",
+		Long: `Read a targets.yaml file and import each entry into the backplane.
+
+Default: if any target in the file already exists the entire import is
+aborted — no partial write. Use --update to PATCH existing targets
+instead of aborting.
+
+Use --dry-run to preview the plan without making write API calls.
+Combine with --json for machine-parseable output.
+
+Tenant scoping: targets are imported into the tenant carried by your
+JWT. To target a different tenant, run "meho login <url>" with the
+appropriate credentials first.`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("read %s: %w", args[0], err)
+			}
+			entries, err := parseTargetsYAML(data)
+			if err != nil {
+				return err
+			}
+			if len(entries) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No targets found in file.")
+				return nil
+			}
+
+			bpURL, err := resolveURL(backplane)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), asJSON)
+			}
+			client, err := api.NewAuthedClient(cmd.Context(), bpURL, api.AuthedClientOptions{})
+			if err != nil {
+				if api.IsTokenNotFound(err) {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", bpURL, bpURL)),
+						asJSON)
+				}
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("build client: %v", err)),
+					asJSON)
+			}
+
+			plan, err := buildImportPlan(cmd.Context(), client, entries, update)
+			if err != nil {
+				if api.IsNoRefreshToken(err) {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.AuthExpired(fmt.Sprintf("token expired; run `meho login %s`", bpURL)),
+						asJSON)
+				}
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unreachable(fmt.Sprintf("list existing targets: %v", err)),
+					asJSON)
+			}
+
+			if dryRun {
+				return printImportPlan(cmd, plan, asJSON)
+			}
+
+			if !update && len(plan.Conflicts) > 0 {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"Import aborted: %d target(s) already exist. Re-run with --update to patch them:\n",
+					len(plan.Conflicts))
+				for _, name := range plan.Conflicts {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", name)
+				}
+				return errors.New("import conflict — use --update")
+			}
+
+			return executeImportPlan(cmd.Context(), cmd, client, plan)
+		},
+	}
+	cmd.Flags().BoolVar(&update, "update", false, "PATCH existing targets instead of aborting on conflict")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print plan without making write API calls")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output plan as JSON (use with --dry-run)")
+	cmd.Flags().StringVar(&backplane, "backplane", "", "backplane URL (overrides config)")
+	return cmd
+}
+
+// parseTargetsYAML unmarshals a targets.yaml and returns importEntry slice.
+// Unknown fields per entry are spilled into importEntry.Extras.
+func parseTargetsYAML(data []byte) ([]importEntry, error) {
+	var f struct {
+		Targets []map[string]any `yaml:"targets"`
+	}
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+	entries := make([]importEntry, 0, len(f.Targets))
+	for i, raw := range f.Targets {
+		e, err := parseYAMLEntry(i, raw)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
+func parseYAMLEntry(i int, raw map[string]any) (importEntry, error) {
+	var e importEntry
+
+	name, ok := raw["name"].(string)
+	if !ok || name == "" {
+		return e, fmt.Errorf("entry %d: missing required field 'name'", i)
+	}
+	e.Name = name
+
+	product, ok := raw["product"].(string)
+	if !ok || product == "" {
+		return e, fmt.Errorf("entry %d (%s): missing required field 'product'", i, name)
+	}
+	e.Product = product
+
+	host, ok := raw["host"].(string)
+	if !ok || host == "" {
+		return e, fmt.Errorf("entry %d (%s): missing required field 'host'", i, name)
+	}
+	e.Host = host
+
+	e.Aliases = []string{}
+	if raw["aliases"] != nil {
+		if seq, ok := raw["aliases"].([]any); ok {
+			for _, a := range seq {
+				if s, ok := a.(string); ok {
+					e.Aliases = append(e.Aliases, s)
+				}
+			}
+		}
+	}
+
+	if raw["port"] != nil {
+		if p, ok := raw["port"].(int); ok {
+			e.Port = &p
+		}
+	}
+
+	if v, ok := raw["secret_ref"].(string); ok {
+		e.SecretRef = &v
+	}
+
+	if v, ok := raw["vpn_required"].(bool); ok {
+		e.VPNRequired = v
+	}
+
+	if v, ok := raw["notes"].(string); ok {
+		e.Notes = &v
+	}
+
+	if v, ok := raw["auth_model"].(string); ok {
+		e.AuthModel = v
+	} else {
+		e.AuthModel = "shared_service_account"
+	}
+
+	e.Extras = make(map[string]any)
+	for k, v := range raw {
+		if !knownYAMLFields[k] {
+			e.Extras[k] = v
+		}
+	}
+
+	return e, nil
+}
+
+// buildImportPlan fetches existing targets and classifies each entry as
+// CREATE or UPDATE.
+func buildImportPlan(ctx context.Context, client *api.AuthedClient, entries []importEntry, update bool) (*importPlan, error) {
+	existing, err := listAllTargets(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	existingNames := make(map[string]bool, len(existing))
+	for _, t := range existing {
+		existingNames[t.Name] = true
+	}
+
+	plan := &importPlan{}
+	for _, e := range entries {
+		if existingNames[e.Name] {
+			plan.Actions = append(plan.Actions, importAction{Action: "UPDATE", Entry: e})
+			if !update {
+				plan.Conflicts = append(plan.Conflicts, e.Name)
+			}
+		} else {
+			plan.Actions = append(plan.Actions, importAction{Action: "CREATE", Entry: e})
+		}
+	}
+	return plan, nil
+}
+
+// listAllTargets pages through GET /api/v1/targets until exhausted.
+func listAllTargets(ctx context.Context, client *api.AuthedClient) ([]api.TargetSummary, error) {
+	limit := 500
+	var all []api.TargetSummary
+	var cursor *string
+	for {
+		page, _, err := client.ListTargets(ctx, &api.ListTargetsParams{
+			Limit:  &limit,
+			Cursor: cursor,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if len(page) < limit {
+			break
+		}
+		last := page[len(page)-1].Name
+		cursor = &last
+	}
+	return all, nil
+}
+
+// printImportPlan renders the plan to stdout in human or JSON format.
+func printImportPlan(cmd *cobra.Command, plan *importPlan, asJSON bool) error {
+	creates := filterActions(plan.Actions, "CREATE")
+	updates := filterActions(plan.Actions, "UPDATE")
+
+	if asJSON {
+		type jsonPlan struct {
+			Create []string `json:"create"`
+			Update []string `json:"update"`
+			Skip   []string `json:"skip"`
+		}
+		out := jsonPlan{
+			Create: entryNames(creates),
+			Update: entryNames(updates),
+			Skip:   []string{},
+		}
+		b, _ := json.Marshal(out)
+		fmt.Fprintln(cmd.OutOrStdout(), string(b))
+		return nil
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Plan: %d target(s) in input\n\n", len(plan.Actions))
+	for _, a := range plan.Actions {
+		e := a.Entry
+		fmt.Fprintf(cmd.OutOrStdout(), "  %-6s  %-30s (product=%-12s host=%s)\n",
+			a.Action, e.Name, e.Product, e.Host)
+	}
+	if len(plan.Conflicts) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"\nNote: %d target(s) already exist. Use --update to patch them.\n",
+			len(plan.Conflicts))
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "\nRun without --dry-run to apply.")
+	return nil
+}
+
+// executeImportPlan applies the plan: POST new, PATCH existing.
+func executeImportPlan(ctx context.Context, cmd *cobra.Command, client *api.AuthedClient, plan *importPlan) error {
+	var errMsgs []string
+	created, updated := 0, 0
+
+	for _, a := range plan.Actions {
+		switch a.Action {
+		case "CREATE":
+			_, status, err := client.CreateTarget(ctx, entryToCreateRequest(a.Entry))
+			if err != nil {
+				if status == http.StatusConflict {
+					errMsgs = append(errMsgs, fmt.Sprintf("create %s: already exists (use --update)", a.Entry.Name))
+				} else {
+					errMsgs = append(errMsgs, fmt.Sprintf("create %s: %v", a.Entry.Name, err))
+				}
+				continue
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "created  %s\n", a.Entry.Name)
+			created++
+		case "UPDATE":
+			_, _, err := client.UpdateTarget(ctx, a.Entry.Name, entryToUpdateRequest(a.Entry))
+			if err != nil {
+				errMsgs = append(errMsgs, fmt.Sprintf("update %s: %v", a.Entry.Name, err))
+				continue
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "updated  %s\n", a.Entry.Name)
+			updated++
+		}
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "\nDone: %d created, %d updated", created, updated)
+	if len(errMsgs) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), ", %d failed\n", len(errMsgs))
+		for _, e := range errMsgs {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  error: %s\n", e)
+		}
+		return fmt.Errorf("%d import error(s)", len(errMsgs))
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), ".")
+	return nil
+}
+
+func entryToCreateRequest(e importEntry) api.TargetCreateRequest {
+	return api.TargetCreateRequest{
+		Name:        e.Name,
+		Aliases:     e.Aliases,
+		Product:     e.Product,
+		Host:        e.Host,
+		Port:        e.Port,
+		SecretRef:   e.SecretRef,
+		AuthModel:   e.AuthModel,
+		VPNRequired: e.VPNRequired,
+		Extras:      e.Extras,
+		Notes:       e.Notes,
+	}
+}
+
+func entryToUpdateRequest(e importEntry) api.TargetUpdateRequest {
+	return api.TargetUpdateRequest{
+		Aliases:     e.Aliases,
+		Host:        e.Host,
+		Port:        e.Port,
+		SecretRef:   e.SecretRef,
+		AuthModel:   e.AuthModel,
+		VPNRequired: e.VPNRequired,
+		Extras:      e.Extras,
+		Notes:       e.Notes,
+	}
+}
+
+func filterActions(actions []importAction, kind string) []importAction {
+	var out []importAction
+	for _, a := range actions {
+		if a.Action == kind {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func entryNames(actions []importAction) []string {
+	names := make([]string, len(actions))
+	for i, a := range actions {
+		names[i] = a.Entry.Name
+	}
+	return names
+}

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -44,6 +44,10 @@ type importEntry struct {
 	Notes       *string
 	AuthModel   string
 	Extras      map[string]any
+	// presentFields tracks which optional YAML keys were explicitly set.
+	// Used by entryToUpdateRequest to build a sparse PATCH body so that
+	// fields absent from the YAML do not clobber existing target data.
+	presentFields map[string]bool
 }
 
 // importAction describes what the import will do with a single entry.
@@ -172,6 +176,7 @@ func parseTargetsYAML(data []byte) ([]importEntry, error) {
 
 func parseYAMLEntry(i int, raw map[string]any) (importEntry, error) {
 	var e importEntry
+	e.presentFields = make(map[string]bool)
 
 	name, ok := raw["name"].(string)
 	if !ok || name == "" {
@@ -200,6 +205,7 @@ func parseYAMLEntry(i int, raw map[string]any) (importEntry, error) {
 				}
 			}
 		}
+		e.presentFields["aliases"] = true
 	}
 
 	if raw["port"] != nil {
@@ -214,6 +220,7 @@ func parseYAMLEntry(i int, raw map[string]any) (importEntry, error) {
 
 	if v, ok := raw["vpn_required"].(bool); ok {
 		e.VPNRequired = v
+		e.presentFields["vpn_required"] = true
 	}
 
 	if v, ok := raw["notes"].(string); ok {
@@ -222,6 +229,7 @@ func parseYAMLEntry(i int, raw map[string]any) (importEntry, error) {
 
 	if v, ok := raw["auth_model"].(string); ok {
 		e.AuthModel = v
+		e.presentFields["auth_model"] = true
 	} else {
 		e.AuthModel = "shared_service_account"
 	}
@@ -379,17 +387,33 @@ func entryToCreateRequest(e importEntry) api.TargetCreateRequest {
 	}
 }
 
-func entryToUpdateRequest(e importEntry) api.TargetUpdateRequest {
-	return api.TargetUpdateRequest{
-		Aliases:     e.Aliases,
-		Host:        e.Host,
-		Port:        e.Port,
-		SecretRef:   e.SecretRef,
-		AuthModel:   e.AuthModel,
-		VPNRequired: e.VPNRequired,
-		Extras:      e.Extras,
-		Notes:       e.Notes,
+func entryToUpdateRequest(e importEntry) map[string]any {
+	// host is required in YAML, always included.
+	m := map[string]any{"host": e.Host}
+	// Optional fields: only send what was explicitly set in the YAML so that
+	// the backend's exclude_unset logic leaves all other fields untouched.
+	if e.presentFields["aliases"] {
+		m["aliases"] = e.Aliases
 	}
+	if e.Port != nil {
+		m["port"] = *e.Port
+	}
+	if e.SecretRef != nil {
+		m["secret_ref"] = *e.SecretRef
+	}
+	if e.presentFields["vpn_required"] {
+		m["vpn_required"] = e.VPNRequired
+	}
+	if e.Notes != nil {
+		m["notes"] = *e.Notes
+	}
+	if e.presentFields["auth_model"] {
+		m["auth_model"] = e.AuthModel
+	}
+	if len(e.Extras) > 0 {
+		m["extras"] = e.Extras
+	}
+	return m
 }
 
 func filterActions(actions []importAction, kind string) []importAction {

--- a/cli/internal/cmd/targets/import_test.go
+++ b/cli/internal/cmd/targets/import_test.go
@@ -1,0 +1,466 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---- YAML parsing unit tests -----------------------------------------------
+
+func TestParseTargetsYAML_HappyPath(t *testing.T) {
+	yaml := []byte(`
+targets:
+  - name: rdc-vcenter
+    aliases: [rdc, host-vcenter]
+    product: vcenter
+    host: vc-dc.evba.lab
+    port: 443
+    secret_ref: secret/rdc/vsphere
+    sso_realm: evba.lab
+    vpn_required: true
+    notes: "Host vCenter"
+`)
+	entries, err := parseTargetsYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Name != "rdc-vcenter" {
+		t.Errorf("name: want rdc-vcenter, got %q", e.Name)
+	}
+	if e.Product != "vcenter" {
+		t.Errorf("product: want vcenter, got %q", e.Product)
+	}
+	if e.Host != "vc-dc.evba.lab" {
+		t.Errorf("host: want vc-dc.evba.lab, got %q", e.Host)
+	}
+	if e.Port == nil || *e.Port != 443 {
+		t.Errorf("port: want 443, got %v", e.Port)
+	}
+	if e.SecretRef == nil || *e.SecretRef != "secret/rdc/vsphere" {
+		t.Errorf("secret_ref: want secret/rdc/vsphere, got %v", e.SecretRef)
+	}
+	if !e.VPNRequired {
+		t.Error("vpn_required: want true")
+	}
+	if e.Notes == nil || *e.Notes != "Host vCenter" {
+		t.Errorf("notes: want 'Host vCenter', got %v", e.Notes)
+	}
+	if len(e.Aliases) != 2 {
+		t.Errorf("aliases: want 2, got %d", len(e.Aliases))
+	}
+	// sso_realm spills into extras
+	if e.Extras["sso_realm"] != "evba.lab" {
+		t.Errorf("extras[sso_realm]: want evba.lab, got %v", e.Extras["sso_realm"])
+	}
+	// known fields must NOT appear in extras
+	if _, ok := e.Extras["name"]; ok {
+		t.Error("name must not appear in extras")
+	}
+}
+
+func TestParseTargetsYAML_DefaultAuthModel(t *testing.T) {
+	yaml := []byte(`
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+`)
+	entries, err := parseTargetsYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entries[0].AuthModel != "shared_service_account" {
+		t.Errorf("auth_model default: want shared_service_account, got %q", entries[0].AuthModel)
+	}
+}
+
+func TestParseTargetsYAML_ExplicitAuthModel(t *testing.T) {
+	yaml := []byte(`
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+    auth_model: impersonation
+`)
+	entries, err := parseTargetsYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entries[0].AuthModel != "impersonation" {
+		t.Errorf("auth_model: want impersonation, got %q", entries[0].AuthModel)
+	}
+}
+
+func TestParseTargetsYAML_MissingName(t *testing.T) {
+	yaml := []byte(`
+targets:
+  - product: rke2
+    host: 10.0.0.1
+`)
+	_, err := parseTargetsYAML(yaml)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error should mention 'name', got: %v", err)
+	}
+}
+
+func TestParseTargetsYAML_MissingProduct(t *testing.T) {
+	yaml := []byte(`
+targets:
+  - name: alpha
+    host: 10.0.0.1
+`)
+	_, err := parseTargetsYAML(yaml)
+	if err == nil {
+		t.Fatal("expected error for missing product")
+	}
+	if !strings.Contains(err.Error(), "product") {
+		t.Errorf("error should mention 'product', got: %v", err)
+	}
+}
+
+func TestParseTargetsYAML_MissingHost(t *testing.T) {
+	yaml := []byte(`
+targets:
+  - name: alpha
+    product: rke2
+`)
+	_, err := parseTargetsYAML(yaml)
+	if err == nil {
+		t.Fatal("expected error for missing host")
+	}
+	if !strings.Contains(err.Error(), "host") {
+		t.Errorf("error should mention 'host', got: %v", err)
+	}
+}
+
+func TestParseTargetsYAML_MalformedYAML(t *testing.T) {
+	_, err := parseTargetsYAML([]byte(":\t:bad yaml:::"))
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
+func TestParseTargetsYAML_UnknownFieldsGoToExtras(t *testing.T) {
+	yaml := []byte(`
+targets:
+  - name: rke2-prod
+    product: kubernetes
+    host: 10.5.50.1
+    kubeconfig_field: kubeconfig
+    account: my-sa@project.iam.gserviceaccount.com
+    project_id: gcp-prod-123
+`)
+	entries, err := parseTargetsYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	e := entries[0]
+	if e.Extras["kubeconfig_field"] != "kubeconfig" {
+		t.Errorf("extras[kubeconfig_field]: got %v", e.Extras["kubeconfig_field"])
+	}
+	if e.Extras["account"] != "my-sa@project.iam.gserviceaccount.com" {
+		t.Errorf("extras[account]: got %v", e.Extras["account"])
+	}
+	if e.Extras["project_id"] != "gcp-prod-123" {
+		t.Errorf("extras[project_id]: got %v", e.Extras["project_id"])
+	}
+}
+
+func TestParseTargetsYAML_EmptyAliases(t *testing.T) {
+	yaml := []byte(`
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+`)
+	entries, err := parseTargetsYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entries[0].Aliases == nil {
+		t.Error("aliases should be empty slice, not nil")
+	}
+	if len(entries[0].Aliases) != 0 {
+		t.Errorf("aliases: want 0, got %d", len(entries[0].Aliases))
+	}
+}
+
+func TestParseTargetsYAML_EmptyFile(t *testing.T) {
+	entries, err := parseTargetsYAML([]byte("targets: []"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+// ---- HTTP integration tests (fake server) ----------------------------------
+
+func fakeImportServer(t *testing.T, existing []map[string]any) string {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// GET /api/v1/targets — returns existing list
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			b, _ := json.Marshal(existing)
+			_, _ = w.Write(b)
+			return
+		}
+		if r.Method == http.MethodPost {
+			// Accept any POST as a 201 Created
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			// Echo back a minimal target from the request body
+			b, _ := json.Marshal(map[string]any{
+				"id": "new-id", "tenant_id": "ttt",
+				"name": "created", "aliases": []string{},
+				"product": "rke2", "host": "10.0.0.1",
+				"auth_model": "shared_service_account",
+				"vpn_required": false, "extras": map[string]any{},
+				"created_at": "2026-01-01T00:00:00Z",
+				"updated_at": "2026-01-01T00:00:00Z",
+			})
+			_, _ = w.Write(b)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	// PATCH /api/v1/targets/{name} — accept update
+	mux.HandleFunc("/api/v1/targets/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.Header().Set("Content-Type", "application/json")
+			b, _ := json.Marshal(map[string]any{
+				"id": "existing-id", "tenant_id": "ttt",
+				"name": "patched", "aliases": []string{},
+				"product": "rke2", "host": "10.0.0.1",
+				"auth_model": "shared_service_account",
+				"vpn_required": false, "extras": map[string]any{},
+				"created_at": "2026-01-01T00:00:00Z",
+				"updated_at": "2026-01-01T00:00:00Z",
+			})
+			_, _ = w.Write(b)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func writeTempYAML(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "targets.yaml")
+	if err := os.WriteFile(f, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp yaml: %v", err)
+	}
+	return f
+}
+
+func TestImport_DryRun_NoWrites(t *testing.T) {
+	xdg := withTempXDG(t)
+	// empty existing targets
+	url := fakeImportServer(t, nil)
+	seedCreds(t, xdg, url)
+
+	f := writeTempYAML(t, `
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+  - name: beta
+    product: vault
+    host: 10.0.0.2
+`)
+	stdout, _, err := runCobraCmd(t, newImportCmd(), f, "--dry-run")
+	if err != nil {
+		t.Fatalf("dry-run returned error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "CREATE") {
+		t.Errorf("expected CREATE in dry-run output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "alpha") {
+		t.Errorf("expected alpha in dry-run output, got:\n%s", out)
+	}
+}
+
+func TestImport_DryRun_JSON(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeImportServer(t, nil)
+	seedCreds(t, xdg, url)
+
+	f := writeTempYAML(t, `
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+`)
+	stdout, _, err := runCobraCmd(t, newImportCmd(), f, "--dry-run", "--json")
+	if err != nil {
+		t.Fatalf("dry-run --json returned error: %v", err)
+	}
+	var plan map[string]any
+	if jerr := json.Unmarshal([]byte(strings.TrimSpace(stdout.String())), &plan); jerr != nil {
+		t.Fatalf("not valid JSON: %v\n%s", jerr, stdout)
+	}
+	creates, _ := plan["create"].([]any)
+	if len(creates) != 1 {
+		t.Errorf("expected 1 create, got %v", plan["create"])
+	}
+	if creates[0] != "alpha" {
+		t.Errorf("expected alpha in create, got %v", creates[0])
+	}
+	// skip array must be present (even if empty)
+	if _, ok := plan["skip"]; !ok {
+		t.Error("json plan must include 'skip' key")
+	}
+}
+
+func TestImport_HappyPath_AllNew(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeImportServer(t, nil)
+	seedCreds(t, xdg, url)
+
+	f := writeTempYAML(t, `
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+`)
+	stdout, _, err := runCobraCmd(t, newImportCmd(), f)
+	if err != nil {
+		t.Fatalf("import returned error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "created") {
+		t.Errorf("expected 'created' in output, got:\n%s", stdout)
+	}
+}
+
+func TestImport_Conflict_AbortsByDefault(t *testing.T) {
+	xdg := withTempXDG(t)
+	existing := []map[string]any{
+		{"id": "aaa", "name": "alpha", "aliases": []string{}, "product": "rke2", "host": "10.0.0.1"},
+	}
+	url := fakeImportServer(t, existing)
+	seedCreds(t, xdg, url)
+
+	f := writeTempYAML(t, `
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+`)
+	_, stderr, err := runCobraCmd(t, newImportCmd(), f)
+	if err == nil {
+		t.Fatal("expected error when target already exists without --update")
+	}
+	if !strings.Contains(stderr.String(), "alpha") {
+		t.Errorf("expected alpha in conflict error, got:\n%s", stderr)
+	}
+	if !strings.Contains(strings.ToLower(stderr.String()), "--update") {
+		t.Errorf("expected --update hint in stderr, got:\n%s", stderr)
+	}
+}
+
+func TestImport_Update_PatchesExisting(t *testing.T) {
+	xdg := withTempXDG(t)
+	existing := []map[string]any{
+		{"id": "aaa", "name": "alpha", "aliases": []string{}, "product": "rke2", "host": "10.0.0.1"},
+	}
+	url := fakeImportServer(t, existing)
+	seedCreds(t, xdg, url)
+
+	f := writeTempYAML(t, `
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+    notes: "updated notes"
+`)
+	stdout, _, err := runCobraCmd(t, newImportCmd(), f, "--update")
+	if err != nil {
+		t.Fatalf("import --update returned error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "updated") {
+		t.Errorf("expected 'updated' in output, got:\n%s", stdout)
+	}
+}
+
+func TestImport_NoCreds(t *testing.T) {
+	_ = withTempXDG(t)
+	f := writeTempYAML(t, `
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+`)
+	_, stderr, err := runCobraCmd(t, newImportCmd(), f)
+	if err == nil {
+		t.Fatal("expected error for no-creds path")
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected `meho login` hint, got: %q", stderr)
+	}
+}
+
+func TestImport_FileNotFound(t *testing.T) {
+	xdg := withTempXDG(t)
+	url := fakeImportServer(t, nil)
+	seedCreds(t, xdg, url)
+
+	_, _, err := runCobraCmd(t, newImportCmd(), "/no/such/file.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestImport_DryRun_ShowsUpdateForExisting(t *testing.T) {
+	xdg := withTempXDG(t)
+	existing := []map[string]any{
+		{"id": "aaa", "name": "alpha", "aliases": []string{}, "product": "rke2", "host": "10.0.0.1"},
+	}
+	url := fakeImportServer(t, existing)
+	seedCreds(t, xdg, url)
+
+	f := writeTempYAML(t, `
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+  - name: beta
+    product: vault
+    host: 10.0.0.2
+`)
+	stdout, _, err := runCobraCmd(t, newImportCmd(), f, "--dry-run", "--update")
+	if err != nil {
+		t.Fatalf("dry-run --update returned error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "UPDATE") {
+		t.Errorf("expected UPDATE for existing target, got:\n%s", out)
+	}
+	if !strings.Contains(out, "CREATE") {
+		t.Errorf("expected CREATE for new target, got:\n%s", out)
+	}
+}

--- a/cli/internal/cmd/targets/import_test.go
+++ b/cli/internal/cmd/targets/import_test.go
@@ -407,6 +407,73 @@ targets:
 	}
 }
 
+func TestImport_Update_PatchBodyIsSparse(t *testing.T) {
+	// Verify that PATCH body only contains fields explicitly set in the YAML.
+	// Fields absent from YAML (vpn_required, auth_model, aliases) must not be
+	// sent so the backend's exclude_unset logic leaves them untouched.
+	xdg := withTempXDG(t)
+	var patchBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		b, _ := json.Marshal([]map[string]any{
+			{"id": "aaa", "name": "alpha", "aliases": []string{}, "product": "rke2", "host": "10.0.0.1"},
+		})
+		_, _ = w.Write(b)
+	})
+	mux.HandleFunc("/api/v1/targets/alpha", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		b, _ := json.Marshal(map[string]any{
+			"id": "aaa", "tenant_id": "ttt",
+			"name": "alpha", "aliases": []string{},
+			"product": "rke2", "host": "10.0.0.1",
+			"auth_model": "shared_service_account",
+			"vpn_required": false, "extras": map[string]any{},
+			"created_at": "2026-01-01T00:00:00Z",
+			"updated_at": "2026-01-01T00:00:00Z",
+		})
+		_, _ = w.Write(b)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	seedCreds(t, xdg, srv.URL)
+
+	f := writeTempYAML(t, `
+targets:
+  - name: alpha
+    product: rke2
+    host: 10.0.0.1
+    notes: "only this field"
+`)
+	_, _, err := runCobraCmd(t, newImportCmd(), f, "--update")
+	if err != nil {
+		t.Fatalf("import --update returned error: %v", err)
+	}
+	if _, ok := patchBody["vpn_required"]; ok {
+		t.Errorf("PATCH body must not include vpn_required when absent from YAML, got: %v", patchBody)
+	}
+	if _, ok := patchBody["auth_model"]; ok {
+		t.Errorf("PATCH body must not include auth_model when absent from YAML, got: %v", patchBody)
+	}
+	if _, ok := patchBody["aliases"]; ok {
+		t.Errorf("PATCH body must not include aliases when absent from YAML, got: %v", patchBody)
+	}
+	if patchBody["notes"] != "only this field" {
+		t.Errorf("PATCH body should include notes='only this field', got: %v", patchBody)
+	}
+	if patchBody["host"] != "10.0.0.1" {
+		t.Errorf("PATCH body should always include host, got: %v", patchBody)
+	}
+}
+
 func TestImport_NoCreds(t *testing.T) {
 	_ = withTempXDG(t)
 	f := writeTempYAML(t, `

--- a/cli/internal/cmd/targets/targets.go
+++ b/cli/internal/cmd/targets/targets.go
@@ -3,14 +3,12 @@
 
 // Package targets implements the `meho targets` subcommand tree.
 //
-// Three verbs:
+// Four verbs:
 //
 //   - meho targets list [--product P] [--json]
 //   - meho targets describe <name|alias> [--json]
 //   - meho targets probe <name|alias>
-//
-// All verbs are read-only (operator role). Write verbs (create / update /
-// delete) are deferred to v0.2 per the T5 out-of-scope list.
+//   - meho targets import <file> [--update] [--dry-run] [--json]
 package targets
 
 import (
@@ -22,15 +20,17 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "targets",
 		Short: "Operate the MEHO targets registry",
-		Long: "List, describe, and probe targets registered in the operator's " +
-			"tenant.\n\n" +
-			"All verbs are read-only in v0.2; write operations (create, update, " +
-			"delete) are available via the REST API at /api/v1/targets.",
+		Long: "List, describe, probe, and import targets registered in the " +
+			"operator's tenant.\n\n" +
+			"Use 'meho targets import <file>' to bulk-import from a targets.yaml " +
+			"file. Other write operations (create, update, delete) are available " +
+			"via the REST API at /api/v1/targets.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newDescribeCmd())
 	cmd.AddCommand(newProbeCmd())
+	cmd.AddCommand(newImportCmd())
 	return cmd
 }

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -59,23 +59,25 @@ cli/
     │   ├── login_test.go      # override-resolution + help-flag tests.
     │   ├── status.go          # `meho status` subcommand + --json + URL resolver.
     │   ├── status_test.go     # happy/JSON/no-creds/unreachable/401/redaction tests.
-    │   └── targets/           # `meho targets` subcommand tree (G0.3-T5 #256).
+    │   └── targets/           # `meho targets` subcommand tree (G0.3-T5/T6 #256/#257).
     │       ├── targets.go     # parent command (NewCommand).
     │       ├── helpers.go     # resolveURL / normalizeURL shared by verbs.
     │       ├── list.go        # `meho targets list [--product P] [--json]`.
     │       ├── describe.go    # `meho targets describe <name|alias> [--json]`.
     │       ├── probe.go       # `meho targets probe <name|alias> [--json]`.
+    │       ├── import.go      # `meho targets import <file> [--update] [--dry-run] [--json]`.
     │       ├── helpers_test.go # withTempXDG / seedCreds / runCobraCmd shared test helpers.
     │       ├── list_test.go   # human/JSON/product-filter/empty/no-creds/override tests.
     │       ├── describe_test.go # human/JSON/404-near-miss/alias/no-creds tests.
-    │       └── probe_test.go  # ok/failed/501-friendly/404/no-creds tests.
+    │       ├── probe_test.go  # ok/failed/501-friendly/404/no-creds tests.
+    │       └── import_test.go # YAML parsing / dry-run / conflict / --update tests.
     ├── discovery/
     │   ├── discovery.go       # /api/v1/commands manifest fetch + cobra graft.
     │   └── discovery_test.go  # 200/404/transport/decode + collision tests.
     ├── output/
     │   ├── format.go          # human + JSON formatters + structured exit codes.
     │   ├── format_test.go     # human/JSON/exit-code pinning.
-    │   └── targets.go         # PrintTargetsTable / PrintTarget / PrintProbeResult (G0.3-T5 #256).
+    │   └── targets.go         # PrintTargetsTable / PrintTarget / PrintProbeResult / PrintTargetNearMisses (G0.3-T5/T6 #256/#257).
     └── version/
         └── version.go         # build-time identity (Version/Commit/Date).
 ```


### PR DESCRIPTION
## Summary

- Adds `meho targets import <file>` cobra subcommand (`cli/internal/cmd/targets/import.go`)
- Parses `targets.yaml` (top-level `targets:` list); unknown fields spill into `extras` JSONB
- Three modes: default (abort on conflict), `--update` (PATCH existing), `--dry-run` (print plan, no writes)
- `--dry-run --json` emits `{create: [...], update: [...], skip: []}` for machine-readable pipelines
- Adds `CreateTarget` / `UpdateTarget` to `cli/internal/api/targets.go` with JSON body + 401-retry
- Fixes `ListTargets` to pass `limit` query param (was declared but unused)
- Adds `gopkg.in/yaml.v3 v3.0.1` direct dependency to `cli/go.mod` (already in go.sum as transitive)
- 13 Go unit tests covering YAML parsing, dry-run, conflict abort, `--update`, no-creds
- 13 Python integration tests for POST/PATCH round-trip, duplicate 409, extras preservation, cross-tenant isolation
- Updates `docs/codebase/cli.md` module layout

Closes #257

Parent Initiative: #224

## Test plan

- [x] `uv run pytest backend/tests/test_api_v1_targets_import.py -q` → 13 passed
- [x] `uv run pytest backend/ -q --ignore=tests/test_observability.py --ignore=tests/integration/` → 609 passed, 1 skipped (no regressions)
- [ ] Go tests: `go test ./cli/internal/cmd/targets/... ./cli/internal/api/...` — verified by CI (Go not installed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)