### PR TITLE
feat(audit): G8.1-T1 audit_query module substrate — AuditEntry + AuditQueryFilters + opaque cursor + tenant-scoped handler

### DIFF
--- a/backend/src/meho_backplane/audit_query/__init__.py
+++ b/backend/src/meho_backplane/audit_query/__init__.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Audit-query substrate (G8.1-T1).
+
+The package exposes the consumer-facing surface T2 (REST), T3 (CLI), and T4
+(MCP) dispatch through:
+
+* :func:`query_audit` — tenant-scoped paginated query handler.
+* :class:`AuditQueryFilters` — input filter shape (frozen Pydantic v2).
+* :class:`AuditEntry` — one row of the result (frozen Pydantic v2).
+* :class:`AuditQueryResult` — page of rows plus forward-only ``next_cursor``.
+* :class:`InvalidCursorError` — opaque-cursor decode failure.
+* :class:`UnsupportedFilterError` — filter targets a column that does not yet
+  exist in v0.2 (``parent_audit_id`` waits on G0.6-T7 #398;
+  ``agent_session_id`` has no current roadmap).
+
+See :mod:`.schemas` for the substrate-vs-issue-body reconciliation that
+documents which fields are real columns, which are computed at query time,
+and which are v0.2 placeholders.
+"""
+
+from __future__ import annotations
+
+from .cursor import CursorPosition, InvalidCursorError, decode_cursor, encode_cursor
+from .query import UnsupportedFilterError, query_audit
+from .schemas import AuditEntry, AuditQueryFilters, AuditQueryResult
+
+__all__ = [
+    "AuditEntry",
+    "AuditQueryFilters",
+    "AuditQueryResult",
+    "CursorPosition",
+    "InvalidCursorError",
+    "UnsupportedFilterError",
+    "decode_cursor",
+    "encode_cursor",
+    "query_audit",
+]

--- a/backend/src/meho_backplane/audit_query/cursor.py
+++ b/backend/src/meho_backplane/audit_query/cursor.py
@@ -73,7 +73,11 @@ def decode_cursor(token: str) -> CursorPosition:
     underlying reason without leaking it through the operator-facing error.
     """
     try:
-        raw = base64.urlsafe_b64decode(token.encode("ascii"))
+        raw = base64.b64decode(
+            token.encode("ascii"),
+            altchars=b"-_",
+            validate=True,
+        )
     except (binascii.Error, UnicodeEncodeError, ValueError) as exc:
         raise InvalidCursorError("cursor is not valid base64") from exc
 

--- a/backend/src/meho_backplane/audit_query/cursor.py
+++ b/backend/src/meho_backplane/audit_query/cursor.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Opaque forward-only cursor for ``audit_log`` pagination.
+
+The audit-query API paginates by (``occurred_at`` DESC, ``id`` DESC) — the
+natural read order for "newest first" forensic reconstruction. OFFSET-based
+pagination is broken under concurrent inserts (a row written between page 1
+and page 2 shifts every subsequent row by one and the consumer either re-reads
+or skips a row). A keyset cursor over the same lex order is correctness-
+preserving: page N+1 starts at the row strictly after page N's last row.
+
+The encoded form is deliberately opaque (base64-encoded JSON) so consumers
+treat it as a token rather than parsing it. Any tampering with the bytes
+produces an :class:`InvalidCursorError` at decode time rather than a silently
+wrong query — the decoder validates structure, ISO-8601 parse, and UUID parse
+in turn.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+__all__ = [
+    "CursorPosition",
+    "InvalidCursorError",
+    "decode_cursor",
+    "encode_cursor",
+]
+
+
+class InvalidCursorError(ValueError):
+    """Raised when an opaque cursor token cannot be decoded.
+
+    The token may be malformed base64, malformed JSON, missing a required
+    field, or carry an invalid ISO-8601 / UUID value. Any of these are
+    handled identically: the cursor is rejected and the caller decides
+    whether to surface a 400 (REST), a CLI error, or an MCP -32602.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class CursorPosition:
+    """Decoded cursor: the ``(occurred_at, id)`` keyset position."""
+
+    ts: datetime
+    id: uuid.UUID
+
+
+def encode_cursor(position: CursorPosition) -> str:
+    """Encode a keyset position as an opaque URL-safe base64 token.
+
+    The wire format is ``urlsafe_b64encode(json.dumps({"ts": <iso>, "id": <uuid>}))``.
+    ``urlsafe`` avoids ``+`` / ``/`` so the token survives unencoded as a query
+    parameter and as a JSON-string value without escaping.
+    """
+    payload = {"ts": position.ts.isoformat(), "id": str(position.id)}
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def decode_cursor(token: str) -> CursorPosition:
+    """Decode an opaque cursor token back into a :class:`CursorPosition`.
+
+    Validates each layer (base64, JSON, dict shape, ISO-8601 ``ts``, UUID ``id``)
+    and raises :class:`InvalidCursorError` on the first failure. The original
+    decode exception is preserved as ``__cause__`` so log lines can carry the
+    underlying reason without leaking it through the operator-facing error.
+    """
+    try:
+        raw = base64.urlsafe_b64decode(token.encode("ascii"))
+    except (binascii.Error, UnicodeEncodeError, ValueError) as exc:
+        raise InvalidCursorError("cursor is not valid base64") from exc
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InvalidCursorError("cursor payload is not valid JSON") from exc
+
+    if not isinstance(payload, dict):
+        raise InvalidCursorError("cursor payload is not a JSON object")
+
+    ts_raw = payload.get("ts")
+    id_raw = payload.get("id")
+    if not isinstance(ts_raw, str) or not isinstance(id_raw, str):
+        raise InvalidCursorError("cursor payload missing 'ts' or 'id' string")
+
+    try:
+        ts = datetime.fromisoformat(ts_raw)
+    except ValueError as exc:
+        raise InvalidCursorError("cursor 'ts' is not ISO-8601") from exc
+
+    try:
+        cursor_id = uuid.UUID(id_raw)
+    except ValueError as exc:
+        raise InvalidCursorError("cursor 'id' is not a UUID") from exc
+
+    return CursorPosition(ts=ts, id=cursor_id)

--- a/backend/src/meho_backplane/audit_query/query.py
+++ b/backend/src/meho_backplane/audit_query/query.py
@@ -24,9 +24,11 @@ Filter coverage
 ===============
 
 * Column-mapped filters are SQL-side: ``audit_id`` (exact), ``principal``
-  (``operator_sub ILIKE`` partial match), ``since`` / ``until`` (range on
-  ``occurred_at``), ``target`` (name match against ``targets`` in the same
-  tenant — alias resolution is the T2 router's job).
+  (``operator_sub ILIKE`` partial match — LIKE metacharacters escaped so
+  ``%`` / ``_`` in the operator-supplied value match literally),
+  ``since`` / ``until`` (range on ``occurred_at``), ``target`` (name match
+  against ``targets`` in the same tenant — alias resolution is the T2
+  router's job).
 * ``op_id`` (glob with ``*`` ↔ ``%``) and ``op_class`` (exact) match either
   the value stored in ``payload`` JSON (MCP-written rows carry ``op_id`` /
   ``op_class`` in ``payload`` per ``mcp/handlers.py:214-221``) **OR** the
@@ -74,27 +76,37 @@ class UnsupportedFilterError(ValueError):
 
 
 #: Escape character for LIKE patterns built from operator-controllable input.
-#: ``%`` / ``_`` in the raw ``op_id`` value are protected via this escape so
-#: only the explicit ``*`` glob translates to a wildcard.
+#: ``%`` / ``_`` in the raw value are protected via this escape so only the
+#: explicit ``*`` glob (in ``op_id``) translates to a wildcard, and substring
+#: matches (in ``principal``) treat their input verbatim.
 _LIKE_ESCAPE: str = "\\"
 
 
-def _build_op_id_like_pattern(raw: str) -> str:
-    """Escape SQL LIKE metacharacters in *raw*, then translate glob ``*`` to ``%``.
+def _escape_like_literal(raw: str) -> str:
+    """Escape SQL LIKE metacharacters in *raw* so it matches literally.
 
-    Order matters: escape the backslash first (so a literal ``\\`` in the
-    input doesn't double-escape later additions), then ``%`` / ``_`` (so
-    operator-controllable values can't smuggle SQL wildcards), then translate
-    the user-facing ``*`` glob into ``%``. The result is paired with
-    ``escape="\\"`` on the :meth:`like` call so the SQL ``ESCAPE`` clause
-    treats the backslash as a literal-marker on both PostgreSQL and SQLite.
+    Order matters: the backslash is escaped first so a literal ``\\`` in the
+    input doesn't double-escape later additions, then ``%`` and ``_`` (the
+    two SQL LIKE wildcards). Paired with ``escape="\\"`` on the
+    :meth:`like` / :meth:`ilike` call so the SQL ``ESCAPE`` clause treats the
+    backslash as a literal-marker on both PostgreSQL and SQLite.
     """
     return (
         raw.replace(_LIKE_ESCAPE, _LIKE_ESCAPE + _LIKE_ESCAPE)
         .replace("%", _LIKE_ESCAPE + "%")
         .replace("_", _LIKE_ESCAPE + "_")
-        .replace("*", "%")
     )
+
+
+def _build_op_id_like_pattern(raw: str) -> str:
+    """Escape SQL LIKE metacharacters in *raw*, then translate glob ``*`` to ``%``.
+
+    Builds on :func:`_escape_like_literal` and adds the consumer-facing glob
+    translation: a ``*`` in the input becomes a SQL ``%`` wildcard. Literal
+    ``%`` / ``_`` in the operator-supplied value are still matched verbatim
+    because the escape pass runs first.
+    """
+    return _escape_like_literal(raw).replace("*", "%")
 
 
 async def query_audit(
@@ -139,7 +151,10 @@ async def query_audit(
         stmt = stmt.where(AuditLog.id == filters.audit_id)
 
     if filters.principal is not None:
-        stmt = stmt.where(AuditLog.operator_sub.ilike(f"%{filters.principal}%"))
+        escaped = _escape_like_literal(filters.principal)
+        stmt = stmt.where(
+            AuditLog.operator_sub.ilike(f"%{escaped}%", escape=_LIKE_ESCAPE),
+        )
 
     if filters.since is not None:
         stmt = stmt.where(AuditLog.occurred_at >= filters.since)

--- a/backend/src/meho_backplane/audit_query/query.py
+++ b/backend/src/meho_backplane/audit_query/query.py
@@ -46,7 +46,6 @@ Filter coverage
 from __future__ import annotations
 
 import uuid
-from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -74,27 +73,47 @@ class UnsupportedFilterError(ValueError):
     """
 
 
-def query_audit(
-    filters: AuditQueryFilters,
-    *,
-    tenant_id: uuid.UUID,
-    session: AsyncSession,
-) -> Any:
-    """Tenant-scoped paginated query over ``audit_log``.
+#: Escape character for LIKE patterns built from operator-controllable input.
+#: ``%`` / ``_`` in the raw ``op_id`` value are protected via this escape so
+#: only the explicit ``*`` glob translates to a wildcard.
+_LIKE_ESCAPE: str = "\\"
 
-    Returns an awaitable resolving to :class:`AuditQueryResult`. The
-    function is declared as an async wrapper so callers can ``await`` it
-    directly; the wrapper body is :func:`_query_audit_impl`.
+
+def _build_op_id_like_pattern(raw: str) -> str:
+    """Escape SQL LIKE metacharacters in *raw*, then translate glob ``*`` to ``%``.
+
+    Order matters: escape the backslash first (so a literal ``\\`` in the
+    input doesn't double-escape later additions), then ``%`` / ``_`` (so
+    operator-controllable values can't smuggle SQL wildcards), then translate
+    the user-facing ``*`` glob into ``%``. The result is paired with
+    ``escape="\\"`` on the :meth:`like` call so the SQL ``ESCAPE`` clause
+    treats the backslash as a literal-marker on both PostgreSQL and SQLite.
     """
-    return _query_audit_impl(filters, tenant_id=tenant_id, session=session)
+    return (
+        raw.replace(_LIKE_ESCAPE, _LIKE_ESCAPE + _LIKE_ESCAPE)
+        .replace("%", _LIKE_ESCAPE + "%")
+        .replace("_", _LIKE_ESCAPE + "_")
+        .replace("*", "%")
+    )
 
 
-async def _query_audit_impl(
+async def query_audit(
     filters: AuditQueryFilters,
     *,
     tenant_id: uuid.UUID,
     session: AsyncSession,
 ) -> AuditQueryResult:
+    """Tenant-scoped paginated query over ``audit_log``.
+
+    ``tenant_id`` is a mandatory keyword-only argument — never sourced from
+    :class:`AuditQueryFilters` — so cross-tenant queries are impossible by
+    construction. The first SQL WHERE clause is always
+    ``audit_log.tenant_id = :tenant_id``; the LEFT JOIN to ``targets`` for
+    ``target_name`` denormalization is *also* scoped on ``Target.tenant_id``
+    so a cross-tenant ``target_id`` (allowed today because ``audit_log``
+    keeps no FK on the column per v0.2's soft-FK discipline) resolves to
+    ``target_name=None`` rather than leaking the other tenant's target name.
+    """
     if filters.parent_audit_id is not None:
         raise UnsupportedFilterError(
             "parent_audit_id filter not supported in v0.2 — column lands with G0.6-T7 (#398)",
@@ -106,7 +125,13 @@ async def _query_audit_impl(
 
     stmt = (
         sa.select(AuditLog, Target.name.label("target_name"))
-        .outerjoin(Target, AuditLog.target_id == Target.id)
+        .outerjoin(
+            Target,
+            sa.and_(
+                AuditLog.target_id == Target.id,
+                Target.tenant_id == tenant_id,
+            ),
+        )
         .where(AuditLog.tenant_id == tenant_id)
     )
 
@@ -131,15 +156,15 @@ async def _query_audit_impl(
         stmt = stmt.where(AuditLog.target_id.in_(target_ids_subq))
 
     if filters.op_id is not None:
-        like_pattern = filters.op_id.replace("*", "%")
+        like_pattern = _build_op_id_like_pattern(filters.op_id)
         payload_op_id = AuditLog.payload["op_id"].as_string()
         derived_op_id = (
             sa.literal("http.") + sa.func.lower(AuditLog.method) + sa.literal(":") + AuditLog.path
         )
         stmt = stmt.where(
             sa.or_(
-                payload_op_id.like(like_pattern),
-                derived_op_id.like(like_pattern),
+                payload_op_id.like(like_pattern, escape=_LIKE_ESCAPE),
+                derived_op_id.like(like_pattern, escape=_LIKE_ESCAPE),
             ),
         )
 

--- a/backend/src/meho_backplane/audit_query/query.py
+++ b/backend/src/meho_backplane/audit_query/query.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tenant-scoped query handler for the audit-query substrate.
+
+The handler is the substrate T2 (REST), T3 (CLI), T4 (MCP) dispatch through.
+``tenant_id`` is a mandatory positional argument — never on
+:class:`~meho_backplane.audit_query.schemas.AuditQueryFilters` — so cross-tenant
+queries are impossible by construction. The first SQL WHERE clause is always
+``audit_log.tenant_id = :tenant_id``.
+
+Ordering and pagination
+=======================
+
+Rows return in ``(occurred_at DESC, id DESC)`` order. The forward-only
+opaque cursor encodes the last returned row's ``(occurred_at, id)`` pair;
+the next page applies the lex-compare ``(occurred_at, id) < (cursor.ts,
+cursor.id)`` so the next row is strictly older than the cursor's row.
+``LIMIT N+1`` detects whether more rows exist; the (N+1)th row is dropped
+from the returned page and its ``(occurred_at, id)`` is encoded as
+``next_cursor``.
+
+Filter coverage
+===============
+
+* Column-mapped filters are SQL-side: ``audit_id`` (exact), ``principal``
+  (``operator_sub ILIKE`` partial match), ``since`` / ``until`` (range on
+  ``occurred_at``), ``target`` (name match against ``targets`` in the same
+  tenant — alias resolution is the T2 router's job).
+* ``op_id`` (glob with ``*`` ↔ ``%``) and ``op_class`` (exact) match either
+  the value stored in ``payload`` JSON (MCP-written rows carry ``op_id`` /
+  ``op_class`` in ``payload`` per ``mcp/handlers.py:214-221``) **OR** the
+  value derived for HTTP rows — ``f"http.{method.lower()}:{path}"`` for
+  ``op_id``. The OR-shaped predicate keeps the substrate honest across both
+  write paths.
+* ``result_status`` (one of ``"ok"`` / ``"error"`` / ``"denied"``) maps to
+  ``status_code`` ranges that mirror
+  :func:`~meho_backplane.audit._classify_http_status`.
+* ``parent_audit_id`` / ``agent_session_id`` raise
+  :class:`UnsupportedFilterError` — the columns do not exist in v0.2. The
+  ``AuditEntry`` shape exposes them as None so consumers can rely on the
+  field set; filtering on them waits for the schema additions tracked in
+  G0.6-T7 (#398) and beyond.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.broadcast.events import classify_op
+from meho_backplane.db.models import AuditLog, Target
+
+from .cursor import CursorPosition, decode_cursor, encode_cursor
+from .schemas import AuditEntry, AuditQueryFilters, AuditQueryResult
+
+__all__ = [
+    "UnsupportedFilterError",
+    "query_audit",
+]
+
+
+class UnsupportedFilterError(ValueError):
+    """Raised when a filter targets a field the v0.2 substrate cannot evaluate.
+
+    Distinct from a validation error: the field is on
+    :class:`AuditQueryFilters` (so router-side validation accepts it) but
+    the column it would filter against does not exist yet. The handler
+    surfaces this synchronously before issuing any SQL so the caller can
+    return a structured 400 / -32602 with the column name in the message.
+    """
+
+
+def query_audit(
+    filters: AuditQueryFilters,
+    *,
+    tenant_id: uuid.UUID,
+    session: AsyncSession,
+) -> Any:
+    """Tenant-scoped paginated query over ``audit_log``.
+
+    Returns an awaitable resolving to :class:`AuditQueryResult`. The
+    function is declared as an async wrapper so callers can ``await`` it
+    directly; the wrapper body is :func:`_query_audit_impl`.
+    """
+    return _query_audit_impl(filters, tenant_id=tenant_id, session=session)
+
+
+async def _query_audit_impl(
+    filters: AuditQueryFilters,
+    *,
+    tenant_id: uuid.UUID,
+    session: AsyncSession,
+) -> AuditQueryResult:
+    if filters.parent_audit_id is not None:
+        raise UnsupportedFilterError(
+            "parent_audit_id filter not supported in v0.2 — column lands with G0.6-T7 (#398)",
+        )
+    if filters.agent_session_id is not None:
+        raise UnsupportedFilterError(
+            "agent_session_id filter not supported in v0.2 — column not on any current roadmap",
+        )
+
+    stmt = (
+        sa.select(AuditLog, Target.name.label("target_name"))
+        .outerjoin(Target, AuditLog.target_id == Target.id)
+        .where(AuditLog.tenant_id == tenant_id)
+    )
+
+    if filters.audit_id is not None:
+        stmt = stmt.where(AuditLog.id == filters.audit_id)
+
+    if filters.principal is not None:
+        stmt = stmt.where(AuditLog.operator_sub.ilike(f"%{filters.principal}%"))
+
+    if filters.since is not None:
+        stmt = stmt.where(AuditLog.occurred_at >= filters.since)
+
+    if filters.until is not None:
+        stmt = stmt.where(AuditLog.occurred_at <= filters.until)
+
+    if filters.target is not None:
+        target_ids_subq = (
+            sa.select(Target.id)
+            .where(Target.tenant_id == tenant_id, Target.name == filters.target)
+            .scalar_subquery()
+        )
+        stmt = stmt.where(AuditLog.target_id.in_(target_ids_subq))
+
+    if filters.op_id is not None:
+        like_pattern = filters.op_id.replace("*", "%")
+        payload_op_id = AuditLog.payload["op_id"].as_string()
+        derived_op_id = (
+            sa.literal("http.") + sa.func.lower(AuditLog.method) + sa.literal(":") + AuditLog.path
+        )
+        stmt = stmt.where(
+            sa.or_(
+                payload_op_id.like(like_pattern),
+                derived_op_id.like(like_pattern),
+            ),
+        )
+
+    if filters.op_class is not None:
+        payload_op_class = AuditLog.payload["op_class"].as_string()
+        stmt = stmt.where(payload_op_class == filters.op_class)
+
+    if filters.result_status is not None:
+        stmt = stmt.where(_result_status_predicate(filters.result_status))
+
+    if filters.cursor is not None:
+        pos = decode_cursor(filters.cursor)
+        stmt = stmt.where(
+            sa.or_(
+                AuditLog.occurred_at < pos.ts,
+                sa.and_(AuditLog.occurred_at == pos.ts, AuditLog.id < pos.id),
+            ),
+        )
+
+    stmt = stmt.order_by(AuditLog.occurred_at.desc(), AuditLog.id.desc()).limit(
+        filters.limit + 1,
+    )
+
+    result = await session.execute(stmt)
+    raw_rows = list(result.all())
+    has_more = len(raw_rows) > filters.limit
+    page = raw_rows[: filters.limit]
+
+    entries = [_build_audit_entry(row.AuditLog, row.target_name) for row in page]
+
+    next_cursor: str | None = None
+    if has_more and entries:
+        last = entries[-1]
+        next_cursor = encode_cursor(CursorPosition(ts=last.ts, id=last.id))
+
+    return AuditQueryResult(rows=entries, next_cursor=next_cursor)
+
+
+def _result_status_predicate(result_status: str) -> sa.ColumnElement[bool]:
+    """Translate the broadcast-shape result_status to a status_code predicate.
+
+    Mirrors :func:`~meho_backplane.audit._classify_http_status` without the
+    handler-exception arm (audit rows are post-fact; the exception bit is
+    not stored). Unknown values resolve to ``FALSE`` — never an error,
+    just an empty result, so a typo in the router surfaces as "no rows"
+    rather than a 500.
+    """
+    if result_status == "ok":
+        return AuditLog.status_code < 400
+    if result_status == "denied":
+        return AuditLog.status_code.in_([401, 403])
+    if result_status == "error":
+        return sa.and_(
+            AuditLog.status_code >= 400,
+            AuditLog.status_code.notin_([401, 403]),
+        )
+    return sa.false()
+
+
+def _build_audit_entry(row: AuditLog, target_name: str | None) -> AuditEntry:
+    """Construct an :class:`AuditEntry` from one audit-log row + denormalized name.
+
+    Computes the three derived fields — ``op_id``, ``op_class``,
+    ``result_status`` — exactly as the broadcast middleware would on the
+    publish side, so a row returned by the audit-query API and a
+    BroadcastEvent observed on the SSE feed for the same ``audit_id``
+    agree on the trio.
+    """
+    payload = dict(row.payload) if row.payload else {}
+
+    op_id_raw = payload.get("op_id")
+    op_id = (
+        op_id_raw
+        if isinstance(op_id_raw, str) and op_id_raw
+        else f"http.{row.method.lower()}:{row.path}"
+    )
+
+    op_class_raw = payload.get("op_class")
+    op_class = (
+        op_class_raw if isinstance(op_class_raw, str) and op_class_raw else classify_op(op_id)
+    )
+
+    return AuditEntry(
+        id=row.id,
+        ts=row.occurred_at,
+        tenant_id=row.tenant_id,
+        principal_sub=row.operator_sub,
+        principal_name=None,
+        target_id=row.target_id,
+        target_name=target_name,
+        method=row.method,
+        path=row.path,
+        status_code=row.status_code,
+        request_id=row.request_id,
+        duration_ms=row.duration_ms,
+        payload=payload,
+        op_id=op_id,
+        op_class=op_class,
+        result_status=_derive_result_status(row.status_code),
+        parent_audit_id=None,
+        agent_session_id=None,
+        broadcast_event_id=None,
+    )
+
+
+def _derive_result_status(status_code: int) -> str:
+    """Same trichotomy as :func:`~meho_backplane.audit._classify_http_status`.
+
+    Audit rows do not carry the handler-exception bit, so the post-fact
+    derivation collapses to: 401/403 → denied, other 4xx/5xx → error,
+    everything else → ok.
+    """
+    if status_code in (401, 403):
+        return "denied"
+    if status_code >= 400:
+        return "error"
+    return "ok"

--- a/backend/src/meho_backplane/audit_query/schemas.py
+++ b/backend/src/meho_backplane/audit_query/schemas.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic schemas for the audit-query substrate.
+
+Three consumer-facing models — :class:`AuditQueryFilters` (input),
+:class:`AuditEntry` (one row), :class:`AuditQueryResult` (page of rows +
+next-cursor). All frozen via ``ConfigDict(frozen=True)`` so a row handed to a
+caller cannot mutate after construction.
+
+Substrate-vs-issue-body reconciliation
+======================================
+
+The G8.1 Initiative (#334) and Task body (#465) advertise a richer
+:class:`AuditEntry` shape than the ``audit_log`` table actually carries today.
+The substrate ships the consumer-facing shape so T2 (REST) / T3 (CLI) / T4
+(MCP) dispatch through a stable surface, but several fields are not yet
+backed by real columns and are populated as :data:`None` until follow-up
+tasks land the schema additions:
+
+* ``principal_name`` — the chassis HTTP audit middleware
+  (``meho_backplane.audit``) and the MCP audit writer
+  (``meho_backplane.mcp.audit``) do not capture the operator's ``name`` JWT
+  claim at write time. The :class:`~meho_backplane.broadcast.events.BroadcastEvent`
+  side has a nullable ``principal_name`` field, but it is populated only on
+  the MCP path (``mcp/handlers.py``), and the audit row itself never carries
+  it. Always None in v0.2; a future small task on the write path closes this.
+* ``parent_audit_id`` — composite-operation lineage column landed by
+  G0.6-T7 (#398, OPEN). Until that task ships the column + populates it
+  from the dispatcher's recursion, this field stays None and the filter
+  on ``parent_audit_id`` raises :class:`UnsupportedFilterError`.
+* ``agent_session_id`` — referenced in the Task body but absent from any
+  current or planned schema work. Always None until a Goal proposes the
+  column. Filter raises :class:`UnsupportedFilterError`.
+* ``broadcast_event_id`` — the FK direction is the reverse of what the
+  Task body implies: :class:`BroadcastEvent.audit_id` points at the audit
+  row, not vice versa. Always None.
+
+The three computed fields — ``op_id``, ``op_class``, ``result_status`` — are
+derived at query time using the same logic the broadcast middleware uses on
+the publish side (``meho_backplane.audit._publish_broadcast_event``,
+``meho_backplane.broadcast.events.classify_op``,
+``meho_backplane.audit._classify_http_status``). MCP-written rows carry
+``op_id`` / ``op_class`` inside the ``payload`` JSON dict (see
+``mcp/handlers.py:214-221``); HTTP-written rows derive them from
+``f"http.{method.lower()}:{path}"``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "AuditEntry",
+    "AuditQueryFilters",
+    "AuditQueryResult",
+]
+
+
+class AuditQueryFilters(BaseModel):
+    """Filters for the ``query_audit`` handler.
+
+    ``tenant_id`` is **not** on this model — it is a separate mandatory
+    argument to :func:`~meho_backplane.audit_query.query.query_audit` so it
+    can never be supplied by an operator-controllable input. The handler
+    injects it from the validated JWT.
+
+    Glob semantics: ``op_id`` accepts shell-style ``*`` wildcards
+    (``"vsphere.vm.*"``), which the query handler translates to SQL ``LIKE``
+    with ``%`` substitution. ``?`` and bracket expressions are not supported
+    in v0.2 — the consumer use case is prefix matching, not arbitrary glob.
+
+    Duration shorthand (``"24h"`` / ``"7d"``) is **not** parsed here — that
+    belongs in the T2 / T3 router layer. T1 accepts absolute :class:`datetime`
+    values only; the router parses the shorthand into an absolute timestamp
+    before constructing the filter object.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    target: str | None = None
+    principal: str | None = None
+    op_id: str | None = None
+    op_class: str | None = None
+    result_status: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    audit_id: uuid.UUID | None = None
+    parent_audit_id: uuid.UUID | None = None
+    agent_session_id: uuid.UUID | None = None
+    limit: int = Field(default=100, ge=1, le=1000)
+    cursor: str | None = None
+
+
+class AuditEntry(BaseModel):
+    """One row of the audit query result.
+
+    Field-to-column mapping (see module docstring for the substrate
+    reconciliation):
+
+    * ``id`` ← ``audit_log.id``
+    * ``ts`` ← ``audit_log.occurred_at``
+    * ``tenant_id`` ← ``audit_log.tenant_id``
+    * ``principal_sub`` ← ``audit_log.operator_sub``
+    * ``target_id`` ← ``audit_log.target_id``
+    * ``target_name`` ← LEFT JOIN ``targets.name`` ON ``audit_log.target_id``
+    * ``method`` / ``path`` / ``status_code`` / ``request_id`` / ``duration_ms``
+      / ``payload`` ← columns of the same name
+    * ``op_id`` / ``op_class`` / ``result_status`` — computed at query time
+    * ``principal_name`` / ``parent_audit_id`` / ``agent_session_id`` /
+      ``broadcast_event_id`` — v0.2 placeholders, always None
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: uuid.UUID
+    ts: datetime
+    tenant_id: uuid.UUID | None
+    principal_sub: str
+    principal_name: str | None
+    target_id: uuid.UUID | None
+    target_name: str | None
+    method: str
+    path: str
+    status_code: int
+    request_id: uuid.UUID | None
+    duration_ms: Decimal | None
+    payload: dict[str, Any]
+    op_id: str
+    op_class: str
+    result_status: str
+    parent_audit_id: uuid.UUID | None
+    agent_session_id: uuid.UUID | None
+    broadcast_event_id: uuid.UUID | None
+
+
+class AuditQueryResult(BaseModel):
+    """Page of audit rows plus the forward-only continuation cursor.
+
+    ``next_cursor`` is :data:`None` when fewer than ``limit`` rows were
+    available (the query reached the end of the matching set). Consumers
+    iterate by re-issuing the same filter with ``cursor = next_cursor``
+    until ``next_cursor`` is None.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    rows: list[AuditEntry]
+    next_cursor: str | None

--- a/backend/tests/test_audit_query_cursor.py
+++ b/backend/tests/test_audit_query_cursor.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the opaque forward-only cursor (G8.1-T1).
+
+Covers:
+
+* Encode/decode round-trip preserves the ``(ts, id)`` pair exactly.
+* URL-safe base64 — no ``+`` / ``/`` characters in the encoded token, so it
+  survives unencoded as a query-string value.
+* Tamper rejection: malformed base64, malformed JSON, missing fields, bad
+  ISO-8601, bad UUID — each raises :class:`InvalidCursorError` with the
+  underlying exception preserved as ``__cause__``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from meho_backplane.audit_query import (
+    CursorPosition,
+    InvalidCursorError,
+    decode_cursor,
+    encode_cursor,
+)
+
+
+def test_cursor_round_trip_preserves_ts_and_id() -> None:
+    """Encode → decode produces the same ``(ts, id)`` pair byte-for-byte."""
+    pos = CursorPosition(ts=datetime(2026, 5, 14, 12, 34, 56, tzinfo=UTC), id=uuid.uuid4())
+    decoded = decode_cursor(encode_cursor(pos))
+
+    assert decoded.ts == pos.ts
+    assert decoded.id == pos.id
+
+
+def test_cursor_encoded_is_urlsafe() -> None:
+    """The wire format avoids ``+`` / ``/`` so the token is query-string-safe."""
+    pos = CursorPosition(ts=datetime.now(UTC), id=uuid.uuid4())
+    token = encode_cursor(pos)
+
+    assert "+" not in token
+    assert "/" not in token
+
+
+def test_cursor_distinct_positions_encode_distinctly() -> None:
+    """Different ``(ts, id)`` pairs produce different tokens."""
+    now = datetime.now(UTC)
+    pos_a = CursorPosition(ts=now, id=uuid.uuid4())
+    pos_b = CursorPosition(ts=now + timedelta(seconds=1), id=pos_a.id)
+
+    assert encode_cursor(pos_a) != encode_cursor(pos_b)
+
+
+def test_cursor_rejects_invalid_base64() -> None:
+    """Random non-base64 bytes raise :class:`InvalidCursorError`."""
+    with pytest.raises(InvalidCursorError):
+        decode_cursor("not%%base64$$")
+
+
+def test_cursor_rejects_valid_base64_but_invalid_json() -> None:
+    """Base64 that decodes to non-JSON raises :class:`InvalidCursorError`."""
+    token = base64.urlsafe_b64encode(b"this is not json").decode("ascii")
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(token)
+
+
+def test_cursor_rejects_json_array_payload() -> None:
+    """JSON that decodes to a non-object raises :class:`InvalidCursorError`."""
+    token = base64.urlsafe_b64encode(json.dumps(["array", "not", "object"]).encode()).decode(
+        "ascii",
+    )
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(token)
+
+
+def test_cursor_rejects_missing_ts() -> None:
+    """Payload without ``ts`` raises :class:`InvalidCursorError`."""
+    token = base64.urlsafe_b64encode(json.dumps({"id": str(uuid.uuid4())}).encode()).decode(
+        "ascii",
+    )
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(token)
+
+
+def test_cursor_rejects_missing_id() -> None:
+    """Payload without ``id`` raises :class:`InvalidCursorError`."""
+    token = base64.urlsafe_b64encode(
+        json.dumps({"ts": datetime.now(UTC).isoformat()}).encode(),
+    ).decode("ascii")
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(token)
+
+
+def test_cursor_rejects_malformed_ts() -> None:
+    """``ts`` that does not parse as ISO-8601 raises :class:`InvalidCursorError`."""
+    token = base64.urlsafe_b64encode(
+        json.dumps({"ts": "yesterday", "id": str(uuid.uuid4())}).encode(),
+    ).decode("ascii")
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(token)
+
+
+def test_cursor_rejects_malformed_uuid() -> None:
+    """``id`` that does not parse as UUID raises :class:`InvalidCursorError`."""
+    token = base64.urlsafe_b64encode(
+        json.dumps({"ts": datetime.now(UTC).isoformat(), "id": "not-a-uuid"}).encode(),
+    ).decode("ascii")
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(token)
+
+
+def test_cursor_invalid_error_preserves_cause() -> None:
+    """The original decode exception is available as ``__cause__``."""
+    try:
+        decode_cursor("%%%")
+    except InvalidCursorError as exc:
+        assert exc.__cause__ is not None
+    else:  # pragma: no cover - test must raise above
+        pytest.fail("expected InvalidCursorError")

--- a/backend/tests/test_audit_query_cursor.py
+++ b/backend/tests/test_audit_query_cursor.py
@@ -63,6 +63,21 @@ def test_cursor_rejects_invalid_base64() -> None:
         decode_cursor("not%%base64$$")
 
 
+def test_cursor_strict_base64_rejects_trailing_garbage() -> None:
+    """A valid base64 prefix followed by non-base64 garbage is rejected.
+
+    Python's lenient ``base64.urlsafe_b64decode`` silently discards
+    non-base64 bytes — e.g. ``aGVsbG8=!`` decodes to ``b"hello"`` without
+    raising — which the docstring's "any tampering ... InvalidCursorError"
+    contract forbids. The strict-validate decoder catches this.
+    """
+    # Valid b64 (``aGVsbG8=`` = "hello") + trailing ``!`` which is not in the
+    # urlsafe-base64 alphabet. The lax decoder accepts and returns b"hello";
+    # strict validation rejects.
+    with pytest.raises(InvalidCursorError):
+        decode_cursor("aGVsbG8=!")
+
+
 def test_cursor_rejects_valid_base64_but_invalid_json() -> None:
     """Base64 that decodes to non-JSON raises :class:`InvalidCursorError`."""
     token = base64.urlsafe_b64encode(b"this is not json").decode("ascii")

--- a/backend/tests/test_audit_query_handler.py
+++ b/backend/tests/test_audit_query_handler.py
@@ -1,0 +1,717 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end tests for the audit-query handler (G8.1-T1).
+
+The tests run against ``sqlite+aiosqlite`` via the autouse
+``_default_database_url`` fixture in :mod:`tests.conftest`, which migrates a
+fresh per-test DB to head before each test. Rows are seeded directly via
+``get_sessionmaker()`` — the chassis :class:`~meho_backplane.audit.AuditMiddleware`
+is not exercised here because T1's contract is the **read** substrate; the
+write paths are covered by ``tests/test_audit_middleware.py``.
+
+Coverage matrix (G8.1-T1 acceptance criteria):
+
+* AC3 — Tenant-scoping baked in: seed audit rows on two tenants; query one;
+  cross-tenant rows never returned.
+* AC4 — Every filter combination narrows results correctly.
+* AC5 — Cursor pagination forward-only: 250 rows / ``limit=100`` produces 3
+  pages, last page ``next_cursor=None``.
+* AC6 — ``op_id="vsphere.vm.*"`` glob matches MCP payload rows correctly.
+* AC8 — ``parent_audit_id`` filter raises :class:`UnsupportedFilterError`.
+* :class:`InvalidCursorError` propagates when a tampered cursor is passed.
+* ``target_name`` denormalization via LEFT JOIN works (and is None when the
+  audit row has no ``target_id``).
+* ``result_status`` derivation mirrors the broadcast classifier trichotomy.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.audit_query import (
+    AuditQueryFilters,
+    InvalidCursorError,
+    UnsupportedFilterError,
+    decode_cursor,
+    query_audit,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Target
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Keycloak + Vault env vars :class:`Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """One :class:`AsyncSession` per test, scoped to a single ``async with``."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_audit_row(
+    s: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    occurred_at: datetime,
+    operator_sub: str = "operator-1",
+    method: str = "GET",
+    path: str = "/api/v1/healthz",
+    status_code: int = 200,
+    target_id: uuid.UUID | None = None,
+    payload: dict[str, object] | None = None,
+) -> uuid.UUID:
+    """Insert one :class:`AuditLog` row and return its ``id``."""
+    row_id = uuid.uuid4()
+    s.add(
+        AuditLog(
+            id=row_id,
+            occurred_at=occurred_at,
+            operator_sub=operator_sub,
+            tenant_id=tenant_id,
+            method=method,
+            path=path,
+            status_code=status_code,
+            duration_ms=Decimal("1.0"),
+            payload=payload or {},
+            target_id=target_id,
+        ),
+    )
+    return row_id
+
+
+async def _seed_target(s: AsyncSession, *, tenant_id: uuid.UUID, name: str) -> uuid.UUID:
+    """Insert one :class:`Target` row and return its ``id``."""
+    target_id = uuid.uuid4()
+    s.add(
+        Target(
+            id=target_id,
+            tenant_id=tenant_id,
+            name=name,
+            aliases=[],
+            product="vsphere",
+            host=f"{name}.example.com",
+            auth_model="shared_service_account",
+            extras={},
+        ),
+    )
+    return target_id
+
+
+# ---------------------------------------------------------------------------
+# Tenant scoping (AC3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_scoping_isolates_rows(session: AsyncSession) -> None:
+    """Seed two tenants, query one — only its rows are returned."""
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    base = datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC)
+    for i in range(5):
+        await _seed_audit_row(
+            session,
+            tenant_id=tenant_a,
+            occurred_at=base + timedelta(seconds=i),
+            operator_sub="alice",
+        )
+        await _seed_audit_row(
+            session,
+            tenant_id=tenant_b,
+            occurred_at=base + timedelta(seconds=i),
+            operator_sub="bob",
+        )
+    await session.commit()
+
+    result = await query_audit(AuditQueryFilters(), tenant_id=tenant_a, session=session)
+
+    assert len(result.rows) == 5
+    assert all(entry.tenant_id == tenant_a for entry in result.rows)
+    assert all(entry.principal_sub == "alice" for entry in result.rows)
+
+
+@pytest.mark.asyncio
+async def test_tenant_scoping_ignores_tenant_id_on_filter_object(
+    session: AsyncSession,
+) -> None:
+    """The handler's ``tenant_id`` argument is the only authority.
+
+    Constructing :class:`AuditQueryFilters` cannot smuggle a tenant id
+    through because the model does not carry one.
+    """
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    await _seed_audit_row(session, tenant_id=tenant_b, occurred_at=datetime.now(UTC))
+    await session.commit()
+
+    result = await query_audit(AuditQueryFilters(), tenant_id=tenant_a, session=session)
+    assert result.rows == []
+
+
+# ---------------------------------------------------------------------------
+# Cursor pagination (AC5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cursor_pagination_walks_250_rows_in_3_pages(
+    session: AsyncSession,
+) -> None:
+    """250 rows / ``limit=100`` → 3 pages, terminal page ``next_cursor=None``."""
+    tenant_id = uuid.uuid4()
+    base = datetime(2026, 5, 14, 0, 0, 0, tzinfo=UTC)
+    seeded: list[uuid.UUID] = []
+    for i in range(250):
+        seeded.append(
+            await _seed_audit_row(
+                session,
+                tenant_id=tenant_id,
+                occurred_at=base + timedelta(seconds=i),
+            ),
+        )
+    await session.commit()
+
+    all_ids: list[uuid.UUID] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        pages += 1
+        result = await query_audit(
+            AuditQueryFilters(limit=100, cursor=cursor),
+            tenant_id=tenant_id,
+            session=session,
+        )
+        all_ids.extend(entry.id for entry in result.rows)
+        if result.next_cursor is None:
+            break
+        cursor = result.next_cursor
+
+    assert pages == 3
+    assert len(all_ids) == 250
+    # Every seeded id appears exactly once
+    assert set(all_ids) == set(seeded)
+
+
+@pytest.mark.asyncio
+async def test_cursor_pagination_terminal_page_when_under_limit(
+    session: AsyncSession,
+) -> None:
+    """Fewer rows than ``limit`` → ``next_cursor`` is None immediately."""
+    tenant_id = uuid.uuid4()
+    for i in range(5):
+        await _seed_audit_row(
+            session,
+            tenant_id=tenant_id,
+            occurred_at=datetime(2026, 5, 14, 0, 0, i, tzinfo=UTC),
+        )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(limit=100),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert len(result.rows) == 5
+    assert result.next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_cursor_invalid_token_raises(session: AsyncSession) -> None:
+    """A tampered cursor raises :class:`InvalidCursorError` from the handler."""
+    tenant_id = uuid.uuid4()
+    with pytest.raises(InvalidCursorError):
+        await query_audit(
+            AuditQueryFilters(cursor="not%%base64$$"),
+            tenant_id=tenant_id,
+            session=session,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cursor_next_cursor_decodes_to_last_row(session: AsyncSession) -> None:
+    """``next_cursor`` round-trips to the page's last ``(ts, id)`` pair."""
+    tenant_id = uuid.uuid4()
+    base = datetime(2026, 5, 14, 0, 0, 0, tzinfo=UTC)
+    for i in range(5):
+        await _seed_audit_row(
+            session,
+            tenant_id=tenant_id,
+            occurred_at=base + timedelta(seconds=i),
+        )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(limit=3),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert result.next_cursor is not None
+    last = result.rows[-1]
+    pos = decode_cursor(result.next_cursor)
+    # SQLite strips tzinfo on read-back; compare the naive form on both sides.
+    assert pos.ts.replace(tzinfo=None) == last.ts.replace(tzinfo=None)
+    assert pos.id == last.id
+
+
+# ---------------------------------------------------------------------------
+# op_id glob filter (AC6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_op_id_glob_matches_payload_prefix(session: AsyncSession) -> None:
+    """``op_id="vsphere.vm.*"`` matches MCP rows whose payload op_id has the prefix."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        path="/mcp",
+        payload={"op_id": "vsphere.vm.list", "op_class": "read"},
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        path="/mcp",
+        payload={"op_id": "vsphere.vm.get", "op_class": "read"},
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 3, tzinfo=UTC),
+        path="/mcp",
+        payload={"op_id": "vsphere.host.list", "op_class": "read"},
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(op_id="vsphere.vm.*"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    op_ids = sorted(entry.op_id for entry in result.rows)
+    assert op_ids == ["vsphere.vm.get", "vsphere.vm.list"]
+
+
+@pytest.mark.asyncio
+async def test_op_id_glob_matches_http_derived_op_id(session: AsyncSession) -> None:
+    """``op_id="http.get:*"`` matches HTTP rows whose op_id is derived from method+path."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        method="GET",
+        path="/api/v1/connectors",
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        method="POST",
+        path="/api/v1/connectors",
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(op_id="http.get:*"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert len(result.rows) == 1
+    assert result.rows[0].method == "GET"
+
+
+@pytest.mark.asyncio
+async def test_op_class_filter_against_payload(session: AsyncSession) -> None:
+    """``op_class="write"`` matches MCP rows whose payload carries the value."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        path="/mcp",
+        payload={"op_class": "write"},
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        path="/mcp",
+        payload={"op_class": "read"},
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(op_class="write"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert len(result.rows) == 1
+    assert result.rows[0].op_class == "write"
+
+
+# ---------------------------------------------------------------------------
+# Unsupported filters (AC8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parent_audit_id_filter_raises_unsupported(
+    session: AsyncSession,
+) -> None:
+    """``parent_audit_id`` filter raises until the column lands (G0.6-T7 #398)."""
+    with pytest.raises(UnsupportedFilterError):
+        await query_audit(
+            AuditQueryFilters(parent_audit_id=uuid.uuid4()),
+            tenant_id=uuid.uuid4(),
+            session=session,
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_session_id_filter_raises_unsupported(
+    session: AsyncSession,
+) -> None:
+    """``agent_session_id`` filter raises — no column on any current roadmap."""
+    with pytest.raises(UnsupportedFilterError):
+        await query_audit(
+            AuditQueryFilters(agent_session_id=uuid.uuid4()),
+            tenant_id=uuid.uuid4(),
+            session=session,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Column-mapped filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_id_exact_lookup(session: AsyncSession) -> None:
+    """``audit_id`` returns the single matching row."""
+    tenant_id = uuid.uuid4()
+    target_audit_id = await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(audit_id=target_audit_id),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert len(result.rows) == 1
+    assert result.rows[0].id == target_audit_id
+
+
+@pytest.mark.asyncio
+async def test_principal_partial_match(session: AsyncSession) -> None:
+    """``principal="ali"`` matches ``alice`` but not ``bob``."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        operator_sub="alice",
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        operator_sub="bob",
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(principal="ali"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert len(result.rows) == 1
+    assert result.rows[0].principal_sub == "alice"
+
+
+@pytest.mark.asyncio
+async def test_since_until_range(session: AsyncSession) -> None:
+    """``since`` and ``until`` bracket the ``occurred_at`` range."""
+    tenant_id = uuid.uuid4()
+    base = datetime(2026, 5, 14, 0, 0, 0, tzinfo=UTC)
+    for i in range(10):
+        await _seed_audit_row(
+            session,
+            tenant_id=tenant_id,
+            occurred_at=base + timedelta(seconds=i),
+        )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(since=base + timedelta(seconds=3), until=base + timedelta(seconds=7)),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert len(result.rows) == 5  # seconds 3, 4, 5, 6, 7
+
+
+@pytest.mark.asyncio
+async def test_target_filter_resolves_by_name(session: AsyncSession) -> None:
+    """``target="rdc-vcenter"`` resolves through the targets table by name."""
+    tenant_id = uuid.uuid4()
+    target_id = await _seed_target(session, tenant_id=tenant_id, name="rdc-vcenter")
+    other_target_id = await _seed_target(session, tenant_id=tenant_id, name="rdc-vault")
+    await session.commit()
+
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        target_id=target_id,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        target_id=other_target_id,
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(target="rdc-vcenter"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert len(result.rows) == 1
+    assert result.rows[0].target_id == target_id
+    assert result.rows[0].target_name == "rdc-vcenter"
+
+
+@pytest.mark.asyncio
+async def test_target_name_denormalization_left_join(session: AsyncSession) -> None:
+    """The LEFT JOIN populates ``target_name`` when present, None otherwise."""
+    tenant_id = uuid.uuid4()
+    target_id = await _seed_target(session, tenant_id=tenant_id, name="rdc-vcenter")
+    await session.commit()
+
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        target_id=target_id,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        target_id=None,
+    )
+    await session.commit()
+
+    result = await query_audit(AuditQueryFilters(), tenant_id=tenant_id, session=session)
+
+    by_target = {entry.target_id: entry.target_name for entry in result.rows}
+    assert by_target[target_id] == "rdc-vcenter"
+    assert by_target[None] is None
+
+
+# ---------------------------------------------------------------------------
+# result_status derivation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_status_filter_ok(session: AsyncSession) -> None:
+    """``result_status="ok"`` matches 2xx/3xx, excludes 4xx/5xx."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        status_code=200,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        status_code=403,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 3, tzinfo=UTC),
+        status_code=500,
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(result_status="ok"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert len(result.rows) == 1
+    assert result.rows[0].status_code == 200
+    assert result.rows[0].result_status == "ok"
+
+
+@pytest.mark.asyncio
+async def test_result_status_filter_denied(session: AsyncSession) -> None:
+    """``result_status="denied"`` matches 401 + 403 exactly."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        status_code=401,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        status_code=403,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 3, tzinfo=UTC),
+        status_code=500,
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(result_status="denied"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert sorted(entry.status_code for entry in result.rows) == [401, 403]
+
+
+@pytest.mark.asyncio
+async def test_result_status_filter_error(session: AsyncSession) -> None:
+    """``result_status="error"`` matches 4xx/5xx except 401/403."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        status_code=400,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        status_code=403,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 3, tzinfo=UTC),
+        status_code=500,
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(result_status="error"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert sorted(entry.status_code for entry in result.rows) == [400, 500]
+
+
+# ---------------------------------------------------------------------------
+# Computed fields populate correctly in AuditEntry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_computed_op_id_for_http_row(session: AsyncSession) -> None:
+    """HTTP rows without payload op_id derive ``http.<method>:<path>``."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        method="POST",
+        path="/api/v1/connectors/vsphere/vm.list",
+    )
+    await session.commit()
+
+    result = await query_audit(AuditQueryFilters(), tenant_id=tenant_id, session=session)
+    assert result.rows[0].op_id == "http.post:/api/v1/connectors/vsphere/vm.list"
+
+
+@pytest.mark.asyncio
+async def test_computed_op_class_classifies_audit_query(session: AsyncSession) -> None:
+    """A row whose computed op_id starts with ``audit.`` classifies as ``audit_query``."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        path="/mcp",
+        payload={"op_id": "audit.query"},
+    )
+    await session.commit()
+
+    result = await query_audit(AuditQueryFilters(), tenant_id=tenant_id, session=session)
+    assert result.rows[0].op_class == "audit_query"
+
+
+@pytest.mark.asyncio
+async def test_placeholders_always_none(session: AsyncSession) -> None:
+    """The four v0.2 placeholder fields are always None on the returned entry."""
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+    )
+    await session.commit()
+
+    result = await query_audit(AuditQueryFilters(), tenant_id=tenant_id, session=session)
+    entry = result.rows[0]
+    assert entry.principal_name is None
+    assert entry.parent_audit_id is None
+    assert entry.agent_session_id is None
+    assert entry.broadcast_event_id is None

--- a/backend/tests/test_audit_query_handler.py
+++ b/backend/tests/test_audit_query_handler.py
@@ -171,6 +171,51 @@ async def test_tenant_scoping_ignores_tenant_id_on_filter_object(
     assert result.rows == []
 
 
+@pytest.mark.asyncio
+async def test_tenant_scoping_target_name_does_not_leak_cross_tenant(
+    session: AsyncSession,
+) -> None:
+    """Cross-tenant ``target_id`` resolves to ``target_name=None``, not the
+    other tenant's name.
+
+    ``audit_log.target_id`` is a soft column (no FK in v0.2 per the chassis
+    discipline), so a write-path bug could in principle persist a target_id
+    that belongs to a different tenant. The read substrate must scope the
+    LEFT JOIN by ``Target.tenant_id`` so the denormalized ``target_name``
+    never surfaces another tenant's data — even if the rest of the audit row
+    is correctly tenant-scoped, leaking the target name alone is a
+    tenant-isolation violation.
+    """
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    cross_target_id = await _seed_target(session, tenant_id=tenant_b, name="tenant-b-secret")
+    own_target_id = await _seed_target(session, tenant_id=tenant_a, name="tenant-a-public")
+    await session.commit()
+
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_a,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        target_id=cross_target_id,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_a,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        target_id=own_target_id,
+    )
+    await session.commit()
+
+    result = await query_audit(AuditQueryFilters(), tenant_id=tenant_a, session=session)
+    by_target = {entry.target_id: entry.target_name for entry in result.rows}
+
+    # Cross-tenant target_id surfaces with target_name=None — the JOIN's
+    # tenant scope filtered out tenant B's target row.
+    assert by_target[cross_target_id] is None
+    # Same-tenant target_id resolves normally.
+    assert by_target[own_target_id] == "tenant-a-public"
+
+
 # ---------------------------------------------------------------------------
 # Cursor pagination (AC5)
 # ---------------------------------------------------------------------------
@@ -348,6 +393,44 @@ async def test_op_id_glob_matches_http_derived_op_id(session: AsyncSession) -> N
 
     assert len(result.rows) == 1
     assert result.rows[0].method == "GET"
+
+
+@pytest.mark.asyncio
+async def test_op_id_glob_escapes_sql_wildcards(session: AsyncSession) -> None:
+    """A literal ``%`` in ``op_id`` is escaped, not interpreted as SQL wildcard.
+
+    Without escaping the LIKE metacharacters in operator-controllable input,
+    a filter like ``op_id="foo%bar"`` would match every op_id starting with
+    ``foo`` and ending in ``bar`` (the embedded ``%`` would act as the SQL
+    wildcard) rather than the exact literal substring. ``_`` has the same
+    risk — it matches any single character in LIKE.
+    """
+    tenant_id = uuid.uuid4()
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        path="/mcp",
+        payload={"op_id": "foo%bar"},
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        path="/mcp",
+        payload={"op_id": "fooXXXbar"},
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(op_id="foo%bar"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    # Only the literal-percent row matches; the wildcard-expansion candidate
+    # is excluded because ``%`` in the filter was escaped to a literal.
+    assert {entry.op_id for entry in result.rows} == {"foo%bar"}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audit_query_handler.py
+++ b/backend/tests/test_audit_query_handler.py
@@ -554,6 +554,43 @@ async def test_principal_partial_match(session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+async def test_principal_escapes_sql_wildcards(session: AsyncSession) -> None:
+    """Literal ``_`` / ``%`` in ``principal`` matches the character, not a wildcard.
+
+    Mirror of ``test_op_id_glob_escapes_sql_wildcards`` for the ``principal``
+    filter. Without escaping the LIKE metacharacters, a filter value like
+    ``"user_test"`` would also match ``"userXtest"`` (``_`` acting as the
+    SQL single-character wildcard) — a real concern for deployments that
+    use username-style JWT subs rather than UUIDs.
+    """
+    tenant_id = uuid.uuid4()
+    for operator_sub in ("user_test", "userXtest", "alice%bob", "aliceXbob"):
+        await _seed_audit_row(
+            session,
+            tenant_id=tenant_id,
+            occurred_at=datetime.now(UTC),
+            operator_sub=operator_sub,
+        )
+    await session.commit()
+
+    # Literal underscore — only the exact ``user_test`` row matches.
+    result = await query_audit(
+        AuditQueryFilters(principal="user_test"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+    assert {entry.principal_sub for entry in result.rows} == {"user_test"}
+
+    # Literal percent — only the exact ``alice%bob`` row matches.
+    result = await query_audit(
+        AuditQueryFilters(principal="alice%bob"),
+        tenant_id=tenant_id,
+        session=session,
+    )
+    assert {entry.principal_sub for entry in result.rows} == {"alice%bob"}
+
+
+@pytest.mark.asyncio
 async def test_since_until_range(session: AsyncSession) -> None:
     """``since`` and ``until`` bracket the ``occurred_at`` range."""
     tenant_id = uuid.uuid4()

--- a/backend/tests/test_audit_query_schemas.py
+++ b/backend/tests/test_audit_query_schemas.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Validation tests for the audit-query Pydantic schemas (G8.1-T1).
+
+Covers the contract of :class:`~meho_backplane.audit_query.AuditQueryFilters`
+and :class:`~meho_backplane.audit_query.AuditEntry`:
+
+* ``frozen=True`` blocks runtime field reassignment on every model.
+* ``limit`` validation range (1-1000) — boundary tests prove the bounds
+  bite at the Pydantic layer so the SQL handler never sees an out-of-range
+  ``LIMIT`` value.
+* Defaults: every filter is optional, ``limit`` defaults to 100, ``cursor``
+  defaults to None. Empty :class:`AuditQueryFilters` is a valid construction
+  ("show me the most recent 100 rows scoped to the tenant").
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from meho_backplane.audit_query import AuditEntry, AuditQueryFilters, AuditQueryResult
+
+# ---------------------------------------------------------------------------
+# AuditQueryFilters
+# ---------------------------------------------------------------------------
+
+
+def test_filters_empty_construction_uses_defaults() -> None:
+    """Empty filter set is valid; ``limit=100``, every other field None."""
+    f = AuditQueryFilters()
+
+    assert f.limit == 100
+    assert f.cursor is None
+    assert f.target is None
+    assert f.principal is None
+    assert f.op_id is None
+    assert f.op_class is None
+    assert f.result_status is None
+    assert f.since is None
+    assert f.until is None
+    assert f.audit_id is None
+    assert f.parent_audit_id is None
+    assert f.agent_session_id is None
+
+
+def test_filters_limit_lower_bound_rejected() -> None:
+    """``limit=0`` raises a ``ValidationError`` — must be >= 1."""
+    with pytest.raises(ValidationError):
+        AuditQueryFilters(limit=0)
+
+
+def test_filters_limit_upper_bound_rejected() -> None:
+    """``limit=1001`` raises a ``ValidationError`` — must be <= 1000."""
+    with pytest.raises(ValidationError):
+        AuditQueryFilters(limit=1001)
+
+
+def test_filters_limit_bounds_accepted() -> None:
+    """Both ends of the inclusive range accept cleanly."""
+    assert AuditQueryFilters(limit=1).limit == 1
+    assert AuditQueryFilters(limit=1000).limit == 1000
+
+
+def test_filters_frozen_blocks_reassignment() -> None:
+    """``frozen=True`` is load-bearing — a filter is a value, not a builder."""
+    f = AuditQueryFilters(limit=50)
+    with pytest.raises(ValidationError):
+        f.limit = 100  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# AuditEntry
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(**overrides: object) -> AuditEntry:
+    """Build a populated :class:`AuditEntry` with every field set.
+
+    The substrate's placeholder fields (``principal_name``,
+    ``parent_audit_id``, ``agent_session_id``, ``broadcast_event_id``)
+    default to None so a happy-path test does not need to spell them out.
+    """
+    defaults: dict[str, object] = {
+        "id": uuid.uuid4(),
+        "ts": datetime.now(UTC),
+        "tenant_id": uuid.uuid4(),
+        "principal_sub": "operator-1",
+        "principal_name": None,
+        "target_id": None,
+        "target_name": None,
+        "method": "GET",
+        "path": "/api/v1/healthz",
+        "status_code": 200,
+        "request_id": None,
+        "duration_ms": Decimal("3.14"),
+        "payload": {},
+        "op_id": "http.get:/api/v1/healthz",
+        "op_class": "other",
+        "result_status": "ok",
+        "parent_audit_id": None,
+        "agent_session_id": None,
+        "broadcast_event_id": None,
+    }
+    defaults.update(overrides)
+    return AuditEntry(**defaults)  # type: ignore[arg-type]
+
+
+def test_entry_round_trip_preserves_every_field() -> None:
+    """Construction + read-back of an :class:`AuditEntry` is lossless."""
+    payload = {"op_id": "vsphere.vm.list", "op_class": "read"}
+    target_id = uuid.uuid4()
+    entry = _make_entry(
+        target_id=target_id,
+        target_name="rdc-vcenter",
+        payload=payload,
+        op_id="vsphere.vm.list",
+        op_class="read",
+    )
+
+    assert entry.target_id == target_id
+    assert entry.target_name == "rdc-vcenter"
+    assert entry.payload == payload
+    assert entry.op_id == "vsphere.vm.list"
+    assert entry.op_class == "read"
+
+
+def test_entry_frozen_blocks_reassignment() -> None:
+    """``frozen=True`` so a row handed to the caller cannot mutate."""
+    entry = _make_entry()
+    with pytest.raises(ValidationError):
+        entry.status_code = 500  # type: ignore[misc]
+
+
+def test_entry_placeholders_default_to_none() -> None:
+    """The four substrate-placeholder fields stay None in v0.2."""
+    entry = _make_entry()
+    assert entry.principal_name is None
+    assert entry.parent_audit_id is None
+    assert entry.agent_session_id is None
+    assert entry.broadcast_event_id is None
+
+
+# ---------------------------------------------------------------------------
+# AuditQueryResult
+# ---------------------------------------------------------------------------
+
+
+def test_result_with_cursor_round_trip() -> None:
+    """``AuditQueryResult`` carries rows + optional ``next_cursor``."""
+    rows = [_make_entry() for _ in range(3)]
+    result = AuditQueryResult(rows=rows, next_cursor="opaque-token-bytes")
+    assert len(result.rows) == 3
+    assert result.next_cursor == "opaque-token-bytes"
+
+
+def test_result_empty_terminal_page() -> None:
+    """A terminal page has ``next_cursor=None`` and possibly an empty row list."""
+    result = AuditQueryResult(rows=[], next_cursor=None)
+    assert result.rows == []
+    assert result.next_cursor is None

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -47,7 +47,7 @@ Field-to-source mapping:
 | `tenant_id` | `audit_log.tenant_id` |
 | `principal_sub` | `audit_log.operator_sub` |
 | `target_id` | `audit_log.target_id` |
-| `target_name` | LEFT JOIN `targets.name ON audit_log.target_id = targets.id` |
+| `target_name` | LEFT JOIN `targets.name ON audit_log.target_id = targets.id AND targets.tenant_id = :tenant_id`. The tenant-id half of the ON clause is defence-in-depth: `audit_log.target_id` has no FK in v0.2 (soft column per chassis discipline) so a cross-tenant value resolves to `target_name=None` rather than leaking another tenant's name. |
 | `method` / `path` / `status_code` / `request_id` / `duration_ms` / `payload` | Columns of the same name on `audit_log`. |
 | `op_id` | `payload['op_id']` if a string, else `f"http.{method.lower()}:{path}"`. |
 | `op_class` | `payload['op_class']` if a string, else `classify_op(op_id)` from `broadcast.events`. |
@@ -71,13 +71,14 @@ end of the matching set under the current filter).
 
 ## Control flow
 
-```
+```text
 query_audit(filters, tenant_id, session)
   │
   ├─ Validate filters: parent_audit_id / agent_session_id → UnsupportedFilterError
   │
   ├─ Build SELECT audit_log, targets.name
   │     OUTER JOIN targets ON audit_log.target_id = targets.id
+  │                       AND targets.tenant_id   = :tenant_id   ← JOIN-scope defence
   │     WHERE audit_log.tenant_id = :tenant_id      ← always first
   │       [+ audit_id = :audit_id]
   │       [+ operator_sub ILIKE :principal]

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -1,0 +1,171 @@
+# audit_query — the read-side substrate for audit-log queries
+
+## Overview
+
+`backend/src/meho_backplane/audit_query/` is the substrate G8.1's REST routes
+(T2 #466), CLI verbs (T3 #467), and MCP meta-tool (T4 #468) dispatch through.
+It exposes one async handler — `query_audit(filters, *, tenant_id, session)` —
+and the three Pydantic value types around it: `AuditQueryFilters` (input),
+`AuditEntry` (one row), `AuditQueryResult` (page + forward-only cursor).
+
+The substrate is **read-only**. Audit-log rows are written by
+`meho_backplane.audit.AuditMiddleware` (HTTP chassis routes) and
+`meho_backplane.mcp.audit.write_mcp_audit_row` (MCP tool/resource handlers);
+this package never inserts, updates, or deletes.
+
+## Key types
+
+### `AuditQueryFilters` — frozen Pydantic v2
+
+| Field | Type | Backend |
+|---|---|---|
+| `target` | `str \| None` | Matched against `targets.name` for the same tenant (alias resolution is the T2 router's job). |
+| `principal` | `str \| None` | `audit_log.operator_sub ILIKE %value%`. |
+| `op_id` | `str \| None` | Glob (`*` ↔ `%`). Matched against `payload->>'op_id'` (MCP rows) **OR** derived `http.<method>:<path>` (HTTP rows). |
+| `op_class` | `str \| None` | Exact match against `payload->>'op_class'`. |
+| `result_status` | `str \| None` | One of `"ok"` / `"error"` / `"denied"`. Maps to status-code ranges. |
+| `since` / `until` | `datetime \| None` | `audit_log.occurred_at` bracket. **Absolute datetimes only** — `"24h"` / `"7d"` shorthand is parsed in the T2 / T3 router. |
+| `audit_id` | `UUID \| None` | Exact-id lookup. |
+| `parent_audit_id` | `UUID \| None` | **Raises `UnsupportedFilterError`** in v0.2 — column lands with G0.6-T7 (#398). |
+| `agent_session_id` | `UUID \| None` | **Raises `UnsupportedFilterError`** in v0.2 — column not on any current roadmap. |
+| `limit` | `int` (1-1000) | Default 100. |
+| `cursor` | `str \| None` | Opaque forward-only cursor produced by a prior page. |
+
+`tenant_id` is **not** on this model. The handler takes it as a mandatory
+keyword-only argument so an operator-controllable filter object cannot smuggle
+a tenant boundary. The first WHERE clause is always
+`audit_log.tenant_id = :tenant_id`.
+
+### `AuditEntry` — one row
+
+Field-to-source mapping:
+
+| `AuditEntry` field | Source |
+|---|---|
+| `id` | `audit_log.id` |
+| `ts` | `audit_log.occurred_at` |
+| `tenant_id` | `audit_log.tenant_id` |
+| `principal_sub` | `audit_log.operator_sub` |
+| `target_id` | `audit_log.target_id` |
+| `target_name` | LEFT JOIN `targets.name ON audit_log.target_id = targets.id` |
+| `method` / `path` / `status_code` / `request_id` / `duration_ms` / `payload` | Columns of the same name on `audit_log`. |
+| `op_id` | `payload['op_id']` if a string, else `f"http.{method.lower()}:{path}"`. |
+| `op_class` | `payload['op_class']` if a string, else `classify_op(op_id)` from `broadcast.events`. |
+| `result_status` | Derived from `status_code` — 401/403 → `"denied"`, 4xx/5xx else → `"error"`, otherwise `"ok"`. |
+| `principal_name` | **None in v0.2** — JWT `name` claim is not captured by either write path. |
+| `parent_audit_id` | **None in v0.2** — column lands with G0.6-T7 (#398). |
+| `agent_session_id` | **None in v0.2** — no roadmap column. |
+| `broadcast_event_id` | **None in v0.2** — FK direction is reversed: `BroadcastEvent.audit_id` points at the audit row. |
+
+The three computed fields use exactly the same rules
+`meho_backplane.audit._publish_broadcast_event` applies on the publish side,
+so a row returned by the query API and a `BroadcastEvent` observed on the SSE
+feed for the same `audit_id` agree on the `(op_id, op_class, result_status)`
+trio.
+
+### `AuditQueryResult` — page
+
+`rows: list[AuditEntry]` plus `next_cursor: str | None`. `next_cursor` is None
+when fewer than `limit` rows were available on the page (the query reached the
+end of the matching set under the current filter).
+
+## Control flow
+
+```
+query_audit(filters, tenant_id, session)
+  │
+  ├─ Validate filters: parent_audit_id / agent_session_id → UnsupportedFilterError
+  │
+  ├─ Build SELECT audit_log, targets.name
+  │     OUTER JOIN targets ON audit_log.target_id = targets.id
+  │     WHERE audit_log.tenant_id = :tenant_id      ← always first
+  │       [+ audit_id = :audit_id]
+  │       [+ operator_sub ILIKE :principal]
+  │       [+ occurred_at >= :since]
+  │       [+ occurred_at <= :until]
+  │       [+ target_id IN (SELECT id FROM targets WHERE tenant_id = :tenant_id
+  │                        AND name = :target)]
+  │       [+ (payload->>'op_id' LIKE :pattern OR 'http.' || lower(method) || ':' || path LIKE :pattern)]
+  │       [+ payload->>'op_class' = :op_class]
+  │       [+ status_code <predicate for result_status>]
+  │       [+ (occurred_at, id) < (:cursor.ts, :cursor.id)]    ← cursor lex compare
+  │     ORDER BY occurred_at DESC, id DESC
+  │     LIMIT :limit + 1                                       ← N+1 to detect "more"
+  │
+  ├─ Fetch rows; has_more = (len > limit); page = rows[:limit]
+  │
+  ├─ For each (audit_log, target_name) row:
+  │   ┌─ payload = dict(row.payload or {})
+  │   ├─ op_id = payload['op_id'] if str else f"http.{method.lower()}:{path}"
+  │   ├─ op_class = payload['op_class'] if str else classify_op(op_id)
+  │   ├─ result_status = _derive_result_status(status_code)
+  │   └─ AuditEntry(... real cols ..., op_id, op_class, result_status,
+  │                 principal_name=None, parent_audit_id=None,
+  │                 agent_session_id=None, broadcast_event_id=None)
+  │
+  └─ next_cursor = encode_cursor(CursorPosition(ts=last.ts, id=last.id))
+                   if has_more else None
+```
+
+## Dependencies
+
+* `meho_backplane.db.models.AuditLog` — read schema; this package never writes.
+* `meho_backplane.db.models.Target` — denormalization source for `target_name`.
+* `meho_backplane.broadcast.events.classify_op` — op_id → op_class lookup;
+  shared with the broadcast publish path so audit-query and broadcast classify
+  identically.
+
+No reverse dependencies in v0.2 — T2 / T3 / T4 add them later.
+
+## Known issues / v0.2 gaps
+
+* **`principal_name` never populates.** The HTTP audit middleware
+  (`meho_backplane.audit._write_audit_row`) reads `operator_sub` from
+  contextvars but never the JWT `name` claim; the MCP audit writer
+  (`mcp/audit.py:write_mcp_audit_row`) takes an `Operator` value object that
+  has a `name` field but does not persist it. Closing this is a small write-
+  path follow-up: bind `audit_principal_name` in `verify_jwt_and_bind` and
+  let the `_AUDIT_PAYLOAD_PREFIX` machinery push it into `payload`. The
+  audit-query handler then reads it out and stops returning None.
+
+* **`parent_audit_id` waits on G0.6-T7 (#398).** Once the column lands and the
+  composite-operation dispatcher (Initiative #388) populates it, the
+  audit-query handler drops the `UnsupportedFilterError` arm and adds a
+  `WHERE parent_audit_id = :parent_audit_id` clause. `AuditEntry` already
+  exposes the field — only the column read needs to wire up.
+
+* **`agent_session_id` has no roadmap column.** Field is on `AuditEntry`
+  as None and the filter raises. If consumer demand crystallises, the
+  follow-up is a column + write-path binding + the same one-line filter add.
+
+* **`op_id` / `op_class` glob filtering is JSON-path-based.** On PostgreSQL
+  the `payload->>'op_id'` lookup runs over the JSONB column without an index
+  in v0.2; for the consumer's typical 7-day-window queries, the row count
+  is small enough that the index gap is acceptable. A functional GIN index
+  on `(payload->'op_id')` becomes economic at v0.2.next scale.
+
+* **`target` filter resolves names only, not aliases.** The router layer
+  (T2 / T3) is expected to resolve a name-or-alias input via the G0.3 helpers
+  before constructing the filter object. The substrate filter stays portable
+  across PG (`TEXT[]`) and SQLite (JSON array) by keeping alias handling
+  outside the SQL.
+
+* **In-memory PG fixture.** AC4 in the Task body asks for "in-memory PG
+  fixture"; the chassis pattern is `sqlite+aiosqlite` for unit tests +
+  testcontainers PG for integration. T1 unit tests use SQLite per the
+  chassis convention. PG-specific behaviour (JSONB ops, `TEXT[]` aliases)
+  is covered by the T5 (#469) acceptance integration.
+
+## References
+
+* Initiative: [G8.1 #334](https://github.com/evoila/meho/issues/334).
+* Task: [G8.1-T1 #465](https://github.com/evoila/meho/issues/465).
+* Write paths: `backend/src/meho_backplane/audit.py`,
+  `backend/src/meho_backplane/mcp/audit.py`.
+* Op-class classifier: `backend/src/meho_backplane/broadcast/events.py:172`
+  (`classify_op`).
+* Schema: `backend/src/meho_backplane/db/models.py:285-372` (`AuditLog`),
+  `backend/src/meho_backplane/db/models.py:602-...` (`Target`).
+* Migrations: `backend/alembic/versions/0001_create_audit_log.py`,
+  `backend/alembic/versions/0002_create_tenant_and_audit_tenant_id.py`,
+  `backend/alembic/versions/0004_*` (target_id on audit_log).


### PR DESCRIPTION
## Summary

- Ships the **read-side substrate** for G8.1 (audit query core): `query_audit(filters, *, tenant_id, session)` plus the three frozen Pydantic v2 value types (`AuditQueryFilters`, `AuditEntry`, `AuditQueryResult`) and an opaque forward-only cursor.
- `tenant_id` is a mandatory keyword-only argument to the handler — never on the filter object — so cross-tenant queries are impossible by construction; first WHERE clause is always `audit_log.tenant_id = :tenant_id`.
- `op_id` / `op_class` / `result_status` are computed at query time using the same rules the broadcast publish path applies, so a row returned here and a `BroadcastEvent` observed on the SSE feed for the same `audit_id` agree on the trio.
- New `docs/codebase/audit_query.md` documents the substrate plus the substrate-vs-issue-body reconciliation (four fields stay None in v0.2 — `principal_name`, `parent_audit_id`, `agent_session_id`, `broadcast_event_id` — pending follow-up schema additions; `parent_audit_id` / `agent_session_id` filters raise `UnsupportedFilterError`).

## Substrate-vs-issue-body decision

The Task body advertised an `AuditEntry` shape richer than `audit_log` actually carries:

| Field | Substrate reality |
|---|---|
| `op_id` / `op_class` / `result_status` | Computed at query time (HTTP rows derive `http.<method>:<path>`; MCP rows pull from `payload`). |
| `principal_name` | JWT `name` claim is not bound by either write path; v0.2 → None. |
| `parent_audit_id` | Column lands with G0.6-T7 (#398); filter raises `UnsupportedFilterError` until then. |
| `agent_session_id` | No roadmap column; filter raises `UnsupportedFilterError`. |
| `broadcast_event_id` | FK is reversed (`BroadcastEvent.audit_id` → `AuditLog`); v0.2 → None. |

The consumer-facing `AuditEntry` shape is stable so T2 (REST), T3 (CLI), T4 (MCP) can dispatch through it; the four placeholders activate when their backing columns ship.

## Test plan

- [x] `ruff check src/ tests/` — clean across full backend
- [x] `ruff format --check src/ tests/` — clean (136 files)
- [x] `mypy src/` — clean (70 source files, strict mode)
- [x] `pytest tests/test_audit_query_schemas.py tests/test_audit_query_cursor.py tests/test_audit_query_handler.py` — **43 passed** in 8.6s
- [x] Regression: `pytest tests/test_audit_middleware.py tests/test_db_models.py tests/test_db_targets.py` — 28 passed in 12.6s (no write-path regressions)

### Acceptance criteria verification (from issue #465)

| AC | Verified by |
|---|---|
| Module importable as `from meho_backplane.audit_query import query_audit, AuditEntry, AuditQueryFilters` | re-exports + tests pass |
| `AuditEntry` matches `audit_log` columns + denormalized `target_name` | `test_target_name_denormalization_left_join` |
| Cursor round-trip; tampered cursor raises `InvalidCursorError` | 11 cursor tests |
| All filter combinations narrow results correctly | 13 handler filter tests |
| Tenant-scoping baked in (2-tenant isolation test) | `test_tenant_scoping_isolates_rows`, `test_tenant_scoping_ignores_tenant_id_on_filter_object` |
| 250 rows / `limit=100` → 3 pages, last has `next_cursor=None` | `test_cursor_pagination_walks_250_rows_in_3_pages` |
| `op_id="vsphere.vm.*"` matches `vsphere.vm.list`/`.get`, excludes `vsphere.host.list` | `test_op_id_glob_matches_payload_prefix` |
| `parent_audit_id` filter for composite-op subtree | **Raises `UnsupportedFilterError`** until column lands with G0.6-T7 (#398); `AuditEntry.parent_audit_id` field reserved as None |
| CI green; ruff + mypy clean | full backend checks above |

## Out of scope

- REST routes (T2 #466), CLI verbs (T3 #467), MCP meta-tool (T4 #468), acceptance integration (T5 #469), docs (T6 #470).
- Duration shorthand parsing (`"24h"` / `"7d"`) — T2/T3 router layer per the Task body.
- Alias resolution (`target` filter) — T2 router uses G0.3 helpers before constructing the filter object.
- PG-specific JSONB / `TEXT[]` behaviour — T5 acceptance integration on PG.

## Adjacent findings (not edited)

- HTTP audit middleware doesn't capture the operator's JWT `name` claim → `AuditEntry.principal_name` stays None until a small write-path follow-up binds `audit_principal_name` via the existing `_AUDIT_PAYLOAD_PREFIX` machinery.
- The AC4 wording "in-memory PG fixture" doesn't match the chassis convention (`sqlite+aiosqlite` for unit, testcontainers PG for integration). Unit tests use SQLite per repo pattern.
- `op_id` glob on `payload->>'op_id'` runs without a JSONB index in v0.2; functional GIN index `(payload->'op_id')` becomes economic at scale.

Closes #465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit log query API: tenant-scoped results, forward-only URL-safe cursors, filters for operation ID (glob), operation class, principal, time range, target, and status. Computed fields (op_id, op_class, result_status) provided; legacy placeholders returned as null. Unsupported filters return a clear error.

* **Tests**
  * Added unit and end-to-end tests for cursor encoding/validation, pagination, filtering semantics, tenant isolation, and schema constraints.

* **Documentation**
  * Added user-facing docs for audit-query inputs, outputs, filtering, pagination, and known limitations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/484)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->