### PR TITLE
ci(security-scan): authenticate Docker Hub pulls via container.credentials (G2.9-T0)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,6 +45,22 @@ jobs:
     container:
       # Bump cadence: monthly review or on advisory.
       image: semgrep/semgrep:1.160.0
+      # Authenticated Docker Hub pull. The ARC scale-set runs every job
+      # as an ephemeral pod sharing one cluster-egress NAT IP, which
+      # exhausts Docker Hub's anonymous 100-pulls-per-6h limit fast and
+      # has tripped this Semgrep job in production. Authenticated
+      # Personal-tier doubles the bucket to 200/6h
+      # (https://docs.docker.com/docker-hub/usage/pulls/) — enough
+      # short-term while G2.9-T1..T3 stand up the in-cluster
+      # pull-through cache that retires this block.
+      #
+      # `credentials:` is consumed by the runner BEFORE any step runs,
+      # so `docker/login-action` cannot substitute. Secrets are
+      # provisioned at the `evoila` org level so all sibling repos
+      # inherit them without per-repo duplication.
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,29 +38,72 @@ permissions:
   security-events: write  # required for SARIF upload to Code Scanning
 
 jobs:
+  # Gate job: reads the optional Docker Hub secrets and surfaces their
+  # presence as a JSON-encoded container spec on a job output. This
+  # indirection is required because the `secrets` context is NOT
+  # available at `jobs.<job_id>.container` (top-level) per
+  # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+  # — only `github, inputs, matrix, needs, strategy, vars` are allowed
+  # there. `needs.<job>.outputs.*` IS available, so the gate publishes
+  # the full container map (with or without `credentials:`) and the
+  # consumer job parses it via `fromJSON()`.
+  #
+  # A previous iteration attempted `container: ${{ ... secrets.X ... }}`
+  # directly; actionlint correctly rejected the `secrets` references at
+  # that scope, and the bare `credentials: { username: ${{ secrets.X }} }`
+  # before that failed GH Actions template validation at parse time
+  # with "Unexpected value ''" (run 25864725292, 'Set up job'). The
+  # gate-job pattern is the documented workaround.
+  check-secrets:
+    name: Check Docker Hub credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      container_spec: ${{ steps.compute.outputs.container_spec }}
+    steps:
+      - id: compute
+        # Build the container spec as a JSON string. When both secrets
+        # are set, include `credentials`; otherwise emit the bare image
+        # spec so the downstream pull is anonymous. The JSON is emitted
+        # via the secret-aware shell (where `secrets` IS available) and
+        # passed to the consumer job through `outputs:` (allowed in
+        # `needs` context).
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
+            spec=$(jq -c -n \
+              --arg user "$DOCKERHUB_USERNAME" \
+              --arg pass "$DOCKERHUB_TOKEN" \
+              '{image: "semgrep/semgrep:1.160.0", credentials: {username: $user, password: $pass}}')
+          else
+            spec='{"image":"semgrep/semgrep:1.160.0"}'
+          fi
+          echo "container_spec=$spec" >> "$GITHUB_OUTPUT"
+
   semgrep:
     name: Semgrep SAST
+    needs: check-secrets
     runs-on: meho-runners
     timeout-minutes: 15
-    container:
-      # Bump cadence: monthly review or on advisory.
-      image: semgrep/semgrep:1.160.0
-      # Authenticated Docker Hub pull. The ARC scale-set runs every job
-      # as an ephemeral pod sharing one cluster-egress NAT IP, which
-      # exhausts Docker Hub's anonymous 100-pulls-per-6h limit fast and
-      # has tripped this Semgrep job in production. Authenticated
-      # Personal-tier doubles the bucket to 200/6h
-      # (https://docs.docker.com/docker-hub/usage/pulls/) — enough
-      # short-term while G2.9-T1..T3 stand up the in-cluster
-      # pull-through cache that retires this block.
-      #
-      # `credentials:` is consumed by the runner BEFORE any step runs,
-      # so `docker/login-action` cannot substitute. Secrets are
-      # provisioned at the `evoila` org level so all sibling repos
-      # inherit them without per-repo duplication.
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    # Authenticated Docker Hub pull. The ARC scale-set runs every job
+    # as an ephemeral pod sharing one cluster-egress NAT IP, which
+    # exhausts Docker Hub's anonymous 100-pulls-per-6h limit fast and
+    # has tripped this Semgrep job in production. Authenticated
+    # Personal-tier doubles the bucket to 200/6h
+    # (https://docs.docker.com/docker-hub/usage/pulls/) — enough
+    # short-term while G2.9-T1..T3 stand up the in-cluster
+    # pull-through cache that retires this block.
+    #
+    # `credentials:` is consumed by the runner BEFORE any step runs,
+    # so `docker/login-action` cannot substitute. Secrets are
+    # provisioned at the `evoila` org level so all sibling repos
+    # inherit them without per-repo duplication.
+    #
+    # `container` is materialised from `check-secrets`' output (see the
+    # comment on that job). Bump cadence: monthly review or on advisory.
+    container: ${{ fromJSON(needs.check-secrets.outputs.container_spec) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 


### PR DESCRIPTION
## Summary

- Add a `check-secrets` gate job + conditional `container:` construction to `.github/workflows/security-scan.yml` so the Semgrep job runs an authenticated Docker Hub pull when `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` org secrets exist, and degrades to an anonymous pull when they don't — without failing GH Actions template validation in the unset state. Authenticated pull doubles the runner pool's shared 6h pull bucket from 100 to 200, unsticking the recurring `unauthenticated pull rate limit` failure on `meho-runners`.
- Tactical fix only — `G2.9-T1..T3` (initiative #67) build the permanent in-cluster pull-through cache that retires this block.

## Implementation notes

The naive `credentials: { username: ${{ secrets.DOCKERHUB_USERNAME }}, password: ${{ secrets.DOCKERHUB_TOKEN }} }` block — what the issue body proposed — hard-fails GH Actions template validation at parse time when either secret is unset (the bootstrap state):

```
The template is not valid. .github/workflows/security-scan.yml (Line: 62, Col: 19): Unexpected value '',
.github/workflows/security-scan.yml (Line: 63, Col: 19): Unexpected value ''
```

This fires during `Set up job`, **before** any image pull is attempted. It is not an "auth failure during pull" — the workflow never reaches the pull. (Empirical confirmation: run [25864725292](https://github.com/evoila/meho/actions/runs/25864725292/job/76003627858).) An earlier iteration of the PR body claimed an auth-failure fallback mode; that was wrong and is corrected here.

CodeRabbit's suggested top-level `container: ${{ ... secrets.X ... }}` fromJSON ternary doesn't work either: per GitHub's documented [context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), `jobs.<job_id>.container` only allows `github, inputs, matrix, needs, strategy, vars` — `secrets` is excluded. `actionlint` correctly rejects the reference.

The fix is the documented workaround: a small `check-secrets` gate job runs first on `ubuntu-latest`, where `secrets` IS available inside a step's `run:` block. It computes a JSON container spec with `jq` — with `credentials` when both secrets are non-empty, without when either is unset — and exposes it on a job output. The `semgrep` job consumes it via `needs.check-secrets.outputs.container_spec` + `fromJSON()`, both of which ARE allowed at top-level `container:`.

```yaml
jobs:
  check-secrets:
    runs-on: ubuntu-latest
    outputs:
      container_spec: ${{ steps.compute.outputs.container_spec }}
    steps:
      - id: compute
        env:
          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
        run: |
          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
            spec=$(jq -c -n --arg user "$DOCKERHUB_USERNAME" --arg pass "$DOCKERHUB_TOKEN" \
              '{image: "semgrep/semgrep:1.160.0", credentials: {username: $user, password: $pass}}')
          else
            spec='{"image":"semgrep/semgrep:1.160.0"}'
          fi
          echo "container_spec=$spec" >> "$GITHUB_OUTPUT"

  semgrep:
    needs: check-secrets
    runs-on: meho-runners
    container: ${{ fromJSON(needs.check-secrets.outputs.container_spec) }}
    # ...
```

`credentials:` is still the right knob for the consumer (not `docker/login-action`): GHA pulls `container.image` *before* any step runs, so a login step inside the job cannot affect that pull. The gate job is a small price for the parse-time-validity property.

Docs: https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container, https://docs.github.com/en/actions/learn-github-actions/contexts.

## Deviation from the issue body — chart.yml is NOT in scope

Issue #68 lists `.github/workflows/chart.yml`'s `services:` block for `pgvector/pgvector:pg16` as a second target. **There is no such block in chart.yml.** The pgvector image is pulled inside a kind cluster spun up by the `helm-test` job, which:

1. Runs on `ubuntu-latest` (GitHub-hosted), NOT `meho-runners`, so it does not share the ARC cluster's NAT egress and does not consume the 100/6h ARC-shared bucket that triggered this fire.
2. Pulls the image via the kind cluster's node, not via a GHA `services:`/`container:` block. `container.credentials:` does not apply to images pulled inside a kind cluster.

Acceptance criterion #4 ("Both workflows reference `credentials:` under their respective `container:`/`services:` blocks") therefore cannot be literally satisfied for chart.yml without restructuring the workflow (e.g., introducing a real `services:` container in place of the in-cluster pod). That restructuring is a larger change with its own design questions and is **out of scope for this tactical unstick**. The actual failure mode the initiative is solving (`semgrep` in `security-scan.yml`) is fixed by this PR alone.

If the chart.yml pgvector pull ever does need authenticated access, the right fix is the permanent in-cluster cache from G2.9-T2/T3 (it covers any Docker Hub pull transparently, including pulls originating inside kind on a GitHub-hosted runner once those runners point at the cache — though the GH-hosted runner case is moot for our ARC-rate-limit concern).

## Org-level secrets — manual ops precondition

This PR's YAML edits expect `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to exist as **org-level GitHub Secrets** on the `evoila` org, accessible to `evoila/meho`. I was unable to verify their presence from this session (`gh secret list --org evoila` → HTTP 403, requires org-admin permission).

Required before this PR's runs benefit from authenticated pulls:

1. Create a Docker Hub access token (NOT the account password) scoped `Public Repo Read-only` per https://docs.docker.com/security/for-developers/access-tokens/.
2. Store username + token in 1Password using `op-cli` skill conventions; record the item name in a follow-up comment on this PR (acceptance criterion #2).
3. Mirror them to `evoila` org secrets:
   ```
   gh secret set DOCKERHUB_USERNAME --org evoila --visibility all
   gh secret set DOCKERHUB_TOKEN    --org evoila --visibility all
   ```
4. Verify with `gh secret list --org evoila` (acceptance criterion #1).

Until the secrets are provisioned, `check-secrets` outputs the anonymous-pull spec and `semgrep` continues to share the 100/6h anonymous bucket. After provisioning, the next workflow run sees the populated secrets and the spec carries `credentials:`, doubling the bucket to 200/6h.

## Test plan

- [x] `actionlint .github/workflows/security-scan.yml` — exit 0
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses; both `check-secrets` and `semgrep` jobs declared; `semgrep.container` is a `${{ fromJSON(...) }}` expression.
- [x] Both fromJSON shapes (with and without `credentials`) parse as valid GH Actions container maps via local `python -c "import json; ..."` sanity check.
- [x] Diff is targeted: one workflow file, one new gate job, one consumer-side `container:` expression swap.
- [ ] (Post-merge) Verify the next run of Security Scan reaches the `semgrep` job successfully — i.e. `Set up job` no longer hard-fails template validation regardless of secret state (acceptance criterion #5).
- [ ] (Post-merge, ops-gated) Once secrets are provisioned, re-run Security Scan and verify no `unauthenticated pull rate limit` line appears in the Semgrep job logs (acceptance criterion #5 second-order).
- [ ] (Post-merge) Re-run every workflow on `main` once to confirm no regression (acceptance criterion #6).

## Out of scope

- `.github/workflows/chart.yml` — no `services:`/`container:` block to attach `credentials:` to (see deviation note above).
- G2.9-T1 (#69): Docker Hub service account → 1Password → K8s Secret.
- G2.9-T2 (#70): registry:2 pull-through cache deployment.
- G2.9-T3 (#71): ARC `registry-mirrors` injection + smoke test.

Closes #68

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-14)

Addressed review findings from `.claude/auto/review-results/pr-447-iter-1.json`:

- **B1** `a2af1e6` — Replaced direct `container.credentials: { username: secrets.X }` with a `check-secrets` gate job that publishes the JSON container spec on an output; consumer `semgrep` job reads it via `needs.check-secrets.outputs.container_spec` + `fromJSON()`. Both parse-time-validates when secrets are unset AND carries credentials when secrets are set. CodeRabbit's suggested top-level `${{ ... secrets.X ... }}` ternary was rejected by `actionlint` because `secrets` is not allowed at `jobs.<job_id>.container` per [GH context-availability docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability); the gate-job pattern is the documented workaround.

Adjacent improvement folded in (per review's `adjacent_improvements`):

- PR body updated to reflect the empirically-observed failure mode (parse-time template validation), correcting the earlier "auth failure during pull" claim that conflated parse-time and pull-time failure modes.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI security-scan workflow now supports authenticated container image pulls when credentials are available, falling back to anonymous pulls otherwise. The workflow dynamically selects the image specification while preserving existing scan and SARIF upload steps for consistent reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/447)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
