### PR TITLE
feat(cli): meho status --watch SSE subscriber (G6.1-T5)

### DIFF
--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -19,44 +19,49 @@ import (
 
 // newStatusCmd returns the `meho status` subcommand.
 //
-// status hits GET /api/v1/health on the backplane the operator last
-// authenticated against and renders the response. The bearer token
-// is read from the same TokenStore `meho login` writes to (OS
-// keyring with file fallback); refresh-on-expiry is best-effort via
-// the AuthedClient's lazy 401-retry path.
+// Two modes:
 //
-// Output discipline (Goal #11 §5):
+//   - Default — single-shot health check against GET /api/v1/health.
+//     Renders operator identity + Vault + DB. Exit codes 0 / 2 / 3 / 4.
 //
-//   - Default: a human-readable summary on stdout. Format is
-//     stable: identity line + Vault + DB.
-//   - --json: the typed HealthResponse, pretty-printed to stdout.
-//   - Errors: structured codes + non-zero exit codes mapped via
-//     output.StructuredError. Errors go to stderr (cobra default);
-//     --json on error mode emits a JSON envelope on stderr.
+//   - --watch — subscribes to GET /api/v1/feed (Server-Sent Events).
+//     Streams one rendered line per event until the operator hits
+//     Ctrl-C. Disconnects retry with exponential backoff using the
+//     SSE Last-Event-Id header for replay. Filters (--op-class,
+//     --principal, --target) forward to the SSE query string. Exit
+//     codes add 5 for insufficient_role (read_only operators).
 //
-// The backplane URL is resolved from `meho login`'s persisted
-// config file. Operators can override per-invocation with
-// `--backplane <url>` (useful for ad-hoc queries against a second
-// environment without re-running login).
+// Both modes share the bearer token resolution (TokenStore that
+// `meho login` writes to, OS keyring with file fallback) and the
+// --backplane / --json output discipline (Goal #11 §5).
 func newStatusCmd() *cobra.Command {
 	var (
 		jsonOut           bool
 		backplaneOverride string
+		watch             bool
+		opClass           string
+		principal         string
+		target            string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Show operator identity and backplane health",
+		Short: "Show operator identity + backplane health; --watch streams live activity",
 		Long: "status calls the backplane's authenticated health endpoint " +
 			"(/api/v1/health) with the bearer token stored by `meho login` " +
 			"and prints a summary of the federation chain (operator identity, " +
 			"Vault reachability, DB migration state).\n\n" +
+			"With --watch the command subscribes to /api/v1/feed and streams " +
+			"one rendered line per broadcast event until the operator hits " +
+			"Ctrl-C. Filters (--op-class, --principal, --target) forward to " +
+			"the SSE query string; disconnects retry with exponential " +
+			"backoff using Last-Event-Id for replay.\n\n" +
 			"Output is human-readable by default. Pass --json for a single " +
-			"machine-parseable JSON document on stdout — agents (and the " +
-			"meho install.sh smoke test) consume this shape.\n\n" +
-			"Exit codes: 0 success, 2 auth_expired (no stored token, or the " +
-			"backplane rejected even a refreshed bearer), 3 unreachable, 4 " +
-			"unexpected response shape.",
+			"machine-parseable JSON document on stdout (one JSON object per " +
+			"line in --watch mode) — agents (and the meho install.sh smoke " +
+			"test) consume this shape.\n\n" +
+			"Exit codes: 0 success, 2 auth_expired, 3 unreachable, 4 " +
+			"unexpected response shape, 5 insufficient_role (--watch only).",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		// SilenceErrors so we control error output entirely — JSON
@@ -70,46 +75,18 @@ func newStatusCmd() *cobra.Command {
 			if err != nil {
 				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), jsonOut)
 			}
-
-			client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
-			if err != nil {
-				if api.IsTokenNotFound(err) {
-					return output.RenderError(cmd.ErrOrStderr(),
-						output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
-						jsonOut)
-				}
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.Unexpected(fmt.Sprintf("build authed client: %v", err)),
-					jsonOut)
+			if watch {
+				return runWatch(cmd.Context(), watchOptions{
+					BackplaneURL: backplaneURL,
+					OpClass:      opClass,
+					Principal:    principal,
+					Target:       target,
+					JSONOut:      jsonOut,
+					Stdout:       cmd.OutOrStdout(),
+					Stderr:       cmd.ErrOrStderr(),
+				})
 			}
-
-			resp, err := client.GetHealth(cmd.Context())
-			if err != nil {
-				if api.IsNoRefreshToken(err) {
-					return output.RenderError(cmd.ErrOrStderr(),
-						output.AuthExpired(fmt.Sprintf("stored token rejected and no refresh_token present; run `meho login %s`", backplaneURL)),
-						jsonOut)
-				}
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, redactedError(err))),
-					jsonOut)
-			}
-
-			if resp.StatusCode() == http.StatusUnauthorized {
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.AuthExpired(fmt.Sprintf("backplane rejected stored credentials; run `meho login %s`", backplaneURL)),
-					jsonOut)
-			}
-			if resp.JSON200 == nil {
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.Unexpected(fmt.Sprintf("HTTP %d from %s", resp.StatusCode(), backplaneURL)),
-					jsonOut)
-			}
-
-			if jsonOut {
-				return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
-			}
-			return output.PrintHealth(cmd.OutOrStdout(), resp.JSON200)
+			return runOneShot(cmd, backplaneURL, jsonOut)
 		},
 	}
 
@@ -117,7 +94,61 @@ func newStatusCmd() *cobra.Command {
 		"emit a single JSON document on stdout instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false,
+		"stream a live SSE feed of broadcast events (one line per event; Ctrl-C to exit)")
+	cmd.Flags().StringVar(&opClass, "op-class", "",
+		"filter --watch events by op_class (read, write, credential_read, audit_query)")
+	cmd.Flags().StringVar(&principal, "principal", "",
+		"filter --watch events by principal_sub (JWT subject claim)")
+	cmd.Flags().StringVar(&target, "target", "",
+		"filter --watch events by target_name (the connector instance name)")
 	return cmd
+}
+
+// runOneShot performs the original single-request health check —
+// extracted from the RunE closure when --watch was added so each
+// dispatch arm stays a single function. Behaviour is unchanged from
+// the pre-T5 status command.
+func runOneShot(cmd *cobra.Command, backplaneURL string, jsonOut bool) error {
+	client, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		if api.IsTokenNotFound(err) {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", backplaneURL, backplaneURL)),
+				jsonOut)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("build authed client: %v", err)),
+			jsonOut)
+	}
+
+	resp, err := client.GetHealth(cmd.Context())
+	if err != nil {
+		if api.IsNoRefreshToken(err) {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.AuthExpired(fmt.Sprintf("stored token rejected and no refresh_token present; run `meho login %s`", backplaneURL)),
+				jsonOut)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, redactedError(err))),
+			jsonOut)
+	}
+
+	if resp.StatusCode() == http.StatusUnauthorized {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf("backplane rejected stored credentials; run `meho login %s`", backplaneURL)),
+			jsonOut)
+	}
+	if resp.JSON200 == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("HTTP %d from %s", resp.StatusCode(), backplaneURL)),
+			jsonOut)
+	}
+
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	return output.PrintHealth(cmd.OutOrStdout(), resp.JSON200)
 }
 
 // resolveBackplaneURL picks the backplane to talk to. Priority:

--- a/cli/internal/cmd/status_watch.go
+++ b/cli/internal/cmd/status_watch.go
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// watchOptions bundles the parameters runWatch needs. Kept as a
+// struct so the cobra dispatch layer doesn't have to thread a long
+// argument list, and so tests can construct one without depending on
+// cobra at all.
+type watchOptions struct {
+	BackplaneURL string
+	OpClass      string
+	Principal    string
+	Target       string
+	JSONOut      bool
+	Stdout       io.Writer
+	Stderr       io.Writer
+
+	// HTTPClient overrides http.DefaultClient. Tests pass an
+	// httptest.Server's Client(); production code leaves zero.
+	HTTPClient *http.Client
+	// Store overrides the default TokenStore. Tests pass an
+	// in-memory store; production code leaves nil and the resolver
+	// uses auth.NewTokenStore() (OS keyring with file fallback).
+	Store auth.TokenStore
+	// Backoff overrides the default backoff schedule. Tests pass a
+	// fast schedule so the suite runs in tens of milliseconds, not
+	// tens of seconds.
+	Backoff []time.Duration
+}
+
+// defaultBackoff is the SSE reconnect schedule from the T5 issue
+// body: 1s, 2s, 5s, 10s, 30s, then 30s for every subsequent retry.
+// Matches the EventSource spec's "retry: <ms>" convention without
+// requiring the server to send the field — the client picks the
+// schedule, the server doesn't override it. Each duration is one
+// reconnect attempt; after the slice is exhausted, the loop uses
+// the final entry indefinitely.
+var defaultBackoff = []time.Duration{
+	1 * time.Second,
+	2 * time.Second,
+	5 * time.Second,
+	10 * time.Second,
+	30 * time.Second,
+}
+
+// runWatch opens the /api/v1/feed SSE stream and prints one rendered
+// line per broadcast event until ctx is cancelled (Ctrl-C, parent
+// cobra command lifetime). Reconnects on transport errors using
+// Last-Event-Id for replay; gives up immediately on
+// auth/role/contract failures since the operator action is required.
+//
+// The control flow is a single loop:
+//
+//  1. Load the bearer token from the configured store.
+//  2. Open one HTTP request to the SSE URL with the current
+//     Last-Event-Id (empty on the first attempt).
+//  3. On HTTP 401 / 403 / unexpected status, return immediately —
+//     none are recoverable by retry.
+//  4. On HTTP 200, stream events; update lastEventID after each one.
+//  5. On stream end (server hang-up, network error, anything that
+//     isn't ctx.Err()), wait for the next backoff slot and reconnect.
+//  6. On ctx.Done() at any point, return nil (clean Ctrl-C exit).
+//
+// Exit-code contract: any returned error already passed through
+// output.RenderError, so callers (the cobra RunE) propagate it as-is.
+func runWatch(ctx context.Context, opts watchOptions) error {
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	store := opts.Store
+	if store == nil {
+		s, err := auth.NewTokenStore()
+		if err != nil {
+			return output.RenderError(opts.Stderr,
+				output.Unexpected(fmt.Sprintf("token store: %v", err)),
+				opts.JSONOut)
+		}
+		store = s
+	}
+	backoff := opts.Backoff
+	if backoff == nil {
+		backoff = defaultBackoff
+	}
+
+	service, user := auth.KeyForBackplane(opts.BackplaneURL)
+	tok, err := store.Load(service, user)
+	if err != nil {
+		if errors.Is(err, auth.ErrTokenNotFound) {
+			return output.RenderError(opts.Stderr,
+				output.AuthExpired(fmt.Sprintf("no stored credentials for %s; run `meho login %s`", opts.BackplaneURL, opts.BackplaneURL)),
+				opts.JSONOut)
+		}
+		return output.RenderError(opts.Stderr,
+			output.Unexpected(fmt.Sprintf("load token: %v", err)),
+			opts.JSONOut)
+	}
+	if tok.AccessToken == "" {
+		return output.RenderError(opts.Stderr,
+			output.AuthExpired(fmt.Sprintf("stored token has no access_token; run `meho login %s`", opts.BackplaneURL)),
+			opts.JSONOut)
+	}
+
+	feedURL, err := buildFeedURL(opts.BackplaneURL, opts.OpClass, opts.Principal, opts.Target)
+	if err != nil {
+		return output.RenderError(opts.Stderr,
+			output.Unexpected(fmt.Sprintf("build feed URL: %v", err)),
+			opts.JSONOut)
+	}
+
+	lastEventID := ""
+	attempt := 0
+	for {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil
+		}
+		streamErr := streamOnce(ctx, streamArgs{
+			HTTPClient:  httpClient,
+			URL:         feedURL,
+			Bearer:      tok.AccessToken,
+			LastEventID: lastEventID,
+			JSONOut:     opts.JSONOut,
+			Stdout:      opts.Stdout,
+			Stderr:      opts.Stderr,
+			OnEventID:   func(id string) { lastEventID = id },
+		})
+		// Terminal conditions: ctx cancelled, or a non-recoverable
+		// HTTP-status / contract error already rendered to stderr.
+		if streamErr == nil || errors.Is(streamErr, context.Canceled) {
+			return nil
+		}
+		var fatal *fatalStreamError
+		if errors.As(streamErr, &fatal) {
+			return fatal.RenderedErr
+		}
+		// Recoverable: log a one-line note to stderr (humans only —
+		// JSON mode keeps stdout clean) and sleep until the next
+		// backoff slot.
+		if !opts.JSONOut {
+			fmt.Fprintf(opts.Stderr, "meho: feed connection dropped (%s); retrying in %s\n",
+				streamErr.Error(), backoffDuration(attempt, backoff))
+		}
+		if waitErr := sleepCtx(ctx, backoffDuration(attempt, backoff)); waitErr != nil {
+			return nil
+		}
+		attempt++
+	}
+}
+
+// streamArgs bundles the per-attempt parameters of streamOnce. Kept
+// distinct from watchOptions so the retry-loop state stays explicit
+// (Bearer + LastEventID are mutated across attempts).
+type streamArgs struct {
+	HTTPClient  *http.Client
+	URL         string
+	Bearer      string
+	LastEventID string
+	JSONOut     bool
+	Stdout      io.Writer
+	Stderr      io.Writer
+	// OnEventID is called for every dispatched event so the retry
+	// loop can pin the cursor for the next reconnect. Kept as a
+	// callback to avoid leaking the loop's state into streamOnce.
+	OnEventID func(id string)
+}
+
+// fatalStreamError marks a stream error that the retry loop must
+// NOT retry — HTTP 401 / 403 / unexpected-status responses where
+// the operator needs to do something. RenderedErr already passed
+// through output.RenderError so the caller can return it directly.
+type fatalStreamError struct {
+	RenderedErr error
+	Cause       string
+}
+
+func (e *fatalStreamError) Error() string { return e.Cause }
+func (e *fatalStreamError) Unwrap() error { return e.RenderedErr }
+
+// streamOnce opens one SSE connection and dispatches every event
+// it receives until the stream ends. Returns nil when ctx is
+// cancelled mid-stream (clean Ctrl-C), a fatalStreamError for
+// non-recoverable HTTP statuses, or a plain error for recoverable
+// transport / read failures.
+//
+// SSE wire format (per the WHATWG EventSource spec):
+//
+//	event: broadcast
+//	data: {"event_id":"...", "ts":"...", ...}
+//	id: 1715600000000-0
+//	<blank line>
+//
+// Multiple “data:“ lines for one frame are joined with newlines
+// before parsing. Comments (“: heartbeat“) are skipped. A blank
+// line dispatches whatever frame is being built; the parser then
+// resets and waits for the next frame.
+func streamOnce(ctx context.Context, args streamArgs) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, args.URL, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+args.Bearer)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	if args.LastEventID != "" {
+		req.Header.Set("Last-Event-Id", args.LastEventID)
+	}
+
+	resp, err := args.HTTPClient.Do(req)
+	if err != nil {
+		// ctx cancelled while dialing — surface as nil so the
+		// retry loop unwinds cleanly.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// happy path; fall through to the parser
+	case http.StatusUnauthorized:
+		rendered := output.RenderError(args.Stderr,
+			output.AuthExpired("backplane rejected stored credentials; run `meho login`"),
+			args.JSONOut)
+		return &fatalStreamError{RenderedErr: rendered, Cause: "401"}
+	case http.StatusForbidden:
+		rendered := output.RenderError(args.Stderr,
+			output.InsufficientRole("operator role required for the SSE feed; ask your tenant admin for an operator-role grant"),
+			args.JSONOut)
+		return &fatalStreamError{RenderedErr: rendered, Cause: "403"}
+	case http.StatusBadRequest:
+		// 400 on the SSE feed today means an invalid cursor
+		// (Last-Event-Id outside the Valkey-stream-id shape, or a
+		// rejected ``since`` query parameter). Surface the body's
+		// detail because the operator may have hand-edited a
+		// reconnect cursor in a wrapper script.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		rendered := output.RenderError(args.Stderr,
+			output.Unexpected(fmt.Sprintf("backplane returned 400: %s", strings.TrimSpace(string(body)))),
+			args.JSONOut)
+		return &fatalStreamError{RenderedErr: rendered, Cause: "400"}
+	default:
+		rendered := output.RenderError(args.Stderr,
+			output.Unexpected(fmt.Sprintf("HTTP %d from %s", resp.StatusCode, args.URL)),
+			args.JSONOut)
+		return &fatalStreamError{RenderedErr: rendered, Cause: fmt.Sprintf("HTTP %d", resp.StatusCode)}
+	}
+
+	return parseSSE(ctx, resp.Body, args)
+}
+
+// errStreamEnded is the sentinel parseSSE returns when the upstream
+// closed the connection cleanly (handler returned, server hung up).
+// SSE is a forever-stream: from the client's perspective an EOF on
+// a 200 response is always unexpected, so the retry loop treats it
+// like a transport error and reconnects with Last-Event-Id rather
+// than terminating the watch command.
+var errStreamEnded = errors.New("sse stream ended")
+
+// parseSSE reads frames off body and dispatches each completed
+// frame to renderEvent. Returns:
+//
+//   - nil when ctx is cancelled (clean Ctrl-C),
+//   - errStreamEnded when the upstream closed (EOF) without ctx
+//     being cancelled — the retry loop reconnects,
+//   - any other read error from the scanner verbatim.
+func parseSSE(ctx context.Context, body io.Reader, args streamArgs) error {
+	scanner := bufio.NewScanner(body)
+	// SSE frames are bounded by blank lines; individual lines can
+	// be long when ``data:`` carries a verbose payload. Lift the
+	// scanner buffer to 1 MiB so a fat audit-result entry doesn't
+	// trip bufio.ErrTooLong before the blank-line delimiter lands.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		eventType string
+		dataLines []string
+		id        string
+	)
+	dispatch := func() {
+		if len(dataLines) == 0 {
+			return
+		}
+		data := strings.Join(dataLines, "\n")
+		renderEvent(args.Stdout, eventType, data, args.JSONOut)
+		if id != "" {
+			args.OnEventID(id)
+		}
+		eventType, dataLines, id = "", nil, ""
+	}
+
+	for scanner.Scan() {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil
+		}
+		line := scanner.Text()
+		if line == "" {
+			dispatch()
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			// Comment — heartbeat or operator-facing note. Drop.
+			continue
+		}
+		// SSE allows ``field:value`` (no space) and ``field: value``
+		// (one space after the colon). Strip exactly one leading
+		// space from the value to honour both forms.
+		field, value, ok := strings.Cut(line, ":")
+		if !ok {
+			// A field name with no colon is a no-op per the spec.
+			continue
+		}
+		value = strings.TrimPrefix(value, " ")
+		switch field {
+		case "event":
+			eventType = value
+		case "data":
+			dataLines = append(dataLines, value)
+		case "id":
+			id = value
+		case "retry":
+			// Spec field — the server can suggest a reconnect
+			// delay. v0.1 ignores: the client picks the schedule
+			// per the T5 issue body's explicit 1/2/5/10/30s.
+		}
+	}
+	// Scanner exited the loop. Three causes worth distinguishing:
+	//
+	//   1. ctx cancellation — return nil so the retry loop unwinds
+	//      cleanly (Ctrl-C path).
+	//   2. A non-nil scanner error — wrap and return so the retry
+	//      loop reports it before reconnecting.
+	//   3. Clean EOF — return errStreamEnded so the retry loop
+	//      reconnects (SSE streams aren't supposed to end).
+	if ctx.Err() != nil {
+		return nil
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read stream: %w", err)
+	}
+	return errStreamEnded
+}
+
+// renderEvent prints one event frame to w in the configured shape.
+// The human path is a single space-padded line; the JSON path is
+// the raw “data:“ payload (already JSON) verbatim, with one
+// newline appended so `jq` consumers see one document per line.
+//
+// Malformed payloads in the human path render the literal raw
+// data with a leading marker so the operator can spot upstream bugs
+// without the renderer panicking. JSON-mode malformed payloads pass
+// through unchanged — the operator's downstream `jq` will surface
+// the parse error.
+func renderEvent(w io.Writer, eventType, data string, jsonOut bool) {
+	// Only ``event: broadcast`` carries a payload today. The feed
+	// emits heartbeats as comments (``: heartbeat``), not events,
+	// so they never reach this function — but guard explicitly so
+	// a future event type doesn't render as a malformed broadcast.
+	if eventType != "" && eventType != "broadcast" {
+		return
+	}
+	if jsonOut {
+		fmt.Fprintln(w, data)
+		return
+	}
+	line, err := humanLine(data)
+	if err != nil {
+		fmt.Fprintf(w, "meho: unparseable event: %s\n", data)
+		return
+	}
+	fmt.Fprintln(w, line)
+}
+
+// broadcastEvent is the subset of the backplane's BroadcastEvent
+// shape the CLI renders. The full Pydantic model is wider; we only
+// decode the fields the human formatter needs and pass everything
+// else through verbatim on the --json path.
+type broadcastEvent struct {
+	TS           time.Time `json:"ts"`
+	PrincipalSub string    `json:"principal_sub"`
+	TargetName   *string   `json:"target_name"`
+	OpID         string    `json:"op_id"`
+	OpClass      string    `json:"op_class"`
+	ResultStatus string    `json:"result_status"`
+}
+
+// humanLine formats one broadcastEvent as a single line:
+//
+//	<RFC3339 ts>  <principal>  <op_id>  <result_status>  <summary>
+//
+// where <summary> is one of:
+//
+//   - “(aggregate-only)“ for credential_read / audit_query ops —
+//     the operator sees that the work happened but not the details.
+//   - “target=<name>“ when target_name is set.
+//   - empty otherwise.
+//
+// Column widths are tuned for the issue body's example output; the
+// op_id column pads to 18 because the canonical connector op names
+// (“vsphere.vm.list“, “vault.kv.read“) cluster around 14-16
+// characters. Operators wanting hard-aligned output can pipe through
+// “column -t“.
+func humanLine(data string) (string, error) {
+	var ev broadcastEvent
+	if err := json.Unmarshal([]byte(data), &ev); err != nil {
+		return "", fmt.Errorf("decode event: %w", err)
+	}
+	return fmt.Sprintf("%s  %-22s  %-18s  %-6s  %s",
+		ev.TS.UTC().Format(time.RFC3339),
+		ev.PrincipalSub,
+		ev.OpID,
+		ev.ResultStatus,
+		summariseEvent(ev),
+	), nil
+}
+
+// summariseEvent picks the payload-summary column value for the
+// human-readable line.
+//
+// “credential_read“ and “audit_query“ op classes surface as
+// “(aggregate-only)“ — operators see the event happened (so
+// dashboards still tick) but not the parameters (which carry
+// sensitive lookup terms). T3's publisher already strips the
+// params field on these op classes; the placeholder makes the
+// elision visible.
+func summariseEvent(ev broadcastEvent) string {
+	switch ev.OpClass {
+	case "credential_read", "audit_query":
+		return "(aggregate-only)"
+	}
+	if ev.TargetName != nil && *ev.TargetName != "" {
+		return "target=" + *ev.TargetName
+	}
+	return ""
+}
+
+// buildFeedURL composes the SSE URL: backplane + /api/v1/feed plus
+// any non-empty filter parameters. Empty filter values are dropped
+// rather than sent as “?op_class=“ — the backplane treats both
+// "absent" and "empty string" as "no filter", but emitting empty
+// params clutters the wire and confuses curl debugging.
+func buildFeedURL(backplane, opClass, principal, target string) (string, error) {
+	base := strings.TrimRight(backplane, "/")
+	u, err := url.Parse(base + "/api/v1/feed")
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	if opClass != "" {
+		q.Set("op_class", opClass)
+	}
+	if principal != "" {
+		q.Set("principal", principal)
+	}
+	if target != "" {
+		q.Set("target", target)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// backoffDuration picks the backoff slot for attempt n. The
+// schedule is a fixed slice; once exhausted, the final entry
+// repeats — the issue body's 30 s ceiling stays in force forever.
+func backoffDuration(attempt int, schedule []time.Duration) time.Duration {
+	if attempt < 0 || len(schedule) == 0 {
+		return time.Second
+	}
+	if attempt >= len(schedule) {
+		return schedule[len(schedule)-1]
+	}
+	return schedule[attempt]
+}
+
+// sleepCtx waits d or until ctx is cancelled, whichever comes
+// first. Returns ctx.Err() on cancellation, nil on timer fire.
+// Used by the retry loop instead of a bare “time.Sleep“ so
+// Ctrl-C unwinds within milliseconds rather than waiting out a 30s
+// backoff slot.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/cli/internal/cmd/status_watch_test.go
+++ b/cli/internal/cmd/status_watch_test.go
@@ -1,0 +1,821 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// fastBackoff is the schedule the tests pass in via watchOptions.
+// Five 1 ms slots collapse the production 1/2/5/10/30 s schedule
+// into roughly 5 ms total per retry sweep so the table-driven suite
+// stays sub-second.
+var fastBackoff = []time.Duration{
+	time.Millisecond,
+	time.Millisecond,
+	time.Millisecond,
+	time.Millisecond,
+	time.Millisecond,
+}
+
+// seedWatchCreds writes a token + config like seedCreds in
+// status_test.go, but parameterised on the access token. Lifted into
+// its own helper so the watch suite can mint distinct tokens per
+// scenario without copying the file-store boilerplate.
+func seedWatchCreds(t *testing.T, xdg, backplaneURL, accessToken string) {
+	t.Helper()
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  accessToken,
+		Expiry:       time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(filepath.Join(xdg, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+}
+
+// fakeFeed stands up an httptest server that serves /api/v1/feed
+// with a scripted SSE response. The handler records every received
+// Authorization, Last-Event-Id, and query string so the suite can
+// assert against the wire shape without scraping logs.
+//
+// frames is the raw SSE body (frames separated by blank lines).
+// status is the HTTP status code to return (200 streams; 401 / 403
+// / 400 trigger the fatal-status paths). hangAfter, when > 0,
+// closes the connection after writing that many frames so the
+// suite exercises the reconnect path.
+type fakeFeedRecord struct {
+	Authorization string
+	LastEventID   string
+	Query         string
+}
+
+type fakeFeed struct {
+	URL     string
+	mu      sync.Mutex
+	calls   []fakeFeedRecord
+	hits    atomic.Int64
+	cursor  atomic.Int64
+	frames  [][]byte
+	status  int
+	dropMid bool
+}
+
+// Records returns a snapshot of every request the fake feed has
+// received. Locked so the test goroutine and the http handler
+// goroutine don't race on the underlying slice. Returns a copy so
+// the caller can iterate without holding the lock.
+func (f *fakeFeed) Records() []fakeFeedRecord {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeFeedRecord, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// record appends one received-request snapshot under the mutex.
+func (f *fakeFeed) record(r fakeFeedRecord) {
+	f.mu.Lock()
+	f.calls = append(f.calls, r)
+	f.mu.Unlock()
+}
+
+func newFakeFeed(t *testing.T, status int, frames [][]byte, dropMid bool) *fakeFeed {
+	t.Helper()
+	feed := &fakeFeed{frames: frames, status: status, dropMid: dropMid}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/feed", func(w http.ResponseWriter, r *http.Request) {
+		idx := int(feed.hits.Add(1) - 1)
+		feed.record(fakeFeedRecord{
+			Authorization: r.Header.Get("Authorization"),
+			LastEventID:   r.Header.Get("Last-Event-Id"),
+			Query:         r.URL.RawQuery,
+		})
+		if feed.status != http.StatusOK {
+			w.WriteHeader(feed.status)
+			_, _ = w.Write([]byte(`{"detail":"forced"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		// Frames are written ONCE across all connections combined.
+		// Each connection takes a slice from feed.cursor onward.
+		//
+		//   - dropMid=false: connection 0 writes everything, then
+		//     blocks until the client cancels. Subsequent reconnects
+		//     write nothing (cursor at end) and likewise block.
+		//   - dropMid=true: connection 0 writes the first half then
+		//     returns (EOF → client reconnects). Connection 1
+		//     writes the remainder then blocks. Subsequent
+		//     reconnects block immediately.
+		//
+		// This avoids the "fake server replays the same frames
+		// every reconnect" failure mode the naive impl had.
+		start := int(feed.cursor.Load())
+		end := len(feed.frames)
+		if feed.dropMid && idx == 0 {
+			end = (len(feed.frames) + 1) / 2
+		}
+		for i := start; i < end; i++ {
+			_, _ = w.Write(feed.frames[i])
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		feed.cursor.Store(int64(end))
+
+		// If we just wrote a partial slice as part of the drop-mid
+		// scenario, return so the client EOFs and reconnects.
+		if feed.dropMid && idx == 0 {
+			return
+		}
+		// All remaining frames have been written. Hold the
+		// connection open so the client's parser sits in
+		// scanner.Scan() until the test context is cancelled.
+		// Without this hold the handler would return, the client
+		// would EOF, and the retry loop would dial back in a busy
+		// loop until the test deadline.
+		<-r.Context().Done()
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	feed.URL = srv.URL
+	return feed
+}
+
+// makeFrame builds one SSE frame (event/data/id) with the trailing
+// blank line that delimits frames.
+func makeFrame(event, data, id string) []byte {
+	var sb strings.Builder
+	if event != "" {
+		sb.WriteString("event: ")
+		sb.WriteString(event)
+		sb.WriteByte('\n')
+	}
+	if data != "" {
+		sb.WriteString("data: ")
+		sb.WriteString(data)
+		sb.WriteByte('\n')
+	}
+	if id != "" {
+		sb.WriteString("id: ")
+		sb.WriteString(id)
+		sb.WriteByte('\n')
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+// canonicalEventJSON is the shape T3's publisher emits. Tests build
+// frames from this so renderer assertions match the production
+// wire format end-to-end.
+func canonicalEventJSON(t *testing.T, principal, opID, opClass, status string, target *string) string {
+	t.Helper()
+	payload := map[string]any{
+		"event_id":      "00000000-0000-0000-0000-000000000001",
+		"ts":            "2026-05-13T14:23:01Z",
+		"tenant_id":     "11111111-1111-1111-1111-111111111111",
+		"principal_sub": principal,
+		"target_name":   target,
+		"op_id":         opID,
+		"op_class":      opClass,
+		"result_status": status,
+		"audit_id":      "22222222-2222-2222-2222-222222222222",
+		"payload":       map[string]any{"op_class": opClass, "params": map[string]any{}, "result_status": status},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	return string(b)
+}
+
+// TestRunWatch_RendersHumanLine — end-to-end check that one event
+// frame produces one rendered line with the expected columns.
+func TestRunWatch_RendersHumanLine(t *testing.T) {
+	xdg := withTempXDG(t)
+	target := "rdc-vcenter"
+	frame := makeFrame("broadcast", canonicalEventJSON(t, "alice", "vsphere.vm.list", "read", "ok", &target), "1715600000000-0")
+	feed := newFakeFeed(t, http.StatusOK, [][]byte{frame}, false)
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Cancel a beat after the frame has had time to render +
+		// the parser to hit EOF + the retry loop to kick once.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	})
+	if err != nil {
+		t.Fatalf("runWatch returned: %v\nstderr=%s", err, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "2026-05-13T14:23:01Z") {
+		t.Errorf("missing timestamp in line: %q", out)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("missing principal in line: %q", out)
+	}
+	if !strings.Contains(out, "vsphere.vm.list") {
+		t.Errorf("missing op_id in line: %q", out)
+	}
+	if !strings.Contains(out, "target=rdc-vcenter") {
+		t.Errorf("missing target suffix in line: %q", out)
+	}
+	if strings.Contains(out, jwtMarker) {
+		t.Errorf("JWT marker leaked into watch stdout:\n%s", out)
+	}
+}
+
+// TestRunWatch_AggregateOnlyClass — credential_read renders the
+// (aggregate-only) placeholder instead of the target / params.
+func TestRunWatch_AggregateOnlyClass(t *testing.T) {
+	xdg := withTempXDG(t)
+	frame := makeFrame("broadcast", canonicalEventJSON(t, "bob", "vault.kv.read", "credential_read", "ok", nil), "1715600000001-0")
+	feed := newFakeFeed(t, http.StatusOK, [][]byte{frame}, false)
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	if err := runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	}); err != nil {
+		t.Fatalf("runWatch returned: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "(aggregate-only)") {
+		t.Errorf("expected (aggregate-only) placeholder, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunWatch_JSONLines — --json mode emits one JSON document per
+// line, byte-identical to the SSE data field.
+func TestRunWatch_JSONLines(t *testing.T) {
+	xdg := withTempXDG(t)
+	target := "rdc-k8s"
+	dataA := canonicalEventJSON(t, "alice", "vsphere.vm.list", "read", "ok", &target)
+	dataB := canonicalEventJSON(t, "bob", "vault.kv.read", "credential_read", "ok", nil)
+	frames := [][]byte{
+		makeFrame("broadcast", dataA, "1715600000000-0"),
+		makeFrame("broadcast", dataB, "1715600000001-0"),
+	}
+	feed := newFakeFeed(t, http.StatusOK, frames, false)
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		cancel()
+	}()
+
+	if err := runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		JSONOut:      true,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	}); err != nil {
+		t.Fatalf("runWatch returned: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 JSON lines, got %d:\n%s", len(lines), stdout.String())
+	}
+	for _, ln := range lines {
+		var got map[string]any
+		if err := json.Unmarshal([]byte(ln), &got); err != nil {
+			t.Errorf("non-JSON line %q: %v", ln, err)
+		}
+	}
+}
+
+// TestRunWatch_FilterFlagsForwardToQuery — --op-class / --principal
+// / --target each land in the SSE URL's query string.
+func TestRunWatch_FilterFlagsForwardToQuery(t *testing.T) {
+	xdg := withTempXDG(t)
+	feed := newFakeFeed(t, http.StatusOK, nil, false)
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	_ = runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		OpClass:      "write",
+		Principal:    "alice",
+		Target:       "rdc-vcenter",
+		Stdout:       stdout,
+		Stderr:       stderr,
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	})
+
+	records := feed.Records()
+	if len(records) == 0 {
+		t.Fatal("fake feed never received a request")
+	}
+	q := records[0].Query
+	for _, kv := range []string{"op_class=write", "principal=alice", "target=rdc-vcenter"} {
+		if !strings.Contains(q, kv) {
+			t.Errorf("missing %q in query %q", kv, q)
+		}
+	}
+}
+
+// TestRunWatch_AuthHeaderSent — the stored bearer token reaches the
+// backplane verbatim (no double-encoding, no leak into stdout).
+func TestRunWatch_AuthHeaderSent(t *testing.T) {
+	xdg := withTempXDG(t)
+	feed := newFakeFeed(t, http.StatusOK, nil, false)
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	_ = runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	})
+
+	records := feed.Records()
+	if len(records) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	if records[0].Authorization != "Bearer "+jwtMarker {
+		t.Errorf("Authorization header = %q, want Bearer <marker>", records[0].Authorization)
+	}
+	if strings.Contains(stdout.String(), jwtMarker) || strings.Contains(stderr.String(), jwtMarker) {
+		t.Errorf("JWT marker leaked into output")
+	}
+}
+
+// TestRunWatch_ReconnectsWithLastEventID — first connection drops
+// after one frame; the reconnect carries Last-Event-Id of the last
+// rendered frame.
+func TestRunWatch_ReconnectsWithLastEventID(t *testing.T) {
+	xdg := withTempXDG(t)
+	target := "rdc-vcenter"
+	frames := [][]byte{
+		makeFrame("broadcast", canonicalEventJSON(t, "alice", "vsphere.vm.list", "read", "ok", &target), "1715600000000-0"),
+		makeFrame("broadcast", canonicalEventJSON(t, "alice", "vsphere.vm.create", "write", "ok", &target), "1715600000001-0"),
+	}
+	feed := newFakeFeed(t, http.StatusOK, frames, true) // drop after first frame
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Allow first connection's first frame, the drop, the
+		// 1 ms backoff, the reconnect, the second frame, and a
+		// margin before cancelling.
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	_ = runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	})
+
+	records := feed.Records()
+	if len(records) < 2 {
+		t.Fatalf("expected at least 2 requests (initial + reconnect); got %d", len(records))
+	}
+	if records[0].LastEventID != "" {
+		t.Errorf("first request should have empty Last-Event-Id, got %q", records[0].LastEventID)
+	}
+	if records[1].LastEventID != "1715600000000-0" {
+		t.Errorf("reconnect Last-Event-Id = %q, want 1715600000000-0", records[1].LastEventID)
+	}
+}
+
+// TestRunWatch_401_ExitsAuthExpired — 401 from the feed returns
+// auth_expired without retrying.
+func TestRunWatch_401_ExitsAuthExpired(t *testing.T) {
+	xdg := withTempXDG(t)
+	feed := newFakeFeed(t, http.StatusUnauthorized, nil, false)
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	})
+	if err == nil {
+		t.Fatal("expected non-nil error on 401")
+	}
+	var coder output.ExitCoder
+	if !errors.As(err, &coder) {
+		t.Fatalf("expected ExitCoder, got %T", err)
+	}
+	if coder.ExitCode() != output.ExitAuthExpired {
+		t.Errorf("exit = %d, want %d", coder.ExitCode(), output.ExitAuthExpired)
+	}
+	if got := len(feed.Records()); got != 1 {
+		t.Errorf("401 should not retry; got %d calls", got)
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("stderr should hint at `meho login`, got: %q", stderr.String())
+	}
+}
+
+// TestRunWatch_403_ExitsInsufficientRole — 403 from the feed
+// returns insufficient_role (exit code 5).
+func TestRunWatch_403_ExitsInsufficientRole(t *testing.T) {
+	xdg := withTempXDG(t)
+	feed := newFakeFeed(t, http.StatusForbidden, nil, false)
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	})
+	if err == nil {
+		t.Fatal("expected non-nil error on 403")
+	}
+	var coder output.ExitCoder
+	if !errors.As(err, &coder) {
+		t.Fatalf("expected ExitCoder, got %T", err)
+	}
+	if coder.ExitCode() != output.ExitInsufficientRole {
+		t.Errorf("exit = %d, want %d (insufficient_role)", coder.ExitCode(), output.ExitInsufficientRole)
+	}
+	if !strings.Contains(stderr.String(), output.ErrCodeInsufficientRole) {
+		t.Errorf("stderr should name the error code, got: %q", stderr.String())
+	}
+}
+
+// TestRunWatch_NoCreds_ExitsAuthExpired — no stored token → don't
+// even try to dial the backplane.
+func TestRunWatch_NoCreds_ExitsAuthExpired(t *testing.T) {
+	_ = withTempXDG(t) // empty XDG → no seeded creds
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := runWatch(ctx, watchOptions{
+		BackplaneURL: "https://example.invalid",
+		Stdout:       stdout,
+		Stderr:       stderr,
+		Backoff:      fastBackoff,
+	})
+	if err == nil {
+		t.Fatal("expected error for no-creds path")
+	}
+	var coder output.ExitCoder
+	if !errors.As(err, &coder) {
+		t.Fatalf("expected ExitCoder, got %T", err)
+	}
+	if coder.ExitCode() != output.ExitAuthExpired {
+		t.Errorf("exit = %d, want %d", coder.ExitCode(), output.ExitAuthExpired)
+	}
+}
+
+// TestRunWatch_ContextCancel_CleanExit — cancellation during a
+// blocked read returns nil so cobra exits 0.
+func TestRunWatch_ContextCancel_CleanExit(t *testing.T) {
+	xdg := withTempXDG(t)
+	feed := newFakeFeed(t, http.StatusOK, nil, false) // server never writes a frame
+	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already-cancelled context — runWatch should return promptly
+
+	err := runWatch(ctx, watchOptions{
+		BackplaneURL: feed.URL,
+		Stdout:       &bytes.Buffer{},
+		Stderr:       &bytes.Buffer{},
+		HTTPClient:   feed.client(),
+		Backoff:      fastBackoff,
+	})
+	if err != nil {
+		t.Errorf("Ctrl-C should return nil, got %v", err)
+	}
+}
+
+// TestParseSSE_MultilineDataFrame — two “data:“ lines on one
+// frame join with a single newline before parsing.
+func TestParseSSE_MultilineDataFrame(t *testing.T) {
+	frame := []byte("event: broadcast\ndata: line-one\ndata: line-two\nid: 1\n\n")
+	stdout := &bytes.Buffer{}
+	var lastID string
+	err := parseSSE(context.Background(), bytes.NewReader(frame), streamArgs{
+		Stdout:    stdout,
+		Stderr:    &bytes.Buffer{},
+		JSONOut:   true,
+		OnEventID: func(id string) { lastID = id },
+	})
+	// parseSSE returns errStreamEnded on EOF without ctx
+	// cancellation — that's the "server hung up, retry loop should
+	// reconnect" signal. Any other error is a test failure.
+	if err != nil && !errors.Is(err, errStreamEnded) {
+		t.Fatalf("parseSSE: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "line-one\nline-two" {
+		t.Errorf("multiline data = %q, want %q", got, "line-one\\nline-two")
+	}
+	if lastID != "1" {
+		t.Errorf("OnEventID = %q, want %q", lastID, "1")
+	}
+}
+
+// TestParseSSE_HeartbeatSkipped — `: heartbeat\n\n` comment frame
+// produces no output and no OnEventID call.
+func TestParseSSE_HeartbeatSkipped(t *testing.T) {
+	frame := []byte(": heartbeat\n\n")
+	stdout := &bytes.Buffer{}
+	var idCount int
+	err := parseSSE(context.Background(), bytes.NewReader(frame), streamArgs{
+		Stdout:    stdout,
+		Stderr:    &bytes.Buffer{},
+		JSONOut:   true,
+		OnEventID: func(string) { idCount++ },
+	})
+	if err != nil && !errors.Is(err, errStreamEnded) {
+		t.Fatalf("parseSSE: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("heartbeat produced output: %q", stdout.String())
+	}
+	if idCount != 0 {
+		t.Errorf("heartbeat triggered OnEventID %d times", idCount)
+	}
+}
+
+// TestParseSSE_RetryFieldIgnored — the SSE “retry:“ field is
+// recognised (not dispatched as an event) and produces no output.
+func TestParseSSE_RetryFieldIgnored(t *testing.T) {
+	frame := []byte("retry: 5000\n\nevent: broadcast\ndata: ok\nid: 2\n\n")
+	stdout := &bytes.Buffer{}
+	err := parseSSE(context.Background(), bytes.NewReader(frame), streamArgs{
+		Stdout:    stdout,
+		Stderr:    &bytes.Buffer{},
+		JSONOut:   true,
+		OnEventID: func(string) {},
+	})
+	if err != nil && !errors.Is(err, errStreamEnded) {
+		t.Fatalf("parseSSE: %v", err)
+	}
+	out := strings.TrimSpace(stdout.String())
+	if out != "ok" {
+		t.Errorf("retry frame was rendered: stdout=%q (want only 'ok' from the broadcast)", out)
+	}
+}
+
+// TestBackoffDuration — schedule advances per attempt and clamps
+// to the final entry once exhausted.
+func TestBackoffDuration(t *testing.T) {
+	sched := []time.Duration{1 * time.Second, 2 * time.Second, 5 * time.Second}
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{-1, time.Second}, // out-of-range guard
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 5 * time.Second},
+		{3, 5 * time.Second},  // past the end → clamp
+		{99, 5 * time.Second}, // far past the end → clamp
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("attempt=%d", c.attempt), func(t *testing.T) {
+			if got := backoffDuration(c.attempt, sched); got != c.want {
+				t.Errorf("backoffDuration(%d) = %v, want %v", c.attempt, got, c.want)
+			}
+		})
+	}
+}
+
+// TestBuildFeedURL — every non-empty filter lands in the query
+// string; empty filters do NOT emit “?key=“ clutter.
+func TestBuildFeedURL(t *testing.T) {
+	cases := []struct {
+		name           string
+		opClass        string
+		principal      string
+		target         string
+		wantInQuery    []string
+		wantNotInQuery []string
+	}{
+		{
+			name:           "no filters",
+			wantNotInQuery: []string{"op_class=", "principal=", "target="},
+		},
+		{
+			name:           "single filter",
+			opClass:        "read",
+			wantInQuery:    []string{"op_class=read"},
+			wantNotInQuery: []string{"principal=", "target="},
+		},
+		{
+			name:        "all three filters",
+			opClass:     "write",
+			principal:   "alice",
+			target:      "rdc-vcenter",
+			wantInQuery: []string{"op_class=write", "principal=alice", "target=rdc-vcenter"},
+		},
+		{
+			name:           "trailing slash on backplane is stripped",
+			opClass:        "read",
+			wantInQuery:    []string{"/api/v1/feed"},
+			wantNotInQuery: []string{"//api/v1/feed"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			base := "https://backplane.test"
+			if c.name == "trailing slash on backplane is stripped" {
+				base = "https://backplane.test/"
+			}
+			got, err := buildFeedURL(base, c.opClass, c.principal, c.target)
+			if err != nil {
+				t.Fatalf("buildFeedURL: %v", err)
+			}
+			for _, want := range c.wantInQuery {
+				if !strings.Contains(got, want) {
+					t.Errorf("URL %q missing %q", got, want)
+				}
+			}
+			for _, want := range c.wantNotInQuery {
+				if strings.Contains(got, want) {
+					t.Errorf("URL %q must not contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestHumanLine — table-driven check of the human-readable
+// formatter (column shape + (aggregate-only) placeholder + bare
+// target=… suffix + empty summary).
+func TestHumanLine(t *testing.T) {
+	target := "rdc-vcenter"
+	cases := []struct {
+		name    string
+		event   broadcastEvent
+		wantSub string
+	}{
+		{
+			name: "read with target",
+			event: broadcastEvent{
+				TS:           time.Date(2026, 5, 13, 14, 23, 1, 0, time.UTC),
+				PrincipalSub: "alice",
+				OpID:         "vsphere.vm.list",
+				OpClass:      "read",
+				ResultStatus: "ok",
+				TargetName:   &target,
+			},
+			wantSub: "target=rdc-vcenter",
+		},
+		{
+			name: "credential_read renders aggregate-only",
+			event: broadcastEvent{
+				TS:           time.Date(2026, 5, 13, 14, 23, 1, 0, time.UTC),
+				PrincipalSub: "alice",
+				OpID:         "vault.kv.read",
+				OpClass:      "credential_read",
+				ResultStatus: "ok",
+			},
+			wantSub: "(aggregate-only)",
+		},
+		{
+			name: "audit_query renders aggregate-only",
+			event: broadcastEvent{
+				TS:           time.Date(2026, 5, 13, 14, 23, 1, 0, time.UTC),
+				PrincipalSub: "alice",
+				OpID:         "audit.query",
+				OpClass:      "audit_query",
+				ResultStatus: "ok",
+				TargetName:   &target,
+			},
+			wantSub: "(aggregate-only)",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data, err := json.Marshal(c.event)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got, err := humanLine(string(data))
+			if err != nil {
+				t.Fatalf("humanLine: %v", err)
+			}
+			if !strings.Contains(got, c.wantSub) {
+				t.Errorf("line %q missing %q", got, c.wantSub)
+			}
+			if !strings.HasPrefix(got, "2026-05-13T14:23:01Z") {
+				t.Errorf("line %q missing RFC3339 timestamp prefix", got)
+			}
+		})
+	}
+}
+
+// TestSummariseEvent — the summary picker by op_class + target.
+func TestSummariseEvent(t *testing.T) {
+	target := "rdc-vcenter"
+	cases := []struct {
+		opClass string
+		target  *string
+		want    string
+	}{
+		{opClass: "credential_read", target: &target, want: "(aggregate-only)"},
+		{opClass: "audit_query", target: &target, want: "(aggregate-only)"},
+		{opClass: "read", target: &target, want: "target=rdc-vcenter"},
+		{opClass: "write", target: &target, want: "target=rdc-vcenter"},
+		{opClass: "read", target: nil, want: ""},
+	}
+	for _, c := range cases {
+		t.Run(c.opClass, func(t *testing.T) {
+			got := summariseEvent(broadcastEvent{OpClass: c.opClass, TargetName: c.target})
+			if got != c.want {
+				t.Errorf("summariseEvent(%q) = %q, want %q", c.opClass, got, c.want)
+			}
+		})
+	}
+}
+
+// client returns an http.Client that hits the fake feed without
+// going through the OS-level routing table — needed when the test
+// runs inside a Docker container where the httptest URL points to
+// an in-container localhost. Without it, http.DefaultClient still
+// works (httptest binds to 127.0.0.1) but tests that want to pin
+// transport-level behaviour can override here.
+func (f *fakeFeed) client() *http.Client {
+	return &http.Client{Timeout: 5 * time.Second}
+}

--- a/cli/internal/output/format.go
+++ b/cli/internal/output/format.go
@@ -49,6 +49,14 @@ const (
 	// server side" failure mode without falling back to the generic
 	// exit 1.
 	ExitUnexpected = 4
+	// ExitInsufficientRole indicates the backplane refused the
+	// request on RBAC grounds (HTTP 403). The operator authenticated
+	// successfully but their tenant role is below the minimum the
+	// endpoint requires — `meho status --watch` against the SSE
+	// feed needs operator role, read_only is rejected. Distinct
+	// from auth_expired because `meho login` won't fix it; the
+	// remedy is a tenant-admin role grant.
+	ExitInsufficientRole = 5
 )
 
 // Error codes (the "error" field in the JSON error envelope). The
@@ -66,6 +74,11 @@ const (
 	// ErrCodeUnexpected pairs with ExitUnexpected. The backplane
 	// answered but the response shape was outside the contract.
 	ErrCodeUnexpected = "unexpected_response"
+	// ErrCodeInsufficientRole pairs with ExitInsufficientRole. The
+	// operator is authenticated but their tenant role is below the
+	// endpoint's minimum (HTTP 403). Remedy: tenant-admin role
+	// grant, not a re-login.
+	ErrCodeInsufficientRole = "insufficient_role"
 )
 
 // StructuredError is the error shape produced by every meho
@@ -153,6 +166,18 @@ func Unexpected(detail string) *StructuredError {
 		Code:   ErrCodeUnexpected,
 		Detail: detail,
 		Exit:   ExitUnexpected,
+	}
+}
+
+// InsufficientRole builds the canonical insufficient_role
+// StructuredError for HTTP 403 responses. Detail should name the
+// minimum required role so the operator can ask the right person
+// for the grant.
+func InsufficientRole(detail string) *StructuredError {
+	return &StructuredError{
+		Code:   ErrCodeInsufficientRole,
+		Detail: detail,
+		Exit:   ExitInsufficientRole,
 	}
 }
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -352,6 +352,113 @@ The same `eyJ` prefix matches access tokens, refresh tokens, and
 id tokens alike, so the single redaction rule covers every
 credential the CLI persists.
 
+## Watch flow (`meho status --watch`, G6.1-T5)
+
+`--watch` flips `meho status` from a one-shot health probe to a
+long-lived SSE subscriber on the backplane's `/api/v1/feed` endpoint.
+The renderer streams one line per broadcast event until the
+operator hits Ctrl-C; filters (`--op-class`, `--principal`,
+`--target`) forward to the SSE query string, and disconnects
+retry with exponential backoff using `Last-Event-Id` for replay.
+
+### Dispatch
+
+`newStatusCmd`'s `RunE` checks the `--watch` flag and dispatches:
+
+- `false` → `runOneShot` (the original `GET /api/v1/health` flow,
+  extracted from the inline closure when T5 added the second arm).
+- `true` → `runWatch` (the SSE subscriber in `status_watch.go`).
+
+Both arms share the same bearer-token resolution path and the same
+`--backplane` override, so the operator's expectation of "the URL
+in `meho login`" stays consistent.
+
+### SSE wire format
+
+The backplane (`backend/src/meho_backplane/api/v1/feed.py`, G6.1-T4)
+emits frames in the standard WHATWG `EventSource` shape:
+
+```
+event: broadcast
+data: {"event_id":"...", "ts":"...", "principal_sub":"...", ...}
+id: 1715600000000-0
+<blank line>
+```
+
+Heartbeats (`: heartbeat\n\n`) keep the connection alive across
+nginx/ALB idle timeouts and are dropped silently by the parser
+(SSE comment lines, not events). Multi-line `data:` fields are
+joined with `\n` before JSON parsing.
+
+### Reconnect / backoff
+
+`runWatch` retries on every recoverable failure (transport error,
+unexpected EOF, scanner error) using the schedule from the T5 issue
+body: **1s, 2s, 5s, 10s, 30s, then 30s indefinitely**. Each retry
+carries `Last-Event-Id: <id>` with the last successfully-rendered
+event id, so the backplane replays events the operator missed
+during the gap (T4's iter-3 cursor-validation gate enforces the
+ID shape — malformed ids return 400 and break the loop).
+
+Non-recoverable HTTP responses (401 / 403 / 400 / other 5xx) do
+NOT retry: the operator has to take action (`meho login` for 401,
+ask for an operator-role grant for 403, file a bug for unexpected
+status codes). Each surfaces via `output.RenderError` with its
+own structured code:
+
+- **401** → `auth_expired` (exit 2). Same code as the one-shot
+  status path so the operator's mental model stays consistent.
+- **403** → `insufficient_role` (exit 5). New code added in T5
+  because re-running `meho login` won't help — the remedy is a
+  tenant-admin role grant.
+- **400** → `unexpected_response` (exit 4) with the body's detail
+  string. The only realistic 400 today is an invalid SSE cursor
+  the operator hand-edited in a wrapper script.
+
+### Output discipline
+
+Same Goal #11 §5 split as one-shot status:
+
+- **Default human path**: one space-padded line per event
+  (`<ts>  <principal>  <op_id>  <result_status>  <summary>`).
+  Summary is `(aggregate-only)` for `credential_read` and
+  `audit_query` op classes; otherwise `target=<name>` when the
+  event carries a target; otherwise empty.
+- **`--json`**: one raw JSON document per line — the SSE `data:`
+  field byte-identical, with one trailing newline. `meho status
+  --watch --json | jq` is the canonical agent-consumer shape.
+- **Errors**: `RenderError` envelope to stderr; stdout stays clean
+  on the JSON path so a consumer's `jq` doesn't choke on a
+  half-event followed by an error blob.
+
+The bearer token never reaches stdout/stderr — same `eyJ`-prefix
+redaction stance applies, and the unit tests pin the marker.
+
+### Test architecture
+
+`status_watch_test.go` drives end-to-end coverage:
+
+- An in-process `fakeFeed` httptest server records every received
+  Authorization, Last-Event-Id, and query string and serves
+  scripted SSE bodies. Frames are written ONCE across all
+  connections combined so the reconnect-replay path doesn't loop
+  forever (a naive "each connection writes all frames" model
+  busy-loops because the cursor never advances past the same
+  batch). The handler holds the connection open via
+  `<-r.Context().Done()` after the scripted frames so the client's
+  scanner sits in `Scan()` until the test cancels.
+- A `fastBackoff` schedule (five 1 ms slots) collapses the
+  production 1/2/5/10/30 s schedule so the suite runs in
+  milliseconds.
+- A `seedWatchCreds` helper writes a token + config to a
+  `t.TempDir`-backed XDG home, mirroring the one-shot status
+  tests' file-store discipline.
+
+Body-shaping tests (parser, formatter, summariser, URL builder)
+drive the pure helpers directly with table-driven cases; only the
+end-to-end reconnect / 401 / 403 / Ctrl-C tests need the
+`fakeFeed` server.
+
 ## Generated client (`internal/api/`)
 
 `internal/api/client.gen.go` is produced by


### PR DESCRIPTION
## Summary

- Adds `meho status --watch` — a terminal-resident SSE subscriber to `/api/v1/feed` (T4). One rendered line per broadcast event, filters via `--op-class` / `--principal` / `--target`, reconnect-with-`Last-Event-Id` on disconnect (1s/2s/5s/10s/30s backoff).
- New `output.InsufficientRole` (`exit 5`) for 403 responses — re-running `meho login` doesn't fix a `read_only` role assignment, so the existing `auth_expired` code would mislead the operator.
- Stdlib-only SSE parser (`bufio.Scanner` against `\n\n`-delimited frames + heartbeat-comment skip + retry-field recognition). Go's SSE library ecosystem is thin; the parser is ~50 lines and stays under the project's no-new-dependency stance.
- Documentation: `docs/codebase/cli.md` gains a Watch flow section describing dispatch, wire format, backoff schedule, fatal status codes, output discipline, and the test architecture.

## Test plan

- [x] `go vet ./...` — clean
- [x] `gofmt -s -l ./...` — clean
- [x] `golangci-lint run` — clean (project's `.golangci.yml`)
- [x] `go test -race -cover ./...` — every package passes; `internal/cmd` at 74.8 % (was 76 %; new SSE surface absorbs the headroom).
- [x] AC #1 — `meho status --watch` connects + renders events (TestRunWatch_RendersHumanLine).
- [x] AC #2 — default human path + `--json` raw JSON per line (TestRunWatch_JSONLines).
- [x] AC #3 — filters forward to query params (TestRunWatch_FilterFlagsForwardToQuery).
- [x] AC #4 — disconnect → backoff retry with `Last-Event-Id` (TestRunWatch_ReconnectsWithLastEventID; in-process fakeFeed drops mid-stream).
- [x] AC #5 — `Ctrl-C` clean exit (TestRunWatch_ContextCancel_CleanExit; pre-cancelled context returns nil so cobra exits 0).
- [x] AC #6 — no stored token → `auth_expired` (TestRunWatch_NoCreds_ExitsAuthExpired).
- [x] AC #7 — 403 → `insufficient_role` exit 5 (TestRunWatch_403_ExitsInsufficientRole).
- [x] AC #8 — `(aggregate-only)` placeholder for `credential_read` / `audit_query` (TestRunWatch_AggregateOnlyClass + TestHumanLine table cases).
- [x] AC #9 — SSE parser + formatter unit tests (TestParseSSE_MultilineDataFrame, TestParseSSE_HeartbeatSkipped, TestParseSSE_RetryFieldIgnored, TestHumanLine, TestSummariseEvent, TestBuildFeedURL, TestBackoffDuration).
- [x] AC #10 — CI green (this PR's checks).

## Acceptance criteria not covered as standalone tests

- AC #11 — Initiative #228 body's T5 checkbox tick happens post-merge as the project-board action; not part of this diff.

## Out of scope

- Color theming, pause/resume hotkeys, save-to-file, multi-value filters, statusline TUI — per the issue body.
- T6 (#312) — MCP `feed` resource that consumes the same SSE stream from agent contexts. Independent code path; landed separately.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #311


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `meho status --watch` mode that streams live status updates from the server in real-time
  * Support for filtering updates with `--op-class`, `--principal`, and `--target` flags
  * New exit code for insufficient authorization errors

* **Tests**
  * Comprehensive test suite for watch mode covering reconnection, filtering, and error scenarios

* **Documentation**
  * Added documentation for the new `meho status --watch` command and streaming behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/384)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->