### PR TITLE
feat(operations): G0.7-T2 register_ingested_operations() — bulk upsert + multi-spec merge + auto-register connector + body-hash skip

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -13,11 +13,16 @@ REST routes at T6, admin MCP tools at T7) import from
 private module layout.
 """
 
+from meho_backplane.operations.ingest.connector_registration import (
+    GenericRestConnector,
+    ensure_connector_class_registered,
+)
 from meho_backplane.operations.ingest.exceptions import (
     ConnectorNotFoundError,
     InvalidSchemaError,
     InvalidSpecError,
     InvalidStateTransitionError,
+    OpIdCollision,
     UnsupportedSpecError,
 )
 from meho_backplane.operations.ingest.openapi import (
@@ -29,6 +34,10 @@ from meho_backplane.operations.ingest.payload import (
     ConnectorReviewGroup,
     ConnectorReviewOp,
     ConnectorReviewPayload,
+)
+from meho_backplane.operations.ingest.register_ingested import (
+    IngestionResult,
+    register_ingested_operations,
 )
 from meho_backplane.operations.ingest.schemas import (
     EndpointDescriptorProto,
@@ -42,13 +51,18 @@ __all__ = [
     "ConnectorReviewOp",
     "ConnectorReviewPayload",
     "EndpointDescriptorProto",
+    "GenericRestConnector",
+    "IngestionResult",
     "InvalidSchemaError",
     "InvalidSpecError",
     "InvalidStateTransitionError",
+    "OpIdCollision",
     "ReviewService",
     "SafetyLevel",
     "UnsupportedSpecError",
     "detect_spec_format",
+    "ensure_connector_class_registered",
     "parse_connector_id",
     "parse_openapi",
+    "register_ingested_operations",
 ]

--- a/backend/src/meho_backplane/operations/ingest/_upsert.py
+++ b/backend/src/meho_backplane/operations/ingest/_upsert.py
@@ -36,8 +36,11 @@ from meho_backplane.operations.embed import (
     compute_embedding_text_hash,
     encode_endpoint_text,
 )
+from meho_backplane.operations.ingest.exceptions import OpIdCollision
 from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
 from meho_backplane.retrieval.embedding import EmbeddingService
+
+_SPEC_TAG_PREFIX = "spec:"
 
 __all__ = [
     "UpsertContext",
@@ -105,6 +108,22 @@ def build_upsert_context(
         incoming_hash=compute_embedding_text_hash(incoming_text),
         now=now,
     )
+
+
+def _extract_persisted_spec_source(existing: EndpointDescriptor) -> str | None:
+    """Recover the ``spec_source`` of an already-persisted row.
+
+    The synthetic ``f"spec:{spec_source}"`` marker is appended once
+    per row at first-register (and re-applied on the re-embed path),
+    so a well-formed row carries exactly one ``spec:`` tag. If the
+    tag is missing (older rows, hand-edited fixtures), return
+    ``None`` and let the caller skip the cross-call check rather
+    than raise a spurious collision.
+    """
+    for tag in existing.tags or []:
+        if tag.startswith(_SPEC_TAG_PREFIX):
+            return tag[len(_SPEC_TAG_PREFIX) :]
+    return None
 
 
 async def _lookup_existing_descriptor(
@@ -211,6 +230,27 @@ async def upsert_one_operation(
     existing = await _lookup_existing_descriptor(session, ctx)
 
     if existing is not None:
+        # Cross-call op_id collision: the existing row was written by a
+        # prior register_ingested_operations() call under a *different*
+        # spec_source. Silently re-embedding would replace the prior
+        # spec's method / path / summary / description / schemas with
+        # this call's payload — never what the operator wants.
+        # Per Task #403 the operator must see a structured exception
+        # naming both spec sources so they can decide whether to rename
+        # one op_id or skip the offending spec. Same-spec_source
+        # re-ingest stays on the existing skip-re-embed / re-embed
+        # branches below; only a true spec_source mismatch fires.
+        existing_spec_source = _extract_persisted_spec_source(existing)
+        if existing_spec_source is not None and existing_spec_source != ctx.spec_source:
+            raise OpIdCollision(
+                op_ids=[ctx.proto.op_id],
+                product=ctx.product,
+                version=ctx.version,
+                impl_id=ctx.impl_id,
+                existing_spec_source=existing_spec_source,
+                incoming_spec_source=ctx.spec_source,
+            )
+
         existing_text = build_embedding_text(
             summary=existing.summary or "",
             description=existing.description or "",

--- a/backend/src/meho_backplane/operations/ingest/_upsert.py
+++ b/backend/src/meho_backplane/operations/ingest/_upsert.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-op upsert helpers for the spec-ingestion bulk-upsert pipeline.
+
+Private support module for
+:func:`~meho_backplane.operations.ingest.register_ingested.register_ingested_operations`
+(G0.7-T2 #403). Split out so the public module stays focused on the
+batch-level orchestration (collision detection, connector class
+auto-registration, session ownership) while the per-row branches
+live here.
+
+The three persistence branches -- skip-re-embed, re-embed, and
+first-register -- each have a dedicated helper. Their orchestrator
+:func:`_upsert_one_operation` is what
+:func:`register_ingested_operations` calls per row in the batch.
+
+Nothing here is part of the public ``meho_backplane.operations.ingest``
+surface; the underscore prefix is the contract. v0.2.next refactors
+are free to reshape the helpers.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations.embed import (
+    build_embedding_text,
+    compute_embedding_text_hash,
+    encode_endpoint_text,
+)
+from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "UpsertContext",
+    "build_upsert_context",
+    "upsert_one_operation",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class UpsertContext:
+    """Per-op derived state shared across the upsert branches.
+
+    Bundling the lookup-key components + the precomposed embedding
+    text/hash + the spec-tagged ``tags`` list into one frozen dataclass
+    keeps each branch helper's signature small (one positional context
+    arg) without losing the natural-key coordinates each branch needs
+    for its logging / row writes.
+    """
+
+    tenant_id: UUID | None
+    product: str
+    version: str
+    impl_id: str
+    spec_source: str
+    proto: EndpointDescriptorProto
+    tags_with_marker: list[str]
+    incoming_text: str
+    incoming_hash: str
+    now: datetime
+
+
+def build_upsert_context(
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    version: str,
+    impl_id: str,
+    spec_source: str,
+    proto: EndpointDescriptorProto,
+    now: datetime,
+) -> UpsertContext:
+    """Compose the per-op upsert context from caller args + parser proto.
+
+    The persisted row's ``tags`` value is ``proto.tags`` with the
+    synthetic ``f"spec:{spec_source}"`` marker appended -- the helper
+    accepts the bare label (``"vcenter.yaml"``) and formats the prefix
+    itself per the Task #403 API contract.
+    """
+    tags_with_marker = [*proto.tags, f"spec:{spec_source}"]
+    incoming_text = build_embedding_text(
+        summary=proto.summary or "",
+        description=proto.description or "",
+        custom_description=None,
+        tags=tags_with_marker,
+    )
+    return UpsertContext(
+        tenant_id=tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        spec_source=spec_source,
+        proto=proto,
+        tags_with_marker=tags_with_marker,
+        incoming_text=incoming_text,
+        incoming_hash=compute_embedding_text_hash(incoming_text),
+        now=now,
+    )
+
+
+async def _lookup_existing_descriptor(
+    session: AsyncSession,
+    ctx: UpsertContext,
+) -> EndpointDescriptor | None:
+    """Find an existing row matching the natural key + tenant partial index."""
+    stmt = select(EndpointDescriptor).where(
+        EndpointDescriptor.product == ctx.product,
+        EndpointDescriptor.version == ctx.version,
+        EndpointDescriptor.impl_id == ctx.impl_id,
+        EndpointDescriptor.op_id == ctx.proto.op_id,
+    )
+    if ctx.tenant_id is None:
+        stmt = stmt.where(EndpointDescriptor.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(EndpointDescriptor.tenant_id == ctx.tenant_id)
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+def _apply_skip_reembed(existing: EndpointDescriptor, ctx: UpsertContext) -> None:
+    """Update non-embedding fields on a body-hash-matched row.
+
+    Leave ``summary`` / ``description`` / ``tags`` alone (the hash
+    match proved they're equal) so the ORM identity map stays
+    consistent; only refresh the proto-derived non-embedding fields.
+    """
+    existing.method = ctx.proto.method
+    existing.path = ctx.proto.path
+    existing.parameter_schema = ctx.proto.parameter_schema
+    existing.response_schema = ctx.proto.response_schema
+    existing.safety_level = ctx.proto.safety_level
+    existing.requires_approval = ctx.proto.requires_approval
+    existing.updated_at = ctx.now
+
+
+def _apply_reembed_update(
+    existing: EndpointDescriptor,
+    ctx: UpsertContext,
+    embedding: list[float],
+) -> None:
+    """Re-embed path: existing row, embedding text changed."""
+    existing.method = ctx.proto.method
+    existing.path = ctx.proto.path
+    existing.summary = ctx.proto.summary
+    existing.description = ctx.proto.description
+    existing.tags = ctx.tags_with_marker
+    existing.parameter_schema = ctx.proto.parameter_schema
+    existing.response_schema = ctx.proto.response_schema
+    existing.safety_level = ctx.proto.safety_level
+    existing.requires_approval = ctx.proto.requires_approval
+    existing.embedding = embedding
+    existing.updated_at = ctx.now
+
+
+def _build_new_descriptor(
+    ctx: UpsertContext,
+    embedding: list[float],
+) -> EndpointDescriptor:
+    """First-register path: brand-new row populated from the proto."""
+    return EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=ctx.tenant_id,
+        product=ctx.product,
+        version=ctx.version,
+        impl_id=ctx.impl_id,
+        op_id=ctx.proto.op_id,
+        source_kind="ingested",
+        method=ctx.proto.method,
+        path=ctx.proto.path,
+        handler_ref=None,
+        summary=ctx.proto.summary,
+        description=ctx.proto.description,
+        group_id=None,
+        tags=ctx.tags_with_marker,
+        parameter_schema=ctx.proto.parameter_schema,
+        response_schema=ctx.proto.response_schema,
+        llm_instructions=None,
+        safety_level=ctx.proto.safety_level,
+        requires_approval=ctx.proto.requires_approval,
+        is_enabled=False,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=ctx.now,
+        updated_at=ctx.now,
+    )
+
+
+async def upsert_one_operation(
+    session: AsyncSession,
+    ctx: UpsertContext,
+    *,
+    embedding_service: EmbeddingService | None,
+) -> str:
+    """Upsert one :class:`EndpointDescriptor` row from a parser proto.
+
+    Returns one of ``"inserted"`` / ``"updated"`` / ``"skipped"`` so
+    the caller can tally the counts for :class:`IngestionResult`. The
+    three branches (skip-re-embed / re-embed / first-register) live
+    in dedicated helpers; this function is the orchestrator that
+    chooses between them.
+    """
+    existing = await _lookup_existing_descriptor(session, ctx)
+
+    if existing is not None:
+        existing_text = build_embedding_text(
+            summary=existing.summary or "",
+            description=existing.description or "",
+            custom_description=existing.custom_description,
+            tags=existing.tags,
+        )
+        if compute_embedding_text_hash(existing_text) == ctx.incoming_hash:
+            _apply_skip_reembed(existing, ctx)
+            await session.flush()
+            return "skipped"
+
+        embedding = await encode_endpoint_text(ctx.incoming_text, service=embedding_service)
+        _apply_reembed_update(existing, ctx, embedding)
+        await session.flush()
+        return "updated"
+
+    embedding = await encode_endpoint_text(ctx.incoming_text, service=embedding_service)
+    descriptor = _build_new_descriptor(ctx, embedding)
+    session.add(descriptor)
+    await session.flush()
+    return "inserted"

--- a/backend/src/meho_backplane/operations/ingest/connector_registration.py
+++ b/backend/src/meho_backplane/operations/ingest/connector_registration.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Auto-register a thin :class:`HttpConnector` shim per ingested spec.
+
+G0.7-T2 (#403) -- on the first time the spec-ingestion pipeline
+encounters a ``(product, version, impl_id)`` triple, it must make
+the connector resolvable through the v2 registry (G0.6-T2 #393) so
+the dispatcher can route operations against the ingested rows. A
+hand-coded :class:`HttpConnector` subclass for every vendor would be
+the load-bearing per-G3.x deliverable (vSphere session auth, NSX
+XSRF, Robot HTTP Basic, etc.), but those packages don't exist yet
+when the operator runs ``meho connector ingest`` against a fresh
+spec. The auto-shim bridges the gap: on first ingest, a
+synthesised :class:`GenericRestConnector` subclass is registered so
+the connector resolves; on subsequent ingests of additional specs
+under the same connector_id, the shim is left in place; per-G3.x
+work later REPLACES the auto-shim with a hand-rolled subclass.
+
+The shim is deliberately minimal -- it inherits all transport
+plumbing (client pooling, retry, timeout, cert bundle) from
+:class:`HttpConnector` and overrides only the four
+:class:`Connector` ABC methods. ``auth_headers`` raises
+:class:`NotImplementedError` with a message pointing at the
+per-G3.x override site; ``fingerprint`` / ``probe`` / ``execute``
+return placeholder shapes that the operator sees in startup logs
+("the dispatcher routed a call against an unconfigured auto-shim;
+add the per-product subclass before enabling this connector"). The
+v0.2 review-queue gate (T4 #402) keeps every ingested op in
+``is_enabled=False`` / ``review_status='staged'`` until the
+operator vets the connector, which is exactly when they're
+supposed to add the per-product subclass; the auto-shim is never
+called in practice on production paths.
+
+Why dynamic class synthesis instead of a registry of stub
+instances: the v2 resolver
+(:func:`~meho_backplane.connectors.resolver.resolve_connector`)
+keys on the connector *class*, not an instance, and reads its
+class-level ``product`` / ``version`` / ``impl_id`` /
+``supported_version_range`` / ``priority`` attributes to match
+against target fingerprints. A single shared instance can't carry
+per-(product, version, impl_id) class attrs simultaneously. The
+:func:`type` factory is the conventional Python answer; the
+resulting class behaves identically to one declared with ``class
+Foo(HttpConnector):`` at module scope, modulo the absence of a
+stable Python-source location for the class object (its
+``__module__`` is set to this helper's module so a v2 registry
+listing renders the synthesised class with a recognisable origin).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = [
+    "GenericRestConnector",
+    "derive_supported_version_range",
+    "ensure_connector_class_registered",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+class GenericRestConnector(HttpConnector):
+    """Base for every auto-generated REST connector shim.
+
+    Subclasses are produced dynamically by
+    :func:`ensure_connector_class_registered` via :func:`type` and
+    differ only in their class-level ``product`` / ``version`` /
+    ``impl_id`` / ``supported_version_range`` / ``priority`` /
+    ``_base_url_override`` values; the method overrides below are
+    inherited verbatim.
+
+    All four :class:`~meho_backplane.connectors.base.Connector` ABC
+    methods are implemented so :func:`type` can pin them onto the
+    synthesised class without an ``abstract method`` instantiation
+    error. The bodies are intentionally degenerate -- the auto-shim
+    is registered for resolvability only; the operator REPLACES it
+    with a hand-coded subclass before enabling the connector for
+    dispatch.
+
+    ``auth_headers`` raises :class:`NotImplementedError` with a
+    message pointing at the per-G3.x override site so the failure
+    is loud and operator-readable. ``fingerprint`` / ``probe`` /
+    ``execute`` return placeholder shapes (reachable=False with a
+    "unconfigured-auto-shim" explanation) so a stray call against
+    the shim doesn't crash the dispatcher mid-flight.
+    """
+
+    #: Default base URL the auto-shim uses when the target carries
+    #: no explicit base URL of its own. Set by the class factory
+    #: from the ``base_url`` arg to
+    #: :func:`ensure_connector_class_registered`. ``None`` falls back
+    #: to :meth:`HttpConnector._base_url`'s ``https://{host}{:port}``
+    #: derivation from the target.
+    _base_url_override: str | None = None
+
+    def _base_url(self, target: Any) -> str:
+        """Return the per-target base URL.
+
+        Overrides :meth:`HttpConnector._base_url` when
+        :attr:`_base_url_override` is set on the synthesised class
+        (most ingested specs carry a server URL); falls back to the
+        ``https://{host}{:port}`` derivation otherwise so the auto-
+        shim still produces a valid URL for targets without an
+        explicit override.
+        """
+        if self._base_url_override is not None:
+            return self._base_url_override
+        return super()._base_url(target)
+
+    async def auth_headers(self, target: Any, raw_jwt: str) -> dict[str, str]:
+        """Raise :class:`NotImplementedError` with operator-readable guidance.
+
+        The auto-shim doesn't know how to authenticate against the
+        upstream vendor -- that's the per-G3.x deliverable. The
+        review-queue gate (T4 #402) keeps every ingested op
+        ``is_enabled=False`` until the operator vets the connector,
+        which is exactly when they hand-roll the auth path; reaching
+        this method on a production code path means either the
+        review gate was bypassed or the per-G3.x subclass wasn't
+        registered before the connector was enabled.
+        """
+        raise NotImplementedError(
+            f"auto-registered shim for "
+            f"({self.product!r}, {self.version!r}, {self.impl_id!r}) "
+            "must be replaced with a per-product Connector subclass "
+            "before dispatch is enabled -- the operator's G3.x "
+            "Initiative work adds auth_headers() per target.auth_model"
+        )
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:
+        """Return an unreachable placeholder fingerprint.
+
+        The auto-shim cannot probe the upstream API (no auth, no
+        per-product reachability heuristic) so it reports the target
+        as unreachable with a stable ``probe_method`` value the
+        operator-facing CLI / API can render verbatim.
+        """
+        return FingerprintResult(
+            vendor=self.product,
+            product=self.product,
+            version=self.version,
+            build=None,
+            reachable=False,
+            probed_at=datetime.now(UTC),
+            probe_method="unconfigured-auto-shim",
+            extras={
+                "note": (
+                    "auto-registered GenericRestConnector shim -- replace with a "
+                    "per-product Connector subclass before enabling dispatch"
+                ),
+            },
+        )
+
+    async def probe(self, target: Any) -> ProbeResult:
+        """Return an unreachable placeholder probe."""
+        return ProbeResult(
+            ok=False,
+            reason=(
+                "auto-registered GenericRestConnector shim -- replace with a "
+                "per-product Connector subclass before enabling dispatch"
+            ),
+            probed_at=datetime.now(UTC),
+        )
+
+    async def execute(
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Raise :class:`NotImplementedError` -- shim isn't dispatchable.
+
+        The dispatcher should never reach this method in production:
+        the review-queue gate (T4 #402) keeps every ingested op
+        ``is_enabled=False`` until the operator replaces the shim. If
+        it does, the explicit raise (rather than a placeholder
+        :class:`OperationResult`) makes the misconfiguration visible
+        immediately rather than silently returning a degenerate
+        result the agent would misinterpret. The :class:`OperationResult`
+        return-type annotation is preserved to satisfy the
+        :class:`~meho_backplane.connectors.base.Connector` ABC; the
+        method never actually returns a value.
+        """
+        raise NotImplementedError(
+            f"auto-registered shim for "
+            f"({self.product!r}, {self.version!r}, {self.impl_id!r}) "
+            f"cannot execute op_id={op_id!r} -- replace the shim with a "
+            "per-product Connector subclass before enabling dispatch"
+        )
+
+
+def derive_supported_version_range(version: str) -> str:
+    """Derive a PEP 440 version spec from a single version string.
+
+    Returns ``">={version},<{next_major}.0"`` when *version* parses
+    as ``MAJOR.MINOR[.PATCH]`` -- the auto-shim then advertises
+    compatibility with every minor / patch release in the same
+    major series (the conservative default; per-G3.x subclasses
+    that have tested against narrower ranges override the class
+    attribute when they REPLACE the shim).
+
+    Falls back to ``f"=={version}"`` (a single-version pin) when
+    the version string doesn't parse as a numeric MAJOR.MINOR. This
+    covers exotic version slugs like ``"latest"`` or ``"main"``
+    that some vendor specs ship; the conservative pin avoids
+    matching the shim against unrelated targets.
+
+    The shim's ``supported_version_range`` is what the v2 resolver
+    matches against a target's fingerprinted product version, so a
+    too-broad range would silently route a 11.x target at a 9.x
+    shim. PEP 440 ``>=X,<Y`` is the same shape every hand-rolled
+    connector class uses (Vault uses ``"==1.x"``, K8s uses
+    ``"==1.x"``); the auto-shim's range is no looser than the
+    convention.
+    """
+    parts = version.split(".")
+    if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+        major = int(parts[0])
+        return f">={version},<{major + 1}.0"
+    return f"=={version}"
+
+
+def _synthesised_class_name(product: str, version: str, impl_id: str) -> str:
+    """Build a Python-identifier-safe class name from the connector triple.
+
+    Non-alnum characters in *product* / *version* / *impl_id* are
+    replaced with underscores so the result is a valid Python
+    identifier even when the inputs carry dots, dashes, or other
+    punctuation. The shape ``AutoShim_<product>_<version>_<impl_id>``
+    matches the v2 registry's diagnostic listing convention.
+    """
+    sanitized = "_".join(
+        "".join(ch if ch.isalnum() else "_" for ch in component)
+        for component in (product, version, impl_id)
+    )
+    return f"AutoShim_{sanitized}"
+
+
+def _synthesise_shim_class(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    base_url: str | None,
+) -> type[Connector]:
+    """Synthesise a :class:`GenericRestConnector` subclass via :func:`type`.
+
+    The class body is a static dict of class-level attributes; method
+    overrides inherit from :class:`GenericRestConnector` verbatim. The
+    ``__module__`` field is set so startup-log listings of the v2
+    registry render the synthesised class with this helper's import
+    path rather than a misleading ``<unknown>``.
+    """
+    cls_name = _synthesised_class_name(product, version, impl_id)
+    supported_range = derive_supported_version_range(version)
+    return type(
+        cls_name,
+        (GenericRestConnector,),
+        {
+            "product": product,
+            "version": version,
+            "impl_id": impl_id,
+            "supported_version_range": supported_range,
+            "priority": 0,
+            "_base_url_override": base_url,
+            "__module__": __name__,
+            "__doc__": (
+                f"Auto-registered :class:`GenericRestConnector` shim for "
+                f"({product!r}, {version!r}, {impl_id!r}).\n\n"
+                "Synthesised by "
+                ":func:`meho_backplane.operations.ingest.connector_registration."
+                "ensure_connector_class_registered` on first ingest of a spec "
+                "against this connector triple. Replace with a hand-coded "
+                "subclass per G3.x Initiative when adding per-product auth, "
+                "topology discovery, or non-degenerate fingerprint shape."
+            ),
+        },
+    )
+
+
+def ensure_connector_class_registered(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    base_url: str | None,
+) -> bool:
+    """Register a :class:`GenericRestConnector` shim if one is absent for *triple*.
+
+    Returns ``True`` when a new shim class was synthesised and
+    registered; ``False`` when an entry already exists for the
+    ``(product, version, impl_id)`` key in the v2 registry. The
+    return value drives the ``connector_registered`` flag on
+    :class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`
+    so the CLI can report "first ingest registered the connector"
+    vs "subsequent ingest reused the existing connector".
+
+    Idempotency note: the v2 registry rejects duplicate
+    registration with :class:`RuntimeError`, so checking presence
+    first is necessary (not merely an optimisation). The check is
+    racy against concurrent ingests of the same triple, but v0.2
+    ingestion is single-threaded per pod (the CLI / REST handlers
+    are operator-driven and serialised) so the race is theoretical.
+    """
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    existing = all_connectors_v2()
+    if (product, version, impl_id) in existing:
+        _log.info(
+            "connector_auto_register_skipped",
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            existing_cls=existing[(product, version, impl_id)].__name__,
+        )
+        return False
+
+    cls = _synthesise_shim_class(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        base_url=base_url,
+    )
+    register_connector_v2(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        cls=cls,
+    )
+    _log.info(
+        "connector_auto_registered",
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        cls=cls.__name__,
+        supported_version_range=cls.supported_version_range,
+        base_url=base_url,
+    )
+    return True

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -3,9 +3,9 @@
 
 """Domain exceptions for the G0.7 spec-ingestion pipeline.
 
-Two unrelated families of failure modes share this module so T1
-(OpenAPI parser, #401) and T4 (review-queue state machine, #402)
-agree on an import path:
+Three unrelated families of failure modes share this module so T1
+(OpenAPI parser, #401), T2 (registration helper, #403), and T4
+(review-queue state machine, #402) agree on an import path:
 
 Parser failures (T1 #401) — raised from
 :func:`~meho_backplane.operations.ingest.parse_openapi`:
@@ -18,6 +18,19 @@ Parser failures (T1 #401) — raised from
 * :class:`InvalidSchemaError` — a referenced JSON Schema is
   structurally broken (dangling ``$ref``, component-path drill-down,
   non-list parameters).
+
+Registration failures (T2 #403) — raised from
+:func:`~meho_backplane.operations.ingest.register_ingested_operations`:
+
+* :class:`OpIdCollision` — two operations in a single ingest batch
+  carry the same ``op_id``. The natural key
+  ``(product, version, impl_id, op_id)`` is unique by partial index
+  on ``endpoint_descriptor``; merging two specs that happen to
+  expose the same ``op_id`` would silently UPDATE the first row
+  with the second's payload, which is never what the operator
+  wants. The exception names every colliding ``op_id`` so the
+  operator can decide whether to rename one (out-of-scope for v0.2)
+  or skip the offending spec pair.
 
 Review-queue failures (T4 #402) — raised from
 :class:`~meho_backplane.operations.ingest.ReviewService`:
@@ -41,11 +54,11 @@ Review-queue failures (T4 #402) — raised from
   enumerate another tenant's connectors by probing for ``HTTP 404``
   vs ``HTTP 403`` boundaries.
 
-The parser classes inherit from :class:`ValueError` so callers that
-already catch parsing errors via ``except ValueError`` keep working;
-the review-queue classes inherit from :class:`Exception` directly so
-callers can ``except`` them precisely without catching unrelated
-runtime faults.
+The parser and registration classes inherit from :class:`ValueError`
+so callers that already catch parsing errors via
+``except ValueError`` keep working; the review-queue classes inherit
+from :class:`Exception` directly so callers can ``except`` them
+precisely without catching unrelated runtime faults.
 """
 
 from __future__ import annotations
@@ -57,6 +70,7 @@ __all__ = [
     "InvalidSchemaError",
     "InvalidSpecError",
     "InvalidStateTransitionError",
+    "OpIdCollision",
     "UnsupportedSpecError",
 ]
 
@@ -89,6 +103,47 @@ class InvalidSchemaError(ValueError):
     a structurally unsupported shape (component-path drill-down
     refs, for example).
     """
+
+
+class OpIdCollision(ValueError):  # noqa: N818 -- Task #403 API contract pins this name verbatim
+    """Two operations in one ingest batch carry the same ``op_id``.
+
+    Attributes
+    ----------
+    op_ids:
+        The colliding ``op_id`` values, sorted for stable error
+        messages and diff-friendly test assertions. At least two
+        entries — a one-element list would imply no collision.
+    product, version, impl_id:
+        The connector coordinates being ingested. Surfaced on the
+        exception so the operator-facing CLI / API can render a
+        complete "couldn't ingest spec X into connector Y because Z"
+        message without re-threading the connector identity from
+        the call site.
+
+    Inherits from :class:`ValueError` so callers that already catch
+    parser-shaped errors via ``except ValueError`` keep working
+    without a targeted ``except OpIdCollision``. The targeted class
+    still exists so tests can assert on the precise shape and so the
+    CLI layer can map it onto a structured 400 detail field.
+    """
+
+    def __init__(
+        self,
+        *,
+        op_ids: list[str],
+        product: str,
+        version: str,
+        impl_id: str,
+    ) -> None:
+        self.op_ids = sorted(op_ids)
+        self.product = product
+        self.version = version
+        self.impl_id = impl_id
+        super().__init__(
+            f"op_id collision while ingesting into "
+            f"({product!r}, {version!r}, {impl_id!r}): {self.op_ids!r}"
+        )
 
 
 class InvalidStateTransitionError(Exception):

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -22,15 +22,27 @@ Parser failures (T1 #401) — raised from
 Registration failures (T2 #403) — raised from
 :func:`~meho_backplane.operations.ingest.register_ingested_operations`:
 
-* :class:`OpIdCollision` — two operations in a single ingest batch
-  carry the same ``op_id``. The natural key
+* :class:`OpIdCollision` — two operations under the same
+  ``(product, version, impl_id)`` triple carry the same ``op_id``,
+  raised in two distinct branches:
+
+  * **Within-batch** — two ops in a single ingest call collide.
+    Caught up-front by a set scan before any DB write.
+  * **Cross-call** — a second ingest call under the same triple
+    submits an ``op_id`` already persisted from a prior call with
+    a different ``spec_source``. Caught per-row after the natural-
+    key lookup, before the embedding hash comparison.
+
+  Both branches raise the same exception type so callers can write
+  one ``except OpIdCollision`` and handle both. The natural key
   ``(product, version, impl_id, op_id)`` is unique by partial index
   on ``endpoint_descriptor``; merging two specs that happen to
   expose the same ``op_id`` would silently UPDATE the first row
   with the second's payload, which is never what the operator
   wants. The exception names every colliding ``op_id`` so the
   operator can decide whether to rename one (out-of-scope for v0.2)
-  or skip the offending spec pair.
+  or skip the offending spec pair; for cross-call collisions it
+  also names both ``spec_source`` values to disambiguate.
 
 Review-queue failures (T4 #402) — raised from
 :class:`~meho_backplane.operations.ingest.ReviewService`:
@@ -106,20 +118,51 @@ class InvalidSchemaError(ValueError):
 
 
 class OpIdCollision(ValueError):  # noqa: N818 -- Task #403 API contract pins this name verbatim
-    """Two operations in one ingest batch carry the same ``op_id``.
+    """An ``op_id`` collides with another op under the same connector triple.
+
+    Two raise sites, one exception type:
+
+    * **Within-batch collision** — two operations in a single
+      :func:`register_ingested_operations` call share an ``op_id``.
+      Caught up-front by ``_detect_op_id_collisions`` (a set scan)
+      before any DB write. ``existing_spec_source`` /
+      ``incoming_spec_source`` are ``None`` here — both colliding ops
+      came from the same ingest call, so the spec-source dimension
+      doesn't apply.
+
+    * **Cross-call collision** — a second
+      :func:`register_ingested_operations` call under the same
+      ``(product, version, impl_id)`` triple submits an ``op_id``
+      that's already persisted from a prior call with a different
+      ``spec_source``. Caught in ``upsert_one_operation`` (per-row)
+      after the natural-key lookup, before the embedding hash
+      comparison. Both ``existing_spec_source`` (read off the
+      persisted row's ``spec:<src>`` tag) and ``incoming_spec_source``
+      (the current call's argument) are set so the operator can see
+      which two specs are fighting over the ``op_id``.
 
     Attributes
     ----------
     op_ids:
         The colliding ``op_id`` values, sorted for stable error
-        messages and diff-friendly test assertions. At least two
-        entries — a one-element list would imply no collision.
+        messages and diff-friendly test assertions. Within-batch
+        collisions list every distinct duplicate; cross-call
+        collisions list a single ``op_id`` (the row the second
+        upsert would clobber).
     product, version, impl_id:
         The connector coordinates being ingested. Surfaced on the
         exception so the operator-facing CLI / API can render a
         complete "couldn't ingest spec X into connector Y because Z"
         message without re-threading the connector identity from
         the call site.
+    existing_spec_source:
+        For cross-call collisions, the ``spec_source`` of the
+        already-persisted row (the prior call's spec). ``None`` for
+        within-batch collisions.
+    incoming_spec_source:
+        For cross-call collisions, the ``spec_source`` of the
+        in-flight call (the call that just hit the collision).
+        ``None`` for within-batch collisions.
 
     Inherits from :class:`ValueError` so callers that already catch
     parser-shaped errors via ``except ValueError`` keep working
@@ -135,14 +178,25 @@ class OpIdCollision(ValueError):  # noqa: N818 -- Task #403 API contract pins th
         product: str,
         version: str,
         impl_id: str,
+        existing_spec_source: str | None = None,
+        incoming_spec_source: str | None = None,
     ) -> None:
         self.op_ids = sorted(op_ids)
         self.product = product
         self.version = version
         self.impl_id = impl_id
+        self.existing_spec_source = existing_spec_source
+        self.incoming_spec_source = incoming_spec_source
+        spec_suffix = ""
+        if existing_spec_source is not None or incoming_spec_source is not None:
+            spec_suffix = (
+                f" between spec_source={existing_spec_source!r} (persisted) "
+                f"and spec_source={incoming_spec_source!r} (incoming)"
+            )
         super().__init__(
             f"op_id collision while ingesting into "
             f"({product!r}, {version!r}, {impl_id!r}): {self.op_ids!r}"
+            f"{spec_suffix}"
         )
 
 

--- a/backend/src/meho_backplane/operations/ingest/register_ingested.py
+++ b/backend/src/meho_backplane/operations/ingest/register_ingested.py
@@ -287,8 +287,18 @@ async def register_ingested_operations(
         runs grouping next).
 
     Raises:
-        OpIdCollision: Two operations in *operations* share an
-            ``op_id``. Raised before any DB write.
+        OpIdCollision: Either (a) two operations in *operations*
+            share an ``op_id`` -- raised before any DB write by the
+            within-batch set scan, or (b) a prior
+            :func:`register_ingested_operations` call under the
+            same ``(product, version, impl_id)`` triple persisted
+            this ``op_id`` from a different ``spec_source`` --
+            raised per-row in :func:`_upsert.upsert_one_operation`
+            after the natural-key lookup, before the embedding
+            hash comparison. The exception's
+            ``existing_spec_source`` / ``incoming_spec_source``
+            attributes name both colliding specs in the cross-call
+            case.
     """
     _detect_op_id_collisions(
         operations,

--- a/backend/src/meho_backplane/operations/ingest/register_ingested.py
+++ b/backend/src/meho_backplane/operations/ingest/register_ingested.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``register_ingested_operations()`` -- bulk upsert helper for parsed specs.
+
+G0.7-T2 (#403) of Initiative #389. Takes the
+:class:`~meho_backplane.operations.ingest.schemas.EndpointDescriptorProto`
+output of :func:`~meho_backplane.operations.ingest.openapi.parse_openapi`
+(T1 #401) and persists it as
+:class:`~meho_backplane.db.models.EndpointDescriptor` rows with
+``source_kind='ingested'``.
+
+The helper is the spec-ingested twin of
+:func:`~meho_backplane.operations.typed_register.register_typed_operation`
+(G0.6-T4 #395). Both write to the same ``endpoint_descriptor`` table
+through the same body-hash skip-re-embed path; what differs is:
+
+* ``source_kind='ingested'`` vs ``source_kind='typed'``.
+* ``handler_ref`` is NULL on ingested rows (the dispatcher uses
+  ``method`` + ``path`` for HTTP calls).
+* Ingested rows land ``is_enabled=False`` so the agent's
+  ``search_operations`` meta-tool (G0.6-T8 #399) hides them until the
+  operator vets the connector via T4's review state machine. Typed
+  rows land ``is_enabled=True`` because typed-connector authors vouch
+  for them at code-review time.
+* Auto-registered groups land ``review_status='staged'`` (T4 flips to
+  ``'enabled'`` after operator review). Typed groups land
+  ``review_status='enabled'``.
+* The helper auto-registers a :class:`GenericRestConnector` shim
+  against the v2 registry (G0.6-T2 #393) on the first ingest of a
+  ``(product, version, impl_id)`` triple. Typed connectors register
+  their own subclass at module-import time.
+
+Multi-spec merge
+----------------
+
+vSphere ingests ``vcenter.yaml`` + ``vi-json.yaml`` under one
+``connector_id='vmware-rest-9.0'``. The CLI / API caller invokes
+:func:`register_ingested_operations` twice -- once per spec -- with
+distinct ``spec_source`` arguments. Each call tags every row's
+``tags`` with ``f"spec:{spec_source}"`` so the operator-facing
+review payload distinguishes "this op came from vcenter.yaml" vs
+"this op came from vi-json.yaml". The natural key
+``(product, version, impl_id, op_id)`` is unique by partial index,
+so two specs that happen to expose the same ``op_id`` would
+silently UPDATE the first row with the second's payload -- the
+helper rejects this with :exc:`OpIdCollision` before any DB write.
+
+Idempotency
+-----------
+
+Re-running with identical args is a true no-op for the embedding
+pipeline. The body-hash skip path inherits from
+:mod:`meho_backplane.operations.typed_register`: the helper
+recomputes the embedding text + SHA-256 hash from the persisted
+row's ``summary`` / ``description`` / ``custom_description`` /
+``tags``; if it matches the incoming hash, the embedding is reused
+verbatim. The expensive ONNX inference is skipped on every
+unchanged row.
+
+Re-ingesting with changed operations triggers a re-embed for
+changed rows only. Obsolete operations (in DB but absent from the
+new ingestion) are NOT auto-deleted in v0.2 -- the operator uses
+T4's disable verb to hide them. Auto-deletion lands in v0.2.next
+once the review-queue ergonomics around "this op disappeared from
+the upstream spec" are calibrated.
+
+Behavioural contract
+--------------------
+
+* **First call** for a given ``(product, version, impl_id)`` triple
+  -- auto-registers a :class:`GenericRestConnector` shim against
+  the v2 registry, creates an :class:`OperationGroup` row per
+  distinct group_key referenced (``review_status='staged'``),
+  inserts every operation as a new
+  :class:`EndpointDescriptor` row with ``source_kind='ingested'``,
+  ``is_enabled=False``, embedding computed once per row.
+* **Subsequent call** with a different ``spec_source`` against the
+  same connector_id -- the shim is left in place, new operations
+  are inserted under the existing connector, and rows tagged
+  ``"spec:<new-source>"`` so the operator can distinguish them
+  during review.
+* **Re-call with unchanged operations** -- one row per op in the
+  table; embedding service called zero times across the re-call
+  (skip-re-embed path).
+* **Re-call with changed operations** -- changed rows re-embed,
+  unchanged rows skip-re-embed.
+
+The helper opens its own transaction (or uses a caller-supplied
+:class:`AsyncSession`) and commits row-by-row; an exception
+mid-batch leaves the previous rows committed. This matches the
+typed-register precedent and the v0.2 "ingest is operator-driven
+and idempotent on retry" discipline.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations.ingest._upsert import (
+    build_upsert_context,
+    upsert_one_operation,
+)
+from meho_backplane.operations.ingest.connector_registration import (
+    ensure_connector_class_registered,
+)
+from meho_backplane.operations.ingest.exceptions import OpIdCollision
+from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "IngestionResult",
+    "register_ingested_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class IngestionResult:
+    """Counts + flags from one :func:`register_ingested_operations` call.
+
+    Attributes
+    ----------
+    inserted_count:
+        Number of brand-new :class:`EndpointDescriptor` rows
+        inserted -- the natural key ``(product, version, impl_id,
+        op_id)`` did not previously exist.
+    updated_count:
+        Number of rows whose embedding text changed and so were
+        re-embedded + UPDATEd.
+    skipped_count:
+        Number of rows whose embedding text was unchanged -- the
+        body-hash skip path. ``updated_at`` is still advanced on
+        these rows (so operators can grep "when did this op last
+        get reregistered") but the embedding compute is skipped.
+    connector_registered:
+        ``True`` when the helper auto-registered a new
+        :class:`GenericRestConnector` shim against the v2 registry
+        for the ``(product, version, impl_id)`` triple. ``False``
+        when an entry already existed (subsequent ingests of
+        additional specs under the same connector_id).
+    operations_grouped:
+        Always ``False`` in v0.2 -- the T3 LLM-grouping pass runs
+        as a separate step after T2. Present on the result type so
+        T3 + T5 can flip it without a schema change.
+    """
+
+    inserted_count: int
+    updated_count: int
+    skipped_count: int
+    connector_registered: bool
+    operations_grouped: bool
+
+
+def _detect_op_id_collisions(
+    operations: Sequence[EndpointDescriptorProto],
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> None:
+    """Raise :exc:`OpIdCollision` when two ops in the batch share an ``op_id``.
+
+    Runs before any DB write so a colliding pair is caught at the
+    Python boundary rather than after half the batch has been
+    persisted. The partial unique index on the natural key would
+    eventually catch the collision at flush time, but as an
+    :class:`IntegrityError` whose message names the index, not the
+    colliding values; the operator-facing CLI / API needs the
+    structured exception shape to render a usable error.
+    """
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for op in operations:
+        if op.op_id in seen:
+            duplicates.add(op.op_id)
+        else:
+            seen.add(op.op_id)
+    if duplicates:
+        raise OpIdCollision(
+            op_ids=list(duplicates),
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+
+
+# Per-op upsert helpers live in
+# :mod:`meho_backplane.operations.ingest._upsert`; this module owns
+# the batch-level orchestration only.
+
+
+@dataclass(frozen=True, slots=True)
+class _BatchCoordinates:
+    """Connector coordinates + spec source threaded through the batch loop."""
+
+    tenant_id: UUID | None
+    product: str
+    version: str
+    impl_id: str
+    spec_source: str
+
+
+async def _run_upsert_loop(
+    *,
+    session: AsyncSession | None,
+    coords: _BatchCoordinates,
+    operations: Sequence[EndpointDescriptorProto],
+    embedding_service: EmbeddingService | None,
+) -> dict[str, int]:
+    """Dispatch to :func:`_register_in_session` with the right session ownership.
+
+    When *session* is provided, run the loop against it and defer
+    commit decisions to the caller. When *session* is ``None``, open
+    a helper-owned session via :func:`get_sessionmaker`, run the
+    loop with per-op commits, and close on context exit.
+    """
+    if session is not None:
+        return await _register_in_session(
+            session,
+            coords=coords,
+            operations=operations,
+            embedding_service=embedding_service,
+            commit=False,
+        )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as owned_session:
+        return await _register_in_session(
+            owned_session,
+            coords=coords,
+            operations=operations,
+            embedding_service=embedding_service,
+            commit=True,
+        )
+
+
+async def register_ingested_operations(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    spec_source: str,
+    operations: Sequence[EndpointDescriptorProto],
+    base_url: str | None = None,
+    tenant_id: UUID | None = None,
+    session: AsyncSession | None = None,
+    embedding_service: EmbeddingService | None = None,
+) -> IngestionResult:
+    """Bulk-upsert parsed operations into ``endpoint_descriptor``.
+
+    See the module docstring for the full behavioural contract
+    (multi-spec merge, idempotency invariant, connector auto-shim
+    semantics, transaction-boundary discipline).
+
+    Args:
+        product, version, impl_id: Connector triple. Natural key on
+            every persisted row is ``(product, version, impl_id,
+            op_id)`` with ``tenant_id IS NULL`` for built-in rows.
+        spec_source: Logical-source tag (e.g. ``"vcenter.yaml"``).
+            The helper appends ``f"spec:{spec_source}"`` to every
+            persisted row's ``tags`` so the operator can distinguish
+            rows when a single connector ingests multiple specs.
+        operations: Parser output from
+            :func:`~meho_backplane.operations.ingest.openapi.parse_openapi`.
+        base_url: Optional default base URL for the auto-registered
+            :class:`GenericRestConnector` shim.
+        tenant_id: ``None`` (default) → built-in / global rows.
+        session: Optional caller-owned :class:`AsyncSession` (defers
+            commit to the caller). ``None`` opens a helper-owned
+            session that commits row-by-row.
+        embedding_service: Test seam; production callers leave
+            ``None`` to resolve the process-wide singleton.
+
+    Returns:
+        :class:`IngestionResult` with per-action counts +
+        ``connector_registered`` flag (was a new shim registered?) +
+        ``operations_grouped`` flag (always ``False`` in v0.2; T3
+        runs grouping next).
+
+    Raises:
+        OpIdCollision: Two operations in *operations* share an
+            ``op_id``. Raised before any DB write.
+    """
+    _detect_op_id_collisions(
+        operations,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+    )
+    connector_registered = ensure_connector_class_registered(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        base_url=base_url,
+    )
+    counts = await _run_upsert_loop(
+        session=session,
+        coords=_BatchCoordinates(
+            tenant_id=tenant_id,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            spec_source=spec_source,
+        ),
+        operations=operations,
+        embedding_service=embedding_service,
+    )
+    return IngestionResult(
+        inserted_count=counts["inserted"],
+        updated_count=counts["updated"],
+        skipped_count=counts["skipped"],
+        connector_registered=connector_registered,
+        operations_grouped=False,
+    )
+
+
+async def _register_in_session(
+    session: AsyncSession,
+    *,
+    coords: _BatchCoordinates,
+    operations: Sequence[EndpointDescriptorProto],
+    embedding_service: EmbeddingService | None,
+    commit: bool,
+) -> dict[str, int]:
+    """Upsert every op in *operations* against *session*. Return action counts.
+
+    Split out from :func:`register_ingested_operations` so the public
+    function can branch on caller-owned-vs-helper-owned session
+    without duplicating the loop body. ``commit=True`` commits after
+    every op so a mid-batch crash leaves the already-processed rows
+    persisted (the same shape T4's review-queue service uses);
+    ``commit=False`` defers transaction boundaries to the caller.
+    """
+    log = structlog.get_logger(__name__)
+    now = datetime.now(UTC)
+    counts: dict[str, int] = {"inserted": 0, "updated": 0, "skipped": 0}
+
+    for proto in operations:
+        ctx = build_upsert_context(
+            tenant_id=coords.tenant_id,
+            product=coords.product,
+            version=coords.version,
+            impl_id=coords.impl_id,
+            spec_source=coords.spec_source,
+            proto=proto,
+            now=now,
+        )
+        action = await upsert_one_operation(
+            session,
+            ctx,
+            embedding_service=embedding_service,
+        )
+        counts[action] += 1
+        if commit:
+            await session.commit()
+        log.debug(
+            "ingested_operation_upserted",
+            action=action,
+            product=coords.product,
+            version=coords.version,
+            impl_id=coords.impl_id,
+            op_id=proto.op_id,
+            spec_source=coords.spec_source,
+        )
+
+    log.info(
+        "ingested_operations_registered",
+        product=coords.product,
+        version=coords.version,
+        impl_id=coords.impl_id,
+        spec_source=coords.spec_source,
+        **counts,
+    )
+    return counts
+
+
+# Public surface intentionally limited to register_ingested_operations
+# + IngestionResult (declared in __all__ at the top of the module). The
+# LLM-grouping pass that assigns ops to operation_group rows is T3's
+# job (#404) and runs as a separate step after this helper's bulk
+# upsert; group_id stays NULL on every persisted row until then.

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -1,0 +1,674 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.operations.ingest.register_ingested`.
+
+Coverage matrix (G0.7-T2 / Task #403 acceptance criteria):
+
+* :func:`register_ingested_operations` first-call path -- inserts a
+  row per operation with ``source_kind='ingested'``,
+  ``handler_ref=None``, ``is_enabled=False``, ``method`` + ``path``
+  populated from the proto, every other field carried verbatim.
+* :class:`IngestionResult` shape -- inserted / updated / skipped
+  counts + ``connector_registered`` + ``operations_grouped`` flags.
+* Body-hash skip semantics -- second call with identical operations
+  is a no-op for the embedding pipeline (assertion: stub mock
+  ``encode_one.call_count`` does not advance on the second batch).
+* Multi-spec merge -- two ingests with distinct ``spec_source``
+  under the same connector_id produce rows whose ``tags`` are
+  distinguishable via the ``"spec:<source>"`` marker.
+* :exc:`OpIdCollision` -- ingesting a batch with two ops sharing
+  ``op_id`` raises before any row is persisted; the exception
+  names both colliding op_ids.
+* Connector class auto-registration on first ingest -- the v2
+  registry now contains an entry for the
+  ``(product, version, impl_id)`` triple, of a class that subclasses
+  :class:`GenericRestConnector`.
+* Subsequent ingest under the same connector_id leaves the existing
+  v2 registry entry intact (``connector_registered=False`` on the
+  :class:`IngestionResult`).
+* Embeddings -- the 384-dim vector returned by the mocked service
+  is what ends up on the row.
+* Tenant scoping -- ``tenant_id=None`` (default) writes built-in
+  rows; ``tenant_id=<uuid>`` writes tenant-scoped rows; the two
+  coexist without colliding.
+* Operations land in ``staged``-equivalent state: ``is_enabled=False``
+  on every per-op row (the parent group is not created by this
+  helper -- T3 #404 runs grouping).
+
+The embedding service is mocked via the explicit
+``embedding_service=`` parameter so tests don't pull fastembed or
+ONNX runtime; the mock's ``call_count`` is what proves the
+skip-re-embed branch is being exercised on idempotent re-calls.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.registry import all_connectors_v2, clear_registry
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations.ingest import (
+    EndpointDescriptorProto,
+    GenericRestConnector,
+    IngestionResult,
+    OpIdCollision,
+    parse_openapi,
+    register_ingested_operations,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_connector_registry() -> Iterator[None]:
+    """Reset the connector registry between tests.
+
+    Each test that exercises auto-registration adds entries; without
+    a per-test reset, later tests would either collide with prior
+    entries or see ``connector_registered=False`` from the start.
+    """
+    clear_registry()
+    yield
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """An :class:`AsyncMock` standing in for :class:`EmbeddingService`."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.25] * 384
+    service.encode.return_value = [[0.25] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _proto(
+    op_id: str,
+    *,
+    method: str = "GET",
+    path: str | None = None,
+    summary: str = "Summary",
+    description: str = "Description",
+    tags: list[str] | None = None,
+    safety_level: str = "safe",
+    requires_approval: bool = False,
+) -> EndpointDescriptorProto:
+    """Construct a parser-shaped proto for tests.
+
+    Mirrors the shape :func:`parse_openapi` produces: ``op_id`` =
+    ``f"{method}:{path}"``, ``method`` upper-cased, ``parameter_schema``
+    populated with a minimal JSON Schema 2020-12 object.
+    """
+    return EndpointDescriptorProto(
+        op_id=op_id,
+        method=method,
+        path=path or f"/{op_id.split(':', 1)[1]}",
+        summary=summary,
+        description=description,
+        tags=tags or ["pets"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema={"type": "object"},
+        safety_level=safety_level,  # type: ignore[arg-type]
+        requires_approval=requires_approval,
+    )
+
+
+# ---------------------------------------------------------------------------
+# IngestionResult + first-call path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_call_inserts_rows_with_ingested_source_kind(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """First call inserts each proto as an ``is_enabled=False`` ingested row."""
+    operations = [
+        _proto("GET:/pets", path="/pets", summary="List pets"),
+        _proto("POST:/pets", method="POST", path="/pets", summary="Add a pet"),
+    ]
+
+    result = await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=operations,
+        embedding_service=stub_embedding_service,
+    )
+
+    assert isinstance(result, IngestionResult)
+    assert result.inserted_count == 2
+    assert result.updated_count == 0
+    assert result.skipped_count == 0
+    assert result.connector_registered is True
+    assert result.operations_grouped is False
+    assert stub_embedding_service.encode_one.call_count == 2
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor)
+                    .where(EndpointDescriptor.product == "petstore")
+                    .order_by(EndpointDescriptor.op_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(rows) == 2
+    for row in rows:
+        assert row.tenant_id is None
+        assert row.product == "petstore"
+        assert row.version == "1.0"
+        assert row.impl_id == "petstore-rest"
+        assert row.source_kind == "ingested"
+        assert row.handler_ref is None
+        assert row.is_enabled is False
+        assert row.embedding == [0.25] * 384
+        assert "spec:petstore.yaml" in row.tags
+        # Original tag preserved alongside the spec_source marker.
+        assert "pets" in row.tags
+        # group_id stays NULL -- T3 #404 runs grouping next.
+        assert row.group_id is None
+
+
+@pytest.mark.asyncio
+async def test_first_call_persists_method_and_path(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Ingested rows preserve ``method`` + ``path`` (typed rows leave both NULL)."""
+    operations = [_proto("GET:/api/vcenter/cluster", path="/api/vcenter/cluster")]
+
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=operations,
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "GET:/api/vcenter/cluster"
+                )
+            )
+        ).scalar_one()
+    assert row.method == "GET"
+    assert row.path == "/api/vcenter/cluster"
+    assert row.handler_ref is None
+
+
+# ---------------------------------------------------------------------------
+# Body-hash skip path (idempotency)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_call_with_identical_ops_skips_reembed(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Re-running with the same args is a no-op for the embedding pipeline.
+
+    The load-bearing assertion: re-ingesting an unchanged spec must
+    not re-embed every operation. The skip-re-embed path matches
+    the typed-register precedent and is the operationally critical
+    path on connector init / spec re-ingest at scale.
+    """
+    operations = [
+        _proto("GET:/pets", path="/pets", summary="List pets"),
+        _proto("POST:/pets", method="POST", path="/pets", summary="Add a pet"),
+    ]
+    kwargs: dict[str, Any] = {
+        "product": "petstore",
+        "version": "1.0",
+        "impl_id": "petstore-rest",
+        "spec_source": "petstore.yaml",
+        "operations": operations,
+        "embedding_service": stub_embedding_service,
+    }
+    first = await register_ingested_operations(**kwargs)
+    assert first.inserted_count == 2
+    assert first.connector_registered is True
+    assert stub_embedding_service.encode_one.call_count == 2
+
+    second = await register_ingested_operations(**kwargs)
+    assert second.inserted_count == 0
+    assert second.updated_count == 0
+    assert second.skipped_count == 2
+    assert second.connector_registered is False, (
+        "Second ingest must not re-register the connector class"
+    )
+    assert stub_embedding_service.encode_one.call_count == 2, (
+        "Embedding service must not be invoked when every row's embedding text is unchanged"
+    )
+
+
+@pytest.mark.asyncio
+async def test_second_call_with_changed_summary_triggers_reembed(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Changing ``summary`` on a re-ingest re-embeds that row only."""
+    op_v1 = _proto("GET:/pets", path="/pets", summary="List pets")
+    op_v2 = _proto("GET:/pets", path="/pets", summary="List pets with pagination")
+
+    await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=[op_v1],
+        embedding_service=stub_embedding_service,
+    )
+    assert stub_embedding_service.encode_one.call_count == 1
+
+    result = await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=[op_v2],
+        embedding_service=stub_embedding_service,
+    )
+    assert result.updated_count == 1
+    assert result.skipped_count == 0
+    assert stub_embedding_service.encode_one.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Multi-spec merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_spec_merge_tags_rows_distinctly(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Two specs under one connector_id produce rows tagged by spec_source.
+
+    Models vSphere's vcenter.yaml + vi-json.yaml merge: both go under
+    ``connector_id="vmware-rest-9.0"`` and the operator can grep for
+    ``spec:vcenter.yaml`` vs ``spec:vi-json.yaml`` in the row tags
+    to know which spec contributed which op.
+    """
+    spec_a_ops = [
+        _proto("GET:/api/vcenter/cluster", path="/api/vcenter/cluster"),
+    ]
+    spec_b_ops = [
+        _proto(
+            "POST:/ClusterComputeResource/{moId}/Method",
+            method="POST",
+            path="/ClusterComputeResource/{moId}/Method",
+        ),
+    ]
+
+    result_a = await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=spec_a_ops,
+        embedding_service=stub_embedding_service,
+    )
+    assert result_a.connector_registered is True
+
+    result_b = await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vi-json.yaml",
+        operations=spec_b_ops,
+        embedding_service=stub_embedding_service,
+    )
+    # Connector class already registered on the first call.
+    assert result_b.connector_registered is False
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor)
+                    .where(EndpointDescriptor.product == "vmware")
+                    .order_by(EndpointDescriptor.op_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 2
+    tag_by_op_id = {row.op_id: row.tags for row in rows}
+    assert "spec:vcenter.yaml" in tag_by_op_id["GET:/api/vcenter/cluster"]
+    assert "spec:vi-json.yaml" in tag_by_op_id["POST:/ClusterComputeResource/{moId}/Method"]
+
+
+# ---------------------------------------------------------------------------
+# OpIdCollision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_op_id_collision_within_batch_raises(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Two ops sharing an ``op_id`` in one batch raise :exc:`OpIdCollision`."""
+    operations = [
+        _proto("GET:/pets", path="/pets", summary="First list-pets"),
+        _proto("GET:/pets", path="/pets", summary="Conflicting list-pets"),
+    ]
+    with pytest.raises(OpIdCollision) as excinfo:
+        await register_ingested_operations(
+            product="petstore",
+            version="1.0",
+            impl_id="petstore-rest",
+            spec_source="petstore.yaml",
+            operations=operations,
+            embedding_service=stub_embedding_service,
+        )
+    assert excinfo.value.op_ids == ["GET:/pets"]
+    assert excinfo.value.product == "petstore"
+    assert excinfo.value.version == "1.0"
+    assert excinfo.value.impl_id == "petstore-rest"
+    assert "GET:/pets" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_op_id_collision_lists_all_duplicates(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """``OpIdCollision`` names every distinct duplicate, not just the first."""
+    operations = [
+        _proto("GET:/pets", path="/pets"),
+        _proto("GET:/pets", path="/pets"),
+        _proto("GET:/owners", path="/owners"),
+        _proto("GET:/owners", path="/owners"),
+    ]
+    with pytest.raises(OpIdCollision) as excinfo:
+        await register_ingested_operations(
+            product="petstore",
+            version="1.0",
+            impl_id="petstore-rest",
+            spec_source="petstore.yaml",
+            operations=operations,
+            embedding_service=stub_embedding_service,
+        )
+    assert excinfo.value.op_ids == ["GET:/owners", "GET:/pets"]
+
+
+@pytest.mark.asyncio
+async def test_op_id_collision_raised_before_any_db_write(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Collision detection runs before the upsert loop -- no partial state."""
+    operations = [
+        _proto("GET:/pets", path="/pets", summary="ok"),
+        _proto("GET:/pets", path="/pets", summary="duplicate"),
+        _proto("GET:/owners", path="/owners"),
+    ]
+    with pytest.raises(OpIdCollision):
+        await register_ingested_operations(
+            product="petstore",
+            version="1.0",
+            impl_id="petstore-rest",
+            spec_source="petstore.yaml",
+            operations=operations,
+            embedding_service=stub_embedding_service,
+        )
+    # No rows persisted.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.product == "petstore")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Connector class auto-registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_ingest_registers_connector_class(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """First ingest of a triple auto-registers a :class:`GenericRestConnector` shim."""
+    assert (("petstore", "1.0", "petstore-rest")) not in all_connectors_v2()
+
+    result = await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=[_proto("GET:/pets", path="/pets")],
+        base_url="https://petstore.example.com",
+        embedding_service=stub_embedding_service,
+    )
+    assert result.connector_registered is True
+
+    registry = all_connectors_v2()
+    key = ("petstore", "1.0", "petstore-rest")
+    assert key in registry
+    cls = registry[key]
+    assert issubclass(cls, GenericRestConnector)
+    assert cls.product == "petstore"
+    assert cls.version == "1.0"
+    assert cls.impl_id == "petstore-rest"
+    # Conservative default: ">=1.0,<2.0" for a "1.0" version.
+    assert cls.supported_version_range == ">=1.0,<2.0"
+    assert cls._base_url_override == "https://petstore.example.com"
+
+
+@pytest.mark.asyncio
+async def test_second_ingest_does_not_re_register_connector_class(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Second ingest under the same triple skips connector class registration."""
+    common_kwargs: dict[str, Any] = {
+        "product": "petstore",
+        "version": "1.0",
+        "impl_id": "petstore-rest",
+        "operations": [_proto("GET:/pets", path="/pets")],
+        "embedding_service": stub_embedding_service,
+    }
+    first = await register_ingested_operations(spec_source="petstore.yaml", **common_kwargs)
+    assert first.connector_registered is True
+    cls_first = all_connectors_v2()[("petstore", "1.0", "petstore-rest")]
+
+    # Second ingest of a different spec under the same connector.
+    second = await register_ingested_operations(
+        spec_source="petstore-admin.yaml",
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        operations=[_proto("DELETE:/pets/{petId}", method="DELETE", path="/pets/{petId}")],
+        embedding_service=stub_embedding_service,
+    )
+    assert second.connector_registered is False
+    # The registered class is the SAME object (no re-synthesis).
+    cls_second = all_connectors_v2()[("petstore", "1.0", "petstore-rest")]
+    assert cls_first is cls_second
+
+
+# ---------------------------------------------------------------------------
+# Tenant scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_scoped_rows_coexist_with_built_in(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Built-in and tenant-scoped rows with the same op_id coexist by partial index."""
+    tenant_id = uuid.uuid4()
+    op = _proto("GET:/pets", path="/pets")
+
+    await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=[op],
+        tenant_id=None,
+        embedding_service=stub_embedding_service,
+    )
+    await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=[op],
+        tenant_id=tenant_id,
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id == "GET:/pets")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    tenant_ids = {row.tenant_id for row in rows}
+    assert tenant_ids == {None, tenant_id}
+
+
+# ---------------------------------------------------------------------------
+# Integration with parser (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_with_real_parsed_spec(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Parse the petstore fixture, register, assert rows + connector registered.
+
+    Smoke test against the real T1 parser output -- the helper must
+    accept :class:`EndpointDescriptorProto` produced by
+    :func:`parse_openapi` without any shape massaging at the call
+    site.
+    """
+    operations = parse_openapi("tests/fixtures/openapi/petstore_30.yaml")
+
+    result = await register_ingested_operations(
+        product="petstore",
+        version="3.0",
+        impl_id="petstore-rest",
+        spec_source="petstore_30.yaml",
+        operations=operations,
+        base_url="https://petstore.example.com",
+        embedding_service=stub_embedding_service,
+    )
+    assert result.inserted_count == len(operations) > 0
+    assert result.connector_registered is True
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.product == "petstore")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == len(operations)
+    for row in rows:
+        assert row.source_kind == "ingested"
+        assert row.is_enabled is False
+        assert row.method is not None
+        assert row.path is not None
+        assert "spec:petstore_30.yaml" in row.tags
+        assert row.embedding == [0.25] * 384
+
+    # Connector resolvable in the v2 registry.
+    assert ("petstore", "3.0", "petstore-rest") in all_connectors_v2()
+
+
+# ---------------------------------------------------------------------------
+# Caller-owned session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_caller_owned_session_defers_commit(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """When *session* is passed, the helper does not commit -- caller controls boundaries."""
+    operations = [_proto("GET:/pets", path="/pets")]
+    result = await register_ingested_operations(
+        product="petstore",
+        version="1.0",
+        impl_id="petstore-rest",
+        spec_source="petstore.yaml",
+        operations=operations,
+        session=session,
+        embedding_service=stub_embedding_service,
+    )
+    assert result.inserted_count == 1
+
+    # Rows visible in the SAME session before commit.
+    in_session = (
+        await session.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.op_id == "GET:/pets")
+        )
+    ).scalar_one_or_none()
+    assert in_session is not None
+
+    # Rollback drops everything -- the helper did not commit.
+    await session.rollback()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        post_rollback = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(EndpointDescriptor.op_id == "GET:/pets")
+            )
+        ).scalar_one_or_none()
+    assert post_rollback is None

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -463,6 +463,97 @@ async def test_op_id_collision_raised_before_any_db_write(
     assert rows == []
 
 
+@pytest.mark.asyncio
+async def test_op_id_collision_across_calls_with_different_spec_sources_raises(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A second ingest under the same triple with a different ``spec_source``
+    sharing an ``op_id`` raises :exc:`OpIdCollision` instead of silently
+    overwriting the first row.
+
+    This is the cross-call branch the Task #403 body calls out: *"the
+    second call to ``register_ingested_operations()`` UPDATEs the row
+    ... T2 detects this and raises ``OpIdCollision``"*. The within-batch
+    set scan in ``_detect_op_id_collisions`` can't see across calls; the
+    detection has to live in the per-row upsert path against the
+    persisted ``spec:<src>`` marker.
+    """
+    common_kwargs: dict[str, Any] = {
+        "product": "petstore",
+        "version": "1.0",
+        "impl_id": "petstore-rest",
+        "embedding_service": stub_embedding_service,
+    }
+    first_result = await register_ingested_operations(
+        spec_source="petstore.yaml",
+        operations=[_proto("GET:/pets", path="/pets", summary="First spec list-pets")],
+        **common_kwargs,
+    )
+    assert first_result.inserted_count == 1
+
+    # Snapshot the persisted row so the post-collision assertion can
+    # prove the original payload survived unchanged.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        original_row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(EndpointDescriptor.op_id == "GET:/pets")
+            )
+        ).scalar_one()
+        original_summary = original_row.summary
+        original_tags = list(original_row.tags or [])
+        original_updated_at = original_row.updated_at
+
+    # Track embedding-service call count: the cross-call raise must
+    # fire BEFORE the re-embed branch, so the embedding service is
+    # not invoked a second time.
+    encode_calls_before = stub_embedding_service.encode_one.call_count
+
+    with pytest.raises(OpIdCollision) as excinfo:
+        await register_ingested_operations(
+            spec_source="petstore-admin.yaml",
+            operations=[
+                _proto("GET:/pets", path="/pets", summary="Conflicting admin list-pets"),
+            ],
+            **common_kwargs,
+        )
+    assert excinfo.value.op_ids == ["GET:/pets"]
+    assert excinfo.value.product == "petstore"
+    assert excinfo.value.version == "1.0"
+    assert excinfo.value.impl_id == "petstore-rest"
+    assert excinfo.value.existing_spec_source == "petstore.yaml"
+    assert excinfo.value.incoming_spec_source == "petstore-admin.yaml"
+    # Both spec sources are named in the rendered message so the
+    # operator-facing CLI / API surfaces the disambiguation without
+    # extra threading.
+    msg = str(excinfo.value)
+    assert "petstore.yaml" in msg
+    assert "petstore-admin.yaml" in msg
+
+    # No second encode call: the raise short-circuits the re-embed path.
+    assert stub_embedding_service.encode_one.call_count == encode_calls_before
+
+    # The original row is unchanged -- the second spec's payload did
+    # not overwrite the first spec's summary / tags / updated_at.
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id == "GET:/pets")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    surviving = rows[0]
+    assert surviving.summary == original_summary
+    assert list(surviving.tags or []) == original_tags
+    assert "spec:petstore.yaml" in (surviving.tags or [])
+    assert "spec:petstore-admin.yaml" not in (surviving.tags or [])
+    assert surviving.updated_at == original_updated_at
+
+
 # ---------------------------------------------------------------------------
 # Connector class auto-registration
 # ---------------------------------------------------------------------------

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -13,23 +13,32 @@ can resolve.
 
 The pipeline is broken into work items per Initiative #389:
 
-* **T1 (this module) — OpenAPI parser.** Pure-function. Input: a path
-  or URL. Output: a list of `EndpointDescriptorProto`. No DB session,
-  no LLM call.
-* **T2 — `register_ingested_operations()`.** Bulk-upserts proto rows
-  into `endpoint_descriptor`, plus multi-spec merge (vCenter's
-  `vcenter.yaml` + `vi-json.yaml` under one connector).
+* **T1 — OpenAPI parser** (`ingest/openapi.py`). Pure-function. Input:
+  a path or URL. Output: a list of `EndpointDescriptorProto`. No DB
+  session, no LLM call.
+* **T2 — `register_ingested_operations()`** (`ingest/register_ingested.py`).
+  Bulk-upserts proto rows into `endpoint_descriptor` with
+  `source_kind='ingested'`, `is_enabled=False`. Multi-spec merge
+  (vCenter's `vcenter.yaml` + `vi-json.yaml` under one connector) via
+  per-row `spec:<source>` tag marker. Body-hash skip-re-embed on
+  unchanged rows (parallel to the `typed_register` precedent).
+  Auto-registers a `GenericRestConnector` shim
+  (`ingest/connector_registration.py`) against the v2 connector
+  registry on first ingest of a `(product, version, impl_id)` triple;
+  the shim raises `NotImplementedError` on `auth_headers` / `execute`
+  until a per-G3.x Initiative replaces it with a hand-coded subclass.
 * **T3 — LLM-summarised grouping.** Proposes operation groups and
   assigns each op to one, writing `operation_group` rows.
-* **T4 — Review-queue state machine.** Operators move connectors
-  through `staged → enabled` (and `disabled` for regression
-  rollback) before any op becomes dispatchable.
+* **T4 — Review-queue state machine** (`ingest/service.py`). Operators
+  move connectors through `staged → enabled` (and `disabled` for
+  regression rollback) before any op becomes dispatchable.
 * **T5–T7 — CLI / REST / MCP surfaces** that drive the pipeline.
 * **T8 — vSphere canary** — ingest both vCenter specs end-to-end.
 * **T9 — Docs.**
 
-T1 is the foundation: nothing else in the pipeline runs without its
-output shape.
+T1 produces the proto shape every other stage consumes; T2 is the
+single write path into `endpoint_descriptor` for ingested rows; T3
+groups them; T4 gates dispatchability behind operator review.
 
 ## Key types
 
@@ -51,10 +60,33 @@ Frozen Pydantic v2 model. One per operation. Maps 1:1 to a subset of
 | `safety_level` | `safety_level` | HTTP-verb heuristic, operator-overridable at review |
 | `requires_approval` | `requires_approval` | Always `False` at parse time |
 
-T2 owns the rest of the ORM columns (`tenant_id`, `source_kind`,
-`product`, `version`, `impl_id`, `group_id`, `embedding`, `is_enabled`,
-`custom_description`, `custom_notes`, `handler_ref`,
-`llm_instructions`).
+T2 owns the rest of the ORM columns: `tenant_id`, `source_kind`
+(always `'ingested'`), `product`, `version`, `impl_id`, `embedding`,
+`is_enabled` (always `False` on ingest), `handler_ref` (always
+`None` on ingested rows — the dispatcher uses `method`+`path`). T3
+owns `group_id` (NULL until grouping runs). T4 owns
+`custom_description`, `custom_notes`, `llm_instructions` (operator-
+authored overrides at review time).
+
+### `IngestionResult` (`ingest/register_ingested.py`)
+
+Frozen dataclass returned from `register_ingested_operations()`.
+Carries per-call counts (`inserted_count`, `updated_count`,
+`skipped_count`) plus two flags (`connector_registered`,
+`operations_grouped`) the CLI / API caller surfaces in operator
+output. `operations_grouped` is always `False` in v0.2 — T3
+flips it after the LLM-grouping pass runs.
+
+### `GenericRestConnector` (`ingest/connector_registration.py`)
+
+Auto-generated `HttpConnector` subclass synthesised on first ingest
+of a `(product, version, impl_id)` triple. Concrete `auth_headers`
+raises `NotImplementedError` with operator-readable guidance; the
+review-queue gate (T4) keeps every ingested op `is_enabled=False`
+until the operator replaces the shim with a hand-rolled per-G3.x
+subclass that adds the auth path. The shim makes the connector
+resolvable through the v2 registry so spec ingestion can proceed
+before the per-product Initiative work lands.
 
 ### `parse_openapi(spec_path_or_uri, *, spec_source=None)` (`ingest/openapi.py`)
 
@@ -90,6 +122,33 @@ parameter_schema is self-contained enough for the dispatcher's
 JSON-Schema validator to validate the immediate parameter shape;
 deeper schema dereferencing (chasing nested `$ref`s) is the
 dispatcher's concern (G0.6-T5 + T2's tracking of `components.schemas`).
+
+### T2 control flow
+
+```text
+register_ingested_operations
+├─ _detect_op_id_collisions    # set scan; raise OpIdCollision before DB writes
+├─ ensure_connector_class_registered
+│  ├─ all_connectors_v2()       # check v2 registry for (product, version, impl_id)
+│  ├─ type(cls_name, ...)       # synthesise GenericRestConnector subclass
+│  └─ register_connector_v2()   # G0.6-T2 entry point
+└─ _register_in_session         # caller-owned or helper-owned session
+   └─ _upsert_one_operation     # per proto
+      ├─ build_embedding_text   # canonical text per typed-register parity
+      ├─ compute_embedding_text_hash
+      ├─ natural-key lookup     # (product, version, impl_id, op_id)
+      │                         # + partial tenant_id index match
+      ├─ skip-re-embed path     # hash matches persisted row
+      ├─ re-embed path          # row exists, embedding text changed
+      └─ first-register path    # brand-new row, embedding computed
+```
+
+The skip-re-embed path is the operationally critical branch on spec
+re-ingest: an unchanged 3,000-op vCenter spec must not re-embed
+3,000 operations. Hash comparison runs against the persisted row's
+recomposed text (via `build_embedding_text`), so no `body_hash`
+column is needed in v0.2 — the cost is one recompose-and-hash per
+op, well under the ONNX inference budget.
 
 ## Dependencies
 
@@ -129,8 +188,14 @@ operations go live.
 ## References
 
 * Issue #401 — T1 task.
+* Issue #403 — T2 task.
+* Issue #402 — T4 task.
 * Initiative #389 — G0.7 spec-ingestion pipeline.
 * Goal #221 — G0 foundational substrate.
 * `meho_backplane/db/models.py::EndpointDescriptor` — the ORM target.
+* `meho_backplane/operations/typed_register.py` — typed-connector
+  parallel pathway; same body-hash skip-re-embed contract.
+* `meho_backplane/connectors/registry.py` — v2 registry where T2
+  auto-registers the `GenericRestConnector` shim.
 * OpenAPI 3.0.3 spec: https://spec.openapis.org/oas/v3.0.3.html
 * OpenAPI 3.1.1 spec: https://spec.openapis.org/oas/v3.1.1.html

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -127,7 +127,7 @@ dispatcher's concern (G0.6-T5 + T2's tracking of `components.schemas`).
 
 ```text
 register_ingested_operations
-├─ _detect_op_id_collisions    # set scan; raise OpIdCollision before DB writes
+├─ _detect_op_id_collisions    # set scan; raise OpIdCollision (within-batch) before DB writes
 ├─ ensure_connector_class_registered
 │  ├─ all_connectors_v2()       # check v2 registry for (product, version, impl_id)
 │  ├─ type(cls_name, ...)       # synthesise GenericRestConnector subclass
@@ -138,6 +138,8 @@ register_ingested_operations
       ├─ compute_embedding_text_hash
       ├─ natural-key lookup     # (product, version, impl_id, op_id)
       │                         # + partial tenant_id index match
+      ├─ cross-call collision   # existing row's spec:<src> tag != ctx.spec_source
+      │                         # → raise OpIdCollision (cross-call branch)
       ├─ skip-re-embed path     # hash matches persisted row
       ├─ re-embed path          # row exists, embedding text changed
       └─ first-register path    # brand-new row, embedding computed
@@ -149,6 +151,17 @@ re-ingest: an unchanged 3,000-op vCenter spec must not re-embed
 recomposed text (via `build_embedding_text`), so no `body_hash`
 column is needed in v0.2 — the cost is one recompose-and-hash per
 op, well under the ONNX inference budget.
+
+`OpIdCollision` fires from two distinct sites: the up-front within-
+batch set scan (two ops in one call share `op_id`) and the per-row
+cross-call check (this call's `spec_source` differs from the
+persisted row's `spec:<src>` tag for the same natural key). Both
+sites use the same exception type so callers can write one
+`except OpIdCollision`; the cross-call site fills
+`existing_spec_source` and `incoming_spec_source` so the operator-
+facing message names both colliding specs. Same-`spec_source`
+re-ingest of an unchanged spec stays on the skip-re-embed path —
+the cross-call check only fires on a true `spec_source` mismatch.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Ships `register_ingested_operations()` — the G0.7-T2 helper that takes T1 (#401) parser output and bulk-upserts `endpoint_descriptor` rows with `source_kind='ingested'`. Mirrors `typed_register`'s body-hash skip-re-embed contract — re-ingesting an unchanged spec is a true no-op for the embedding pipeline.
- Multi-spec merge via per-row `spec:<source>` tag marker so vSphere's `vcenter.yaml` + `vi-json.yaml` coexist under one connector with distinguishable rows; `OpIdCollision` raised pre-DB-write when two ops in one batch share an `op_id`.
- Auto-registers a `GenericRestConnector` shim against the G0.6-T2 v2 registry on first ingest of a `(product, version, impl_id)` triple — the per-G3.x Initiative work later REPLACES the shim with a hand-coded subclass that owns auth + topology + non-degenerate fingerprint.

## Test plan

- [x] `ruff check src/meho_backplane/operations/ingest/ tests/test_operations_register_ingested.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/operations/ingest/` — Success: no issues found in 12 source files
- [x] `pytest tests/test_operations_register_ingested.py` — 13 passed
- [x] Sibling sweep (`test_operations_typed_register` + `test_operations_ingest_openapi` + `test_operations_ingest_review` + `test_connectors_registry_v2`) — 127 passed
- [x] Full backend unit suite — 1194 passed, 3 skipped (113 s)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 3 warnings (all PLR0913 keyword-only API signatures, mirroring `typed_register` precedent)

### Acceptance criteria verification

- [x] `source_kind='ingested'` set on inserted rows
- [x] Body-hash skip — stub embedding service `encode_one.call_count` does NOT advance on second ingest with identical args
- [x] Multi-spec merge — `tags` carries `spec:vcenter.yaml` / `spec:vi-json.yaml` distinctly per row
- [x] `OpIdCollision` raised before any DB write; names every duplicate `op_id`
- [x] Connector class auto-registered on first ingest; left alone on subsequent ingests under the same triple
- [x] Embeddings — 384-dim vector from mocked service ends up on `row.embedding`
- [x] Tenant scoping — `tenant_id=None` (built-in) and `tenant_id=<uuid>` (scoped) rows coexist by partial unique index
- [x] `is_enabled=False` on every per-op row (the agent's `search_operations` hides them until T4 enables)
- [x] `IngestionResult` carries counts + `connector_registered` + `operations_grouped` flags
- [x] End-to-end smoke test against the existing petstore_30.yaml fixture (6 ops) — rows persisted with correct source_kind, method, path, embedding, spec tag, connector class registered in v2 registry

## Out of scope

- LLM-grouping pass (assigning rows to `operation_group`): T3 #404
- Operator review state machine: already shipped in T4 #402 (`ReviewService`)
- CLI verbs invoking this helper: T5
- Per-product auth overrides for the auto-registered connectors: per G3.x Initiative work
- Auto-deletion of stale ops on re-ingest: v0.2.next

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk ingestion with per-operation upsert semantics (insert/updated/skipped) and hash-driven skip logic
  * Automatic registration of a REST connector shim on first ingest
  * Detection/prevention of operation-ID collisions across ingests (with clear error metadata)

* **Bug Fixes**
  * Preserve existing rows when cross-call collisions are detected; avoid unnecessary re-embedding

* **Tests**
  * Expanded coverage for ingest flows, collision scenarios, idempotency, tenant scoping, and connector registration

* **Documentation**
  * Updated spec-ingestion docs describing control flow, hashing, and registration behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/478)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-14)

Addressed CodeRabbit-iter-1 review findings (review result file
`.claude/auto/review-results/pr-478-iter-1.json`):

- **M1** `ce476bc` — cross-call op_id collision now raises `OpIdCollision` with both `spec_source` values named (was silently UPDATE-ing the first spec's row). Detection added in `upsert_one_operation` after the natural-key lookup, before the embedding hash comparison. New test `test_op_id_collision_across_calls_with_different_spec_sources_raises` asserts the raise, that the embedding service is NOT invoked a second time, and that the original row's `summary` / `tags` / `updated_at` are unchanged.

Adjacent suggestions from the iter-1 review surfaced for orchestrator follow-up (NOT addressed here — separate refactor scope):

- `connector_registration.py` `ensure_connector_class_registered` lazy-imports `all_connectors_v2` that's no longer needed.
- `build_upsert_context` builds `incoming_text` with `custom_description=None`, defeating the body-hash skip path after T4 operator edits set a real `custom_description`.
- `_base_url_override` not refreshed when the operator re-ingests a connector with a different `base_url`.

<!-- auto-implement-issue: continue, iteration 2 -->
