### PR TITLE
feat(mcp): meho://tenant/{id}/feed resource + broadcast onboarding doc (G6.1-T6a)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -93,6 +93,7 @@ select = [
 "tests/test_mcp_audit.py" = ["F811"]
 "tests/test_mcp_tool_meho_status.py" = ["F811"]
 "tests/test_mcp_resource_tenant_info.py" = ["F811"]
+"tests/test_mcp_resource_tenant_feed.py" = ["F811"]
 # A005 flags any module name that matches a stdlib module by short name,
 # regardless of package path. These two are namespaced under
 # `meho_backplane.*` and are never imported as bare `operator` / `logging`,

--- a/backend/src/meho_backplane/mcp/resources/tenant_feed.py
+++ b/backend/src/meho_backplane/mcp/resources/tenant_feed.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho://tenant/{tenant_id}/feed`` — recent broadcast events snapshot (G6.1-T6a).
+
+A polling MCP surface onto the same per-tenant Valkey stream the SSE
+endpoint at :mod:`meho_backplane.api.v1.feed` streams in real time.
+The resource returns the most recent :data:`_FEED_SNAPSHOT_COUNT`
+events in chronological order; MCP clients that need live updates
+re-read the resource on their own cadence. v0.2 advertises no
+``subscribe`` capability (per the MCP 2025-06-18 spec, omitting the
+field declares no subscription support, which is the correct shape
+for a poll-only resource).
+
+Tenant-boundary enforcement
+===========================
+
+The handler validates the URI-bound ``tenant_id`` against the
+operator's JWT-derived ``tenant_id`` before issuing any Valkey
+command. The check runs *before* the stream read so a probe attempt
+against an arbitrary tenant UUID can't time-channel-leak whether
+that tenant produces events. Cross-tenant reads collapse onto
+:class:`~meho_backplane.mcp.server.McpInvalidParamsError` (-32602),
+matching the convention :mod:`tenant_info` established for the
+``meho://tenant/{tenant_id}/info`` resource.
+
+Why XREVRANGE + reverse instead of XRANGE
+==========================================
+
+``XREVRANGE meho:feed:{tenant_id} + - COUNT N`` reads the
+most-recent N entries directly from the stream tail without
+scanning the whole key. A naive ``XRANGE ... + COUNT N`` (start from
+the head) would return the oldest N entries, exactly the wrong
+half. The handler then reverses the result so the JSON output
+reads chronologically (oldest-first), which matches operator
+intuition when scanning a feed in a terminal.
+
+Failure shapes (each maps to ``McpInvalidParamsError``)
+========================================================
+
+* **Malformed ``tenant_id``** — URI bound a non-UUID string.
+* **Cross-tenant read** — bound tenant != operator's JWT tenant.
+* Other failure modes (Valkey unreachable, redis-py teardown race)
+  bubble up to the dispatcher as ``McpInternalError`` (-32603); the
+  read path is not fail-open the way the publisher is — a failing
+  resource read is a real signal to the operator, not a degraded
+  feed.
+
+Skipped entries during deserialisation
+=======================================
+
+Same safety net as the SSE generator at
+:mod:`meho_backplane.api.v1.feed`: entries XADD'd with an unknown
+field shape, or whose ``event`` field doesn't parse as a
+:class:`BroadcastEvent`, are logged and skipped. T3's publisher is
+the only writer today; this branch is forward-compat against a
+future Slack-mirror / downstream tool writing alternate shapes.
+
+References
+----------
+
+* Valkey ``XREVRANGE``: https://valkey.io/commands/xrevrange/
+* MCP 2025-06-18 Resources:
+  https://modelcontextprotocol.io/specification/2025-06-18/server/resources
+* Sibling SSE surface: :mod:`meho_backplane.api.v1.feed` (G6.1-T4).
+* Cross-repo onboarding: ``docs/cross-repo/broadcast-onboarding.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, cast
+from uuid import UUID
+
+import structlog
+from pydantic import ValidationError
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent, get_broadcast_client
+from meho_backplane.mcp.registry import (
+    ResourceTemplateDefinition,
+    register_mcp_resource,
+)
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+__all__: list[str] = []
+
+_log = structlog.get_logger(__name__)
+
+
+#: How many most-recent entries the resource returns per read. Pinned
+#: to 50 per the issue body ("Returns the last N events; default 50").
+#: Bounded by :data:`~meho_backplane.broadcast.publisher.BROADCAST_MAXLEN`
+#: (10000) — a fresh-deploy tenant with fewer than 50 events returns
+#: whatever's there without padding. Operators who need a deeper window
+#: subscribe via the SSE feed (T4); the MCP poll-shaped resource caps
+#: at 50 to keep one ``resources/read`` response bounded in size.
+_FEED_SNAPSHOT_COUNT: Final[int] = 50
+
+
+def _stream_key(tenant_id: UUID) -> str:
+    """Build the per-tenant stream key. Mirrors the publisher + SSE helpers."""
+    return f"meho:feed:{tenant_id}"
+
+
+def _parse_entry(
+    entry_id: str,
+    fields: dict[str, str],
+    *,
+    stream_key: str,
+) -> BroadcastEvent | None:
+    """Deserialise one stream entry; log + skip on shape / parse failure.
+
+    Returns ``None`` rather than raising so the surrounding loop can
+    drop the entry without tearing down the whole resource read. The
+    skip paths match the SSE generator's at
+    :func:`meho_backplane.api.v1.feed._process_entries`:
+
+    * **Unknown field shape** — entry was XADD'd without an ``event``
+      field, or with the ``event`` value as non-string. T3's publisher
+      always emits ``{"event": <json>}``; this branch is the
+      forward-compat safety net.
+    * **Malformed JSON** — ``event`` field doesn't deserialise to a
+      :class:`BroadcastEvent`. Same shape as the SSE side; logged with
+      ``entry_id`` so an operator chasing the event trail can correlate.
+    """
+    raw_event_json = fields.get("event")
+    if not isinstance(raw_event_json, str):
+        _log.warning(
+            "tenant_feed_skipped_unknown_field_shape",
+            stream_key=stream_key,
+            entry_id=entry_id,
+            fields=list(fields.keys()),
+        )
+        return None
+    try:
+        return BroadcastEvent.model_validate_json(raw_event_json)
+    except ValidationError:
+        _log.warning(
+            "tenant_feed_skipped_malformed_event",
+            stream_key=stream_key,
+            entry_id=entry_id,
+        )
+        return None
+
+
+async def _tenant_feed_handler(
+    operator: Operator,
+    bound: dict[str, str],
+) -> dict[str, Any]:
+    """Return the most recent :data:`_FEED_SNAPSHOT_COUNT` events for the tenant.
+
+    Two rejection arms mapped onto ``McpInvalidParamsError`` (-32602):
+    the URI bound a non-UUID string, or the bound tenant differs from
+    the operator's JWT tenant. Both run *before* the Valkey read so a
+    probe attempt against an arbitrary UUID doesn't reach the stream
+    layer.
+
+    Successful response shape::
+
+        {
+            "tenant_id": "<uuid>",
+            "count": <int>,        # actual events in this read; ≤ 50
+            "events": [
+                <BroadcastEvent.model_dump(mode="json") for each event>,
+                ...
+            ]
+        }
+
+    Events are in chronological order (oldest-first). An operator
+    scanning the feed in a terminal reads top-to-bottom as time-forward,
+    which matches the SSE-stream tail. Empty stream → ``count: 0``
+    + ``events: []``; never a 404 — the resource always exists for
+    every tenant.
+    """
+    raw_id = bound["tenant_id"]
+    try:
+        bound_uuid = UUID(raw_id)
+    except ValueError as exc:
+        raise McpInvalidParamsError(
+            f"tenant_feed: invalid tenant_id (not a UUID): {raw_id!r}",
+        ) from exc
+
+    if bound_uuid != operator.tenant_id:
+        raise McpInvalidParamsError(
+            "tenant_feed: cross-tenant access denied — bound "
+            f"tenant_id {raw_id!r} does not match the operator's tenant",
+        )
+
+    stream_key = _stream_key(bound_uuid)
+    client = get_broadcast_client()
+    # XREVRANGE returns newest-first; for the response we reverse to
+    # chronological (oldest-first). The redis-py signature is
+    # ``xrevrange(name, max='+', min='-', count=None)``: with
+    # ``+``/``-`` (full range, no replay cursor), ``count`` is the
+    # bound on entries returned from the tail.
+    raw_entries = cast(
+        "list[tuple[str, dict[str, str]]]",
+        await client.xrevrange(
+            stream_key,
+            max="+",
+            min="-",
+            count=_FEED_SNAPSHOT_COUNT,
+        ),
+    )
+
+    events: list[BroadcastEvent] = []
+    # raw_entries is newest-first; iterate reversed to produce
+    # oldest-first output.
+    for entry_id, fields in reversed(raw_entries):
+        event = _parse_entry(entry_id, fields, stream_key=stream_key)
+        if event is not None:
+            events.append(event)
+
+    return {
+        "tenant_id": str(bound_uuid),
+        "count": len(events),
+        "events": [event.model_dump(mode="json") for event in events],
+    }
+
+
+register_mcp_resource(
+    definition=ResourceTemplateDefinition(
+        uriTemplate="meho://tenant/{tenant_id}/feed",
+        name="Tenant activity feed",
+        description=(
+            "Snapshot of the operator's tenant activity feed — the "
+            "most recent 50 audited operations in chronological order. "
+            "Cross-tenant reads return INVALID_PARAMS. Clients needing "
+            "live updates use GET /api/v1/feed (Server-Sent Events) or "
+            "re-read this resource on their own cadence; the MCP "
+            "server advertises no subscribe capability."
+        ),
+        mimeType="application/json",
+        required_role=TenantRole.OPERATOR,
+    ),
+    handler=_tenant_feed_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -118,19 +118,24 @@ def isolated_registry() -> Iterator[None]:
     to re-execute so each test starts from a known registered state
     regardless of cross-file ordering.
 
-    Reloading both ``meho_status`` and ``tenant_info`` unconditionally
+    Reloading ``meho_status`` and both resource modules unconditionally
     is harmless even for tool-only / resource-only test files: the
     tests assert specific entries exist, not that the registry is
-    minimal. Folding both reloads here keeps the autouse fixture
+    minimal. Folding the reloads here keeps the autouse fixture
     single-shape across test files (the duplication driver Sonar
-    flagged pre-T5).
+    flagged pre-T5). ``tenant_feed`` (G6.1-T6a, #312) joins the
+    reload list for the same reason — without it, this fixture's
+    ``clear_registries()`` would leave the feed resource unregistered
+    in any test file that imports the fixture after the first one
+    runs.
     """
-    from meho_backplane.mcp.resources import tenant_info
+    from meho_backplane.mcp.resources import tenant_feed, tenant_info
     from meho_backplane.mcp.tools import meho_status
 
     clear_registries()
     importlib.reload(meho_status)
     importlib.reload(tenant_info)
+    importlib.reload(tenant_feed)
     yield
     clear_registries()
 

--- a/backend/tests/test_mcp_resource_tenant_feed.py
+++ b/backend/tests/test_mcp_resource_tenant_feed.py
@@ -1,0 +1,450 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``meho://tenant/{tenant_id}/feed`` MCP resource (G6.1-T6a, #312).
+
+Covers issue #312's user-facing acceptance criteria:
+
+* **AC #1** — the resource template surfaces via ``resources/templates/list``
+  for an operator (and stays hidden from read-only operators).
+* **AC #2** — ``resources/read meho://tenant/<own>/feed`` returns the
+  last 50 events in chronological order.
+* **AC #3** — ``resources/read meho://tenant/<other>/feed`` rejects with
+  INVALID_PARAMS (the JSON-RPC -32602 mapping `tenant_info` established
+  for the equivalent HTTP 403 case).
+
+AC #4 + AC #5 (50 RPS load test + Valkey-restart chaos) are explicitly
+deferred to T7 per the pushback on the issue body; no test in this
+file attempts them.
+
+The integration suite at the bottom is Docker-gated: it spins up a
+``valkey/valkey:8`` container via testcontainers, XADDs two
+:class:`BroadcastEvent`-shaped entries, and asserts the handler reads
+them back in chronological order. The mocked-client tests in the body
+cover the rejection arms + the deserialisation safety net without
+needing Docker.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    dispose_broadcast_client,
+    get_broadcast_client,
+    publish_event,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.mcp.resources.tenant_feed import _tenant_feed_handler
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.settings import get_settings
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    build_operator,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_AUDIT_ID: UUID = UUID("33333333-3333-3333-3333-333333333333")
+
+
+# ---------------------------------------------------------------------------
+# Per-test broadcast-client isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_broadcast_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear the cached client + pin a stub URL around every test.
+
+    The handler under test calls ``get_broadcast_client()``, which
+    instantiates a real :class:`redis.asyncio.Redis` from the
+    process-wide ``BROADCAST_REDIS_URL``. Pinning the env var keeps
+    the construction path free of "URL not set" failures; the actual
+    client's ``xrevrange`` is then patched per-test.
+    """
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    get_settings.cache_clear()
+    reset_broadcast_client_for_testing()
+    yield
+    reset_broadcast_client_for_testing()
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    *,
+    tenant_id: UUID = OPERATOR_TENANT_ID,
+    op_id: str = "vsphere.vm.list",
+    op_class: str = "read",
+    result_status: str = "ok",
+) -> BroadcastEvent:
+    return BroadcastEvent(
+        event_id=uuid4(),
+        ts=datetime(2026, 5, 13, tzinfo=UTC),
+        tenant_id=tenant_id,
+        principal_sub="op-test",
+        op_id=op_id,
+        op_class=op_class,
+        result_status=result_status,
+        audit_id=_AUDIT_ID,
+        payload={"op_class": op_class, "params": {}, "result_status": result_status},
+    )
+
+
+def _xrevrange_entry(event: BroadcastEvent, entry_id: str) -> tuple[str, dict[str, str]]:
+    """Build one ``XREVRANGE``-shaped entry tuple from a :class:`BroadcastEvent`."""
+    return entry_id, {"event": event.model_dump_json()}
+
+
+# ---------------------------------------------------------------------------
+# resources/templates/list — visibility per role
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_templates_list_exposes_tenant_feed_for_operator(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #1: operator sees the tenant_feed template entry."""
+    client, _op = client_with_operator
+
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "resources/templates/list"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    templates = body["result"]["resourceTemplates"]
+    tenant_feed = [t for t in templates if t["uriTemplate"] == "meho://tenant/{tenant_id}/feed"]
+    assert len(tenant_feed) == 1
+    assert tenant_feed[0]["mimeType"] == "application/json"
+    # MEHO-internal RBAC field stripped from the wire shape.
+    assert "required_role" not in tenant_feed[0]
+
+
+def test_resources_templates_list_hides_tenant_feed_for_read_only(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #1 (negative): read-only operator does not see tenant_feed.
+
+    Read-only is below the resource's ``required_role=OPERATOR`` gate,
+    so :func:`all_resource_templates_for` filters the entry out before
+    the wire shape is built. The ``tenant_info`` resource (required
+    role: READ_ONLY) stays visible — proves the filter is per-resource,
+    not all-or-nothing.
+    """
+    client, _op = client_with_operator  # default fixture role is READ_ONLY
+
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 2, "method": "resources/templates/list"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    templates = body["result"]["resourceTemplates"]
+    feed_templates = [t for t in templates if t["uriTemplate"].endswith("/feed")]
+    assert feed_templates == [], "read_only must not see operator-gated tenant_feed"
+    # Read-only IS allowed to see tenant_info — the role filter is per-resource.
+    info_templates = [t for t in templates if t["uriTemplate"].endswith("/info")]
+    assert len(info_templates) == 1
+
+
+# ---------------------------------------------------------------------------
+# resources/read — happy path through the MCP dispatcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_read_own_tenant_returns_chronological_events(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #2: read returns the recent events, chronological (oldest-first).
+
+    Patches ``xrevrange`` on the broadcast client to return three
+    entries newest-first; asserts the handler reverses them into
+    chronological order in the response.
+    """
+    client, op = client_with_operator
+    uri = f"meho://tenant/{op.tenant_id}/feed"
+
+    # Three events; XREVRANGE returns newest-first.
+    e_new = _make_event(op_id="vsphere.vm.create")  # newest
+    e_mid = _make_event(op_id="vsphere.vm.list")
+    e_old = _make_event(op_id="vault.kv.read")  # oldest
+    xrev_payload = [
+        _xrevrange_entry(e_new, "1715600003000-0"),
+        _xrevrange_entry(e_mid, "1715600002000-0"),
+        _xrevrange_entry(e_old, "1715600001000-0"),
+    ]
+
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrevrange", new=AsyncMock(return_value=xrev_payload)) as xrev:
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "resources/read",
+                "params": {"uri": uri},
+            },
+        )
+
+    xrev.assert_awaited_once()
+    args = xrev.await_args.args
+    kwargs = xrev.await_args.kwargs
+    assert args[0] == f"meho:feed:{op.tenant_id}"
+    assert kwargs["max"] == "+"
+    assert kwargs["min"] == "-"
+    assert kwargs["count"] == 50
+
+    assert response.status_code == 200
+    body = response.json()
+    contents = body["result"]["contents"]
+    assert contents[0]["uri"] == uri
+    assert contents[0]["mimeType"] == "application/json"
+
+    payload = json.loads(contents[0]["text"])
+    assert payload["tenant_id"] == str(op.tenant_id)
+    assert payload["count"] == 3
+    # Chronological order: oldest first → newest last.
+    op_ids = [e["op_id"] for e in payload["events"]]
+    assert op_ids == ["vault.kv.read", "vsphere.vm.list", "vsphere.vm.create"]
+
+
+# ---------------------------------------------------------------------------
+# resources/read — rejection arms
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_read_cross_tenant_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC #3: a URI bound to a different tenant rejects with -32602.
+
+    The tenant-boundary check runs *before* the XREVRANGE call, so the
+    test doesn't even need to patch ``xrevrange`` — the handler short-
+    circuits on the operator-vs-URI mismatch before reaching the
+    Valkey layer.
+    """
+    client, _op = client_with_operator
+    foreign_tenant = uuid4()
+    uri = f"meho://tenant/{foreign_tenant}/feed"
+
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrevrange", new=AsyncMock(return_value=[])) as xrev:
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "resources/read",
+                "params": {"uri": uri},
+            },
+        )
+
+    xrev.assert_not_awaited()  # short-circuited before any Valkey call
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "cross-tenant" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_read_invalid_uuid_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """A non-UUID bound to ``{tenant_id}`` rejects with -32602."""
+    client, _op = client_with_operator
+    uri = "meho://tenant/not-a-uuid/feed"
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "resources/read",
+            "params": {"uri": uri},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "not a uuid" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_read_empty_stream_returns_empty_events(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """Empty stream → count=0 + events=[] (never 404 — resource always exists)."""
+    client, op = client_with_operator
+    uri = f"meho://tenant/{op.tenant_id}/feed"
+
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrevrange", new=AsyncMock(return_value=[])):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "resources/read",
+                "params": {"uri": uri},
+            },
+        )
+
+    body = response.json()
+    payload = json.loads(body["result"]["contents"][0]["text"])
+    assert payload == {
+        "tenant_id": str(op.tenant_id),
+        "count": 0,
+        "events": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Handler-level: deserialisation safety net (skip + log on bad entry)
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_skips_unknown_field_shape() -> None:
+    """An entry without an ``event`` field is logged + skipped, not raised.
+
+    Exercises the safety net at :func:`_parse_entry`: T3's publisher
+    always emits ``{"event": <json>}``, but a future Slack-mirror or
+    third-party writer could XADD a different shape onto the same
+    stream key. The handler must keep going, not 500.
+    """
+    op = build_operator(TenantRole.OPERATOR)
+    # Two entries: one valid (the good one), one with the wrong field shape.
+    good = _make_event()
+    raw_entries = [
+        _xrevrange_entry(good, "1715600002000-0"),
+        ("1715600001000-0", {"unexpected_key": "nothing-useful"}),
+    ]
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrevrange", new=AsyncMock(return_value=raw_entries)):
+        result = await _tenant_feed_handler(op, {"tenant_id": str(op.tenant_id)})
+
+    # One event survived; the unknown-shape entry got dropped.
+    assert result["count"] == 1
+    assert result["events"][0]["event_id"] == str(good.event_id)
+
+
+async def test_handler_skips_malformed_event_json() -> None:
+    """An entry whose ``event`` field doesn't parse as ``BroadcastEvent`` is skipped."""
+    op = build_operator(TenantRole.OPERATOR)
+    good = _make_event()
+    raw_entries = [
+        _xrevrange_entry(good, "1715600002000-0"),
+        ("1715600001000-0", {"event": '{"this": "is not", "a": "BroadcastEvent"}'}),
+    ]
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrevrange", new=AsyncMock(return_value=raw_entries)):
+        result = await _tenant_feed_handler(op, {"tenant_id": str(op.tenant_id)})
+
+    assert result["count"] == 1
+    assert result["events"][0]["event_id"] == str(good.event_id)
+
+
+# ---------------------------------------------------------------------------
+# Optional testcontainers integration suite — publish-and-read round-trip
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_DOCKER_AVAILABLE = _docker_socket_present()
+_SKIP_REASON = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason=_SKIP_REASON)
+class TestTenantFeedIntegration:
+    """End-to-end smoke: publish two events → handler reads them in order.
+
+    Drives the same publisher T3 uses (``publish_event``) so the
+    integration covers the full XADD → XREVRANGE seam this resource
+    wires up. Mirrors the ``TestBroadcastIntegration`` pattern from
+    ``test_broadcast_client`` / ``test_broadcast_publisher``.
+    """
+
+    @pytest.fixture
+    async def valkey_url(self, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[str]:
+        from testcontainers.redis import RedisContainer
+
+        image = os.environ.get("MEHO_TEST_VALKEY_IMAGE", "valkey/valkey:8")
+        with RedisContainer(image) as container:
+            host = container.get_container_host_ip()
+            port = container.get_exposed_port(6379)
+            url = f"redis://{host}:{port}"
+            monkeypatch.setenv("BROADCAST_REDIS_URL", url)
+            get_settings.cache_clear()
+            reset_broadcast_client_for_testing()
+            try:
+                yield url
+            finally:
+                await dispose_broadcast_client()
+                get_settings.cache_clear()
+
+    async def test_xadd_then_resource_read_round_trip(self, valkey_url: str) -> None:
+        """Publish two events; the handler reads them back oldest-first."""
+        op = build_operator(TenantRole.OPERATOR)
+        e_old = _make_event(op_id="vsphere.vm.list")
+        e_new = _make_event(op_id="vsphere.vm.create")
+        # Publish in order: old first, then new. XREVRANGE returns
+        # newest-first; the handler reverses to chronological.
+        await publish_event(e_old)
+        await publish_event(e_new)
+
+        result = await _tenant_feed_handler(op, {"tenant_id": str(op.tenant_id)})
+
+        assert result["tenant_id"] == str(op.tenant_id)
+        assert result["count"] == 2
+        op_ids = [e["op_id"] for e in result["events"]]
+        assert op_ids == ["vsphere.vm.list", "vsphere.vm.create"]

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -382,6 +382,30 @@ this stage it exposes:
   during T4 so the chassis route and the MCP tool share the same
   federation-proof probe chain rather than diverging.
 
+* MCP tenant activity feed resource (G6.1-T6a, #312) —
+  `backend/src/meho_backplane/mcp/resources/tenant_feed.py` registers
+  `meho://tenant/{tenant_id}/feed` as a `ResourceTemplateDefinition`
+  (required role: `operator`). The handler validates the URI-bound
+  `tenant_id` against `operator.tenant_id` *before* any Valkey call
+  (same boundary discipline as `tenant_info`), then issues
+  `XREVRANGE meho:feed:{tenant_id} + - COUNT 50` and reverses the
+  result into chronological (oldest-first) order. Response shape:
+  `{tenant_id, count, events: [<BroadcastEvent.model_dump(mode="json")>]}`.
+  The MCP server advertises no `subscribe` capability (per the
+  2025-06-18 spec, an omitted field declares no subscription
+  support — the correct shape for a poll-only resource); clients
+  needing live push use `GET /api/v1/feed` (SSE, T4) or
+  `meho status --watch` (T5). Entries with an unknown field shape
+  or whose `event` JSON doesn't validate as a `BroadcastEvent` are
+  logged and skipped — same forward-compat safety net the SSE
+  generator at `api/v1/feed.py` uses against a future Slack-mirror
+  / downstream tool writing alternate shapes onto the same stream
+  key. T6 originally bundled a load-test acceptance + Valkey-restart
+  chaos test on the same task; the `/auto-implement-issue` Phase 4
+  pushback split T6 into T6a (this resource + onboarding doc) and a
+  follow-up T7 that lands once chart-CI hardening (#347 follow-up)
+  makes the helm-test job gating.
+
 * MCP tool + resource registries (Task #248, G0.5-T3) — the substrate
   every G3–G9 verb registers against. `backend/src/meho_backplane/mcp/registry.py`
   exposes `register_mcp_tool(definition, handler)` /

--- a/docs/cross-repo/broadcast-onboarding.md
+++ b/docs/cross-repo/broadcast-onboarding.md
@@ -1,0 +1,277 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Broadcast onboarding — consumer-side recipe
+
+> Operator-facing recipe for subscribing to the MEHO activity
+> broadcast. The implementation lives in
+> [`backend/src/meho_backplane/broadcast/`](../../backend/src/meho_backplane/broadcast/)
+> and `api/v1/feed.py`; this doc is the surface every consumer reads
+> when wiring `meho status --watch`, an MCP client, or a custom
+> downstream subscriber.
+
+## What broadcast is
+
+Every authenticated request that produces an audit row also produces
+exactly one **broadcast event** on a per-tenant Valkey stream
+(`meho:feed:<tenant_id>`). Subscribers tail the stream to get a
+real-time view of what every operator in their tenant is doing —
+the equivalent of `git log --follow` for inventory operations.
+
+The audit row is the **canonical record** (durable, queryable via
+G8's audit-query API). The broadcast feed is the **real-time view**
+(in-memory in Valkey, capped at ~10 000 events per tenant, ~24 h
+worth at moderate load). A subscriber that misses an event still
+finds it in `audit_log`; a subscriber that needs ordering guarantees
+queries audit_log by `audit_id` to reconcile gaps.
+
+## Three transports
+
+Every transport reads the same per-tenant stream. Pick by use case:
+
+| Transport | Best for | Spec |
+|---|---|---|
+| `meho status --watch` CLI | Terminal-resident operator triage | G6.1-T5 (#311) |
+| `GET /api/v1/feed` SSE | Custom dashboards, browser-side viewers, scripts that need live push | G6.1-T4 (#310) |
+| `meho://tenant/{tenant_id}/feed` MCP resource | LLM clients (Claude, MCP-aware agents) that poll a snapshot | G6.1-T6 (this task) |
+
+The Slack mirror (G6.2 #333) and any future web admin UI subscribe
+the same way — XREAD against the per-tenant stream key.
+
+## CLI: `meho status --watch`
+
+The fastest path for an operator at a terminal:
+
+```console
+$ meho status --watch
+[12:04:01] ok       op-alice   vsphere.vm.list      cluster=prod-vc-1
+[12:04:02] denied   op-bob     vault.kv.read        (credential read — aggregate-only)
+[12:04:05] ok       op-alice   k8s.pod.get          target=meho-prod
+```
+
+Filters (composable):
+
+```console
+$ meho status --watch --filter op=vault           # only vault ops
+$ meho status --filter principal=op-alice         # only one operator
+$ meho status --watch --filter target=meho-prod   # only one target
+```
+
+The CLI handles reconnect-with-replay automatically via SSE's
+`Last-Event-Id`. A laptop closing its lid loses no events on
+reconnect — the Valkey stream replays from the last seen entry id.
+
+## HTTP SSE: `GET /api/v1/feed`
+
+Standard WHATWG `EventSource` protocol. Use this when the CLI doesn't
+fit (custom dashboard, headless script, third-party tool):
+
+```javascript
+const events = new EventSource(
+  `${BACKPLANE_URL}/api/v1/feed?op_class=write`,
+  { withCredentials: true },
+);
+
+events.addEventListener("broadcast", (msg) => {
+  const event = JSON.parse(msg.data);
+  console.log(event.op_id, event.principal_sub, event.result_status);
+});
+```
+
+Query parameters (all optional, exact-match):
+
+* `op_class` — one of `read`, `write`, `credential_read`,
+  `audit_query`, `other`.
+* `principal` — JWT `sub` claim (operator identifier).
+* `target` — target name (when the op operates on a specific target).
+* `since=<entry_id>` — replay cursor (server-side bridges; SSE
+  clients use the `Last-Event-Id` header instead).
+
+Heartbeats: the server emits `: heartbeat\n\n` (SSE comment line)
+every 30 s of outbound silence so intermediaries (nginx, ALB,
+CloudFront) don't idle-timeout the connection.
+
+Disconnect handling: client disconnect propagates as cancellation
+into the server-side generator; the next event-loop tick releases
+the Valkey BLOCKing read.
+
+## MCP resource: `meho://tenant/{tenant_id}/feed`
+
+Designed for LLM clients that poll a snapshot rather than maintain
+a live socket. The resource returns the **most recent 50 events** in
+chronological order:
+
+```console
+$ mcp-inspector --uri "meho://tenant/<your-uuid>/feed"
+{
+  "tenant_id": "<uuid>",
+  "count": 47,
+  "events": [
+    {"event_id": "...", "ts": "...", "op_id": "vault.kv.read", ...},
+    {"event_id": "...", "ts": "...", "op_id": "k8s.pod.get",  ...},
+    ...
+  ]
+}
+```
+
+The MCP server advertises **no subscribe capability**: clients that
+need live updates re-read the resource on their own cadence. SSE is
+the canonical live-push surface; the MCP resource exists for clients
+that don't speak SSE (most pure JSON-RPC LLM tooling).
+
+Cross-tenant reads (`meho://tenant/<someone-else>/feed`) reject
+with JSON-RPC `INVALID_PARAMS` (-32602). The bound `tenant_id` must
+match the operator's JWT-derived tenant.
+
+## PII defaults (decision #3)
+
+The publisher applies a sensitivity classifier to every event
+**before** XADD onto the stream. The taxonomy:
+
+| `op_class` | Examples | Payload visibility |
+|---|---|---|
+| `credential_read` | `vault.kv.read`, `vault.kv.list` | **Aggregate only.** Payload: `{op_id, target_name, result_status}`. Path / key names / values are stripped. |
+| `audit_query` | G8 audit verbs | **Aggregate only.** Payload: `{op_id, result_status, row_count}`. Filter contents stripped. |
+| `read` | `.list`, `.info`, `.get`, `.about`, `.ls` suffix | **Full detail.** Payload carries request params + structured response summary. |
+| `write` | `.create`, `.update`, `.delete`, `.patch` suffix | **Full detail.** Same shape as `read`. |
+| `other` | Anything else (chassis HTTP routes, unmapped ops) | **Full detail.** |
+
+Operators verifying credential reads are correctly aggregate-only:
+
+```console
+$ meho status --watch --filter op=vault | head -1
+[12:04:02] denied   op-bob     vault.kv.read   (no path / no key)
+```
+
+A `vault.kv.read` event whose payload includes a `path` field would
+be a privacy regression — the integration test
+[`test_broadcast_publisher.py`](../../backend/tests/test_broadcast_publisher.py)
+explicitly negative-asserts this.
+
+Future tightening (G6.3 #333-class follow-up): per-tenant
+opt-in/opt-out flags will let operators flip `credential_read` /
+`audit_query` to full-detail (e.g. for internal-only-trusted
+tenants). v0.2 ships conservative defaults; the toggle is a separate
+Initiative.
+
+## Authentication + RBAC
+
+All three transports honour the same gates:
+
+* **JWT validation** — every request carries a Keycloak-minted JWT;
+  the chassis `verify_jwt` chain validates issuer / audience / kid
+  rotation / `exp` / `nbf`. See
+  [`keycloak-tenant-claims.md`](keycloak-tenant-claims.md) for the
+  claim contract.
+* **Tenant scoping** — the stream key is derived from
+  `operator.tenant_id` (the JWT claim, not a request parameter).
+  Cross-tenant subscription is impossible by construction — there's
+  no body field or URI fragment that accepts another tenant's ID,
+  and the MCP resource rejects URI-bound mismatches with
+  `INVALID_PARAMS`.
+* **Role** — `operator` minimum on SSE + MCP feed. `read_only`
+  operators have lower-friction surfaces (`meho status` snapshot,
+  knowledge-base search) and don't get live activity. `tenant_admin`
+  inherits operator privileges.
+
+A `read_only` operator hitting `GET /api/v1/feed` receives `403
+insufficient_role` + an `insufficient_role` structured log event for
+operator triage.
+
+## Troubleshooting
+
+### `401 Unauthorized` from `/api/v1/feed` or `connection closed: 401`
+
+Token expired or audience mismatch. Verify:
+
+```console
+$ meho auth whoami        # prints sub / tenant_id / expiry
+$ meho status             # tests the federation chain end-to-end
+```
+
+If `meho status` works but `meho status --watch` doesn't, the issue
+is the audience-binding split between `/api/v1/*` and `/mcp`. The
+SSE feed uses the chassis audience (`KEYCLOAK_AUDIENCE`); the MCP
+resource uses the MCP audience (`MCP_RESOURCE_URI`). A token minted
+for one won't satisfy the other.
+
+### `403 insufficient_role`
+
+The operator's `tenant_role` JWT claim is `read_only`. Either
+elevate to `operator` in Keycloak or switch to the snapshot surface
+(`meho status` without `--watch`).
+
+### Empty feed despite running operations
+
+* Check `broadcast_publish_errors_total` on `/metrics` — a sustained
+  nonzero rate indicates the publisher swallowed events (Valkey
+  unreachable, redis-py teardown race). Audit rows still land; only
+  the broadcast feed is degraded.
+* Check the Valkey pod is reachable from the backplane:
+  `/ready` returns 503 with detail `unreachable: <ExcClass>` when
+  the `broadcast_readiness_probe` can't reach Valkey.
+
+### SSE connection drops every 60 s
+
+An intermediary (nginx, ALB, CloudFront) is idle-timing-out a quiet
+stream. The server emits heartbeats every 30 s of outbound silence
+specifically to defeat this. If you still see drops, check:
+
+* The proxy honours SSE: `Cache-Control: no-cache` + `X-Accel-Buffering: no`
+  response headers are set by the backplane; some proxies strip them.
+* `proxy_read_timeout` / equivalent is ≥ 60 s.
+
+### MCP `INVALID_PARAMS: cross-tenant access denied`
+
+The URI bound a `tenant_id` that doesn't match the operator's JWT
+claim. Use the operator's OWN `tenant_id` (visible via the
+`meho://tenant/<id>/info` resource).
+
+### Replay gaps after a Valkey pod restart
+
+Valkey's RDB snapshot recovers most events on restart, but a
+sub-second window of in-flight XADDs may be lost between snapshot
+intervals. The audit_log row is always durable — a subscriber that
+needs gap-free ordering queries `audit_log` by `audit_id` after
+replay. The load-test acceptance for the chaos case ships in
+[G6.1-T7](https://github.com/evoila/meho/issues/312#issuecomment-pushback-thread)
+(separate task; see issue #312 pushback thread).
+
+## What gets broadcast vs. what doesn't
+
+**Broadcast:**
+
+* Every authenticated HTTP request to `/api/v1/*` (audit-middleware
+  publishes after the audit row commits).
+* Every MCP `tools/call` and `resources/read` (MCP handlers publish
+  in the same finally block as their audit row).
+
+**Not broadcast:**
+
+* Unauthenticated requests (`/healthz`, `/ready`, `/metrics`,
+  `/.well-known/oauth-protected-resource`) — no operator to
+  attribute, no broadcast row.
+* 401 responses — same reason.
+* The MCP `initialize` / `ping` / `notifications/initialized`
+  JSON-RPC envelope itself — only the wrapped tool/resource calls
+  generate broadcast events.
+* Internal cron jobs and lifespan hooks (engine pre-warm, embedding
+  preload) — no JWT, no operator.
+
+## References
+
+* Initiative: [#228](https://github.com/evoila/meho/issues/228).
+* Component spec: [`docs/codebase/backend.md`](../codebase/backend.md)
+  (Broadcast publish-on-write hook section).
+* SSE endpoint:
+  [`backend/src/meho_backplane/api/v1/feed.py`](../../backend/src/meho_backplane/api/v1/feed.py).
+* MCP resource:
+  [`backend/src/meho_backplane/mcp/resources/tenant_feed.py`](../../backend/src/meho_backplane/mcp/resources/tenant_feed.py).
+* CLI verb:
+  [`cli/internal/cmd/status_watch.go`](../../cli/internal/cmd/status_watch.go).
+* Decision #3 (PII defaults): `docs/planning/v0.2-decisions.md`.
+* Valkey Streams reference: <https://valkey.io/topics/streams-intro/>
+* MCP 2025-06-18 Resources spec:
+  <https://modelcontextprotocol.io/specification/2025-06-18/server/resources>


### PR DESCRIPTION
## Summary

Lands the user-facing half of **G6.1-T6** (#312) — MCP resource +
cross-repo onboarding doc. The load-test acceptance and Valkey-restart
chaos test that the original T6 also bundled defer to a new T7 ticket
per the Phase-4 pushback (full rationale in the issue thread).

- **`mcp/resources/tenant_feed.py`** registers
  `meho://tenant/{tenant_id}/feed` (`required_role=OPERATOR`). Handler
  validates the URI-bound `tenant_id` against `operator.tenant_id`
  **before** any Valkey call (same discipline `tenant_info` uses);
  cross-tenant / malformed-UUID rejections map to
  `McpInvalidParamsError` (-32602). Issues `XREVRANGE meho:feed:{id}
  + - COUNT 50` and reverses to chronological order. Entries with
  unknown field shape or unparseable JSON are logged + skipped — same
  forward-compat safety net the SSE generator uses against a future
  Slack-mirror writing alternate shapes onto the stream key.
- **`docs/cross-repo/broadcast-onboarding.md`** is the operator
  recipe: why broadcast exists, how to subscribe (CLI / SSE / MCP),
  the PII contract per decision #3 (credential_read + audit_query
  aggregate-only), and troubleshooting for token-expired /
  role-insufficient / pod-unreachable / SSE idle-timeout.
- **`docs/codebase/backend.md`** picks up a Key types row for the
  new MCP resource next to `tenant_info`, with the T6 split
  rationale recorded.

The MCP server advertises **no `subscribe` capability** (per the
[2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18/server/resources),
an omitted field declares no subscription support — the correct shape
for a poll-only resource). Clients needing live push use the SSE
feed (T4) or `meho status --watch` (T5).

## Test plan

- [x] `uv run ruff check src/ tests/` — All checks passed.
- [x] `uv run ruff format --check src/ tests/` — 118 files already formatted.
- [x] `uv run mypy src/` — Success: no issues found in 61 source files (strict mode).
- [x] `uv run pytest tests/test_mcp_resource_tenant_feed.py -v` — 9 passed in ~20s, including the Docker-gated real-Valkey integration test (`TestTenantFeedIntegration::test_xadd_then_resource_read_round_trip`).
- [x] `uv run pytest tests/` (full regression) — **632 passed**, 2 skipped (slow fastembed + macOS-only `process_resident_memory_bytes`), 2 deselected (the same pre-existing `test_observability` Darwin gap + `test_connectors_k8s_k3d::test_api_client_cached_against_live_k3s` failure that reproduces on `origin/main`).
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 1 length warning on the handler (73 lines, threshold 60; ~half is docstring + the load-bearing cross-tenant boundary check that the docstring explicitly calls out as ordered-before-the-Valkey-read).

### Acceptance criteria mapping

- [x] **AC #1** — `meho://tenant/<id>/feed` listed via `resources/templates/list` for an operator — `test_resources_templates_list_exposes_tenant_feed_for_operator[operator]`. Negative coverage (`read_only` does NOT see the entry, but DOES still see `tenant_info`) — `test_resources_templates_list_hides_tenant_feed_for_read_only`.
- [x] **AC #2** — `resources/read meho://tenant/<id>/feed` returns the last 50 events (default 50) — `test_resources_read_own_tenant_returns_chronological_events[operator]` asserts the call passed `count=50, max="+", min="-"` to `xrevrange` and the response is chronological (oldest-first).
- [x] **AC #3** — Cross-tenant read returns 403 (mapped to `INVALID_PARAMS` -32602 on the JSON-RPC transport) — `test_resources_read_cross_tenant_returns_invalid_params[operator]` confirms the handler short-circuits **before** any Valkey call.
- [x] **AC #6** — `docs/cross-repo/broadcast-onboarding.md` written and ready for consumer review. **The "reviewed by consumer before merge" half is a human gate I can't satisfy from inside the implementation** — flagging here so a reviewer can assign the consumer maintainer before this lands.
- [x] **AC #7** — CI: pending (will reflect the same green local checks above).
- [ ] **AC #8** — Initiative #228 body checklist line for T6 ticked — post-merge action.
- [🔀] **AC #4** — Load test (50 RPS / 30s / p99 < 1s, all 1500 events delivered) — **deferred to T7** per Phase-4 pushback (Option A). Reasons: no load-test harness currently in the test stack (no `locust` / `k6` / custom RPS harness); the only place this test could plausibly run is the chart-CI `helm-test` job (#347), which currently fails on PR builds because the migration Job's image `ghcr.io/evoila/meho:test` isn't pushed for PR builds. T7 lands after chart-CI hardening (an existing committed-but-unfiled follow-up from PR #347's review). Full rationale + Option A acceptance: pushback thread on #312.
- [🔀] **AC #5** — Valkey restart resilience (forced pod restart mid-test, < 1% event loss) — **deferred to T7** for the same reason; needs kind cluster orchestration + a working chart-CI pipeline.

## Out of scope

- **Load test + chaos test (AC #4 + #5)** — will land in T7 alongside chart-CI hardening. I'll file T7 immediately after this PR opens with `Depends on: #312 + chart-CI hardening follow-up`. AC #4 + #5 of #312 carry across verbatim.
- T5 sibling (`meho status --watch` CLI, #311) — open in PR #384, independent track. Zero file collision with this PR (T5 touches `cli/*.go`, this touches `mcp/resources/*.py`).
- Slack mirror (G6.2 #333) — separate Initiative.

## Reviewer notes

- The MCP test fixture `mcp_test_fixtures.py` grows by one `importlib.reload(tenant_feed)` call to keep cross-test registry isolation working. The fixture is shared with the existing 3 MCP test files; the reload is harmless for them (they assert specific entries exist, not registry size). Same pattern the comment in that fixture's docstring justifies.
- `pyproject.toml` F811 per-file-ignore list grows by one matching entry — same convention the other three MCP-fixture-importing test files already use (the pytest-fixture-injection-by-parameter-name pattern triggers F811 by design).
- The `_tenant_feed_handler` function-size warning (73 lines, threshold 60) is mostly docstring + the boundary-check-then-Valkey-fetch sequence the docstring calls out as load-bearing. Extracting helpers would obscure the ordering invariant — left as-is.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tenant activity feed resource enabling per-tenant broadcast event polling with chronological snapshot delivery.

* **Documentation**
  * Added broadcast onboarding guide covering consumer-side subscription and integration patterns.
  * Added tenant feed resource documentation with authentication, access controls, and troubleshooting guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/385)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->