### PR TITLE
fix(api): coerce TargetORM.aliases list -> tuple in v1 schema mappers (#356 follow-up)

### DIFF
--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -81,7 +81,10 @@ def _to_summary(t: TargetORM) -> TargetSummary:
     return TargetSummary(
         id=t.id,
         name=t.name,
-        aliases=t.aliases,
+        # ORM stores aliases as ``list[str]`` (mutable JSON column);
+        # the response schema declares ``tuple[str, ...]`` for
+        # frozen-model immutability. Coerce at the boundary.
+        aliases=tuple(t.aliases),
         product=t.product,
         host=t.host,
     )
@@ -92,7 +95,7 @@ def _to_full(t: TargetORM) -> Target:
         id=t.id,
         tenant_id=t.tenant_id,
         name=t.name,
-        aliases=t.aliases,
+        aliases=tuple(t.aliases),
         product=t.product,
         host=t.host,
         port=t.port,


### PR DESCRIPTION
## Summary

One-line follow-up to #356 (G0.3-T3). Coerce `TargetORM.aliases` (`list[str]`) → `tuple[str, ...]` at the two response-schema mapper boundaries (`_to_summary`, `_to_full`) so mypy strict stops failing on `main`.

## Why

The response schemas `Target` + `TargetSummary` are frozen and declare `aliases: tuple[str, ...]` for immutability; the ORM stores the same field as `list[str]` (JSON column). The two mappers were passing the list directly, which mypy strict flags as an arg-type incompatibility:

```
src/meho_backplane/api/v1/targets.py:84: error: Argument "aliases" to "TargetSummary" has incompatible type "list[str]"; expected "tuple[str, ...]"  [arg-type]
src/meho_backplane/api/v1/targets.py:95: error: Argument "aliases" to "Target" has incompatible type "list[str]"; expected "tuple[str, ...]"  [arg-type]
```

The Python CI job has been failing on every branch built off `main` since #356 merged. No runtime behaviour change — Pydantic v2 already validates and materialises a tuple at the model boundary; the coercion just satisfies mypy ahead of the validator.

## Scope

Strictly the two mapper call sites. No schema changes, no test changes, no docs changes. Could have been folded into #356 originally but landing it standalone unblocks every other branch (e.g. #429) that's currently rebasing onto a CI-failing `main`.

## Test plan

- [x] `uv run mypy src/` — 89 source files clean (was: 2 errors in `targets.py`)
- [x] `uv run ruff check src/meho_backplane/api/v1/` — clean
- [x] `uv run pytest tests/ -k targets` — 66 passed, 1 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated target API responses to ensure aliases use immutable data structures for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/439)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->