### PR TITLE
feat(connectors): G9.1-T2 Connector ABC topology hooks + Pydantic schemas

### DIFF
--- a/backend/src/meho_backplane/connectors/__init__.py
+++ b/backend/src/meho_backplane/connectors/__init__.py
@@ -24,21 +24,33 @@ from meho_backplane.connectors.resolver import (
 )
 from meho_backplane.connectors.schemas import (
     AuthModel,
+    CandidateHint,
+    EdgeHint,
+    EdgeKind,
     FingerprintResult,
+    NodeHint,
+    NodeKind,
     OperationResult,
     ProbeResult,
     ResultHandle,
+    TopologyHints,
 )
 
 __all__ = [
     "AmbiguousConnectorResolution",
     "AuthModel",
+    "CandidateHint",
     "Connector",
+    "EdgeHint",
+    "EdgeKind",
     "FingerprintResult",
     "NoMatchingConnector",
+    "NodeHint",
+    "NodeKind",
     "OperationResult",
     "ProbeResult",
     "ResultHandle",
+    "TopologyHints",
     "all_connectors",
     "all_connectors_v2",
     "get_connector",

--- a/backend/src/meho_backplane/connectors/base.py
+++ b/backend/src/meho_backplane/connectors/base.py
@@ -10,9 +10,16 @@ in T5 once G0.3 lands the Target model.
 """
 
 from abc import ABC, abstractmethod
+from datetime import UTC, datetime
 from typing import Any
 
-from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
+from meho_backplane.connectors.schemas import (
+    CandidateHint,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+    TopologyHints,
+)
 
 __all__ = ["Connector"]
 
@@ -92,3 +99,44 @@ class Connector(ABC):
         common path is "look up handler_ref from endpoint_descriptor,
         call the handler".
         """
+
+    # G9.1-T2 (#449) — topology discovery hooks. Default no-op implementations
+    # keep every shipped subclass compilable without modification; per-product
+    # overrides land in G3.x Initiative tasks (vSphere, Kubernetes, Vault).
+    async def discover_topology(self, target: Target) -> TopologyHints:
+        """Return the topology snapshot for ``target``.
+
+        The G9.1-T3 refresh service calls this method on demand and on a
+        scheduled cadence; the returned :class:`TopologyHints` is diffed
+        against existing ``graph_node`` + ``graph_edge`` rows for the
+        same ``(tenant_id, target_id)`` and applied as inserts /
+        updates / soft-deletes.
+
+        The base-class default returns an empty :class:`TopologyHints`
+        with ``discovered_at`` stamped at call time. Connectors that
+        can derive nodes + edges from a probe (vSphere, Kubernetes,
+        Vault — per Initiative #363) override this method; connectors
+        with nothing to contribute inherit the no-op default.
+        """
+        return TopologyHints(discovered_at=datetime.now(UTC))
+
+    async def list_candidates(
+        self,
+        seed_target: Target | None = None,
+    ) -> list[CandidateHint]:
+        """Return potentially-reachable targets the connector inferred.
+
+        The G9.1-T6 ``meho targets discover`` CLI verb surfaces these
+        candidates to the operator; ``seed_target`` is optional and lets
+        a connector scope the discovery to one known target's reach
+        (e.g. for Kubernetes, ``seed_target=cluster-1`` can surface peer
+        clusters present in the same kubeconfig context tree).
+
+        The base-class default returns ``[]``. Connectors that can list
+        candidates (vSphere — ESXi hosts a vCenter sees but no target
+        exists for; Kubernetes — peer cluster contexts) override.
+        Auto-registration is out of scope (Initiative #363): the
+        operator reviews returned candidates and runs ``meho targets
+        create`` to register them.
+        """
+        return []

--- a/backend/src/meho_backplane/connectors/schemas.py
+++ b/backend/src/meho_backplane/connectors/schemas.py
@@ -31,18 +31,58 @@ from collections.abc import Mapping
 from datetime import datetime
 from enum import StrEnum
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
 __all__ = [
     "AuthModel",
+    "CandidateHint",
+    "EdgeHint",
+    "EdgeKind",
     "FingerprintResult",
+    "NodeHint",
+    "NodeKind",
     "OperationResult",
     "ProbeResult",
     "ResultHandle",
+    "TopologyHints",
 ]
+
+
+NodeKind = Literal[
+    "target",
+    "vm",
+    "host",
+    "network",
+    "datastore",
+    "namespace",
+    "pod",
+    "service",
+    "ingress",
+    "node",
+    "principal",
+    "vault-role",
+    "vault-mount",
+    "volume",
+]
+"""Closed enum of node kinds the v0.2 graph supports.
+
+The vocabulary is the auto-discoverable subset agreed in G9.1 (#363) —
+the curated cross-system kinds (e.g. ``"workload"``, ``"deployment"``)
+land in G9.2 once operator annotation flows ship.
+"""
+
+
+EdgeKind = Literal["runs-on", "mounts", "routes-through", "belongs-to"]
+"""The four edge kinds high-confidence probes can derive.
+
+Cross-system semantic edges (``"authenticates-via"``, ``"depends-on"``,
+``"replicates-to"``, ``"backed-up-by"``) need explicit operator
+assertion and land in G9.2 — auto-inferring them from probes is the
+failure mode this split guards against (per Initiative #363).
+"""
 
 
 class AuthModel(StrEnum):
@@ -153,6 +193,116 @@ class ResultHandle(BaseModel):
         if value is None:
             return None
         return [dict(row) for row in value]
+
+
+class NodeHint(BaseModel):
+    """One node a connector's :meth:`Connector.discover_topology` returns.
+
+    The G9.1-T3 refresh service translates a list of these (plus
+    :class:`EdgeHint` entries) into ``graph_node`` rows, scoped to the
+    tenant of the seed target. ``properties`` is a free-form bag for
+    connector-supplied detail (e.g. a VM's power state, a pod's QoS
+    class) that the refresh service persists as JSONB.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: NodeKind
+    name: str
+    properties: Mapping[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _freeze_properties(self) -> "NodeHint":
+        object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
+        return self
+
+    @field_serializer("properties")
+    def _serialize_properties(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        return dict(value)
+
+
+class EdgeHint(BaseModel):
+    """One edge a connector's :meth:`Connector.discover_topology` returns.
+
+    Edges are directed (``from`` → ``to``) and identified by the
+    ``(kind, name)`` tuples of the endpoints, not by node IDs — the
+    refresh service maps the tuples to ``graph_node.id`` rows on apply.
+    The kind/name pair is unique within ``(tenant_id, kind)`` per the
+    ``graph_node`` schema in G9.1-T1.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    from_kind: NodeKind
+    from_name: str
+    to_kind: NodeKind
+    to_name: str
+    kind: EdgeKind
+    properties: Mapping[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _freeze_properties(self) -> "EdgeHint":
+        object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
+        return self
+
+    @field_serializer("properties")
+    def _serialize_properties(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        return dict(value)
+
+
+class TopologyHints(BaseModel):
+    """Connector-supplied topology snapshot for one target.
+
+    Returned by :meth:`Connector.discover_topology`. The G9.1-T3 refresh
+    service diffs this against existing ``graph_node`` + ``graph_edge``
+    rows for the same ``(tenant_id, target_id)`` and applies inserts /
+    updates / soft-deletes.
+
+    ``nodes`` and ``edges`` are :class:`tuple` — not :class:`list` — so
+    the frozen model is deeply immutable end-to-end, mirroring the
+    :attr:`ResultHandle.sample_rows` pattern. A ``list`` argument at
+    construction is accepted and converted by Pydantic's validation.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    nodes: tuple[NodeHint, ...] = ()
+    edges: tuple[EdgeHint, ...] = ()
+    discovered_at: datetime
+
+
+class CandidateHint(BaseModel):
+    """One candidate target a connector's :meth:`Connector.list_candidates` returns.
+
+    Candidates are potentially-reachable targets the connector inferred
+    from an existing seed (e.g. a vCenter exposing its managed ESXi
+    hosts; a kubeconfig listing peer cluster contexts). The
+    G9.1-T6 ``meho targets discover`` CLI verb surfaces these to the
+    operator; auto-registration is intentionally out of scope per
+    Initiative #363 (operator runs ``meho targets create`` after review).
+
+    ``evidence`` is the debugging payload — whatever made the connector
+    think this candidate exists (e.g. ``{"source": "kubeconfig",
+    "context_name": "cluster-2"}``); ``confidence`` is the connector's
+    self-assessment of probe-vs-curation reliability.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    host: str
+    port: int | None = None
+    evidence: Mapping[str, Any]
+    confidence: Literal["high", "medium", "low"]
+
+    @model_validator(mode="after")
+    def _freeze_evidence(self) -> "CandidateHint":
+        object.__setattr__(self, "evidence", MappingProxyType(dict(self.evidence)))
+        return self
+
+    @field_serializer("evidence")
+    def _serialize_evidence(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        return dict(value)
 
 
 class OperationResult(BaseModel):

--- a/backend/tests/test_connectors_topology.py
+++ b/backend/tests/test_connectors_topology.py
@@ -1,0 +1,441 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the G9.1-T2 connector topology hooks and Pydantic schemas.
+
+Coverage (per Task #449 acceptance criteria):
+
+* ``Connector`` ABC exposes :meth:`Connector.discover_topology` and
+  :meth:`Connector.list_candidates` as **non-abstract** methods with
+  no-op defaults — every shipped v1 subclass that did not exist when
+  these methods were added (VaultConnector #244, KubernetesConnector
+  skeleton #321) must still instantiate without overriding them.
+* Default :meth:`discover_topology` returns an empty
+  :class:`TopologyHints` with ``discovered_at`` close to call time.
+* Default :meth:`list_candidates` returns ``[]``.
+* A subclass override of :meth:`discover_topology` returns the
+  override's value via the ABC dispatch.
+* :class:`NodeHint`, :class:`EdgeHint`, :class:`TopologyHints`, and
+  :class:`CandidateHint` are frozen end-to-end: field reassignment
+  raises :exc:`pydantic.ValidationError`; nested mappings raise
+  :exc:`TypeError` on in-place mutation; round-tripping through
+  ``model_dump`` / ``model_validate`` is lossless.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from meho_backplane.connectors import (
+    CandidateHint,
+    Connector,
+    EdgeHint,
+    FingerprintResult,
+    NodeHint,
+    OperationResult,
+    ProbeResult,
+    TopologyHints,
+)
+from meho_backplane.connectors.schemas import (
+    CandidateHint as _CandidateDirect,
+)
+from meho_backplane.connectors.schemas import (
+    EdgeHint as _EdgeDirect,
+)
+from meho_backplane.connectors.schemas import (
+    NodeHint as _NodeDirect,
+)
+from meho_backplane.connectors.schemas import (
+    TopologyHints as _TopologyDirect,
+)
+
+_NOW = datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Package-level export checks (mirror test_connectors_base.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_package_exports_topology_schemas() -> None:
+    for cls in (NodeHint, EdgeHint, TopologyHints, CandidateHint):
+        assert cls is not None
+
+
+def test_package_root_aliases_match_submodule() -> None:
+    assert NodeHint is _NodeDirect
+    assert EdgeHint is _EdgeDirect
+    assert TopologyHints is _TopologyDirect
+    assert CandidateHint is _CandidateDirect
+
+
+# ---------------------------------------------------------------------------
+# Test subclasses (shared)
+# ---------------------------------------------------------------------------
+
+
+class _DefaultsConnector(Connector):
+    """Subclass that inherits both topology defaults — exercises the no-op path."""
+
+    product = "default-topology"
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:
+        raise NotImplementedError
+
+
+class _OverridingConnector(Connector):
+    """Subclass that overrides both topology methods — exercises dispatch."""
+
+    product = "override-topology"
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:
+        raise NotImplementedError
+
+    async def discover_topology(self, target: Any) -> TopologyHints:
+        return TopologyHints(
+            nodes=(
+                NodeHint(kind="vm", name="vm-01"),
+                NodeHint(kind="host", name="esxi-01"),
+            ),
+            edges=(
+                EdgeHint(
+                    from_kind="vm",
+                    from_name="vm-01",
+                    to_kind="host",
+                    to_name="esxi-01",
+                    kind="runs-on",
+                ),
+            ),
+            discovered_at=_NOW,
+        )
+
+    async def list_candidates(self, seed_target: Any | None = None) -> list[CandidateHint]:
+        return [
+            CandidateHint(
+                name="cluster-2",
+                host="10.0.0.42",
+                port=6443,
+                evidence={"source": "kubeconfig", "context_name": "cluster-2"},
+                confidence="high",
+            ),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Connector ABC — no-op defaults are non-abstract
+# ---------------------------------------------------------------------------
+
+
+def test_connector_defaults_subclass_instantiates_without_overrides() -> None:
+    # The two new methods must NOT be abstract — otherwise existing v1
+    # subclasses break. _DefaultsConnector overrides only fingerprint/
+    # probe/execute and must remain instantiable.
+    conn = _DefaultsConnector()
+    assert conn.product == "default-topology"
+
+
+def test_default_discover_topology_returns_empty_topology_hints() -> None:
+    conn = _DefaultsConnector()
+    before = datetime.now(UTC)
+    result = asyncio.run(conn.discover_topology(target=None))
+    after = datetime.now(UTC)
+    assert isinstance(result, TopologyHints)
+    assert result.nodes == ()
+    assert result.edges == ()
+    # discovered_at is stamped at call time, well inside [before, after].
+    assert before - timedelta(seconds=1) <= result.discovered_at <= after + timedelta(seconds=1)
+    assert result.discovered_at.tzinfo is UTC
+
+
+def test_default_list_candidates_returns_empty_list() -> None:
+    conn = _DefaultsConnector()
+    result = asyncio.run(conn.list_candidates())
+    assert result == []
+    # The contract is "empty list" — a returned tuple would silently
+    # break callers iterating with .append() before persisting.
+    assert isinstance(result, list)
+
+
+def test_default_list_candidates_accepts_seed_target() -> None:
+    # The parameter is optional + plain ``Any | None`` — exercises both
+    # the default (no arg) and the explicit-None call shapes.
+    conn = _DefaultsConnector()
+    result_default = asyncio.run(conn.list_candidates())
+    result_none = asyncio.run(conn.list_candidates(seed_target=None))
+    result_seeded = asyncio.run(conn.list_candidates(seed_target=object()))
+    assert result_default == [] == result_none == result_seeded
+
+
+# ---------------------------------------------------------------------------
+# Connector ABC — overrides dispatch via the abstract base
+# ---------------------------------------------------------------------------
+
+
+def test_overridden_discover_topology_dispatches_via_abc() -> None:
+    # Hold the binding as ``Connector`` — the dispatch must go through
+    # the abstract base reference, proving the override is reachable
+    # via the ABC contract (not just direct method call).
+    conn: Connector = _OverridingConnector()
+    result = asyncio.run(conn.discover_topology(target=None))
+    assert isinstance(result, TopologyHints)
+    assert len(result.nodes) == 2
+    assert result.nodes[0].name == "vm-01"
+    assert result.edges[0].kind == "runs-on"
+    assert result.discovered_at == _NOW
+
+
+def test_overridden_list_candidates_dispatches_via_abc() -> None:
+    conn: Connector = _OverridingConnector()
+    result = asyncio.run(conn.list_candidates(seed_target=None))
+    assert len(result) == 1
+    assert result[0].name == "cluster-2"
+    assert result[0].confidence == "high"
+
+
+# ---------------------------------------------------------------------------
+# Shipped v1 subclasses inherit the new defaults unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_v1_subclasses_inherit_topology_defaults() -> None:
+    # Backward-compat guard: VaultConnector (#244) and KubernetesConnector
+    # skeleton (#321) only set ``product`` and override fingerprint/probe/
+    # execute. They must remain importable AND inherit the new
+    # ``discover_topology`` + ``list_candidates`` defaults without code
+    # change.
+    from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
+    from meho_backplane.connectors.vault.connector import VaultConnector
+
+    # Compare unbound class methods, not bound instance methods, so
+    # we don't have to construct each connector (their constructors
+    # touch settings + Vault).
+    assert VaultConnector.discover_topology is Connector.discover_topology
+    assert VaultConnector.list_candidates is Connector.list_candidates
+    assert KubernetesConnector.discover_topology is Connector.discover_topology
+    assert KubernetesConnector.list_candidates is Connector.list_candidates
+
+
+# ---------------------------------------------------------------------------
+# NodeHint
+# ---------------------------------------------------------------------------
+
+
+def test_node_hint_round_trip() -> None:
+    nh = NodeHint(kind="vm", name="vm-01", properties={"power_state": "on"})
+    dumped = nh.model_dump()
+    restored = NodeHint.model_validate(dumped)
+    assert restored == nh
+
+
+def test_node_hint_default_properties_is_empty_mapping() -> None:
+    nh = NodeHint(kind="host", name="esxi-01")
+    assert dict(nh.properties) == {}
+
+
+def test_node_hint_is_frozen() -> None:
+    nh = NodeHint(kind="vm", name="vm-01")
+    with pytest.raises(ValidationError):
+        nh.name = "mutated"  # type: ignore[misc]
+
+
+def test_node_hint_properties_is_deeply_immutable() -> None:
+    nh = NodeHint(kind="vm", name="vm-01", properties={"k": "v"})
+    with pytest.raises(TypeError):
+        nh.properties["new_key"] = "value"  # type: ignore[index]
+
+
+def test_node_hint_rejects_unknown_kind() -> None:
+    with pytest.raises(ValidationError):
+        NodeHint(kind="not-a-real-kind", name="x")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# EdgeHint
+# ---------------------------------------------------------------------------
+
+
+def test_edge_hint_round_trip() -> None:
+    eh = EdgeHint(
+        from_kind="vm",
+        from_name="vm-01",
+        to_kind="host",
+        to_name="esxi-01",
+        kind="runs-on",
+        properties={"since": "2026-05-14T00:00:00Z"},
+    )
+    dumped = eh.model_dump()
+    restored = EdgeHint.model_validate(dumped)
+    assert restored == eh
+
+
+def test_edge_hint_default_properties_is_empty_mapping() -> None:
+    eh = EdgeHint(
+        from_kind="pod",
+        from_name="p1",
+        to_kind="namespace",
+        to_name="ns-1",
+        kind="belongs-to",
+    )
+    assert dict(eh.properties) == {}
+
+
+def test_edge_hint_is_frozen() -> None:
+    eh = EdgeHint(
+        from_kind="vm",
+        from_name="vm-01",
+        to_kind="host",
+        to_name="esxi-01",
+        kind="runs-on",
+    )
+    with pytest.raises(ValidationError):
+        eh.kind = "belongs-to"  # type: ignore[misc]
+
+
+def test_edge_hint_properties_is_deeply_immutable() -> None:
+    eh = EdgeHint(
+        from_kind="vm",
+        from_name="vm-01",
+        to_kind="host",
+        to_name="esxi-01",
+        kind="runs-on",
+        properties={"k": "v"},
+    )
+    with pytest.raises(TypeError):
+        eh.properties["new_key"] = "value"  # type: ignore[index]
+
+
+def test_edge_hint_rejects_unknown_edge_kind() -> None:
+    with pytest.raises(ValidationError):
+        EdgeHint(
+            from_kind="vm",
+            from_name="vm-01",
+            to_kind="host",
+            to_name="esxi-01",
+            kind="authenticates-via",  # G9.2 territory — not yet allowed
+        )  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# TopologyHints
+# ---------------------------------------------------------------------------
+
+
+def test_topology_hints_round_trip() -> None:
+    th = TopologyHints(
+        nodes=(NodeHint(kind="vm", name="vm-01"),),
+        edges=(
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-01",
+                to_kind="host",
+                to_name="esxi-01",
+                kind="runs-on",
+            ),
+        ),
+        discovered_at=_NOW,
+    )
+    dumped = th.model_dump()
+    restored = TopologyHints.model_validate(dumped)
+    assert restored == th
+
+
+def test_topology_hints_accepts_list_inputs_and_converts_to_tuple() -> None:
+    # Convenience for callers — Pydantic coerces ``list`` → ``tuple`` so
+    # the discover_topology override doesn't have to pre-tuple the args.
+    th = TopologyHints(
+        nodes=[NodeHint(kind="vm", name="vm-01")],
+        edges=[],
+        discovered_at=_NOW,
+    )
+    assert isinstance(th.nodes, tuple)
+    assert isinstance(th.edges, tuple)
+    assert len(th.nodes) == 1
+
+
+def test_topology_hints_defaults_are_empty_tuples() -> None:
+    th = TopologyHints(discovered_at=_NOW)
+    assert th.nodes == ()
+    assert th.edges == ()
+
+
+def test_topology_hints_is_frozen() -> None:
+    th = TopologyHints(discovered_at=_NOW)
+    with pytest.raises(ValidationError):
+        th.discovered_at = datetime.now(UTC)  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# CandidateHint
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_hint_round_trip() -> None:
+    ch = CandidateHint(
+        name="cluster-2",
+        host="10.0.0.42",
+        port=6443,
+        evidence={"source": "kubeconfig", "context_name": "cluster-2"},
+        confidence="high",
+    )
+    dumped = ch.model_dump()
+    restored = CandidateHint.model_validate(dumped)
+    assert restored == ch
+
+
+def test_candidate_hint_optional_port_defaults_to_none() -> None:
+    ch = CandidateHint(
+        name="esxi-09",
+        host="10.0.0.99",
+        evidence={"source": "vcenter.host.list"},
+        confidence="medium",
+    )
+    assert ch.port is None
+
+
+def test_candidate_hint_is_frozen() -> None:
+    ch = CandidateHint(
+        name="x",
+        host="h",
+        evidence={"src": "test"},
+        confidence="low",
+    )
+    with pytest.raises(ValidationError):
+        ch.name = "mutated"  # type: ignore[misc]
+
+
+def test_candidate_hint_evidence_is_deeply_immutable() -> None:
+    ch = CandidateHint(
+        name="x",
+        host="h",
+        evidence={"src": "test"},
+        confidence="low",
+    )
+    with pytest.raises(TypeError):
+        ch.evidence["new_key"] = "value"  # type: ignore[index]
+
+
+def test_candidate_hint_rejects_unknown_confidence() -> None:
+    with pytest.raises(ValidationError):
+        CandidateHint(
+            name="x",
+            host="h",
+            evidence={},
+            confidence="certain",  # not in {high, medium, low}
+        )  # type: ignore[arg-type]

--- a/docs/architecture/connectors.md
+++ b/docs/architecture/connectors.md
@@ -62,7 +62,7 @@ class Connector(ABC):
 
 Three required methods (`fingerprint` / `probe` / `execute`) plus two **non-abstract** topology hooks (G9.1-T2 #449). The topology hooks ship base-class defaults so every v1 subclass (VaultConnector #244, KubernetesConnector skeleton #321) keeps working without code change; per-product overrides land in the G3.x Initiatives.
 
-**Op-id namespace** is `<product>.<resource>.<verb>` — e.g., `vsphere.vm.list`, `vault.kv.read`, `bind9.zone.create`.
+**Op-id namespace** depends on source kind: typed ops use `<product>.<resource>.<verb>` (e.g., `vault.kv.read`, `bind9.zone.create`), while ingested ops use `<METHOD>:<path>` (e.g., `GET:/api/vcenter/cluster`). The `Connector.execute` docstring at [`base.py`](../../backend/src/meho_backplane/connectors/base.py) is the source-of-truth contract.
 
 The G9.1-T3 refresh service calls `discover_topology(target)` on demand + on schedule and diffs the returned `TopologyHints` against `graph_node` + `graph_edge` rows for the same `(tenant_id, target_id)`. The G9.1-T6 `meho targets discover` verb calls `list_candidates(seed_target)` and surfaces candidates to the operator — auto-registration is intentionally out of scope.
 

--- a/docs/architecture/connectors.md
+++ b/docs/architecture/connectors.md
@@ -49,9 +49,22 @@ class Connector(ABC):
     async def execute(
         self, target: Target, op_id: str, params: dict[str, Any]
     ) -> OperationResult: ...
+
+    # G9.1-T2 (#449) — topology discovery hooks. Non-abstract; defaults
+    # return empty hints so every shipped v1 subclass remains compilable
+    # without modification. Per-product overrides land in G3.x.
+    async def discover_topology(self, target: Target) -> TopologyHints: ...
+
+    async def list_candidates(
+        self, seed_target: Target | None = None
+    ) -> list[CandidateHint]: ...
 ```
 
-Three required methods, all async. **Op-id namespace** is `<product>.<resource>.<verb>` — e.g., `vsphere.vm.list`, `vault.kv.read`, `bind9.zone.create`.
+Three required methods (`fingerprint` / `probe` / `execute`) plus two **non-abstract** topology hooks (G9.1-T2 #449). The topology hooks ship base-class defaults so every v1 subclass (VaultConnector #244, KubernetesConnector skeleton #321) keeps working without code change; per-product overrides land in the G3.x Initiatives.
+
+**Op-id namespace** is `<product>.<resource>.<verb>` — e.g., `vsphere.vm.list`, `vault.kv.read`, `bind9.zone.create`.
+
+The G9.1-T3 refresh service calls `discover_topology(target)` on demand + on schedule and diffs the returned `TopologyHints` against `graph_node` + `graph_edge` rows for the same `(tenant_id, target_id)`. The G9.1-T6 `meho targets discover` verb calls `list_candidates(seed_target)` and surfaces candidates to the operator — auto-registration is intentionally out of scope.
 
 ## Result models
 
@@ -110,6 +123,49 @@ class AuthModel(StrEnum):
 ```
 
 Stored on every `Target` row (G0.3); read by the connector at `execute()` time.
+
+### Topology hint models (G9.1-T2 #449)
+
+The four models a connector populates when overriding `discover_topology` + `list_candidates`. All frozen end-to-end (matching the `FingerprintResult.extras` discipline — nested `properties` / `evidence` are wrapped in `MappingProxyType` so in-place mutation also raises).
+
+```python
+NodeKind = Literal[
+    "target", "vm", "host", "network", "datastore", "namespace",
+    "pod", "service", "ingress", "node", "principal",
+    "vault-role", "vault-mount", "volume",
+]  # auto-discoverable subset; curated kinds land in G9.2
+
+EdgeKind = Literal["runs-on", "mounts", "routes-through", "belongs-to"]
+# cross-system semantic edges ("authenticates-via", "depends-on", ...)
+# need operator assertion and land in G9.2
+
+class NodeHint(BaseModel):
+    kind: NodeKind
+    name: str
+    properties: Mapping[str, Any]  # frozen via MappingProxyType
+
+class EdgeHint(BaseModel):
+    from_kind: NodeKind
+    from_name: str
+    to_kind: NodeKind
+    to_name: str
+    kind: EdgeKind
+    properties: Mapping[str, Any]
+
+class TopologyHints(BaseModel):
+    nodes: tuple[NodeHint, ...]   # tuple so the frozen model is deeply immutable
+    edges: tuple[EdgeHint, ...]
+    discovered_at: datetime       # stamped at call time
+
+class CandidateHint(BaseModel):
+    name: str
+    host: str
+    port: int | None
+    evidence: Mapping[str, Any]   # debugging payload — what made the connector think this candidate exists
+    confidence: Literal["high", "medium", "low"]
+```
+
+`NodeKind` is the v0.2 auto-discoverable vocabulary; per-connector kinds (e.g. `"vault-role"`, `"vault-mount"`) are extensible per Initiative #363 via a migration. `EdgeKind` is intentionally narrow — the four high-confidence probe-derived edges. Probe-derived edges have to be high-confidence because a wrong edge in `topology dependents` output misleads the operator on the very op the verb is supposed to make safer.
 
 ## Adapter shapes (G0.2-T3 / T4)
 


### PR DESCRIPTION
## Summary

- Extends [`Connector` ABC](backend/src/meho_backplane/connectors/base.py) with two **non-abstract** async hooks — `discover_topology(target) -> TopologyHints` and `list_candidates(seed_target) -> list[CandidateHint]` — so the G9.1 refresh service (T3 #450) and `meho targets discover` verb (T6 #454) can land independently of the per-product overrides scheduled into G3.x Initiatives.
- Adds four frozen Pydantic v2 models — `NodeHint`, `EdgeHint`, `TopologyHints`, `CandidateHint` — plus the closed-enum `NodeKind` / `EdgeKind` Literal aliases. Models are deeply immutable end-to-end (`MappingProxyType` wrap on `properties` / `evidence`; `tuple[NodeHint, ...]` typing on `TopologyHints.nodes` / `edges`), mirroring the established `FingerprintResult.extras` / `ResultHandle.sample_rows` discipline.
- Updates [`docs/architecture/connectors.md`](docs/architecture/connectors.md) with the two new methods and the four hint models.

### Deliberate deviations from the task body's pseudocode (#449)

Both honor parent Initiative #363's DoD + existing codebase invariants:

1. **Models live in `schemas.py`**, not a new `topology_schemas.py`. Initiative #363 DoD explicitly says "in `schemas.py` alongside `FingerprintResult` / `ProbeResult`". The module is "connector result models" — topology hints are exactly that. File grows from 188 → 311 lines, well under the 600-line code-quality floor.
2. **`nodes` / `edges` typed `tuple[..., ...]`** with `Field(default_factory=...)`, not `list = []` with mutable default. Required to keep the frozen invariant codebase-wide (enforced by [`test_fingerprint_result_extras_is_deeply_immutable`](backend/tests/test_connectors_base.py)). Pydantic still accepts list inputs at construction and coerces to tuple — covered by `test_topology_hints_accepts_list_inputs_and_converts_to_tuple`.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 15 files already formatted
- [x] `uv run mypy src/` (CI-equivalent) — Success: no issues found in 97 source files
- [x] `uv run pytest tests/test_connectors_topology.py tests/test_connectors_base.py -x -q` — 58 passed
- [x] `uv run pytest tests/ -x -q --ignore=tests/integration` — 1009 passed, 3 skipped (no regressions)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0 (clean)

### Acceptance criteria

- [x] **`Connector` ABC has `discover_topology` + `list_candidates` methods with no-op defaults.** Defaults are non-abstract; see [`base.py:74`](backend/src/meho_backplane/connectors/base.py) onward. `test_connector_defaults_subclass_instantiates_without_overrides`.
- [x] **`TopologyHints`, `NodeHint`, `EdgeHint`, `CandidateHint` Pydantic models defined + frozen.** All four use `ConfigDict(frozen=True)` + `MappingProxyType` for nested freezing. `test_node_hint_is_frozen`, `test_node_hint_properties_is_deeply_immutable`, et al.
- [x] **Existing shipped Vault + K8s connectors compile without modification.** Full unit suite (1009 passed) including `test_connectors_vault.py` + `test_connectors_k8s_auth.py` ran green; `test_shipped_v1_subclasses_inherit_topology_defaults` asserts the inheritance explicitly.
- [x] **A test subclass overriding `discover_topology` returns the override's value via the ABC dispatch.** `test_overridden_discover_topology_dispatches_via_abc` holds the binding as `Connector` (not the concrete class) to prove the override is reachable via the abstract contract.
- [x] **Unit test: default `discover_topology()` returns empty `TopologyHints` with current timestamp.** `test_default_discover_topology_returns_empty_topology_hints` asserts `nodes == () and edges == ()` and that `discovered_at` sits in `[before-1s, after+1s]` with `tzinfo is UTC`.
- [x] **CI green; ruff + mypy clean.** Local equivalents all green; CI will confirm.

## Out of scope (per task body + Initiative #363)

- **Per-product `discover_topology` / `list_candidates` overrides** — those land in their G3.x Initiatives (vSphere T2 of #227, Kubernetes T2 of #320, Vault TBD).
- **`graph_node` / `graph_edge` Alembic migration + ORM** — sibling Wave 1 task **#448 (T1)**, independent.
- **Refresh service (diff/apply, advisory-lock rate-limit, scheduled background)** — Wave 2 task **#450 (T3)**, depends on T1 + this PR.
- **Query verbs (`dependents` / `dependencies` / `path` recursive-CTE traversal)** — Wave 2 task **#451 (T4)**, depends on T1.

## Adjacent findings (out of scope; recorded for transparency)

- The python best-practices pack referenced in #449's body (`.claude/skills/explore-and-refactor/python_best_practices.md`) does not exist in this repo. The conventions it would encode (Pydantic v2 frozen models, deep immutability via `MappingProxyType`, `tuple` typing for ordered immutable sequences, `Field(default_factory=...)` over mutable defaults) are all visible in the existing `schemas.py` and were applied here.
- `tests/test_connectors_base.py` has unused `# type: ignore[override]` / `[misc]` markers on its ABC subclass methods + frozen-model assignment tests — they only surface when mypy is run on tests directly. CI runs `mypy src/` only, so they're invisible to CI. Pre-existing pattern; not touched in this PR.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #449


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connectors now expose topology discovery and candidate listing hooks, returning structured, immutable topology and candidate hint models.

* **Tests**
  * Added comprehensive tests for topology hooks, schema immutability, validation, and backward compatibility with existing connectors.

* **Documentation**
  * Updated architecture docs with topology hint model definitions and guidance for connector authors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/459)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-14)

Addressed review findings from [iter-1 review](https://github.com/evoila/meho/pull/459#pullrequestreview-4290945512):

- **M1** `a1cd064` — rewrite `docs/architecture/connectors.md:65` so the "Op-id namespace" sentence covers both typed (`<product>.<resource>.<verb>`) and ingested (`<METHOD>:<path>`) forms, matching the `Connector.execute` docstring contract. Resolves CodeRabbit inline comment 3242168958.

Disputed: _none_

Deferred: _none_

<!-- auto-implement-issue: continue, iteration 1 -->
