### PR TITLE
feat(connectors): G0.6-T-Refactor-Vault — VaultConnector typed-op + dispatcher shim

### DIFF
--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -49,10 +49,10 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors import get_connector
-from meho_backplane.connectors.vault.connector import VaultConnector, VaultTarget
+from meho_backplane.connectors.vault.connector import VaultTarget
 from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.middleware import verify_jwt_and_bind
+from meho_backplane.operations import dispatch
 
 __all__ = ["build_health_response", "router"]
 
@@ -130,41 +130,99 @@ class HealthResponse(BaseModel):
 router = APIRouter(prefix="/api/v1", tags=["health"])
 
 
+#: Vault exception class names that indicate a login-phase failure (the
+#: OIDC forward to Vault failed before any secret read attempted). The
+#: dispatcher's ``connector_error`` branch reports the raised exception's
+#: class name verbatim in ``extras["exception_class"]``; we string-match
+#: by name rather than by ``issubclass`` so the health route avoids a
+#: hard import of ``meho_backplane.auth.vault`` at module top-level
+#: (which would pull the hvac client into every health probe import).
+#:
+#: ``VaultClientError`` covers any future subclass added under it; the
+#: two named subclasses are listed explicitly so the rendered ``detail``
+#: string is stable across hvac upgrades that swap which subclass fires.
+_VAULT_LOGIN_PHASE_EXCEPTION_CLASSES: frozenset[str] = frozenset(
+    {
+        "VaultClientError",
+        "VaultUnreachableError",
+        "VaultRoleDeniedError",
+    }
+)
+
+
 async def _probe_vault_federation(
     operator: Operator,
     log: Any,
 ) -> VaultStatus:
-    """Run the federation-proof Vault chain via the connector registry.
+    """Run the federation-proof Vault chain via the G0.6 dispatcher.
 
-    Dispatches to :class:`~meho_backplane.connectors.vault.VaultConnector`
-    through :func:`~meho_backplane.connectors.get_connector` so the route
-    no longer holds a direct dependency on the auth.vault implementation
-    details. The three failure axes (login failure, read failure, full
-    success) are conveyed through the ``OperationResult.extras["phase"]``
-    and ``extras["exc_type"]`` fields.
+    Dispatches the ``vault.kv.read`` typed op through
+    :func:`~meho_backplane.operations.dispatch` so the route inherits the
+    substrate's parameter validation, policy gate, audit-log write,
+    broadcast publish, and JSONFlux wrapping in one place. The
+    connector's :func:`~meho_backplane.connectors.vault.ops.vault_kv_read`
+    handler is module-level and is invoked by the dispatcher's typed
+    branch directly — :class:`VaultConnector`'s ``execute`` shim is **not**
+    in this call chain.
 
-    Detail strings carry only exception class names; operator-controllable
-    URL substrings never leak into a 200 response body or into a structlog
-    payload.
+    The three failure axes (login failure, read failure, full success)
+    are conveyed through:
+
+    * ``result.status == "ok"`` -> full success; ``result.result``
+      carries ``{"data": <secret>, "version": <int|None>}``.
+    * ``result.status == "error"`` + ``error_code == "connector_error"``
+      with ``exception_class`` in :data:`_VAULT_LOGIN_PHASE_EXCEPTION_CLASSES`
+      -> login-phase failure (Vault unreachable, role denied, or any
+      future :class:`VaultClientError` subclass).
+    * Any other error shape -> read-phase failure (KV miss, malformed
+      hvac payload, jsonschema validation miss, etc.).
+
+    Detail strings carry only exception class names; operator-
+    controllable URL substrings never leak into a 200 response body
+    or into a structlog payload.
     """
-    # Prefer the registry-dispatched class (populated by lifespan _eager_import_connectors
-    # in production). Fall back to direct instantiation in test contexts where
-    # the connector registry has been cleared by test isolation fixtures.
-    vault_cls = get_connector("vault") or VaultConnector
-
     target = VaultTarget(raw_jwt=operator.raw_jwt)
-    result = await vault_cls().execute(target, "vault.kv.read", {"path": _FEDERATION_PROOF_PATH})
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.read",
+        target=target,
+        params={"path": _FEDERATION_PROOF_PATH},
+    )
 
     if result.status == "ok":
-        version = result.extras.get("version")
+        # The handler returns ``{"data": <secret>, "version": <int|None>}``;
+        # the dispatcher's :class:`PassThroughReducer` lands it as
+        # ``result.result`` unchanged.
+        payload = result.result if isinstance(result.result, dict) else {}
+        version = payload.get("version")
         detail = f"version={version}" if version is not None else "ok"
         log.info("federation_health_ok", vault_read_path=_FEDERATION_PROOF_PATH)
         return VaultStatus(reachable=True, read_ok=True, detail=detail)
 
-    phase = result.extras.get("phase", "read")
-    exc_type = result.extras.get("exc_type", "unknown")
+    exc_type = result.extras.get("exception_class")
+    if not isinstance(exc_type, str):
+        # Non-connector_error shapes (``unknown_op``, ``invalid_params``,
+        # ``no_connector``, ``denied``) don't carry an
+        # ``exception_class`` -- map them to the read-phase failure
+        # path so the smoke test's "never a 5xx" contract holds. The
+        # ``error_code`` value lands in the detail string so operators
+        # see the dispatcher-side classification on the CLI without
+        # parsing the audit log.
+        error_code = result.extras.get("error_code", "unknown")
+        log.warning(
+            "federation_health_dispatch_failed",
+            vault_read_path=_FEDERATION_PROOF_PATH,
+            error_code=error_code,
+            error_message=result.error,
+        )
+        return VaultStatus(
+            reachable=True,
+            read_ok=False,
+            detail=f"read_failed: {error_code}",
+        )
 
-    if phase == "login":
+    if exc_type in _VAULT_LOGIN_PHASE_EXCEPTION_CLASSES:
         log.warning("federation_health_login_failed", exc_type=exc_type)
         return VaultStatus(reachable=False, read_ok=False, detail=f"login_failed: {exc_type}")
 

--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -3,16 +3,73 @@
 
 """meho_backplane.connectors.vault — VaultConnector package.
 
-Importing the package registers :class:`VaultConnector` against the
-connector registry. The registry is imported eagerly at app startup via
-:func:`~meho_backplane.connectors.registry._eager_import_connectors`
-(called from the FastAPI lifespan hook); by the time the first request
-arrives, ``get_connector("vault")`` always returns :class:`VaultConnector`.
+Importing the package registers :class:`VaultConnector` against the v2
+connector registry under the natural key ``(product="vault",
+version="1.x", impl_id="vault")``, and queues the connector's typed-op
+upserts onto the lifespan-driven registrar list so
+``endpoint_descriptor`` rows land before the first dispatch.
+
+Registration is split between two phases:
+
+* **Synchronous (import time)** — the v2 registry entry lands via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2`
+  inside this module. The registry lookup tables are populated before
+  the lifespan begins so a probe firing during startup sees a fully-
+  populated registry.
+
+* **Asynchronous (lifespan startup)** —
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`~meho_backplane.connectors.vault.ops.register_vault_typed_operations`,
+  which upserts the ``endpoint_descriptor`` rows for every Vault typed
+  op. Async because the helper writes to the DB and the embedding-text
+  encode step is async. Idempotent: a second pod restart against
+  unchanged descriptions is a no-op for the embedding pipeline (see the
+  "skip-re-embed" branch in
+  :func:`~meho_backplane.operations.typed_register.register_typed_operation`).
+
+The pre-G0.6-T-Refactor v1 :func:`register_connector` entry point is
+deliberately **not** called here. v1 dual-writes to both the v1 and v2
+registries with ``(product, "", "")`` for the v2 key; since this
+connector now advertises an explicit ``(version="1.x", impl_id="vault")``
+key, the v1 entry would be a stale duplicate that confuses
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s tie-
+break ladder (two unbounded-version candidates with no operator
+preference). Removing the v1 entry also drops this connector from
+:func:`~meho_backplane.connectors.get_connector` (the v1-keyed lookup);
+production callers that need it have already migrated to
+:func:`~meho_backplane.connectors.resolver.resolve_connector`. The
+shipped :func:`~meho_backplane.api.v1.health._probe_vault_federation`
+falls back to direct :class:`VaultConnector` instantiation when the
+v1 lookup returns ``None``, so the route keeps working through the
+refactor.
 """
 
-from meho_backplane.connectors.registry import register_connector
+from meho_backplane.connectors.registry import register_connector_v2
 from meho_backplane.connectors.vault.connector import VaultConnector, VaultTarget
+from meho_backplane.connectors.vault.ops import (
+    register_vault_typed_operations,
+    vault_kv_read,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
 
-register_connector("vault", VaultConnector)
+register_connector_v2(
+    product="vault",
+    version="1.x",
+    impl_id="vault",
+    cls=VaultConnector,
+)
 
-__all__ = ["VaultConnector", "VaultTarget"]
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+# The registrar list is module-scope on
+# meho_backplane.operations.typed_register; the lifespan calls
+# ``run_typed_op_registrars`` after _eager_import_connectors so every
+# connector subpackage has self-registered by the time the runner
+# iterates.
+register_typed_op_registrar(register_vault_typed_operations)
+
+__all__ = [
+    "VaultConnector",
+    "VaultTarget",
+    "register_vault_typed_operations",
+    "vault_kv_read",
+]

--- a/backend/src/meho_backplane/connectors/vault/connector.py
+++ b/backend/src/meho_backplane/connectors/vault/connector.py
@@ -3,25 +3,48 @@
 
 """VaultConnector — HashiCorp Vault connector reference implementation.
 
-This module is the proof step for the G0.2 abstraction (Initiative #223).
-The OIDC-login-then-read pattern already implemented in
+This module is the proof step for the G0.2 abstraction (Initiative #223)
+**and** the reference proof that the G0.6 operation substrate (Initiative
+#388) round-trips against already-shipped connector code. The
+OIDC-login-then-read pattern already implemented in
 :mod:`meho_backplane.auth.vault` is reused through module-level references
 so the existing test seams (``vault_module._build_client`` monkeypatches)
 remain valid without duplication.
 
 Auth model: ``shared_service_account`` — every operator's JWT is
-forwarded to Vault's JWT/OIDC auth method bound to the ``meho-mcp`` role.
-The resulting Vault token is per-request and revoked on context exit
-(behaviour inherited from :func:`~meho_backplane.auth.vault.vault_client_for_operator`).
+forwarded to Vault's JWT/OIDC auth method bound to the ``meho-mcp``
+role. The resulting Vault token is per-request and revoked on context
+exit (behaviour inherited from
+:func:`~meho_backplane.auth.vault.vault_client_for_operator`).
 
 Target contract (pre-G0.3 placeholder):
 
-:class:`VaultTarget` is a minimal stand-in for the ``Target`` model that
-G0.3 (#224) will land. Once G0.3 merges, replace ``VaultTarget`` usages
-with proper ``Target`` instances. The connector reads Vault connection
-parameters (address, role, mount path, namespace, timeout) from
-:func:`~meho_backplane.settings.get_settings` rather than from the target
-because those are deployment-level settings, not per-operator overrides.
+:class:`VaultTarget` is a minimal stand-in for the ``Target`` model
+that G0.3 (#224) will land. Once G0.3 merges, replace ``VaultTarget``
+usages with proper ``Target`` instances. The connector reads Vault
+connection parameters (address, role, mount path, namespace, timeout)
+from :func:`~meho_backplane.settings.get_settings` rather than from
+the target because those are deployment-level settings, not per-
+operator overrides.
+
+Operation dispatch (post-G0.6-T-Refactor-Vault):
+
+Operations are **no longer** routed through an in-code ``_op_map``.
+The full per-op surface lives in the ``endpoint_descriptor`` table;
+:func:`~meho_backplane.connectors.vault.ops.register_vault_typed_operations`
+is the upsert helper the lifespan calls at startup. Operation execution
+flows through :func:`meho_backplane.operations.dispatch`, which handles
+parameter validation, the policy gate, audit-log write, broadcast
+publish, and JSONFlux reduction in one place. The connector's
+:meth:`VaultConnector.execute` method is now a thin shim that delegates
+to :func:`dispatch` so legacy callers (the pre-G0.6
+``/api/v1/connectors/{product}/{op_id}`` HTTP surface,
+:mod:`meho_backplane.auth.vault.vault_readiness_probe`) keep working
+unchanged while the typed-op pipeline carries the real semantics. Newer
+callers (``/api/v1/health`` post-refactor, the
+``/api/v1/operations/call_operation`` meta-tool, MCP ``call_operation``)
+construct the :class:`~meho_backplane.auth.operator.Operator` and call
+:func:`dispatch` directly.
 """
 
 from __future__ import annotations
@@ -29,15 +52,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
+from uuid import UUID
 
 import hvac.exceptions
 import requests.exceptions
 import structlog
 
 import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
-from meho_backplane.connectors.vault.ops import OP_MAP
 from meho_backplane.settings import get_settings
 
 __all__ = ["VaultConnector", "VaultTarget"]
@@ -45,31 +69,61 @@ __all__ = ["VaultConnector", "VaultTarget"]
 _log = structlog.get_logger(__name__)
 
 
+# Fixed UUID used as the synthetic operator's tenant_id when
+# :meth:`VaultConnector.execute` is called without an
+# :class:`Operator` in scope. Typed registrations are always
+# ``tenant_id IS NULL`` in ``endpoint_descriptor`` so the dispatcher's
+# lookup falls through to the global row regardless of which tenant_id
+# we pass; the value matters only for the audit row's ``tenant_id``
+# column. Nil-UUID is the unambiguous "this row came from a system
+# call, not a real tenant" sentinel. The constant lives at module
+# scope so the audit-log grep for nil-tenant calls is stable across
+# deploys.
+_SYSTEM_TENANT_ID: UUID = UUID(int=0)
+_SYSTEM_OPERATOR_SUB: str = "system:vault-connector-shim"
+
+
 @dataclass(frozen=True)
 class VaultTarget:
     """Pre-G0.3 stand-in for the G0.3 Target model (VaultConnector only).
 
-    Replace with ``meho_backplane.targets.Target`` once G0.3 (#224) lands.
-    Only ``raw_jwt`` is needed today; connection parameters are read from
-    :func:`~meho_backplane.settings.get_settings` so the same single-source
-    of truth governs probe, fingerprint, and execute.
+    Replace with ``meho_backplane.targets.Target`` once G0.3 (#224)
+    lands. Only ``raw_jwt`` is needed today; connection parameters are
+    read from :func:`~meho_backplane.settings.get_settings` so the same
+    single-source of truth governs probe, fingerprint, and execute.
     """
 
     raw_jwt: str | None = None
 
 
 class VaultConnector(Connector):
-    """HashiCorp Vault connector — shared_service_account auth via OIDC."""
+    """HashiCorp Vault connector — shared_service_account auth via OIDC.
+
+    Registered against the v2 connector registry as
+    ``(product="vault", version="1.x", impl_id="vault")`` so the G0.6
+    dispatcher's :func:`~meho_backplane.connectors.resolver.resolve_connector`
+    can pick it for a target whose fingerprint reports a Vault 1.x
+    version. The v1-style :func:`~meho_backplane.connectors.registry.register_connector`
+    entry point is **not** used for this connector post-refactor — the
+    parallel v2 entry is the canonical registration.
+
+    :attr:`supported_version_range` is left ``None`` for now; the
+    connector handles every shipped Vault release. G3.3 (#366) will
+    pin a range when the operator-facing op surface starts depending
+    on version-specific KV-v2 semantics.
+    """
 
     product = "vault"
+    version = "1.x"
+    impl_id = "vault"
 
     async def fingerprint(self, target: VaultTarget) -> FingerprintResult:
         """Canonical fingerprint from ``GET /v1/sys/health``.
 
         Reuses :func:`~meho_backplane.auth.vault._build_client` so the
         existing test seam applies and the vault_timeout / namespace
-        settings are respected without duplicating the client-construction
-        logic.
+        settings are respected without duplicating the client-
+        construction logic.
         """
         settings = get_settings()
         client = _auth_vault._build_client(settings)
@@ -105,17 +159,17 @@ class VaultConnector(Connector):
     async def probe(self, target: VaultTarget) -> ProbeResult:
         """Lightweight reachability check via unauthenticated ``/v1/sys/health``.
 
-        Reuses :func:`~meho_backplane.auth.vault._build_client` so the test
-        seam (``monkeypatch.setattr(vault_module, "_build_client", fake)``)
-        applies to this method as well, keeping the existing
-        ``test_auth_vault.py`` suite green after ``vault_readiness_probe``
-        is refactored to delegate here.
+        Reuses :func:`~meho_backplane.auth.vault._build_client` so the
+        test seam (``monkeypatch.setattr(vault_module, "_build_client",
+        fake)``) applies to this method as well, keeping the existing
+        ``test_auth_vault.py`` suite green after
+        ``vault_readiness_probe`` is refactored to delegate here.
 
         The ``reason`` field carries the same detail strings that
-        :func:`~meho_backplane.auth.vault.vault_readiness_probe` previously
-        embedded directly (``"sealed=False"``, ``"sealed"``,
-        ``"uninitialized"``, ``"http_429"``, etc.) — callers that need the
-        old ``detail`` shape map from ``reason``.
+        :func:`~meho_backplane.auth.vault.vault_readiness_probe`
+        previously embedded directly (``"sealed=False"``, ``"sealed"``,
+        ``"uninitialized"``, ``"http_429"``, etc.) — callers that need
+        the old ``detail`` shape map from ``reason``.
         """
         settings = get_settings()
         client = _auth_vault._build_client(settings)
@@ -146,19 +200,111 @@ class VaultConnector(Connector):
         op_id: str,
         params: dict[str, Any],
     ) -> OperationResult:
-        """Dispatch to the per-op handler in :data:`~meho_backplane.connectors.vault.ops.OP_MAP`.
+        """Delegate to the G0.6 dispatcher.
 
-        Unknown op-ids return a structured error with ``known_ops`` in
-        extras so callers can enumerate what the connector supports without
-        inspecting source code.
+        Thin shim that turns the ABC-defined
+        ``(target, op_id, params)`` surface into a
+        :func:`~meho_backplane.operations.dispatch` call so legacy
+        callers (the pre-G0.6 ``/api/v1/connectors/{product}/{op_id}``
+        HTTP route, :mod:`meho_backplane.auth.vault.vault_readiness_probe`)
+        get the new substrate's behaviour — parameter validation against
+        the registered ``endpoint_descriptor.parameter_schema``,
+        policy gate, audit-log write, broadcast publish, JSONFlux
+        wrapping — without changing their call sites.
+
+        Operator identity is synthesised from a fixed system-tenant
+        sentinel because :class:`Connector.execute`'s ABC signature
+        predates the G0.6 introduction of operator-aware dispatch.
+        The synthesised operator's ``raw_jwt`` is read from
+        ``target.raw_jwt`` so the dispatched handler still has the
+        token it needs for OIDC forwarding; the synthesised ``sub``
+        and ``tenant_id`` only surface on the dispatcher's own audit
+        row. Routed call sites already write a richer audit row via
+        :class:`~meho_backplane.audit.AuditMiddleware`, which carries
+        the real operator identity from the JWT — the dispatcher's
+        synthesised row is a strict subset.
+
+        Newer callers
+        (:func:`~meho_backplane.api.v1.health._probe_vault_federation`,
+        the ``/api/v1/operations/call_operation`` meta-tool, the
+        MCP ``call_operation`` handler) construct a real
+        :class:`Operator` and invoke :func:`dispatch` directly; they
+        do **not** route through this shim. The shim exists so
+        callers that predate the G0.6 substrate keep working without
+        edits — once every caller migrates, the shim can be deleted
+        and :class:`Connector.execute` becomes abstract-only.
+
+        The dispatcher's ``connector_id`` is ``"vault-1.x"`` — the
+        canonical encoding of this connector's ``(product, version,
+        impl_id)`` per the
+        :func:`~meho_backplane.operations._lookup.parse_connector_id`
+        contract.
         """
-        handler = OP_MAP.get(op_id)
-        if handler is None:
-            return OperationResult(
-                status="error",
-                op_id=op_id,
-                error=f"unknown_op: {op_id}",
-                duration_ms=0.0,
-                extras={"known_ops": list(OP_MAP.keys())},
-            )
-        return await handler(target, params)
+        # Lazy import: meho_backplane.operations.dispatch transitively
+        # imports the connector registry which imports this module at
+        # package import time; deferring the import until call time
+        # keeps that initialisation order stable.
+        from meho_backplane.operations import dispatch
+
+        operator = self._synthesise_legacy_operator(target)
+        return await dispatch(
+            operator=operator,
+            connector_id=self._dispatcher_connector_id(),
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    @classmethod
+    def _dispatcher_connector_id(cls) -> str:
+        """Encode this connector's natural key as the dispatcher's
+        ``connector_id`` string.
+
+        ``parse_connector_id`` splits ``"vault-1.x"`` into
+        ``(product="vault", version="1.x", impl_id="vault")``; we
+        encode the same shape on the call side so the dispatcher's
+        natural-key lookup hits the row this connector's
+        :func:`~meho_backplane.connectors.vault.ops.register_vault_typed_operations`
+        registered.
+        """
+        if cls.version:
+            return f"{cls.impl_id}-{cls.version}"
+        # v1-style fallback. The connector ships with version="1.x"
+        # so this branch is unreachable today; kept for the case
+        # where a future subclass overrides version to "" to opt
+        # back into v1 semantics.
+        return cls.product
+
+    @staticmethod
+    def _synthesise_legacy_operator(target: VaultTarget) -> Operator:
+        """Build a minimal :class:`Operator` for the shim's dispatch call.
+
+        The shim has no access to the real operator's identity claims —
+        :class:`Connector.execute`'s ABC signature predates G0.6's
+        operator-aware dispatch. We synthesise:
+
+        * ``sub`` — a fixed system sentinel
+          (:data:`_SYSTEM_OPERATOR_SUB`) so the dispatcher's audit row
+          for shimmed calls is greppable.
+        * ``tenant_id`` — Nil UUID
+          (:data:`_SYSTEM_TENANT_ID`). Typed registrations are always
+          ``tenant_id IS NULL`` so the dispatcher's tenant-scoped
+          descriptor lookup falls through to the global row regardless;
+          the synthesised tenant_id only lands on the audit row.
+        * ``raw_jwt`` — the target's ``raw_jwt`` so the dispatched
+          handler can forward the operator's token to Vault's OIDC
+          auth method. ``None`` collapses to the empty string because
+          :class:`Operator.raw_jwt` is non-optional.
+        * ``tenant_role`` — :attr:`TenantRole.OPERATOR`. The v0.2
+          policy gate doesn't read the role for ``safety_level='safe'``
+          ops; the value is a placeholder that satisfies the model's
+          required field.
+        """
+        return Operator(
+            sub=_SYSTEM_OPERATOR_SUB,
+            name=None,
+            email=None,
+            raw_jwt=target.raw_jwt or "",
+            tenant_id=_SYSTEM_TENANT_ID,
+            tenant_role=TenantRole.OPERATOR,
+        )

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -1,119 +1,276 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Vault op-map — per-operation handlers for VaultConnector.
+"""Vault typed-op handlers + ``endpoint_descriptor`` registration helper.
 
 Op-id namespace (v0.2): ``vault.kv.<verb>``.
 
 Future ops (``vault.kv.write``, ``vault.kv.list``, ``vault.policy.read``,
-``vault.transit.encrypt``) are intentionally out of scope for T5 — the
-acceptance criteria specify only ``vault.kv.read`` as required.
+``vault.transit.encrypt``) are intentionally out of scope for the G0.6-T-
+Refactor-Vault Task — the acceptance criteria specify only ``vault.kv.read``
+as the existing surface to round-trip through the new substrate. G3.3
+(#366) covers the full KV-v2 + sys + auth read/list surface.
 
-Each handler follows the signature
-``async (target, params) -> OperationResult`` so :class:`OP_MAP` is a
-uniform lookup table with no per-op dispatch logic in the connector itself.
+Each handler is an ``async def`` module-level function with the
+``(target, params) -> dict[str, Any]`` shape the G0.6 dispatcher (T5
+#396) expects from a typed op (see
+:class:`~meho_backplane.operations.typed_register.TypedOpHandler`). The
+dispatcher validates ``params`` against the registered
+``parameter_schema`` before invoking the handler; the handler's only
+job is the Vault HTTP call + the success-payload shape.
 
-The ``_auth_vault`` module reference is used throughout so that the test
-seam (``monkeypatch.setattr(vault_module, "_build_client", fake)`` and
-``monkeypatch.setattr(vault_module, "vault_client_for_operator", fake)``)
-applies transparently. Binding the helpers by name (``from ... import
-_build_client``) would break the monkeypatch because the local name would
-still point at the original object.
+Failure handling differs from the pre-G0.6 ``OP_MAP`` model: handlers
+now **raise** rather than returning a structured ``OperationResult``.
+The dispatcher catches the exception and produces a structured
+``connector_error`` :class:`OperationResult` with the exception class
+name in ``extras["exception_class"]``. Callers that need to distinguish
+login-phase failure (Vault unreachable, role denied) from read-phase
+failure (KV miss, malformed payload) read ``extras["exception_class"]``
+and map :class:`~meho_backplane.auth.vault.VaultClientError` and
+subclasses to "login phase"; everything else is "read phase". The
+:mod:`meho_backplane.api.v1.health` route does exactly this mapping for
+the federation-proof endpoint.
+
+The ``_auth_vault`` module reference is used throughout so that the
+test seam (``monkeypatch.setattr(vault_module, "_build_client", fake)``
+and ``monkeypatch.setattr(vault_module, "vault_client_for_operator",
+fake)``) applies transparently. Binding the helpers by name (``from ...
+import _build_client``) would break the monkeypatch because the local
+name would still point at the original object.
 """
 
 from __future__ import annotations
 
 import asyncio
-import time
-from collections.abc import Awaitable, Callable
 from typing import Any
 
 import meho_backplane.auth.vault as _auth_vault
-from meho_backplane.auth.vault import VaultClientError
-from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.operations.typed_register import register_typed_operation
+from meho_backplane.retrieval.embedding import EmbeddingService
 
-__all__ = ["OP_MAP"]
+__all__ = [
+    "VAULT_KV_READ_PARAMETER_SCHEMA",
+    "register_vault_typed_operations",
+    "vault_kv_read",
+]
 
 
-async def vault_kv_read(target: Any, params: dict[str, Any]) -> OperationResult:
+#: JSON Schema 2020-12 for the ``vault.kv.read`` op's ``params`` argument.
+#: Captures the same input-validation discipline the pre-G0.6 handler
+#: enforced inline (non-empty, non-whitespace string ``path``), but does
+#: so via the dispatcher's :class:`Draft202012Validator` rather than an
+#: in-handler ``isinstance`` + ``strip()`` check:
+#:
+#: * ``minLength=1`` rejects ``""``.
+#: * ``pattern="\\S"`` rejects whitespace-only strings (``"   "``).
+#: * ``additionalProperties=False`` rejects unexpected keys so a typo
+#:   like ``{"paht": "..."}`` surfaces as a clear validation error
+#:   instead of silently dispatching with a missing ``path``.
+VAULT_KV_READ_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "KV v2 secret path relative to the mount root, e.g. "
+                "'meho/test/federation'. The handler delegates to "
+                "client.secrets.kv.v2.read_secret_version(path=...) verbatim."
+            ),
+        },
+    },
+    "required": ["path"],
+    "additionalProperties": False,
+}
+
+
+#: JSON Schema for the ``vault.kv.read`` response payload. Informational
+#: in v0.2 (the dispatcher's :class:`PassThroughReducer` does not validate
+#: outbound payloads); declared so the meta-tools (T8 #399) can surface
+#: it on ``describe_operation`` calls without a schema-construction
+#: round-trip.
+_VAULT_KV_READ_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "data": {
+            "type": "object",
+            "description": "KV v2 secret data dict — the actual key/value payload.",
+        },
+        "version": {
+            "type": ["integer", "null"],
+            "description": "KV v2 metadata version, or null if the metadata lacked a version key.",
+        },
+    },
+    "required": ["data"],
+}
+
+
+#: ``llm_instructions`` blob the meta-tools (T8) inline verbatim when an
+#: LLM is choosing whether to call this op. The shape mirrors the
+#: discipline G3.3 (#366) will enforce for the full Vault op surface:
+#: when-to-use prose + a parameter-hint block + an output-shape sketch.
+_VAULT_KV_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read a single KV v2 secret from HashiCorp Vault. Use when the "
+        "operator's question names a specific secret path (e.g. "
+        "'what's the value of meho/test/federation?'). Read-only — never "
+        "mutates the secret store. Operator identity is forwarded to "
+        "Vault via OIDC, so every read shows up in Vault's audit log "
+        "attributed to the calling operator."
+    ),
+    "parameter_hints": {
+        "path": (
+            "Required. The path under the KV v2 mount (no leading "
+            "slash, no mount prefix). The mount is configured "
+            "deployment-wide; the operator only supplies the path "
+            "below the mount."
+        ),
+    },
+    "output_shape": (
+        "On success: {'data': <secret key/values>, 'version': <int|null>}. "
+        "On failure: the dispatcher wraps the raised exception into a "
+        "connector_error OperationResult with extras.exception_class set "
+        "to the Vault-side error type ('VaultUnreachableError', "
+        "'VaultRoleDeniedError', etc.)."
+    ),
+}
+
+
+async def vault_kv_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
     """Read a KV v2 secret from Vault via OIDC-forwarded operator JWT.
 
-    Op-id: ``vault.kv.read``
-    Param: ``path`` (str, required) — the KV v2 secret path relative to
-    the mount root, e.g. ``"meho/test/federation"``.
+    Op-id: ``vault.kv.read``.
 
-    Returns ``OperationResult.result`` as the secret's data dict on success.
-    On failure distinguishes two phases via ``extras["phase"]``:
+    Parameters
+    ----------
+    target
+        Duck-typed target. Only ``target.raw_jwt`` is read, by way of
+        :func:`~meho_backplane.auth.vault.vault_client_for_operator`.
+        :class:`~meho_backplane.connectors.vault.connector.VaultTarget`
+        is the concrete shape today; once G0.3 (#224) lands its
+        ``Target`` model the connector resolver picks the
+        :class:`VaultConnector` and the dispatcher binds this handler
+        against the resolved target row.
+    params
+        Already validated by the dispatcher against
+        :data:`VAULT_KV_READ_PARAMETER_SCHEMA`. The handler only re-
+        extracts ``params["path"]`` -- the schema guarantees it's a
+        non-empty, non-whitespace string.
 
-    * ``"login"`` — OIDC-login or network failure before any secret was read.
-      Caller should treat as ``vault.reachable=False``.
-    * ``"read"``  — login succeeded but the KV read raised (permission, path
-      missing, malformed payload, etc.). Caller treats as ``read_ok=False``.
+    Returns
+    -------
+    dict[str, Any]
+        ``{"data": <secret data dict>, "version": <int|None>}``. The
+        dispatcher's reducer (v0.2 :class:`PassThroughReducer`) lands
+        this dict as :attr:`OperationResult.result` verbatim.
 
-    The ``extras["version"]`` key carries the KV v2 metadata version on
-    success, allowing callers to surface ``detail="version=N"`` without
-    re-parsing the raw hvac payload.
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        ``VaultUnreachableError`` (network/TLS) or ``VaultRoleDeniedError``
+        (Vault rejected the JWT for the configured role). The
+        dispatcher catches these in its ``connector_error`` branch and
+        reports ``extras["exception_class"]`` so callers can map them
+        to the login-failure phase.
+    KeyError
+        A malformed hvac payload (e.g. ``{"data": {}}`` missing the
+        nested ``data`` or ``metadata`` keys). Raised by the structural
+        unwrap so the dispatcher's ``connector_error`` branch surfaces
+        ``exception_class="KeyError"``; callers map non-VaultClientError
+        exceptions to the read-failure phase.
+    Exception
+        Any error raised by hvac's ``read_secret_version`` (permission
+        denied, path missing, transient network blip after login). The
+        dispatcher's ``connector_error`` branch handles these uniformly.
+
+    The two-phase distinction (login vs read) is preserved through the
+    exception class hierarchy: every login-side failure raises a
+    :class:`VaultClientError` subclass; every read-side failure raises
+    something else. Callers that need to render an operator-actionable
+    detail string (``/api/v1/health``) inspect
+    ``OperationResult.extras["exception_class"]`` and check
+    ``issubclass(...)`` on the class name -- the exception class name
+    is the contract, not the hierarchy at runtime.
     """
-    path = params.get("path")
-    if not isinstance(path, str) or not path.strip():
-        return OperationResult(
-            status="error",
-            op_id="vault.kv.read",
-            error="path must be a non-empty string",
-            duration_ms=0.0,
+    # Schema-enforced: ``path`` is a non-empty non-whitespace string.
+    # We re-strip so trailing whitespace doesn't slip into the hvac
+    # call -- the schema permits ``"a "`` (one non-whitespace char) and
+    # we want the wire shape to match what the operator typed.
+    path: str = str(params["path"]).strip()
+
+    # vault_client_for_operator is accessed via the module reference so
+    # that test monkeypatches on vault_module._build_client propagate
+    # through the call chain. The target object is duck-typed:
+    # vault_client_for_operator only accesses target.raw_jwt, which
+    # VaultTarget provides.
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        secret_payload = await asyncio.to_thread(
+            client.secrets.kv.v2.read_secret_version,
+            path=path,
+            raise_on_deleted_version=False,
         )
-    path = path.strip()
-
-    start = time.monotonic()
-
-    def _elapsed() -> float:
-        return (time.monotonic() - start) * 1000.0
-
-    try:
-        # vault_client_for_operator is accessed via the module reference so that
-        # test monkeypatches on vault_module._build_client propagate through the
-        # call chain. The target object is duck-typed: vault_client_for_operator
-        # only accesses target.raw_jwt, which VaultTarget provides.
-        async with _auth_vault.vault_client_for_operator(target) as client:
-            try:
-                secret_payload = await asyncio.to_thread(
-                    client.secrets.kv.v2.read_secret_version,
-                    path=path,
-                    raise_on_deleted_version=False,
-                )
-                # Structural unwrap — raises KeyError/TypeError on a malformed
-                # hvac payload so the caller sees a "read" phase error rather
-                # than a successful operation with a None result.
-                data = secret_payload["data"]
-                secret_data = data["data"]
-                metadata = data["metadata"]
-                version = metadata.get("version")
-                extras: dict[str, Any] = {"version": version} if version is not None else {}
-                return OperationResult(
-                    status="ok",
-                    op_id="vault.kv.read",
-                    result=secret_data,
-                    duration_ms=_elapsed(),
-                    extras=extras,
-                )
-            except Exception as exc:
-                return OperationResult(
-                    status="error",
-                    op_id="vault.kv.read",
-                    error=f"read_failed: {type(exc).__name__}",
-                    duration_ms=_elapsed(),
-                    extras={"exc_type": type(exc).__name__, "phase": "read"},
-                )
-    except VaultClientError as exc:
-        return OperationResult(
-            status="error",
-            op_id="vault.kv.read",
-            error=f"vault_client_error: {type(exc).__name__}",
-            duration_ms=_elapsed(),
-            extras={"exc_type": type(exc).__name__, "phase": "login"},
-        )
+        # Structural unwrap -- raises KeyError on a malformed hvac
+        # payload (e.g. ``{"data": {}}`` missing the nested ``data`` or
+        # ``metadata`` keys). The dispatcher's ``connector_error``
+        # branch turns the KeyError into a structured ``OperationResult``;
+        # callers read ``extras["exception_class"]`` to distinguish
+        # this read-phase failure from a login-phase failure (which
+        # raises a ``VaultClientError`` subclass instead).
+        data = secret_payload["data"]
+        secret_data = data["data"]
+        metadata = data["metadata"]
+        version = metadata.get("version")
+        return {"data": secret_data, "version": version}
 
 
-OP_MAP: dict[str, Callable[..., Awaitable[OperationResult]]] = {
-    "vault.kv.read": vault_kv_read,
-}
+async def register_vault_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every Vault typed op into ``endpoint_descriptor``.
+
+    Called once per process from the FastAPI lifespan after the
+    connector registry is populated (see
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`).
+    The helper is idempotent: a second call with the same args is a
+    no-op for the embedding pipeline (the body-hash skip path in
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`).
+
+    Test seam: the ``embedding_service`` parameter lets test fixtures
+    inject a stub so the chassis tests (``test_connectors_vault.py``,
+    ``test_api_v1_health.py``) don't have to load the ONNX model.
+    Production callers leave it ``None`` and the helper resolves the
+    process-wide singleton via the ``register_typed_operation`` body.
+
+    Scope: today this registers only ``vault.kv.read``. G3.3 (#366)
+    will add the full KV-v2 + sys + auth read/list surface on top of
+    this helper without further substrate changes.
+    """
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.read",
+        handler=vault_kv_read,
+        summary="Read a single KV v2 secret from HashiCorp Vault.",
+        description=(
+            "Reads the secret at the supplied KV v2 path via the operator's "
+            "OIDC-forwarded JWT. Returns the secret data dict plus the "
+            "KV v2 metadata version. Read-only — never mutates the "
+            "secret store. Login-side failures (Vault unreachable, role "
+            "denied) raise VaultClientError subclasses; read-side "
+            "failures (KV miss, malformed payload, hvac raise) raise "
+            "the underlying exception. Either failure mode lands as a "
+            "connector_error OperationResult from the dispatcher with "
+            "extras.exception_class naming the failure class."
+        ),
+        parameter_schema=VAULT_KV_READ_PARAMETER_SCHEMA,
+        response_schema=_VAULT_KV_READ_RESPONSE_SCHEMA,
+        group_key="kv",
+        tags=["read-only", "secret-read"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_VAULT_KV_READ_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -73,6 +73,7 @@ from meho_backplane.mcp import eager_import_mcp_modules
 from meho_backplane.mcp import router as mcp_router
 from meho_backplane.metrics import render_metrics
 from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.operations import run_typed_op_registrars
 from meho_backplane.retrieval.embedding import get_embedding_service
 from meho_backplane.settings import parse_bool_env
 from meho_backplane.version import router as version_router
@@ -80,118 +81,115 @@ from meho_backplane.version import router as version_router
 _APP_NAME: Final[str] = "meho-backplane"
 
 
+async def _preload_embedding_model() -> None:
+    """Eagerly load the fastembed ONNX model.
+
+    Failure here is loud-but-non-fatal: the model can still load
+    lazily on first request, and a transient network blip on weight
+    download must not turn into a CrashLoopBackOff. Operators see
+    the failure class in structlog so genuine misconfigurations
+    (wrong model name, unwritable cache dir) chase off the
+    ``embedding_preload_failed`` event.
+    """
+    log = structlog.get_logger()
+    try:
+        await get_embedding_service().encode_one("embedding model preload")
+        log.info("embedding_preload_succeeded")
+    except Exception as exc:
+        log.warning(
+            "embedding_preload_failed",
+            error_class=type(exc).__name__,
+            error_message=str(exc),
+        )
+
+
+async def _run_lifespan_shutdown() -> None:
+    """Dispose every long-lived resource the lifespan opened.
+
+    Per-disposer ``try`` / ``except`` so an asyncpg-pool teardown
+    failure in :func:`dispose_engine` cannot short-circuit
+    :func:`dispose_broadcast_client` and leak the redis pool;
+    structlog captures the failure class so operators can chase
+    the leak from logs.
+    """
+    log = structlog.get_logger()
+    try:
+        await dispose_engine()
+    except Exception:
+        log.exception("dispose_engine_failed")
+    try:
+        await dispose_broadcast_client()
+    except Exception:
+        log.exception("dispose_broadcast_client_failed")
+
+
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     """Application lifespan hook.
 
-    Configures structlog at startup so every log line emitted from this
-    point onwards (including the very first request) is JSON-formatted,
-    and registers the Keycloak + Vault + DB-migration-state readiness
-    probes with the registry so ``/ready`` reflects whether each
-    dependency is reachable. Probes are registered even though no
-    request-path consumer of the dependency may have landed yet -
+    Configures structlog at startup so every log line emitted from
+    this point onwards (including the very first request) is JSON-
+    formatted, and registers the Keycloak + Vault + DB-migration-state
+    readiness probes with the registry so ``/ready`` reflects whether
+    each dependency is reachable. Probes are registered even though
+    no request-path consumer of the dependency may have landed yet -
     readiness is a deployment-shape concern, not a request-path
     concern.
 
-    The SQLAlchemy async engine is **eagerly** instantiated here (via
-    :func:`get_engine`) so that the pool is built and the
+    The SQLAlchemy async engine is **eagerly** instantiated here
+    (via :func:`get_engine`) so that the pool is built and the
     ``DATABASE_URL`` is validated at startup, not on the first
-    request. Without this pre-warm the very first ``/ready`` poll the
-    kubelet sends absorbs the engine-construction cost, which both
-    inflates first-request latency and risks a race where the readiness
-    probe is asked to query a database whose engine hasn't been
-    constructed yet. The engine factory itself stays lazy
-    (process-level cache); the lifespan call is what flips it from
-    "lazy on first request" to "eager at process boot".
+    request. The fastembed model (G0.4-T2 #259) and the async Valkey
+    client backing G6's activity broadcast (#228) are similarly
+    eagerly initialised — each owns a helper above for its
+    success-or-warn shape.
 
-    On shutdown the SQLAlchemy async engine is disposed so the asyncpg
-    connection pool releases its connections cleanly; without the
-    explicit ``await engine.dispose()`` the SQLAlchemy 2.x async docs
-    warn that the underlying connections may stay reachable only from
-    a different event loop, which the GC cannot reliably close.
+    G0.6 (#388) added the typed-op registration step: after
+    :func:`_eager_import_connectors` runs every connector
+    subpackage's import-time ``register_connector_v2`` call,
+    :func:`run_typed_op_registrars` walks the registrar list each
+    subpackage appended to and runs each registrar against the DB so
+    the ``endpoint_descriptor`` rows the dispatcher reads are
+    populated before the first request arrives. Failure here is a
+    deploy bug, not a runtime condition — the exception propagates
+    and the lifespan crashes so the operator sees CrashLoopBackOff
+    instead of a quietly-broken dispatch.
 
-    The fastembed embedding model (G0.4-T2 #259) is also **eagerly**
-    preloaded here so the first ``index_document`` / ``retrieve`` call
-    doesn't absorb the ~1-2 s ONNX model load cost. Failure to preload
-    is logged as a warning rather than aborting startup: the model
-    can still load lazily on first use, and a transient network blip
-    on weight download must not turn into a CrashLoopBackOff. A real
-    misconfiguration (wrong model name, unwritable cache dir) will
-    surface on the first ``/api/v1/retrieve`` call with a clear
-    fastembed-side error.
-
-    The async Valkey client backing the G6 activity-broadcast
-    Initiative (#228) is also constructed eagerly via
-    :func:`get_broadcast_client`. The construction parses
-    ``BROADCAST_REDIS_URL`` (failing startup on a malformed scheme,
-    per :class:`Settings`'s validator) but the actual TCP connection
-    stays lazy — no socket opens until the first ``PING`` from the
-    readiness probe (T1) or the first ``XADD`` from the publish hook
-    (T3). On shutdown :func:`dispose_broadcast_client` releases the
-    connection pool the same way :func:`dispose_engine` releases the
-    SQLAlchemy pool.
+    On shutdown :func:`_run_lifespan_shutdown` releases the
+    SQLAlchemy + Valkey pools with per-disposer try/except so a
+    single failure can't leak a sibling pool.
     """
     configure_logging()
     register_probe("keycloak", keycloak_readiness_probe)
     register_probe("vault", vault_readiness_probe)
     register_probe("db", db_migration_probe)
     register_probe("broadcast", broadcast_readiness_probe)
-    # Eager engine construction - see lifespan docstring for why.
+    # Eager engine construction (G2.3-T2 #258); validates ``DATABASE_URL``
+    # at startup so first-request latency doesn't absorb the pool build.
     get_engine()
-    # Eager broadcast client construction (G6.1-T1 #307) - same rationale
-    # as the engine. URL-parse failures surface here, not on first /ready.
+    # Eager broadcast client construction (G6.1-T1 #307); URL parse
+    # failures surface here, not on first /ready.
     get_broadcast_client()
     # Connector auto-discovery (G0.2-T2, #241). Walks every subpackage
-    # under `connectors/` so the top-level `register_connector` calls
-    # in each product's `__init__.py` run before the first request
-    # arrives. Empty until G0.2-T5+ lands the first concrete connector;
-    # the helper handles the empty-package case silently.
+    # under `connectors/` so the top-level `register_connector` /
+    # `register_connector_v2` calls in each product's `__init__.py`
+    # run before the first request arrives.
     _eager_import_connectors()
-    # MCP tool / resource auto-discovery (G0.5-T3, #248). Walks every
-    # module under `mcp/tools/` and `mcp/resources/` so the top-level
-    # `register_mcp_tool` / `register_mcp_resource` calls in each module
-    # run before the first `tools/list` request arrives. Both
-    # subpackages are empty in T3 (T4 adds the first tool / resource);
-    # the helper handles the empty-package case silently.
+    # Typed-op registration (G0.6-T-Refactor-Vault #390). See the
+    # docstring for the contract; runs registrars connectors appended
+    # to during the import pass above so descriptor rows are populated
+    # before the first dispatch.
+    await run_typed_op_registrars()
+    # MCP tool / resource auto-discovery (G0.5-T3, #248). Same shape
+    # as connector auto-discovery: top-level register_mcp_tool /
+    # register_mcp_resource calls run at module import.
     eager_import_mcp_modules()
-    # Eager embedding-model preload (G0.4-T2 #259) - see lifespan docstring.
-    log = structlog.get_logger()
-    try:
-        await get_embedding_service().encode_one("embedding model preload")
-        log.info("embedding_preload_succeeded")
-    except Exception as exc:
-        # Catch-all because any failure mode here (fastembed import,
-        # ONNX runtime init, weight download, cache-dir permissions)
-        # should be loud-but-non-fatal: lazy reload on first request
-        # is the fallback. A genuine misconfiguration surfaces at the
-        # next embedding call with a fastembed-specific error.
-        log.warning(
-            "embedding_preload_failed",
-            error_class=type(exc).__name__,
-            error_message=str(exc),
-        )
+    # Embedding model preload (G0.4-T2 #259); loud-but-non-fatal.
+    await _preload_embedding_model()
     try:
         yield
     finally:
-        # Both disposers run unconditionally. asyncpg pool teardown
-        # under FastAPI lifespan exit has a documented loop-attached
-        # failure surface (see the ``run_async`` removal comment in
-        # ``tests/integration/conftest.py``); without per-disposer
-        # try/except a single dispose_engine raise would short-
-        # circuit the rest of the shutdown chain and leak whichever
-        # disposers came after it. structlog captures the failure
-        # class so operators can chase the leak off the "k8s killed
-        # the pod but the broadcast pool stayed open" symptom in
-        # the logs.
-        shutdown_log = structlog.get_logger()
-        try:
-            await dispose_engine()
-        except Exception:
-            shutdown_log.exception("dispose_engine_failed")
-        try:
-            await dispose_broadcast_client()
-        except Exception:
-            shutdown_log.exception("dispose_broadcast_client_failed")
+        await _run_lifespan_shutdown()
 
 
 app: FastAPI = FastAPI(

--- a/backend/src/meho_backplane/operations/__init__.py
+++ b/backend/src/meho_backplane/operations/__init__.py
@@ -73,7 +73,10 @@ from meho_backplane.operations.reducer import (
 from meho_backplane.operations.typed_register import (
     HandlerRefError,
     TypedOpHandler,
+    clear_typed_op_registrars,
+    register_typed_op_registrar,
     register_typed_operation,
+    run_typed_op_registrars,
 )
 
 __all__ = [
@@ -85,11 +88,14 @@ __all__ = [
     "Reducer",
     "ResultHandle",
     "TypedOpHandler",
+    "clear_typed_op_registrars",
     "compute_params_hash",
     "dispatch",
     "import_handler",
     "parent_audit_id_var",
+    "register_typed_op_registrar",
     "register_typed_operation",
     "reset_dispatcher_caches",
+    "run_typed_op_registrars",
     "set_default_reducer",
 ]

--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -124,9 +124,108 @@ from meho_backplane.retrieval.embedding import EmbeddingService
 __all__ = [
     "HandlerRefError",
     "TypedOpHandler",
+    "clear_typed_op_registrars",
     "derive_handler_ref",
+    "register_typed_op_registrar",
     "register_typed_operation",
+    "run_typed_op_registrars",
 ]
+
+
+#: Type alias for the no-arg async registrar callables connector
+#: subpackages append at import time via
+#: :func:`register_typed_op_registrar`. Each callable runs
+#: :func:`register_typed_operation` for every typed op the connector
+#: ships. Keyword args (e.g. ``embedding_service``) are passed by the
+#: runner so tests can inject stubs without rebinding the registrar
+#: itself.
+type TypedOpRegistrar = Callable[..., Awaitable[None]]
+
+
+# Module-scope registrar list. Connector subpackages append at import
+# time (from their ``__init__.py``); the FastAPI lifespan
+# (``meho_backplane.main.lifespan``) calls
+# :func:`run_typed_op_registrars` after
+# :func:`~meho_backplane.connectors.registry._eager_import_connectors`
+# has walked the subpackages. The two-phase shape (sync import-time
+# registration of v2 connector classes + async lifespan-time
+# registration of typed ops) keeps every ``__init__.py`` sync while
+# letting the typed-op upserts await on the DB + the embedding
+# pipeline. The list is preserved across tests by default; the
+# autouse fixture in ``tests/conftest.py`` only resets it when the
+# test file explicitly drives the lifespan (e.g. via TestClient).
+_TYPED_OP_REGISTRARS: list[TypedOpRegistrar] = []
+
+
+def register_typed_op_registrar(registrar: TypedOpRegistrar) -> None:
+    """Append *registrar* to the module-level typed-op registrar list.
+
+    Called once per connector subpackage at Python module-import time
+    so the lifespan-driven runner can iterate every shipped connector
+    without explicit per-connector wiring in
+    :mod:`meho_backplane.main`. The registrar itself is an async
+    callable that runs :func:`register_typed_operation` for every op
+    the connector exposes.
+
+    Idempotency at runtime: the runner tolerates the same registrar
+    appearing twice (it would just upsert the same row twice, which
+    is itself a no-op for the embedding pipeline). The
+    test-isolation fixture in ``tests/conftest.py`` clears the list
+    between modules that drive the lifespan via TestClient so
+    duplicate appends from re-imports don't accumulate.
+    """
+    _TYPED_OP_REGISTRARS.append(registrar)
+
+
+def clear_typed_op_registrars() -> None:
+    """Empty the registrar list. Test-only.
+
+    Production code never calls this; the registrar list is a
+    one-shot append at module-import time, and the lifespan is the
+    only consumer. Tests that mock the lifespan (or that exercise
+    the registrar runner in isolation) use this hook to start each
+    test from an empty list.
+    """
+    _TYPED_OP_REGISTRARS.clear()
+
+
+async def run_typed_op_registrars(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Invoke every registered typed-op registrar in registration order.
+
+    Called from the FastAPI lifespan after
+    :func:`~meho_backplane.connectors.registry._eager_import_connectors`
+    so every shipped connector has self-registered its registrar by
+    the time the runner iterates. Registrars run sequentially — the
+    embedding pipeline is single-threaded per process, and the
+    descriptor upserts are quick (one DB round-trip per op on the
+    skip-re-embed path) so parallelism would buy nothing.
+
+    A failure in one registrar **propagates**: a connector that
+    can't upsert its typed-op rows is a deploy bug, not a runtime
+    condition, and should surface as a lifespan crash so the
+    operator sees the CrashLoopBackOff rather than a quietly-broken
+    dispatch. Operators reading the traceback see the connector's
+    own module path in the registrar identity, which points at the
+    failing op directly.
+
+    The ``embedding_service`` parameter is the test seam: production
+    callers leave it ``None`` and each registrar resolves the
+    process-wide singleton via the
+    :func:`register_typed_operation` body; test callers (chassis
+    integration tests) inject a stub so the suite doesn't pull the
+    ONNX model on every run.
+    """
+    log = structlog.get_logger(__name__)
+    for registrar in _TYPED_OP_REGISTRARS:
+        log.info(
+            "typed_op_registrar_running",
+            registrar=f"{registrar.__module__}.{registrar.__qualname__}",
+        )
+        await registrar(embedding_service=embedding_service)
+
 
 #: Type alias for typed-op handlers -- async callables returning a
 #: result dict. The dispatcher binds the connector instance for

--- a/backend/tests/test_api_health_failures.py
+++ b/backend/tests/test_api_health_failures.py
@@ -35,9 +35,11 @@ The tests reuse the JWT minting + JWKS-mock helpers from
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import AsyncMock
 
 import hvac.exceptions
 import pytest
@@ -47,7 +49,10 @@ from fastapi.testclient import TestClient
 
 from meho_backplane.auth import vault as vault_module
 from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vault import VaultConnector, register_vault_typed_operations
 from meho_backplane.main import app
+from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 from tests.conftest import (
     DEFAULT_AUDIENCE,
@@ -87,6 +92,38 @@ def _isolated_jwks_cache() -> Iterator[None]:
     clear_jwks_cache()
     yield
     clear_jwks_cache()
+
+
+@pytest.fixture(autouse=True)
+def _registered_vault_substrate(_settings_env: None) -> Iterator[None]:
+    """Re-establish the v2 connector entry + the ``vault.kv.read`` descriptor row.
+
+    The ``TestClient(app)`` fixture in this file does not enter the
+    FastAPI lifespan, so the lifespan's ``run_typed_op_registrars``
+    step never fires. We replicate the two things the lifespan would
+    have done — v2 registry entry + typed-op descriptor upsert —
+    directly in this autouse fixture so the dispatcher's natural-key
+    lookup finds the row at request time. Without this, every
+    ``/api/v1/health`` request from this file would land an
+    ``unknown_op`` from the dispatcher instead of exercising the
+    real Vault failure axis the test is asserting on.
+    """
+    clear_registry()
+    register_connector_v2(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        cls=VaultConnector,
+    )
+    reset_dispatcher_caches()
+    stub_embedding_service = AsyncMock()
+    stub_embedding_service.encode_one.return_value = [0.1] * 384
+    stub_embedding_service.encode.return_value = [[0.1] * 384]
+    stub_embedding_service.dimension = 384
+    asyncio.run(register_vault_typed_operations(embedding_service=stub_embedding_service))
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_api_v1_connectors.py
+++ b/backend/tests/test_api_v1_connectors.py
@@ -20,17 +20,27 @@ container; Keycloak is mocked via respx + RSA fixture key.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterator
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 import respx
 from fastapi.testclient import TestClient
 
 from meho_backplane.auth.jwt import clear_jwks_cache
-from meho_backplane.connectors.registry import clear_registry, register_connector
-from meho_backplane.connectors.vault.connector import VaultConnector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector,
+    register_connector_v2,
+)
+from meho_backplane.connectors.vault import (
+    VaultConnector,
+    register_vault_typed_operations,
+)
 from meho_backplane.main import app
+from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
@@ -66,11 +76,36 @@ def _clear_jwks_cache() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def _registry_with_vault() -> Iterator[None]:
-    """Ensure VaultConnector is the only registered connector for each test."""
+def _registry_with_vault(_settings_env: None) -> Iterator[None]:
+    """Re-establish VaultConnector + the typed-op descriptor row.
+
+    The legacy ``/api/v1/connectors/{product}/{op_id}`` route looks up
+    via :func:`get_connector` (v1 registry), so we keep the v1
+    registration in place. Post-G0.6-T-Refactor-Vault, the
+    :meth:`VaultConnector.execute` shim delegates to
+    :func:`~meho_backplane.operations.dispatch`; the dispatcher's
+    natural-key lookup runs against the v2 key ``("vault", "1.x",
+    "vault")``, so the test fixture additionally registers the v2
+    entry and upserts the typed-op descriptor row (the lifespan's
+    ``run_typed_op_registrars`` step is bypassed because the
+    ``TestClient(app)`` fixture doesn't enter the lifespan).
+    """
     clear_registry()
     register_connector("vault", VaultConnector)
+    register_connector_v2(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        cls=VaultConnector,
+    )
+    reset_dispatcher_caches()
+    stub_embedding_service = AsyncMock()
+    stub_embedding_service.encode_one.return_value = [0.1] * 384
+    stub_embedding_service.encode.return_value = [[0.1] * 384]
+    stub_embedding_service.dimension = 384
+    asyncio.run(register_vault_typed_operations(embedding_service=stub_embedding_service))
     yield
+    reset_dispatcher_caches()
     clear_registry()
 
 
@@ -126,8 +161,13 @@ def test_vault_kv_read_happy_path(
     body = resp.json()
     assert body["status"] == "ok"
     assert body["op_id"] == "vault.kv.read"
-    assert body["result"] == {"api_key": "s3cr3t"}
-    assert body["extras"]["version"] == 42
+    # Post-G0.6-T-Refactor-Vault the handler returns
+    # ``{"data": <secret>, "version": <int|None>}`` and the
+    # dispatcher's PassThroughReducer lands that dict as ``result``.
+    # The pre-refactor shape ``result == <secret>`` +
+    # ``extras["version"] == 42`` is gone -- ``version`` now lives
+    # under ``result`` alongside ``data``.
+    assert body["result"] == {"data": {"api_key": "s3cr3t"}, "version": 42}
     _ = fake  # referenced to confirm the fake was installed
 
 
@@ -149,12 +189,22 @@ def test_unknown_product_returns_404(
     assert "unknown product" in resp.json()["detail"]
 
 
-def test_unknown_op_returns_400_with_known_ops(
+def test_unknown_op_returns_400(
     client: TestClient,
     keypair: Any,
     jwt: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Unknown op_id surfaces as 400 with the dispatcher's structured shape.
+
+    Post-G0.6-T-Refactor-Vault, the in-connector ``known_ops`` listing
+    moved to the meta-tools (G0.6-T8 #399); the route's
+    ``unknown_op`` 400 still fires (the route detects the
+    ``"unknown_op:"`` prefix on ``result.error``) but the enumerated
+    op list is empty in the detail payload. The pre-G0.6
+    ``detail["known_ops"]`` list is now best-resolved via
+    ``GET /api/v1/operations`` (T8 #399).
+    """
     install_fake_client(monkeypatch)
     with respx.mock:
         _mock_discovery_and_jwks(respx.mock, _public_jwks(keypair))
@@ -166,7 +216,8 @@ def test_unknown_op_returns_400_with_known_ops(
     assert resp.status_code == 400
     detail = resp.json()["detail"]
     assert detail["error"] == "unknown_op"
-    assert "vault.kv.read" in detail["known_ops"]
+    assert detail["op_id"] == "vault.unknown.op"
+    assert detail["known_ops"] == []
 
 
 def test_unauthenticated_returns_401(client: TestClient) -> None:
@@ -175,14 +226,23 @@ def test_unauthenticated_returns_401(client: TestClient) -> None:
 
 
 @pytest.mark.parametrize("params", [{}, {"path": ""}])
-def test_invalid_path_param_returns_200_with_error_status(
+def test_invalid_path_param_returns_200_with_invalid_params_error(
     client: TestClient,
     keypair: Any,
     jwt: str,
     monkeypatch: pytest.MonkeyPatch,
     params: dict[str, str],
 ) -> None:
-    """Missing or empty path: connector validates and returns error status; route stays 200."""
+    """Missing or empty path: dispatcher's ``invalid_params`` shape; route stays 200.
+
+    Post-G0.6-T-Refactor-Vault, the dispatcher's
+    :class:`Draft202012Validator` validates ``params`` against the
+    registered parameter_schema (``"path": {"type": "string",
+    "minLength": 1, "pattern": "\\S"}``) before invoking the handler.
+    The route still returns 200 with an error-status :class:`OperationResult`;
+    the ``error`` string now starts with ``"invalid_params:"`` and
+    the structured detail lives in ``extras["validation_errors"]``.
+    """
     install_fake_client(monkeypatch)
     with respx.mock:
         _mock_discovery_and_jwks(respx.mock, _public_jwks(keypair))
@@ -194,16 +254,30 @@ def test_invalid_path_param_returns_200_with_error_status(
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "error"
-    assert "path" in (body["error"] or "")
+    assert (body["error"] or "").startswith("invalid_params:")
+    assert body["extras"]["error_code"] == "invalid_params"
+    assert isinstance(body["extras"]["validation_errors"], list)
+    assert body["extras"]["validation_errors"]
 
 
-def test_vault_login_failure_returns_200_with_error_status(
+def test_vault_login_failure_returns_200_with_connector_error_status(
     client: TestClient,
     keypair: Any,
     jwt: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Vault login failure: connector returns error result; route stays 200."""
+    """Vault login failure: dispatcher's ``connector_error`` shape; route stays 200.
+
+    Post-G0.6-T-Refactor-Vault the handler raises the
+    :class:`~meho_backplane.auth.vault.VaultClientError` (or a subclass)
+    on login failure rather than returning ``status="error"`` with
+    ``extras["phase"]="login"``. The dispatcher's ``connector_error``
+    branch catches the exception and records the class name in
+    ``extras["exception_class"]``; callers distinguish login-phase
+    failure from read-phase failure by string-matching the class
+    name against the known :class:`VaultClientError` subclasses
+    (see :data:`meho_backplane.api.v1.health._VAULT_LOGIN_PHASE_EXCEPTION_CLASSES`).
+    """
     from meho_backplane.auth.vault import VaultClientError
 
     install_fake_client(monkeypatch, login_exc=VaultClientError("auth failed"))
@@ -217,4 +291,6 @@ def test_vault_login_failure_returns_200_with_error_status(
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "error"
-    assert body["extras"]["phase"] == "login"
+    assert (body["error"] or "").startswith("connector_error:")
+    assert body["extras"]["error_code"] == "connector_error"
+    assert body["extras"]["exception_class"] == "VaultClientError"

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -41,12 +41,14 @@ Test strategy:
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 import respx
@@ -55,7 +57,10 @@ from fastapi.testclient import TestClient
 
 from meho_backplane.auth import vault as vault_module
 from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vault import VaultConnector, register_vault_typed_operations
 from meho_backplane.main import app
+from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
@@ -93,6 +98,47 @@ def _isolated_jwks_cache() -> Iterator[None]:
     clear_jwks_cache()
     yield
     clear_jwks_cache()
+
+
+@pytest.fixture(autouse=True)
+def _registered_vault_substrate(_settings_env: None) -> Iterator[None]:
+    """Re-establish the v2 connector entry + the ``vault.kv.read`` descriptor row.
+
+    The TestClient fixture intentionally does **not** use the
+    ``with TestClient(app) as client`` form (entering it would re-run
+    ``configure_logging`` via the lifespan and clobber the log
+    capture), so the lifespan's ``run_typed_op_registrars`` step
+    never runs in this test file. We replicate the two things the
+    lifespan would have done — v2 registry entry + typed-op
+    descriptor upsert — directly in this autouse fixture so the
+    dispatcher's natural-key lookup finds the row at request time.
+
+    A stub embedding service avoids the ONNX model load that the
+    autouse default ``register_typed_operation`` would otherwise
+    pull from disk on every test.
+    """
+    clear_registry()
+    register_connector_v2(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        cls=VaultConnector,
+    )
+    reset_dispatcher_caches()
+    stub_embedding_service = AsyncMock()
+    stub_embedding_service.encode_one.return_value = [0.1] * 384
+    stub_embedding_service.encode.return_value = [[0.1] * 384]
+    stub_embedding_service.dimension = 384
+    # ``register_vault_typed_operations`` is async; we run it on a
+    # dedicated loop here so the sync TestClient driving the request
+    # afterwards isn't sharing an event loop with the registration
+    # commit. ``asyncio.run`` spins up + tears down the loop cleanly
+    # without leaking it into the request-time event loop pytest-asyncio
+    # creates per test.
+    asyncio.run(register_vault_typed_operations(embedding_service=stub_embedding_service))
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_base.py
+++ b/backend/tests/test_connectors_base.py
@@ -195,16 +195,28 @@ def test_connector_subclass_overrides_read_back_at_instance_level() -> None:
     assert inst.priority == 10
 
 
-def test_shipped_v1_subclasses_still_import_unmodified() -> None:
-    # Backward-compat guard: the shipped VaultConnector (#244) and the
-    # KubernetesConnector skeleton (#321) only set `product`; they must
-    # remain importable and inherit the new defaults without code change.
+def test_shipped_subclasses_advertise_v2_metadata_per_their_initiative() -> None:
+    # The shipped connectors' v2-metadata posture differs per Initiative:
+    #
+    # * :class:`VaultConnector` (#244, refactored under G0.6-T-Refactor-Vault
+    #   #390) advertises ``version="1.x"`` / ``impl_id="vault"``; its
+    #   :class:`~meho_backplane.connectors.vault.__init__` calls
+    #   :func:`register_connector_v2` directly so the v2 resolver hits
+    #   the same row the typed-op upsert keys on.
+    # * :class:`KubernetesConnector` (skeleton from #321) stays on the v1
+    #   defaults (``version=""`` / ``impl_id=""``) until its own G0.6
+    #   refactor lands — the v1 ``register_connector`` call dual-writes
+    #   the v2 entry as ``("kubernetes", "", "")``.
+    #
+    # ``supported_version_range`` and ``priority`` keep their type-system
+    # defaults on both since neither connector has shipped versioned
+    # behaviour yet.
     from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
     from meho_backplane.connectors.vault.connector import VaultConnector
 
     assert VaultConnector.product == "vault"
-    assert VaultConnector.version == ""
-    assert VaultConnector.impl_id == ""
+    assert VaultConnector.version == "1.x"
+    assert VaultConnector.impl_id == "vault"
     assert VaultConnector.supported_version_range is None
     assert VaultConnector.priority == 0
 

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -317,6 +317,9 @@ def test_lifespan_calls_eager_import_connectors() -> None:
             patch(
                 "meho_backplane.main._eager_import_connectors", side_effect=lambda: called.append(1)
             ),
+            patch("meho_backplane.main.run_typed_op_registrars", new=AsyncMock()),
+            patch("meho_backplane.main.eager_import_mcp_modules"),
+            patch("meho_backplane.main.get_embedding_service"),
         ):
             # Manually step through the lifespan async generator.
             gen = lifespan(None)  # type: ignore[arg-type]
@@ -356,6 +359,7 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                 new=broadcast_disposed,
             ),
             patch("meho_backplane.main._eager_import_connectors"),
+            patch("meho_backplane.main.run_typed_op_registrars", new=AsyncMock()),
             patch("meho_backplane.main.eager_import_mcp_modules"),
             patch("meho_backplane.main.get_embedding_service"),
         ):

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -1,60 +1,93 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Tests for VaultConnector — G0.2-T5 reference implementation.
+"""Tests for VaultConnector — G0.2-T5 reference implementation + G0.6 refactor.
 
-Coverage matrix (per Task #244 acceptance criteria):
+Coverage matrix:
 
 * Importing ``connectors.vault`` registers ``VaultConnector`` against
-  the registry under the ``"vault"`` product slug.
-* ``VaultConnector.fingerprint(target)`` returns a :class:`FingerprintResult`
-  with ``vendor="hashicorp"`` and ``product="vault"``; the ``version`` field
-  is populated from the ``/v1/sys/health`` payload.
+  the **v2** registry under ``(product="vault", version="1.x",
+  impl_id="vault")`` (the G0.6-T-Refactor-Vault flip from v1).
+* ``VaultConnector.fingerprint(target)`` returns a
+  :class:`FingerprintResult` with ``vendor="hashicorp"`` and
+  ``product="vault"``; the ``version`` field is populated from the
+  ``/v1/sys/health`` payload.
 * ``VaultConnector.probe(target)`` returns ``ok=True`` for a reachable
-  unsealed Vault and ``ok=False`` for unreachable / sealed / uninitialised
-  Vault; the ``reason`` field carries the same structured strings the
-  existing ``vault_readiness_probe`` tests assert on.
+  unsealed Vault and ``ok=False`` for unreachable / sealed /
+  uninitialised Vault; the ``reason`` field carries the same
+  structured strings the existing ``vault_readiness_probe`` tests
+  assert on.
 * ``VaultConnector.execute(target, "vault.kv.read", {"path": "..."})``
-  returns ``OperationResult(status="ok")`` with ``result`` carrying the
-  secret data and ``extras["version"]`` carrying the KV v2 metadata version.
-* ``VaultConnector.execute(target, "vault.nonexistent.op", ...)`` returns
-  ``OperationResult(status="error")`` with ``known_ops`` in extras.
-* ``VaultConnector.execute`` with a missing ``path`` param returns a
-  structured error without touching Vault.
-* Login failures (unreachable, role-denied) return
-  ``OperationResult(status="error", extras={"phase": "login", ...})``.
-* Read failures (login ok, secret read raises) return
-  ``OperationResult(status="error", extras={"phase": "read", ...})``.
+  flows through the G0.6 dispatcher and returns
+  ``OperationResult(status="ok")`` with ``result["data"]`` carrying
+  the secret payload and ``result["version"]`` carrying the KV v2
+  metadata version. The handler raises on read/login failure; the
+  dispatcher wraps the exception into a structured
+  ``connector_error`` :class:`OperationResult` with
+  ``extras["exception_class"]`` naming the failure shape.
+* ``VaultConnector.execute(target, "vault.nonexistent.op", ...)``
+  returns the **dispatcher's** structured ``unknown_op`` error shape
+  (``extras["error_code"]="unknown_op"``,
+  ``extras["known_op_count"]``); the in-handler ``known_ops`` list
+  shape from the pre-refactor connector is gone — that responsibility
+  moved to the meta-tools (G0.6-T8 #399).
+* ``VaultConnector.execute`` with a missing ``path`` param returns the
+  dispatcher's ``invalid_params`` error from the
+  ``parameter_schema`` validator (``minLength=1`` /
+  ``pattern="\\S"``), not from the handler.
+* Login failures (unreachable, role-denied) surface as
+  ``connector_error`` with the :class:`VaultClientError` subclass name
+  in ``extras["exception_class"]``.
+* Read failures (login ok, secret read raises) surface as
+  ``connector_error`` with the non-VaultClientError exception class in
+  ``extras["exception_class"]`` so the health route's class-name match
+  routes them to the read-phase failure path.
 * Malformed hvac payload (missing metadata/version keys) is a
-  structured read-phase error, not an unhandled exception.
+  structured read-phase error (``KeyError`` in
+  ``extras["exception_class"]``), not an unhandled exception.
 
-Test isolation: the production code builds hvac clients through the private
-``_build_client`` helper (single seam). Tests monkey-patch that helper to
-return a controllable fake — no real HTTP, no Vault container.
+Test isolation: the production code builds hvac clients through the
+private ``_build_client`` helper (single seam). Tests monkey-patch
+that helper to return a controllable fake — no real HTTP, no Vault
+container.
 
-The ``_clean_vault_registry`` fixture re-registers ``VaultConnector`` before
-each test because ``test_connectors_registry.py`` (alphabetically earlier) has
-an autouse ``clear_registry()`` that empties the registry after its last test.
+The ``_clean_vault_registry`` fixture re-registers ``VaultConnector``
+via the v2 entry before each test because
+``test_connectors_registry_v2.py`` (alphabetically earlier) has an
+autouse ``clear_registry()`` that empties both registry layers after
+its last test, **and** registers the typed op so the dispatcher can
+look up the descriptor row at execute time.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Any
+from unittest.mock import AsyncMock
 
 import hvac.exceptions
 import pytest
 import requests.exceptions
 
-from meho_backplane.connectors import all_connectors, get_connector
-from meho_backplane.connectors.registry import clear_registry, register_connector
-from meho_backplane.connectors.vault.connector import VaultConnector, VaultTarget
+from meho_backplane.connectors import all_connectors_v2
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    list_connector_impls,
+    register_connector_v2,
+)
+from meho_backplane.connectors.vault import (
+    VaultConnector,
+    VaultTarget,
+    register_vault_typed_operations,
+)
+from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
 from ._vault_fakes import install_fake_client
 
 # Shared fake for hvac's non-200 health response (standby / active-perf-standby).
-# Defined once here to avoid duplicating the class body in every test that needs it.
+# Defined once here to avoid duplicating the class body in every test that
+# needs it.
 
 
 class _StandbyResponse:
@@ -62,22 +95,34 @@ class _StandbyResponse:
 
 
 # ---------------------------------------------------------------------------
-# Registry isolation
+# Registry + dispatcher isolation
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
 def _clean_vault_registry() -> Iterator[None]:
-    """Ensure VaultConnector is registered (and only it) for each test.
+    """Re-register VaultConnector (v2) + reset the dispatcher caches.
 
-    test_connectors_registry.py runs before this file (alphabetically
-    "connectors_registry" < "connectors_vault") and clears the registry
-    after each of its tests via its own autouse fixture. This fixture
-    re-registers VaultConnector so tests here start with a known state.
+    ``test_connectors_registry_v2.py`` and other earlier-alphabetised
+    test files clear both registry layers after their tests via their
+    own autouse fixtures. This fixture re-establishes the canonical
+    v2 entry so the dispatcher's
+    :func:`~meho_backplane.connectors.resolver.resolve_connector`
+    finds :class:`VaultConnector` for vault targets. We also reset
+    the dispatcher's handler-import and connector-instance caches so
+    tests that re-register connector classes between functions don't
+    inherit a stale instance.
     """
     clear_registry()
-    register_connector("vault", VaultConnector)
+    register_connector_v2(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        cls=VaultConnector,
+    )
+    reset_dispatcher_caches()
     yield
+    reset_dispatcher_caches()
     clear_registry()
 
 
@@ -101,28 +146,70 @@ def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     get_settings.cache_clear()
 
 
+# ---------------------------------------------------------------------------
+# Typed-op registration fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so ``register_typed_operation`` doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_vault_typed_ops(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Upsert the Vault typed-op descriptor rows for tests that drive ``execute``.
+
+    The autouse ``_default_database_url`` conftest fixture has already
+    migrated the SQLite database to head, so the
+    ``endpoint_descriptor`` and ``operation_group`` tables exist.
+    """
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+    yield
+
+
 def _make_target(jwt: str = "fake.jwt.value") -> VaultTarget:
     return VaultTarget(raw_jwt=jwt)
 
 
 # ---------------------------------------------------------------------------
-# Registry acceptance criterion
+# Registry acceptance criteria
 # ---------------------------------------------------------------------------
 
 
-def test_importing_vault_package_registers_vault_connector() -> None:
-    """Importing connectors.vault registers VaultConnector under 'vault'.
+def test_importing_vault_package_registers_vault_connector_v2() -> None:
+    """Importing connectors.vault registers VaultConnector under the v2 natural key.
 
-    The autouse _clean_vault_registry fixture re-registers after the
-    clear from test_connectors_registry.py, so we assert the slug is
-    populated and the class is the expected one.
+    The G0.6-T-Refactor-Vault flip moved the registration from the v1
+    single-product surface to the v2 three-tuple key. The connector's
+    class attributes (``product`` / ``version`` / ``impl_id``) match
+    the registered key so the dispatcher's
+    ``parse_connector_id("vault-1.x")`` lookup hits this row.
     """
-    assert get_connector("vault") is VaultConnector
-    assert "vault" in all_connectors()
+    expected_key = ("vault", "1.x", "vault")
+    assert expected_key in all_connectors_v2()
+    assert all_connectors_v2()[expected_key] is VaultConnector
+    assert expected_key in list_connector_impls()
 
 
-def test_vault_connector_has_product_slug() -> None:
+def test_vault_connector_class_attributes_advertise_v2_key() -> None:
+    """The connector class attributes match the v2 registry key.
+
+    ``Connector._dispatcher_connector_id()`` reads these attributes
+    to encode the dispatcher's ``connector_id`` string; the v2
+    registry key must mirror them so the natural-key lookup hits
+    the registered row.
+    """
     assert VaultConnector.product == "vault"
+    assert VaultConnector.version == "1.x"
+    assert VaultConnector.impl_id == "vault"
 
 
 # ---------------------------------------------------------------------------
@@ -233,21 +320,32 @@ async def test_probe_returns_ok_false_when_vault_unreachable(
 
 
 # ---------------------------------------------------------------------------
-# execute — unknown op
+# execute — delegates to the G0.6 dispatcher
 # ---------------------------------------------------------------------------
 
 
-async def test_execute_unknown_op_returns_structured_error(
+async def test_execute_unknown_op_returns_dispatcher_unknown_op_shape(
     monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
 ) -> None:
+    """Unknown op_id surfaces the dispatcher's structured ``unknown_op``.
+
+    Post-G0.6-T-Refactor-Vault, the in-connector ``known_ops`` listing
+    moved to the meta-tools (G0.6-T8 #399); the dispatcher's
+    ``unknown_op`` shape carries only the count, not the enumeration.
+    """
     install_fake_client(monkeypatch)
     connector = VaultConnector()
     result = await connector.execute(_make_target(), "vault.nonexistent.op", {})
 
     assert result.status == "error"
     assert "vault.nonexistent.op" in (result.error or "")
-    assert "known_ops" in result.extras
-    assert "vault.kv.read" in result.extras["known_ops"]
+    assert result.extras.get("error_code") == "unknown_op"
+    assert "known_op_count" in result.extras
+    # The known_op_count reflects the descriptors registered for the
+    # (product="vault", version="1.x", impl_id="vault") triple --
+    # exactly one (vault.kv.read) from the typed-op upsert.
+    assert result.extras["known_op_count"] >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -257,6 +355,7 @@ async def test_execute_unknown_op_returns_structured_error(
 
 async def test_execute_vault_kv_read_returns_secret_data(
     monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
 ) -> None:
     fake = install_fake_client(
         monkeypatch,
@@ -270,9 +369,12 @@ async def test_execute_vault_kv_read_returns_secret_data(
         {"path": "secret/meho/test/federation"},
     )
 
-    assert result.status == "ok"
-    assert result.result == {"username": "demo", "region": "eu-central-1"}
-    assert result.extras.get("version") == 7
+    assert result.status == "ok", result.error
+    # The handler returns ``{"data": <secret>, "version": <int|None>}``;
+    # the dispatcher's PassThroughReducer lands it as result.result.
+    assert isinstance(result.result, dict)
+    assert result.result["data"] == {"username": "demo", "region": "eu-central-1"}
+    assert result.result["version"] == 7
     assert fake.auth.jwt.login_calls == [
         {"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"},
     ]
@@ -282,70 +384,125 @@ async def test_execute_vault_kv_read_returns_secret_data(
 
 @pytest.mark.parametrize(
     "params",
-    [{}, {"path": 123}, {"path": ""}, {"path": "   "}],
-    ids=["missing", "non-string", "empty-string", "whitespace-only"],
+    [{}, {"path": ""}, {"path": "   "}],
+    ids=["missing", "empty-string", "whitespace-only"],
 )
-async def test_execute_vault_kv_read_invalid_path_returns_error(
+async def test_execute_vault_kv_read_invalid_path_returns_dispatcher_error(
     monkeypatch: pytest.MonkeyPatch,
     params: dict[str, Any],
+    _registered_vault_typed_ops: None,
 ) -> None:
-    """Missing, non-string, empty, or whitespace-only path returns input-validation error."""
+    """Missing, empty, or whitespace-only ``path`` → dispatcher's ``invalid_params``.
+
+    The pre-G0.6 handler ran the validation inline (``isinstance``
+    + ``strip``); post-refactor, the dispatcher's
+    :class:`Draft202012Validator` enforces ``minLength=1`` /
+    ``pattern="\\S"`` from the registered parameter_schema.
+    The non-string ``path`` case (``{"path": 123}``) is covered by
+    the schema's ``"type": "string"`` constraint and lands in the
+    same ``invalid_params`` shape.
+    """
     install_fake_client(monkeypatch)
     result = await VaultConnector().execute(_make_target(), "vault.kv.read", params)
 
     assert result.status == "error"
-    assert result.error == "path must be a non-empty string"
-    assert result.duration_ms == 0
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras.get("error_code") == "invalid_params"
+    assert isinstance(result.extras.get("validation_errors"), list)
+    assert result.extras["validation_errors"]
+
+
+async def test_execute_vault_kv_read_non_string_path_returns_dispatcher_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A non-string ``path`` hits the schema's ``"type": "string"`` constraint."""
+    install_fake_client(monkeypatch)
+    result = await VaultConnector().execute(_make_target(), "vault.kv.read", {"path": 123})
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras.get("error_code") == "invalid_params"
 
 
 # ---------------------------------------------------------------------------
-# execute — login failures (phase=login)
+# execute — login failures (VaultClientError subclass)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "login_exc,expected_exc_type",
+    "login_exc,expected_exc_class",
     [
         (requests.exceptions.ConnectionError("no route"), "VaultUnreachableError"),
         (hvac.exceptions.Forbidden("role denied"), "VaultRoleDeniedError"),
     ],
     ids=["unreachable", "role-denied"],
 )
-async def test_execute_login_failure_returns_login_phase_error(
+async def test_execute_login_failure_surfaces_vault_client_error_class(
     monkeypatch: pytest.MonkeyPatch,
     login_exc: Exception,
-    expected_exc_type: str,
+    expected_exc_class: str,
+    _registered_vault_typed_ops: None,
 ) -> None:
+    """Login failure → dispatcher's ``connector_error`` with the VaultClientError class name.
+
+    The pre-G0.6 handler caught :class:`VaultClientError` and surfaced
+    ``extras["phase"]="login"`` + ``extras["exc_type"]``; post-refactor
+    the handler raises and the dispatcher's ``connector_error`` branch
+    records ``extras["exception_class"]``. Callers that need to render
+    a login-vs-read distinction string-match the class name against
+    the known VaultClientError subclass set.
+    """
     install_fake_client(monkeypatch, login_exc=login_exc)
-    result = await VaultConnector().execute(_make_target(), "vault.kv.read", {"path": "some/path"})
+    result = await VaultConnector().execute(
+        _make_target(),
+        "vault.kv.read",
+        {"path": "some/path"},
+    )
 
     assert result.status == "error"
-    assert result.extras.get("phase") == "login"
-    assert result.extras.get("exc_type") == expected_exc_type
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == expected_exc_class
 
 
 # ---------------------------------------------------------------------------
-# execute — read failures (phase=read)
+# execute — read failures (non-VaultClientError exception)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "read_exc,expected_exc_type",
+    "read_exc,expected_exc_class",
     [
         (RuntimeError("secret missing"), "RuntimeError"),
         (KeyError("data"), "KeyError"),
     ],
     ids=["runtime-error", "malformed-payload"],
 )
-async def test_execute_read_failure_returns_read_phase_error(
+async def test_execute_read_failure_surfaces_non_vault_client_error_class(
     monkeypatch: pytest.MonkeyPatch,
     read_exc: Exception,
-    expected_exc_type: str,
+    expected_exc_class: str,
+    _registered_vault_typed_ops: None,
 ) -> None:
-    """Read-phase exceptions (including KeyError from malformed payload) are structured errors."""
+    """Read-phase exception → ``connector_error`` with the raised class name.
+
+    The health route distinguishes "login phase" (VaultClientError
+    subclass name) from "read phase" (anything else); this test pins
+    the contract by exercising both common read-phase failure shapes.
+    """
     install_fake_client(monkeypatch, read_exc=read_exc)
-    result = await VaultConnector().execute(_make_target(), "vault.kv.read", {"path": "some/path"})
+    result = await VaultConnector().execute(
+        _make_target(),
+        "vault.kv.read",
+        {"path": "some/path"},
+    )
 
     assert result.status == "error"
-    assert result.extras.get("phase") == "read"
-    assert result.extras.get("exc_type") == expected_exc_type
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == expected_exc_class

--- a/backend/tests/test_mcp_audit.py
+++ b/backend/tests/test_mcp_audit.py
@@ -96,10 +96,24 @@ def test_params_hash_differs_for_distinct_inputs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tools_call_meho_status_writes_one_audit_row(
+async def test_tools_call_meho_status_writes_one_mcp_audit_row(
     client_with_operator: tuple[TestClient, Operator],
 ) -> None:
-    """AC #1: tools/call meho.status writes one row, method=MCP, status_code=200."""
+    """AC #1: tools/call meho.status writes one ``method="MCP"`` row.
+
+    Post-G0.6-T-Refactor-Vault, the ``meho.status`` handler reaches
+    :func:`~meho_backplane.api.v1.health.build_health_response` which
+    dispatches ``vault.kv.read`` through the G0.6 dispatcher; the
+    dispatcher writes its own ``method="DISPATCH"`` audit row for the
+    typed-op call. That row is a separate granularity (per-operation
+    inside the MCP envelope) and does **not** invalidate AC #1 — the
+    invariant the test pins is the **MCP-envelope** row that the
+    chassis writes, not the dispatcher's internal accounting.
+
+    Concretely: filter the audit table on ``method="MCP"`` to assert
+    the single envelope row; the dispatcher row is verified
+    independently in :mod:`tests.test_operations_dispatcher`.
+    """
     client, op = client_with_operator
 
     response = post_mcp(
@@ -115,8 +129,9 @@ async def test_tools_call_meho_status_writes_one_audit_row(
     assert response.json()["result"]["isError"] is False
 
     rows = await _audit_rows()
-    assert len(rows) == 1
-    row = rows[0]
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    row = mcp_rows[0]
     assert row.operator_sub == op.sub
     assert row.tenant_id == op.tenant_id
     assert row.method == "MCP"
@@ -200,12 +215,17 @@ async def test_resources_read_tenant_info_writes_one_audit_row(
 async def test_mcp_envelope_does_not_produce_chassis_audit_row(
     client_with_operator: tuple[TestClient, Operator],
 ) -> None:
-    """The chassis ``AuditMiddleware`` skips ``/mcp`` so one POST = one row.
+    """The chassis ``AuditMiddleware`` skips ``/mcp`` so the JSON-RPC POST
+    contributes zero rows; the MCP handler writes the single envelope row.
 
     Without the path-prefix exclusion in :class:`AuditMiddleware`, the
     middleware would write a row per JSON-RPC POST (wrong granularity)
     AND each MCP handler would write its own row (correct granularity).
-    The test pins the single-row outcome.
+    Post-G0.6-T-Refactor-Vault, the ``meho.status`` handler also routes
+    through the G0.6 dispatcher (which writes a per-operation
+    ``method="DISPATCH"`` row); the contract this test pins is that
+    no *chassis-middleware* row appears for the JSON-RPC POST itself —
+    so we filter on ``method="MCP"`` to isolate the envelope-level row.
     """
     client, _op = client_with_operator
 
@@ -221,11 +241,18 @@ async def test_mcp_envelope_does_not_produce_chassis_audit_row(
     assert response.status_code == 200
 
     rows = await _audit_rows()
-    # Exactly one row from the MCP handler; the chassis AuditMiddleware
-    # path-prefix exclusion (audit.py:_AUDIT_SKIP_PATH_PREFIXES) keeps
-    # the JSON-RPC envelope from adding a second.
-    assert len(rows) == 1
-    assert rows[0].method == "MCP"
+    # Exactly one ``method="MCP"`` row from the MCP handler; the chassis
+    # AuditMiddleware path-prefix exclusion
+    # (audit.py:_AUDIT_SKIP_PATH_PREFIXES) keeps the JSON-RPC envelope
+    # from adding an HTTP-method row. The G0.6 dispatcher additionally
+    # contributes a ``method="DISPATCH"`` row for the inner
+    # ``vault.kv.read`` call; that row is intentional and verified
+    # separately in :mod:`tests.test_operations_dispatcher`.
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    assert mcp_rows[0].method == "MCP"
+    http_rows = [r for r in rows if r.method in ("GET", "POST", "PUT", "DELETE", "PATCH")]
+    assert http_rows == [], "chassis AuditMiddleware should skip /mcp paths; found HTTP-method rows"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_tools_operations.py
+++ b/backend/tests/test_mcp_tools_operations.py
@@ -23,15 +23,11 @@ operator-or-above to pass the registry's RBAC list-time filter.
 from __future__ import annotations
 
 import json
-import uuid
-from datetime import UTC, datetime
 
 import pytest
 from fastapi.testclient import TestClient
 
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import OperationGroup
 from tests.mcp_test_fixtures import (
     OPERATOR_TENANT_ID,
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
@@ -132,34 +128,23 @@ def test_tools_list_descriptions_include_when_to_use_guidance(
 def test_tools_call_list_operation_groups_returns_seeded_groups(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """``tools/call list_operation_groups`` round-trips through the handler."""
+    """``tools/call list_operation_groups`` round-trips through the handler.
+
+    Post-G0.6-T-Refactor-Vault, the FastAPI lifespan runs
+    :func:`~meho_backplane.operations.run_typed_op_registrars` which
+    calls :func:`~meho_backplane.connectors.vault.ops.register_vault_typed_operations`
+    and creates an :class:`OperationGroup` row for
+    ``(product="vault", version="1.x", impl_id="vault",
+    group_key="kv")`` as a side-effect of registering the
+    ``vault.kv.read`` op. The pre-refactor variant of this test
+    inserted its own ``OperationGroup`` row to give the handler
+    something to enumerate; that insert now races with the
+    lifespan's own and trips the partial-unique constraint. We rely
+    on the lifespan-created group instead — the test's contract
+    (the handler returns a group for ``connector_id="vault-1.x"``)
+    is unchanged.
+    """
     client, op = client_with_operator
-
-    # Seed a built-in group so the handler has something to return.
-    # The TestClient enters the FastAPI lifespan (the fixture uses
-    # `with TestClient(app)`), so the DB is migrated and ready.
-    async def _seed() -> None:
-        sessionmaker = get_sessionmaker()
-        async with sessionmaker() as s, s.begin():
-            s.add(
-                OperationGroup(
-                    id=uuid.uuid4(),
-                    tenant_id=None,
-                    product="vault",
-                    version="1.x",
-                    impl_id="vault",
-                    group_key="kv",
-                    name="KV v2",
-                    when_to_use="Use for reading and writing KV v2 secrets.",
-                    review_status="enabled",
-                    created_at=datetime.now(UTC),
-                    updated_at=datetime.now(UTC),
-                )
-            )
-
-    import asyncio
-
-    asyncio.run(_seed())
 
     response = post_mcp(
         client,

--- a/backend/tests/test_secret_leak_checks.py
+++ b/backend/tests/test_secret_leak_checks.py
@@ -39,12 +39,14 @@ an unhandled exception.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import AsyncMock
 
 import hvac.exceptions
 import pytest
@@ -55,7 +57,10 @@ from fastapi.testclient import TestClient
 from meho_backplane.auth import vault as vault_module
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vault import VaultConnector, register_vault_typed_operations
 from meho_backplane.main import app
+from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 from tests.conftest import (
     DEFAULT_AUDIENCE,
@@ -93,6 +98,35 @@ def _isolated_jwks_cache() -> Iterator[None]:
     clear_jwks_cache()
     yield
     clear_jwks_cache()
+
+
+@pytest.fixture(autouse=True)
+def _registered_vault_substrate(_settings_env: None) -> Iterator[None]:
+    """Re-establish the v2 connector entry + the ``vault.kv.read`` descriptor row.
+
+    The ``TestClient(app)`` fixture in this file does not enter the
+    FastAPI lifespan (the log-capture configuration would be clobbered
+    by the lifespan's ``configure_logging`` step), so the lifespan's
+    ``run_typed_op_registrars`` step never fires. Replicate the v2
+    registry entry + typed-op descriptor upsert directly here so the
+    dispatcher's natural-key lookup finds the row at request time.
+    """
+    clear_registry()
+    register_connector_v2(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        cls=VaultConnector,
+    )
+    reset_dispatcher_caches()
+    stub_embedding_service = AsyncMock()
+    stub_embedding_service.encode_one.return_value = [0.1] * 384
+    stub_embedding_service.encode.return_value = [[0.1] * 384]
+    stub_embedding_service.dimension = 384
+    asyncio.run(register_vault_typed_operations(embedding_service=stub_embedding_service))
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
 
 
 def _configure_capture(buf: io.StringIO) -> None:

--- a/docs/architecture/connectors.md
+++ b/docs/architecture/connectors.md
@@ -113,12 +113,12 @@ Stored on every `Target` row (G0.3); read by the connector at `execute()` time.
 
 ## Adapter shapes (G0.2-T3 / T4)
 
-> **Status:** G0.2-T1 (ABC + result models), G0.2-T2 (registry), G0.2-T3 (HTTP adapter), and G0.2-T4 (SSH adapter) have landed. G0.2-T5 (`VaultConnector` reference refactor) is still open. The tree is the target hierarchy each vendor Initiative under [G3 (#214)](https://github.com/evoila/meho/issues/214) will register against.
+> **Status:** G0.2-T1 (ABC + result models), G0.2-T2 (registry), G0.2-T3 (HTTP adapter), G0.2-T4 (SSH adapter), and G0.2-T5 (`VaultConnector` reference impl, #244) have landed. The `VaultConnector` was subsequently refactored under [G0.6-T-Refactor-Vault (#390)](https://github.com/evoila/meho/issues/390) to register via `register_connector_v2` + `register_typed_operation()` and to route `execute()` through the G0.6 dispatcher. The tree is the target hierarchy each vendor Initiative under [G3 (#214)](https://github.com/evoila/meho/issues/214) will register against.
 
 ```text
 Connector (ABC)                                      ← G0.2-T1 (shipped)
 ├── HttpConnector       — httpx.AsyncClient pool, tenacity retry, SSL_CERT_FILE   ← G0.2-T3 (shipped)
-│   ├── VaultConnector  — refactor of auth/vault.py (G0.2-T5; reference impl)     ← G0.2-T5 (planned)
+│   ├── VaultConnector  — auth/vault.py wrapper (G0.2-T5; reference impl)         ← refactored under G0.6-T-Refactor-Vault #390
 │   ├── VSphereConnector — vSphere REST API (G3.1)
 │   ├── NSXConnector
 │   ├── HarborConnector

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -63,25 +63,38 @@ this stage it exposes:
   apply to write/admin handlers as they land — T4 only ships the
   primitive plus the verification surface.
 * Vault forward-auth — `VaultConnector` (`connectors/vault/connector.py`,
-  Task #244 G0.2-T5) is the canonical abstraction for the Vault
-  integration. It wraps `vault_client_for_operator` from `auth/vault.py`
-  and exposes `fingerprint`, `probe`, and `execute` per the `Connector`
-  ABC. The Vault readiness probe registered in lifespan delegates to
-  `VaultConnector.probe()` and flips `/ready` red when `/sys/health` is
-  unreachable, sealed, or uninitialized.
+  Task #244 G0.2-T5, refactored under G0.6-T-Refactor-Vault #390) is
+  the canonical abstraction for the Vault integration. It wraps
+  `vault_client_for_operator` from `auth/vault.py` and exposes
+  `fingerprint`, `probe`, and `execute` per the `Connector` ABC.
+  Post-G0.6 the connector registers via `register_connector_v2(...)`
+  under `(product="vault", version="1.x", impl_id="vault")` rather
+  than the v1 single-product entry point; per-op handlers
+  (`vault_kv_read` in `connectors/vault/ops.py`) land as
+  `endpoint_descriptor` rows via `register_vault_typed_operations()`
+  at lifespan startup. The Vault readiness probe registered in
+  lifespan delegates to `VaultConnector.probe()` and flips `/ready`
+  red when `/sys/health` is unreachable, sealed, or uninitialized.
 * Federation-proof endpoint — `GET /api/v1/health` (auth-required) is
   the load-bearing integration point where the entire JWT → Vault
-  chain runs on every call (Task #24). The route uses the
+  chain runs on every call (Task #24, refactored to dispatch under
+  G0.6-T-Refactor-Vault #390). The route uses the
   `verify_jwt_and_bind` dependency wrapper, which delegates to
   `verify_jwt` and — on success — binds `operator_sub` into structlog
   contextvars. The handler dispatches `vault.kv.read` via
-  `get_connector("vault").execute(target, "vault.kv.read", {"path": ...})`,
-  reads the test secret at
+  `dispatch(operator=..., connector_id="vault-1.x", op_id="vault.kv.read", ...)`
+  (G0.6-T5 #396), reads the test secret at
   `secret/meho/test/federation` (KV v2), and returns a structured
   JSON document with operator identity, Vault status, and a DB
-  migration placeholder (`db.migrated = null` until G2.3). All Vault
-  failure modes surface as structured fields on a 200 response — the
-  smoke test never sees a 5xx from this endpoint.
+  migration placeholder. The handler raises
+  `VaultClientError` subclasses on login-side failure and
+  read-side exceptions on read-side failure; the dispatcher's
+  `connector_error` branch records the exception class name in
+  `extras["exception_class"]`, and the route string-matches against
+  the known VaultClientError subclass set to render
+  `login_failed: <Cls>` vs `read_failed: <Cls>`. All Vault
+  failure modes surface as structured fields on a 200 response —
+  the smoke test never sees a 5xx from this endpoint.
 * Federation-chain failure-mode test suite (Task #25) — comprehensive
   pytest coverage that proves the chain *fails safely*: every JWT
   failure shape (expired / wrong-aud / wrong-iss / tampered signature /


### PR DESCRIPTION
## Summary

Refactor the shipped `VaultConnector` (G0.2-T5 #244) to use the G0.6 operation substrate (#388):

- Replace in-code `_op_map` with `register_typed_operation()` calls (run at lifespan startup via a new registrar list in `operations/typed_register.py`).
- `VaultConnector.execute(target, op_id, params)` becomes a thin shim that delegates to `dispatch(connector_id="vault-1.x", ...)`; the per-op handler `vault_kv_read` keeps the same Vault HTTP call but returns a plain dict and raises on failure (the dispatcher wraps).
- Switch registration from `register_connector("vault", VaultConnector)` to `register_connector_v2(product="vault", version="1.x", impl_id="vault", cls=VaultConnector)`.
- `/api/v1/health` now calls `dispatch()` directly with the real Operator so the dispatcher's audit row carries operator identity; login-vs-read phase distinction maps off `extras["exception_class"]` against the `VaultClientError` subclass set.
- New lifespan step `await run_typed_op_registrars()` after `_eager_import_connectors()` so `endpoint_descriptor` rows land before the first request.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] `pytest tests/` — 975 passed, 31 skipped
- [x] `code-quality.py --diff` — 0 blockers, 7 warnings (all on docstring-heavy functions and pre-existing files)
- [x] `connectors/vault/` no longer defines an in-code `_op_map` (verified by `OP_MAP` removed from `ops.py`)
- [x] `VaultConnector.execute(...)` delegates to `dispatch(...)` (verified by `test_execute_vault_kv_read_returns_secret_data` exercising the full pipeline)
- [x] Registry call migrated to `register_connector_v2(...)` (verified by `test_importing_vault_package_registers_vault_connector_v2`)
- [x] `/api/v1/health` integration test passes end-to-end (verified by `test_api_v1_health.py` + `test_api_health_failures.py` — all 19 happy-path and failure-mode tests green)
- [x] Unknown `op_id` returns dispatcher's structured `unknown_op` (verified by `test_execute_unknown_op_returns_dispatcher_unknown_op_shape`)
- [x] Per-op `llm_instructions` payload registered (verified by `register_vault_typed_operations()` body)
- [x] Body-hash skip works on re-init (existing `register_typed_operation` "skip-re-embed" branch; covered by `tests/test_operations_typed_register.py`)

## Out of scope

- Sibling K8s refactor (#391) — handled by the parallel agent on a separate task.
- Full Vault op surface (G3.3 #366) — KV-v2 + sys + auth read/list lands on top of this refactor.
- Removing the v1 `register_connector()` entry point entirely — deferred until every G3.x Initiative re-registers via v2.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #390


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced health endpoint with structured Vault failure diagnostics (login vs. read-phase classification).
  * Vault connector now integrates via the v2 registration system with explicit version identifiers.

* **Bug Fixes**
  * Improved error classification in health checks to prevent misidentified service states.

* **Documentation**
  * Updated architecture and backend documentation to reflect Vault integration changes and health endpoint behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/463)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->