### PR TITLE
feat(ingest): G0.7-T1 OpenAPI 3.0/3.1 parser library (#401)

### DIFF
--- a/backend/src/meho_backplane/operations/__init__.py
+++ b/backend/src/meho_backplane/operations/__init__.py
@@ -9,9 +9,10 @@ live here. G0.6 ships the underlying ``endpoint_descriptor`` +
 registry-v2 metadata (T3 #394), :func:`register_typed_operation`
 — the async helper typed connectors call at init time to populate
 the tables (T4 #395) — and :func:`dispatch` (T5 #396), the single
-entry point every operation flows through. G0.7 ships the operator
-review-queue state machine that gates ingested (auto-derived)
-connectors before any of their operations reach agents (T4 #402).
+entry point every operation flows through. G0.7 ships the OpenAPI
+parser (T1 #401) and the operator review-queue state machine that
+gates ingested (auto-derived) connectors before any of their
+operations reach agents (T4 #402).
 
 Sub-modules:
 
@@ -30,11 +31,11 @@ Sub-modules:
 * :mod:`.typed_register` — :func:`register_typed_operation` and its
   :class:`HandlerRefError` for typed-connector init-time
   registration (re-exported at the package level for convenience).
-* :mod:`.ingest` — G0.7 spec-ingestion pipeline. Today: the
-  :class:`~meho_backplane.operations.ingest.ReviewService`
-  state machine (T4 #402). Later: the OpenAPI parser (T1 #401),
-  the bulk-upsert helper (T2 #403), and the LLM-grouping pass
-  (T3 #404).
+* :mod:`.ingest` — G0.7 spec-ingestion pipeline. Today:
+  :func:`~meho_backplane.operations.ingest.parse_openapi` (T1 #401)
+  + the :class:`~meho_backplane.operations.ingest.ReviewService`
+  state machine (T4 #402). Later: the bulk-upsert helper (T2 #403)
+  and the LLM-grouping pass (T3 #404).
 
 The dispatcher reads ``endpoint_descriptor`` rows directly via the
 ORM; the meta-tools (T8, #399) will hit the same surface via the

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -3,9 +3,10 @@
 
 """G0.7 spec-ingestion pipeline subpackage.
 
-This subpackage hosts the operator-facing review-queue state machine
-(:class:`ReviewService`) plus the parsers, bulk-upsert helper, and
-LLM-grouping pass that sibling tasks will land beside it. The
+This subpackage hosts the OpenAPI parser (:func:`parse_openapi`,
+T1 #401), the operator-facing review-queue state machine
+(:class:`ReviewService`, T4 #402), plus the bulk-upsert helper and
+LLM-grouping pass that sibling tasks will land beside them. The
 public surface is re-exported here so consumers (CLI verbs at T5,
 REST routes at T6, admin MCP tools at T7) import from
 ``meho_backplane.operations.ingest`` rather than reaching into the
@@ -14,13 +15,24 @@ private module layout.
 
 from meho_backplane.operations.ingest.exceptions import (
     ConnectorNotFoundError,
+    InvalidSchemaError,
+    InvalidSpecError,
     InvalidStateTransitionError,
+    UnsupportedSpecError,
+)
+from meho_backplane.operations.ingest.openapi import (
+    detect_spec_format,
+    parse_openapi,
 )
 from meho_backplane.operations.ingest.parser import parse_connector_id
 from meho_backplane.operations.ingest.payload import (
     ConnectorReviewGroup,
     ConnectorReviewOp,
     ConnectorReviewPayload,
+)
+from meho_backplane.operations.ingest.schemas import (
+    EndpointDescriptorProto,
+    SafetyLevel,
 )
 from meho_backplane.operations.ingest.service import ReviewService
 
@@ -29,7 +41,14 @@ __all__ = [
     "ConnectorReviewGroup",
     "ConnectorReviewOp",
     "ConnectorReviewPayload",
+    "EndpointDescriptorProto",
+    "InvalidSchemaError",
+    "InvalidSpecError",
     "InvalidStateTransitionError",
     "ReviewService",
+    "SafetyLevel",
+    "UnsupportedSpecError",
+    "detect_spec_format",
     "parse_connector_id",
+    "parse_openapi",
 ]

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -1,19 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Domain exceptions for the G0.7 ingest-review state machine.
+"""Domain exceptions for the G0.7 spec-ingestion pipeline.
 
-The two exception classes here are the documented failure modes
-:class:`~meho_backplane.operations.ingest.ReviewService` raises:
+Two unrelated families of failure modes share this module so T1
+(OpenAPI parser, #401) and T4 (review-queue state machine, #402)
+agree on an import path:
 
-* :class:`InvalidStateTransition` — the caller asked for a
+Parser failures (T1 #401) — raised from
+:func:`~meho_backplane.operations.ingest.parse_openapi`:
+
+* :class:`InvalidSpecError` — the document is not a structurally
+  valid OpenAPI spec or the local file referenced cannot be read.
+* :class:`UnsupportedSpecError` — the document is valid OpenAPI but
+  ships a flavour the parser doesn't ingest (Swagger 2.0, OpenAPI
+  4.x, cross-document ``$ref``).
+* :class:`InvalidSchemaError` — a referenced JSON Schema is
+  structurally broken (dangling ``$ref``, component-path drill-down,
+  non-list parameters).
+
+Review-queue failures (T4 #402) — raised from
+:class:`~meho_backplane.operations.ingest.ReviewService`:
+
+* :class:`InvalidStateTransitionError` — the caller asked for a
   state transition the machine forbids (e.g. ``enabled → staged``).
   This is a programming bug at the call site, not an operator-
   recoverable condition, but the message is kept structured so the
   CLI / API layers (T5 / T6) can map it onto a 400 with a clear
   detail field.
-
-* :class:`ConnectorNotFound` — the
+* :class:`ConnectorNotFoundError` — the
   ``(product, version, impl_id)`` triple the caller targeted has no
   matching rows visible to the operator. Returned uniformly for
   three failure modes: (a) the connector genuinely does not exist,
@@ -26,16 +41,54 @@ The two exception classes here are the documented failure modes
   enumerate another tenant's connectors by probing for ``HTTP 404``
   vs ``HTTP 403`` boundaries.
 
-Both classes inherit from :class:`Exception` directly (not
-:class:`RuntimeError` or any other stdlib subtype) so callers can
-``except`` them precisely without catching unrelated runtime faults.
+The parser classes inherit from :class:`ValueError` so callers that
+already catch parsing errors via ``except ValueError`` keep working;
+the review-queue classes inherit from :class:`Exception` directly so
+callers can ``except`` them precisely without catching unrelated
+runtime faults.
 """
 
 from __future__ import annotations
 
 from uuid import UUID
 
-__all__ = ["ConnectorNotFoundError", "InvalidStateTransitionError"]
+__all__ = [
+    "ConnectorNotFoundError",
+    "InvalidSchemaError",
+    "InvalidSpecError",
+    "InvalidStateTransitionError",
+    "UnsupportedSpecError",
+]
+
+
+class InvalidSpecError(ValueError):
+    """The document is not a structurally valid OpenAPI spec.
+
+    Raised when the root document lacks the ``paths`` key, isn't a
+    mapping, or otherwise fails structural validation that does NOT
+    depend on the OpenAPI version (those raise
+    :exc:`UnsupportedSpecError`).
+    """
+
+
+class UnsupportedSpecError(ValueError):
+    """The document is structurally valid but ships a flavour the parser doesn't ingest.
+
+    Raised for Swagger 2.0, OpenAPI 4.x, cross-document ``$ref``, and
+    similar known-unsupported cases. The exception message always
+    names the offending shape so the operator can decide whether to
+    file a v0.2.next request or pre-process the spec.
+    """
+
+
+class InvalidSchemaError(ValueError):
+    """A referenced JSON Schema is structurally broken.
+
+    Raised when a ``$ref`` points at a component that doesn't exist,
+    when a path's parameter list isn't a list, or when the spec uses
+    a structurally unsupported shape (component-path drill-down
+    refs, for example).
+    """
 
 
 class InvalidStateTransitionError(Exception):

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -158,7 +158,13 @@ def parse_openapi(
         silently skipped.
 
     Raises:
-        InvalidSpecError: Document is not a mapping or lacks ``paths``.
+        InvalidSpecError: Document is not a mapping, lacks ``paths``,
+            or the local file referenced by ``spec_path_or_uri`` cannot
+            be read (missing / not a regular file / permission denied).
+            Local-file OS errors are re-raised as ``InvalidSpecError``
+            so callers see one parser-shaped error type; HTTP fetch
+            failures still bubble as ``httpx.HTTPError`` because those
+            are a transport concern.
         UnsupportedSpecError: Spec version is not 3.0.x / 3.1.x, or the
             document references a cross-document ``$ref``.
         InvalidSchemaError: A local ``$ref`` points at a missing
@@ -199,10 +205,14 @@ def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
     """Resolve ``spec_path_or_uri`` to raw spec bytes.
 
     Local-file inputs are read in binary mode so YAML's BOM handling
-    + UTF-8 decoding stay inside the loader. HTTP(S) inputs are
-    fetched with httpx and a 30 s timeout; non-2xx responses raise
-    :exc:`httpx.HTTPStatusError` (which is a
-    :exc:`httpx.HTTPError` subclass).
+    + UTF-8 decoding stay inside the loader; missing files /
+    permission errors raise :exc:`InvalidSpecError` with the original
+    OS error chained via ``from`` so callers see a single
+    parser-shaped error type. HTTP(S) inputs are fetched with httpx
+    and a 30 s timeout; non-2xx responses raise
+    :exc:`httpx.HTTPStatusError` (an :exc:`httpx.HTTPError` subclass)
+    unwrapped — fetch failures are a transport concern, not a spec
+    concern.
     """
     parsed = urlparse(spec_path_or_uri)
     if parsed.scheme in {"http", "https"}:
@@ -215,8 +225,13 @@ def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
     if parsed.scheme == "file":
         from urllib.request import url2pathname
 
-        return Path(url2pathname(parsed.path)).read_bytes()
-    return Path(spec_path_or_uri).read_bytes()
+        path = Path(url2pathname(parsed.path))
+    else:
+        path = Path(spec_path_or_uri)
+    try:
+        return path.read_bytes()
+    except (FileNotFoundError, IsADirectoryError, PermissionError, OSError) as exc:
+        raise InvalidSpecError(f"could not read spec from {spec_path_or_uri!r}: {exc}") from exc
 
 
 def _decode_spec(content: bytes) -> dict[str, Any]:

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -61,6 +61,9 @@ from meho_backplane.operations.ingest.exceptions import (
     UnsupportedSpecError,
 )
 from meho_backplane.operations.ingest.refs import (
+    normalize_boolean_schema as _normalize_boolean_schema,
+)
+from meho_backplane.operations.ingest.refs import (
     resolve_shallow_ref as _resolve_shallow_ref,
 )
 from meho_backplane.operations.ingest.refs import (
@@ -345,8 +348,19 @@ def _build_proto(
         component_schemas=component_schemas,
     )
 
-    raw_tags = operation.get("tags") or []
-    tags: list[str] = [t for t in raw_tags if isinstance(t, str)]
+    raw_tags = operation.get("tags")
+    if raw_tags is None:
+        tags: list[str] = []
+    elif isinstance(raw_tags, list):
+        tags = [t for t in raw_tags if isinstance(t, str)]
+    else:
+        # ``tags: "admin"`` would otherwise be iterated as characters
+        # by the list comprehension. Fail fast so the spec-author /
+        # operator sees the mistake at ingest time rather than after
+        # the rows are persisted.
+        raise InvalidSchemaError(
+            f"paths.{path}.{method.lower()}.tags must be a list, got {type(raw_tags).__name__}"
+        )
     if spec_source is not None:
         tags.append(spec_source)
 
@@ -463,11 +477,26 @@ def _build_param_property(
     wins; the legacy form falls back to ``{"type": <type>}`` synthesis.
     Description / example metadata is hoisted into the property
     schema so the dispatcher's error messages stay informative.
+
+    OpenAPI 3.1 (aligned with JSON Schema 2020-12) lets ``schema`` be
+    a bare boolean: ``true`` accepts every value, ``false`` rejects
+    every value. Both are normalised to their dict equivalents via
+    :func:`_normalize_boolean_schema` so the rest of the parser can
+    treat the property as a regular dict.
     """
     schema = param.get("schema")
     out: dict[str, object]
-    if isinstance(schema, dict):
-        out = dict(_resolve_shallow_ref(schema, component_schemas))
+    if isinstance(schema, bool):
+        normalised = _normalize_boolean_schema(schema)
+        # _normalize_boolean_schema always returns a dict for bool input.
+        assert normalised is not None
+        out = dict(normalised)
+    elif isinstance(schema, dict):
+        resolved = _resolve_shallow_ref(schema, component_schemas)
+        resolved_normalised = _normalize_boolean_schema(resolved)
+        # ``None`` here means the resolved value isn't a dict OR a bool —
+        # treat as untyped (matches anything). Real specs don't trip this.
+        out = {} if resolved_normalised is None else dict(resolved_normalised)
     elif "type" in param:
         out = {"type": param["type"]}
     else:

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -527,7 +527,12 @@ def _build_body_property(
         return None
     return {
         "schema": media_type_schema,
-        "required": bool(resolved.get("required", False)),
+        # Strict identity check — OpenAPI's requestBody.required is a
+        # boolean per spec, and accepting truthy strings ("yes") or
+        # numbers would mis-mark mistyped specs as required-body when
+        # the author meant something else. Anything not literally
+        # ``True`` is treated as not-required.
+        "required": resolved.get("required") is True,
     }
 
 

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -1,0 +1,526 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pure-function OpenAPI 3.0/3.1 spec parser.
+
+Reads a YAML or JSON OpenAPI document and returns a list of
+:class:`EndpointDescriptorProto`. T2 (#403) consumes the output to
+upsert :class:`meho_backplane.db.models.EndpointDescriptor` rows.
+
+No DB session, no LLM call, no event loop. The only side effects are
+the file read or HTTP GET that pulls the spec bytes — the parsing
+itself is pure.
+
+YAML parsing prefers ``yaml.CSafeLoader`` (LibYAML) for speed on large
+specs and falls back to the pure-Python ``yaml.SafeLoader`` when
+LibYAML isn't built into the local PyYAML wheel. Both loaders refuse
+the unsafe constructors that turn YAML into RCE.
+
+Supported spec dialects:
+
+* OpenAPI 3.0.x (the vCenter / vi-json baseline at v0.2).
+* OpenAPI 3.1.x (jsonschema 2020-12-compatible; newer customer specs).
+
+Out of scope for v0.2 (per Initiative #389):
+
+* Swagger 2.0 — every v0.2 connector publishes OpenAPI 3.x.
+* GraphQL SDL / WSDL / protobuf — separate parsers; v0.2.next.
+* Cross-document ``$ref`` (``$ref: "other.yaml#/..."``) — raises
+  :exc:`UnsupportedSpecError`.
+* Deep ``$ref`` resolution — only top-level refs under each parameter
+  / body schema are inlined; nested ``$ref`` strings are preserved
+  verbatim for the dispatcher's jsonschema validator to resolve at
+  call time.
+
+Known limitation: when an operation declares two parameters with the
+same ``name`` in different ``in`` locations (e.g. a ``cluster`` path
+param **and** a ``cluster`` query param on the same op), the
+flattened ``parameter_schema`` keys collide on the property name and
+only the latter wins. OpenAPI 3.1 does allow this combination, but
+the vCenter / NSX / SDDC Manager specs in scope for v0.2 never
+exercise it. T2's registration helper logs a warning when it spots a
+collision; T1 produces what the spec literally says.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import httpx
+import yaml
+
+from meho_backplane.operations.ingest.exceptions import (
+    InvalidSchemaError,
+    InvalidSpecError,
+    UnsupportedSpecError,
+)
+from meho_backplane.operations.ingest.refs import (
+    resolve_shallow_ref as _resolve_shallow_ref,
+)
+from meho_backplane.operations.ingest.refs import (
+    select_media_type_schema as _select_media_type_schema,
+)
+from meho_backplane.operations.ingest.schemas import (
+    EndpointDescriptorProto,
+    SafetyLevel,
+)
+
+__all__ = [
+    "InvalidSchemaError",
+    "InvalidSpecError",
+    "UnsupportedSpecError",
+    "detect_spec_format",
+    "parse_openapi",
+]
+
+
+try:
+    # LibYAML-backed loader — ~5-10x faster on the 10 MB ``vi-json.yaml``
+    # spec than the pure-Python fallback. Optional because PyYAML wheels
+    # for some platforms / Python versions ship without LibYAML support.
+    _YamlLoader: type[yaml.SafeLoader] = yaml.CSafeLoader
+except AttributeError:  # pragma: no cover — PyYAML always ships SafeLoader
+    _YamlLoader = yaml.SafeLoader
+
+
+# OpenAPI 3.0.x and 3.1.x are the two supported major.minor pairs.
+# Patch level (the third digit) is accepted as-is — semver-style
+# bugfix versions never change the parser's contract.
+_SUPPORTED_OPENAPI_RE = re.compile(r"^3\.(0|1)(\.\d+)?$")
+
+# Path-parameter placeholders look like ``{cluster}`` / ``{vm-id}`` /
+# ``{filter.names}``. Compiled once and reused per operation.
+_PATH_PARAM_RE = re.compile(r"\{([^{}/]+)\}")
+
+# OpenAPI 3.x operation-level keys other than the verbs. Used to skip
+# ``parameters`` / ``summary`` / ``description`` while iterating verbs.
+_VERBS = frozenset({"get", "post", "put", "patch", "delete", "head", "options", "trace"})
+
+# Verbs the parser maps to ``safety_level="caution"`` by default.
+# Anything outside this set + the ``dangerous`` set below falls into
+# the ``safe`` bucket.
+_CAUTION_VERBS = frozenset({"POST", "PUT", "PATCH"})
+_DANGEROUS_VERBS = frozenset({"DELETE"})
+
+# Default HTTP timeouts for spec fetches. Specs sit behind CDN URLs
+# and rarely take more than a couple of seconds; a 30 s ceiling keeps
+# pathological cases from hanging an ingest.
+_HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+
+def detect_spec_format(content: bytes) -> str:
+    """Return ``"json"`` if ``content`` looks like JSON, else ``"yaml"``.
+
+    Sniffs the first non-whitespace byte: ``{`` or ``[`` → JSON;
+    anything else → YAML. Cheap and reliable — both YAML and JSON
+    serialised OpenAPI specs are tens of megabytes, and probing them
+    fully would mean a wasted parse.
+
+    Args:
+        content: Raw spec bytes.
+
+    Returns:
+        ``"json"`` or ``"yaml"``.
+    """
+    for byte in content:
+        if byte in (0x20, 0x09, 0x0A, 0x0D, 0xEF, 0xBB, 0xBF):  # ws + UTF-8 BOM bytes
+            continue
+        return "json" if byte in (0x7B, 0x5B) else "yaml"  # '{' or '['
+    return "yaml"  # empty / whitespace-only document — YAML's parse error is clearer
+
+
+def parse_openapi(
+    spec_path_or_uri: str,
+    *,
+    spec_source: str | None = None,
+) -> list[EndpointDescriptorProto]:
+    """Parse an OpenAPI 3.0 or 3.1 spec into a list of
+    :class:`EndpointDescriptorProto` rows.
+
+    Args:
+        spec_path_or_uri: Local file path or ``http(s)://`` URL.
+        spec_source: Optional logical-source tag (e.g.
+            ``"spec:vcenter.yaml"``) injected into each row's
+            ``tags`` so operators can distinguish rows when a single
+            connector ingests multiple specs (vCenter merges
+            ``vcenter.yaml`` and ``vi-json.yaml``).
+
+    Returns:
+        A list of :class:`EndpointDescriptorProto`. One entry per
+        (method, path) operation; path-level / spec-level metadata
+        is not represented here. Paths with no operations are
+        silently skipped.
+
+    Raises:
+        InvalidSpecError: Document is not a mapping or lacks ``paths``.
+        UnsupportedSpecError: Spec version is not 3.0.x / 3.1.x, or the
+            document references a cross-document ``$ref``.
+        InvalidSchemaError: A local ``$ref`` points at a missing
+            component, or a structurally unsupported shape is used.
+        yaml.YAMLError: Malformed YAML — bubbles up from the loader.
+        json.JSONDecodeError: Malformed JSON — bubbles up.
+        httpx.HTTPError: HTTP fetch failure for URL inputs.
+    """
+    content = _load_spec_bytes(spec_path_or_uri)
+    spec = _decode_spec(content)
+    _validate_openapi_version(spec)
+
+    paths = spec.get("paths")
+    if paths is None:
+        raise InvalidSpecError("OpenAPI document has no 'paths' key")
+    if not isinstance(paths, dict):
+        raise InvalidSpecError(f"'paths' must be a mapping, got {type(paths).__name__}")
+
+    components = spec.get("components") or {}
+    if not isinstance(components, dict):
+        raise InvalidSpecError(f"'components' must be a mapping, got {type(components).__name__}")
+    component_schemas = components.get("schemas") or {}
+    if not isinstance(component_schemas, dict):
+        raise InvalidSpecError(
+            f"'components.schemas' must be a mapping, got {type(component_schemas).__name__}"
+        )
+
+    return list(
+        _iter_operations(
+            paths=paths,
+            component_schemas=cast(dict[str, Any], component_schemas),
+            spec_source=spec_source,
+        )
+    )
+
+
+def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
+    """Resolve ``spec_path_or_uri`` to raw spec bytes.
+
+    Local-file inputs are read in binary mode so YAML's BOM handling
+    + UTF-8 decoding stay inside the loader. HTTP(S) inputs are
+    fetched with httpx and a 30 s timeout; non-2xx responses raise
+    :exc:`httpx.HTTPStatusError` (which is a
+    :exc:`httpx.HTTPError` subclass).
+    """
+    parsed = urlparse(spec_path_or_uri)
+    if parsed.scheme in {"http", "https"}:
+        response = httpx.get(spec_path_or_uri, timeout=_HTTP_TIMEOUT, follow_redirects=True)
+        response.raise_for_status()
+        return response.content
+    # Treat everything else as a local file path. ``Path`` handles
+    # both relative and absolute paths cleanly; ``file://`` URIs go
+    # through ``url2pathname`` for cross-platform correctness.
+    if parsed.scheme == "file":
+        from urllib.request import url2pathname
+
+        return Path(url2pathname(parsed.path)).read_bytes()
+    return Path(spec_path_or_uri).read_bytes()
+
+
+def _decode_spec(content: bytes) -> dict[str, Any]:
+    """Decode raw spec bytes into a Python dict.
+
+    Picks YAML or JSON by sniffing the first non-whitespace byte
+    (:func:`detect_spec_format`). YAML parsing uses the C loader
+    when available; JSON parsing uses stdlib.
+
+    Raises:
+        InvalidSpecError: Root document isn't a mapping.
+        yaml.YAMLError: Malformed YAML.
+        json.JSONDecodeError: Malformed JSON.
+    """
+    fmt = detect_spec_format(content)
+    parsed: Any
+    if fmt == "json":
+        parsed = json.loads(content)
+    else:
+        parsed = yaml.load(io.BytesIO(content), Loader=_YamlLoader)
+    if not isinstance(parsed, dict):
+        raise InvalidSpecError(
+            f"OpenAPI document must parse to a mapping, got {type(parsed).__name__}"
+        )
+    return parsed
+
+
+def _validate_openapi_version(spec: dict[str, Any]) -> None:
+    """Confirm the spec carries a supported ``openapi`` version string.
+
+    OpenAPI 3.0.x and 3.1.x are supported. Swagger 2.0 specs declare
+    ``swagger: "2.0"`` (no ``openapi`` key) and are rejected. Newer
+    specs with future major versions raise the same error.
+    """
+    if "swagger" in spec:
+        version = spec.get("swagger", "<missing>")
+        raise UnsupportedSpecError(
+            "Swagger 2.0 specs are not supported (v0.2.next); "
+            f"document declares swagger={version!r}"
+        )
+    raw_version = spec.get("openapi")
+    if not isinstance(raw_version, str):
+        raise InvalidSpecError("OpenAPI document must declare a string 'openapi' version")
+    if not _SUPPORTED_OPENAPI_RE.match(raw_version):
+        raise UnsupportedSpecError(
+            f"OpenAPI version {raw_version!r} is not supported (expected 3.0.x or 3.1.x)"
+        )
+
+
+def _iter_operations(
+    *,
+    paths: dict[str, Any],
+    component_schemas: dict[str, Any],
+    spec_source: str | None,
+) -> Iterable[EndpointDescriptorProto]:
+    """Yield one :class:`EndpointDescriptorProto` per (method, path)."""
+    for path_template, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            # A non-dict ``paths.<path>`` value is malformed per the
+            # OpenAPI spec. Skip rather than abort the whole ingest;
+            # T4's review queue will surface partial-spec issues.
+            continue
+        path_level_params = path_item.get("parameters") or []
+        if not isinstance(path_level_params, list):
+            raise InvalidSchemaError(
+                f"paths.{path_template}.parameters must be a list, "
+                f"got {type(path_level_params).__name__}"
+            )
+        for verb, operation in path_item.items():
+            if verb not in _VERBS:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            yield _build_proto(
+                method=verb.upper(),
+                path=path_template,
+                operation=operation,
+                path_level_params=path_level_params,
+                component_schemas=component_schemas,
+                spec_source=spec_source,
+            )
+
+
+def _build_proto(
+    *,
+    method: str,
+    path: str,
+    operation: dict[str, Any],
+    path_level_params: list[Any],
+    component_schemas: dict[str, Any],
+    spec_source: str | None,
+) -> EndpointDescriptorProto:
+    """Assemble a single :class:`EndpointDescriptorProto`."""
+    op_params = operation.get("parameters") or []
+    if not isinstance(op_params, list):
+        raise InvalidSchemaError(
+            f"paths.{path}.{method.lower()}.parameters must be a list, "
+            f"got {type(op_params).__name__}"
+        )
+
+    parameter_schema = _build_parameter_schema(
+        path=path,
+        method=method,
+        path_level_params=path_level_params,
+        op_level_params=op_params,
+        request_body=operation.get("requestBody"),
+        component_schemas=component_schemas,
+    )
+    response_schema = _extract_response_schema(
+        responses=operation.get("responses") or {},
+        component_schemas=component_schemas,
+    )
+
+    raw_tags = operation.get("tags") or []
+    tags: list[str] = [t for t in raw_tags if isinstance(t, str)]
+    if spec_source is not None:
+        tags.append(spec_source)
+
+    return EndpointDescriptorProto(
+        op_id=f"{method}:{path}",
+        method=method,
+        path=path,
+        summary=_optional_string(operation.get("summary")),
+        description=_optional_string(operation.get("description")),
+        tags=tags,
+        parameter_schema=parameter_schema,
+        response_schema=response_schema,
+        safety_level=_safety_level_for(method),
+        requires_approval=False,
+    )
+
+
+def _optional_string(value: Any) -> str | None:
+    """Coerce a possibly-empty spec field to ``str | None``."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    return value or None
+
+
+def _safety_level_for(method: str) -> SafetyLevel:
+    """Heuristic safety classification by HTTP verb."""
+    if method in _DANGEROUS_VERBS:
+        return "dangerous"
+    if method in _CAUTION_VERBS:
+        return "caution"
+    return "safe"
+
+
+def _build_parameter_schema(
+    *,
+    path: str,
+    method: str,
+    path_level_params: list[Any],
+    op_level_params: list[Any],
+    request_body: Any,
+    component_schemas: dict[str, Any],
+) -> dict[str, object]:
+    """Flatten path + operation parameters + request body into one JSON Schema object.
+
+    Path-level parameters apply to every operation under the path
+    (OpenAPI 3.x rule); operation-level parameters override them when
+    both ``name`` and ``in`` match. Each surviving parameter becomes
+    a top-level property on the returned object with the
+    ``x-meho-param-loc`` extension carrying its OpenAPI ``in`` value.
+
+    The request body (when present) is inlined as a single ``body``
+    property whose schema is the resolved ``application/json`` (or
+    fallback) schema. Operators rarely need a body-param name; the
+    dispatcher uses ``x-meho-param-loc == "body"`` to recover the
+    payload regardless of property name. Operations with no params
+    at all get the empty-but-valid ``{"type": "object", "properties":
+    {}}``.
+    """
+    properties: dict[str, object] = {}
+    required: list[str] = []
+
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
+    for raw_param in [*path_level_params, *op_level_params]:
+        resolved = _resolve_shallow_ref(raw_param, component_schemas)
+        if not isinstance(resolved, dict):
+            raise InvalidSchemaError(
+                f"paths.{path}.{method.lower()}: parameter must be a mapping, "
+                f"got {type(resolved).__name__}"
+            )
+        name = resolved.get("name")
+        location = resolved.get("in")
+        if not isinstance(name, str) or not isinstance(location, str):
+            # OpenAPI demands both fields. Skip malformed entries
+            # quietly — T4's review surfaces them at operator-review
+            # time; aborting the whole ingest on one bad path would
+            # block a 950-path spec on a single mistake.
+            continue
+        merged[(name, location)] = resolved
+
+    for (name, location), param in merged.items():
+        prop_schema = _build_param_property(param, component_schemas)
+        prop_schema["x-meho-param-loc"] = location
+        properties[name] = prop_schema
+        # Path parameters are implicitly required per OpenAPI 3.x.
+        is_required = param.get("required") is True or location == "path"
+        if is_required and name not in required:
+            required.append(name)
+
+    body_property = _build_body_property(request_body, component_schemas)
+    if body_property is not None:
+        body_schema = dict(body_property["schema"])
+        body_schema["x-meho-param-loc"] = "body"
+        properties["body"] = body_schema
+        if body_property["required"]:
+            required.append("body")
+
+    schema: dict[str, object] = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _build_param_property(
+    param: dict[str, Any],
+    component_schemas: dict[str, Any],
+) -> dict[str, object]:
+    """Extract the JSON Schema fragment for one parameter.
+
+    OpenAPI lets a parameter declare its type either via a ``schema``
+    sub-object (the common case) or — for header / cookie /
+    form-style — via the legacy inline-type form. The schema form
+    wins; the legacy form falls back to ``{"type": <type>}`` synthesis.
+    Description / example metadata is hoisted into the property
+    schema so the dispatcher's error messages stay informative.
+    """
+    schema = param.get("schema")
+    out: dict[str, object]
+    if isinstance(schema, dict):
+        out = dict(_resolve_shallow_ref(schema, component_schemas))
+    elif "type" in param:
+        out = {"type": param["type"]}
+    else:
+        # Untyped param — accept any value. JSON Schema 2020-12 says
+        # an empty object schema matches any value, which is what we
+        # want here.
+        out = {}
+    if "description" in param and isinstance(param["description"], str):
+        out.setdefault("description", param["description"])
+    return out
+
+
+def _build_body_property(
+    request_body: Any,
+    component_schemas: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Return the ``{"schema": ..., "required": bool}`` body slot, or ``None``."""
+    if not isinstance(request_body, dict):
+        return None
+    resolved = _resolve_shallow_ref(request_body, component_schemas)
+    if not isinstance(resolved, dict):
+        return None
+    content = resolved.get("content")
+    if not isinstance(content, dict):
+        return None
+    media_type_schema = _select_media_type_schema(content, component_schemas)
+    if media_type_schema is None:
+        return None
+    return {
+        "schema": media_type_schema,
+        "required": bool(resolved.get("required", False)),
+    }
+
+
+def _collect_2xx_response_codes(responses: dict[str, Any]) -> list[str]:
+    """Return response keys to scan in preference order.
+
+    Most-specific 2xx codes first, then OpenAPI 3.1's wildcard ``2XX``,
+    then any other key starting with ``"2"`` that wasn't already
+    picked.
+    """
+    candidates = [c for c in ("200", "201", "202", "203", "204") if c in responses]
+    if "2XX" in responses:
+        candidates.append("2XX")
+    candidates.extend(
+        key
+        for key in responses
+        if isinstance(key, str) and key.startswith("2") and key not in candidates
+    )
+    return candidates
+
+
+def _extract_response_schema(
+    *,
+    responses: dict[str, Any],
+    component_schemas: dict[str, Any],
+) -> dict[str, object] | None:
+    """Pick the success response's schema, preferring ``200`` over ``201`` over wildcard."""
+    if not isinstance(responses, dict):
+        return None
+    for code in _collect_2xx_response_codes(responses):
+        response = _resolve_shallow_ref(responses[code], component_schemas)
+        if not isinstance(response, dict):
+            continue
+        content = response.get("content")
+        if not isinstance(content, dict):
+            continue
+        schema = _select_media_type_schema(content, component_schemas)
+        if schema is not None:
+            return schema
+    return None

--- a/backend/src/meho_backplane/operations/ingest/refs.py
+++ b/backend/src/meho_backplane/operations/ingest/refs.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``$ref`` resolution + media-type selection helpers.
+
+Lives in its own module so the resolver behaviour can be unit-tested
+without spinning up the full parser, and so T2 (#403) can reuse the
+helpers if multi-spec merge needs to re-resolve component references
+across specs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.operations.ingest.exceptions import (
+    InvalidSchemaError,
+    UnsupportedSpecError,
+)
+
+__all__ = [
+    "PREFERRED_MEDIA_TYPES",
+    "resolve_shallow_ref",
+    "select_media_type_schema",
+    "shallow_resolve_schema_field",
+]
+
+
+# OpenAPI request bodies and responses are keyed by media type. We
+# prefer ``application/json`` (every modern vendor spec uses it for
+# the structured payload); fall back to ``*/*`` (some specs bind
+# everything to wildcard), then to the first declared media type.
+# Order matters — most specific first.
+PREFERRED_MEDIA_TYPES = ("application/json", "*/*")
+
+
+def resolve_shallow_ref(
+    obj: Any,
+    component_schemas: dict[str, Any],
+) -> Any:
+    """Inline one level of ``$ref``; preserve any nested refs unchanged.
+
+    ``$ref: "#/components/schemas/X"`` returns the resolved schema X
+    verbatim (a copy is NOT taken — callers that mutate must copy
+    first). Component-path drill-down refs
+    (``"#/components/schemas/X/properties/Y"``) raise
+    :exc:`InvalidSchemaError`. Cross-document refs raise
+    :exc:`UnsupportedSpecError`.
+
+    Non-dict input or dicts without ``$ref`` pass through unchanged.
+    """
+    if not isinstance(obj, dict) or "$ref" not in obj:
+        return obj
+    ref = obj["$ref"]
+    if not isinstance(ref, str):
+        raise InvalidSchemaError(f"$ref value must be a string, got {type(ref).__name__}")
+    if not ref.startswith("#/components/schemas/"):
+        # Anything else — external file refs, parameter refs, response refs,
+        # or fragment-walk refs into other component buckets — is out of
+        # scope for v0.2. The dispatcher will not validate against them.
+        if not ref.startswith("#/"):
+            raise UnsupportedSpecError(f"cross-document $ref is not supported (got {ref!r})")
+        raise UnsupportedSpecError(
+            f"$ref to non-schema component is not supported (got {ref!r}); "
+            f"v0.2 only inlines #/components/schemas/* refs"
+        )
+    name = ref[len("#/components/schemas/") :]
+    if "/" in name:
+        raise InvalidSchemaError(
+            f"$ref drill-down into component subpaths is not supported (got {ref!r})"
+        )
+    if name not in component_schemas:
+        raise InvalidSchemaError(f"$ref points at missing component (got {ref!r})")
+    return component_schemas[name]
+
+
+def select_media_type_schema(
+    content: dict[str, Any],
+    component_schemas: dict[str, Any],
+) -> dict[str, object] | None:
+    """Pick the JSON-leaning media type out of an OpenAPI ``content`` map."""
+    for media_type in PREFERRED_MEDIA_TYPES:
+        if media_type in content:
+            return shallow_resolve_schema_field(content[media_type], component_schemas)
+    for media_type, payload in content.items():
+        if not isinstance(media_type, str):
+            continue
+        resolved = shallow_resolve_schema_field(payload, component_schemas)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def shallow_resolve_schema_field(
+    media_type_obj: Any,
+    component_schemas: dict[str, Any],
+) -> dict[str, object] | None:
+    """Return the resolved ``schema`` field of an OpenAPI media-type object."""
+    if not isinstance(media_type_obj, dict):
+        return None
+    schema = media_type_obj.get("schema")
+    if not isinstance(schema, dict):
+        return None
+    resolved = resolve_shallow_ref(schema, component_schemas)
+    if not isinstance(resolved, dict):
+        return None
+    return dict(resolved)

--- a/backend/src/meho_backplane/operations/ingest/refs.py
+++ b/backend/src/meho_backplane/operations/ingest/refs.py
@@ -78,12 +78,25 @@ def select_media_type_schema(
     content: dict[str, Any],
     component_schemas: dict[str, Any],
 ) -> dict[str, object] | None:
-    """Pick the JSON-leaning media type out of an OpenAPI ``content`` map."""
+    """Pick the JSON-leaning media type out of an OpenAPI ``content`` map.
+
+    Try each preferred media type in priority order; only return when
+    its schema actually resolves. If none of the preferred types yield
+    a resolvable schema, fall through to the catch-all loop over the
+    remaining declared media types. The earlier shape returned ``None``
+    as soon as a preferred type was present but unresolvable, silently
+    dropping perfectly valid wildcard/fallback schemas.
+    """
     for media_type in PREFERRED_MEDIA_TYPES:
-        if media_type in content:
-            return shallow_resolve_schema_field(content[media_type], component_schemas)
+        if media_type not in content:
+            continue
+        resolved = shallow_resolve_schema_field(content[media_type], component_schemas)
+        if resolved is not None:
+            return resolved
     for media_type, payload in content.items():
         if not isinstance(media_type, str):
+            continue
+        if media_type in PREFERRED_MEDIA_TYPES:
             continue
         resolved = shallow_resolve_schema_field(payload, component_schemas)
         if resolved is not None:

--- a/backend/src/meho_backplane/operations/ingest/refs.py
+++ b/backend/src/meho_backplane/operations/ingest/refs.py
@@ -20,10 +20,41 @@ from meho_backplane.operations.ingest.exceptions import (
 
 __all__ = [
     "PREFERRED_MEDIA_TYPES",
+    "normalize_boolean_schema",
     "resolve_shallow_ref",
     "select_media_type_schema",
     "shallow_resolve_schema_field",
 ]
+
+
+def normalize_boolean_schema(schema: Any) -> dict[str, object] | None:
+    """Map a JSON Schema 2020-12 boolean schema to its dict equivalent.
+
+    OpenAPI 3.1 aligns with JSON Schema 2020-12, which permits a bare
+    boolean wherever a schema object is expected: ``true`` accepts
+    every value, ``false`` rejects every value. The rest of the parser
+    pipeline (parameter flattening, body extraction, response
+    extraction) treats schemas as dicts so it can attach
+    ``x-meho-param-loc`` and stitch them into the parent
+    ``parameter_schema`` object. Rather than pushing ``bool | dict``
+    union types through every helper, callers normalise here.
+
+    * ``True`` → ``{}`` — the empty object schema matches everything,
+      same semantics as ``true``.
+    * ``False`` → ``{"not": {}}`` — ``not`` of the always-matches
+      schema matches nothing, same semantics as ``false``.
+    * ``dict`` → returned as-is. Callers wrap in ``dict(...)`` if
+      they need a mutable copy.
+    * Anything else → ``None``. Callers decide whether to drop the
+      schema, raise, or fall back.
+    """
+    if schema is True:
+        return {}
+    if schema is False:
+        return {"not": {}}
+    if isinstance(schema, dict):
+        return schema
+    return None
 
 
 # OpenAPI request bodies and responses are keyed by media type. We
@@ -108,13 +139,24 @@ def shallow_resolve_schema_field(
     media_type_obj: Any,
     component_schemas: dict[str, Any],
 ) -> dict[str, object] | None:
-    """Return the resolved ``schema`` field of an OpenAPI media-type object."""
+    """Return the resolved ``schema`` field of an OpenAPI media-type object.
+
+    A boolean schema (OpenAPI 3.1 / JSON Schema 2020-12) is normalised
+    to its dict equivalent via :func:`normalize_boolean_schema` so the
+    parser doesn't have to thread ``bool | dict`` through every helper.
+    Refs that resolve to a boolean component schema receive the same
+    treatment.
+    """
     if not isinstance(media_type_obj, dict):
         return None
     schema = media_type_obj.get("schema")
-    if not isinstance(schema, dict):
+    normalised = normalize_boolean_schema(schema)
+    if normalised is None:
         return None
-    resolved = resolve_shallow_ref(schema, component_schemas)
-    if not isinstance(resolved, dict):
-        return None
-    return dict(resolved)
+    if isinstance(schema, dict):
+        resolved = resolve_shallow_ref(schema, component_schemas)
+        resolved_normalised = normalize_boolean_schema(resolved)
+        if resolved_normalised is None:
+            return None
+        return dict(resolved_normalised)
+    return dict(normalised)

--- a/backend/src/meho_backplane/operations/ingest/schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/schemas.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""In-memory shapes produced by :func:`parse_openapi`.
+
+The parser is pure (no DB writes, no LLM calls). It returns a list of
+:class:`EndpointDescriptorProto` values that T2 (#403) consumes via
+``register_ingested_operations()`` to upsert
+:class:`meho_backplane.db.models.EndpointDescriptor` rows.
+
+Decouples parsing from persistence so the parser stays trivially
+testable without an event loop, a DB session, or a tenant context.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "EndpointDescriptorProto",
+    "SafetyLevel",
+]
+
+SafetyLevel = Literal["safe", "caution", "dangerous"]
+
+
+class EndpointDescriptorProto(BaseModel):
+    """Intermediate representation between an OpenAPI operation and the ORM row.
+
+    Each field maps 1:1 to a column on
+    :class:`meho_backplane.db.models.EndpointDescriptor`. Fields the
+    parser cannot populate (``tenant_id``, ``embedding``, ``group_id``,
+    ``source_kind``, ``handler_ref``, ``llm_instructions``, ``custom_*``)
+    are owned by T2 (registration) / T3 (LLM grouping) / T4 (operator
+    review).
+
+    ``parameter_schema`` is a JSON Schema 2020-12 object with one
+    property per OpenAPI parameter. Each property carries an
+    ``x-meho-param-loc`` extension keyword (``"path"`` / ``"query"`` /
+    ``"header"`` / ``"body"``) so the dispatcher (G0.6-T5 #396) can
+    split params back into the correct HTTP slot at call time. The
+    flat shape gives the dispatcher one JSON Schema to validate
+    against; the extension preserves the per-param routing information
+    OpenAPI's nested ``parameters[]`` array would otherwise lose.
+
+    The model is ``frozen=True`` so parser output cannot be mutated
+    between parse and persist (defence against in-place edits that
+    would silently divert from the upstream spec). Field reassignment
+    raises ``ValidationError``; container fields (``tags``,
+    ``parameter_schema``, ``response_schema``) remain mutable at the
+    container level by Pydantic v2 default — callers treat them as
+    read-only.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    op_id: str
+    """Connector-side natural key — ``f"{method.upper()}:{path}"`` for
+    ingested OpenAPI rows (e.g. ``"GET:/api/vcenter/cluster"``)."""
+
+    method: str
+    """Upper-cased HTTP verb (``"GET"`` / ``"POST"`` / ``"PUT"`` /
+    ``"PATCH"`` / ``"DELETE"`` / ``"HEAD"`` / ``"OPTIONS"``)."""
+
+    path: str
+    """URL path template with ``{var}`` placeholders, verbatim from
+    the spec's ``paths`` key."""
+
+    summary: str | None = None
+    description: str | None = None
+
+    tags: list[str] = Field(default_factory=list)
+    """Raw OpenAPI ``tags[]`` array plus the synthetic
+    ``"spec:<source>"`` tag injected by the parser when
+    ``spec_source`` is passed. T3's LLM grouping pass uses these as a
+    starting hint but is free to override."""
+
+    parameter_schema: dict[str, object] = Field(default_factory=dict)
+    """Flattened JSON Schema 2020-12 object with
+    ``x-meho-param-loc`` per property. Empty dict when the operation
+    takes no params."""
+
+    response_schema: dict[str, object] | None = None
+    """JSON Schema for the operation's success response
+    (``2xx``-status ``application/json`` content). ``None`` when the
+    spec declares no success-response schema."""
+
+    safety_level: SafetyLevel = "safe"
+    """Heuristic from the HTTP verb. ``GET`` / ``HEAD`` / ``OPTIONS``
+    → ``safe``; ``POST`` / ``PUT`` / ``PATCH`` → ``caution``;
+    ``DELETE`` → ``dangerous``. Operator can override at review
+    (T4 state machine)."""
+
+    requires_approval: bool = False
+    """Always ``False`` at parse time. Operators flip per-op during
+    review (T4) for ops that should pause the dispatcher for
+    out-of-band approval."""

--- a/backend/tests/fixtures/openapi/petstore_30.yaml
+++ b/backend/tests/fixtures/openapi/petstore_30.yaml
@@ -1,0 +1,131 @@
+openapi: 3.0.3
+info:
+  title: Petstore
+  version: 1.0.0
+paths:
+  /pets:
+    parameters:
+      - name: X-Tenant
+        in: header
+        required: false
+        schema:
+          type: string
+        description: Optional tenant override
+    get:
+      summary: List pets
+      description: Returns a paginated list of pets.
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: A page of pets.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PetPage"
+    post:
+      summary: Create a pet
+      tags:
+        - pets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "201":
+          description: Created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /pets/{petId}:
+    parameters:
+      - name: petId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a pet
+      tags:
+        - pets
+      responses:
+        "200":
+          description: One pet.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+    delete:
+      summary: Delete a pet
+      tags:
+        - pets
+        - destructive
+      responses:
+        "204":
+          description: Removed.
+  /pets/{petId}/photos:
+    parameters:
+      - name: petId
+        in: path
+        required: true
+        schema:
+          type: string
+    put:
+      summary: Replace photos
+      tags:
+        - pets
+      requestBody:
+        required: false
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: Replaced.
+    head:
+      summary: Probe photos exist
+      tags:
+        - pets
+      responses:
+        "200":
+          description: OK.
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        tag:
+          $ref: "#/components/schemas/Tag"
+    PetPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Pet"
+        next_cursor:
+          type: string
+    Tag:
+      type: object
+      properties:
+        slug:
+          type: string

--- a/backend/tests/fixtures/openapi/petstore_31.json
+++ b/backend/tests/fixtures/openapi/petstore_31.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.1.0",
+  "info": {"title": "Petstore31-JSON", "version": "1.0.0"},
+  "paths": {
+    "/zoos": {
+      "get": {
+        "summary": "List zoos",
+        "tags": ["zoos"],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"type": "string"}}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/openapi/petstore_31.yaml
+++ b/backend/tests/fixtures/openapi/petstore_31.yaml
@@ -1,0 +1,48 @@
+openapi: 3.1.0
+info:
+  title: Petstore31
+  version: 2.0.0
+paths:
+  /vets:
+    get:
+      summary: List vets
+      tags:
+        - vets
+      parameters:
+        - name: speciality
+          in: query
+          schema:
+            type: string
+      responses:
+        "2XX":
+          description: A list.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Vet"
+    post:
+      summary: Create a vet
+      tags:
+        - vets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Vet"
+      responses:
+        "201":
+          description: Created.
+components:
+  schemas:
+    Vet:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/backend/tests/integration/test_operations_ingest_vcenter.py
+++ b/backend/tests/integration/test_operations_ingest_vcenter.py
@@ -32,17 +32,25 @@ import pytest
 from meho_backplane.operations.ingest import parse_openapi
 
 
-def _resolve_vcenter_spec() -> Path | None:
+def _resolve_vcenter_spec() -> str | None:
+    """Resolve the vCenter spec from env vars.
+
+    Returns either an ``http(s)://`` URL or a local filesystem path,
+    both of which ``parse_openapi`` accepts. ``None`` when no source
+    is configured — the integration test skips in that case.
+    """
     explicit = os.getenv("MEHO_VCENTER_OPENAPI")
     if explicit:
+        if explicit.startswith(("http://", "https://")):
+            return explicit
         candidate = Path(explicit)
         if candidate.exists():
-            return candidate
+            return str(candidate)
     consumer_docs = os.getenv("MEHO_CONSUMER_DOCS_ROOT")
     if consumer_docs:
         candidate = Path(consumer_docs) / "vcenter-9.0" / "vcenter.yaml"
         if candidate.exists():
-            return candidate
+            return str(candidate)
     return None
 
 
@@ -57,7 +65,7 @@ def _resolve_vcenter_spec() -> Path | None:
 def test_parse_vcenter_meets_path_coverage_threshold() -> None:
     spec_path = _resolve_vcenter_spec()
     assert spec_path is not None  # guarded by skipif above
-    rows = parse_openapi(str(spec_path), spec_source="spec:vcenter.yaml")
+    rows = parse_openapi(spec_path, spec_source="spec:vcenter.yaml")
     distinct_paths = {row.path for row in rows}
     assert len(rows) >= 950, f"got {len(rows)} rows; acceptance threshold is 950"
     assert len(distinct_paths) >= 950, (
@@ -69,6 +77,8 @@ def test_parse_vcenter_meets_path_coverage_threshold() -> None:
     caution = [r for r in rows if r.method == "POST"]
     dangerous = [r for r in rows if r.method == "DELETE"]
     assert safe, "spec must have at least one GET"
+    assert caution, "spec must have at least one POST"
+    assert dangerous, "spec must have at least one DELETE"
     assert all(r.safety_level == "safe" for r in safe[:5])
     assert all(r.safety_level == "caution" for r in caution[:5])
     assert all(r.safety_level == "dangerous" for r in dangerous[:5])

--- a/backend/tests/integration/test_operations_ingest_vcenter.py
+++ b/backend/tests/integration/test_operations_ingest_vcenter.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration test for :func:`parse_openapi` against vCenter's published spec.
+
+Skipped when the spec isn't reachable on the runner.
+
+Two sources are accepted, in priority order:
+
+1. ``MEHO_VCENTER_OPENAPI`` env var — explicit path or URL. The
+   ingestion pipeline (T8 #408) will provision this in CI via the
+   consumer's checked-in ``docs/vcenter-9.0/vcenter.yaml`` once that
+   ship-ride is set up.
+2. ``${MEHO_CONSUMER_DOCS_ROOT}/vcenter-9.0/vcenter.yaml`` — points
+   at the consumer repo's ``docs/`` tree. Local-dev convenience for
+   anyone with the consumer-needs repo cloned.
+
+When neither is set, the test is skipped (not failed) so CI runs that
+predate T8's provisioning stay green. The unit-test fixtures cover
+contract behaviour; this test only asserts the parser scales to the
+real spec corpus per the Initiative's acceptance criterion ("≥95% of
+paths produce a row with non-null parameter_schema").
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from meho_backplane.operations.ingest import parse_openapi
+
+
+def _resolve_vcenter_spec() -> Path | None:
+    explicit = os.getenv("MEHO_VCENTER_OPENAPI")
+    if explicit:
+        candidate = Path(explicit)
+        if candidate.exists():
+            return candidate
+    consumer_docs = os.getenv("MEHO_CONSUMER_DOCS_ROOT")
+    if consumer_docs:
+        candidate = Path(consumer_docs) / "vcenter-9.0" / "vcenter.yaml"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+@pytest.mark.skipif(
+    _resolve_vcenter_spec() is None,
+    reason=(
+        "vcenter.yaml unavailable — set MEHO_VCENTER_OPENAPI or MEHO_CONSUMER_DOCS_ROOT. "
+        "The unit-test fixtures cover the parser contract; this integration test only "
+        "verifies the parser scales to the real spec corpus."
+    ),
+)
+def test_parse_vcenter_meets_path_coverage_threshold() -> None:
+    spec_path = _resolve_vcenter_spec()
+    assert spec_path is not None  # guarded by skipif above
+    rows = parse_openapi(str(spec_path), spec_source="spec:vcenter.yaml")
+    distinct_paths = {row.path for row in rows}
+    assert len(rows) >= 950, f"got {len(rows)} rows; acceptance threshold is 950"
+    assert len(distinct_paths) >= 950, (
+        f"got {len(distinct_paths)} distinct paths; acceptance threshold is 950"
+    )
+    rows_with_params = [r for r in rows if r.parameter_schema.get("properties")]
+    # Spot-checks per acceptance criteria: GET → safe, POST → caution, DELETE → dangerous.
+    safe = [r for r in rows if r.method == "GET"]
+    caution = [r for r in rows if r.method == "POST"]
+    dangerous = [r for r in rows if r.method == "DELETE"]
+    assert safe, "spec must have at least one GET"
+    assert all(r.safety_level == "safe" for r in safe[:5])
+    assert all(r.safety_level == "caution" for r in caution[:5])
+    assert all(r.safety_level == "dangerous" for r in dangerous[:5])
+    # Every row with parameters has x-meho-param-loc populated.
+    for row in rows_with_params:
+        properties = row.parameter_schema["properties"]
+        assert isinstance(properties, dict)
+        for prop_name, prop_schema in properties.items():
+            assert isinstance(prop_schema, dict), f"{row.op_id}: {prop_name} not a dict"
+            assert "x-meho-param-loc" in prop_schema, (
+                f"{row.op_id}: parameter {prop_name!r} missing x-meho-param-loc"
+            )
+            assert prop_schema["x-meho-param-loc"] in {"path", "query", "header", "body"}
+    # spec_source threading.
+    assert all("spec:vcenter.yaml" in row.tags for row in rows)

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -320,6 +320,82 @@ paths:
         parse_openapi(str(spec))
 
 
+def test_non_list_tags_raises(tmp_path: Path) -> None:
+    """A spec with ``tags: "admin"`` would otherwise iterate as characters."""
+    spec = tmp_path / "bad_tags.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    get:
+      tags: admin
+      responses:
+        "200":
+          description: ok
+        """.lstrip()
+    )
+    with pytest.raises(InvalidSchemaError, match=r"tags must be a list"):
+        parse_openapi(str(spec))
+
+
+def test_openapi_31_boolean_parameter_schema(tmp_path: Path) -> None:
+    """OpenAPI 3.1 allows ``schema: true`` / ``schema: false`` on parameters."""
+    spec = tmp_path / "bool_param.yaml"
+    spec.write_text(
+        """
+openapi: '3.1.0'
+info: {title: x, version: '1'}
+paths:
+  /any:
+    get:
+      parameters:
+        - {name: anything, in: query, schema: true}
+        - {name: nothing, in: query, schema: false}
+      responses:
+        "200":
+          description: ok
+        """.lstrip()
+    )
+    rows = parse_openapi(str(spec))
+    props = rows[0].parameter_schema["properties"]
+    assert isinstance(props, dict)
+    # true → {} (matches anything)
+    assert props["anything"] == {"x-meho-param-loc": "query"}
+    # false → {"not": {}} (matches nothing) + the loc keyword
+    assert props["nothing"] == {"not": {}, "x-meho-param-loc": "query"}
+
+
+def test_openapi_31_boolean_body_and_response_schema(tmp_path: Path) -> None:
+    """Boolean body / response schemas survive the parser pipeline."""
+    spec = tmp_path / "bool_body.yaml"
+    spec.write_text(
+        """
+openapi: '3.1.0'
+info: {title: x, version: '1'}
+paths:
+  /any:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: true
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: false
+        """.lstrip()
+    )
+    rows = parse_openapi(str(spec))
+    body = rows[0].parameter_schema["properties"]["body"]
+    assert body == {"x-meho-param-loc": "body"}  # true → {} merged with loc keyword
+    assert rows[0].response_schema == {"not": {}}  # false → {"not": {}}
+
+
 def test_drilldown_schema_ref_raises(tmp_path: Path) -> None:
     spec = tmp_path / "drilldown.yaml"
     spec.write_text(

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :mod:`meho_backplane.operations.ingest.openapi`.
+
+Fixture specs live next to this file at ``tests/fixtures/openapi/``.
+Each fixture exercises one or two parser concerns so the failures
+point at a specific contract violation rather than a soup of issues.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+import yaml
+from pydantic import ValidationError
+
+from meho_backplane.operations.ingest import (
+    EndpointDescriptorProto,
+    InvalidSchemaError,
+    InvalidSpecError,
+    UnsupportedSpecError,
+    detect_spec_format,
+    parse_openapi,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "openapi"
+PETSTORE_30 = FIXTURES / "petstore_30.yaml"
+PETSTORE_31_YAML = FIXTURES / "petstore_31.yaml"
+PETSTORE_31_JSON = FIXTURES / "petstore_31.json"
+
+
+def _by_op_id(rows: list[EndpointDescriptorProto]) -> dict[str, EndpointDescriptorProto]:
+    return {r.op_id: r for r in rows}
+
+
+# -- detect_spec_format -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (b"{", "json"),
+        (b"  \n {", "json"),
+        (b'["x"]', "json"),
+        (b"openapi: 3.0.3", "yaml"),
+        (b"# leading comment\nopenapi: 3.1.0", "yaml"),
+        (b"\xef\xbb\xbf{", "json"),  # UTF-8 BOM
+        (b"", "yaml"),
+        (b"   \n\t  ", "yaml"),
+    ],
+)
+def test_detect_spec_format(content: bytes, expected: str) -> None:
+    assert detect_spec_format(content) == expected
+
+
+# -- parse_openapi: happy paths --------------------------------------------
+
+
+def test_parse_petstore_30_yields_expected_ops() -> None:
+    rows = parse_openapi(str(PETSTORE_30), spec_source="spec:petstore_30.yaml")
+    ops = _by_op_id(rows)
+    expected_ids = {
+        "GET:/pets",
+        "POST:/pets",
+        "GET:/pets/{petId}",
+        "DELETE:/pets/{petId}",
+        "PUT:/pets/{petId}/photos",
+        "HEAD:/pets/{petId}/photos",
+    }
+    assert set(ops) == expected_ids
+
+
+def test_parse_petstore_30_safety_heuristic() -> None:
+    rows = parse_openapi(str(PETSTORE_30))
+    ops = _by_op_id(rows)
+    assert ops["GET:/pets"].safety_level == "safe"
+    assert ops["POST:/pets"].safety_level == "caution"
+    assert ops["DELETE:/pets/{petId}"].safety_level == "dangerous"
+    assert ops["PUT:/pets/{petId}/photos"].safety_level == "caution"
+    assert ops["HEAD:/pets/{petId}/photos"].safety_level == "safe"
+
+
+def test_parse_petstore_30_path_and_query_param_locations() -> None:
+    rows = parse_openapi(str(PETSTORE_30))
+    list_pets = _by_op_id(rows)["GET:/pets"]
+    props = list_pets.parameter_schema["properties"]
+    assert isinstance(props, dict)
+    # Path-level X-Tenant header propagates onto the GET.
+    assert props["X-Tenant"]["x-meho-param-loc"] == "header"
+    # Operation-level limit query param.
+    assert props["limit"]["x-meho-param-loc"] == "query"
+    # No body on a list endpoint.
+    assert "body" not in props
+    # X-Tenant is optional so it must NOT be required; limit is also optional.
+    assert (
+        "required" not in list_pets.parameter_schema or list_pets.parameter_schema["required"] == []
+    )
+
+
+def test_parse_petstore_30_path_param_is_required() -> None:
+    rows = parse_openapi(str(PETSTORE_30))
+    get_pet = _by_op_id(rows)["GET:/pets/{petId}"]
+    props = get_pet.parameter_schema["properties"]
+    assert props["petId"]["x-meho-param-loc"] == "path"
+    assert "petId" in get_pet.parameter_schema["required"]
+
+
+def test_parse_petstore_30_request_body_inlined_with_param_loc() -> None:
+    rows = parse_openapi(str(PETSTORE_30))
+    post = _by_op_id(rows)["POST:/pets"]
+    props = post.parameter_schema["properties"]
+    body = props["body"]
+    assert body["x-meho-param-loc"] == "body"
+    # $ref to #/components/schemas/Pet got inlined one level deep.
+    assert body["type"] == "object"
+    assert set(body["properties"].keys()) == {"id", "name", "tag"}
+    # Nested $ref to Tag is preserved verbatim.
+    assert body["properties"]["tag"] == {"$ref": "#/components/schemas/Tag"}
+    # Body required because requestBody.required == true.
+    assert "body" in post.parameter_schema["required"]
+
+
+def test_parse_petstore_30_optional_body_not_required() -> None:
+    rows = parse_openapi(str(PETSTORE_30))
+    put = _by_op_id(rows)["PUT:/pets/{petId}/photos"]
+    assert put.parameter_schema["properties"]["body"]["x-meho-param-loc"] == "body"
+    # requestBody.required omitted → not required.
+    assert "body" not in put.parameter_schema.get("required", [])
+
+
+def test_parse_petstore_30_response_schema_extracted() -> None:
+    rows = parse_openapi(str(PETSTORE_30))
+    list_pets = _by_op_id(rows)["GET:/pets"]
+    # PetPage was inlined; nested $ref to Pet preserved.
+    assert list_pets.response_schema is not None
+    assert list_pets.response_schema["type"] == "object"
+    items_schema = list_pets.response_schema["properties"]["items"]
+    assert items_schema["items"] == {"$ref": "#/components/schemas/Pet"}
+
+
+def test_parse_petstore_30_204_response_yields_none() -> None:
+    rows = parse_openapi(str(PETSTORE_30))
+    delete = _by_op_id(rows)["DELETE:/pets/{petId}"]
+    assert delete.response_schema is None
+
+
+def test_parse_petstore_30_tags_include_spec_source() -> None:
+    rows = parse_openapi(str(PETSTORE_30), spec_source="spec:petstore_30.yaml")
+    list_pets = _by_op_id(rows)["GET:/pets"]
+    assert "pets" in list_pets.tags
+    assert "spec:petstore_30.yaml" in list_pets.tags
+
+
+def test_parse_petstore_30_without_spec_source_omits_tag() -> None:
+    rows = parse_openapi(str(PETSTORE_30))
+    list_pets = _by_op_id(rows)["GET:/pets"]
+    assert list_pets.tags == ["pets"]
+    # No accidental injection of an empty string or None.
+    assert "" not in list_pets.tags
+
+
+def test_parse_petstore_31_yaml_wildcard_2xx_response() -> None:
+    rows = parse_openapi(str(PETSTORE_31_YAML))
+    ops = _by_op_id(rows)
+    list_vets = ops["GET:/vets"]
+    assert list_vets.response_schema is not None
+    # Wildcard 2XX response picked up.
+    assert list_vets.response_schema["type"] == "array"
+
+
+def test_parse_petstore_31_json_route() -> None:
+    rows = parse_openapi(str(PETSTORE_31_JSON))
+    assert {r.op_id for r in rows} == {"GET:/zoos"}
+    assert rows[0].response_schema == {"type": "array", "items": {"type": "string"}}
+
+
+# -- spec_source merging ---------------------------------------------------
+
+
+def test_spec_source_threads_distinctly_across_two_specs(tmp_path: Path) -> None:
+    """vCenter ingests vcenter.yaml + vi-json.yaml under one connector;
+    rows from each spec must carry distinguishable ``spec:<source>`` tags."""
+    rows_a = parse_openapi(str(PETSTORE_30), spec_source="spec:vcenter.yaml")
+    rows_b = parse_openapi(str(PETSTORE_31_YAML), spec_source="spec:vi-json.yaml")
+    all_tags_a = {tag for row in rows_a for tag in row.tags}
+    all_tags_b = {tag for row in rows_b for tag in row.tags}
+    assert "spec:vcenter.yaml" in all_tags_a
+    assert "spec:vi-json.yaml" in all_tags_b
+    assert "spec:vcenter.yaml" not in all_tags_b
+
+
+# -- failure modes ---------------------------------------------------------
+
+
+def test_unsupported_swagger_2_raises(tmp_path: Path) -> None:
+    spec = tmp_path / "swagger.yaml"
+    spec.write_text("swagger: '2.0'\ninfo: {title: x, version: '1'}\npaths: {}\n")
+    with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0"):
+        parse_openapi(str(spec))
+
+
+def test_unsupported_openapi_4_raises(tmp_path: Path) -> None:
+    spec = tmp_path / "v4.yaml"
+    spec.write_text("openapi: '4.0.0'\ninfo: {title: x, version: '1'}\npaths: {}\n")
+    with pytest.raises(UnsupportedSpecError, match=r"4\.0\.0"):
+        parse_openapi(str(spec))
+
+
+def test_invalid_spec_missing_paths_raises(tmp_path: Path) -> None:
+    spec = tmp_path / "broken.yaml"
+    spec.write_text("openapi: '3.1.0'\ninfo: {title: x, version: '1'}\n")
+    with pytest.raises(InvalidSpecError, match="no 'paths' key"):
+        parse_openapi(str(spec))
+
+
+def test_invalid_spec_non_mapping_root_raises(tmp_path: Path) -> None:
+    spec = tmp_path / "list.yaml"
+    spec.write_text("- not\n- a\n- mapping\n")
+    with pytest.raises(InvalidSpecError, match="must parse to a mapping"):
+        parse_openapi(str(spec))
+
+
+def test_malformed_yaml_bubbles_up(tmp_path: Path) -> None:
+    spec = tmp_path / "bad.yaml"
+    spec.write_text("openapi: '3.0.3'\npaths:\n  /x:\n   get:\n   summary: oops\n  : bad\n")
+    with pytest.raises(yaml.YAMLError):
+        parse_openapi(str(spec))
+
+
+def test_malformed_json_bubbles_up(tmp_path: Path) -> None:
+    spec = tmp_path / "bad.json"
+    spec.write_text('{"openapi": "3.0.3", broken')
+    with pytest.raises(json.JSONDecodeError):
+        parse_openapi(str(spec))
+
+
+def test_external_ref_raises(tmp_path: Path) -> None:
+    spec = tmp_path / "ext.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    get:
+      parameters:
+        - $ref: 'other.yaml#/components/schemas/X'
+      responses:
+        "200":
+          description: ok
+        """.lstrip()
+    )
+    with pytest.raises(UnsupportedSpecError, match="cross-document"):
+        parse_openapi(str(spec))
+
+
+def test_non_schema_local_ref_raises(tmp_path: Path) -> None:
+    spec = tmp_path / "param_ref.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/Shared'
+      responses:
+        "200":
+          description: ok
+components:
+  parameters:
+    Shared:
+      name: shared
+      in: query
+      schema:
+        type: string
+        """.lstrip()
+    )
+    with pytest.raises(UnsupportedSpecError, match="non-schema component"):
+        parse_openapi(str(spec))
+
+
+def test_missing_schema_ref_raises(tmp_path: Path) -> None:
+    spec = tmp_path / "dangling.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Missing'
+      responses:
+        "200":
+          description: ok
+        """.lstrip()
+    )
+    with pytest.raises(InvalidSchemaError, match="missing component"):
+        parse_openapi(str(spec))
+
+
+def test_drilldown_schema_ref_raises(tmp_path: Path) -> None:
+    spec = tmp_path / "drilldown.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/X/properties/y'
+      responses:
+        "200":
+          description: ok
+components:
+  schemas:
+    X:
+      type: object
+      properties:
+        y: {type: string}
+        """.lstrip()
+    )
+    with pytest.raises(InvalidSchemaError, match="drill-down"):
+        parse_openapi(str(spec))
+
+
+# -- model behaviour -------------------------------------------------------
+
+
+def test_proto_is_frozen() -> None:
+    proto = EndpointDescriptorProto(op_id="GET:/x", method="GET", path="/x")
+    with pytest.raises(ValidationError):
+        proto.op_id = "POST:/x"  # type: ignore[misc]
+
+
+def test_proto_safety_level_literal_rejects_garbage() -> None:
+    with pytest.raises(ValidationError):
+        EndpointDescriptorProto(
+            op_id="GET:/x",
+            method="GET",
+            path="/x",
+            safety_level="extreme",  # type: ignore[arg-type]
+        )
+
+
+# -- HTTP fetch ------------------------------------------------------------
+
+
+def test_http_fetch_round_trip() -> None:
+    """``http(s)://`` URLs are fetched via httpx."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get("https://example.test/spec.yaml").mock(
+            return_value=httpx.Response(
+                200,
+                content=PETSTORE_31_YAML.read_bytes(),
+                headers={"content-type": "application/yaml"},
+            )
+        )
+        rows = parse_openapi("https://example.test/spec.yaml", spec_source="http")
+    op_ids = {r.op_id for r in rows}
+    assert op_ids == {"GET:/vets", "POST:/vets"}
+
+
+def test_http_fetch_404_raises() -> None:
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get("https://example.test/missing.yaml").mock(
+            return_value=httpx.Response(404, content=b"not found")
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            parse_openapi("https://example.test/missing.yaml")

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -225,6 +225,17 @@ def test_invalid_spec_non_mapping_root_raises(tmp_path: Path) -> None:
         parse_openapi(str(spec))
 
 
+def test_missing_local_file_raises_invalid_spec(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.yaml"
+    with pytest.raises(InvalidSpecError, match="could not read spec"):
+        parse_openapi(str(missing))
+
+
+def test_directory_path_raises_invalid_spec(tmp_path: Path) -> None:
+    with pytest.raises(InvalidSpecError, match="could not read spec"):
+        parse_openapi(str(tmp_path))
+
+
 def test_malformed_yaml_bubbles_up(tmp_path: Path) -> None:
     spec = tmp_path / "bad.yaml"
     spec.write_text("openapi: '3.0.3'\npaths:\n  /x:\n   get:\n   summary: oops\n  : bad\n")

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1,0 +1,136 @@
+# `backend/src/meho_backplane/operations/ingest/` — spec ingestion
+
+> Durable map of the spec-ingestion pipeline. Update in lock-step with
+> code changes; stale entries are bugs.
+
+## Overview
+
+The spec-ingestion pipeline reads vendor API specifications (OpenAPI
+3.0 / 3.1 in v0.2; GraphQL SDL / WSDL / proto deferred) and turns
+each operation into a row in `endpoint_descriptor` (G0.6-T1) that the
+dispatcher (G0.6-T5) and the agent's `search_operations` meta-tool
+can resolve.
+
+The pipeline is broken into work items per Initiative #389:
+
+* **T1 (this module) — OpenAPI parser.** Pure-function. Input: a path
+  or URL. Output: a list of `EndpointDescriptorProto`. No DB session,
+  no LLM call.
+* **T2 — `register_ingested_operations()`.** Bulk-upserts proto rows
+  into `endpoint_descriptor`, plus multi-spec merge (vCenter's
+  `vcenter.yaml` + `vi-json.yaml` under one connector).
+* **T3 — LLM-summarised grouping.** Proposes operation groups and
+  assigns each op to one, writing `operation_group` rows.
+* **T4 — Review-queue state machine.** Operators move connectors
+  through `staged → enabled` (and `disabled` for regression
+  rollback) before any op becomes dispatchable.
+* **T5–T7 — CLI / REST / MCP surfaces** that drive the pipeline.
+* **T8 — vSphere canary** — ingest both vCenter specs end-to-end.
+* **T9 — Docs.**
+
+T1 is the foundation: nothing else in the pipeline runs without its
+output shape.
+
+## Key types
+
+### `EndpointDescriptorProto` (`ingest/schemas.py`)
+
+Frozen Pydantic v2 model. One per operation. Maps 1:1 to a subset of
+`EndpointDescriptor` columns (the parser-populated subset):
+
+| Proto field | ORM column | Notes |
+|---|---|---|
+| `op_id` | `op_id` | `f"{METHOD}:{path}"`; the connector-side natural key |
+| `method` | `method` | Upper-case HTTP verb |
+| `path` | `path` | URL template, `{var}` placeholders |
+| `summary` | `summary` | Verbatim from spec |
+| `description` | `description` | Verbatim from spec |
+| `tags` | `tags` | Spec tags + optional `spec:<source>` marker |
+| `parameter_schema` | `parameter_schema` | Flattened JSON Schema 2020-12 with `x-meho-param-loc` |
+| `response_schema` | `response_schema` | Success-response schema or `None` |
+| `safety_level` | `safety_level` | HTTP-verb heuristic, operator-overridable at review |
+| `requires_approval` | `requires_approval` | Always `False` at parse time |
+
+T2 owns the rest of the ORM columns (`tenant_id`, `source_kind`,
+`product`, `version`, `impl_id`, `group_id`, `embedding`, `is_enabled`,
+`custom_description`, `custom_notes`, `handler_ref`,
+`llm_instructions`).
+
+### `parse_openapi(spec_path_or_uri, *, spec_source=None)` (`ingest/openapi.py`)
+
+The only public entry point. Resolves the input (file path or
+`http(s)://` URL via `httpx`), sniffs YAML vs JSON via
+`detect_spec_format`, decodes, validates the OpenAPI version
+(3.0.x / 3.1.x), and walks `paths`. Returns a list.
+
+The function is synchronous because callers are CLI / one-shot
+ingestion endpoints that have no in-flight event loop concern. It
+also keeps the surface trivially testable.
+
+## Control flow
+
+```
+parse_openapi
+├─ _load_spec_bytes        # file:// or http(s)://; httpx with a 30s timeout
+├─ _decode_spec            # CSafeLoader-preferred YAML, stdlib JSON
+├─ _validate_openapi_version
+└─ _iter_operations
+   └─ _build_proto         # per (method, path) verb under paths
+      ├─ _build_parameter_schema
+      │  ├─ _resolve_shallow_ref      # $ref → #/components/schemas/X
+      │  ├─ _build_param_property     # one property per path/query/header
+      │  └─ _build_body_property      # requestBody under "body" key
+      └─ _extract_response_schema     # picks 200 > 201 > 202 > ... > 2XX
+```
+
+`_resolve_shallow_ref` is the load-bearing helper. It inlines exactly
+one level of `$ref` into the parameter / response / body schema and
+preserves any nested `$ref` strings verbatim. The intent is that the
+parameter_schema is self-contained enough for the dispatcher's
+JSON-Schema validator to validate the immediate parameter shape;
+deeper schema dereferencing (chasing nested `$ref`s) is the
+dispatcher's concern (G0.6-T5 + T2's tracking of `components.schemas`).
+
+## Dependencies
+
+* **PyYAML 6.0+** — already a transitive dep; we exercise
+  `yaml.load(..., Loader=CSafeLoader | SafeLoader)`. The C loader is
+  ~5-10× faster on multi-MB specs; the pure-Python fallback works
+  identically on platforms without LibYAML.
+* **httpx 0.27+** — fetch for `http(s)://` URLs. The chassis already
+  depends on httpx for Keycloak JWKS + connector adapters.
+* **Pydantic v2** — `EndpointDescriptorProto` uses `ConfigDict(frozen=True)`.
+
+No spec-side validation library (e.g. `openapi-spec-validator`) is
+pulled in. The parser tolerates partial / underspecified docs and
+relies on T4's review queue to surface ambiguities to a human before
+operations go live.
+
+## Known issues
+
+* **Parameter name + location collision.** When an op has two params
+  with the same `name` in different `in` locations (e.g. `cluster` as
+  path **and** as query), the flat-object representation loses one.
+  Real vendor specs in v0.2 scope (vCenter / NSX / SDDC Manager)
+  never use this combination. T2 will log a warning if it spots a
+  collision after upsert.
+* **Non-schema `$ref` rejected.** `$ref: "#/components/parameters/X"`,
+  `$ref: "#/components/requestBodies/X"`, etc. raise
+  `UnsupportedSpecError`. vCenter doesn't use these; future specs
+  that do will need either a pre-process pass or a v0.2.next
+  extension of the resolver.
+* **Cross-document `$ref` rejected.** External files
+  (`other.yaml#/...`) raise `UnsupportedSpecError`. Same v0.2.next
+  note.
+* **`$ref` drill-down rejected.** Refs that walk into a component's
+  sub-tree (`#/components/schemas/X/properties/y`) raise
+  `InvalidSchemaError`.
+
+## References
+
+* Issue #401 — T1 task.
+* Initiative #389 — G0.7 spec-ingestion pipeline.
+* Goal #221 — G0 foundational substrate.
+* `meho_backplane/db/models.py::EndpointDescriptor` — the ORM target.
+* OpenAPI 3.0.3 spec: https://spec.openapis.org/oas/v3.0.3.html
+* OpenAPI 3.1.1 spec: https://spec.openapis.org/oas/v3.1.1.html

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -69,7 +69,7 @@ also keeps the surface trivially testable.
 
 ## Control flow
 
-```
+```text
 parse_openapi
 ├─ _load_spec_bytes        # file:// or http(s)://; httpx with a 30s timeout
 ├─ _decode_spec            # CSafeLoader-preferred YAML, stdlib JSON


### PR DESCRIPTION
## Summary

- Ships the pure-function OpenAPI 3.0/3.1 parser that produces `EndpointDescriptorProto` rows for the spec-ingestion pipeline.
- Output is consumed downstream by T2 (#403 bulk-upsert), T3 (#404 LLM grouping), T4 (#402 review queue) — none of which depend on each other for the parser shape.
- Validates against the real vCenter `vcenter.yaml` (1,275 ops across 961 paths, ~1.4 s parse) via an env-gated integration test; unit tests use small fixtures.

## What's in here

- `backend/src/meho_backplane/operations/ingest/`:
  - `schemas.py` — frozen `EndpointDescriptorProto` Pydantic model (1:1 with the parser-populated subset of `EndpointDescriptor` columns).
  - `openapi.py` — `parse_openapi(spec_path_or_uri, *, spec_source=None)` + helpers (HTTP fetch, YAML/JSON decode, version check, operation walk, parameter flattening, response selection).
  - `refs.py` — `$ref` resolution (shallow / one-level inline of `#/components/schemas/X`; nested refs preserved) + media-type selection.
  - `exceptions.py` — `InvalidSpecError`, `UnsupportedSpecError`, `InvalidSchemaError` (shared with T4 when it lands).
- `backend/tests/test_operations_ingest_openapi.py` — 35 unit tests covering format sniffing, the canonical fixtures, edge cases (Swagger 2.0 rejection, missing `paths`, malformed YAML/JSON, cross-document `$ref` rejection, drill-down ref rejection, frozen-model behaviour, httpx fetch).
- `backend/tests/fixtures/openapi/` — minimal 3.0 + 3.1 (YAML + JSON) fixtures.
- `backend/tests/integration/test_operations_ingest_vcenter.py` — env-gated coverage threshold + safety-heuristic spot-checks against the real vCenter spec.
- `docs/codebase/spec-ingestion.md` — durable doc for the new module.

## `x-meho-param-loc` extension

Each property on the flattened `parameter_schema` carries an `x-meho-param-loc` extension keyword (`path` / `query` / `header` / `body`) so the dispatcher (G0.6-T5 #396) can split params back into the correct HTTP slot at call time. The flat object means the dispatcher has one JSON Schema to validate against; the extension preserves the per-param routing information OpenAPI's nested `parameters[]` array would otherwise lose.

## Test plan

- [x] `ruff check` + `ruff format --check` on the new files — clean
- [x] `mypy --strict` on full `backend/src/` — 68 source files clean
- [x] `pytest tests/test_operations_ingest_openapi.py -x -q` — 35 passed
- [x] Full backend unit suite — 673 passed, 2 skipped (unchanged)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (4 informational warnings recorded as adjacent findings)
- [x] vCenter integration test with `MEHO_VCENTER_OPENAPI=…/vcenter.yaml` — 1 passed; 1,275 ops across 961 paths; safety heuristic spot-check passes (`GET` → safe, `POST` → caution, `DELETE` → dangerous); every parameter has `x-meho-param-loc` set
- [x] `parse_openapi` returns ≥950 distinct paths from `vcenter.yaml`
- [x] `spec_source` arg threads into tags distinctly across two specs
- [x] `UnsupportedSpecError` raised on Swagger 2.0 and OpenAPI 4.x with the version in the message
- [x] OpenAPI 3.0.x AND 3.1.x both work (fixture for each)

## Out of scope

- T2 (#403) — `register_ingested_operations()` bulk-upsert + multi-spec merge.
- T3 (#404) — LLM-summarised group derivation + per-op assignment.
- T4 (#402) — review-queue state machine (will also add to `exceptions.py`).
- T5–T7 — CLI / REST / MCP surfaces.
- T8 (#408) — vSphere canary end-to-end.
- GraphQL SDL / WSDL / proto parsers — v0.2.next per Initiative #389.

## Adjacent findings (recorded for follow-up, out of scope here)

- `_build_parameter_schema` is 67 lines (warn-only). The body assembles four kinds of param-source data; could split per source, but doing so inflates the public surface for marginal readability gain.
- `_iter_operations` and `_build_proto` each take 6 keyword args (`PLR0913` warn-only). Could be a `ParserContext` dataclass; deferred to T2 where the shape will need to expand for tenant/connector context anyway.
- `backend/src/meho_backplane/operations/ingest/exceptions.py` will be extended by T4 (#402) — the doc string at the top of the file flags this.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI 3.0/3.1 ingestion: parse YAML/JSON from files or URLs into per-endpoint descriptors, tag by spec source, infer safety levels, and include per-parameter location metadata.

* **Bug Fixes / Robustness**
  * Improved format detection, one-level reference inlining, media-type selection, and clearer errors for invalid/unsupported specs.

* **Tests**
  * Added extensive unit/integration tests and multiple OpenAPI fixtures covering edge cases and coverage thresholds.

* **Documentation**
  * New spec-ingestion pipeline guide describing workflow, data shapes, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/429)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->