### PR TITLE
feat(operations): G0.7-T3 LLM-summarised operation grouping — two-pass via chassis LLM client

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "asyncssh>=2.18,<3.0",
     "packaging>=24.0",
     "python-frontmatter>=1.1.0",
+    "jinja2>=3.1.6",
 ]
 
 [dependency-groups]

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -22,8 +22,16 @@ from meho_backplane.operations.ingest.exceptions import (
     InvalidSchemaError,
     InvalidSpecError,
     InvalidStateTransitionError,
+    LlmOutputInvalid,
     OpIdCollision,
     UnsupportedSpecError,
+)
+from meho_backplane.operations.ingest.llm_groups import (
+    DEFAULT_GROUPING_BATCH_SIZE,
+    GroupingResult,
+    GroupProposal,
+    LlmClient,
+    run_llm_grouping,
 )
 from meho_backplane.operations.ingest.openapi import (
     detect_spec_format,
@@ -46,16 +54,21 @@ from meho_backplane.operations.ingest.schemas import (
 from meho_backplane.operations.ingest.service import ReviewService
 
 __all__ = [
+    "DEFAULT_GROUPING_BATCH_SIZE",
     "ConnectorNotFoundError",
     "ConnectorReviewGroup",
     "ConnectorReviewOp",
     "ConnectorReviewPayload",
     "EndpointDescriptorProto",
     "GenericRestConnector",
+    "GroupProposal",
+    "GroupingResult",
     "IngestionResult",
     "InvalidSchemaError",
     "InvalidSpecError",
     "InvalidStateTransitionError",
+    "LlmClient",
+    "LlmOutputInvalid",
     "OpIdCollision",
     "ReviewService",
     "SafetyLevel",
@@ -65,4 +78,5 @@ __all__ = [
     "parse_connector_id",
     "parse_openapi",
     "register_ingested_operations",
+    "run_llm_grouping",
 ]

--- a/backend/src/meho_backplane/operations/ingest/_internals.py
+++ b/backend/src/meho_backplane/operations/ingest/_internals.py
@@ -39,6 +39,7 @@ __all__ = [
     "OP_EDIT_OP",
     "OP_ENABLE_CONNECTOR",
     "OP_ENABLE_GROUP",
+    "OP_LLM_GROUPING",
     "VALID_SAFETY_LEVELS",
     "ConnectorScope",
     "cascade_is_enabled",
@@ -62,6 +63,7 @@ OP_DISABLE_CONNECTOR: Final[str] = "meho.connector.disable"
 OP_ENABLE_GROUP: Final[str] = "meho.connector.enable_group"
 OP_EDIT_GROUP: Final[str] = "meho.connector.edit_group"
 OP_EDIT_OP: Final[str] = "meho.connector.edit_op"
+OP_LLM_GROUPING: Final[str] = "meho.connector.llm_grouping"
 
 #: Allowed values for :attr:`EndpointDescriptor.safety_level`. The
 #: same set is enforced by the DB CHECK constraint; the Python-side

--- a/backend/src/meho_backplane/operations/ingest/_llm_grouping_internals.py
+++ b/backend/src/meho_backplane/operations/ingest/_llm_grouping_internals.py
@@ -1,0 +1,548 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Private helpers for the T3 LLM grouping orchestrator.
+
+Schemas, parsers, prompt-rendering, and DB-query helpers live here so
+:mod:`meho_backplane.operations.ingest.llm_groups` stays focused on
+orchestration. The split keeps both files comfortably under the
+project's per-file size budget; nothing in this module is part of the
+public surface re-exported by ``__init__.py``.
+
+Re-exports the system prompts as module-level constants so the
+orchestrator can pass them verbatim to :meth:`LlmClient.generate_json`
+without re-declaring them in every call site.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Iterable, Sequence
+from typing import Any, Final, Protocol
+from uuid import UUID
+
+import structlog
+from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest.exceptions import LlmOutputInvalid
+
+__all__ = [
+    "ASSIGN_OPS_SYSTEM_PROMPT",
+    "DEFAULT_GROUPING_BATCH_SIZE",
+    "DEFAULT_MAX_GROUPS",
+    "DEFAULT_MIN_GROUPS",
+    "NONE_GROUP_KEY",
+    "PASS1_MAX_OUTPUT_TOKENS",
+    "PASS2_MAX_OUTPUT_TOKENS",
+    "PROPOSE_GROUPS_SYSTEM_PROMPT",
+    "GroupAssignment",
+    "GroupProposal",
+    "LlmClient",
+    "build_connector_id",
+    "chunk_sequence",
+    "expected_llm_call_count",
+    "load_existing_groups",
+    "load_unassigned_ops",
+    "parse_assignment_response",
+    "parse_proposal_response",
+    "render_assign_ops_prompt",
+    "render_propose_groups_prompt",
+]
+
+_log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+#: Default batch size for Pass 2 (per-op assignment). The op count
+#: divided by this number determines the Pass-2 LLM call count.
+#: Sized to keep each batch's prompt well under the Anthropic Messages
+#: API's 200K-token context window even with verbose op summaries; the
+#: real ceiling is per-call latency + cost, not context length.
+DEFAULT_GROUPING_BATCH_SIZE: Final[int] = 50
+
+#: Minimum number of groups the LLM is asked to propose. Below ~8, the
+#: taxonomy collapses into vendor-bucket-by-tag; above ~15, the agent's
+#: scope-then-search flow starts to feel like keyword search again.
+#: Operator can override per ingest if the spec has unusual shape.
+DEFAULT_MIN_GROUPS: Final[int] = 8
+
+#: Maximum number of groups (see :data:`DEFAULT_MIN_GROUPS`).
+DEFAULT_MAX_GROUPS: Final[int] = 15
+
+#: Group-key sentinel returned by Pass 2 when no group is a fit. Ops
+#: assigned to this value stay ``group_id=NULL`` and bubble up as
+#: ``operations_unassigned`` -- the operator assigns them manually
+#: via T4's ``edit_op``.
+NONE_GROUP_KEY: Final[str] = "none"
+
+#: Pattern enforcing snake_case on ``group_key``. Same shape the
+#: typed-connector groups use (``vm_lifecycle``, ``cluster``,
+#: ``events``) so the operator-facing review payload looks uniform
+#: across spec-ingested and typed connectors.
+_GROUP_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+#: Token budget for Pass 1. Sized for the median connector (~50-100
+#: ops); large connectors are still well under model output limits
+#: because each proposal is 100-200 tokens and the model is bounded to
+#: ``DEFAULT_MAX_GROUPS`` entries by the prompt instructions.
+PASS1_MAX_OUTPUT_TOKENS: Final[int] = 4096
+
+#: Token budget for one Pass-2 batch. Each entry is a ``"op_id":
+#: "group_key"`` pair, ~30-80 tokens; 50 ops fits comfortably under
+#: this budget with room for the response wrapper.
+PASS2_MAX_OUTPUT_TOKENS: Final[int] = 4096
+
+PROPOSE_GROUPS_SYSTEM_PROMPT: Final[str] = (
+    "You design operation taxonomies for the MEHO backplane. You are given a list of "
+    "API operations from a vendor's OpenAPI specification and must propose a small, "
+    "agent-actionable set of operation groups. You respond with ONLY a JSON array. "
+    "Do not include explanatory prose, code fences, or any text outside the JSON. "
+    "Every group's when_to_use field must be specific enough that an AI agent reading "
+    "only that paragraph can decide whether to scope a search to this group."
+)
+
+ASSIGN_OPS_SYSTEM_PROMPT: Final[str] = (
+    "You assign API operations to operation groups for the MEHO backplane. You receive "
+    "a fixed set of group definitions and a batch of operations, and must return a JSON "
+    'object mapping each operation\'s op_id to exactly one group_key (or "none" when no '
+    "group fits). Respond with ONLY the JSON object. Do not include explanatory prose, "
+    "code fences, or any text outside the JSON."
+)
+
+
+# ---------------------------------------------------------------------------
+# LLM client Protocol
+# ---------------------------------------------------------------------------
+
+
+class LlmClient(Protocol):
+    """Minimum surface the grouping pass needs from a chassis LLM client.
+
+    Designed as a structural :class:`Protocol` rather than an abstract
+    base so the chassis can ship a concrete adapter (Anthropic Sonnet/
+    Haiku via the Messages API), tests can ship a deterministic stub,
+    and downstream code paths can mock with ``unittest.mock.AsyncMock``
+    without inheriting an ABC.
+
+    Implementations resolve their model id, API key, retry/backoff,
+    and prompt-caching policy internally. T3 only cares about the
+    request/response shape: a system prompt + a user prompt go in, a
+    raw string comes back. JSON validation is T3's concern, not the
+    client's.
+    """
+
+    async def generate_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        max_output_tokens: int,
+    ) -> str:
+        """Return the LLM's raw text response."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Output schemas (LLM-facing JSON contract)
+# ---------------------------------------------------------------------------
+
+
+class GroupProposal(BaseModel):
+    """One group proposed by Pass 1.
+
+    The full LLM Pass-1 response is a JSON array of these. ``frozen=True``
+    keeps the validator output read-only between parse and persist.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    group_key: str = Field(min_length=1, max_length=64)
+    name: str = Field(min_length=1, max_length=128)
+    when_to_use: str = Field(min_length=1, max_length=2048)
+
+    @field_validator("group_key")
+    @classmethod
+    def _group_key_must_be_snake_case(cls, value: str) -> str:
+        if not _GROUP_KEY_PATTERN.fullmatch(value):
+            raise ValueError(
+                f"group_key {value!r} must match {_GROUP_KEY_PATTERN.pattern!r} "
+                "(snake_case, starts with a letter)",
+            )
+        return value
+
+
+class GroupAssignment(BaseModel):
+    """One element of the Pass-2 mapping (verbatim from the LLM).
+
+    Pass 2's response is a JSON object ``{"<op_id>": "<group_key>", ...}``
+    rather than a list, so this model isn't validated directly --
+    instead :func:`parse_assignment_response` builds it per pair after
+    JSON-loading. The class exists primarily for type clarity on
+    internal call sites; the JSON validation lives in
+    :func:`parse_assignment_response`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    op_id: str = Field(min_length=1)
+    group_key: str = Field(min_length=1, max_length=64)
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering
+# ---------------------------------------------------------------------------
+
+
+def _build_jinja_environment() -> Environment:
+    """Build the Jinja2 :class:`Environment` for the prompt templates.
+
+    ``StrictUndefined`` raises :class:`jinja2.UndefinedError` on any
+    missing variable so a typo in the call site breaks the test loudly
+    rather than silently rendering ``""``. ``autoescape`` is disabled
+    via :func:`select_autoescape` with an empty list -- the rendered
+    output is sent verbatim to an LLM, not embedded in HTML, so
+    autoescaping would actively corrupt the prompt (e.g. ``&`` ->
+    ``&amp;``).
+    """
+    return Environment(
+        loader=PackageLoader(
+            "meho_backplane.operations.ingest",
+            package_path="prompts",
+        ),
+        undefined=StrictUndefined,
+        autoescape=select_autoescape(enabled_extensions=()),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+    )
+
+
+def _op_view(proto_or_row: Any) -> dict[str, Any]:
+    """Project an op into the dict shape the prompt templates iterate over."""
+    return {
+        "op_id": proto_or_row.op_id,
+        "summary": proto_or_row.summary,
+        "tags": list(proto_or_row.tags or []),
+    }
+
+
+def render_propose_groups_prompt(
+    *,
+    connector_id: str,
+    product: str,
+    version: str,
+    impl_id: str,
+    operations: Sequence[Any],
+    min_groups: int = DEFAULT_MIN_GROUPS,
+    max_groups: int = DEFAULT_MAX_GROUPS,
+) -> str:
+    """Render the Pass-1 (propose-groups) prompt body as a string."""
+    env = _build_jinja_environment()
+    template = env.get_template("propose_groups.md.j2")
+    return template.render(
+        connector_id=connector_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_count=len(operations),
+        operations=[_op_view(op) for op in operations],
+        min_groups=min_groups,
+        max_groups=max_groups,
+    )
+
+
+def render_assign_ops_prompt(
+    *,
+    connector_id: str,
+    product: str,
+    version: str,
+    groups: Sequence[GroupProposal],
+    operations: Sequence[Any],
+) -> str:
+    """Render the Pass-2 (assign-ops) prompt body as a string."""
+    env = _build_jinja_environment()
+    template = env.get_template("assign_op_to_group.md.j2")
+    return template.render(
+        connector_id=connector_id,
+        product=product,
+        version=version,
+        groups=[
+            {
+                "group_key": g.group_key,
+                "name": g.name,
+                "when_to_use": g.when_to_use,
+            }
+            for g in groups
+        ],
+        operations=[_op_view(op) for op in operations],
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM-output parsing
+# ---------------------------------------------------------------------------
+
+#: Strip leading/trailing fenced-code markup the model sometimes emits
+#: in addition to bare JSON. Matches a single optional ```json``` or
+#: ``` ... ``` block; everything outside the first match is preserved
+#: so unexpected wrapper prose still surfaces in the parse error.
+_FENCE_PATTERN = re.compile(
+    r"^\s*```(?:json)?\s*\n?(.*?)\n?```\s*$",
+    re.DOTALL,
+)
+
+
+def strip_code_fences(raw: str) -> str:
+    """Remove a single surrounding ```json ... ``` fence, if present."""
+    match = _FENCE_PATTERN.match(raw)
+    if match is None:
+        return raw.strip()
+    return match.group(1).strip()
+
+
+def parse_proposal_response(raw_output: str) -> list[GroupProposal]:
+    """Parse Pass-1 output into a validated :class:`GroupProposal` list.
+
+    Failure modes that raise :class:`LlmOutputInvalid`:
+
+    * JSON parse error (the model wrapped its output in prose, or
+      truncated mid-token).
+    * Top-level value isn't a JSON array.
+    * Any element fails the :class:`GroupProposal` pydantic schema
+      (missing fields, oversized ``when_to_use``, non-snake_case
+      ``group_key``).
+    * Duplicate ``group_key`` values across the array -- the row
+      uniqueness constraint on :class:`OperationGroup` would catch
+      this at DB flush time, but we'd rather fail fast with a clearer
+      message.
+    """
+    cleaned = strip_code_fences(raw_output)
+    try:
+        decoded = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise LlmOutputInvalid(
+            pass_name="propose_groups",
+            raw_output=raw_output,
+            parse_error=exc,
+        ) from exc
+    if not isinstance(decoded, list):
+        raise LlmOutputInvalid(
+            pass_name="propose_groups",
+            raw_output=raw_output,
+            parse_error=ValueError(
+                f"expected a JSON array at the top level, got {type(decoded).__name__}",
+            ),
+        )
+    try:
+        proposals = [GroupProposal.model_validate(item) for item in decoded]
+    except ValidationError as exc:
+        raise LlmOutputInvalid(
+            pass_name="propose_groups",
+            raw_output=raw_output,
+            parse_error=exc,
+        ) from exc
+    seen: set[str] = set()
+    for proposal in proposals:
+        if proposal.group_key in seen:
+            raise LlmOutputInvalid(
+                pass_name="propose_groups",
+                raw_output=raw_output,
+                parse_error=ValueError(
+                    f"duplicate group_key in proposal: {proposal.group_key!r}",
+                ),
+            )
+        seen.add(proposal.group_key)
+    return proposals
+
+
+def _decode_assignment_json(raw_output: str) -> dict[str, Any]:
+    """Decode + structurally-validate a Pass-2 LLM response.
+
+    Returns the raw JSON dict; the caller filters its entries against
+    the known ``op_id`` and ``group_key`` sets. Raises
+    :class:`LlmOutputInvalid` if the top-level structure is wrong.
+    """
+    cleaned = strip_code_fences(raw_output)
+    try:
+        decoded = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise LlmOutputInvalid(
+            pass_name="assign_ops",
+            raw_output=raw_output,
+            parse_error=exc,
+        ) from exc
+    if not isinstance(decoded, dict):
+        raise LlmOutputInvalid(
+            pass_name="assign_ops",
+            raw_output=raw_output,
+            parse_error=ValueError(
+                f"expected a JSON object at the top level, got {type(decoded).__name__}",
+            ),
+        )
+    return decoded
+
+
+def parse_assignment_response(
+    raw_output: str,
+    *,
+    valid_op_ids: set[str],
+    valid_group_keys: set[str],
+) -> dict[str, str]:
+    """Parse Pass-2 output into an ``op_id -> group_key`` mapping.
+
+    The parser is **defensive but not destructive**:
+
+    * Unknown keys (an ``op_id`` not in *valid_op_ids*) are dropped
+      with a warning log.
+    * Unknown values (a ``group_key`` not in *valid_group_keys* and
+      not :data:`NONE_GROUP_KEY`) are coerced to ``"none"`` (operator
+      assigns manually later). The op stays in the result as
+      unassigned -- we still want to record that the model
+      considered it.
+
+    The only conditions that raise :class:`LlmOutputInvalid` are
+    structural: JSON parse error or top-level value isn't a JSON
+    object. Both cases would otherwise leave the caller with no
+    actionable signal.
+    """
+    decoded = _decode_assignment_json(raw_output)
+    mapping: dict[str, str] = {}
+    for raw_key, raw_value in decoded.items():
+        if not isinstance(raw_key, str) or not isinstance(raw_value, str):
+            _log.warning(
+                "llm_grouping_assignment_skipped_non_string",
+                op_id_type=type(raw_key).__name__,
+                value_type=type(raw_value).__name__,
+            )
+            continue
+        if raw_key not in valid_op_ids:
+            _log.warning(
+                "llm_grouping_assignment_skipped_unknown_op",
+                op_id=raw_key,
+            )
+            continue
+        if raw_value == NONE_GROUP_KEY:
+            mapping[raw_key] = NONE_GROUP_KEY
+            continue
+        if raw_value not in valid_group_keys:
+            _log.warning(
+                "llm_grouping_assignment_unknown_group_key",
+                op_id=raw_key,
+                group_key=raw_value,
+            )
+            mapping[raw_key] = NONE_GROUP_KEY
+            continue
+        mapping[raw_key] = raw_value
+    return mapping
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+async def load_unassigned_ops(
+    session: AsyncSession,
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    tenant_id: UUID | None,
+) -> list[EndpointDescriptor]:
+    """Return every :class:`EndpointDescriptor` for the connector with no ``group_id``.
+
+    Sort by ``op_id`` so re-runs see deterministic batch boundaries --
+    helpful for prompt-cache hit rates and for diff-friendly test
+    assertions across runs.
+    """
+    stmt = (
+        select(EndpointDescriptor)
+        .where(
+            EndpointDescriptor.product == product,
+            EndpointDescriptor.version == version,
+            EndpointDescriptor.impl_id == impl_id,
+            EndpointDescriptor.group_id.is_(None),
+        )
+        .order_by(EndpointDescriptor.op_id)
+    )
+    if tenant_id is None:
+        stmt = stmt.where(EndpointDescriptor.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(EndpointDescriptor.tenant_id == tenant_id)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def load_existing_groups(
+    session: AsyncSession,
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    tenant_id: UUID | None,
+) -> list[OperationGroup]:
+    """Return every :class:`OperationGroup` row in the connector scope.
+
+    Drives the partial-regrouping branch: if existing groups are
+    present, we skip Pass 1 and use them as-is for Pass 2 over the
+    unassigned-op subset.
+    """
+    stmt = (
+        select(OperationGroup)
+        .where(
+            OperationGroup.product == product,
+            OperationGroup.version == version,
+            OperationGroup.impl_id == impl_id,
+        )
+        .order_by(OperationGroup.group_key)
+    )
+    if tenant_id is None:
+        stmt = stmt.where(OperationGroup.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(OperationGroup.tenant_id == tenant_id)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+def build_connector_id(product: str, version: str, impl_id: str) -> str:
+    """Render the operator-facing ``<impl_id>-<version>`` identifier.
+
+    Inverse of :func:`meho_backplane.operations.ingest.parser.parse_connector_id`.
+    Used to populate audit-row payloads and structlog kwargs so the
+    string operators see in logs / CLI output matches the one they
+    typed at ``meho connector ingest`` time.
+    """
+    return f"{impl_id}-{version}"
+
+
+def chunk_sequence(items: Sequence[Any], size: int) -> Iterable[Sequence[Any]]:
+    """Yield successive *size*-length slices of *items*.
+
+    Pure helper -- avoids pulling :func:`itertools.batched` to keep
+    the project's import surface minimal and the helper trivially
+    unit-testable.
+    """
+    for offset in range(0, len(items), size):
+        yield items[offset : offset + size]
+
+
+def expected_llm_call_count(op_count: int, batch_size: int) -> int:
+    """Return the LLM-call count a full grouping run produces.
+
+    ``1`` for Pass 1 plus ``ceil(op_count / batch_size)`` for Pass 2.
+    Used by the test suite to pin the documented call-count contract;
+    not part of the production hot path.
+    """
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1; got {batch_size}")
+    if op_count < 1:
+        return 0
+    return 1 + math.ceil(op_count / batch_size)

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -82,6 +82,7 @@ __all__ = [
     "InvalidSchemaError",
     "InvalidSpecError",
     "InvalidStateTransitionError",
+    "LlmOutputInvalid",
     "OpIdCollision",
     "UnsupportedSpecError",
 ]
@@ -235,6 +236,62 @@ class InvalidStateTransitionError(Exception):
         suffix = f" (group={group_key})" if group_key is not None else ""
         super().__init__(
             f"cannot transition {current_status!r} -> {requested_status!r}{suffix}",
+        )
+
+
+class LlmOutputInvalid(Exception):  # noqa: N818 -- Task #404 API contract pins this name
+    """Raised when an LLM grouping-pass response fails schema validation.
+
+    The chassis LLM client is prompted to emit a tightly-shaped JSON
+    payload (an array of group proposals for Pass 1, an op_id-to-
+    group_key map for Pass 2). When the model returns prose around the
+    JSON, malformed JSON, or a JSON value that fails its Pydantic
+    schema, T3 surfaces this exception so the operator-facing CLI / API
+    layer can log the raw output and prompt for a retry rather than
+    persisting half-baked taxonomy.
+
+    Attributes
+    ----------
+    pass_name:
+        Which of the two passes produced the bad output --
+        ``"propose_groups"`` (Pass 1) or ``"assign_ops"`` (Pass 2). Used
+        by the CLI's retry prompt and by analytics that bucket prompt
+        failures per pass.
+    raw_output:
+        The verbatim string the LLM returned, before any parsing or
+        normalisation. Truncated to 8 KiB in the message to keep the
+        exception printable; the full value is preserved on the
+        attribute for debug logging.
+    parse_error:
+        The underlying parser / validator exception, attached as the
+        cause for ``raise ... from ...`` chains. Lifted onto a named
+        attribute so callers can inspect the structured pydantic
+        ``ValidationError`` shape without crawling ``__cause__``.
+
+    Distinct from :class:`InvalidSpecError` and :class:`InvalidSchemaError`
+    (which describe upstream OpenAPI breakage) -- this exception is
+    specifically about LLM output quality, an operational concern that
+    deserves its own retry path.
+    """
+
+    _MESSAGE_PREVIEW_LIMIT = 8 * 1024
+
+    def __init__(
+        self,
+        *,
+        pass_name: str,
+        raw_output: str,
+        parse_error: Exception,
+    ) -> None:
+        self.pass_name = pass_name
+        self.raw_output = raw_output
+        self.parse_error = parse_error
+        preview = raw_output
+        if len(preview) > self._MESSAGE_PREVIEW_LIMIT:
+            preview = preview[: self._MESSAGE_PREVIEW_LIMIT] + "...<truncated>"
+        super().__init__(
+            f"LLM output failed validation in pass {pass_name!r}: "
+            f"{parse_error!r}; raw_output={preview!r}",
         )
 
 

--- a/backend/src/meho_backplane/operations/ingest/llm_groups.py
+++ b/backend/src/meho_backplane/operations/ingest/llm_groups.py
@@ -398,11 +398,17 @@ def _apply_assignments_to_rows(
     Updates *totals.operations_assigned* and
     *totals.operations_unassigned* in place. The orchestrator's
     surrounding transaction is what makes the mutations durable.
+
+    Ops the LLM omitted from its Pass-2 response (``op_id`` absent from
+    *assignment_map*) and ops explicitly mapped to
+    :data:`NONE_GROUP_KEY` are both counted exactly once as
+    ``operations_unassigned``. This preserves the
+    ``operations_assigned + operations_unassigned == len(operations)``
+    reconciliation invariant the audit row depends on.
     """
-    all_op_ids = {op.op_id for op in operations}
     for op_row in operations:
-        assigned_key = assignment_map.get(op_row.op_id, NONE_GROUP_KEY)
-        if assigned_key == NONE_GROUP_KEY:
+        assigned_key = assignment_map.get(op_row.op_id)
+        if assigned_key is None or assigned_key == NONE_GROUP_KEY:
             totals.operations_unassigned += 1
             continue
         group_uuid = group_key_to_id.get(assigned_key)
@@ -411,9 +417,6 @@ def _apply_assignments_to_rows(
             continue
         op_row.group_id = group_uuid
         totals.operations_assigned += 1
-    # Ops the LLM omitted from its response are also unassigned.
-    missing = all_op_ids - assignment_map.keys()
-    totals.operations_unassigned += len(missing)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/operations/ingest/llm_groups.py
+++ b/backend/src/meho_backplane/operations/ingest/llm_groups.py
@@ -1,0 +1,657 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+# code-quality-allow: orchestrator + result/config dataclasses + 5 phase helpers
+# read top-to-bottom; further splitting would hide the linear two-pass flow
+# the module docstring + diagram describe.
+
+"""LLM-summarised operation grouping pass (G0.7-T3).
+
+T3 runs *after* T2's :func:`register_ingested_operations` has bulk-
+upserted parser output into ``endpoint_descriptor`` rows. The pass
+groups those rows into agent-actionable buckets via two sequential LLM
+calls per ingested connector:
+
+* **Pass 1 -- group derivation.** The LLM receives every operation
+  (``op_id``, ``summary``, ``tags``) and proposes 8-15 groups, each
+  carrying a snake_case ``group_key``, a Title Case ``name``, and a
+  paragraph-length ``when_to_use`` description. The proposal is
+  validated against :class:`GroupProposal`; output that fails schema
+  validation raises :class:`LlmOutputInvalid`.
+* **Pass 2 -- per-op assignment.** The LLM receives the group list
+  and the ops it must assign, in batches whose size is bounded by
+  ``batch_size`` (default 50). Each batch returns a JSON mapping of
+  ``op_id`` -> ``group_key`` (or ``"none"`` for the operator-review
+  bucket). ``op_id``s the model omits or assigns to an unknown
+  group stay ``group_id=NULL`` and count toward
+  :attr:`GroupingResult.operations_unassigned`.
+
+The function persists nothing until both passes complete, then writes
+proposed groups (``review_status='staged'``) + per-op ``group_id``
+assignments + one ``meho.connector.llm_grouping`` audit row in a
+single transaction. Re-running on a fully-grouped connector is a
+no-op (every op already has ``group_id`` set, no LLM call fires);
+re-running on a partially-grouped connector runs only Pass 2 on the
+unassigned rows against the existing :class:`OperationGroup` rows.
+
+Per :file:`docs/codebase/spec-ingestion.md` and the T3 task body in
+issue #404: this pass is non-optional for v0.2. Raw semantic+BM25
+search across thousands of vendor endpoints ranks poorly; what makes
+``search_operations`` agent-useful is "ask the connector for its
+operation groups first, then scope a query to one". The grouping
+pass + operator review (T4) is what produces that surface.
+
+The LLM client itself is injected as a :class:`LlmClient` Protocol so
+the chassis can swap the real Anthropic Messages-API adapter without
+re-plumbing T3. Production callers (T5's ``meho connector ingest``)
+will resolve a configured Sonnet/Haiku-backed implementation; tests
+inject a deterministic stub. There is no module-level singleton --
+every call site passes a client.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from uuid import UUID
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest._internals import (
+    OP_LLM_GROUPING,
+    write_audit_row,
+)
+from meho_backplane.operations.ingest._llm_grouping_internals import (
+    ASSIGN_OPS_SYSTEM_PROMPT,
+    DEFAULT_GROUPING_BATCH_SIZE,
+    DEFAULT_MAX_GROUPS,
+    DEFAULT_MIN_GROUPS,
+    NONE_GROUP_KEY,
+    PASS1_MAX_OUTPUT_TOKENS,
+    PASS2_MAX_OUTPUT_TOKENS,
+    PROPOSE_GROUPS_SYSTEM_PROMPT,
+    GroupProposal,
+    LlmClient,
+    build_connector_id,
+    chunk_sequence,
+    expected_llm_call_count,
+    load_existing_groups,
+    load_unassigned_ops,
+    parse_assignment_response,
+    parse_proposal_response,
+    render_assign_ops_prompt,
+    render_propose_groups_prompt,
+)
+
+__all__ = [
+    "DEFAULT_GROUPING_BATCH_SIZE",
+    "DEFAULT_MAX_GROUPS",
+    "DEFAULT_MIN_GROUPS",
+    "GroupProposal",
+    "GroupingConfig",
+    "GroupingResult",
+    "LlmClient",
+    "expected_llm_call_count",
+    "render_assign_ops_prompt",
+    "render_propose_groups_prompt",
+    "run_llm_grouping",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public result + config shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class GroupingResult:
+    """Counts + timings returned by :func:`run_llm_grouping`.
+
+    Surfaced verbatim in the operator-facing CLI / API output (T5).
+
+    Attributes
+    ----------
+    connector_id:
+        Operator-facing identifier (``"<impl_id>-<version>"``) for the
+        connector that was grouped.
+    groups_created:
+        Number of brand-new :class:`OperationGroup` rows inserted by
+        this pass. Zero on a re-run that found existing groups (the
+        partial-regrouping path).
+    operations_assigned:
+        Number of :class:`EndpointDescriptor` rows whose ``group_id``
+        was set by this pass.
+    operations_unassigned:
+        Number of rows that remained ``group_id=NULL`` -- the LLM
+        returned ``"none"`` for them, omitted them from the
+        response, or assigned them to an unknown ``group_key``.
+        Operator assigns these manually via T4's ``edit_op``.
+    llm_call_count:
+        Total LLM calls issued. ``1 + ceil(op_count / batch_size)``
+        on a full grouping run (1 Pass-1 + N Pass-2 batches). Zero
+        on a no-op re-run that found every op already grouped.
+    llm_duration_ms:
+        Wall-clock time spent inside
+        ``await llm_client.generate_json(...)``, summed across both
+        passes. Excludes DB time and prompt-render time so operators
+        can monitor the LLM-side cost component independently.
+    """
+
+    connector_id: str
+    groups_created: int
+    operations_assigned: int
+    operations_unassigned: int
+    llm_call_count: int
+    llm_duration_ms: float
+
+
+@dataclass(frozen=True, slots=True)
+class GroupingConfig:
+    """Tunable knobs threaded through the orchestrator phases.
+
+    Bundled into a config dataclass so individual phase helpers stay
+    under a small positional / keyword-argument count without losing
+    visibility on which knob each helper consumes. Public callers
+    typically construct one with defaults; the
+    :func:`run_llm_grouping` entry point also accepts the same knobs
+    as keyword arguments and builds the :class:`GroupingConfig`
+    internally.
+
+    Attributes
+    ----------
+    batch_size:
+        Pass-2 batch size. Default
+        :data:`DEFAULT_GROUPING_BATCH_SIZE` (50).
+    min_groups, max_groups:
+        Bounds on the Pass-1 group count. Default 8-15.
+    """
+
+    batch_size: int = DEFAULT_GROUPING_BATCH_SIZE
+    min_groups: int = DEFAULT_MIN_GROUPS
+    max_groups: int = DEFAULT_MAX_GROUPS
+
+    def validate(self) -> None:
+        """Raise :class:`ValueError` if any knob is out of bounds.
+
+        Called once at the top of :func:`run_llm_grouping` so an
+        invalid configuration fails before any LLM call or DB query.
+        """
+        if self.min_groups < 1:
+            raise ValueError(f"min_groups must be >= 1; got {self.min_groups}")
+        if self.max_groups < self.min_groups:
+            raise ValueError(
+                "max_groups must be >= min_groups; "
+                f"got max_groups={self.max_groups} min_groups={self.min_groups}",
+            )
+        if self.batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1; got {self.batch_size}")
+
+
+# ---------------------------------------------------------------------------
+# Internal orchestrator state
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _PhaseTotals:
+    """Mutable accumulator threaded through the orchestrator's phases.
+
+    Each helper updates its slice and the orchestrator reads the final
+    totals when building the :class:`GroupingResult`.
+    """
+
+    llm_call_count: int = 0
+    llm_duration_ms: float = 0.0
+    groups_created: int = 0
+    operations_assigned: int = 0
+    operations_unassigned: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _ConnectorTriple:
+    """Connector coordinates threaded through phase helpers.
+
+    Keeping the three columns together as a frozen tuple lets phase
+    helpers take a single argument instead of three positional
+    strings -- mirrors the :class:`ConnectorScope` precedent in
+    :mod:`meho_backplane.operations.ingest._internals` for the
+    review-queue service.
+    """
+
+    product: str
+    version: str
+    impl_id: str
+    tenant_id: UUID | None
+
+    @property
+    def connector_id(self) -> str:
+        return build_connector_id(self.product, self.version, self.impl_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 helpers (group derivation)
+# ---------------------------------------------------------------------------
+
+
+async def _propose_groups_via_llm(
+    llm_client: LlmClient,
+    *,
+    triple: _ConnectorTriple,
+    operations: Sequence[EndpointDescriptor],
+    config: GroupingConfig,
+    totals: _PhaseTotals,
+) -> list[GroupProposal]:
+    """Run Pass 1 against the LLM and return the validated proposals.
+
+    Updates *totals* in place with the LLM-call count and duration.
+    Pass-1 output that fails schema validation raises
+    :class:`LlmOutputInvalid`; the orchestrator does not catch it,
+    because the operator-facing CLI / API layer above us is the
+    right surface to render the retry prompt.
+    """
+    propose_prompt = render_propose_groups_prompt(
+        connector_id=triple.connector_id,
+        product=triple.product,
+        version=triple.version,
+        impl_id=triple.impl_id,
+        operations=operations,
+        min_groups=config.min_groups,
+        max_groups=config.max_groups,
+    )
+    t0 = time.monotonic()
+    raw_pass1 = await llm_client.generate_json(
+        system_prompt=PROPOSE_GROUPS_SYSTEM_PROMPT,
+        user_prompt=propose_prompt,
+        max_output_tokens=PASS1_MAX_OUTPUT_TOKENS,
+    )
+    totals.llm_duration_ms += (time.monotonic() - t0) * 1000.0
+    totals.llm_call_count += 1
+    return parse_proposal_response(raw_pass1)
+
+
+def _persist_proposed_groups(
+    session: AsyncSession,
+    *,
+    triple: _ConnectorTriple,
+    proposals: Sequence[GroupProposal],
+) -> list[OperationGroup]:
+    """Insert one :class:`OperationGroup` per proposal in ``staged`` state.
+
+    The caller flushes after this returns so subsequent Pass-2 lookups
+    by ``group_key`` see the new rows. Commit is deferred until the
+    audit row + per-op updates land, so the whole pass is atomic.
+    """
+    rows: list[OperationGroup] = []
+    for proposal in proposals:
+        row = OperationGroup(
+            tenant_id=triple.tenant_id,
+            product=triple.product,
+            version=triple.version,
+            impl_id=triple.impl_id,
+            group_key=proposal.group_key,
+            name=proposal.name,
+            when_to_use=proposal.when_to_use,
+            review_status="staged",
+        )
+        session.add(row)
+        rows.append(row)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 helpers (per-op assignment)
+# ---------------------------------------------------------------------------
+
+
+async def _assign_ops_in_batches(
+    llm_client: LlmClient,
+    *,
+    triple: _ConnectorTriple,
+    operations: Sequence[EndpointDescriptor],
+    groups: Sequence[GroupProposal],
+    config: GroupingConfig,
+    totals: _PhaseTotals,
+) -> dict[str, str]:
+    """Run Pass-2 in :attr:`GroupingConfig.batch_size`-sized batches.
+
+    Each batch produces a partial ``op_id -> group_key`` mapping; the
+    helper merges them into a single dict. ``totals`` accumulates the
+    Pass-2 LLM-call count + duration across batches.
+    """
+    valid_group_keys = {g.group_key for g in groups}
+    batches = list(chunk_sequence(operations, config.batch_size))
+    _log.info(
+        "llm_grouping_pass2_start",
+        connector_id=triple.connector_id,
+        batch_count=len(batches),
+        batch_size=config.batch_size,
+        op_count=len(operations),
+    )
+    assignment_map: dict[str, str] = {}
+    for batch_index, batch in enumerate(batches):
+        batch_assignments = await _assign_single_batch(
+            llm_client,
+            triple=triple,
+            batch=batch,
+            groups=groups,
+            valid_group_keys=valid_group_keys,
+            totals=totals,
+        )
+        assignment_map.update(batch_assignments)
+        _log.info(
+            "llm_grouping_pass2_batch_complete",
+            connector_id=triple.connector_id,
+            batch_index=batch_index,
+            batch_op_count=len(batch),
+            assigned_in_batch=sum(1 for v in batch_assignments.values() if v != NONE_GROUP_KEY),
+        )
+    return assignment_map
+
+
+async def _assign_single_batch(
+    llm_client: LlmClient,
+    *,
+    triple: _ConnectorTriple,
+    batch: Sequence[EndpointDescriptor],
+    groups: Sequence[GroupProposal],
+    valid_group_keys: set[str],
+    totals: _PhaseTotals,
+) -> dict[str, str]:
+    """LLM-assign one Pass-2 batch and return its ``op_id -> group_key`` map."""
+    batch_op_ids = {op.op_id for op in batch}
+    assign_prompt = render_assign_ops_prompt(
+        connector_id=triple.connector_id,
+        product=triple.product,
+        version=triple.version,
+        groups=groups,
+        operations=batch,
+    )
+    t0 = time.monotonic()
+    raw_pass2 = await llm_client.generate_json(
+        system_prompt=ASSIGN_OPS_SYSTEM_PROMPT,
+        user_prompt=assign_prompt,
+        max_output_tokens=PASS2_MAX_OUTPUT_TOKENS,
+    )
+    totals.llm_duration_ms += (time.monotonic() - t0) * 1000.0
+    totals.llm_call_count += 1
+    return parse_assignment_response(
+        raw_pass2,
+        valid_op_ids=batch_op_ids,
+        valid_group_keys=valid_group_keys,
+    )
+
+
+def _apply_assignments_to_rows(
+    *,
+    operations: Sequence[EndpointDescriptor],
+    assignment_map: dict[str, str],
+    group_key_to_id: dict[str, UUID],
+    totals: _PhaseTotals,
+) -> None:
+    """Mutate each :class:`EndpointDescriptor`'s ``group_id`` per *assignment_map*.
+
+    Updates *totals.operations_assigned* and
+    *totals.operations_unassigned* in place. The orchestrator's
+    surrounding transaction is what makes the mutations durable.
+    """
+    all_op_ids = {op.op_id for op in operations}
+    for op_row in operations:
+        assigned_key = assignment_map.get(op_row.op_id, NONE_GROUP_KEY)
+        if assigned_key == NONE_GROUP_KEY:
+            totals.operations_unassigned += 1
+            continue
+        group_uuid = group_key_to_id.get(assigned_key)
+        if group_uuid is None:  # pragma: no cover -- guarded by parser
+            totals.operations_unassigned += 1
+            continue
+        op_row.group_id = group_uuid
+        totals.operations_assigned += 1
+    # Ops the LLM omitted from its response are also unassigned.
+    missing = all_op_ids - assignment_map.keys()
+    totals.operations_unassigned += len(missing)
+
+
+# ---------------------------------------------------------------------------
+# Group-resolution branch (full-grouping vs partial-regrouping)
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_groups_for_pass2(
+    session: AsyncSession,
+    llm_client: LlmClient,
+    *,
+    triple: _ConnectorTriple,
+    unassigned_ops: Sequence[EndpointDescriptor],
+    config: GroupingConfig,
+    totals: _PhaseTotals,
+) -> tuple[list[GroupProposal], dict[str, UUID]]:
+    """Return the groups Pass 2 will assign against, plus their UUIDs.
+
+    Full grouping path -- no existing groups in scope: run Pass 1 to
+    propose them, persist as ``staged``, flush, return.
+
+    Partial regrouping path -- existing groups present: skip Pass 1
+    entirely, project the existing rows into :class:`GroupProposal`
+    instances, return.
+    """
+    existing_groups = await load_existing_groups(
+        session,
+        product=triple.product,
+        version=triple.version,
+        impl_id=triple.impl_id,
+        tenant_id=triple.tenant_id,
+    )
+    if existing_groups:
+        _log.info(
+            "llm_grouping_partial_regrouping",
+            connector_id=triple.connector_id,
+            existing_group_count=len(existing_groups),
+            unassigned_op_count=len(unassigned_ops),
+        )
+        groups = [
+            GroupProposal(
+                group_key=row.group_key,
+                name=row.name,
+                when_to_use=row.when_to_use,
+            )
+            for row in existing_groups
+        ]
+        return groups, {row.group_key: row.id for row in existing_groups}
+
+    _log.info(
+        "llm_grouping_pass1_start",
+        connector_id=triple.connector_id,
+        op_count=len(unassigned_ops),
+        min_groups=config.min_groups,
+        max_groups=config.max_groups,
+    )
+    groups = await _propose_groups_via_llm(
+        llm_client,
+        triple=triple,
+        operations=unassigned_ops,
+        config=config,
+        totals=totals,
+    )
+    _log.info(
+        "llm_grouping_pass1_complete",
+        connector_id=triple.connector_id,
+        proposed_group_count=len(groups),
+    )
+    persisted_rows = _persist_proposed_groups(
+        session,
+        triple=triple,
+        proposals=groups,
+    )
+    await session.flush()
+    totals.groups_created = len(persisted_rows)
+    return groups, {row.group_key: row.id for row in persisted_rows}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def _build_result(triple: _ConnectorTriple, totals: _PhaseTotals) -> GroupingResult:
+    """Project the orchestrator's mutable totals into the public result shape."""
+    return GroupingResult(
+        connector_id=triple.connector_id,
+        groups_created=totals.groups_created,
+        operations_assigned=totals.operations_assigned,
+        operations_unassigned=totals.operations_unassigned,
+        llm_call_count=totals.llm_call_count,
+        llm_duration_ms=totals.llm_duration_ms,
+    )
+
+
+async def _write_grouping_audit_row(
+    session: AsyncSession,
+    *,
+    operator_sub: str,
+    operator_tenant_id: UUID,
+    triple: _ConnectorTriple,
+    totals: _PhaseTotals,
+    config: GroupingConfig,
+) -> None:
+    """Emit the ``meho.connector.llm_grouping`` audit row for the pass."""
+    await write_audit_row(
+        session,
+        operator_sub=operator_sub,
+        operator_tenant_id=operator_tenant_id,
+        op_id=OP_LLM_GROUPING,
+        payload={
+            "connector_id": triple.connector_id,
+            "groups_created": totals.groups_created,
+            "operations_assigned": totals.operations_assigned,
+            "operations_unassigned": totals.operations_unassigned,
+            "llm_call_count": totals.llm_call_count,
+            "batch_size": config.batch_size,
+        },
+    )
+
+
+async def _drive_two_pass_grouping(
+    session: AsyncSession,
+    llm_client: LlmClient,
+    *,
+    triple: _ConnectorTriple,
+    unassigned_ops: Sequence[EndpointDescriptor],
+    config: GroupingConfig,
+    totals: _PhaseTotals,
+) -> None:
+    """Run Pass-1 + Pass-2 + apply ORM mutations against *session*.
+
+    Side-effects only: persists :class:`OperationGroup` rows (Pass 1),
+    sets ``group_id`` on each :class:`EndpointDescriptor` (Pass 2),
+    and updates *totals* in place. The orchestrator commits after this
+    returns so the entire pass is atomic.
+    """
+    groups, group_key_to_id = await _resolve_groups_for_pass2(
+        session,
+        llm_client,
+        triple=triple,
+        unassigned_ops=unassigned_ops,
+        config=config,
+        totals=totals,
+    )
+    assignment_map = await _assign_ops_in_batches(
+        llm_client,
+        triple=triple,
+        operations=unassigned_ops,
+        groups=groups,
+        config=config,
+        totals=totals,
+    )
+    _apply_assignments_to_rows(
+        operations=unassigned_ops,
+        assignment_map=assignment_map,
+        group_key_to_id=group_key_to_id,
+        totals=totals,
+    )
+
+
+async def run_llm_grouping(
+    *,
+    llm_client: LlmClient,
+    operator_sub: str,
+    operator_tenant_id: UUID,
+    product: str,
+    version: str,
+    impl_id: str,
+    tenant_id: UUID | None = None,
+    batch_size: int = DEFAULT_GROUPING_BATCH_SIZE,
+    min_groups: int = DEFAULT_MIN_GROUPS,
+    max_groups: int = DEFAULT_MAX_GROUPS,
+    sessionmaker: async_sessionmaker[AsyncSession] | None = None,
+) -> GroupingResult:
+    """Run the two-pass LLM grouping for an ingested connector.
+
+    See the module docstring for the full behavioural contract.
+    *operator_sub* / *operator_tenant_id* attribute the audit row;
+    *product* / *version* / *impl_id* / *tenant_id* scope the rows
+    grouped. *batch_size* / *min_groups* / *max_groups* tune the
+    grouping run (see :class:`GroupingConfig`); *sessionmaker* is a
+    test seam.
+
+    Raises :class:`LlmOutputInvalid` when either pass returns output
+    that fails schema validation.
+    """  # code-quality-allow: orchestrator entry point keeps every knob explicit
+    config = GroupingConfig(batch_size=batch_size, min_groups=min_groups, max_groups=max_groups)
+    config.validate()
+    triple = _ConnectorTriple(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        tenant_id=tenant_id,
+    )
+    log = _log.bind(
+        connector_id=triple.connector_id,
+        tenant_id=str(tenant_id) if tenant_id is not None else None,
+    )
+    resolved_sessionmaker = sessionmaker if sessionmaker is not None else get_sessionmaker()
+    totals = _PhaseTotals()
+
+    async with resolved_sessionmaker() as session:
+        unassigned_ops = await load_unassigned_ops(
+            session,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            tenant_id=tenant_id,
+        )
+        if not unassigned_ops:
+            log.info("llm_grouping_noop", reason="all_ops_already_grouped")
+            return _build_result(triple, totals)
+
+        await _drive_two_pass_grouping(
+            session,
+            llm_client,
+            triple=triple,
+            unassigned_ops=unassigned_ops,
+            config=config,
+            totals=totals,
+        )
+        await _write_grouping_audit_row(
+            session,
+            operator_sub=operator_sub,
+            operator_tenant_id=operator_tenant_id,
+            triple=triple,
+            totals=totals,
+            config=config,
+        )
+        await session.commit()
+
+    log.info(
+        "llm_grouping_complete",
+        groups_created=totals.groups_created,
+        operations_assigned=totals.operations_assigned,
+        operations_unassigned=totals.operations_unassigned,
+        llm_call_count=totals.llm_call_count,
+        llm_duration_ms=totals.llm_duration_ms,
+    )
+    return _build_result(triple, totals)

--- a/backend/src/meho_backplane/operations/ingest/prompts/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/prompts/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Jinja2 prompt templates for the T3 LLM operation-grouping pass.
+
+The templates ship as package data (``.j2`` files alongside this
+module) so :func:`jinja2.PackageLoader` resolves them via
+``importlib.resources`` in both source-checkout and installed-wheel
+layouts.
+
+Prompt text lives in version control (per
+``ai_engineering_best_practices.md`` -- "Prompts as code"); editing a
+template is a reviewed code change with a corresponding eval / mock-
+LLM run in the test suite. The two templates are intentionally
+self-contained -- no shared partials, no per-call dynamic include --
+so a snapshot test of the rendered output catches drift end-to-end.
+"""

--- a/backend/src/meho_backplane/operations/ingest/prompts/assign_op_to_group.md.j2
+++ b/backend/src/meho_backplane/operations/ingest/prompts/assign_op_to_group.md.j2
@@ -1,0 +1,22 @@
+Assign each operation below to ONE of the groups listed. If no group is a
+clear fit, return "none" -- the operator will assign manually during review.
+
+The connector is: {{ connector_id }} (product={{ product }}, version={{ version }}).
+
+Groups:
+{% for group in groups -%}
+- {{ group.group_key }} ({{ group.name }}): {{ group.when_to_use }}
+{% endfor %}
+
+Operations:
+{% for op in operations -%}
+- {{ op.op_id }}: {{ op.summary or "(no summary)" }} [tags: {{ op.tags | join(", ") if op.tags else "(none)" }}]
+{% endfor %}
+
+Output ONLY a JSON object mapping each op_id (verbatim) to one group_key (or
+"none"). No prose before or after. Schema:
+
+{
+  "<op_id>": "<group_key>",
+  ...
+}

--- a/backend/src/meho_backplane/operations/ingest/prompts/propose_groups.md.j2
+++ b/backend/src/meho_backplane/operations/ingest/prompts/propose_groups.md.j2
@@ -1,0 +1,35 @@
+You are designing the operation taxonomy for a MEHO connector -- a structured
+catalog of vendor API operations that an AI agent will navigate when working
+on infrastructure operations.
+
+The connector is: {{ connector_id }} (product={{ product }}, version={{ version }}, impl_id={{ impl_id }})
+You will see {{ op_count }} operations below. Each has:
+  - op_id (the operation identifier; usually METHOD:path for REST)
+  - summary (one-line from the vendor's OpenAPI spec)
+  - tags (raw OpenAPI tags from the spec)
+
+Your task: propose between {{ min_groups }} and {{ max_groups }} operation GROUPS
+that organize these operations into agent-actionable categories. Anchor your
+groupings on the existing OpenAPI tags and top-level path families where
+sensible, but you are free to override the spec's tags when a more
+agent-actionable taxonomy is apparent. For each group, produce:
+
+  - group_key: snake_case identifier (e.g. "vm_lifecycle", "storage", "events")
+  - name: human-readable display name (Title Case)
+  - when_to_use: one paragraph (2-5 sentences) that an AI agent reads when
+    deciding to scope a search to this group. Be specific: name the
+    resources, the actions, the typical operator question that maps to this
+    group. Do not name vendor brands the agent already knows from the
+    connector identifier.
+
+Operations:
+{% for op in operations -%}
+- {{ op.op_id }}: {{ op.summary or "(no summary)" }} [tags: {{ op.tags | join(", ") if op.tags else "(none)" }}]
+{% endfor %}
+
+Output ONLY a JSON array of objects. No prose before or after. Schema:
+
+[
+  {"group_key": "snake_case_string", "name": "Title Case String", "when_to_use": "Paragraph string."},
+  ...
+]

--- a/backend/tests/fixtures/llm_groups/__init__.py
+++ b/backend/tests/fixtures/llm_groups/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Hand-curated test fixtures for the T3 LLM grouping pipeline.
+
+Two sizes ship today:
+
+* :mod:`small_corpus` -- 5 ops, 2 groups. Drives the happy-path test
+  + the prompt-rendering snapshot.
+* :mod:`medium_corpus` -- 50 ops, multiple group buckets, one
+  ``"none"`` assignment. Drives the call-count assertion
+  (``1 + ceil(50/50) = 2`` LLM calls) + the audit-payload shape.
+
+Per the AI-engineering best-practices pack ("hand-curated ground truth
+before LLM-judge"), the fixtures are checked into source control with
+deterministic stub responses so the test suite is fully reproducible
+without a real LLM. A future opt-in integration test runs the same
+fixtures against a real Claude Haiku call to verify the prompt + schema
+roundtrip on a live model -- but that test stays off the unit-test
+gate (gated on ``ANTHROPIC_API_KEY``).
+"""

--- a/backend/tests/fixtures/llm_groups/medium_corpus.py
+++ b/backend/tests/fixtures/llm_groups/medium_corpus.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Medium 50-op test corpus for the T3 LLM grouping pipeline.
+
+The corpus is synthetic but follows the shape vCenter REST produces:
+distinct top-level path families (cluster / vm / storage / network /
+event / session), HTTP verb spread across the family. Drives the
+documented LLM-call-count contract:
+
+    1 (Pass-1) + ceil(50 / 50) = 2 LLM calls
+
+The stub responses produce a clean 8-group taxonomy and a complete
+op-to-group mapping; one synthetic op deliberately gets ``"none"`` so
+the test suite covers the unassigned-row path without inflating the
+fixture data by inventing an outlier op.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
+
+__all__ = [
+    "EXPECTED_GROUP_KEYS",
+    "EXPECTED_UNASSIGNED_OP_ID",
+    "PROTOS",
+    "STUB_ASSIGNMENT_RESPONSE",
+    "STUB_PROPOSE_RESPONSE",
+    "make_protos",
+]
+
+#: The eight group keys the Pass-1 stub returns. Tests assert that
+#: each one ends up in the persisted ``operation_group`` rows.
+EXPECTED_GROUP_KEYS: tuple[str, ...] = (
+    "cluster",
+    "events",
+    "network",
+    "performance",
+    "session",
+    "storage",
+    "vm_inventory",
+    "vm_lifecycle",
+)
+
+#: The single op the Pass-2 stub assigns to ``"none"``. The test
+#: asserts this op ends up ``group_id=NULL`` and counted under
+#: :attr:`GroupingResult.operations_unassigned`.
+EXPECTED_UNASSIGNED_OP_ID: str = "GET:/api/vcenter/health/probe"
+
+
+def _make_op(
+    op_id: str,
+    *,
+    method: str,
+    path: str,
+    summary: str,
+    tags: list[str],
+    safety_level: str,
+) -> EndpointDescriptorProto:
+    return EndpointDescriptorProto(
+        op_id=op_id,
+        method=method,
+        path=path,
+        summary=summary,
+        tags=tags,
+        parameter_schema={"type": "object", "properties": {}},
+        safety_level=safety_level,  # type: ignore[arg-type]
+    )
+
+
+def make_protos() -> list[EndpointDescriptorProto]:
+    """Return a fresh list of 50 EndpointDescriptorProto rows.
+
+    Buckets:
+
+    * 8 cluster ops, 12 vm-inventory ops, 8 vm-lifecycle ops
+    * 6 storage ops, 6 network ops, 3 events ops, 3 performance ops
+    * 3 session ops, 1 outlier (health probe -> unassigned)
+    """
+    ops: list[EndpointDescriptorProto] = []
+
+    # Cluster: 8 ops
+    for i in range(8):
+        ops.append(
+            _make_op(
+                op_id=f"GET:/api/vcenter/cluster-{i:02d}",
+                method="GET",
+                path=f"/api/vcenter/cluster-{i:02d}",
+                summary=f"Read cluster object {i:02d}",
+                tags=["Cluster"],
+                safety_level="safe",
+            ),
+        )
+
+    # VM inventory: 12 ops (mostly reads)
+    for i in range(12):
+        ops.append(
+            _make_op(
+                op_id=f"GET:/api/vcenter/vm/inventory-{i:02d}",
+                method="GET",
+                path=f"/api/vcenter/vm/inventory-{i:02d}",
+                summary=f"List VM inventory slice {i:02d}",
+                tags=["VM"],
+                safety_level="safe",
+            ),
+        )
+
+    # VM lifecycle: 8 ops (mutations)
+    lifecycle_verbs = (
+        "POST",
+        "DELETE",
+        "POST",
+        "DELETE",
+        "POST",
+        "DELETE",
+        "POST",
+        "DELETE",
+    )
+    for i, verb in enumerate(lifecycle_verbs):
+        ops.append(
+            _make_op(
+                op_id=f"{verb}:/api/vcenter/vm/lifecycle-{i:02d}",
+                method=verb,
+                path=f"/api/vcenter/vm/lifecycle-{i:02d}",
+                summary=f"Mutate VM lifecycle slice {i:02d}",
+                tags=["VM"],
+                safety_level="caution" if verb == "POST" else "dangerous",
+            ),
+        )
+
+    # Storage: 6 ops
+    for i in range(6):
+        ops.append(
+            _make_op(
+                op_id=f"GET:/api/vcenter/storage-{i:02d}",
+                method="GET",
+                path=f"/api/vcenter/storage-{i:02d}",
+                summary=f"Read storage object {i:02d}",
+                tags=["Datastore"],
+                safety_level="safe",
+            ),
+        )
+
+    # Network: 6 ops
+    for i in range(6):
+        ops.append(
+            _make_op(
+                op_id=f"GET:/api/vcenter/network-{i:02d}",
+                method="GET",
+                path=f"/api/vcenter/network-{i:02d}",
+                summary=f"Read network object {i:02d}",
+                tags=["Network"],
+                safety_level="safe",
+            ),
+        )
+
+    # Events: 3 ops
+    for i in range(3):
+        ops.append(
+            _make_op(
+                op_id=f"GET:/api/vcenter/event-{i:02d}",
+                method="GET",
+                path=f"/api/vcenter/event-{i:02d}",
+                summary=f"Read event {i:02d}",
+                tags=["Event"],
+                safety_level="safe",
+            ),
+        )
+
+    # Performance: 3 ops
+    for i in range(3):
+        ops.append(
+            _make_op(
+                op_id=f"GET:/api/vcenter/perf-{i:02d}",
+                method="GET",
+                path=f"/api/vcenter/perf-{i:02d}",
+                summary=f"Read performance counter {i:02d}",
+                tags=["PerfManager"],
+                safety_level="safe",
+            ),
+        )
+
+    # Session: 3 ops
+    for i, verb in enumerate(("POST", "DELETE", "GET")):
+        ops.append(
+            _make_op(
+                op_id=f"{verb}:/api/vcenter/session-{i:02d}",
+                method=verb,
+                path=f"/api/vcenter/session-{i:02d}",
+                summary=f"Manage session {i:02d}",
+                tags=["Session"],
+                safety_level="caution",
+            ),
+        )
+
+    # Outlier: 1 op the stub assigns to "none"
+    ops.append(
+        _make_op(
+            op_id=EXPECTED_UNASSIGNED_OP_ID,
+            method="GET",
+            path="/api/vcenter/health/probe",
+            summary="Liveness probe -- not part of any operator-facing taxonomy",
+            tags=[],
+            safety_level="safe",
+        ),
+    )
+
+    assert len(ops) == 50, f"medium corpus should have 50 ops, got {len(ops)}"
+    return ops
+
+
+PROTOS: Sequence[EndpointDescriptorProto] = make_protos()
+
+
+def _build_propose_response() -> str:
+    """Return the deterministic Pass-1 response for the medium corpus."""
+    proposals = [
+        {
+            "group_key": "cluster",
+            "name": "Cluster",
+            "when_to_use": (
+                "Use when the operator is reading cluster topology or "
+                "membership. Covers cluster enumeration and per-cluster "
+                "configuration reads."
+            ),
+        },
+        {
+            "group_key": "events",
+            "name": "Events",
+            "when_to_use": (
+                "Use when the operator needs the platform event stream -- "
+                "audit-style logs of state changes, alarms, and notifications "
+                "emitted by the vendor."
+            ),
+        },
+        {
+            "group_key": "network",
+            "name": "Network",
+            "when_to_use": (
+                "Use when the operator is reading or troubleshooting "
+                "virtual networking objects -- port groups, switches, and "
+                "their attached state."
+            ),
+        },
+        {
+            "group_key": "performance",
+            "name": "Performance",
+            "when_to_use": (
+                "Use when the operator is investigating performance "
+                "counters or capacity metrics for compute, storage, or "
+                "network resources."
+            ),
+        },
+        {
+            "group_key": "session",
+            "name": "Session",
+            "when_to_use": (
+                "Use when the operator is managing API sessions -- "
+                "authentication tokens, logout, and session metadata."
+            ),
+        },
+        {
+            "group_key": "storage",
+            "name": "Storage",
+            "when_to_use": (
+                "Use when the operator is reading datastore or volume "
+                "objects, capacity, or mount metadata. Covers read-only "
+                "storage inspection."
+            ),
+        },
+        {
+            "group_key": "vm_inventory",
+            "name": "VM Inventory",
+            "when_to_use": (
+                "Use when the operator is listing, browsing, or counting "
+                "virtual machines without mutating them. Read-only "
+                "enumeration only."
+            ),
+        },
+        {
+            "group_key": "vm_lifecycle",
+            "name": "VM Lifecycle",
+            "when_to_use": (
+                "Use when the operator is creating, deleting, or otherwise "
+                "mutating virtual machines. State-changing operations on "
+                "the VM resource."
+            ),
+        },
+    ]
+    return json.dumps(proposals)
+
+
+def _build_assignment_response() -> str:
+    """Return the deterministic Pass-2 response keyed by op_id.
+
+    The mapping covers every op in :func:`make_protos` except the
+    outlier (``EXPECTED_UNASSIGNED_OP_ID``), which is assigned to
+    ``"none"`` so the test suite exercises the unassigned path.
+    """
+    mapping: dict[str, str] = {}
+    for proto in make_protos():
+        op_id = proto.op_id
+        if op_id == EXPECTED_UNASSIGNED_OP_ID:
+            mapping[op_id] = "none"
+            continue
+        if op_id.startswith("GET:/api/vcenter/cluster"):
+            mapping[op_id] = "cluster"
+        elif op_id.startswith("GET:/api/vcenter/vm/inventory"):
+            mapping[op_id] = "vm_inventory"
+        elif "/api/vcenter/vm/lifecycle" in op_id:
+            mapping[op_id] = "vm_lifecycle"
+        elif op_id.startswith("GET:/api/vcenter/storage"):
+            mapping[op_id] = "storage"
+        elif op_id.startswith("GET:/api/vcenter/network"):
+            mapping[op_id] = "network"
+        elif op_id.startswith("GET:/api/vcenter/event"):
+            mapping[op_id] = "events"
+        elif op_id.startswith("GET:/api/vcenter/perf"):
+            mapping[op_id] = "performance"
+        elif "/api/vcenter/session" in op_id:
+            mapping[op_id] = "session"
+        else:
+            mapping[op_id] = "none"
+    return json.dumps(mapping)
+
+
+STUB_PROPOSE_RESPONSE: str = _build_propose_response()
+STUB_ASSIGNMENT_RESPONSE: str = _build_assignment_response()

--- a/backend/tests/fixtures/llm_groups/small_corpus.py
+++ b/backend/tests/fixtures/llm_groups/small_corpus.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Small 5-op test corpus for the T3 LLM grouping pipeline.
+
+Each op mirrors the shape :class:`EndpointDescriptorProto` carries
+after T1's parser runs (op_id = METHOD:path; tags from OpenAPI). The
+stub LLM responses below are tightened to the schemas T3 validates --
+real model calls produce more varied prose but the shape contract is
+identical.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
+
+__all__ = [
+    "EXPECTED_ASSIGNMENT_BY_OP_ID",
+    "PROTOS",
+    "STUB_ASSIGNMENT_RESPONSE",
+    "STUB_PROPOSE_RESPONSE",
+    "make_protos",
+]
+
+
+def make_protos() -> list[EndpointDescriptorProto]:
+    """Return a fresh list of 5 EndpointDescriptorProto rows."""
+    return [
+        EndpointDescriptorProto(
+            op_id="GET:/api/vcenter/cluster",
+            method="GET",
+            path="/api/vcenter/cluster",
+            summary="List clusters",
+            tags=["Cluster"],
+            parameter_schema={"type": "object", "properties": {}},
+            safety_level="safe",
+        ),
+        EndpointDescriptorProto(
+            op_id="GET:/api/vcenter/vm",
+            method="GET",
+            path="/api/vcenter/vm",
+            summary="List VMs",
+            tags=["VM"],
+            parameter_schema={"type": "object", "properties": {}},
+            safety_level="safe",
+        ),
+        EndpointDescriptorProto(
+            op_id="POST:/api/vcenter/vm",
+            method="POST",
+            path="/api/vcenter/vm",
+            summary="Create a VM",
+            tags=["VM"],
+            parameter_schema={"type": "object", "properties": {}},
+            safety_level="caution",
+        ),
+        EndpointDescriptorProto(
+            op_id="DELETE:/api/vcenter/vm/{vm}",
+            method="DELETE",
+            path="/api/vcenter/vm/{vm}",
+            summary="Delete a VM",
+            tags=["VM"],
+            parameter_schema={"type": "object", "properties": {}},
+            safety_level="dangerous",
+        ),
+        EndpointDescriptorProto(
+            op_id="POST:/api/vcenter/vm/{vm}/snapshot",
+            method="POST",
+            path="/api/vcenter/vm/{vm}/snapshot",
+            summary="Take a VM snapshot",
+            tags=["VM", "Snapshot"],
+            parameter_schema={"type": "object", "properties": {}},
+            safety_level="caution",
+        ),
+    ]
+
+
+PROTOS: Sequence[EndpointDescriptorProto] = make_protos()
+
+
+#: Pass-1 stub response. The LLM is asked for 8-15 groups but a
+#: small corpus reasonably proposes fewer; the test suite pins the
+#: actual value but the production prompt's bounds are stricter. For
+#: schema-validation tests we only need 2 groups to demonstrate.
+STUB_PROPOSE_RESPONSE: str = json.dumps(
+    [
+        {
+            "group_key": "inventory",
+            "name": "Inventory",
+            "when_to_use": (
+                "Use when the operator needs to list, browse, or count "
+                "infrastructure objects such as clusters and VMs without "
+                "mutating them. Read-only enumeration of compute and "
+                "container resources falls here."
+            ),
+        },
+        {
+            "group_key": "vm_lifecycle",
+            "name": "VM Lifecycle",
+            "when_to_use": (
+                "Use when the operator is creating, deleting, or snapshotting "
+                "virtual machines. Covers state mutations on the VM resource "
+                "and any direct child resources such as snapshots."
+            ),
+        },
+    ],
+)
+
+#: Pass-2 stub response keyed by op_id. The fifth op (snapshot) is
+#: deliberately ambiguous between the two groups; the stub assigns
+#: it to ``vm_lifecycle`` because the verb is POST (a mutation).
+STUB_ASSIGNMENT_RESPONSE: str = json.dumps(
+    {
+        "GET:/api/vcenter/cluster": "inventory",
+        "GET:/api/vcenter/vm": "inventory",
+        "POST:/api/vcenter/vm": "vm_lifecycle",
+        "DELETE:/api/vcenter/vm/{vm}": "vm_lifecycle",
+        "POST:/api/vcenter/vm/{vm}/snapshot": "vm_lifecycle",
+    },
+)
+
+#: Inverse of :data:`STUB_ASSIGNMENT_RESPONSE` -- the expected
+#: ``op_id -> group_key`` mapping after parsing. Tests assert
+#: against this; updating the stub above without updating this map
+#: surfaces as a clear test failure rather than a silent drift.
+EXPECTED_ASSIGNMENT_BY_OP_ID: dict[str, str] = {
+    "GET:/api/vcenter/cluster": "inventory",
+    "GET:/api/vcenter/vm": "inventory",
+    "POST:/api/vcenter/vm": "vm_lifecycle",
+    "DELETE:/api/vcenter/vm/{vm}": "vm_lifecycle",
+    "POST:/api/vcenter/vm/{vm}/snapshot": "vm_lifecycle",
+}

--- a/backend/tests/test_operations_ingest_llm_groups.py
+++ b/backend/tests/test_operations_ingest_llm_groups.py
@@ -552,6 +552,102 @@ async def test_run_llm_grouping_writes_audit_row(
     assert payload["batch_size"] == DEFAULT_GROUPING_BATCH_SIZE
 
 
+@pytest.mark.asyncio
+async def test_run_llm_grouping_omitted_ops_counted_once(
+    stub_embedding_service: Any,
+) -> None:
+    """Regression for CodeRabbit B1 (PR #485).
+
+    The Pass-2 stub deliberately omits two of the five small-corpus
+    op_ids from its response. The buggy ``_apply_assignments_to_rows``
+    counted omitted ops twice: once via the ``NONE_GROUP_KEY`` default
+    in the per-row loop and again via a trailing
+    ``missing = all_op_ids - assignment_map.keys()`` block, inflating
+    ``operations_unassigned`` and breaking the
+    ``assigned + unassigned == len(operations)`` reconciliation
+    invariant the audit row depends on.
+
+    With the fix, omitted ops are counted exactly once. For a 5-op
+    corpus with 3 assigned and 2 omitted, ``operations_unassigned``
+    must equal 2 (not 4), and the audit-row payload must match.
+    """
+    await _ingest_small_corpus(stub_embedding_service)
+
+    # Pass-2 response omits the two DELETE/snapshot op_ids entirely.
+    # The parser keeps the three present-and-valid entries; the
+    # remaining two ops should be counted as unassigned exactly once.
+    partial_assignment_response = json.dumps(
+        {
+            "GET:/api/vcenter/cluster": "inventory",
+            "GET:/api/vcenter/vm": "inventory",
+            "POST:/api/vcenter/vm": "vm_lifecycle",
+            # "DELETE:/api/vcenter/vm/{vm}" -- omitted
+            # "POST:/api/vcenter/vm/{vm}/snapshot" -- omitted
+        },
+    )
+    stub = StubLlmClient(
+        responses=[
+            small_corpus.STUB_PROPOSE_RESPONSE,
+            partial_assignment_response,
+        ],
+    )
+    result = await run_llm_grouping(
+        llm_client=stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+    )
+
+    # Core invariant: each op is counted exactly once.
+    assert result.operations_assigned + result.operations_unassigned == len(
+        small_corpus.PROTOS,
+    )
+    assert result.operations_assigned == 3
+    # Without the fix, this would be 4 (the two omitted ops are
+    # counted once via the per-row loop's NONE_GROUP_KEY default and
+    # again via the trailing all_op_ids/missing block).
+    assert result.operations_unassigned == 2
+
+    # Audit-row payload reflects the same (correct) total.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == OP_LLM_GROUPING)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert isinstance(payload, dict)
+    assert payload["operations_assigned"] == 3
+    assert payload["operations_unassigned"] == 2
+    assert payload["operations_assigned"] + payload["operations_unassigned"] == len(
+        small_corpus.PROTOS
+    )
+
+    # Per-row ORM mutations also follow the same invariant: only the
+    # three assigned ops carry a group_id; the two omitted rows stay
+    # NULL (unassigned).
+    async with sessionmaker() as fresh:
+        ops = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor)
+                    .where(EndpointDescriptor.product == "vmware")
+                    .order_by(EndpointDescriptor.op_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assigned_count = sum(1 for op in ops if op.group_id is not None)
+    unassigned_count = sum(1 for op in ops if op.group_id is None)
+    assert assigned_count == 3
+    assert unassigned_count == 2
+
+
 # ---------------------------------------------------------------------------
 # Medium corpus -- AC-pinned batching + unassigned-op path
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_ingest_llm_groups.py
+++ b/backend/tests/test_operations_ingest_llm_groups.py
@@ -1,0 +1,929 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.operations.ingest.llm_groups`.
+
+Coverage matrix (G0.7-T3 / Task #404 acceptance criteria):
+
+* :func:`run_llm_grouping` -- happy-path two-pass run produces
+  :class:`OperationGroup` rows with ``review_status='staged'``,
+  non-empty ``when_to_use``, non-empty ``name``, and a
+  :class:`GroupingResult` with the documented counts + LLM-call shape.
+* Per-op assignment -- each ingested op gets ``group_id`` set (or stays
+  NULL for the ``"none"`` sentinel path).
+* Pass-1 output validation -- malformed JSON / wrong shape / non-snake-case
+  ``group_key`` raises :class:`LlmOutputInvalid`.
+* Pass-2 batching -- 50-op corpus triggers exactly ``1 + ceil(50/50) = 2``
+  LLM calls; 100 ops with batch=50 trigger ``1 + 2 = 3``.
+* Idempotency -- re-running on a fully-grouped connector is a no-op
+  (zero LLM calls, zero rows mutated, no audit row).
+* Partial regrouping -- re-running on a partially-grouped connector
+  runs Pass-2-only over the unassigned rows, reusing existing groups.
+* Audit row -- one ``meho.connector.llm_grouping`` row written with
+  ``{connector_id, groups_created, operations_assigned,
+  operations_unassigned, llm_call_count, batch_size}`` payload.
+* Prompt rendering -- snapshot-style assertions on the rendered Jinja
+  templates so silent prompt drift is caught at test time.
+
+The chassis LLM client is stubbed via a fake :class:`LlmClient`
+implementation whose ``generate_json`` returns canned responses from
+the corpus fixtures. A real-LLM integration test stub lives at the
+end of the file, guarded by an ``ANTHROPIC_API_KEY`` env check that
+keeps the unit-test gate green in sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import (
+    GroupingResult,
+    GroupProposal,
+    LlmOutputInvalid,
+    register_ingested_operations,
+    run_llm_grouping,
+)
+from meho_backplane.operations.ingest._internals import (
+    AUDIT_METHOD,
+    OP_LLM_GROUPING,
+)
+from meho_backplane.operations.ingest._llm_grouping_internals import (
+    ASSIGN_OPS_SYSTEM_PROMPT,
+    DEFAULT_GROUPING_BATCH_SIZE,
+    PROPOSE_GROUPS_SYSTEM_PROMPT,
+    expected_llm_call_count,
+    parse_assignment_response,
+    parse_proposal_response,
+    render_assign_ops_prompt,
+    render_propose_groups_prompt,
+    strip_code_fences,
+)
+from meho_backplane.settings import get_settings
+from tests.fixtures.llm_groups import medium_corpus, small_corpus
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_connector_registry() -> Iterator[None]:
+    """Reset the v2 connector registry between tests."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> Any:
+    """An AsyncMock standing in for EmbeddingService."""
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.encode_one.return_value = [0.25] * 384
+    service.encode.return_value = [[0.25] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an AsyncSession against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class StubLlmClient:
+    """Deterministic :class:`LlmClient` for unit tests.
+
+    Returns a canned response per call site. The caller seeds the
+    response list in construction order; each ``generate_json`` call
+    pops the next entry. Excess calls (more than seeded) raise
+    :class:`AssertionError` so a test that fires the LLM more often
+    than expected fails loudly rather than silently looping.
+
+    Records every call's (system_prompt, user_prompt, max_output_tokens)
+    triple on :attr:`calls` so assertions on call count, prompt shape,
+    and system-prompt stability are straightforward.
+    """
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses: list[str] = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def generate_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        max_output_tokens: int,
+    ) -> str:
+        self.calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "max_output_tokens": max_output_tokens,
+            },
+        )
+        if not self._responses:
+            raise AssertionError(
+                f"StubLlmClient: ran out of canned responses (call #{len(self.calls)})",
+            )
+        return self._responses.pop(0)
+
+    @property
+    def call_count(self) -> int:
+        return len(self.calls)
+
+
+_OPERATOR_SUB = "op-test-1"
+_OPERATOR_TENANT = uuid.UUID("00000000-0000-0000-0000-00000000a0a0")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _ingest_small_corpus(
+    embedding_service: Any,
+    *,
+    product: str = "vmware",
+    version: str = "9.0",
+    impl_id: str = "vmware-rest",
+    spec_source: str = "vcenter.yaml",
+) -> None:
+    """Drive T2's bulk-upsert helper on the small fixture corpus.
+
+    Convenience wrapper so each grouping test starts from a clean
+    set of ingested rows without rebuilding the connector triple
+    in every test body.
+    """
+    await register_ingested_operations(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        spec_source=spec_source,
+        operations=small_corpus.PROTOS,
+        embedding_service=embedding_service,
+    )
+
+
+async def _ingest_medium_corpus(embedding_service: Any) -> None:
+    """Drive T2 on the medium 50-op corpus."""
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=medium_corpus.PROTOS,
+        embedding_service=embedding_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering -- snapshot-style assertions
+# ---------------------------------------------------------------------------
+
+
+def test_render_propose_groups_prompt_contains_op_count_and_bounds() -> None:
+    """Pass-1 prompt embeds op count + group-count bounds verbatim."""
+    rendered = render_propose_groups_prompt(
+        connector_id="vmware-rest-9.0",
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        operations=small_corpus.PROTOS,
+        min_groups=8,
+        max_groups=15,
+    )
+    assert "You will see 5 operations below" in rendered
+    assert "between 8 and 15 operation GROUPS" in rendered
+    assert "vmware-rest-9.0" in rendered
+    # Every op_id appears in the rendered prompt.
+    for proto in small_corpus.PROTOS:
+        assert proto.op_id in rendered
+    # Output schema instruction present and unambiguous.
+    assert "Output ONLY a JSON array" in rendered
+
+
+def test_render_propose_groups_prompt_handles_empty_tags() -> None:
+    """Ops with no tags render as ``[tags: (none)]`` rather than crashing."""
+    proto = medium_corpus.PROTOS[-1]
+    assert proto.op_id == medium_corpus.EXPECTED_UNASSIGNED_OP_ID
+    rendered = render_propose_groups_prompt(
+        connector_id="vmware-rest-9.0",
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        operations=[proto],
+    )
+    assert "[tags: (none)]" in rendered
+
+
+def test_render_assign_ops_prompt_lists_every_group() -> None:
+    """Pass-2 prompt contains each group's key + when_to_use."""
+    groups = parse_proposal_response(small_corpus.STUB_PROPOSE_RESPONSE)
+    rendered = render_assign_ops_prompt(
+        connector_id="vmware-rest-9.0",
+        product="vmware",
+        version="9.0",
+        groups=groups,
+        operations=small_corpus.PROTOS,
+    )
+    for group in groups:
+        assert group.group_key in rendered
+        # The first ~30 chars of when_to_use are enough to verify the
+        # paragraph made it through without storing the full prose
+        # twice in source.
+        assert group.when_to_use[:30] in rendered
+    assert "Output ONLY a JSON object" in rendered
+
+
+# ---------------------------------------------------------------------------
+# LLM-output parsing -- failure modes
+# ---------------------------------------------------------------------------
+
+
+def teststrip_code_fences_removes_json_fence() -> None:
+    """The fenced-code wrapper the model sometimes emits is stripped cleanly."""
+    raw = '```json\n[{"group_key": "x", "name": "X", "when_to_use": "y"}]\n```'
+    cleaned = strip_code_fences(raw)
+    assert cleaned.startswith("[")
+    assert cleaned.endswith("]")
+
+
+def teststrip_code_fences_preserves_unfenced_input() -> None:
+    """Bare JSON passes through unchanged (modulo whitespace)."""
+    raw = '  [{"group_key": "x", "name": "X", "when_to_use": "y"}]  '
+    assert strip_code_fences(raw) == raw.strip()
+
+
+def testparse_proposal_response_happy_path() -> None:
+    """Stub corpus produces validated GroupProposal instances."""
+    groups = parse_proposal_response(small_corpus.STUB_PROPOSE_RESPONSE)
+    assert len(groups) == 2
+    assert {g.group_key for g in groups} == {"inventory", "vm_lifecycle"}
+    for group in groups:
+        assert group.name.strip()
+        assert group.when_to_use.strip()
+
+
+def testparse_proposal_response_rejects_malformed_json() -> None:
+    """Non-JSON output raises LlmOutputInvalid pinned to pass_name='propose_groups'."""
+    with pytest.raises(LlmOutputInvalid) as excinfo:
+        parse_proposal_response("this is not JSON at all")
+    assert excinfo.value.pass_name == "propose_groups"
+    assert "this is not JSON at all" in excinfo.value.raw_output
+
+
+def testparse_proposal_response_rejects_non_array() -> None:
+    """A JSON object at the top level (instead of array) raises."""
+    with pytest.raises(LlmOutputInvalid) as excinfo:
+        parse_proposal_response('{"group_key": "x"}')
+    assert "expected a JSON array" in repr(excinfo.value)
+
+
+def testparse_proposal_response_rejects_invalid_group_key() -> None:
+    """A non-snake-case group_key fails GroupProposal validation."""
+    bad = json.dumps(
+        [
+            {
+                "group_key": "Bad-Key",
+                "name": "Bad",
+                "when_to_use": "irrelevant",
+            },
+        ],
+    )
+    with pytest.raises(LlmOutputInvalid) as excinfo:
+        parse_proposal_response(bad)
+    # The chained ValidationError surfaces on .parse_error.
+    assert excinfo.value.parse_error is not None
+
+
+def testparse_proposal_response_rejects_duplicate_group_key() -> None:
+    """Two entries sharing a group_key raise before any DB write."""
+    bad = json.dumps(
+        [
+            {
+                "group_key": "x",
+                "name": "X",
+                "when_to_use": "first",
+            },
+            {
+                "group_key": "x",
+                "name": "Y",
+                "when_to_use": "second",
+            },
+        ],
+    )
+    with pytest.raises(LlmOutputInvalid) as excinfo:
+        parse_proposal_response(bad)
+    assert "duplicate group_key" in repr(excinfo.value)
+
+
+def testparse_proposal_response_rejects_missing_when_to_use() -> None:
+    """Pass-1 output must carry a non-empty ``when_to_use``."""
+    bad = json.dumps(
+        [
+            {
+                "group_key": "x",
+                "name": "X",
+                "when_to_use": "",
+            },
+        ],
+    )
+    with pytest.raises(LlmOutputInvalid):
+        parse_proposal_response(bad)
+
+
+def testparse_assignment_response_coerces_unknown_group_to_none() -> None:
+    """An op assigned to an unknown group_key is silently coerced to ``"none"``.
+
+    The parser logs a warning but the operator-facing flow handles
+    unknown-group as "leave for manual review" rather than aborting.
+    """
+    raw = json.dumps(
+        {
+            "op-1": "real_group",
+            "op-2": "ghost_group",
+            "op-3": "none",
+        },
+    )
+    mapping = parse_assignment_response(
+        raw,
+        valid_op_ids={"op-1", "op-2", "op-3"},
+        valid_group_keys={"real_group"},
+    )
+    assert mapping == {"op-1": "real_group", "op-2": "none", "op-3": "none"}
+
+
+def testparse_assignment_response_drops_unknown_op_id() -> None:
+    """An op_id the parser doesn't recognise is silently dropped."""
+    raw = json.dumps({"op-1": "g1", "rogue": "g1"})
+    mapping = parse_assignment_response(
+        raw,
+        valid_op_ids={"op-1"},
+        valid_group_keys={"g1"},
+    )
+    assert mapping == {"op-1": "g1"}
+
+
+def testparse_assignment_response_rejects_non_object() -> None:
+    """Top-level array (instead of object) raises."""
+    with pytest.raises(LlmOutputInvalid) as excinfo:
+        parse_assignment_response(
+            "[]",
+            valid_op_ids=set(),
+            valid_group_keys=set(),
+        )
+    assert excinfo.value.pass_name == "assign_ops"
+
+
+# ---------------------------------------------------------------------------
+# expected_llm_call_count contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op_count", "batch_size", "expected"),
+    [
+        (50, 50, 2),  # vCenter median path; AC explicit
+        (100, 50, 3),
+        (1000, 50, 21),
+        (5, 50, 2),
+        (961, 50, 21),  # full vCenter REST
+        (1, 50, 2),
+        (0, 50, 0),
+    ],
+)
+def test_expected_llm_call_count(
+    op_count: int,
+    batch_size: int,
+    expected: int,
+) -> None:
+    """1 + ceil(op_count / batch_size) -- the documented call-count rule."""
+    assert expected_llm_call_count(op_count, batch_size) == expected
+
+
+# ---------------------------------------------------------------------------
+# run_llm_grouping -- end-to-end happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_llm_grouping_small_corpus_persists_groups_and_assigns_ops(
+    stub_embedding_service: Any,
+) -> None:
+    """Happy path: Pass-1 + Pass-2 + audit row + ORM mutations."""
+    await _ingest_small_corpus(stub_embedding_service)
+
+    stub = StubLlmClient(
+        responses=[
+            small_corpus.STUB_PROPOSE_RESPONSE,
+            small_corpus.STUB_ASSIGNMENT_RESPONSE,
+        ],
+    )
+    result = await run_llm_grouping(
+        llm_client=stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+    )
+
+    assert isinstance(result, GroupingResult)
+    assert result.connector_id == "vmware-rest-9.0"
+    assert result.groups_created == 2
+    assert result.operations_assigned == 5
+    assert result.operations_unassigned == 0
+    assert result.llm_call_count == 2
+    assert result.llm_duration_ms >= 0.0
+
+    # Two LLM calls -- one Pass 1, one Pass 2 (5 ops fit in one batch).
+    assert stub.call_count == 2
+    assert "Output ONLY a JSON array" in stub.calls[0]["user_prompt"]
+    assert "Output ONLY a JSON object" in stub.calls[1]["user_prompt"]
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        groups = (
+            (
+                await fresh.execute(
+                    select(OperationGroup)
+                    .where(OperationGroup.product == "vmware")
+                    .order_by(OperationGroup.group_key)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(groups) == 2
+        for group in groups:
+            assert group.review_status == "staged"
+            assert group.when_to_use.strip()
+            assert group.name.strip()
+            assert group.tenant_id is None
+        group_id_by_key = {g.group_key: g.id for g in groups}
+
+        ops = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor)
+                    .where(EndpointDescriptor.product == "vmware")
+                    .order_by(EndpointDescriptor.op_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(ops) == 5
+        assigned_by_op_id = {op.op_id: op.group_id for op in ops}
+        for op_id, expected_key in small_corpus.EXPECTED_ASSIGNMENT_BY_OP_ID.items():
+            assert assigned_by_op_id[op_id] == group_id_by_key[expected_key]
+
+
+@pytest.mark.asyncio
+async def test_run_llm_grouping_writes_audit_row(
+    stub_embedding_service: Any,
+) -> None:
+    """One ``meho.connector.llm_grouping`` audit row with the documented payload."""
+    await _ingest_small_corpus(stub_embedding_service)
+    stub = StubLlmClient(
+        responses=[
+            small_corpus.STUB_PROPOSE_RESPONSE,
+            small_corpus.STUB_ASSIGNMENT_RESPONSE,
+        ],
+    )
+    await run_llm_grouping(
+        llm_client=stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == OP_LLM_GROUPING)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.method == AUDIT_METHOD
+    assert row.operator_sub == _OPERATOR_SUB
+    assert row.tenant_id == _OPERATOR_TENANT
+    assert row.status_code == 200
+    payload = row.payload
+    assert isinstance(payload, dict)
+    assert payload["connector_id"] == "vmware-rest-9.0"
+    assert payload["groups_created"] == 2
+    assert payload["operations_assigned"] == 5
+    assert payload["operations_unassigned"] == 0
+    assert payload["llm_call_count"] == 2
+    assert payload["batch_size"] == DEFAULT_GROUPING_BATCH_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Medium corpus -- AC-pinned batching + unassigned-op path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_llm_grouping_medium_corpus_two_llm_calls(
+    stub_embedding_service: Any,
+) -> None:
+    """50 ops + batch_size=50 -> exactly 2 LLM calls (1 + ceil(50/50))."""
+    await _ingest_medium_corpus(stub_embedding_service)
+
+    stub = StubLlmClient(
+        responses=[
+            medium_corpus.STUB_PROPOSE_RESPONSE,
+            medium_corpus.STUB_ASSIGNMENT_RESPONSE,
+        ],
+    )
+    result = await run_llm_grouping(
+        llm_client=stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+    )
+    assert result.llm_call_count == 2
+    assert stub.call_count == 2
+    assert result.groups_created == 8
+    assert result.operations_assigned == 49
+    assert result.operations_unassigned == 1
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        groups = (
+            (await fresh.execute(select(OperationGroup).where(OperationGroup.product == "vmware")))
+            .scalars()
+            .all()
+        )
+        assert {g.group_key for g in groups} == set(medium_corpus.EXPECTED_GROUP_KEYS)
+        unassigned = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == medium_corpus.EXPECTED_UNASSIGNED_OP_ID,
+                )
+            )
+        ).scalar_one()
+        assert unassigned.group_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_llm_grouping_medium_corpus_with_smaller_batch(
+    stub_embedding_service: Any,
+) -> None:
+    """batch_size=25 over 50 ops -> 1 + ceil(50/25) = 3 LLM calls.
+
+    The two Pass-2 batches each see half the ops; the parser merges
+    the two response dicts into the final assignment map. Each batch's
+    response covers exactly the op_ids in that batch.
+    """
+    await _ingest_medium_corpus(stub_embedding_service)
+
+    # Split the stub assignment response across two batches based on
+    # op_id sort order (the production code sorts ops by op_id before
+    # batching, so this matches what the real call would see).
+    full_assignments: dict[str, str] = json.loads(medium_corpus.STUB_ASSIGNMENT_RESPONSE)
+    ordered_op_ids = sorted(op.op_id for op in medium_corpus.PROTOS)
+    batch_a_ids = set(ordered_op_ids[:25])
+    batch_b_ids = set(ordered_op_ids[25:])
+    batch_a = {k: v for k, v in full_assignments.items() if k in batch_a_ids}
+    batch_b = {k: v for k, v in full_assignments.items() if k in batch_b_ids}
+
+    stub = StubLlmClient(
+        responses=[
+            medium_corpus.STUB_PROPOSE_RESPONSE,
+            json.dumps(batch_a),
+            json.dumps(batch_b),
+        ],
+    )
+    result = await run_llm_grouping(
+        llm_client=stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        batch_size=25,
+    )
+    assert result.llm_call_count == 3
+    assert stub.call_count == 3
+    assert result.operations_assigned == 49
+    assert result.operations_unassigned == 1
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + partial regrouping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_llm_grouping_noop_on_fully_grouped_connector(
+    stub_embedding_service: Any,
+) -> None:
+    """A second invocation with no unassigned rows is a true no-op."""
+    await _ingest_small_corpus(stub_embedding_service)
+    stub = StubLlmClient(
+        responses=[
+            small_corpus.STUB_PROPOSE_RESPONSE,
+            small_corpus.STUB_ASSIGNMENT_RESPONSE,
+        ],
+    )
+    await run_llm_grouping(
+        llm_client=stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+    )
+    assert stub.call_count == 2  # 1 + 1
+
+    # Second invocation -- nothing to do.
+    second_stub = StubLlmClient(responses=[])
+    second_result = await run_llm_grouping(
+        llm_client=second_stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+    )
+    assert second_result.llm_call_count == 0
+    assert second_result.groups_created == 0
+    assert second_result.operations_assigned == 0
+    assert second_result.operations_unassigned == 0
+    assert second_stub.call_count == 0
+
+    # No second audit row was written.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == OP_LLM_GROUPING)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_llm_grouping_partial_regrouping_runs_pass2_only(
+    stub_embedding_service: Any,
+) -> None:
+    """Re-running on a partially-grouped connector skips Pass 1.
+
+    Setup: ingest the small corpus + group it. Then ingest one extra op
+    (the partial-state simulation) and re-run grouping. The Pass-1 step
+    must be skipped because existing groups are present; Pass-2 runs
+    only on the new op.
+    """
+    await _ingest_small_corpus(stub_embedding_service)
+    first_stub = StubLlmClient(
+        responses=[
+            small_corpus.STUB_PROPOSE_RESPONSE,
+            small_corpus.STUB_ASSIGNMENT_RESPONSE,
+        ],
+    )
+    await run_llm_grouping(
+        llm_client=first_stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+    )
+
+    # Inject one extra ingested op under the same connector, leaving
+    # group_id=NULL -- this matches what T2 does for any new spec
+    # operation before T3 has run.
+    new_op = small_corpus.make_protos()[0].model_copy(
+        update={
+            "op_id": "GET:/api/vcenter/cluster-extra",
+            "path": "/api/vcenter/cluster-extra",
+            "summary": "List extra cluster",
+        },
+    )
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[new_op],
+        embedding_service=stub_embedding_service,
+    )
+
+    # Stub only Pass-2; Pass-1 should not fire.
+    partial_stub = StubLlmClient(
+        responses=[
+            json.dumps({"GET:/api/vcenter/cluster-extra": "inventory"}),
+        ],
+    )
+    result = await run_llm_grouping(
+        llm_client=partial_stub,
+        operator_sub=_OPERATOR_SUB,
+        operator_tenant_id=_OPERATOR_TENANT,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+    )
+    assert partial_stub.call_count == 1, "Pass-1 should be skipped when existing groups are present"
+    assert result.llm_call_count == 1
+    assert result.groups_created == 0  # no new groups
+    assert result.operations_assigned == 1
+    assert result.operations_unassigned == 0
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        groups = (
+            (await fresh.execute(select(OperationGroup).where(OperationGroup.product == "vmware")))
+            .scalars()
+            .all()
+        )
+        assert len(groups) == 2  # unchanged from the first run
+
+        new_row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "GET:/api/vcenter/cluster-extra",
+                )
+            )
+        ).scalar_one()
+        assert new_row.group_id is not None
+
+
+# ---------------------------------------------------------------------------
+# Validation / argument-shape failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_llm_grouping_rejects_bad_min_max_groups(
+    stub_embedding_service: Any,
+) -> None:
+    """Bad bounds raise ValueError before any LLM call."""
+    await _ingest_small_corpus(stub_embedding_service)
+    stub = StubLlmClient(responses=[])
+    with pytest.raises(ValueError, match="min_groups"):
+        await run_llm_grouping(
+            llm_client=stub,
+            operator_sub=_OPERATOR_SUB,
+            operator_tenant_id=_OPERATOR_TENANT,
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            min_groups=0,
+        )
+    with pytest.raises(ValueError, match="max_groups"):
+        await run_llm_grouping(
+            llm_client=stub,
+            operator_sub=_OPERATOR_SUB,
+            operator_tenant_id=_OPERATOR_TENANT,
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            min_groups=10,
+            max_groups=5,
+        )
+    with pytest.raises(ValueError, match="batch_size"):
+        await run_llm_grouping(
+            llm_client=stub,
+            operator_sub=_OPERATOR_SUB,
+            operator_tenant_id=_OPERATOR_TENANT,
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            batch_size=0,
+        )
+    assert stub.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_llm_grouping_surfaces_pass1_failure(
+    stub_embedding_service: Any,
+) -> None:
+    """Pass-1 malformed output bubbles up as LlmOutputInvalid.
+
+    The function aborts before Pass-2 fires (the test only seeds one
+    response; a Pass-2 call would raise StubLlmClient's
+    out-of-responses assertion, which is exactly the contract we want).
+    """
+    await _ingest_small_corpus(stub_embedding_service)
+    stub = StubLlmClient(responses=["not json"])
+    with pytest.raises(LlmOutputInvalid) as excinfo:
+        await run_llm_grouping(
+            llm_client=stub,
+            operator_sub=_OPERATOR_SUB,
+            operator_tenant_id=_OPERATOR_TENANT,
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+        )
+    assert excinfo.value.pass_name == "propose_groups"
+    assert stub.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Frozen GroupProposal -- defence-in-depth
+# ---------------------------------------------------------------------------
+
+
+def test_group_proposal_is_frozen() -> None:
+    """Re-assigning a GroupProposal field raises ValidationError."""
+    from pydantic import ValidationError
+
+    proposal = GroupProposal(
+        group_key="x",
+        name="X",
+        when_to_use="something useful here",
+    )
+    with pytest.raises(ValidationError):
+        proposal.group_key = "y"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Real-LLM integration test (opt-in via env)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="real-LLM integration test; requires ANTHROPIC_API_KEY",
+)
+async def test_run_llm_grouping_with_real_claude_haiku(
+    stub_embedding_service: Any,
+) -> None:
+    """Integration sanity: run against real Claude Haiku on the medium corpus.
+
+    Opt-in: skipped in sandbox + CI. Operators / engineers verifying
+    prompt quality run this manually with their own API key. The
+    assertion is the *shape* contract -- the response validates, every
+    op gets either a group_id or a recorded "none" -- not specific
+    group choices, which would be model-version dependent.
+
+    Note: this test exercises only the public surface; it does not
+    pull the Anthropic SDK at import time. A concrete LlmClient
+    backed by ``anthropic.AsyncAnthropic`` lives in the chassis (when
+    that lands at T5 #405 or later); for v0.2 this test stays
+    as a manual sanity hook.
+    """
+    pytest.skip(
+        "real-LLM integration adapter not yet wired; "
+        "T5 (#405) lands the chassis LlmClient implementation",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression -- system prompts are stable strings (cacheable prefix)
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompts_are_pure_text_no_dynamic_substitution() -> None:
+    """System prompts must not contain Jinja-style template tags.
+
+    The AI-eng-pack 'Prompt caching' rule: cache the stable prefix.
+    A system prompt that interpolates per-call values breaks prompt
+    caching on every call. Keep the dynamism in the user-prompt body
+    (rendered by the Jinja templates); the system prompt is verbatim
+    text.
+    """
+    template_tag = re.compile(r"\{\{|\{%")
+    assert not template_tag.search(PROPOSE_GROUPS_SYSTEM_PROMPT)
+    assert not template_tag.search(ASSIGN_OPS_SYSTEM_PROMPT)
+    # Both system prompts must explicitly forbid prose-around-JSON.
+    assert "ONLY" in PROPOSE_GROUPS_SYSTEM_PROMPT
+    assert "ONLY" in ASSIGN_OPS_SYSTEM_PROMPT

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -963,6 +963,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "joserfc"
 version = "1.6.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1200,6 +1212,7 @@ dependencies = [
     { name = "fastembed" },
     { name = "httpx" },
     { name = "hvac" },
+    { name = "jinja2" },
     { name = "jsonschema" },
     { name = "kubernetes-asyncio" },
     { name = "packaging" },
@@ -1238,6 +1251,7 @@ requires-dist = [
     { name = "fastembed", specifier = ">=0.7,<1.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "hvac", specifier = ">=2.4.0" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "kubernetes-asyncio", specifier = ">=32,<33" },
     { name = "packaging", specifier = ">=24.0" },

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -27,8 +27,14 @@ The pipeline is broken into work items per Initiative #389:
   registry on first ingest of a `(product, version, impl_id)` triple;
   the shim raises `NotImplementedError` on `auth_headers` / `execute`
   until a per-G3.x Initiative replaces it with a hand-coded subclass.
-* **T3 — LLM-summarised grouping.** Proposes operation groups and
-  assigns each op to one, writing `operation_group` rows.
+* **T3 — LLM-summarised grouping** (`ingest/llm_groups.py` +
+  `ingest/_llm_grouping_internals.py` + `ingest/prompts/`). Two-pass
+  LLM run: (1) propose 8–15 groups from the full op list, (2) assign
+  each op to a group in batches of 50. Proposed groups land
+  `review_status='staged'`; each per-op `group_id` is set in the same
+  transaction as the audit row. The LLM is injected as the
+  :class:`LlmClient` Protocol; production T5 wires the chassis
+  Anthropic adapter, tests inject a deterministic stub.
 * **T4 — Review-queue state machine** (`ingest/service.py`). Operators
   move connectors through `staged → enabled` (and `disabled` for
   regression rollback) before any op becomes dispatchable.
@@ -39,6 +45,50 @@ The pipeline is broken into work items per Initiative #389:
 T1 produces the proto shape every other stage consumes; T2 is the
 single write path into `endpoint_descriptor` for ingested rows; T3
 groups them; T4 gates dispatchability behind operator review.
+
+### T3 (LLM grouping) at a glance
+
+`run_llm_grouping()` opens its own transaction and runs:
+
+1. **Pass 1 (group derivation)** — only when no `operation_group`
+   rows yet exist for the connector triple. Sends every unassigned
+   op's `(op_id, summary, tags)` to the LLM and asks for an array of
+   `{group_key, name, when_to_use}` proposals. Output is validated
+   against `GroupProposal` (snake_case key, non-empty fields, bounded
+   lengths, no duplicate keys) and persisted as
+   `OperationGroup` rows in `review_status='staged'`.
+2. **Pass 2 (per-op assignment)** — splits the unassigned-op set
+   into batches of `batch_size` (default 50). Each batch asks the LLM
+   for a JSON object mapping `op_id` to `group_key`, where
+   `group_key` is either one of the Pass-1 keys or the sentinel
+   `"none"`. Each row's `EndpointDescriptor.group_id` is set to the
+   matching group's UUID; sentinel and unknown-key entries leave
+   `group_id=NULL`.
+
+The function commits exactly once at the end of both passes, in the
+same transaction as a single `meho.connector.llm_grouping` audit row
+that records `{connector_id, groups_created, operations_assigned,
+operations_unassigned, llm_call_count, batch_size}`. Partial failure
+(LLM output that fails schema validation) raises
+`LlmOutputInvalid`, rolls back the transaction, and leaves the
+connector in whatever state preceded the call — operator retries via
+the CLI verb T5 will ship.
+
+Idempotency:
+
+* No unassigned ops → true no-op, zero LLM calls, no audit row.
+* Existing `operation_group` rows present but some ops still
+  unassigned → Pass 1 skipped, Pass 2 only runs against the
+  unassigned-op subset using the existing groups verbatim. This is
+  the "partial-regrouping" branch.
+* Fully fresh connector → both passes run, all groups + assignments
+  persist in one transaction.
+
+The LLM client is injected as a `LlmClient` `Protocol` (one async
+method, `generate_json`). Tests pass a deterministic stub from
+`tests/fixtures/llm_groups/{small,medium}_corpus.py`. The chassis
+adapter (Anthropic Messages API) lands with T5 (#405) which will
+also surface the model id + retry policy as `Settings` knobs.
 
 ## Key types
 
@@ -67,6 +117,30 @@ T2 owns the rest of the ORM columns: `tenant_id`, `source_kind`
 owns `group_id` (NULL until grouping runs). T4 owns
 `custom_description`, `custom_notes`, `llm_instructions` (operator-
 authored overrides at review time).
+
+### `GroupProposal` / `GroupingResult` / `GroupingConfig` (`ingest/llm_groups.py`)
+
+Pydantic `frozen=True` model + two frozen-slotted dataclasses, one
+per role in the T3 grouping run:
+
+* `GroupProposal` — the per-group dict the LLM emits in Pass 1
+  (`group_key`, `name`, `when_to_use`). Snake-case key enforced via
+  validator; oversized prose rejected via bounded `max_length`.
+* `GroupingResult` — counts + timings the orchestrator returns
+  (`groups_created`, `operations_assigned`, `operations_unassigned`,
+  `llm_call_count`, `llm_duration_ms`). Surfaced in the operator-
+  facing CLI / API at T5.
+* `GroupingConfig` — tunable knobs (`batch_size`, `min_groups`,
+  `max_groups`). Constructed from the keyword arguments to
+  `run_llm_grouping()`; `validate()` raises `ValueError` before any
+  LLM or DB I/O.
+
+`LlmOutputInvalid` (in `exceptions.py`) raises when either pass
+returns malformed JSON or output that fails schema validation. It
+carries `pass_name` (`"propose_groups"` / `"assign_ops"`),
+`raw_output` (the verbatim model response, capped in the message
+preview), and `parse_error` (the underlying `ValidationError` or
+`JSONDecodeError`).
 
 ### `IngestionResult` (`ingest/register_ingested.py`)
 
@@ -163,6 +237,36 @@ facing message names both colliding specs. Same-`spec_source`
 re-ingest of an unchanged spec stays on the skip-re-embed path —
 the cross-call check only fires on a true `spec_source` mismatch.
 
+### T3 control flow
+
+```text
+run_llm_grouping
+├─ GroupingConfig.validate     # bounds check on min/max/batch_size
+├─ load_unassigned_ops         # group_id IS NULL + scope match
+│  └─ early return GroupingResult(...zeros...) if none
+├─ _resolve_groups_for_pass2
+│  ├─ load_existing_groups
+│  ├─ if existing → project rows into GroupProposal list (skip Pass 1)
+│  └─ else
+│     ├─ render_propose_groups_prompt
+│     ├─ llm_client.generate_json   # Pass 1 LLM call
+│     ├─ parse_proposal_response   # GroupProposal schema validation
+│     └─ _persist_proposed_groups  # session.add per row + flush
+├─ _assign_ops_in_batches
+│  └─ for each batch of `batch_size` ops:
+│     ├─ render_assign_ops_prompt
+│     ├─ llm_client.generate_json   # Pass 2 LLM call
+│     └─ parse_assignment_response  # filter unknown ops + coerce unknown keys
+├─ _apply_assignments_to_rows   # mutate EndpointDescriptor.group_id
+├─ _write_grouping_audit_row    # meho.connector.llm_grouping
+└─ session.commit               # atomic: groups + assignments + audit
+```
+
+The two passes use distinct system prompts (`PROPOSE_GROUPS_SYSTEM_PROMPT`
+/ `ASSIGN_OPS_SYSTEM_PROMPT`) so each pass's cacheable prefix on the
+Anthropic Messages API stays stable across batches; per-call dynamism
+lives in the user-prompt body rendered from the Jinja templates.
+
 ## Dependencies
 
 * **PyYAML 6.0+** — already a transitive dep; we exercise
@@ -172,6 +276,10 @@ the cross-call check only fires on a true `spec_source` mismatch.
 * **httpx 0.27+** — fetch for `http(s)://` URLs. The chassis already
   depends on httpx for Keycloak JWKS + connector adapters.
 * **Pydantic v2** — `EndpointDescriptorProto` uses `ConfigDict(frozen=True)`.
+* **Jinja2 3.1+** — renders the T3 prompt templates from `ingest/prompts/`.
+  Used with `StrictUndefined` so any missing template variable raises
+  immediately, and `autoescape` disabled because the rendered output
+  goes to an LLM (not HTML).
 
 No spec-side validation library (e.g. `openapi-spec-validator`) is
 pulled in. The parser tolerates partial / underspecified docs and
@@ -202,6 +310,7 @@ operations go live.
 
 * Issue #401 — T1 task.
 * Issue #403 — T2 task.
+* Issue #404 — T3 task (LLM grouping; this module).
 * Issue #402 — T4 task.
 * Initiative #389 — G0.7 spec-ingestion pipeline.
 * Goal #221 — G0 foundational substrate.


### PR DESCRIPTION
## Summary

- Adds the **two-pass LLM grouping pipeline** (G0.7-T3) that runs after T2's bulk-upsert: Pass 1 proposes 8–15 operation groups with `when_to_use` hints, Pass 2 assigns each ingested op to one group in batches of 50.
- Output is validated via Pydantic schemas before persistence; groups land `review_status='staged'` so T4's review-queue state machine gates dispatchability behind operator review.
- LLM client injected as `LlmClient` `Protocol` (chassis adapter ships with T5 #405); tests use a deterministic stub against hand-curated 5-op + 50-op corpora.
- Prompts checked in as Jinja templates under `ingest/prompts/` (reviewable diffs, per the prompts-as-code best practice).
- One `meho.connector.llm_grouping` audit row per run with `{groups_created, operations_assigned, operations_unassigned, llm_call_count, batch_size}`.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — clean (117 source files)
- [x] `pytest tests/test_operations_ingest_llm_groups.py` — **31 passed, 1 skipped** (skip is the opt-in real-LLM integration sanity hook; lands with T5's chassis adapter)
- [x] `pytest tests/ --ignore=tests/integration` — **1289 passed, 4 skipped** (no regressions across the unit suite)
- [x] Code-quality hook (`code-quality.py --diff`) — 0 blockers
- [x] `run_llm_grouping()` produces 8–15 `operation_group` rows with `review_status='staged'`, non-empty `when_to_use`, non-empty `name` (medium-corpus test asserts exactly 8)
- [x] Each ingested op gets `group_id` set (or `NULL` for the `"none"` sentinel path)
- [x] Idempotency: re-running on a fully-grouped connector is a true no-op (0 LLM calls, no audit row)
- [x] Partial regrouping: re-running on a partially-grouped connector runs Pass-2 only on unassigned rows
- [x] Pass-1 output validated against `GroupProposal`; malformed JSON / non-snake-case `group_key` / duplicate keys / missing `when_to_use` → `LlmOutputInvalid`
- [x] Pass-2 batching: 50 ops + `batch_size=50` → exactly `1 + ceil(50/50) = 2` LLM calls; 50 ops + `batch_size=25` → 3 calls. `expected_llm_call_count(961, 50) = 21` parametrically asserted.
- [x] Audit row: one `meho.connector.llm_grouping` row written with the documented payload

## Out of scope (recorded as adjacent findings / follow-ups)

- **The chassis Anthropic adapter** for `LlmClient` — T5 (#405) wires `meho connector ingest` and is the natural place to land the production adapter + `Settings` knobs (model id, retry policy).
- **Operator review of proposed groups** — T4 (#402) already merged; the review-queue state machine consumes the staged rows this PR writes.
- **CLI verb** that invokes this pipeline — T5 (#405).
- **Re-grouping a connector from scratch via a dedicated verb** — v0.2.next per task body.
- **LLM-judge evaluation of grouping quality** — v0.2 ships deterministic-fixture tests + an opt-in real-LLM sanity skip; LLM-as-judge is v0.2.next per G4.3's out-of-scope.
- **Parallel async on Pass-2 batches** — v0.2.next per task body; v0.2 ships sequential.

## CI note

CI on `evoila/meho` is currently hitting Docker Hub anonymous-pull rate limits per the pre-existing flake described in #447. Per orchestrator user policy, this PR should be admin-merged regardless of red CI; `@coderabbitai review` is triggered for second-opinion signal.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - LLM-powered automatic grouping of connector operations with batched two-pass assignment, idempotent/partial regrouping, and a fallback "none" group for unmatched ops.
* **Documentation**
  - Detailed spec for the grouping stage, configs, error semantics, and prompts.
* **Tests**
  - Deterministic fixtures and end-to-end tests covering prompt rendering, parsing, batching, and error cases.
* **Dependencies**
  - Added Jinja2 for prompt template rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/485)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-14)

Addressed CodeRabbit iter-1 review (REQUEST_CHANGES, 1 Blocker):

- **B1** `07a4da8` — `_apply_assignments_to_rows` no longer double-counts LLM-omitted ops. Dropped the trailing `all_op_ids` / `missing` block; switched the loop to a default-less `assignment_map.get()` gated on `assigned_key is None or assigned_key == NONE_GROUP_KEY`. New regression test `test_run_llm_grouping_omitted_ops_counted_once` pins `assigned + unassigned == len(operations)`, `operations_unassigned == 2` (not 4), and the same totals on the audit-row payload.

<!-- auto-implement-issue: continue, iteration 2 -->
