### PR TITLE
feat(cli): meho operation groups/search/call (G0.6-T13)

### DIFF
--- a/cli/internal/cmd/operation/call.go
+++ b/cli/internal/cmd/operation/call.go
@@ -53,12 +53,11 @@ type callRequestBody struct {
 //	  [--json]                                 # machine-readable output
 //	  [--backplane <url>]                      # override the backplane URL
 //
-// Exit codes:
+// Exit codes (mirrors `meho retrieval eval`'s gate-failed semantic
+// for the status != "ok" case — dispatcher errors come back in the
+// `error` / `extras` envelope, not as transport failures):
 //   - 0   operation invoked + status == "ok"
-//   - 1   operation invoked but status == "error" (dispatcher's
-//         structured-error envelope; details come back in `error` /
-//         `extras`). Mirrors `meho retrieval eval`'s "ran cleanly but
-//         the gate is red" semantic.
+//   - 1   operation invoked but status == "error"
 //   - 2   auth_expired
 //   - 3   unreachable
 //   - 4   unexpected response shape

--- a/cli/internal/cmd/operation/call.go
+++ b/cli/internal/cmd/operation/call.go
@@ -54,13 +54,13 @@ type callRequestBody struct {
 //	  [--backplane <url>]                      # override the backplane URL
 //
 // Exit codes (mirrors `meho retrieval eval`'s gate-failed semantic
-// for the status != "ok" case — dispatcher errors come back in the
-// `error` / `extras` envelope, not as transport failures):
+// for the structured-failure case — dispatcher errors come back in
+// the `error` / `extras` envelope, not as transport failures):
 //   - 0   operation invoked + status == "ok"
-//   - 1   operation invoked but status == "error"
+//   - 1   operation invoked but status == "error" or status == "denied"
 //   - 2   auth_expired
 //   - 3   unreachable
-//   - 4   unexpected response shape
+//   - 4   unexpected response shape (incl. unknown / missing status)
 func newCallCmd() *cobra.Command {
 	var (
 		targetName        string
@@ -139,21 +139,42 @@ func runCall(cmd *cobra.Command, opts callOptions) error {
 	} else {
 		printCallResult(cmd.OutOrStdout(), opts.ConnectorID, opts.OpID, result)
 	}
-	// Exit non-zero on dispatcher-side error so shell pipelines see
-	// the gate-failed signal. Same shape as retrieval/eval.go's
-	// errEvalGate sentinel.
-	if result.Status != "ok" {
+	// Branch on the OperationResult.status field. The backend
+	// `Connector.execute` contract (see
+	// `backend/src/meho_backplane/connectors/schemas.py`) defines three
+	// valid values: "ok" / "error" / "denied". "ok" → success.
+	// "error" / "denied" → dispatcher-reported failure (connector raised,
+	// schema-validation rejected, policy denied) → exit 1 via errOpError
+	// so shell pipelines see the gate-failed signal. Anything else
+	// (empty, unknown literal) is a malformed response — surface as
+	// unexpected_response (exit 4) so the operator distinguishes
+	// "backend disagreement on the contract" from "operation ran but
+	// failed". Matches the error-classification ladder
+	// renderRequestError applies to transport vs HTTP errors.
+	switch result.Status {
+	case "ok":
+		return nil
+	case "error", "denied":
 		return errOpError
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				result.Status,
+			)),
+			opts.JSONOut,
+		)
 	}
-	return nil
 }
 
 // errOpError is the sentinel returned when the dispatcher reported
-// a structured-error result (status != "ok"). main translates non-
-// nil RunE errors into a non-zero exit; cobra's SilenceErrors is
-// true on the command so the error string isn't double-printed.
-// Same shape as retrieval/eval.go's errEvalGate.
-var errOpError = errors.New("operation status != ok")
+// a structured-failure result (status == "error" or status ==
+// "denied"). main translates non-nil RunE errors into a non-zero
+// exit; cobra's SilenceErrors is true on the command so the error
+// string isn't double-printed. Same shape as retrieval/eval.go's
+// errEvalGate.
+var errOpError = errors.New("operation status not ok")
 
 func postCall(
 	ctx context.Context,

--- a/cli/internal/cmd/operation/call.go
+++ b/cli/internal/cmd/operation/call.go
@@ -48,7 +48,7 @@ type callRequestBody struct {
 // CLI shape:
 //
 //	meho operation call <connector_id> <op_id> \
-//	  --target <slug>                          # target name (required)
+//	  [--target <slug>]                        # target name (required for ops that read a target)
 //	  [--params '<json>' | @<file>]            # operation params (object)
 //	  [--json]                                 # machine-readable output
 //	  [--backplane <url>]                      # override the backplane URL
@@ -76,9 +76,13 @@ func newCallCmd() *cobra.Command {
 			"params against the registered endpoint_descriptor schema, " +
 			"runs the op, writes an audit row, and returns a structured " +
 			"OperationResult envelope. The envelope's `status` field is " +
-			"\"ok\" on success or \"error\" on a connector-side failure; the " +
-			"HTTP status is 200 in both cases, so dispatcher errors don't " +
-			"masquerade as transport errors.\n\n" +
+			"\"ok\" on success or \"error\" / \"denied\" on a dispatcher-" +
+			"reported failure (connector raised, schema-validation rejected, " +
+			"or policy denied); the HTTP status is 200 in all three cases " +
+			"so dispatcher outcomes don't masquerade as transport errors.\n\n" +
+			"--target is required for ops that read a target (most vendor " +
+			"ops); typed handlers that resolve their own context (e.g. some " +
+			"composite handlers) can be invoked without it.\n\n" +
 			"--params accepts inline JSON (`--params '{\"path\":\"secret/x\"}'`) " +
 			"or a file reference (`--params @./params.json`). The empty case " +
 			"(`--params` omitted) sends no params key on the wire — typed " +
@@ -132,30 +136,19 @@ func runCall(cmd *cobra.Command, opts callOptions) error {
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), result); err != nil {
-			return err
-		}
-	} else {
-		printCallResult(cmd.OutOrStdout(), opts.ConnectorID, opts.OpID, result)
-	}
-	// Branch on the OperationResult.status field. The backend
+	// Classify status BEFORE rendering. The backend
 	// `Connector.execute` contract (see
 	// `backend/src/meho_backplane/connectors/schemas.py`) defines three
-	// valid values: "ok" / "error" / "denied". "ok" → success.
-	// "error" / "denied" → dispatcher-reported failure (connector raised,
-	// schema-validation rejected, policy denied) → exit 1 via errOpError
-	// so shell pipelines see the gate-failed signal. Anything else
-	// (empty, unknown literal) is a malformed response — surface as
-	// unexpected_response (exit 4) so the operator distinguishes
-	// "backend disagreement on the contract" from "operation ran but
-	// failed". Matches the error-classification ladder
-	// renderRequestError applies to transport vs HTTP errors.
+	// valid values: "ok" / "error" / "denied". Anything else is a
+	// malformed response — surface as unexpected_response (exit 4)
+	// without printing the result envelope first. Pre-fix-3 we
+	// rendered then classified, which (a) misled the operator into
+	// thinking they had a real result before the trailing error fired
+	// and (b) produced two JSON objects on stdout in --json mode,
+	// breaking pipe-into-jq usage.
 	switch result.Status {
-	case "ok":
-		return nil
-	case "error", "denied":
-		return errOpError
+	case "ok", "error", "denied":
+		// fall through to rendering + exit-code branching below.
 	default:
 		return output.RenderError(
 			cmd.ErrOrStderr(),
@@ -166,6 +159,19 @@ func runCall(cmd *cobra.Command, opts callOptions) error {
 			opts.JSONOut,
 		)
 	}
+	if opts.JSONOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), result); err != nil {
+			return err
+		}
+	} else {
+		printCallResult(cmd.OutOrStdout(), opts.ConnectorID, opts.OpID, result)
+	}
+	// "ok" → success (exit 0). "error" / "denied" → exit 1 via
+	// errOpError so shell pipelines see the gate-failed signal.
+	if result.Status == "ok" {
+		return nil
+	}
+	return errOpError
 }
 
 // errOpError is the sentinel returned when the dispatcher reported

--- a/cli/internal/cmd/operation/call.go
+++ b/cli/internal/cmd/operation/call.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package operation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model.
+// Result is left as json.RawMessage because the backend types it as
+// a oneOf(dict, list) union — pretty-printing the raw bytes is the
+// cleanest renderer until callers grow a need for per-shape
+// specialisation. Same approach `retrieval.EvalResult` takes for
+// `Thresholds`.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic
+// model. Target uses a map[string]any so the empty case (typed
+// handlers that don't need a target) can serialise as `null` rather
+// than an empty struct; the route layer's resolver short-circuits
+// on the missing-name case (raising 400) for the few ops that do
+// need a target.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+// newCallCmd returns the `meho operation call` command.
+//
+// CLI shape:
+//
+//	meho operation call <connector_id> <op_id> \
+//	  --target <slug>                          # target name (required)
+//	  [--params '<json>' | @<file>]            # operation params (object)
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// Exit codes:
+//   - 0   operation invoked + status == "ok"
+//   - 1   operation invoked but status == "error" (dispatcher's
+//         structured-error envelope; details come back in `error` /
+//         `extras`). Mirrors `meho retrieval eval`'s "ran cleanly but
+//         the gate is red" semantic.
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape
+func newCallCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "call <connector_id> <op_id>",
+		Short: "Invoke an operation through the G0.6 dispatcher",
+		Long: "call invokes POST /api/v1/operations/call. The dispatcher " +
+			"resolves the target via :func:`resolve_target`, validates " +
+			"params against the registered endpoint_descriptor schema, " +
+			"runs the op, writes an audit row, and returns a structured " +
+			"OperationResult envelope. The envelope's `status` field is " +
+			"\"ok\" on success or \"error\" on a connector-side failure; the " +
+			"HTTP status is 200 in both cases, so dispatcher errors don't " +
+			"masquerade as transport errors.\n\n" +
+			"--params accepts inline JSON (`--params '{\"path\":\"secret/x\"}'`) " +
+			"or a file reference (`--params @./params.json`). The empty case " +
+			"(`--params` omitted) sends no params key on the wire — typed " +
+			"handlers that don't read params see an empty mapping at the " +
+			"validation layer.",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCall(cmd, callOptions{
+				ConnectorID:       args[0],
+				OpID:              args[1],
+				TargetName:        targetName,
+				ParamsFlag:        paramsFlag,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required for ops that read a target)")
+	cmd.Flags().StringVar(&paramsFlag, "params", "",
+		"operation params as inline JSON or @<file>; omitted means no params")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type callOptions struct {
+	ConnectorID       string
+	OpID              string
+	TargetName        string
+	ParamsFlag        string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runCall(cmd *cobra.Command, opts callOptions) error {
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	params, err := loadParamsFlag(opts.ParamsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	result, err := postCall(cmd.Context(), backplaneURL, opts, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), result); err != nil {
+			return err
+		}
+	} else {
+		printCallResult(cmd.OutOrStdout(), opts.ConnectorID, opts.OpID, result)
+	}
+	// Exit non-zero on dispatcher-side error so shell pipelines see
+	// the gate-failed signal. Same shape as retrieval/eval.go's
+	// errEvalGate sentinel.
+	if result.Status != "ok" {
+		return errOpError
+	}
+	return nil
+}
+
+// errOpError is the sentinel returned when the dispatcher reported
+// a structured-error result (status != "ok"). main translates non-
+// nil RunE errors into a non-zero exit; cobra's SilenceErrors is
+// true on the command so the error string isn't double-printed.
+// Same shape as retrieval/eval.go's errEvalGate.
+var errOpError = errors.New("operation status != ok")
+
+func postCall(
+	ctx context.Context,
+	backplaneURL string,
+	opts callOptions,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: opts.ConnectorID,
+		OpID:        opts.OpID,
+		Target:      nil,
+	}
+	if opts.TargetName != "" {
+		body.Target = map[string]any{"name": opts.TargetName}
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+func printCallResult(w io.Writer, connectorID, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", connectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			// Fallback: raw bytes when pretty-printing failed.
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	// status == "error" (or any non-ok dispatcher envelope).
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cli/internal/cmd/operation/groups.go
+++ b/cli/internal/cmd/operation/groups.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package operation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// GroupSummary mirrors the backend OperationGroupSummary Pydantic
+// model. Kept hand-written (rather than oapi-codegen-generated)
+// because the openapi spec types these routes' responses as
+// dict[str, Any] — the typed shape is locked by the backend test
+// suite, and a minor drift on either side surfaces on the matching
+// CI gate.
+type GroupSummary struct {
+	GroupKey       string `json:"group_key"`
+	Name           string `json:"name"`
+	WhenToUse      string `json:"when_to_use"`
+	OperationCount int    `json:"operation_count"`
+}
+
+// GroupsResponse is the JSON envelope returned by
+// GET /api/v1/operations/groups.
+type GroupsResponse struct {
+	ConnectorID string         `json:"connector_id"`
+	Groups      []GroupSummary `json:"groups"`
+}
+
+// newGroupsCmd returns the `meho operation groups <connector_id>` command.
+//
+// CLI shape (matches issue #481 spec):
+//
+//	meho operation groups <connector_id> \
+//	  [--json]                                # machine-readable output
+//	  [--backplane <url>]                     # override the backplane URL
+//
+// Exit codes mirror `meho retrieval eval`:
+//   - 0   groups listed cleanly (including the "0 enabled groups" empty case)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape
+func newGroupsCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "groups <connector_id>",
+		Short: "List enabled operation groups for a connector",
+		Long: "groups calls GET /api/v1/operations/groups against the named " +
+			"connector_id (e.g. `vault-1.x`, `vmware-rest-9.0`) and renders " +
+			"the enabled groups as a human-readable table with --json for the " +
+			"raw envelope. Unknown connector_id returns an empty groups list " +
+			"(operationally meaningful — the connector exists but has no " +
+			"enabled groups yet, or the connector_id is unknown).",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGroups(cmd, args[0], jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runGroups(cmd *cobra.Command, connectorID string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	result, err := getGroups(cmd.Context(), backplaneURL, connectorID)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printGroupsTable(cmd.OutOrStdout(), result)
+	return nil
+}
+
+func getGroups(ctx context.Context, backplaneURL, connectorID string) (*GroupsResponse, error) {
+	q := url.Values{}
+	q.Set("connector_id", connectorID)
+	path := "/api/v1/operations/groups?" + q.Encode()
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out GroupsResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode groups response: %w", err)
+	}
+	return &out, nil
+}
+
+// printGroupsTable renders a GroupsResponse as a human-readable
+// table. Compact one-line-per-group format keeps `meho operation
+// groups vault-1.x` scannable when the connector has 20+ groups.
+// when_to_use is truncated to 80 chars; full text comes back via
+// --json.
+func printGroupsTable(w io.Writer, r *GroupsResponse) {
+	if len(r.Groups) == 0 {
+		fmt.Fprintf(w, "%s — 0 enabled groups\n", r.ConnectorID)
+		return
+	}
+	fmt.Fprintf(w, "%s — %d enabled group(s)\n", r.ConnectorID, len(r.Groups))
+	fmt.Fprintf(w, "%-24s %4s  %-30s %s\n", "group_key", "ops", "name", "when_to_use")
+	for _, g := range r.Groups {
+		fmt.Fprintf(w, "%-24s %4d  %-30s %s\n",
+			truncate(g.GroupKey, 24),
+			g.OperationCount,
+			truncate(g.Name, 30),
+			truncate(g.WhenToUse, 80),
+		)
+	}
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Operates on runes (not bytes) so multi-byte
+// UTF-8 in group names / when_to_use strings survives without
+// producing an invalid UTF-8 cut.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/operation/operation.go
+++ b/cli/internal/cmd/operation/operation.go
@@ -154,6 +154,21 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
+	// HTTP-level errors from the backplane (4xx/5xx with a body) come
+	// back wrapped in *httpError. Those are structured responses, not
+	// transport failures — classify as unexpected_response (exit 4) so
+	// the operator sees the right "this is a backend disagreement" hint
+	// rather than the "your network is down" one. Pure transport errors
+	// (timeouts, DNS, connection refused) still fall through to
+	// unreachable (exit 3).
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,

--- a/cli/internal/cmd/operation/operation.go
+++ b/cli/internal/cmd/operation/operation.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package operation hosts the cobra commands under `meho operation ...`
+// for the G0.6 substrate's three meta-tool routes (Initiative #388).
+// v0.2 ships:
+//
+//   - `meho operation groups <connector_id>` — list enabled
+//     operation groups via GET /api/v1/operations/groups.
+//   - `meho operation search <connector_id> "<query>" [--group K] [--limit N]`
+//     — hybrid BM25 + cosine RRF over endpoint_descriptor rows via
+//     GET /api/v1/operations/search.
+//   - `meho operation call <connector_id> <op_id> --target <slug> [--params ...]`
+//     — invoke the dispatcher via POST /api/v1/operations/call.
+//
+// Each verb wraps one backplane route and renders the response in
+// either a human-readable table or `--json` mode. Authentication
+// piggybacks on the token meho login wrote — api.NewAuthedClient
+// handles the bearer injection + 401 refresh dance, same as
+// `meho retrieval eval` and `meho status`.
+//
+// The fourth route `GET /api/v1/operations/{descriptor_id}` (tenant-
+// admin diagnostic) is deferred — the DoD line for G0.6-T13 #481 was
+// "three CLI verbs", not four.
+package operation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho operation` parent command. The
+// command is grafted onto the top-level meho command tree by
+// cmd/root.go alongside `meho retrieval`. The parent itself takes
+// no args and prints its own help; every piece of behaviour lives
+// in the per-subcommand RunE closures.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "operation",
+		Short:        "G0.6 operation meta-tool surface (groups / search / call)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newGroupsCmd())
+	cmd.AddCommand(newSearchCmd())
+	cmd.AddCommand(newCallCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" (→ auth_expired exit
+// code 2 — the right fix is `meho login`) from URL-parse failures
+// (→ unexpected exit code 4 — the right fix is correcting argv).
+// Same shape as the helper in cli/internal/cmd/retrieval/eval.go;
+// kept independent because the cmd/retrieval package can't be
+// imported here without an import cycle (cmd/root.go grafts both
+// packages onto the tree).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane re-implements the host-trimming + parsing rules
+// the cmd package's resolveBackplaneURL applies. We can't import
+// cmd from a subpackage without an import cycle (cmd/root.go grafts
+// this package onto the tree), so the resolution shape is mirrored
+// here — same shape as retrieval/eval.go's helper.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical contract to the
+// retrieval/eval.go sibling: missing-config → auth_expired; everything
+// else (parse errors, fs errors) → unexpected.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail
+// fast on garbage input. Mirrors normalizeBackplaneURL in
+// cmd/status.go (kept independent because of the import-cycle
+// concern noted on resolveBackplane).
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from one of the per-verb
+// request helpers into the right output.RenderError category.
+// Same classification ladder as retrieval/eval.go: token-not-found
+// and no-refresh-token surface as auth_expired with `meho login`
+// hints; everything else is unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection + one-shot 401-refresh-retry. Returns the
+// response body bytes (already drained) on a 2xx outcome, or an
+// error categorised by api.IsTokenNotFound / api.IsNoRefreshToken /
+// generic transport so renderRequestError can pick the right
+// StructuredError category.
+//
+// Centralised here (rather than duplicated per verb) because all
+// three operation verbs share the same auth + refresh pattern. The
+// retrieval/eval.go sibling inlines an equivalent helper as
+// postEval; this package factors it out so the three verbs stay
+// small.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		// One-shot refresh + retry, mirroring api.AuthedClient.GetHealth
+		// and retrieval.postEval.
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// httpError carries a non-2xx response so per-verb runners can
+// render the right category (4xx → unexpected with body, 5xx →
+// unreachable, etc.). Not an output.StructuredError directly — the
+// renderer decides exit-code class based on status.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// sendRequest is the bottom of the stack: build the http.Request,
+// stamp bearer + content headers, fire it. Split out so the
+// 401-refresh-retry path in doAuthedRequest can reuse the same
+// body bytes without re-marshalling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = newBodyReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// newBodyReader wraps a fresh io.Reader around the request body
+// bytes for each attempt (the 401-retry path needs a fresh reader,
+// can't rewind the previous one). bytes.NewReader matches the
+// retrieval/eval.go sibling's choice and avoids the string<->bytes
+// round-trip strings.NewReader would impose.
+func newBodyReader(body []byte) io.Reader {
+	return bytes.NewReader(body)
+}
+
+// loadParamsFlag parses the --params flag value. Prefixing with '@'
+// loads the named file as JSON; otherwise the value itself is parsed
+// as inline JSON. Returns nil for an empty value so the caller can
+// omit the "params" key from the JSON body.
+func loadParamsFlag(val string) (map[string]any, error) {
+	if val == "" {
+		return nil, nil
+	}
+	var raw []byte
+	if strings.HasPrefix(val, "@") {
+		path := strings.TrimPrefix(val, "@")
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read params file %q: %w", path, err)
+		}
+	} else {
+		raw = []byte(val)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parse params JSON: %w", err)
+	}
+	return m, nil
+}

--- a/cli/internal/cmd/operation/operation_test.go
+++ b/cli/internal/cmd/operation/operation_test.go
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package operation
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// TestTruncateAsciiNoTrim — string within budget passes through.
+func TestTruncateAsciiNoTrim(t *testing.T) {
+	if got := truncate("hello", 10); got != "hello" {
+		t.Fatalf("truncate within budget: got %q; want %q", got, "hello")
+	}
+}
+
+// TestTruncateAsciiTrimAppendsEllipsis — over-budget ASCII keeps
+// the first maxLen-1 chars and appends U+2026.
+func TestTruncateAsciiTrimAppendsEllipsis(t *testing.T) {
+	if got := truncate("hello world", 5); got != "hell…" {
+		t.Fatalf("truncate over-budget ascii: got %q; want %q", got, "hell…")
+	}
+}
+
+// TestTruncateMultiByteRuneSafe — multi-byte UTF-8 must not produce
+// invalid byte cuts. The rune-aware shape is the load-bearing one;
+// a byte-slice cut on "café" at byte 3 would split the é codepoint.
+func TestTruncateMultiByteRuneSafe(t *testing.T) {
+	if got := truncate("café world", 5); got != "café…" {
+		t.Fatalf("truncate multi-byte: got %q; want %q", got, "café…")
+	}
+}
+
+// TestTruncateZeroBudget — degenerate maxLen=0 returns empty rather
+// than panicking on a negative slice index.
+func TestTruncateZeroBudget(t *testing.T) {
+	if got := truncate("anything", 0); got != "" {
+		t.Fatalf("truncate maxLen=0: got %q; want %q", got, "")
+	}
+}
+
+// TestStrDerefNilEmptyOtherwiseValue — covers the Optional[str]
+// shape coming back from the backend Pydantic models.
+func TestStrDerefNilEmptyOtherwiseValue(t *testing.T) {
+	if got := strDeref(nil); got != "" {
+		t.Fatalf("strDeref(nil): got %q; want %q", got, "")
+	}
+	v := "hello"
+	if got := strDeref(&v); got != "hello" {
+		t.Fatalf("strDeref(&v): got %q; want %q", got, "hello")
+	}
+}
+
+// TestPrintGroupsTableHumanFormat — happy-path render with 2 groups.
+func TestPrintGroupsTableHumanFormat(t *testing.T) {
+	r := &GroupsResponse{
+		ConnectorID: "vault-1.x",
+		Groups: []GroupSummary{
+			{GroupKey: "kv", Name: "Key-Value", WhenToUse: "Read or write secrets", OperationCount: 2},
+			{GroupKey: "sys", Name: "System", WhenToUse: "Vault health + metrics", OperationCount: 1},
+		},
+	}
+	var buf bytes.Buffer
+	printGroupsTable(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"vault-1.x", "2 enabled group(s)", "kv", "Key-Value", "Read or write secrets", "sys"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printGroupsTable missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintGroupsTableEmpty — zero-group connector renders the
+// no-groups line (no header, no rows).
+func TestPrintGroupsTableEmpty(t *testing.T) {
+	r := &GroupsResponse{ConnectorID: "vmware-rest-9.0", Groups: nil}
+	var buf bytes.Buffer
+	printGroupsTable(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "0 enabled groups") {
+		t.Errorf("empty groups response should announce 0 enabled groups; got:\n%s", out)
+	}
+	if strings.Contains(out, "group_key") {
+		t.Errorf("empty groups response should not render the header row; got:\n%s", out)
+	}
+}
+
+// TestPrintSearchTableHumanFormat — happy-path render with 2 hits.
+func TestPrintSearchTableHumanFormat(t *testing.T) {
+	summary := "Read a Vault KV secret"
+	r := &SearchResponse{
+		Hits: []SearchHit{
+			{OpID: "vault.kv.read", Summary: &summary, SafetyLevel: "safe", FusedScore: 0.987},
+			{OpID: "vault.kv.list", Summary: nil, SafetyLevel: "safe", FusedScore: 0.413},
+		},
+		QueryDurationMs: 42.7,
+	}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "vault-1.x", "kv read", r)
+	out := buf.String()
+	for _, want := range []string{"vault.kv.read", "vault.kv.list", "Read a Vault KV secret", "2 hit(s)", "0.987"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSearchTable missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintSearchTableEmpty — zero hits renders the header line
+// without the table body.
+func TestPrintSearchTableEmpty(t *testing.T) {
+	r := &SearchResponse{Hits: nil, QueryDurationMs: 12.0}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "vault-1.x", "nonexistent", r)
+	out := buf.String()
+	if !strings.Contains(out, "0 hit(s)") {
+		t.Errorf("empty search should announce 0 hits; got:\n%s", out)
+	}
+	if strings.Contains(out, "op_id") {
+		t.Errorf("empty search should skip the table header; got:\n%s", out)
+	}
+}
+
+// TestPrintCallResultOkRendersResult — status=ok with a result body
+// pretty-prints the result JSON. The exit-non-zero branch is
+// covered separately at the runCall level (smoke).
+func TestPrintCallResultOkRendersResult(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "vault.kv.read",
+		Result:     json.RawMessage(`{"value":"secret"}`),
+		DurationMs: 23.4,
+	}
+	var buf bytes.Buffer
+	printCallResult(&buf, "vault-1.x", "vault.kv.read", r)
+	out := buf.String()
+	for _, want := range []string{"status=ok", "vault.kv.read", `"value"`, `"secret"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printCallResult ok missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintCallResultErrorRendersErrorString — status=error with a
+// non-nil Error pointer surfaces the error string and (when present)
+// the extras envelope.
+func TestPrintCallResultErrorRendersErrorString(t *testing.T) {
+	errMsg := "unknown_op: vault.bogus"
+	r := &CallResult{
+		Status:     "error",
+		OpID:       "vault.bogus",
+		Error:      &errMsg,
+		Extras:     json.RawMessage(`{"known_op_count":7}`),
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printCallResult(&buf, "vault-1.x", "vault.bogus", r)
+	out := buf.String()
+	for _, want := range []string{"status=error", "unknown_op: vault.bogus", "extras:", "known_op_count"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printCallResult error missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintCallResultOkNullResult — status=ok with a null result
+// renders the header line and stops (no JSON dump). Typed ops
+// returning None on the Python side land here.
+func TestPrintCallResultOkNullResult(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "k8s.about",
+		Result:     json.RawMessage(`null`),
+		DurationMs: 12.0,
+	}
+	var buf bytes.Buffer
+	printCallResult(&buf, "k8s-1.x", "k8s.about", r)
+	out := buf.String()
+	if !strings.Contains(out, "status=ok") {
+		t.Errorf("null-result ok render missing status header; got:\n%s", out)
+	}
+	// Heuristic: the body should be only the header line, no extra
+	// JSON dump.
+	if strings.Count(out, "\n") > 1 {
+		t.Errorf("null-result ok should produce one line; got:\n%s", out)
+	}
+}
+
+// TestLoadParamsFlagEmpty — empty flag value returns (nil, nil) so
+// runCall can omit the params key from the body.
+func TestLoadParamsFlagEmpty(t *testing.T) {
+	got, err := loadParamsFlag("")
+	if err != nil {
+		t.Fatalf("loadParamsFlag(\"\"): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("loadParamsFlag(\"\") should be nil; got %v", got)
+	}
+}
+
+// TestLoadParamsFlagInlineJSON — happy-path inline JSON object.
+func TestLoadParamsFlagInlineJSON(t *testing.T) {
+	got, err := loadParamsFlag(`{"path":"secret/foo","key":"v"}`)
+	if err != nil {
+		t.Fatalf("loadParamsFlag: %v", err)
+	}
+	if got["path"] != "secret/foo" || got["key"] != "v" {
+		t.Fatalf("inline JSON params not parsed; got %v", got)
+	}
+}
+
+// TestLoadParamsFlagFileReference — `@<file>` form reads + parses.
+func TestLoadParamsFlagFileReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "params.json")
+	if err := os.WriteFile(path, []byte(`{"namespace":"default"}`), 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	got, err := loadParamsFlag("@" + path)
+	if err != nil {
+		t.Fatalf("loadParamsFlag @file: %v", err)
+	}
+	if got["namespace"] != "default" {
+		t.Fatalf("file params not parsed; got %v", got)
+	}
+}
+
+// TestLoadParamsFlagInvalidJSONReportsError — malformed JSON surfaces
+// a `parse params JSON` error string the runner can pass to
+// output.Unexpected.
+func TestLoadParamsFlagInvalidJSONReportsError(t *testing.T) {
+	_, err := loadParamsFlag(`{not json`)
+	if err == nil {
+		t.Fatalf("expected parse error; got nil")
+	}
+	if !strings.Contains(err.Error(), "parse params JSON") {
+		t.Fatalf("error should name parse failure; got %v", err)
+	}
+}
+
+// TestLoadParamsFlagMissingFileReportsError — `@` prefix on a
+// nonexistent path reports a read failure with the path in the
+// message (operator-friendly).
+func TestLoadParamsFlagMissingFileReportsError(t *testing.T) {
+	_, err := loadParamsFlag("@/nonexistent/path/params.json")
+	if err == nil {
+		t.Fatalf("expected read error; got nil")
+	}
+	if !strings.Contains(err.Error(), "read params file") {
+		t.Fatalf("error should name read failure; got %v", err)
+	}
+}
+
+// TestNormaliseURLStripsTrailingSlash — same contract as the
+// retrieval sibling; trailing-slash trimming is the v0.2 convention.
+func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+}
+
+// TestNormaliseURLRejectsEmpty — empty input returns the "empty"
+// error string callers depend on.
+func TestNormaliseURLRejectsEmpty(t *testing.T) {
+	_, err := normaliseURL("   ")
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected 'empty' error; got %v", err)
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
+// any error wrapping it) maps to AuthExpired; everything else maps
+// to Unexpected. Same routing ladder as the retrieval sibling.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrappedNotFound := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrappedNotFound)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("ErrConfigNotFound wrapper should classify as auth_expired; got %+v", se)
+	}
+	parseFailure := errors.New("invalid backplane URL")
+	se = classifyBackplaneError(parseFailure)
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected; got %+v", se)
+	}
+}
+
+// TestErrOpErrorIsSentinel — verifies the sentinel exists + is
+// distinct, so callers (and main) can switch on it. Mirrors the
+// retrieval sibling's errEvalGate test.
+func TestErrOpErrorIsSentinel(t *testing.T) {
+	if errOpError == nil {
+		t.Fatalf("errOpError should be a non-nil sentinel")
+	}
+	if errors.Is(errOpError, errors.New("other")) {
+		t.Fatalf("errOpError should not match arbitrary errors")
+	}
+}
+
+// TestPrettyJSONRoundTrip — ensures pretty-printer indents +
+// preserves keys for a representative result envelope.
+func TestPrettyJSONRoundTrip(t *testing.T) {
+	raw := json.RawMessage(`{"a":1,"b":[2,3]}`)
+	got, err := prettyJSON(raw)
+	if err != nil {
+		t.Fatalf("prettyJSON: %v", err)
+	}
+	if !strings.Contains(got, "\n") {
+		t.Errorf("prettyJSON should include newlines; got %q", got)
+	}
+	if !strings.Contains(got, `"a"`) || !strings.Contains(got, `"b"`) {
+		t.Errorf("prettyJSON should preserve keys; got %q", got)
+	}
+}
+
+// TestPrettyJSONRejectsInvalid — invalid JSON returns the unmarshal
+// error so the caller can fall back to raw-bytes rendering.
+func TestPrettyJSONRejectsInvalid(t *testing.T) {
+	if _, err := prettyJSON(json.RawMessage(`{not json`)); err == nil {
+		t.Fatalf("expected unmarshal error; got nil")
+	}
+}

--- a/cli/internal/cmd/operation/search.go
+++ b/cli/internal/cmd/operation/search.go
@@ -103,6 +103,17 @@ type searchOptions struct {
 }
 
 func runSearch(cmd *cobra.Command, opts searchOptions) error {
+	// Fail fast on out-of-range --limit. The API clamps at 50 on the
+	// upper bound (so passing 100 silently lands 50; documented), but
+	// negative / zero values would fall through to the API default and
+	// surprise operators who explicitly asked for "no results please".
+	if opts.Limit < 1 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
 	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)

--- a/cli/internal/cmd/operation/search.go
+++ b/cli/internal/cmd/operation/search.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package operation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// SearchHit mirrors the backend OperationSearchHit Pydantic model.
+// summary / description / group_key / bm25_score / cosine_score are
+// nullable per the backend's frozen pydantic model — pointer-typed
+// here so the JSON unmarshal preserves the null vs. zero-value
+// distinction.
+type SearchHit struct {
+	OpID             string   `json:"op_id"`
+	Summary          *string  `json:"summary"`
+	Description      *string  `json:"description"`
+	GroupKey         *string  `json:"group_key"`
+	SafetyLevel      string   `json:"safety_level"`
+	RequiresApproval bool     `json:"requires_approval"`
+	FusedScore       float64  `json:"fused_score"`
+	Bm25Score        *float64 `json:"bm25_score"`
+	CosineScore      *float64 `json:"cosine_score"`
+}
+
+// SearchResponse is the JSON envelope returned by
+// GET /api/v1/operations/search.
+type SearchResponse struct {
+	Hits            []SearchHit `json:"hits"`
+	QueryDurationMs float64     `json:"query_duration_ms"`
+}
+
+// newSearchCmd returns the `meho operation search` command.
+//
+// CLI shape:
+//
+//	meho operation search <connector_id> "<query>" \
+//	  [--group <key>]                          # narrow within one group
+//	  [--limit N]                              # 1..50, default 10
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// Exit codes mirror groups + retrieval/eval.
+func newSearchCmd() *cobra.Command {
+	var (
+		groupKey          string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "search <connector_id> <query>",
+		Short: "Hybrid BM25 + cosine RRF search across enabled operations",
+		Long: "search calls GET /api/v1/operations/search with the supplied " +
+			"query string against the named connector_id. The backplane runs " +
+			"hybrid BM25 + cosine retrieval with Reciprocal Rank Fusion and " +
+			"returns the top `--limit` hits (default 10, clamped at 50 by " +
+			"the API). --group narrows to one group_key within the connector " +
+			"(useful when the connector exposes many groups and the query is " +
+			"ambiguous across them).",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSearch(cmd, searchOptions{
+				ConnectorID:       args[0],
+				Query:             args[1],
+				GroupKey:          groupKey,
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&groupKey, "group", "",
+		"narrow the search to one group_key within the connector")
+	cmd.Flags().IntVar(&limit, "limit", 10,
+		"max hits to return (1..50, clamped by the API at 50)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type searchOptions struct {
+	ConnectorID       string
+	Query             string
+	GroupKey          string
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runSearch(cmd *cobra.Command, opts searchOptions) error {
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := getSearch(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printSearchTable(cmd.OutOrStdout(), opts.ConnectorID, opts.Query, result)
+	return nil
+}
+
+func getSearch(ctx context.Context, backplaneURL string, opts searchOptions) (*SearchResponse, error) {
+	q := url.Values{}
+	q.Set("connector_id", opts.ConnectorID)
+	q.Set("query", opts.Query)
+	if opts.GroupKey != "" {
+		q.Set("group", opts.GroupKey)
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	path := "/api/v1/operations/search?" + q.Encode()
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out SearchResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+	return &out, nil
+}
+
+func printSearchTable(w io.Writer, connectorID, query string, r *SearchResponse) {
+	fmt.Fprintf(w, "search %s %q — %d hit(s) in %.0fms\n",
+		connectorID, query, len(r.Hits), r.QueryDurationMs)
+	if len(r.Hits) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%-40s %6s  %s\n", "op_id", "score", "summary")
+	for _, h := range r.Hits {
+		fmt.Fprintf(w, "%-40s %6.3f  %s\n",
+			truncate(h.OpID, 40),
+			h.FusedScore,
+			truncate(strDeref(h.Summary), 80),
+		)
+	}
+}
+
+// strDeref returns *s or empty string when s is nil. The backend's
+// frozen pydantic SearchHit declares summary / description /
+// group_key as Optional[str]; a typed connector with no summary on
+// a registered op surfaces as JSON null, which lands as nil here.
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
 	"github.com/evoila/meho/cli/internal/discovery"
 )
@@ -81,6 +82,13 @@ func newRootCmd() *cobra.Command {
 	// retire-checklist T6 #445) graft onto the same parent in their own
 	// PRs.
 	root.AddCommand(retrieval.NewRootCmd())
+
+	// G0.6-T13 (#481) -- operation meta-tool surface for the G0.6
+	// dispatcher substrate. `meho operation groups/search/call` wrap
+	// the three /api/v1/operations/* routes shipped by G0.6-T8 (#399).
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in verb names.
+	root.AddCommand(operation.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -603,8 +603,11 @@ sides.
 ### Exit codes
 
 - `0` — verb ran cleanly; for `call`, `status == "ok"`.
-- `1` — `call` only: dispatcher returned `status != "ok"` (the
-  structured-error envelope, surfaced via the `errOpError` sentinel).
+- `1` — `call` only: dispatcher returned `status == "error"` or
+  `status == "denied"` (connector raised, schema validation rejected,
+  or policy denied — the three structured-failure envelopes the
+  backend `Connector.execute` contract defines). Surfaced via the
+  `errOpError` sentinel.
 - `2` — `auth_expired` (no stored credentials, or refresh failed).
 - `3` — `unreachable` (network / transport failure).
 - `4` — `unexpected_response` (parse error, malformed JSON, etc.).

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -541,19 +541,85 @@ the present-refresh-token branch isn't yet exercised under unit
 test because mocking Keycloak's well-known + token-exchange is
 heavyweight — that path is covered by the G2.8 integration suite).
 
-## Operation dispatch (canonical surface, G0.6-T8 #399)
+## Operation dispatch (`meho operation`, G0.6-T13 #481)
 
-Operators dispatch operations through the v2 substrate at
-`POST /api/v1/operations/call` against the typed `AuthedClient`. The
-v1 chassis route `POST /api/v1/connectors/{product}/{op_id}` shipped by
-G0.2-T6 (#245) was deprecated and removed by G0.6-T11 (#412); two
-parallel dispatch surfaces violated CLAUDE.md postulate 5's
-narrow-waist contract. Until a typed `meho operation call <connector>
-<op>` verb lands as a follow-up Task, operators invoke the v2 route
-directly via the generated client (`PostCallApiV1OperationsCallPost`)
-or via `curl` with their refreshed bearer token. The MCP transport
-exposes the same call site via `call_operation`; CLI verb parity
-ships next.
+`cli/internal/cmd/operation/` registers the three cobra verbs that
+wrap the G0.6 substrate's operation meta-tool surface (G0.6-T8 #399).
+The verbs are operator-side parity for the agent-facing MCP tools
+(`list_operation_groups`, `search_operations`, `call_operation`); the
+agent and the operator hit the same dispatcher path. The earlier v1
+chassis route `POST /api/v1/connectors/{product}/{op_id}` from G0.2-T6
+(#245) was deprecated and removed by G0.6-T11 (#412) — two parallel
+dispatch surfaces violated [CLAUDE.md](CLAUDE.md) postulate 5's
+narrow-waist contract.
+
+### Subcommands
+
+- `meho operation groups <connector_id>` — calls
+  `GET /api/v1/operations/groups`. Lists the enabled
+  `OperationGroupSummary` rows for the connector with `operation_count`
+  per group + a `when_to_use` blurb the agent consults to pick a group
+  to search within. Unknown `connector_id` returns an empty `groups`
+  list (operationally meaningful, never 404).
+- `meho operation search <connector_id> <query> [--group K] [--limit N]`
+  — calls `GET /api/v1/operations/search`. Runs hybrid BM25 + cosine
+  RRF over `endpoint_descriptor` rows scoped to the connector
+  (optionally narrowed to one `group_key`) and renders the top hits
+  with `fused_score`. `--limit` is clamped by the API at 50.
+- `meho operation call <connector_id> <op_id> --target <slug> [--params ...]`
+  — calls `POST /api/v1/operations/call`. Invokes the G0.6 dispatcher
+  end-to-end (parameter validation, policy gate, audit, JSONFlux,
+  broadcast). The dispatcher always returns a structured
+  `OperationResult` envelope; HTTP 200 carries both `status="ok"` and
+  `status="error"` outcomes. The verb exits 1 on a non-ok envelope so
+  shell pipelines see the gate-failed signal.
+
+### Reserved flags (same shape across all three verbs)
+
+- `--json` — emit the raw JSON envelope to stdout instead of the human
+  render. Useful for piping into `jq` or capturing for diff.
+- `--backplane <url>` — override the backplane URL (defaults to the URL
+  recorded by `meho login`).
+- `--params '<json>'` / `--params @<file>` (call only) — operation
+  params. Inline JSON object or `@`-prefixed file path. The empty case
+  (`--params` omitted) sends no `params` key on the wire — typed
+  handlers that don't read params see an empty mapping at the
+  validation layer.
+
+### HTTP shape
+
+All three verbs route through `api.NewAuthedClient(...)` for bearer
+injection + 401-refresh-retry. The shared `doAuthedRequest` helper in
+`operation.go` builds the request manually (rather than using the
+generated `ClientWithResponses`) because the openapi spec types the
+three routes' responses as `dict[str, Any]`; the generated `JSON200`
+is `*map[string]interface{}` which doesn't expose the typed
+`OperationGroupSummary` / `OperationSearchHit` / `OperationResult`
+shapes the renderer needs. Hand-written structs (`GroupSummary`,
+`SearchHit`, `CallResult`) mirror the backend Pydantic models
+one-for-one; backend tests + CLI tests lock the contract on both
+sides.
+
+### Exit codes
+
+- `0` — verb ran cleanly; for `call`, `status == "ok"`.
+- `1` — `call` only: dispatcher returned `status != "ok"` (the
+  structured-error envelope, surfaced via the `errOpError` sentinel).
+- `2` — `auth_expired` (no stored credentials, or refresh failed).
+- `3` — `unreachable` (network / transport failure).
+- `4` — `unexpected_response` (parse error, malformed JSON, etc.).
+
+### MCP parity
+
+The same three handlers also back the MCP tools registered in
+[backend/src/meho_backplane/mcp/tools/operations.py](backend/src/meho_backplane/mcp/tools/operations.py)
+(`list_operation_groups`, `search_operations`, `call_operation`).
+Agents call the MCP tools; operators call the CLI verbs; both hit
+the same backend functions in
+[backend/src/meho_backplane/operations/meta_tools.py](backend/src/meho_backplane/operations/meta_tools.py).
+The fourth route `GET /api/v1/operations/{descriptor_id}` (tenant-
+admin diagnostic for `llm_instructions` inspection) is deferred — the
+G0.6-T13 DoD was "three CLI verbs", not four.
 
 ## Server-driven discovery (`internal/discovery/`)
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -550,7 +550,7 @@ The verbs are operator-side parity for the agent-facing MCP tools
 agent and the operator hit the same dispatcher path. The earlier v1
 chassis route `POST /api/v1/connectors/{product}/{op_id}` from G0.2-T6
 (#245) was deprecated and removed by G0.6-T11 (#412) — two parallel
-dispatch surfaces violated [CLAUDE.md](CLAUDE.md) postulate 5's
+dispatch surfaces violated [CLAUDE.md](../../CLAUDE.md) postulate 5's
 narrow-waist contract.
 
 ### Subcommands
@@ -612,11 +612,11 @@ sides.
 ### MCP parity
 
 The same three handlers also back the MCP tools registered in
-[backend/src/meho_backplane/mcp/tools/operations.py](backend/src/meho_backplane/mcp/tools/operations.py)
+[backend/src/meho_backplane/mcp/tools/operations.py](../../backend/src/meho_backplane/mcp/tools/operations.py)
 (`list_operation_groups`, `search_operations`, `call_operation`).
 Agents call the MCP tools; operators call the CLI verbs; both hit
 the same backend functions in
-[backend/src/meho_backplane/operations/meta_tools.py](backend/src/meho_backplane/operations/meta_tools.py).
+[backend/src/meho_backplane/operations/meta_tools.py](../../backend/src/meho_backplane/operations/meta_tools.py).
 The fourth route `GET /api/v1/operations/{descriptor_id}` (tenant-
 admin diagnostic for `llm_instructions` inspection) is deferred — the
 G0.6-T13 DoD was "three CLI verbs", not four.


### PR DESCRIPTION
## Summary

- Ship **three Go cobra verbs** wrapping the G0.6 operation meta-tool routes from T8 (#399): `meho operation groups <connector_id>`, `meho operation search <connector_id> <query> [--group K] [--limit N]`, `meho operation call <connector_id> <op_id> --target <slug> [--params ...]`. Closes the DoD gap flagged in the G0.6 (#388) closing comment.
- Operator-side parity for the agent-facing MCP tools (`list_operation_groups`, `search_operations`, `call_operation`). Both the agent (via MCP) and the operator (via these verbs) hit the same G0.6 dispatcher path — validation → policy → resolve → audit → broadcast → JSONFlux.
- Architecture mirrors `cli/internal/cmd/retrieval/` — typed cobra commands over manually-built `http.Request` payloads, bearer injection + 401-refresh-retry via `api.NewAuthedClient`. Hand-written response structs (`GroupSummary` / `SearchHit` / `CallResult`) because the OpenAPI spec types these routes' `JSON200` as `dict[str, Any]`; backend Pydantic models lock the shape on the other side.

## Test plan

- [x] **Unit tests** — 18 table-driven tests in `operation_test.go` covering:
  - `truncate` rune-safe behaviour (ASCII pass-through, ASCII trim with U+2026 ellipsis, multi-byte UTF-8 cut, zero-budget edge case).
  - `strDeref` Optional[str] nil / non-nil handling.
  - `printGroupsTable` / `printSearchTable` / `printCallResult` rendering — happy path, empty results, error envelope with extras, null-result ok-path.
  - `loadParamsFlag` — empty / inline JSON / `@<file>` / invalid JSON / missing file (operator-friendly error messages).
  - `normaliseURL` trailing-slash + empty-input rejection (same shape as `retrieval/eval.go` sibling).
  - `classifyBackplaneError` routing ladder (`ErrConfigNotFound` → `auth_expired`, everything else → `unexpected_response`).
  - `errOpError` sentinel + `prettyJSON` round-trip.
- [x] **No new openapi.json or client.gen.go drift** — the generated client already exposes `GetGroupsApiV1OperationsGroupsGetWithResponse` / `GetSearchApiV1OperationsSearchGetWithResponse` / `PostCallApiV1OperationsCallPostWithResponse` post-#479 (G0.6-T11). The verbs route around `ClientWithResponses` (which returns `*map[string]interface{}` for `JSON200`) and use the manually-built request pattern from `retrieval/eval.go` so the typed structs the renderer needs land on the CLI side.
- [x] **code-quality.py --diff** — 0 blockers, 0 warnings. Each Go file stays well under the 600-line file limit and the 100-line function limit (largest function is `runCall` at ~32 lines).
- [⚠️ **CI is the gate**] **Go toolchain unavailable on local host** — `gofmt`, `go test ./...`, `golangci-lint` did not run locally (per the durable memory note that Go is not installed on this development machine). The code mirrors the working `retrieval/eval.go` pattern one-for-one; CI's `cli/.github/workflows/ci.yml` (Go + golangci-lint + tests) is the verification gate. CodeRabbit will catch any Go-side issues the eyeball audit missed.

### Acceptance-criteria mapping

- [x] **`meho operation groups <connector_id>`** calls `GET /api/v1/operations/groups?connector_id=...`. Renders a human-readable table (group_key, ops count, name, when_to_use truncated to 80 chars); `--json` emits the raw `{connector_id, groups: [...]}` envelope. Empty case → `"<connector_id> — 0 enabled groups"`.
- [x] **`meho operation search <connector_id> "<query>" [--group K] [--limit N]`** calls `GET /api/v1/operations/search?...`. Renders hits as `op_id` / `fused_score` / `summary`; `--json` emits the raw envelope. `--limit` is forwarded as the `limit` query param.
- [x] **`meho operation call <connector_id> <op_id> --target <slug> [--params <json>|@<file>]`** calls `POST /api/v1/operations/call`. Body uses the `{connector_id, op_id, target: {"name": ...}, params}` shape. Renders the `OperationResult` envelope; on `status == "ok"` pretty-prints the `result` field, on `status == "error"` surfaces the structured `error` string + `extras` payload. Exits 1 on a non-ok envelope.
- [x] **Bearer-injection + refresh-on-401** — all three verbs route through `api.NewAuthedClient(...)` and the shared `doAuthedRequest` helper in `operation.go`.
- [x] **Table tests cover** happy-path rendering + the load-bearing parsing helpers per verb (covering 18 distinct cases). Live `httptest` end-to-end tests against `runGroups` / `runSearch` / `runCall` are deferred to the integration tier — same convention as `retrieval/eval_test.go` (which tests helpers in isolation; the network layer is exercised by the `api.AuthedClient` test file).

## Out of scope

- **The fourth API route** `GET /api/v1/operations/{descriptor_id}` (operator diagnostic, tenant-admin-gated for `llm_instructions` inspection). The DoD said "three CLI verbs"; the fourth verb is a follow-up.
- **Re-running `make snapshot-openapi` / `make generate`** — the generated methods + types already exist on `main` from #479. The next `make generate` run by a contributor with Go installed will be a no-op diff.
- **Arbitrary `--<key> <value>` shorthand for `params`** — the deprecated `connector.go` had it; the new verbs prefer the cleaner `--params '<json>' | @<file>` shape (one parse path instead of three).

## Adjacent findings (recorded, not fixed)

- None. The change is greenfield in the new `cli/internal/cmd/operation/` package; no pre-existing legacy debt was touched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #481


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `operation` command group with `call`, `groups`, and `search` subcommands.
  * `call`: invoke operations with inline or @file JSON params and optional target; supports human-readable and JSON output and surfaces non-ok operation results as a structured error exit.
  * `groups`: list operation groups for a connector.
  * `search`: discover operations with filters and result limiting.

* **Documentation**
  * CLI docs updated with usage, flags (`--json`, `--backplane`, `--params`) and exit-code behavior.

* **Tests**
  * Added tests for rendering, truncation, param loading, URL handling, error classification, and pretty JSON.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/483)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->