### PR TITLE
feat(connectors): G0.2-T6 CLI dispatch + /api/v1/connectors/{product}/{op_id} route

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors.py
+++ b/backend/src/meho_backplane/api/v1/connectors.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``POST /api/v1/connectors/{product}/{op_id}`` — generic connector dispatch route.
+
+End-to-end acceptance surface for G0.2 (Initiative #223, Task #245).
+
+The route resolves the product slug to a registered connector class, builds
+a pre-G0.3 target stub from the operator's JWT, and delegates to
+``connector.execute(target, op_id, params)``. The entire authentication +
+registry + connector chain is exercised on every call.
+
+**Target resolution (pre-G0.3):** ``_TargetStub`` carries only ``raw_jwt``.
+Once G0.3 (#224) lands, replace ``_build_target`` with a call to
+``resolve_target(operator.tenant_id, request.target)`` that returns a real
+``Target`` row from the DB. The connector's duck-type contract (any object
+with ``raw_jwt`` works) is forward-compatible; no rework needed in T6 once
+G0.3 lands.
+
+**HTTP contract:**
+
+- ``404`` — unknown product (not in registry).
+- ``400`` — unknown op-id (the connector returned ``unknown_op`` in the result).
+- ``401`` — unauthenticated or expired JWT (raised by ``verify_jwt_and_bind``).
+- ``200`` — all other outcomes, including connector-side errors (connection
+  failure, read failure, param-validation errors). Callers inspect
+  ``OperationResult.status`` to distinguish success from errors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import get_connector
+from meho_backplane.middleware import verify_jwt_and_bind
+
+__all__ = ["router"]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/connectors", tags=["connectors"])
+
+
+class ConnectorExecRequest(BaseModel):
+    """Request body for connector operation dispatch."""
+
+    target: str
+    params: dict[str, Any] = {}
+
+
+@dataclass(frozen=True)
+class _TargetStub:
+    """Pre-G0.3 target stand-in. Duck-types as VaultTarget via ``raw_jwt``.
+
+    Replace with ``resolve_target(tenant_id, slug)`` from G0.3 once it lands.
+    Any connector whose execute() reads ``target.raw_jwt`` works with this stub.
+    """
+
+    raw_jwt: str | None = None
+
+
+def _build_target(operator: Operator, _target_slug: str) -> _TargetStub:
+    """Resolve a target slug to a usable target object.
+
+    Pre-G0.3 stub: ignores the slug and returns a stub carrying the operator's
+    JWT so VaultConnector's OIDC-forward path works. G0.3-T3 replaces this with
+    a real DB lookup against the targets table.
+    """
+    return _TargetStub(raw_jwt=operator.raw_jwt)
+
+
+@router.post("/{product}/{op_id}")
+async def execute_op(
+    product: str,
+    op_id: str,
+    request: ConnectorExecRequest,
+    operator: Operator = Depends(verify_jwt_and_bind),
+) -> dict[str, Any]:
+    """Dispatch an operation to the named connector.
+
+    Looks up the connector by product slug, builds a pre-G0.3 target stub,
+    and delegates to ``connector.execute(target, op_id, params)``. Returns
+    the ``OperationResult`` as JSON on success. Returns 404 for an unknown
+    product and 400 for an unknown op-id (with the known ops list in the
+    error body so operators can enumerate what the connector supports).
+    """
+    log = _log.bind(product=product, op_id=op_id, target=request.target)
+
+    cls = get_connector(product)
+    if cls is None:
+        log.warning("connector_not_found", product=product)
+        raise HTTPException(status_code=404, detail=f"unknown product: {product}")
+
+    target = _build_target(operator, request.target)
+    connector = cls()
+    # Connectors use fully-qualified op ids (e.g. "vault.kv.read").
+    # The URL path splits that into {product}/{op_id}, so we re-join here.
+    qualified_op_id = f"{product}.{op_id}"
+    result = await connector.execute(target, qualified_op_id, request.params)
+
+    unknown_op = result.status == "error" and (result.error or "").startswith("unknown_op")
+    if unknown_op:
+        known_ops = list(result.extras.get("known_ops", []))
+        log.warning("connector_unknown_op", op_id=qualified_op_id, known_ops=known_ops)
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "unknown_op", "op_id": qualified_op_id, "known_ops": known_ops},
+        )
+
+    log.info(
+        "connector_op_dispatched",
+        status=result.status,
+        duration_ms=result.duration_ms,
+    )
+    return result.model_dump()

--- a/backend/src/meho_backplane/api/v1/connectors.py
+++ b/backend/src/meho_backplane/api/v1/connectors.py
@@ -30,7 +30,7 @@ G0.3 lands.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any  # used in ConnectorExecRequest.params
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
@@ -38,6 +38,7 @@ from pydantic import BaseModel
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors import get_connector
+from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.middleware import verify_jwt_and_bind
 
 __all__ = ["router"]
@@ -52,6 +53,14 @@ class ConnectorExecRequest(BaseModel):
 
     target: str
     params: dict[str, Any] = {}
+
+
+class UnknownOpError(BaseModel):
+    """400 response body when the connector doesn't know the requested op."""
+
+    error: str
+    op_id: str
+    known_ops: list[str]
 
 
 @dataclass(frozen=True)
@@ -75,13 +84,20 @@ def _build_target(operator: Operator, _target_slug: str) -> _TargetStub:
     return _TargetStub(raw_jwt=operator.raw_jwt)
 
 
-@router.post("/{product}/{op_id}")
+@router.post(
+    "/{product}/{op_id}",
+    responses={
+        400: {"model": UnknownOpError, "description": "Unknown operation for this connector"},
+        401: {"description": "Unauthenticated or expired JWT"},
+        404: {"description": "Unknown connector product"},
+    },
+)
 async def execute_op(
     product: str,
     op_id: str,
     request: ConnectorExecRequest,
     operator: Operator = Depends(verify_jwt_and_bind),
-) -> dict[str, Any]:
+) -> OperationResult:
     """Dispatch an operation to the named connector.
 
     Looks up the connector by product slug, builds a pre-G0.3 target stub,
@@ -118,4 +134,4 @@ async def execute_op(
         status=result.status,
         duration_ms=result.duration_ms,
     )
-    return result.model_dump()
+    return result

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -48,6 +48,7 @@ from fastapi import FastAPI, Response
 
 from meho_backplane import __version__
 from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_router
+from meho_backplane.api.v1.connectors import router as api_v1_connectors_router
 from meho_backplane.api.v1.feed import router as api_v1_feed_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.api.v1.retrieve import router as api_v1_retrieve_router
@@ -242,6 +243,10 @@ app.include_router(api_v1_retrieve_router)
 # from the JWT's tenant_id claim so cross-tenant subscription is
 # impossible by construction.
 app.include_router(api_v1_feed_router)
+# G0.2-T6 (#245) -- generic connector dispatch at POST /api/v1/connectors/{product}/{op_id}.
+# Auth-required (verify_jwt_and_bind); the operator's JWT is forwarded
+# to the connector's execute() as part of the pre-G0.3 target stub.
+app.include_router(api_v1_connectors_router)
 # MCP Streamable HTTP transport entrypoint (G0.5-T1, #246) and the
 # RFC 9728 protected-resource metadata document (G0.5-T2, #247).
 #

--- a/backend/tests/test_api_v1_connectors.py
+++ b/backend/tests/test_api_v1_connectors.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for POST /api/v1/connectors/{product}/{op_id} — G0.2-T6 acceptance.
+
+Coverage per Task #245 acceptance criteria:
+
+* Happy path: vault.kv.read → 200 with OperationResult body.
+* Unknown product → 404 with structured error detail.
+* Unknown op → 400 with known_ops list in error detail.
+* Unauthenticated request → 401.
+* Missing / empty ``path`` param → 200 with error-status OperationResult
+  (the connector, not the route, owns param validation — HTTP status stays 200).
+* Login failure (Vault unreachable) → 200 with OperationResult status="error".
+
+Test strategy: mirrors test_api_v1_health.py — monkeypatches
+``meho_backplane.auth.vault._build_client`` to avoid any real Vault
+container; Keycloak is mocked via respx + RSA fixture key.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.connectors.registry import clear_registry, register_connector
+from meho_backplane.connectors.vault.connector import VaultConnector
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Settings + JWKS-cache fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_vault() -> Iterator[None]:
+    """Ensure VaultConnector is the only registered connector for each test."""
+    clear_registry()
+    register_connector("vault", VaultConnector)
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def keypair() -> Any:
+    return _make_rsa_keypair("test-kid-connectors")
+
+
+@pytest.fixture()
+def jwt(keypair: Any) -> str:
+    return _mint_token(keypair)
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+_VAULT_KV_READ_URL = "/api/v1/connectors/vault/kv.read"
+_VALID_BODY = {"target": "vault-test", "params": {"path": "meho/test/federation"}}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_vault_kv_read_happy_path(
+    client: TestClient,
+    keypair: Any,
+    jwt: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: vault.kv.read returns 200 with OperationResult."""
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"api_key": "s3cr3t"},
+        kv_version=42,
+    )
+    with respx.mock:
+        _mock_discovery_and_jwks(respx.mock, _public_jwks(keypair))
+        resp = client.post(_VAULT_KV_READ_URL, json=_VALID_BODY, headers=_auth_headers(jwt))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["op_id"] == "vault.kv.read"
+    assert body["result"] == {"api_key": "s3cr3t"}
+    assert body["extras"]["version"] == 42
+    _ = fake  # referenced to confirm the fake was installed
+
+
+def test_unknown_product_returns_404(
+    client: TestClient,
+    keypair: Any,
+    jwt: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_client(monkeypatch)
+    with respx.mock:
+        _mock_discovery_and_jwks(respx.mock, _public_jwks(keypair))
+        resp = client.post(
+            "/api/v1/connectors/nonexistent-product/kv.read",
+            json=_VALID_BODY,
+            headers=_auth_headers(jwt),
+        )
+    assert resp.status_code == 404
+    assert "unknown product" in resp.json()["detail"]
+
+
+def test_unknown_op_returns_400_with_known_ops(
+    client: TestClient,
+    keypair: Any,
+    jwt: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_client(monkeypatch)
+    with respx.mock:
+        _mock_discovery_and_jwks(respx.mock, _public_jwks(keypair))
+        resp = client.post(
+            "/api/v1/connectors/vault/unknown.op",
+            json=_VALID_BODY,
+            headers=_auth_headers(jwt),
+        )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["error"] == "unknown_op"
+    assert "vault.kv.read" in detail["known_ops"]
+
+
+def test_unauthenticated_returns_401(client: TestClient) -> None:
+    resp = client.post(_VAULT_KV_READ_URL, json=_VALID_BODY)
+    assert resp.status_code == 401
+
+
+def test_missing_path_param_returns_200_with_error_status(
+    client: TestClient,
+    keypair: Any,
+    jwt: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing path param: connector validates and returns error status; route stays 200."""
+    install_fake_client(monkeypatch)
+    with respx.mock:
+        _mock_discovery_and_jwks(respx.mock, _public_jwks(keypair))
+        resp = client.post(
+            _VAULT_KV_READ_URL,
+            json={"target": "vault-test", "params": {}},
+            headers=_auth_headers(jwt),
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert "path" in (body["error"] or "")
+
+
+def test_vault_login_failure_returns_200_with_error_status(
+    client: TestClient,
+    keypair: Any,
+    jwt: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vault login failure: connector returns error result; route stays 200."""
+    from meho_backplane.auth.vault import VaultClientError
+
+    install_fake_client(monkeypatch, login_exc=VaultClientError("auth failed"))
+    with respx.mock:
+        _mock_discovery_and_jwks(respx.mock, _public_jwks(keypair))
+        resp = client.post(
+            _VAULT_KV_READ_URL,
+            json=_VALID_BODY,
+            headers=_auth_headers(jwt),
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["extras"]["phase"] == "login"

--- a/backend/tests/test_api_v1_connectors.py
+++ b/backend/tests/test_api_v1_connectors.py
@@ -174,19 +174,21 @@ def test_unauthenticated_returns_401(client: TestClient) -> None:
     assert resp.status_code == 401
 
 
-def test_missing_path_param_returns_200_with_error_status(
+@pytest.mark.parametrize("params", [{}, {"path": ""}])
+def test_invalid_path_param_returns_200_with_error_status(
     client: TestClient,
     keypair: Any,
     jwt: str,
     monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, str],
 ) -> None:
-    """Missing path param: connector validates and returns error status; route stays 200."""
+    """Missing or empty path: connector validates and returns error status; route stays 200."""
     install_fake_client(monkeypatch)
     with respx.mock:
         _mock_discovery_and_jwks(respx.mock, _public_jwks(keypair))
         resp = client.post(
             _VAULT_KV_READ_URL,
-            json={"target": "vault-test", "params": {}},
+            json={"target": "vault-test", "params": params},
             headers=_auth_headers(jwt),
         )
     assert resp.status_code == 200

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -79,6 +79,28 @@
         }
       }
     },
+    "/api/v1/auth-config": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Auth Config",
+        "description": "Return Keycloak issuer + audience for the CLI's device-code flow.\n\nReads :func:`~meho_backplane.settings.get_settings` so the response\ncannot drift from the values :mod:`~meho_backplane.auth.jwt` uses\nwhen it validates inbound JWTs. The issuer URL is trailing-slash-\nnormalised here \u2014 Keycloak's discovery document advertises the\ncanonical form without a trailing slash and the CLI's own URL\nconstruction (``<issuer>/.well-known/openid-configuration``) is\ncleaner against the normalised form.",
+        "operationId": "auth_config_api_v1_auth_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/health": {
       "get": {
         "tags": [
@@ -107,6 +129,290 @@
                 "schema": {
                   "$ref": "#/components/schemas/HealthResponse"
                 }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/retrieve": {
+      "post": {
+        "tags": [
+          "retrieval"
+        ],
+        "summary": "Retrieve Endpoint",
+        "description": "Run hybrid retrieval against the requesting tenant's corpus.\n\nTenant-scoped to ``operator.tenant_id`` -- there is no surface\nthat accepts a tenant id in the body. ``read_only`` operators get\n403 via :func:`require_role` before reaching this handler.\n\nBinds four ``audit_*`` contextvars **before** the retrieval call\nso the audit_log row's ``payload`` JSONB carries the privacy-\npreserving query trace even if the handler raises mid-retrieval\n(the partial payload is itself a useful incident-postmortem\nsignal). The raw query is never bound -- only its SHA-256 hash.",
+        "operationId": "retrieve_endpoint_api_v1_retrieve_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetrieveResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/feed": {
+      "get": {
+        "tags": [
+          "feed"
+        ],
+        "summary": "Feed Endpoint",
+        "description": "Stream broadcast events for the operator's tenant as Server-Sent Events.\n\nHeaders:\n    ``Last-Event-Id``: optional SSE reconnect cursor. Takes\n    precedence over the ``since`` query parameter when both are\n    present.\n\nReturns:\n    :class:`StreamingResponse` with ``media_type=text/event-stream``.\n    ``Cache-Control: no-cache, no-store, must-revalidate`` and\n    ``X-Accel-Buffering: no`` keep intermediaries from buffering\n    the stream into a single response (nginx default behaviour\n    would otherwise stall every event behind its buffer flush).",
+        "operationId": "feed_endpoint_api_v1_feed_get",
+        "parameters": [
+          {
+            "name": "op_class",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "description": "Filter by event op_class.",
+              "title": "Op Class"
+            },
+            "description": "Filter by event op_class."
+          },
+          {
+            "name": "principal",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "description": "Filter by principal_sub.",
+              "title": "Principal"
+            },
+            "description": "Filter by principal_sub."
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "description": "Filter by target_name.",
+              "title": "Target"
+            },
+            "description": "Filter by target_name."
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "description": "Explicit replay cursor; superseded by Last-Event-Id when present.",
+              "title": "Since"
+            },
+            "description": "Explicit replay cursor; superseded by Last-Event-Id when present."
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connectors/{product}/{op_id}": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Execute Op",
+        "description": "Dispatch an operation to the named connector.\n\nLooks up the connector by product slug, builds a pre-G0.3 target stub,\nand delegates to ``connector.execute(target, op_id, params)``. Returns\nthe ``OperationResult`` as JSON on success. Returns 404 for an unknown\nproduct and 400 for an unknown op-id (with the known ops list in the\nerror body so operators can enumerate what the connector supports).",
+        "operationId": "execute_op_api_v1_connectors__product___op_id__post",
+        "parameters": [
+          {
+            "name": "product",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Product"
+            }
+          },
+          {
+            "name": "op_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Op Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorExecRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Execute Op Api V1 Connectors  Product   Op Id  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/.well-known/oauth-protected-resource": {
+      "get": {
+        "tags": [
+          "discovery"
+        ],
+        "summary": "Protected Resource Metadata",
+        "description": "Return the RFC 9728 protected-resource metadata document.\n\nFields per RFC 9728 \u00a73:\n\n* ``resource`` (REQUIRED) \u2014 the canonical MCP server URI clients\n  pass as the ``resource`` parameter in OAuth requests per RFC 8707.\n  Resolved via :func:`~meho_backplane.mcp.auth.mcp_resource_uri`,\n  which prefers an explicit ``MCP_RESOURCE_URI`` setting and falls\n  back to ``f\"{backplane_url}/mcp\"``.\n* ``authorization_servers`` \u2014 the Keycloak issuer URL. MCP 2025-06-18\n  \u00a7Authorization Server Discovery requires this to be non-empty.\n* ``scopes_supported`` \u2014 v0.2 ships two scopes that downstream\n  Tasks (T3 RBAC filter, T4 reference tool, T5 audit) consume.\n  Conservative: clients that request only ``mcp:read`` can list /\n  inspect but not invoke side-effecting tools.\n* ``bearer_methods_supported`` \u2014 ``[\"header\"]`` only. MCP transport\n  forbids tokens in the URI query (see \u00a7\"Access Token Usage\").\n\nNo authentication is enforced on this endpoint by design: RFC 9728\ndiscovery is the bootstrap step that lets unauthenticated clients\nlearn how to obtain a token. The chassis middleware chain still\nruns \u2014 the request_id stays bound for log correlation, and\nAuditMiddleware skips the row because no ``operator_sub`` is bound\n(the standard unauthenticated-route path).",
+        "operationId": "protected_resource_metadata__well_known_oauth_protected_resource_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Protected Resource Metadata  Well Known Oauth Protected Resource Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp": {
+      "post": {
+        "tags": [
+          "mcp"
+        ],
+        "summary": "Mcp Dispatch",
+        "description": "Dispatch a single JSON-RPC 2.0 request or notification.\n\nThe Streamable HTTP body contract (\u00a7\"Sending Messages to the Server\"):\n\n* Input is a JSON object \u2014 batch arrays are unsupported in T1.\n* On a *request* (id present): return 200 + single JSON envelope.\n* On a *notification* (id absent, or method prefix\n  ``notifications/``): return 202 with no body, regardless of\n  whether the handler errored \u2014 JSON-RPC \u00a74.1.2 forbids replying.\n\nAuthentication (G0.5-T2, #247): every request to this route MUST\ncarry a Bearer token whose ``aud`` claim equals the canonical MCP\nresource URI per RFC 8707 \u00a72. Validation runs as a FastAPI\ndependency before the body is parsed, so a missing or invalid\ntoken short-circuits to 401 + ``WWW-Authenticate: Bearer\nresource_metadata=...`` per RFC 9728 \u00a75.1 \u2014 the dispatch pipeline\nnever sees an unauthenticated request. The :class:`Operator` is\ninjected into this handler for downstream use even though T2\nitself doesn't consume the identity beyond the contextvar binding\nside effect; T3 / T4 / T5 will pull tenant / role data off it.\n\nThe function is the orchestrator only; each phase of the dispatch\npipeline lives in its own helper so the per-phase contract is grep-\nable and the cognitive complexity stays under the project's\nSonarCloud threshold:\n\n* :func:`_parse_request_body` \u2014 body \u2192 ``dict`` or transport error.\n* :func:`JsonRpcRequest.model_validate` + :func:`_coerce_request_id`\n  \u2014 envelope shape validation.\n* :func:`_validate_protocol_version_header` \u2014 spec \u00a7\"Protocol\n  Version Header\" enforcement.\n* :func:`_dispatch_to_handler` \u2014 handler lookup + execution + error\n  mapping.\n\nGET requests on this path automatically return HTTP 405 (FastAPI's\ndefault for an unmatched method) which satisfies the spec's\nfallback when the server does not implement the GET-opens-SSE\nbranch of the Streamable HTTP transport.",
+        "operationId": "mcp_dispatch_mcp_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           },
@@ -166,6 +472,45 @@
   },
   "components": {
     "schemas": {
+      "AuthConfigResponse": {
+        "properties": {
+          "keycloak_issuer": {
+            "type": "string",
+            "title": "Keycloak Issuer"
+          },
+          "audience": {
+            "type": "string",
+            "title": "Audience"
+          }
+        },
+        "type": "object",
+        "required": [
+          "keycloak_issuer",
+          "audience"
+        ],
+        "title": "AuthConfigResponse",
+        "description": "OAuth discovery surface returned to ``meho login``.\n\nField names match the CLI's expected JSON keys (``keycloak_issuer``\nand ``audience``); renaming either field is a wire-compat break."
+      },
+      "ConnectorExecRequest": {
+        "properties": {
+          "target": {
+            "type": "string",
+            "title": "Target"
+          },
+          "params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Params",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "required": [
+          "target"
+        ],
+        "title": "ConnectorExecRequest",
+        "description": "Request body for connector operation dispatch."
+      },
       "DbStatus": {
         "properties": {
           "migrated": {
@@ -241,6 +586,139 @@
         "title": "OperatorIdentity",
         "description": "Operator identity surface exposed to the CLI.\n\nExcludes ``raw_jwt`` deliberately \u2014 the bearer token must never\nappear in a response body, and the :class:`Operator` model carries\nit for downstream Vault forward-auth only."
       },
+      "RetrievalHit": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Document Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "source_id": {
+            "type": "string",
+            "title": "Source Id"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "body": {
+            "type": "string",
+            "title": "Body"
+          },
+          "doc_metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Doc Metadata"
+          },
+          "fused_score": {
+            "type": "number",
+            "title": "Fused Score"
+          },
+          "bm25_score": {
+            "type": "number",
+            "nullable": true,
+            "title": "Bm25 Score"
+          },
+          "cosine_score": {
+            "type": "number",
+            "nullable": true,
+            "title": "Cosine Score"
+          },
+          "bm25_rank": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Bm25 Rank"
+          },
+          "cosine_rank": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Cosine Rank"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "tenant_id",
+          "source",
+          "source_id",
+          "kind",
+          "body",
+          "doc_metadata",
+          "fused_score",
+          "bm25_score",
+          "cosine_score",
+          "bm25_rank",
+          "cosine_rank"
+        ],
+        "title": "RetrievalHit",
+        "description": "One document in a ranked retrieval response.\n\nFrozen pydantic v2 model: the retrieve helper builds these once\nand the API surface (T5) returns them unchanged. The per-signal\nscores + ranks are carried for observability -- callers tuning\nembedding model choice want to see whether the top hit had\ncontributions from both signals or just one.\n\n``fused_score`` is the RRF score the documents are sorted by;\n``bm25_score`` and ``cosine_score`` are the raw per-signal\nscores (None if the document didn't appear in that signal's\ntop-:data:`CANDIDATE_LIMIT`). Likewise ``bm25_rank`` /\n``cosine_rank`` are the 1-based ranks (1 = best) the document\nheld in each signal's list, None when absent."
+      },
+      "RetrieveRequest": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Query"
+          },
+          "source": {
+            "type": "string",
+            "maxLength": 64,
+            "nullable": true,
+            "title": "Source"
+          },
+          "kind": {
+            "type": "string",
+            "maxLength": 64,
+            "nullable": true,
+            "title": "Kind"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 50.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 10
+          }
+        },
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "title": "RetrieveRequest",
+        "description": "POST body for ``/api/v1/retrieve``.\n\nField validation is the load-bearing first gate: empty queries\nshort-circuit at the framework (422 Unprocessable Entity) so the\nembedding pipeline never sees a zero-token input, and oversized\nqueries are rejected before they hit the model. The\n``max_length=2000`` cap is a generous upper bound on realistic\nfree-form operator queries; operators with longer payloads\nshould use the embedding pipeline directly via G4 / G5 ingestion\npaths."
+      },
+      "RetrieveResponse": {
+        "properties": {
+          "hits": {
+            "items": {
+              "$ref": "#/components/schemas/RetrievalHit"
+            },
+            "type": "array",
+            "title": "Hits"
+          },
+          "query_duration_ms": {
+            "type": "number",
+            "title": "Query Duration Ms"
+          }
+        },
+        "type": "object",
+        "required": [
+          "hits",
+          "query_duration_ms"
+        ],
+        "title": "RetrieveResponse",
+        "description": "Successful response shape for ``/api/v1/retrieve``.\n\n``query_duration_ms`` is the wall-clock time from request entry\nto response build (covers both the embedding compute and the two\nSQL round-trips); operators tuning embedding-model choice or\ndebugging retrieval latency consume this value. Frozen so a\nhandler accidentally mutating it post-construction surfaces as a\npydantic error rather than a silently-modified response."
+      },
       "ValidationError": {
         "properties": {
           "loc": {
@@ -303,7 +781,7 @@
           "read_ok"
         ],
         "title": "VaultStatus",
-        "description": "Vault federation-chain status.\n\n``reachable`` is true when ``vault_client_for_operator`` returns a\nlogged-in client (TCP + TLS + JWT/OIDC login all worked). ``read_ok``\nis true when the test secret read succeeded against that client.\n``detail`` carries a short structured string for the CLI to render\non failure paths \u2014 never an unbounded exception message."
+        "description": "Vault federation-chain status.\n\n``reachable`` is true when the OIDC login succeeded (TCP + TLS +\nJWT forward all worked). ``read_ok`` is true when the test secret\nread succeeded against the resulting Vault token. ``detail`` carries\na short structured string for the CLI to render on failure paths \u2014\nnever an unbounded exception message."
       }
     }
   }

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -343,12 +343,26 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Execute Op Api V1 Connectors  Product   Op Id  Post"
+                  "$ref": "#/components/schemas/OperationResult"
                 }
               }
             }
+          },
+          "400": {
+            "description": "Unknown operation for this connector",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnknownOpError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated or expired JWT"
+          },
+          "404": {
+            "description": "Unknown connector product"
           },
           "422": {
             "description": "Validation Error",
@@ -560,6 +574,54 @@
         "title": "HealthResponse",
         "description": "``GET /api/v1/health`` response body."
       },
+      "OperationResult": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              }
+            ],
+            "nullable": true,
+            "title": "Result"
+          },
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "title": "Error"
+          },
+          "duration_ms": {
+            "type": "number",
+            "title": "Duration Ms"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Extras"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "op_id",
+          "duration_ms"
+        ],
+        "title": "OperationResult",
+        "description": "Connector op execution result."
+      },
       "OperatorIdentity": {
         "properties": {
           "sub": {
@@ -718,6 +780,33 @@
         ],
         "title": "RetrieveResponse",
         "description": "Successful response shape for ``/api/v1/retrieve``.\n\n``query_duration_ms`` is the wall-clock time from request entry\nto response build (covers both the embedding compute and the two\nSQL round-trips); operators tuning embedding-model choice or\ndebugging retrieval latency consume this value. Frozen so a\nhandler accidentally mutating it post-construction surfaces as a\npydantic error rather than a silently-modified response."
+      },
+      "UnknownOpError": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "title": "Error"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "known_ops": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Known Ops"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "op_id",
+          "known_ops"
+        ],
+        "title": "UnknownOpError",
+        "description": "400 response body when the connector doesn't know the requested op."
       },
       "ValidationError": {
         "properties": {

--- a/cli/api/snapshot-openapi.py
+++ b/cli/api/snapshot-openapi.py
@@ -36,20 +36,25 @@ from typing import Any
 def _downgrade_anyof_null(node: Any) -> Any:
     """Recursively rewrite OpenAPI 3.1 nullable anyOf patterns to 3.0 nullable."""
     if isinstance(node, dict):
-        # anyOf collapse: [<schema>, {"type": "null"}] → schema with nullable: true.
+        # anyOf collapse: remove {"type": "null"} branches and add nullable:true.
+        #   [<schema>, {"type":"null"}]           → schema + nullable:true  (simple)
+        #   [s1, s2, ..., {"type":"null"}]        → {anyOf:[s1,s2,...], nullable:true}
         any_of = node.get("anyOf")
-        if isinstance(any_of, list) and len(any_of) == 2:
+        if isinstance(any_of, list):
             null_branches = [s for s in any_of if isinstance(s, dict) and s.get("type") == "null"]
             non_null = [s for s in any_of if not (isinstance(s, dict) and s.get("type") == "null")]
-            if len(null_branches) == 1 and len(non_null) == 1:
-                replacement = dict(non_null[0])
-                replacement["nullable"] = True
-                # Preserve sibling keys (title, description, default, etc.).
-                for key, value in node.items():
-                    if key == "anyOf":
-                        continue
-                    # Don't overwrite a copied key from the surviving branch.
-                    replacement.setdefault(key, value)
+            if null_branches:
+                sibling = {k: v for k, v in node.items() if k != "anyOf"}
+                if len(non_null) == 1:
+                    # Simple: collapse to single schema + nullable.
+                    replacement = dict(non_null[0])
+                    replacement["nullable"] = True
+                    for key, value in sibling.items():
+                        replacement.setdefault(key, value)
+                else:
+                    # Complex: keep anyOf without null, add nullable at parent.
+                    replacement = {"anyOf": non_null, "nullable": True}
+                    replacement.update(sibling)
                 return _downgrade_anyof_null(replacement)
         return {k: _downgrade_anyof_null(v) for k, v in node.items()}
     if isinstance(node, list):

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -86,6 +86,27 @@ type HealthResponse struct {
 	Vault VaultStatus `json:"vault"`
 }
 
+// OperationResult Connector op execution result.
+type OperationResult struct {
+	DurationMs float32                 `json:"duration_ms"`
+	Error      *string                 `json:"error"`
+	Extras     *map[string]interface{} `json:"extras,omitempty"`
+	OpId       string                  `json:"op_id"`
+	Result     *OperationResult_Result `json:"result"`
+	Status     string                  `json:"status"`
+}
+
+// OperationResultResult0 defines model for .
+type OperationResultResult0 map[string]interface{}
+
+// OperationResultResult1 defines model for .
+type OperationResultResult1 = []interface{}
+
+// OperationResult_Result defines model for OperationResult.Result.
+type OperationResult_Result struct {
+	union json.RawMessage
+}
+
 // OperatorIdentity Operator identity surface exposed to the CLI.
 //
 // Excludes “raw_jwt“ deliberately — the bearer token must never
@@ -154,6 +175,13 @@ type RetrieveRequest struct {
 type RetrieveResponse struct {
 	Hits            []RetrievalHit `json:"hits"`
 	QueryDurationMs float32        `json:"query_duration_ms"`
+}
+
+// UnknownOpError 400 response body when the connector doesn't know the requested op.
+type UnknownOpError struct {
+	Error    string   `json:"error"`
+	KnownOps []string `json:"known_ops"`
+	OpId     string   `json:"op_id"`
 }
 
 // ValidationError defines model for ValidationError.
@@ -230,6 +258,68 @@ type ExecuteOpApiV1ConnectorsProductOpIdPostJSONRequestBody = ConnectorExecReque
 
 // RetrieveEndpointApiV1RetrievePostJSONRequestBody defines body for RetrieveEndpointApiV1RetrievePost for application/json ContentType.
 type RetrieveEndpointApiV1RetrievePostJSONRequestBody = RetrieveRequest
+
+// AsOperationResultResult0 returns the union data inside the OperationResult_Result as a OperationResultResult0
+func (t OperationResult_Result) AsOperationResultResult0() (OperationResultResult0, error) {
+	var body OperationResultResult0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOperationResultResult0 overwrites any union data inside the OperationResult_Result as the provided OperationResultResult0
+func (t *OperationResult_Result) FromOperationResultResult0(v OperationResultResult0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOperationResultResult0 performs a merge with any union data inside the OperationResult_Result, using the provided OperationResultResult0
+func (t *OperationResult_Result) MergeOperationResultResult0(v OperationResultResult0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsOperationResultResult1 returns the union data inside the OperationResult_Result as a OperationResultResult1
+func (t OperationResult_Result) AsOperationResultResult1() (OperationResultResult1, error) {
+	var body OperationResultResult1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOperationResultResult1 overwrites any union data inside the OperationResult_Result as the provided OperationResultResult1
+func (t *OperationResult_Result) FromOperationResultResult1(v OperationResultResult1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOperationResultResult1 performs a merge with any union data inside the OperationResult_Result, using the provided OperationResultResult1
+func (t *OperationResult_Result) MergeOperationResultResult1(v OperationResultResult1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t OperationResult_Result) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *OperationResult_Result) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
 
 // AsValidationErrorLoc0 returns the union data inside the ValidationError_Loc_Item as a ValidationErrorLoc0
 func (t ValidationError_Loc_Item) AsValidationErrorLoc0() (ValidationErrorLoc0, error) {
@@ -1237,7 +1327,8 @@ func (r AuthConfigApiV1AuthConfigGetResponse) StatusCode() int {
 type ExecuteOpApiV1ConnectorsProductOpIdPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *map[string]interface{}
+	JSON200      *OperationResult
+	JSON400      *UnknownOpError
 	JSON422      *HTTPValidationError
 }
 
@@ -1654,11 +1745,18 @@ func ParseExecuteOpApiV1ConnectorsProductOpIdPostResponse(rsp *http.Response) (*
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest map[string]interface{}
+		var dest OperationResult
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest UnknownOpError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,7 +14,23 @@ import (
 	"strings"
 
 	"github.com/oapi-codegen/runtime"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
+
+// AuthConfigResponse OAuth discovery surface returned to “meho login“.
+//
+// Field names match the CLI's expected JSON keys (“keycloak_issuer“
+// and “audience“); renaming either field is a wire-compat break.
+type AuthConfigResponse struct {
+	Audience       string `json:"audience"`
+	KeycloakIssuer string `json:"keycloak_issuer"`
+}
+
+// ConnectorExecRequest Request body for connector operation dispatch.
+type ConnectorExecRequest struct {
+	Params *map[string]interface{} `json:"params,omitempty"`
+	Target string                  `json:"target"`
+}
 
 // DbStatus Database migration status.
 //
@@ -61,11 +78,11 @@ type HealthResponse struct {
 
 	// Vault Vault federation-chain status.
 	//
-	// ``reachable`` is true when ``vault_client_for_operator`` returns a
-	// logged-in client (TCP + TLS + JWT/OIDC login all worked). ``read_ok``
-	// is true when the test secret read succeeded against that client.
-	// ``detail`` carries a short structured string for the CLI to render
-	// on failure paths — never an unbounded exception message.
+	// ``reachable`` is true when the OIDC login succeeded (TCP + TLS +
+	// JWT forward all worked). ``read_ok`` is true when the test secret
+	// read succeeded against the resulting Vault token. ``detail`` carries
+	// a short structured string for the CLI to render on failure paths —
+	// never an unbounded exception message.
 	Vault VaultStatus `json:"vault"`
 }
 
@@ -78,6 +95,65 @@ type OperatorIdentity struct {
 	Email *string `json:"email"`
 	Name  *string `json:"name"`
 	Sub   string  `json:"sub"`
+}
+
+// RetrievalHit One document in a ranked retrieval response.
+//
+// Frozen pydantic v2 model: the retrieve helper builds these once
+// and the API surface (T5) returns them unchanged. The per-signal
+// scores + ranks are carried for observability -- callers tuning
+// embedding model choice want to see whether the top hit had
+// contributions from both signals or just one.
+//
+// “fused_score“ is the RRF score the documents are sorted by;
+// “bm25_score“ and “cosine_score“ are the raw per-signal
+// scores (None if the document didn't appear in that signal's
+// top-:data:`CANDIDATE_LIMIT`). Likewise “bm25_rank“ /
+// “cosine_rank“ are the 1-based ranks (1 = best) the document
+// held in each signal's list, None when absent.
+type RetrievalHit struct {
+	Bm25Rank    *int                   `json:"bm25_rank"`
+	Bm25Score   *float32               `json:"bm25_score"`
+	Body        string                 `json:"body"`
+	CosineRank  *int                   `json:"cosine_rank"`
+	CosineScore *float32               `json:"cosine_score"`
+	DocMetadata map[string]interface{} `json:"doc_metadata"`
+	DocumentId  openapi_types.UUID     `json:"document_id"`
+	FusedScore  float32                `json:"fused_score"`
+	Kind        string                 `json:"kind"`
+	Source      string                 `json:"source"`
+	SourceId    string                 `json:"source_id"`
+	TenantId    openapi_types.UUID     `json:"tenant_id"`
+}
+
+// RetrieveRequest POST body for “/api/v1/retrieve“.
+//
+// Field validation is the load-bearing first gate: empty queries
+// short-circuit at the framework (422 Unprocessable Entity) so the
+// embedding pipeline never sees a zero-token input, and oversized
+// queries are rejected before they hit the model. The
+// “max_length=2000“ cap is a generous upper bound on realistic
+// free-form operator queries; operators with longer payloads
+// should use the embedding pipeline directly via G4 / G5 ingestion
+// paths.
+type RetrieveRequest struct {
+	Kind   *string `json:"kind"`
+	Limit  *int    `json:"limit,omitempty"`
+	Query  string  `json:"query"`
+	Source *string `json:"source"`
+}
+
+// RetrieveResponse Successful response shape for “/api/v1/retrieve“.
+//
+// “query_duration_ms“ is the wall-clock time from request entry
+// to response build (covers both the embedding compute and the two
+// SQL round-trips); operators tuning embedding-model choice or
+// debugging retrieval latency consume this value. Frozen so a
+// handler accidentally mutating it post-construction surfaces as a
+// pydantic error rather than a silently-modified response.
+type RetrieveResponse struct {
+	Hits            []RetrievalHit `json:"hits"`
+	QueryDurationMs float32        `json:"query_duration_ms"`
 }
 
 // ValidationError defines model for ValidationError.
@@ -102,21 +178,58 @@ type ValidationError_Loc_Item struct {
 
 // VaultStatus Vault federation-chain status.
 //
-// “reachable“ is true when “vault_client_for_operator“ returns a
-// logged-in client (TCP + TLS + JWT/OIDC login all worked). “read_ok“
-// is true when the test secret read succeeded against that client.
-// “detail“ carries a short structured string for the CLI to render
-// on failure paths — never an unbounded exception message.
+// “reachable“ is true when the OIDC login succeeded (TCP + TLS +
+// JWT forward all worked). “read_ok“ is true when the test secret
+// read succeeded against the resulting Vault token. “detail“ carries
+// a short structured string for the CLI to render on failure paths —
+// never an unbounded exception message.
 type VaultStatus struct {
 	Detail    *string `json:"detail"`
 	Reachable bool    `json:"reachable"`
 	ReadOk    bool    `json:"read_ok"`
 }
 
+// ExecuteOpApiV1ConnectorsProductOpIdPostParams defines parameters for ExecuteOpApiV1ConnectorsProductOpIdPost.
+type ExecuteOpApiV1ConnectorsProductOpIdPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// FeedEndpointApiV1FeedGetParams defines parameters for FeedEndpointApiV1FeedGet.
+type FeedEndpointApiV1FeedGetParams struct {
+	// OpClass Filter by event op_class.
+	OpClass *string `form:"op_class,omitempty" json:"op_class,omitempty"`
+
+	// Principal Filter by principal_sub.
+	Principal *string `form:"principal,omitempty" json:"principal,omitempty"`
+
+	// Target Filter by target_name.
+	Target *string `form:"target,omitempty" json:"target,omitempty"`
+
+	// Since Explicit replay cursor; superseded by Last-Event-Id when present.
+	Since         *string `form:"since,omitempty" json:"since,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // AuthenticatedHealthApiV1HealthGetParams defines parameters for AuthenticatedHealthApiV1HealthGet.
 type AuthenticatedHealthApiV1HealthGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
+
+// RetrieveEndpointApiV1RetrievePostParams defines parameters for RetrieveEndpointApiV1RetrievePost.
+type RetrieveEndpointApiV1RetrievePostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// McpDispatchMcpPostParams defines parameters for McpDispatchMcpPost.
+type McpDispatchMcpPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// ExecuteOpApiV1ConnectorsProductOpIdPostJSONRequestBody defines body for ExecuteOpApiV1ConnectorsProductOpIdPost for application/json ContentType.
+type ExecuteOpApiV1ConnectorsProductOpIdPostJSONRequestBody = ConnectorExecRequest
+
+// RetrieveEndpointApiV1RetrievePostJSONRequestBody defines body for RetrieveEndpointApiV1RetrievePost for application/json ContentType.
+type RetrieveEndpointApiV1RetrievePostJSONRequestBody = RetrieveRequest
 
 // AsValidationErrorLoc0 returns the union data inside the ValidationError_Loc_Item as a ValidationErrorLoc0
 func (t ValidationError_Loc_Item) AsValidationErrorLoc0() (ValidationErrorLoc0, error) {
@@ -256,11 +369,33 @@ type ClientInterface interface {
 	// RootGet request
 	RootGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ProtectedResourceMetadataWellKnownOauthProtectedResourceGet request
+	ProtectedResourceMetadataWellKnownOauthProtectedResourceGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AuthConfigApiV1AuthConfigGet request
+	AuthConfigApiV1AuthConfigGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ExecuteOpApiV1ConnectorsProductOpIdPostWithBody request with any body
+	ExecuteOpApiV1ConnectorsProductOpIdPostWithBody(ctx context.Context, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ExecuteOpApiV1ConnectorsProductOpIdPost(ctx context.Context, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, body ExecuteOpApiV1ConnectorsProductOpIdPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// FeedEndpointApiV1FeedGet request
+	FeedEndpointApiV1FeedGet(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// AuthenticatedHealthApiV1HealthGet request
 	AuthenticatedHealthApiV1HealthGet(ctx context.Context, params *AuthenticatedHealthApiV1HealthGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RetrieveEndpointApiV1RetrievePostWithBody request with any body
+	RetrieveEndpointApiV1RetrievePostWithBody(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RetrieveEndpointApiV1RetrievePost(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, body RetrieveEndpointApiV1RetrievePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// HealthzHealthzGet request
 	HealthzHealthzGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// McpDispatchMcpPost request
+	McpDispatchMcpPost(ctx context.Context, params *McpDispatchMcpPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// MetricsMetricsGet request
 	MetricsMetricsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -284,6 +419,66 @@ func (c *Client) RootGet(ctx context.Context, reqEditors ...RequestEditorFn) (*h
 	return c.Client.Do(req)
 }
 
+func (c *Client) ProtectedResourceMetadataWellKnownOauthProtectedResourceGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewProtectedResourceMetadataWellKnownOauthProtectedResourceGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AuthConfigApiV1AuthConfigGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAuthConfigApiV1AuthConfigGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ExecuteOpApiV1ConnectorsProductOpIdPostWithBody(ctx context.Context, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExecuteOpApiV1ConnectorsProductOpIdPostRequestWithBody(c.Server, product, opId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ExecuteOpApiV1ConnectorsProductOpIdPost(ctx context.Context, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, body ExecuteOpApiV1ConnectorsProductOpIdPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExecuteOpApiV1ConnectorsProductOpIdPostRequest(c.Server, product, opId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FeedEndpointApiV1FeedGet(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFeedEndpointApiV1FeedGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) AuthenticatedHealthApiV1HealthGet(ctx context.Context, params *AuthenticatedHealthApiV1HealthGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAuthenticatedHealthApiV1HealthGetRequest(c.Server, params)
 	if err != nil {
@@ -296,8 +491,44 @@ func (c *Client) AuthenticatedHealthApiV1HealthGet(ctx context.Context, params *
 	return c.Client.Do(req)
 }
 
+func (c *Client) RetrieveEndpointApiV1RetrievePostWithBody(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrieveEndpointApiV1RetrievePostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrieveEndpointApiV1RetrievePost(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, body RetrieveEndpointApiV1RetrievePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrieveEndpointApiV1RetrievePostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) HealthzHealthzGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewHealthzHealthzGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) McpDispatchMcpPost(ctx context.Context, params *McpDispatchMcpPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMcpDispatchMcpPostRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -371,6 +602,241 @@ func NewRootGetRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewProtectedResourceMetadataWellKnownOauthProtectedResourceGetRequest generates requests for ProtectedResourceMetadataWellKnownOauthProtectedResourceGet
+func NewProtectedResourceMetadataWellKnownOauthProtectedResourceGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/.well-known/oauth-protected-resource")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAuthConfigApiV1AuthConfigGetRequest generates requests for AuthConfigApiV1AuthConfigGet
+func NewAuthConfigApiV1AuthConfigGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/auth-config")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewExecuteOpApiV1ConnectorsProductOpIdPostRequest calls the generic ExecuteOpApiV1ConnectorsProductOpIdPost builder with application/json body
+func NewExecuteOpApiV1ConnectorsProductOpIdPostRequest(server string, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, body ExecuteOpApiV1ConnectorsProductOpIdPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewExecuteOpApiV1ConnectorsProductOpIdPostRequestWithBody(server, product, opId, params, "application/json", bodyReader)
+}
+
+// NewExecuteOpApiV1ConnectorsProductOpIdPostRequestWithBody generates requests for ExecuteOpApiV1ConnectorsProductOpIdPost with any type of body
+func NewExecuteOpApiV1ConnectorsProductOpIdPostRequestWithBody(server string, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "product", runtime.ParamLocationPath, product)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "op_id", runtime.ParamLocationPath, opId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewFeedEndpointApiV1FeedGetRequest generates requests for FeedEndpointApiV1FeedGet
+func NewFeedEndpointApiV1FeedGetRequest(server string, params *FeedEndpointApiV1FeedGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/feed")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.OpClass != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "op_class", runtime.ParamLocationQuery, *params.OpClass); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Principal != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "principal", runtime.ParamLocationQuery, *params.Principal); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Since != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "since", runtime.ParamLocationQuery, *params.Since); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewAuthenticatedHealthApiV1HealthGetRequest generates requests for AuthenticatedHealthApiV1HealthGet
 func NewAuthenticatedHealthApiV1HealthGetRequest(server string, params *AuthenticatedHealthApiV1HealthGetParams) (*http.Request, error) {
 	var err error
@@ -413,6 +879,61 @@ func NewAuthenticatedHealthApiV1HealthGetRequest(server string, params *Authenti
 	return req, nil
 }
 
+// NewRetrieveEndpointApiV1RetrievePostRequest calls the generic RetrieveEndpointApiV1RetrievePost builder with application/json body
+func NewRetrieveEndpointApiV1RetrievePostRequest(server string, params *RetrieveEndpointApiV1RetrievePostParams, body RetrieveEndpointApiV1RetrievePostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRetrieveEndpointApiV1RetrievePostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewRetrieveEndpointApiV1RetrievePostRequestWithBody generates requests for RetrieveEndpointApiV1RetrievePost with any type of body
+func NewRetrieveEndpointApiV1RetrievePostRequestWithBody(server string, params *RetrieveEndpointApiV1RetrievePostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/retrieve")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewHealthzHealthzGetRequest generates requests for HealthzHealthzGet
 func NewHealthzHealthzGetRequest(server string) (*http.Request, error) {
 	var err error
@@ -435,6 +956,48 @@ func NewHealthzHealthzGetRequest(server string) (*http.Request, error) {
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewMcpDispatchMcpPostRequest generates requests for McpDispatchMcpPost
+func NewMcpDispatchMcpPostRequest(server string, params *McpDispatchMcpPostParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/mcp")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
 	}
 
 	return req, nil
@@ -567,11 +1130,33 @@ type ClientWithResponsesInterface interface {
 	// RootGetWithResponse request
 	RootGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RootGetResponse, error)
 
+	// ProtectedResourceMetadataWellKnownOauthProtectedResourceGetWithResponse request
+	ProtectedResourceMetadataWellKnownOauthProtectedResourceGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse, error)
+
+	// AuthConfigApiV1AuthConfigGetWithResponse request
+	AuthConfigApiV1AuthConfigGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AuthConfigApiV1AuthConfigGetResponse, error)
+
+	// ExecuteOpApiV1ConnectorsProductOpIdPostWithBodyWithResponse request with any body
+	ExecuteOpApiV1ConnectorsProductOpIdPostWithBodyWithResponse(ctx context.Context, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExecuteOpApiV1ConnectorsProductOpIdPostResponse, error)
+
+	ExecuteOpApiV1ConnectorsProductOpIdPostWithResponse(ctx context.Context, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, body ExecuteOpApiV1ConnectorsProductOpIdPostJSONRequestBody, reqEditors ...RequestEditorFn) (*ExecuteOpApiV1ConnectorsProductOpIdPostResponse, error)
+
+	// FeedEndpointApiV1FeedGetWithResponse request
+	FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error)
+
 	// AuthenticatedHealthApiV1HealthGetWithResponse request
 	AuthenticatedHealthApiV1HealthGetWithResponse(ctx context.Context, params *AuthenticatedHealthApiV1HealthGetParams, reqEditors ...RequestEditorFn) (*AuthenticatedHealthApiV1HealthGetResponse, error)
 
+	// RetrieveEndpointApiV1RetrievePostWithBodyWithResponse request with any body
+	RetrieveEndpointApiV1RetrievePostWithBodyWithResponse(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrieveEndpointApiV1RetrievePostResponse, error)
+
+	RetrieveEndpointApiV1RetrievePostWithResponse(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, body RetrieveEndpointApiV1RetrievePostJSONRequestBody, reqEditors ...RequestEditorFn) (*RetrieveEndpointApiV1RetrievePostResponse, error)
+
 	// HealthzHealthzGetWithResponse request
 	HealthzHealthzGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthzHealthzGetResponse, error)
+
+	// McpDispatchMcpPostWithResponse request
+	McpDispatchMcpPostWithResponse(ctx context.Context, params *McpDispatchMcpPostParams, reqEditors ...RequestEditorFn) (*McpDispatchMcpPostResponse, error)
 
 	// MetricsMetricsGetWithResponse request
 	MetricsMetricsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*MetricsMetricsGetResponse, error)
@@ -605,6 +1190,96 @@ func (r RootGetResponse) StatusCode() int {
 	return 0
 }
 
+type ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+}
+
+// Status returns HTTPResponse.Status
+func (r ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AuthConfigApiV1AuthConfigGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AuthConfigResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r AuthConfigApiV1AuthConfigGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AuthConfigApiV1AuthConfigGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ExecuteOpApiV1ConnectorsProductOpIdPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ExecuteOpApiV1ConnectorsProductOpIdPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ExecuteOpApiV1ConnectorsProductOpIdPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type FeedEndpointApiV1FeedGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r FeedEndpointApiV1FeedGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r FeedEndpointApiV1FeedGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type AuthenticatedHealthApiV1HealthGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -628,6 +1303,29 @@ func (r AuthenticatedHealthApiV1HealthGetResponse) StatusCode() int {
 	return 0
 }
 
+type RetrieveEndpointApiV1RetrievePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *RetrieveResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RetrieveEndpointApiV1RetrievePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetrieveEndpointApiV1RetrievePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type HealthzHealthzGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -644,6 +1342,29 @@ func (r HealthzHealthzGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r HealthzHealthzGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type McpDispatchMcpPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r McpDispatchMcpPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r McpDispatchMcpPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -725,6 +1446,50 @@ func (c *ClientWithResponses) RootGetWithResponse(ctx context.Context, reqEditor
 	return ParseRootGetResponse(rsp)
 }
 
+// ProtectedResourceMetadataWellKnownOauthProtectedResourceGetWithResponse request returning *ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse
+func (c *ClientWithResponses) ProtectedResourceMetadataWellKnownOauthProtectedResourceGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse, error) {
+	rsp, err := c.ProtectedResourceMetadataWellKnownOauthProtectedResourceGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse(rsp)
+}
+
+// AuthConfigApiV1AuthConfigGetWithResponse request returning *AuthConfigApiV1AuthConfigGetResponse
+func (c *ClientWithResponses) AuthConfigApiV1AuthConfigGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AuthConfigApiV1AuthConfigGetResponse, error) {
+	rsp, err := c.AuthConfigApiV1AuthConfigGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAuthConfigApiV1AuthConfigGetResponse(rsp)
+}
+
+// ExecuteOpApiV1ConnectorsProductOpIdPostWithBodyWithResponse request with arbitrary body returning *ExecuteOpApiV1ConnectorsProductOpIdPostResponse
+func (c *ClientWithResponses) ExecuteOpApiV1ConnectorsProductOpIdPostWithBodyWithResponse(ctx context.Context, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExecuteOpApiV1ConnectorsProductOpIdPostResponse, error) {
+	rsp, err := c.ExecuteOpApiV1ConnectorsProductOpIdPostWithBody(ctx, product, opId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExecuteOpApiV1ConnectorsProductOpIdPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) ExecuteOpApiV1ConnectorsProductOpIdPostWithResponse(ctx context.Context, product string, opId string, params *ExecuteOpApiV1ConnectorsProductOpIdPostParams, body ExecuteOpApiV1ConnectorsProductOpIdPostJSONRequestBody, reqEditors ...RequestEditorFn) (*ExecuteOpApiV1ConnectorsProductOpIdPostResponse, error) {
+	rsp, err := c.ExecuteOpApiV1ConnectorsProductOpIdPost(ctx, product, opId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExecuteOpApiV1ConnectorsProductOpIdPostResponse(rsp)
+}
+
+// FeedEndpointApiV1FeedGetWithResponse request returning *FeedEndpointApiV1FeedGetResponse
+func (c *ClientWithResponses) FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error) {
+	rsp, err := c.FeedEndpointApiV1FeedGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFeedEndpointApiV1FeedGetResponse(rsp)
+}
+
 // AuthenticatedHealthApiV1HealthGetWithResponse request returning *AuthenticatedHealthApiV1HealthGetResponse
 func (c *ClientWithResponses) AuthenticatedHealthApiV1HealthGetWithResponse(ctx context.Context, params *AuthenticatedHealthApiV1HealthGetParams, reqEditors ...RequestEditorFn) (*AuthenticatedHealthApiV1HealthGetResponse, error) {
 	rsp, err := c.AuthenticatedHealthApiV1HealthGet(ctx, params, reqEditors...)
@@ -734,6 +1499,23 @@ func (c *ClientWithResponses) AuthenticatedHealthApiV1HealthGetWithResponse(ctx 
 	return ParseAuthenticatedHealthApiV1HealthGetResponse(rsp)
 }
 
+// RetrieveEndpointApiV1RetrievePostWithBodyWithResponse request with arbitrary body returning *RetrieveEndpointApiV1RetrievePostResponse
+func (c *ClientWithResponses) RetrieveEndpointApiV1RetrievePostWithBodyWithResponse(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrieveEndpointApiV1RetrievePostResponse, error) {
+	rsp, err := c.RetrieveEndpointApiV1RetrievePostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrieveEndpointApiV1RetrievePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RetrieveEndpointApiV1RetrievePostWithResponse(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, body RetrieveEndpointApiV1RetrievePostJSONRequestBody, reqEditors ...RequestEditorFn) (*RetrieveEndpointApiV1RetrievePostResponse, error) {
+	rsp, err := c.RetrieveEndpointApiV1RetrievePost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrieveEndpointApiV1RetrievePostResponse(rsp)
+}
+
 // HealthzHealthzGetWithResponse request returning *HealthzHealthzGetResponse
 func (c *ClientWithResponses) HealthzHealthzGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthzHealthzGetResponse, error) {
 	rsp, err := c.HealthzHealthzGet(ctx, reqEditors...)
@@ -741,6 +1523,15 @@ func (c *ClientWithResponses) HealthzHealthzGetWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseHealthzHealthzGetResponse(rsp)
+}
+
+// McpDispatchMcpPostWithResponse request returning *McpDispatchMcpPostResponse
+func (c *ClientWithResponses) McpDispatchMcpPostWithResponse(ctx context.Context, params *McpDispatchMcpPostParams, reqEditors ...RequestEditorFn) (*McpDispatchMcpPostResponse, error) {
+	rsp, err := c.McpDispatchMcpPost(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMcpDispatchMcpPostResponse(rsp)
 }
 
 // MetricsMetricsGetWithResponse request returning *MetricsMetricsGetResponse
@@ -796,6 +1587,124 @@ func ParseRootGetResponse(rsp *http.Response) (*RootGetResponse, error) {
 	return response, nil
 }
 
+// ParseProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse parses an HTTP response from a ProtectedResourceMetadataWellKnownOauthProtectedResourceGetWithResponse call
+func ParseProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse(rsp *http.Response) (*ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ProtectedResourceMetadataWellKnownOauthProtectedResourceGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAuthConfigApiV1AuthConfigGetResponse parses an HTTP response from a AuthConfigApiV1AuthConfigGetWithResponse call
+func ParseAuthConfigApiV1AuthConfigGetResponse(rsp *http.Response) (*AuthConfigApiV1AuthConfigGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AuthConfigApiV1AuthConfigGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AuthConfigResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseExecuteOpApiV1ConnectorsProductOpIdPostResponse parses an HTTP response from a ExecuteOpApiV1ConnectorsProductOpIdPostWithResponse call
+func ParseExecuteOpApiV1ConnectorsProductOpIdPostResponse(rsp *http.Response) (*ExecuteOpApiV1ConnectorsProductOpIdPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ExecuteOpApiV1ConnectorsProductOpIdPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseFeedEndpointApiV1FeedGetResponse parses an HTTP response from a FeedEndpointApiV1FeedGetWithResponse call
+func ParseFeedEndpointApiV1FeedGetResponse(rsp *http.Response) (*FeedEndpointApiV1FeedGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &FeedEndpointApiV1FeedGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseAuthenticatedHealthApiV1HealthGetResponse parses an HTTP response from a AuthenticatedHealthApiV1HealthGetWithResponse call
 func ParseAuthenticatedHealthApiV1HealthGetResponse(rsp *http.Response) (*AuthenticatedHealthApiV1HealthGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -812,6 +1721,39 @@ func ParseAuthenticatedHealthApiV1HealthGetResponse(rsp *http.Response) (*Authen
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest HealthResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRetrieveEndpointApiV1RetrievePostResponse parses an HTTP response from a RetrieveEndpointApiV1RetrievePostWithResponse call
+func ParseRetrieveEndpointApiV1RetrievePostResponse(rsp *http.Response) (*RetrieveEndpointApiV1RetrievePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetrieveEndpointApiV1RetrievePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RetrieveResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -849,6 +1791,39 @@ func ParseHealthzHealthzGetResponse(rsp *http.Response) (*HealthzHealthzGetRespo
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseMcpDispatchMcpPostResponse parses an HTTP response from a McpDispatchMcpPostWithResponse call
+func ParseMcpDispatchMcpPostResponse(rsp *http.Response) (*McpDispatchMcpPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &McpDispatchMcpPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	}
 

--- a/cli/internal/cmd/connector.go
+++ b/cli/internal/cmd/connector.go
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// knownConnectors maps each product slug to the ops the CLI registers.
+// v0.2 ships vault only. v0.2.next replaces this with manifest-driven
+// discovery from the backplane's connector manifest endpoint.
+var knownConnectors = []connectorSpec{
+	{product: "vault", ops: []string{"kv.read"}},
+}
+
+type connectorSpec struct {
+	product string
+	ops     []string
+}
+
+// newConnectorCommands returns one root cobra.Command per known connector.
+// Each product command hosts one sub-command per operation. The resulting
+// slice is grafted onto the root command in root.go.
+func newConnectorCommands() []*cobra.Command {
+	cmds := make([]*cobra.Command, 0, len(knownConnectors))
+	for _, spec := range knownConnectors {
+		productCmd := &cobra.Command{
+			Use:          spec.product,
+			Short:        fmt.Sprintf("Run an operation against the %s connector", spec.product),
+			SilenceUsage: true,
+		}
+		for _, op := range spec.ops {
+			productCmd.AddCommand(buildOpCommand(spec.product, op))
+		}
+		cmds = append(cmds, productCmd)
+	}
+	return cmds
+}
+
+// buildOpCommand constructs the per-operation cobra.Command for
+// `meho <product> <op> [flags]`.
+//
+// DisableFlagParsing lets the RunE receive all flags as raw args so
+// arbitrary `--<key> <value>` pairs can be forwarded to the backplane
+// as operation params without declaring them in advance. --target and
+// --json are extracted from the args by parseOpArgs; everything else
+// flows through as params.
+func buildOpCommand(product, op string) *cobra.Command {
+	return &cobra.Command{
+		Use:               op,
+		Short:             fmt.Sprintf("Run %s via the %s connector", op, product),
+		DisableFlagParsing: true,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parsed, err := parseOpArgs(args)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), parsed.jsonOut)
+			}
+			if parsed.target == "" {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected("--target is required"),
+					parsed.jsonOut,
+				)
+			}
+			backplaneURL, err := resolveBackplaneURL(parsed.backplane)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.AuthExpired(err.Error()), parsed.jsonOut)
+			}
+			return runConnectorOp(
+				cmd.Context(), cmd,
+				product, op,
+				parsed.target, parsed.params,
+				backplaneURL, parsed.jsonOut,
+			)
+		},
+	}
+}
+
+// parsedOpArgs holds the result of parseOpArgs.
+type parsedOpArgs struct {
+	target   string
+	jsonOut  bool
+	backplane string
+	params   map[string]interface{}
+}
+
+// parseOpArgs processes the raw []string cobra passes when DisableFlagParsing
+// is set. Recognises:
+//
+//   --target <slug>           the target name to run the op against
+//   --json                    emit machine-readable JSON to stdout
+//   --backplane <url>         override the backplane URL
+//   --params <json>           inline JSON object for operation params
+//   --params @<file>          load operation params from a JSON file
+//   --<key> <val>             shorthand for {"key": "val"} in params
+//   --<key>=<val>             same, = form
+//
+// Unknown flags with no value (boolean flags other than --json) are
+// silently ignored rather than returning an error — forward compatibility.
+func parseOpArgs(args []string) (parsedOpArgs, error) {
+	result := parsedOpArgs{params: make(map[string]interface{})}
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "--") {
+			i++
+			continue
+		}
+		key := strings.TrimPrefix(arg, "--")
+		// Handle --key=value form.
+		if idx := strings.IndexByte(key, '='); idx >= 0 {
+			val := key[idx+1:]
+			key = key[:idx]
+			if err := assignFlag(&result, key, val); err != nil {
+				return result, err
+			}
+			i++
+			continue
+		}
+		// Boolean flag with no value.
+		if key == "json" {
+			result.jsonOut = true
+			i++
+			continue
+		}
+		// Flag that takes the next token as its value.
+		if i+1 >= len(args) || strings.HasPrefix(args[i+1], "--") {
+			// Single-token flag with no value: skip silently.
+			i++
+			continue
+		}
+		val := args[i+1]
+		i += 2
+		if err := assignFlag(&result, key, val); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+// assignFlag populates parsedOpArgs from a key-value pair extracted by
+// parseOpArgs. Reserved keys (target, json, backplane, params) are
+// handled specially; everything else is forwarded into params.
+func assignFlag(r *parsedOpArgs, key, val string) error {
+	switch key {
+	case "target":
+		r.target = val
+	case "json":
+		r.jsonOut = val == "" || val == "true" || val == "1"
+	case "backplane":
+		r.backplane = val
+	case "params":
+		m, err := loadParamsValue(val)
+		if err != nil {
+			return fmt.Errorf("--params: %w", err)
+		}
+		for k, v := range m {
+			r.params[k] = v
+		}
+	default:
+		r.params[key] = val
+	}
+	return nil
+}
+
+// loadParamsValue parses a --params value. Prefixing with '@' loads the
+// named file as JSON; otherwise the value itself is parsed as inline JSON.
+func loadParamsValue(val string) (map[string]interface{}, error) {
+	var raw []byte
+	if strings.HasPrefix(val, "@") {
+		path := strings.TrimPrefix(val, "@")
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read params file %q: %w", path, err)
+		}
+	} else {
+		raw = []byte(val)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parse params JSON: %w", err)
+	}
+	return m, nil
+}
+
+// runConnectorOp calls POST /api/v1/connectors/{product}/{op} and renders
+// the result to the operator.
+func runConnectorOp(
+	ctx context.Context,
+	cmd *cobra.Command,
+	product, op, target string,
+	params map[string]interface{},
+	backplaneURL string,
+	jsonOut bool,
+) error {
+	client, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		if api.IsTokenNotFound(err) {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.AuthExpired(fmt.Sprintf(
+					"no stored credentials for %s; run `meho login %s`",
+					backplaneURL, backplaneURL,
+				)),
+				jsonOut,
+			)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("build authed client: %v", err)),
+			jsonOut,
+		)
+	}
+
+	body := api.ConnectorExecRequest{
+		Target: target,
+		Params: &params,
+	}
+
+	resp, err := client.ExecuteOpApiV1ConnectorsProductOpIdPostWithResponse(
+		ctx, product, op, nil, body,
+	)
+	if err != nil {
+		if api.IsNoRefreshToken(err) {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.AuthExpired(fmt.Sprintf(
+					"stored token rejected and no refresh_token present; run `meho login %s`",
+					backplaneURL,
+				)),
+				jsonOut,
+			)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, redactedError(err))),
+			jsonOut,
+		)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK:
+		if jsonOut {
+			return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+		}
+		return printConnectorResult(cmd.OutOrStdout(), product, op, resp.JSON200)
+
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected stored credentials; run `meho login %s`", backplaneURL,
+			)),
+			jsonOut,
+		)
+
+	case http.StatusNotFound:
+		detail := extractErrorDetail(resp.Body)
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("unknown connector product %q: %s", product, detail)),
+			jsonOut,
+		)
+
+	case http.StatusBadRequest:
+		detail := extractErrorDetail(resp.Body)
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("%s: %s", op, detail)),
+			jsonOut,
+		)
+
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("HTTP %d from %s", resp.StatusCode(), backplaneURL)),
+			jsonOut,
+		)
+	}
+}
+
+// printConnectorResult renders an OperationResult map for human consumption.
+// The default rendering prints status + op_id, then the result fields if
+// present. Errors surface the structured detail from the backplane.
+func printConnectorResult(w io.Writer, product, op string, result *map[string]interface{}) error {
+	if result == nil {
+		fmt.Fprintf(w, "%s %s: (empty response)\n", product, op)
+		return nil
+	}
+	m := *result
+	status, _ := m["status"].(string)
+	if status == "ok" {
+		if res, ok := m["result"]; ok && res != nil {
+			blob, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return fmt.Errorf("meho: marshal result: %w", err)
+			}
+			fmt.Fprintln(w, string(blob))
+		} else {
+			fmt.Fprintf(w, "%s %s: ok\n", product, op)
+		}
+		return nil
+	}
+	// Error or denied status.
+	errStr, _ := m["error"].(string)
+	if errStr == "" {
+		errStr = status
+	}
+	fmt.Fprintf(w, "meho: connector error: %s\n", errStr)
+	return nil
+}
+
+// extractErrorDetail parses the FastAPI error detail string from a non-200
+// body. Returns a short human-readable summary, never a raw stack trace.
+func extractErrorDetail(body []byte) string {
+	var envelope struct {
+		Detail interface{} `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "(unreadable error body)"
+	}
+	switch d := envelope.Detail.(type) {
+	case string:
+		return d
+	case map[string]interface{}:
+		// Structured 400: {"error": "unknown_op", "known_ops": [...]}
+		errCode, _ := d["error"].(string)
+		if ops, ok := d["known_ops"].([]interface{}); ok {
+			strs := make([]string, 0, len(ops))
+			for _, o := range ops {
+				if s, ok := o.(string); ok {
+					strs = append(strs, s)
+				}
+			}
+			return fmt.Sprintf("%s; known ops: %s", errCode, strings.Join(strs, ", "))
+		}
+		return errCode
+	default:
+		return fmt.Sprintf("%v", d)
+	}
+}
+
+// redactedError is defined in status.go (same package).
+// connector.go calls it directly.

--- a/cli/internal/cmd/connector.go
+++ b/cli/internal/cmd/connector.go
@@ -138,7 +138,13 @@ func parseOpArgs(args []string) (parsedOpArgs, error) {
 		}
 		// Flag that takes the next token as its value.
 		if i+1 >= len(args) || strings.HasPrefix(args[i+1], "--") {
-			// Single-token flag with no value: skip silently.
+			// Reserved flags require a value; fail fast so operators get
+			// a clear error rather than a confusing downstream failure.
+			switch key {
+			case "target", "backplane", "params":
+				return result, fmt.Errorf("--%s requires a value", key)
+			}
+			// Unknown/forward-compatible flags: skip silently.
 			i++
 			continue
 		}
@@ -285,19 +291,17 @@ func runConnectorOp(
 	}
 }
 
-// printConnectorResult renders an OperationResult map for human consumption.
-// The default rendering prints status + op_id, then the result fields if
-// present. Errors surface the structured detail from the backplane.
-func printConnectorResult(w io.Writer, product, op string, result *map[string]interface{}) error {
+// printConnectorResult renders an OperationResult for human consumption.
+// The default rendering prints the result fields on success; errors surface
+// the structured detail from the backplane.
+func printConnectorResult(w io.Writer, product, op string, result *api.OperationResult) error {
 	if result == nil {
 		fmt.Fprintf(w, "%s %s: (empty response)\n", product, op)
 		return nil
 	}
-	m := *result
-	status, _ := m["status"].(string)
-	if status == "ok" {
-		if res, ok := m["result"]; ok && res != nil {
-			blob, err := json.MarshalIndent(res, "", "  ")
+	if result.Status == "ok" {
+		if result.Result != nil {
+			blob, err := json.MarshalIndent(result.Result, "", "  ")
 			if err != nil {
 				return fmt.Errorf("meho: marshal result: %w", err)
 			}
@@ -308,9 +312,12 @@ func printConnectorResult(w io.Writer, product, op string, result *map[string]in
 		return nil
 	}
 	// Error or denied status.
-	errStr, _ := m["error"].(string)
+	errStr := ""
+	if result.Error != nil {
+		errStr = *result.Error
+	}
 	if errStr == "" {
-		errStr = status
+		errStr = result.Status
 	}
 	fmt.Fprintf(w, "meho: connector error: %s\n", errStr)
 	return nil

--- a/cli/internal/cmd/connector.go
+++ b/cli/internal/cmd/connector.go
@@ -59,11 +59,11 @@ func newConnectorCommands() []*cobra.Command {
 // flows through as params.
 func buildOpCommand(product, op string) *cobra.Command {
 	return &cobra.Command{
-		Use:               op,
-		Short:             fmt.Sprintf("Run %s via the %s connector", op, product),
+		Use:                op,
+		Short:              fmt.Sprintf("Run %s via the %s connector", op, product),
 		DisableFlagParsing: true,
-		SilenceUsage:      true,
-		SilenceErrors:     true,
+		SilenceUsage:       true,
+		SilenceErrors:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parsed, err := parseOpArgs(args)
 			if err != nil {
@@ -91,22 +91,22 @@ func buildOpCommand(product, op string) *cobra.Command {
 
 // parsedOpArgs holds the result of parseOpArgs.
 type parsedOpArgs struct {
-	target   string
-	jsonOut  bool
+	target    string
+	jsonOut   bool
 	backplane string
-	params   map[string]interface{}
+	params    map[string]interface{}
 }
 
 // parseOpArgs processes the raw []string cobra passes when DisableFlagParsing
 // is set. Recognises:
 //
-//   --target <slug>           the target name to run the op against
-//   --json                    emit machine-readable JSON to stdout
-//   --backplane <url>         override the backplane URL
-//   --params <json>           inline JSON object for operation params
-//   --params @<file>          load operation params from a JSON file
-//   --<key> <val>             shorthand for {"key": "val"} in params
-//   --<key>=<val>             same, = form
+//	--target <slug>           the target name to run the op against
+//	--json                    emit machine-readable JSON to stdout
+//	--backplane <url>         override the backplane URL
+//	--params <json>           inline JSON object for operation params
+//	--params @<file>          load operation params from a JSON file
+//	--<key> <val>             shorthand for {"key": "val"} in params
+//	--<key>=<val>             same, = form
 //
 // Unknown flags with no value (boolean flags other than --json) are
 // silently ignored rather than returning an error — forward compatibility.

--- a/cli/internal/cmd/connector_test.go
+++ b/cli/internal/cmd/connector_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// TestParseOpArgs verifies that parseOpArgs correctly extracts --target,
+// --json, and arbitrary --key=value params from the raw args cobra passes
+// when DisableFlagParsing = true.
+func TestParseOpArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantTarget string
+		wantJSON  bool
+		wantParams map[string]interface{}
+	}{
+		{
+			name:       "target and path",
+			args:       []string{"--target", "vault-test", "--path", "secret/meho/test/federation"},
+			wantTarget: "vault-test",
+			wantParams: map[string]interface{}{"path": "secret/meho/test/federation"},
+		},
+		{
+			name:       "equals form",
+			args:       []string{"--target=vault-test", "--path=secret/x"},
+			wantTarget: "vault-test",
+			wantParams: map[string]interface{}{"path": "secret/x"},
+		},
+		{
+			name:       "json flag",
+			args:       []string{"--target", "t", "--json"},
+			wantTarget: "t",
+			wantJSON:   true,
+			wantParams: map[string]interface{}{},
+		},
+		{
+			name:       "multiple params",
+			args:       []string{"--target", "t", "--key1", "v1", "--key2", "v2"},
+			wantTarget: "t",
+			wantParams: map[string]interface{}{"key1": "v1", "key2": "v2"},
+		},
+		{
+			name:       "empty args",
+			args:       []string{},
+			wantTarget: "",
+			wantParams: map[string]interface{}{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseOpArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseOpArgs: unexpected error: %v", err)
+			}
+			if got.target != tc.wantTarget {
+				t.Errorf("target: got %q want %q", got.target, tc.wantTarget)
+			}
+			if got.jsonOut != tc.wantJSON {
+				t.Errorf("jsonOut: got %v want %v", got.jsonOut, tc.wantJSON)
+			}
+			if tc.wantParams != nil {
+				for k, v := range tc.wantParams {
+					if got.params[k] != v {
+						t.Errorf("params[%q]: got %v want %v", k, got.params[k], v)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestConnectorCmdURLConstruction verifies that the connector command
+// builds the correct URL path and sends the right JSON body.
+func TestConnectorCmdURLConstruction(t *testing.T) {
+	var capturedPath string
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		result := map[string]interface{}{
+			"status":      "ok",
+			"op_id":       "vault.kv.read",
+			"result":      map[string]interface{}{"api_key": "s3cr3t"},
+			"duration_ms": 12.3,
+			"extras":      map[string]interface{}{},
+		}
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	defer srv.Close()
+
+	xdg := withTempXDG(t)
+	const testToken = "eyJ.TEST-CONNECTOR.TOKEN"
+	seedCreds(t, xdg, srv.URL, auth.StoredToken{
+		AccessToken:  testToken,
+		RefreshToken: "rt",
+	})
+
+	var out, errOut bytes.Buffer
+	root := newRootCmd()
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetContext(context.Background())
+
+	root.SetArgs([]string{
+		"vault", "kv.read",
+		"--target", "vault-test",
+		"--path", "secret/meho/test/federation",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v (stderr: %s)", err, errOut.String())
+	}
+
+	if capturedPath != "/api/v1/connectors/vault/kv.read" {
+		t.Errorf("URL path: got %q want %q", capturedPath, "/api/v1/connectors/vault/kv.read")
+	}
+
+	var reqBody struct {
+		Target string                 `json:"target"`
+		Params map[string]interface{} `json:"params"`
+	}
+	if err := json.Unmarshal(capturedBody, &reqBody); err != nil {
+		t.Fatalf("decode captured body: %v", err)
+	}
+	if reqBody.Target != "vault-test" {
+		t.Errorf("body.target: got %q want %q", reqBody.Target, "vault-test")
+	}
+	if reqBody.Params["path"] != "secret/meho/test/federation" {
+		t.Errorf("body.params.path: got %v", reqBody.Params["path"])
+	}
+
+	// Human output should contain the secret value.
+	if !bytes.Contains(out.Bytes(), []byte("s3cr3t")) {
+		t.Errorf("stdout should contain secret value; got: %s", out.String())
+	}
+}
+
+// TestConnectorCmdUnknownProduct verifies the 404 handler.
+func TestConnectorCmdUnknownProduct(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail": "unknown product: bad-product"}`))
+	}))
+	defer srv.Close()
+
+	xdg := withTempXDG(t)
+	seedCreds(t, xdg, srv.URL, auth.StoredToken{
+		AccessToken:  "eyJ.TEST.TOKEN",
+		RefreshToken: "rt",
+	})
+
+	// Temporarily register a "bad-product" connector so cobra routes the command.
+	knownConnectors = append(knownConnectors, connectorSpec{product: "bad-product", ops: []string{"kv.read"}})
+	t.Cleanup(func() {
+		knownConnectors = knownConnectors[:len(knownConnectors)-1]
+	})
+
+	var out, errOut bytes.Buffer
+	root := newRootCmd()
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetContext(context.Background())
+	root.SetArgs([]string{"bad-product", "kv.read", "--target", "x"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if !bytes.Contains(errOut.Bytes(), []byte("unknown connector product")) {
+		t.Errorf("expected 'unknown connector product' in stderr; got: %s", errOut.String())
+	}
+}
+
+// TestConnectorCmdUnknownOp verifies the 400 handler surfaces the known_ops list.
+func TestConnectorCmdUnknownOp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"detail": {"error": "unknown_op", "op_id": "vault.bad.op", "known_ops": ["vault.kv.read"]}}`))
+	}))
+	defer srv.Close()
+
+	xdg := withTempXDG(t)
+	seedCreds(t, xdg, srv.URL, auth.StoredToken{
+		AccessToken:  "eyJ.TEST.TOKEN",
+		RefreshToken: "rt",
+	})
+
+	// Register a test op "bad.op" on vault temporarily.
+	knownConnectors[0].ops = append(knownConnectors[0].ops, "bad.op")
+	t.Cleanup(func() {
+		knownConnectors[0].ops = knownConnectors[0].ops[:len(knownConnectors[0].ops)-1]
+	})
+
+	var out, errOut bytes.Buffer
+	root := newRootCmd()
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetContext(context.Background())
+	root.SetArgs([]string{"vault", "bad.op", "--target", "x"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	if !bytes.Contains(errOut.Bytes(), []byte("vault.kv.read")) {
+		t.Errorf("expected known_ops in stderr; got: %s", errOut.String())
+	}
+}

--- a/cli/internal/cmd/connector_test.go
+++ b/cli/internal/cmd/connector_test.go
@@ -15,6 +15,44 @@ import (
 	"github.com/evoila/meho/cli/internal/auth"
 )
 
+// runConnectorCmd is the shared scaffold for connector integration tests.
+// It seeds an XDG tmpdir + a stored token bound to srvURL, builds a fresh
+// root command, wires stdout/stderr buffers, and runs argv. Tests then
+// assert against the captured buffers and any data the test server itself
+// recorded inside its handler closure.
+func runConnectorCmd(t *testing.T, srvURL string, argv []string) (stdout, stderr *bytes.Buffer, err error) {
+	t.Helper()
+	xdg := withTempXDG(t)
+	seedCreds(t, xdg, srvURL, auth.StoredToken{
+		AccessToken:  "eyJ.TEST.TOKEN",
+		RefreshToken: "rt",
+	})
+
+	stdout = &bytes.Buffer{}
+	stderr = &bytes.Buffer{}
+	root := newRootCmd()
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetContext(context.Background())
+	root.SetArgs(argv)
+	err = root.Execute()
+	return
+}
+
+// newJSONServer returns an httptest server that always responds with the
+// supplied status code and raw JSON body. The server is registered with
+// t.Cleanup so callers don't need a defer.
+func newJSONServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
 // TestParseOpArgs verifies that parseOpArgs correctly extracts --target,
 // --json, and arbitrary --key=value params from the raw args cobra passes
 // when DisableFlagParsing = true.
@@ -107,36 +145,22 @@ func TestConnectorCmdURLConstruction(t *testing.T) {
 		capturedBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		result := map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"status":      "ok",
 			"op_id":       "vault.kv.read",
 			"result":      map[string]interface{}{"api_key": "s3cr3t"},
 			"duration_ms": 12.3,
 			"extras":      map[string]interface{}{},
-		}
-		_ = json.NewEncoder(w).Encode(result)
+		})
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
-	xdg := withTempXDG(t)
-	const testToken = "eyJ.TEST-CONNECTOR.TOKEN"
-	seedCreds(t, xdg, srv.URL, auth.StoredToken{
-		AccessToken:  testToken,
-		RefreshToken: "rt",
-	})
-
-	var out, errOut bytes.Buffer
-	root := newRootCmd()
-	root.SetOut(&out)
-	root.SetErr(&errOut)
-	root.SetContext(context.Background())
-
-	root.SetArgs([]string{
+	out, errOut, err := runConnectorCmd(t, srv.URL, []string{
 		"vault", "kv.read",
 		"--target", "vault-test",
 		"--path", "secret/meho/test/federation",
 	})
-	if err := root.Execute(); err != nil {
+	if err != nil {
 		t.Fatalf("Execute: %v (stderr: %s)", err, errOut.String())
 	}
 
@@ -166,18 +190,7 @@ func TestConnectorCmdURLConstruction(t *testing.T) {
 
 // TestConnectorCmdUnknownProduct verifies the 404 handler.
 func TestConnectorCmdUnknownProduct(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"detail": "unknown product: bad-product"}`))
-	}))
-	defer srv.Close()
-
-	xdg := withTempXDG(t)
-	seedCreds(t, xdg, srv.URL, auth.StoredToken{
-		AccessToken:  "eyJ.TEST.TOKEN",
-		RefreshToken: "rt",
-	})
+	srv := newJSONServer(t, http.StatusNotFound, `{"detail": "unknown product: bad-product"}`)
 
 	// Temporarily register a "bad-product" connector so cobra routes the command.
 	knownConnectors = append(knownConnectors, connectorSpec{product: "bad-product", ops: []string{"kv.read"}})
@@ -185,14 +198,7 @@ func TestConnectorCmdUnknownProduct(t *testing.T) {
 		knownConnectors = knownConnectors[:len(knownConnectors)-1]
 	})
 
-	var out, errOut bytes.Buffer
-	root := newRootCmd()
-	root.SetOut(&out)
-	root.SetErr(&errOut)
-	root.SetContext(context.Background())
-	root.SetArgs([]string{"bad-product", "kv.read", "--target", "x"})
-
-	err := root.Execute()
+	_, errOut, err := runConnectorCmd(t, srv.URL, []string{"bad-product", "kv.read", "--target", "x"})
 	if err == nil {
 		t.Fatal("expected error for 404 response")
 	}
@@ -203,18 +209,8 @@ func TestConnectorCmdUnknownProduct(t *testing.T) {
 
 // TestConnectorCmdUnknownOp verifies the 400 handler surfaces the known_ops list.
 func TestConnectorCmdUnknownOp(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"detail": {"error": "unknown_op", "op_id": "vault.bad.op", "known_ops": ["vault.kv.read"]}}`))
-	}))
-	defer srv.Close()
-
-	xdg := withTempXDG(t)
-	seedCreds(t, xdg, srv.URL, auth.StoredToken{
-		AccessToken:  "eyJ.TEST.TOKEN",
-		RefreshToken: "rt",
-	})
+	srv := newJSONServer(t, http.StatusBadRequest,
+		`{"detail": {"error": "unknown_op", "op_id": "vault.bad.op", "known_ops": ["vault.kv.read"]}}`)
 
 	// Register a test op "bad.op" on vault temporarily.
 	knownConnectors[0].ops = append(knownConnectors[0].ops, "bad.op")
@@ -222,14 +218,7 @@ func TestConnectorCmdUnknownOp(t *testing.T) {
 		knownConnectors[0].ops = knownConnectors[0].ops[:len(knownConnectors[0].ops)-1]
 	})
 
-	var out, errOut bytes.Buffer
-	root := newRootCmd()
-	root.SetOut(&out)
-	root.SetErr(&errOut)
-	root.SetContext(context.Background())
-	root.SetArgs([]string{"vault", "bad.op", "--target", "x"})
-
-	err := root.Execute()
+	_, errOut, err := runConnectorCmd(t, srv.URL, []string{"vault", "bad.op", "--target", "x"})
 	if err == nil {
 		t.Fatal("expected error for 400 response")
 	}

--- a/cli/internal/cmd/connector_test.go
+++ b/cli/internal/cmd/connector_test.go
@@ -20,10 +20,10 @@ import (
 // when DisableFlagParsing = true.
 func TestParseOpArgs(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      []string
+		name       string
+		args       []string
 		wantTarget string
-		wantJSON  bool
+		wantJSON   bool
 		wantParams map[string]interface{}
 	}{
 		{

--- a/cli/internal/cmd/connector_test.go
+++ b/cli/internal/cmd/connector_test.go
@@ -65,6 +65,7 @@ func TestParseOpArgs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parseOpArgs: unexpected error: %v", err)
 			}
+
 			if got.target != tc.wantTarget {
 				t.Errorf("target: got %q want %q", got.target, tc.wantTarget)
 			}
@@ -77,6 +78,19 @@ func TestParseOpArgs(t *testing.T) {
 						t.Errorf("params[%q]: got %v want %v", k, got.params[k], v)
 					}
 				}
+			}
+		})
+	}
+}
+
+// TestParseOpArgsReservedFlagsMissingValue verifies that reserved flags
+// (--target, --backplane, --params) return an error when no value is provided.
+func TestParseOpArgsReservedFlagsMissingValue(t *testing.T) {
+	for _, flag := range []string{"target", "backplane", "params"} {
+		t.Run(flag, func(t *testing.T) {
+			_, err := parseOpArgs([]string{"--" + flag})
+			if err == nil {
+				t.Errorf("--%s with no value: expected error, got nil", flag)
 			}
 		})
 	}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -75,6 +75,15 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newLoginCmd())
 	root.AddCommand(newStatusCmd())
 
+	// G0.2-T6 (#245) — static connector dispatch commands for the
+	// known product set. v0.2 ships vault only; v0.2.next replaces
+	// this with manifest-driven discovery. Registered before
+	// registerDynamicSubcommands so the backplane manifest cannot
+	// shadow a built-in connector name.
+	for _, connCmd := range newConnectorCommands() {
+		root.AddCommand(connCmd)
+	}
+
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists
 	// the full set of operations the backplane advertises. v0.1

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -167,6 +167,17 @@ this stage it exposes:
   so the audit row at session end records a clean 200 close.
   Subscribers (T5 CLI watch #311, T6 MCP resource #312, future
   Slack mirror G6.2) consume the same SSE wire shape.
+* Connector dispatch (G0.2-T6 #245) —
+  `src/meho_backplane/api/v1/connectors.py` exposes
+  `POST /api/v1/connectors/{product}/{op_id}`. The route resolves
+  `product` against the connector registry, builds a pre-G0.3 target
+  stub from the operator JWT, and delegates to
+  `connector.execute(target, op_id, params)`. HTTP contract: 404 for
+  unknown product, 400 for unknown op-id (with `known_ops` list), 401
+  for missing/expired JWT, 200 for all other outcomes including
+  connector-side errors (callers inspect `OperationResult.status`).
+  The `_TargetStub` placeholder is replaced with a real
+  `resolve_target` call once G0.3 (#224) lands.
 * Persistence layer (Task #27) — `src/meho_backplane/db/` houses the
   SQLAlchemy 2.x async engine (`engine.py`), the per-request
   session-factory dependency (`get_session`), and the

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -541,6 +541,43 @@ the present-refresh-token branch isn't yet exercised under unit
 test because mocking Keycloak's well-known + token-exchange is
 heavyweight — that path is covered by the G2.8 integration suite).
 
+## Connector dispatch (`meho <product> <op>`, G0.2-T6 #245)
+
+`connector.go` registers one cobra subcommand per known connector product
+at startup. v0.2 ships `vault` with `kv.read`. Each product command has one
+child per operation; child commands use `DisableFlagParsing = true` so
+arbitrary `--<key> <value>` pairs flow through to the backplane as operation
+params without declaring them in advance.
+
+### Argument parsing
+
+`parseOpArgs` handles the raw arg slice cobra passes. Reserved flags:
+
+- `--target <slug>` — connector target to execute against (required).
+- `--json` — emit raw JSON to stdout instead of human output.
+- `--backplane <url>` — override the backplane URL.
+- `--params @<file.json>` — load params from a JSON file.
+- `--params '<json>'` — inline JSON params object.
+- `--<key> <value>` — shorthand for `{"key": "val"}` in params.
+
+### HTTP dispatch
+
+`runConnectorOp` calls `POST /api/v1/connectors/{product}/{op_id}` via the
+typed `AuthedClient` (same bearer-injection + refresh-on-401 machinery that
+`meho status` uses). The response is rendered:
+
+- `status == "ok"` → JSON `result` field printed (or full response with `--json`).
+- `status == "error"` → structured error message from the connector.
+- HTTP 400 (unknown op-id) → error with known_ops list from backplane.
+- HTTP 404 (unknown product) → "unknown connector product" error.
+- HTTP 401 → "auth_expired" with `meho login` hint.
+
+### Known connectors
+
+`knownConnectors` in `connector.go` is the v0.2 product registry. To add a
+connector before manifest-driven discovery lands: append to `knownConnectors`
+and the root command automatically grows the new product subtree.
+
 ## Server-driven discovery (`internal/discovery/`)
 
 Goal #11 §5 mandates server-driven `--help`: adding an operation to

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,16 +15,22 @@ sonar.sources=.
 # coverage/, etc.) when toolchains land.
 sonar.exclusions=.github/**,**/node_modules/**,**/dist/**,**/build/**
 
-# Copy-paste-detection (CPD) carve-out for test scaffolds. Test fakes are
-# inherently duplicative across suites — each fake stub re-declares the
-# same dataclass surface (login knobs, KV-version overrides, payload
-# fields) because pytest collects suites in isolation and shared
-# fixtures would force every consuming test to add a fixture parameter
-# for no behavioural benefit. The src tree (`backend/src/**`) is *not*
-# excluded, so the production duplication metric still applies; only
-# `backend/tests/**` skips CPD. Standard SonarSource pattern — see
+# Copy-paste-detection (CPD) carve-out for test scaffolds and generated
+# code. Test fakes are inherently duplicative across suites — each fake
+# stub re-declares the same dataclass surface (login knobs, KV-version
+# overrides, payload fields) because pytest collects suites in isolation
+# and shared fixtures would force every consuming test to add a fixture
+# parameter for no behavioural benefit. The src tree (`backend/src/**`)
+# is *not* excluded, so the production duplication metric still applies;
+# only `backend/tests/**` skips CPD.
+#
+# `**/*.gen.go` covers oapi-codegen output (e.g.
+# `cli/internal/api/client.gen.go`). The generator emits one
+# Do/DoWithBody/WithResponse trio per endpoint — the bodies are near-
+# identical by design and edits would be reverted on the next snapshot.
+# Standard SonarSource pattern — see
 # https://docs.sonarsource.com/sonarqube/latest/project-administration/analysis-scope/.
-sonar.cpd.exclusions=backend/tests/**
+sonar.cpd.exclusions=backend/tests/**,**/*.gen.go
 
 # Language-specific blocks — ready to populate when code lands.
 # sonar.python.version=3.13

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,24 +11,29 @@ sonar.host.url=https://sonarcloud.io
 
 sonar.sources=.
 
-# Paths excluded from analysis. Add language-specific dirs (build/, dist/,
-# coverage/, etc.) when toolchains land.
-sonar.exclusions=.github/**,**/node_modules/**,**/dist/**,**/build/**
-
-# Copy-paste-detection (CPD) carve-out for test scaffolds and generated
-# code. Test fakes are inherently duplicative across suites — each fake
-# stub re-declares the same dataclass surface (login knobs, KV-version
-# overrides, payload fields) because pytest collects suites in isolation
-# and shared fixtures would force every consuming test to add a fixture
-# parameter for no behavioural benefit. The src tree (`backend/src/**`)
-# is *not* excluded, so the production duplication metric still applies;
-# only `backend/tests/**` skips CPD.
+# Paths excluded from analysis entirely. Generated code and vendored
+# trees never warrant code-quality scoring — the file is not authored
+# by humans, so smells / duplication / complexity findings can't be
+# acted on without being reverted on the next regen.
 #
 # `**/*.gen.go` covers oapi-codegen output (e.g.
-# `cli/internal/api/client.gen.go`). The generator emits one
-# Do/DoWithBody/WithResponse trio per endpoint — the bodies are near-
-# identical by design and edits would be reverted on the next snapshot.
-# Standard SonarSource pattern — see
+# `cli/internal/api/client.gen.go`, marked with the standard
+# `DO NOT EDIT` header). The generator emits one Do/DoWithBody/
+# WithResponse trio per endpoint — the bodies are near-identical by
+# design.
+sonar.exclusions=.github/**,**/node_modules/**,**/dist/**,**/build/**,**/*.gen.go
+
+# Copy-paste-detection (CPD) carve-out for test scaffolds. Test fakes
+# are inherently duplicative across suites — each fake stub re-declares
+# the same dataclass surface (login knobs, KV-version overrides, payload
+# fields) because pytest collects suites in isolation and shared
+# fixtures would force every consuming test to add a fixture parameter
+# for no behavioural benefit. The src tree (`backend/src/**`) is *not*
+# excluded, so the production duplication metric still applies; only
+# `backend/tests/**` skips CPD. `**/*.gen.go` is also listed here as
+# belt-and-braces against any analyzer that skips `sonar.exclusions`
+# for CPD but honours `sonar.cpd.exclusions`. Standard SonarSource
+# pattern — see
 # https://docs.sonarsource.com/sonarqube/latest/project-administration/analysis-scope/.
 sonar.cpd.exclusions=backend/tests/**,**/*.gen.go
 


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/connectors/{product}/{op_id}` FastAPI route that resolves a product slug to a registered connector, builds a pre-G0.3 `_TargetStub`, and delegates to `connector.execute()`. Returns 404 for unknown product, 400 for unknown op (with known_ops list in body), 200 for all other outcomes including connector-side errors.
- Adds `meho vault kv.read --target <t> --path <p> [--key val …]` CLI command using `DisableFlagParsing` so arbitrary `--key value` pairs flow through as operation params without pre-declaration.
- Regenerates OpenAPI spec + Go client to include `ConnectorExecRequest` and `ExecuteOpApiV1ConnectorsProductOpIdPost`.

## Acceptance criteria

- [x] `POST /api/v1/connectors/vault/kv.read` with valid JWT → 200 `OperationResult{status:ok}`
- [x] Unknown product → 404 `{"detail": "unknown product: …"}`
- [x] Unknown op → 400 `{"detail": {"error": "unknown_op", "known_ops": […]}}`
- [x] Missing `Authorization` header → 401
- [x] Missing `path` param → 200 with `status=error` (connector owns param validation)
- [x] Vault login failure → 200 with `status=error`, `extras.phase=login`
- [x] `meho vault kv.read --target T --path P` CLI command parses and dispatches correctly
- [x] `--params @file` and `--params '{"k":"v"}'` bulk param loading
- [x] All 6 acceptance tests pass; full pytest suite 606 passed 0 failed; Go tests pass; ruff/mypy clean

## Test plan

- [ ] `cd backend && uv run pytest tests/test_api_v1_connectors.py -v` — 6 tests green
- [ ] `cd backend && uv run pytest tests/ -q --tb=short` — no regressions (606 passed)
- [ ] `cd cli && go test ./...` — all packages green
- [ ] Manual: `meho vault kv.read --target vault-test --path meho/test/federation` against a dev backplane

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connector-dispatch API and CLI commands to invoke product operations with flexible parameter forwarding, human/JSON output, and clearer error messages for unknown product/op and auth failures.
  * OpenAPI spec and generated client updated with connector execution plus retrieval, feed, auth-discovery and MCP endpoints.

* **Tests**
  * Added backend and CLI tests covering success, auth failures, unknown product/op, parameter parsing, and connector error cases.

* **Documentation**
  * Added docs describing connector dispatch behavior and CLI usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/387)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->