### PR TITLE
feat(cli): G0.7-T5 meho connector ingest/list/review/edit/enable/disable verb tree

### DIFF
--- a/cli/internal/cmd/connector/connector.go
+++ b/cli/internal/cmd/connector/connector.go
@@ -46,6 +46,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -131,6 +132,13 @@ func normaliseURL(s string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
 	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		// Fail fast on schemes we can't dial (ftp://, ssh://, plain
+		// host names without a scheme parsed as opaque, etc.). Without
+		// this check the verb only fails much later inside the HTTP
+		// client with a less actionable error.
+		return "", fmt.Errorf("backplane URL %q must use http or https", s)
+	}
 	if u.Host == "" {
 		return "", fmt.Errorf("backplane URL %q has no host", s)
 	}
@@ -189,6 +197,26 @@ func renderRequestError(
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
 				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	// Distinguish response-shape failures (decode / contract drift)
+	// from genuine network failures. The former are *Unexpected*
+	// — the request reached the backplane, the backplane returned
+	// 200, but the body didn't match the agreed wire contract. The
+	// latter (default branch) remain *Unreachable*: connection
+	// reset, DNS failure, TLS handshake, etc. Without this split,
+	// a contract drift between T5 and T6 (different field names,
+	// changed status enum) presents to the operator as "your
+	// network is down", which is misleading.
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: invalid JSON response: %v",
+				backplaneURL, err)),
 			jsonOut,
 		)
 	}
@@ -319,10 +347,13 @@ func loadTextFlag(cmd *cobra.Command, name string) (value string, present bool, 
 			return "", false, fmt.Errorf("read --%s file %q: %w", name, path, rerr)
 		}
 		// Trim the trailing newline editors add by reflex. Embedded
-		// newlines inside the text are preserved; only the final \n
-		// is stripped so a 1-line file passed via @ doesn't carry a
-		// gratuitous trailing newline through the JSON body.
-		return strings.TrimRight(string(blob), "\n"), true, nil
+		// newlines inside the text are preserved; only the final
+		// CRLF / LF is stripped so a 1-line file passed via @ doesn't
+		// carry a gratuitous trailing newline through the JSON body.
+		// `\r\n` covers CRLF (Windows) and LF (Unix) line endings;
+		// trimming only `\n` leaves a stray `\r` on CRLF files which
+		// leaks into persisted field values.
+		return strings.TrimRight(string(blob), "\r\n"), true, nil
 	}
 	return raw, true, nil
 }
@@ -368,6 +399,34 @@ func resolveSpecURI(raw string) (string, error) {
 		return "", errors.New("--spec value is empty")
 	}
 	if strings.HasPrefix(raw, "file://") {
+		// Validate locally so operators see a fast CLI error rather
+		// than a backplane 4xx. The contract is `file://<absolute
+		// path>` — relative or scheme-less file URIs are rejected.
+		u, err := url.Parse(raw)
+		if err != nil || u.Scheme != "file" {
+			return "", fmt.Errorf("--spec %q: invalid file URI", raw)
+		}
+		// Per RFC 8089, file URIs have either an empty authority
+		// or `localhost`. A bare `file://relative/path` would
+		// parse `relative` as the host, which is what RFC 3986
+		// says but not what an operator typing the URL means. Reject
+		// any other host so the typo surfaces here instead of as
+		// a confused on-disk lookup.
+		if u.Host != "" && u.Host != "localhost" {
+			return "", fmt.Errorf("--spec %q: file URI host must be empty or \"localhost\"", raw)
+		}
+		// u.Path is the on-disk path with the `file://` (and optional
+		// host) prefix stripped. `path.IsAbs` covers POSIX absolute
+		// paths; the Windows drive-letter form (`/C:/...`) also
+		// satisfies path.IsAbs after url.Parse normalises the leading
+		// slash, so one check covers both.
+		//
+		// Root-only (`file:///`) is rejected too — there's no spec
+		// file name to ingest. `len(u.Path) <= 1` covers both the
+		// empty case and the bare-slash case.
+		if len(u.Path) <= 1 || !path.IsAbs(u.Path) {
+			return "", fmt.Errorf("--spec %q: file URI must be an absolute path to a spec", raw)
+		}
 		return raw, nil
 	}
 	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {

--- a/cli/internal/cmd/connector/connector.go
+++ b/cli/internal/cmd/connector/connector.go
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package connector hosts the cobra commands under `meho connector ...`
+// for the G0.7 spec-ingestion pipeline (Initiative #389). v0.2 ships
+// the seven operator-facing verbs the ingestion workflow walks:
+//
+//   - `meho connector ingest`     — parse vendor specs and register
+//     operations + groups into the endpoint_descriptor table. New
+//     connector lands `review_status=staged` (operations not yet
+//     dispatchable).
+//   - `meho connector list`       — list ingested connectors filtered
+//     by review status.
+//   - `meho connector review`     — show the per-connector review
+//     payload (groups + ops + flags) for operator approval.
+//   - `meho connector edit-group` — patch a group's display name or
+//     `when_to_use` hint.
+//   - `meho connector edit-op`    — patch a per-op override (custom
+//     description, safety level, requires_approval, is_enabled).
+//   - `meho connector enable`     — transition a staged connector to
+//     `review_status=enabled`; operations become dispatchable.
+//   - `meho connector disable`    — flip back to disabled without
+//     deleting rows (per-op overrides preserved for rollback).
+//
+// Each verb is a thin cobra command that POSTs / GETs / PATCHes a
+// single backplane route under `/api/v1/connectors*` (T6 #406).
+// Authentication piggybacks on the token meho login wrote — the
+// shared doAuthedRequest helper handles the bearer injection +
+// 401-refresh dance identically to the `operation` sibling package.
+//
+// Cross-task contract: this package consumes T6 #406's REST routes;
+// the route shape (request/response Pydantic models) is documented
+// in the issue body and stays load-bearing for both PRs. T7 #407's
+// admin MCP tools wrap the same service layer T6 exposes, so the
+// JSON envelope shapes here mirror what `meho.connector.*` MCP
+// tools emit to MCP clients.
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho connector` parent command. cmd/root.go
+// grafts this onto the top-level command tree alongside the other
+// built-in verbs. The parent itself takes no args and prints its
+// own help; every piece of behaviour lives in the per-subcommand
+// RunE closures.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "connector",
+		Short:        "G0.7 spec-ingestion + review workflow (ingest / list / review / edit / enable / disable)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newIngestCmd())
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newReviewCmd())
+	cmd.AddCommand(newEditGroupCmd())
+	cmd.AddCommand(newEditOpCmd())
+	cmd.AddCommand(newEnableCmd())
+	cmd.AddCommand(newDisableCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" (→ auth_expired exit
+// code 2 — the right fix is `meho login`) from URL-parse failures
+// (→ unexpected exit code 4 — the right fix is correcting argv).
+// Same shape as the operation/retrieval helpers; kept independent
+// because cmd/{operation,retrieval,connector} can't import each
+// other without an import cycle (cmd/root.go grafts each onto the
+// tree).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane mirrors the operation package's helper. The CLI
+// resolves the backplane URL in priority order: --backplane override
+// flag → meho config (written by `meho login`).
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical contract to the
+// operation sibling: missing-config → auth_expired; everything
+// else (parse errors, fs errors) → unexpected.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail fast
+// on garbage input. Mirrors the operation sibling.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from doAuthedRequest into
+// the right output.RenderError category. Adds one branch over the
+// operation sibling: HTTP 403 lands as InsufficientRole (exit 5) so
+// the tenant_admin-gated verbs produce the right hint when an
+// operator-role token tries to ingest. HTTP 401-after-refresh,
+// non-recoverable refresh failures, and missing tokens all map to
+// auth_expired (exit 2) as in the sibling.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		// 403 carries a distinct exit code so operators see "ask
+		// the tenant admin for a role grant" rather than "your
+		// network is down". The connector verb tree's mutating
+		// routes (ingest / edit-* / enable / disable) all require
+		// tenant_admin; a plain operator-role token gets the
+		// right hint here.
+		if he.StatusCode == http.StatusForbidden {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.InsufficientRole(fmt.Sprintf(
+					"call %s: HTTP 403: %s (this verb requires tenant_admin role)",
+					backplaneURL, he.Body,
+				)),
+				jsonOut,
+			)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection + one-shot 401-refresh-retry. Mirrors the
+// operation sibling's implementation verbatim (the underlying auth
+// dance is shared; cmd/connector can't import cmd/operation without
+// an import cycle since cmd/root.go grafts both onto the tree).
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	// 4 MiB cap. Higher than the operation sibling's 1 MiB because
+	// an ingest of vcenter.yaml (961 paths) returns an
+	// IngestionResult + GroupingResult envelope that can run into
+	// the hundreds of KiB; review payload for the same connector is
+	// similarly fat (per-op flags + descriptions). 4 MiB is
+	// generous enough for v0.2's largest known spec (vi-json.yaml,
+	// 2195 paths) while still capping pathological responses.
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// httpError carries a non-2xx response so renderRequestError can
+// pick the right StructuredError category (403 → insufficient_role;
+// other 4xx/5xx → unexpected_response). Same shape as the operation
+// sibling.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// sendRequest builds + fires the HTTP request. Split out so the
+// 401-refresh-retry path can reuse the same body bytes without
+// re-marshalling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// loadTextFlag reads a flag value that supports both inline text and
+// the `@<path>` file-reference form. Returns (value, false, nil)
+// when no value is set so callers can omit the field from the PATCH
+// body; returns (value, true, nil) when explicitly set (including
+// empty-string, e.g. operator wants to clear an override). Mirrors
+// `loadParamsFlag` in the operation sibling but for plain text
+// rather than JSON.
+//
+// The third return value distinguishes "operator did not pass the
+// flag" from "operator passed --when-to-use ”" — important for the
+// PATCH semantics where field-omitted means "leave unchanged" and
+// field-present-empty means "reset to default".
+func loadTextFlag(cmd *cobra.Command, name string) (value string, present bool, err error) {
+	if !cmd.Flags().Changed(name) {
+		return "", false, nil
+	}
+	raw, ferr := cmd.Flags().GetString(name)
+	if ferr != nil {
+		return "", false, fmt.Errorf("read --%s: %w", name, ferr)
+	}
+	if strings.HasPrefix(raw, "@") {
+		path := strings.TrimPrefix(raw, "@")
+		blob, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return "", false, fmt.Errorf("read --%s file %q: %w", name, path, rerr)
+		}
+		// Trim the trailing newline editors add by reflex. Embedded
+		// newlines inside the text are preserved; only the final \n
+		// is stripped so a 1-line file passed via @ doesn't carry a
+		// gratuitous trailing newline through the JSON body.
+		return strings.TrimRight(string(blob), "\n"), true, nil
+	}
+	return raw, true, nil
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Operates on runes (not bytes) so multi-byte
+// UTF-8 in group names / when_to_use strings survives without
+// producing an invalid UTF-8 cut. Same implementation as the
+// operation sibling — duplicated to avoid an import cycle.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// resolveSpecURI normalises a --spec flag value into the canonical
+// URI the backplane's IngestRequest accepts. Three input shapes are
+// supported:
+//
+//   - `file://<absolute path>`    — passes through after path validation.
+//   - `https://<url>` / `http://` — passes through.
+//   - `docs:<product-version>/<spec>` — shorthand resolving against
+//     the consumer's checked-in docs/ directory. The base directory
+//     comes from the CLAUDE_RDC_DOCS env var (operator workstation
+//     convention — points at a checkout of
+//     `claude-rdc-hetzner-dc/docs/meho-coordination/`). The resolved
+//     form is `file://<absolute path>` so the backplane sees a uniform
+//     scheme. When CLAUDE_RDC_DOCS is unset, the shorthand resolves
+//     to a bare `docs:<...>` URI and the backplane handles resolution
+//     server-side against its own configured docs root.
+//
+// Anything else returns an error — the operator gets a clear "use
+// one of file:// / https:// / docs:<...>" hint rather than a 422
+// from the backplane.
+func resolveSpecURI(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("--spec value is empty")
+	}
+	if strings.HasPrefix(raw, "file://") {
+		return raw, nil
+	}
+	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {
+		return raw, nil
+	}
+	if strings.HasPrefix(raw, "docs:") {
+		shorthand := strings.TrimPrefix(raw, "docs:")
+		if shorthand == "" {
+			return "", errors.New("--spec docs: shorthand has no path")
+		}
+		root := os.Getenv("CLAUDE_RDC_DOCS")
+		if root == "" {
+			// No env override: pass the shorthand through verbatim
+			// for the backplane to resolve against its own checked-in
+			// docs root. Documented behaviour — the v0.2 backplane
+			// understands the `docs:` scheme natively.
+			return raw, nil
+		}
+		abs := filepath.Join(root, shorthand)
+		if !filepath.IsAbs(abs) {
+			// filepath.Join keeps relative roots relative; reject
+			// rather than ship a half-resolved URI.
+			return "", fmt.Errorf("CLAUDE_RDC_DOCS=%q produced non-absolute spec path %q", root, abs)
+		}
+		return "file://" + abs, nil
+	}
+	return "", fmt.Errorf(
+		"--spec %q: unknown URI scheme; expected file:// / https:// / docs:<product-version>/<spec>",
+		raw,
+	)
+}
+
+// confirm prompts on stdin/stdout with the given message and returns
+// true only when the operator types y/yes/Y. EOF (closed stdin) is
+// treated as a no — scripted use must pass --confirm. Honours
+// cmd.InOrStdin() so tests can wire a bytes.Buffer.
+func confirm(cmd *cobra.Command, prompt string) bool {
+	fmt.Fprintf(cmd.OutOrStdout(), "%s [y/N]: ", prompt)
+	var answer string
+	if _, err := fmt.Fscanln(cmd.InOrStdin(), &answer); err != nil {
+		// Most common error: io.EOF from a piped empty stdin.
+		// Treat as "no" so scripts that pipe /dev/null don't
+		// accidentally enable a connector.
+		return false
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
+}
+
+// pathEscapeOpID escapes the op_id segment for use in a URL path.
+// op_id values contain `:` (method separator) and `/` (path
+// separator) — e.g. `GET:/api/vcenter/cluster`. url.PathEscape on
+// the raw value produces a single segment the FastAPI router can
+// match via `{op_id:path}` (or equivalent). connector_id and
+// group_key never contain reserved chars in v0.2 but pass through
+// the same escape for defence in depth.
+func pathEscapeOpID(s string) string {
+	return url.PathEscape(s)
+}
+
+// decodeJSON unmarshals raw into out and wraps any error with a
+// caller-friendly context string. Pattern matches the operation
+// sibling.
+func decodeJSON(raw []byte, what string, out any) error {
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("decode %s response: %w", what, err)
+	}
+	return nil
+}

--- a/cli/internal/cmd/connector/connector.go
+++ b/cli/internal/cmd/connector/connector.go
@@ -275,7 +275,14 @@ func doAuthedRequest(
 	if readErr != nil {
 		return nil, fmt.Errorf("read response: %w", readErr)
 	}
-	if resp.StatusCode != http.StatusOK {
+	// Accept any 2xx as success. T6 routes return 200 OK for read /
+	// ingest endpoints that ship a JSON body, and 204 No Content for
+	// the four state-mutating routes (PATCH edit-group / edit-op,
+	// POST enable / disable). Callers expecting a JSON body must
+	// inspect the returned slice length before decoding; callers
+	// that expect 204 should pass through the empty slice as a
+	// success signal.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
 	}
 	return raw, nil

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -347,21 +347,22 @@ func TestLoadTextFlagPresentEmpty(t *testing.T) {
 
 // TestPrintIngestSummaryDryRun — dry-run header + counts; no
 // "Connector is in review_status=staged" trailer because that
-// only applies after a real ingest.
+// only applies after a real ingest. The canonical
+// IngestionResultModel ships only the aggregate inserted/updated/
+// skipped counts plus the two boolean flags — no per-spec
+// breakdown, no embeddings split. Total is derived client-side.
 func TestPrintIngestSummaryDryRun(t *testing.T) {
 	r := &IngestResponse{
 		Ingestion: IngestionResult{
-			ConnectorID:     "vmware-rest-9.0",
-			TotalOperations: 12,
-			Inserted:        12,
-			PerSpecCounts:   map[string]int{"vcenter.yaml": 9, "vi-json.yaml": 3},
+			ConnectorID:   "vmware-rest-9.0",
+			InsertedCount: 12,
 		},
 	}
 	opts := ingestOptions{Product: "vmware", Version: "9.0", ImplID: "vmware-rest", DryRun: true}
 	var buf bytes.Buffer
 	printIngestSummary(&buf, opts, r)
 	out := buf.String()
-	for _, want := range []string{"DRY RUN", "12 total", "vcenter.yaml: 9 ops", "vi-json.yaml: 3 ops"} {
+	for _, want := range []string{"DRY RUN", "12 total"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("dry-run render missing %q in:\n%s", want, out)
 		}
@@ -369,32 +370,137 @@ func TestPrintIngestSummaryDryRun(t *testing.T) {
 	if strings.Contains(out, "review_status=staged") {
 		t.Errorf("dry-run render should not announce review_status=staged; got:\n%s", out)
 	}
+	// The dry-run path deliberately omits connector_registered /
+	// operations_grouped because the route returns False for both
+	// when dry_run=True, which is uninteresting noise.
+	if strings.Contains(out, "connector_registered") {
+		t.Errorf("dry-run should not print connector_registered; got:\n%s", out)
+	}
 }
 
 // TestPrintIngestSummaryNonDryRun — happy-path render includes
-// connector_id + next-steps hint.
+// connector_id + next-steps hint + canonical IngestionResult fields
+// (connector_registered, operations_grouped) and the canonical
+// GroupingResult fields (groups_created, llm_call_count).
 func TestPrintIngestSummaryNonDryRun(t *testing.T) {
 	r := &IngestResponse{
 		Ingestion: IngestionResult{
-			ConnectorID:        "vmware-rest-9.0",
-			TotalOperations:    961,
-			Inserted:           961,
-			EmbeddingsComputed: 961,
+			ConnectorID:         "vmware-rest-9.0",
+			InsertedCount:       961,
+			ConnectorRegistered: true,
+			OperationsGrouped:   true,
 		},
 		Grouping: &GroupingResult{
-			GroupsProposed:     9,
+			ConnectorID:        "vmware-rest-9.0",
+			GroupsCreated:      9,
 			OperationsAssigned: 961,
-			Model:              "claude-3-5-sonnet-20241022",
+			LLMCallCount:       20,
+			LLMDurationMs:      4321,
 		},
 	}
 	opts := ingestOptions{Product: "vmware", Version: "9.0", ImplID: "vmware-rest", DryRun: false}
 	var buf bytes.Buffer
 	printIngestSummary(&buf, opts, r)
 	out := buf.String()
-	for _, want := range []string{"connector_id=vmware-rest-9.0", "961 total", "embeddings: 961 computed", "9 groups", "claude-3-5-sonnet", "review_status=staged", "meho connector review vmware-rest-9.0", "meho connector enable vmware-rest-9.0"} {
+	for _, want := range []string{
+		"connector_id=vmware-rest-9.0",
+		"961 total",
+		"connector_registered: true",
+		"operations_grouped: true",
+		"9 groups",
+		"961 ops assigned",
+		"20 LLM call(s)",
+		"4321ms",
+		"review_status=staged",
+		"meho connector review vmware-rest-9.0",
+		"meho connector enable vmware-rest-9.0",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("non-dry-run render missing %q in:\n%s", want, out)
 		}
+	}
+}
+
+// TestIngestResponseDecodesCanonical pins the wire shape: the
+// canonical IngestionResultModel + GroupingResultModel (PR #488
+// api_schemas.py) ship snake_case field names that mirror the
+// Pydantic projections verbatim. Decoding drift here surfaces as
+// a Blocker-class wire-contract failure on the next `meho
+// connector ingest` round-trip.
+func TestIngestResponseDecodesCanonical(t *testing.T) {
+	raw := []byte(`{
+		"ingestion": {
+			"connector_id": "vmware-rest-9.0",
+			"inserted_count": 961,
+			"updated_count": 0,
+			"skipped_count": 0,
+			"connector_registered": true,
+			"operations_grouped": true
+		},
+		"grouping": {
+			"connector_id": "vmware-rest-9.0",
+			"groups_created": 9,
+			"operations_assigned": 961,
+			"operations_unassigned": 0,
+			"llm_call_count": 20,
+			"llm_duration_ms": 4321.5
+		}
+	}`)
+	var got IngestResponse
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode IngestResponse: %v", err)
+	}
+	if got.Ingestion.ConnectorID != "vmware-rest-9.0" {
+		t.Errorf("ingestion.connector_id: got %q", got.Ingestion.ConnectorID)
+	}
+	if got.Ingestion.InsertedCount != 961 ||
+		got.Ingestion.UpdatedCount != 0 ||
+		got.Ingestion.SkippedCount != 0 {
+		t.Errorf("ingestion counts: got %+v", got.Ingestion)
+	}
+	if !got.Ingestion.ConnectorRegistered || !got.Ingestion.OperationsGrouped {
+		t.Errorf("ingestion flags: got %+v", got.Ingestion)
+	}
+	if got.Grouping == nil {
+		t.Fatalf("grouping should not be nil")
+	}
+	if got.Grouping.GroupsCreated != 9 || got.Grouping.OperationsAssigned != 961 {
+		t.Errorf("grouping counts: got %+v", got.Grouping)
+	}
+	if got.Grouping.LLMCallCount != 20 {
+		t.Errorf("llm_call_count: got %d, want 20", got.Grouping.LLMCallCount)
+	}
+	// Float decode preserves sub-ms timing — int would truncate.
+	if got.Grouping.LLMDurationMs != 4321.5 {
+		t.Errorf("llm_duration_ms: got %v, want 4321.5", got.Grouping.LLMDurationMs)
+	}
+}
+
+// TestIngestResponseDecodesDryRun pins the canonical dry-run shape:
+// the route returns IngestionResult with all-zero counts and
+// grouping=null when dry_run=true. The Go decoder must accept
+// JSON `null` for the nullable grouping field.
+func TestIngestResponseDecodesDryRun(t *testing.T) {
+	raw := []byte(`{
+		"ingestion": {
+			"connector_id": "vmware-rest-9.0",
+			"inserted_count": 0,
+			"updated_count": 0,
+			"skipped_count": 0,
+			"connector_registered": false,
+			"operations_grouped": false
+		},
+		"grouping": null
+	}`)
+	var got IngestResponse
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode dry-run IngestResponse: %v", err)
+	}
+	if got.Grouping != nil {
+		t.Errorf("grouping should decode to nil for dry-run; got %+v", got.Grouping)
+	}
+	if got.Ingestion.ConnectorRegistered || got.Ingestion.OperationsGrouped {
+		t.Errorf("dry-run flags should both be false; got %+v", got.Ingestion)
 	}
 }
 
@@ -702,18 +808,19 @@ func TestConfirmEOF(t *testing.T) {
 	}
 }
 
-// TestPrintTransitionResult — happy-path render.
+// TestPrintTransitionResult — happy-path render. T6's enable /
+// disable routes return HTTP 204 No Content, so the renderer's
+// only input is the synthetic transitionResult envelope the verb
+// constructs locally (connector_id + action).
 func TestPrintTransitionResult(t *testing.T) {
-	r := &TransitionResponse{
-		ConnectorID:       "vmware-rest-9.0",
-		ReviewStatus:      "enabled",
-		GroupsUpdated:     9,
-		OperationsUpdated: 961,
+	r := transitionResult{
+		ConnectorID: "vmware-rest-9.0",
+		Action:      "enabled",
 	}
 	var buf bytes.Buffer
 	printTransitionResult(&buf, "enable", r)
 	out := buf.String()
-	for _, want := range []string{"enable vmware-rest-9.0", "review_status=enabled", "9 groups", "961 ops"} {
+	for _, want := range []string{"enable vmware-rest-9.0", "enabled", "204 No Content"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("transition render missing %q in:\n%s", want, out)
 		}
@@ -734,11 +841,12 @@ func TestHTTPErrorString(t *testing.T) {
 // ---------- HTTP wire shape (mocked) ----------
 
 // TestPostIngestRoundTripWithMockServer — pins the wire contract
-// between T5 and T6 (#406). The CLI POSTs the IngestRequest, the
+// between T5 and T6 (#488). The CLI POSTs the IngestRequest, the
 // (mocked) T6 endpoint validates the shape and returns an
-// IngestResponse; the CLI decodes it back. Used for the JSON
-// contract sanity check that doesn't require a live backplane —
-// true end-to-end coverage lives in the T8 canary (#408).
+// IngestResponse with canonical IngestionResultModel /
+// GroupingResultModel fields (inserted_count / groups_created etc).
+// Used for the JSON contract sanity check that doesn't require a
+// live backplane — true end-to-end coverage lives in the T8 canary.
 func TestPostIngestRoundTripWithMockServer(t *testing.T) {
 	srv := mockBackplane(t, map[string]mockHandler{
 		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, r *http.Request) {
@@ -757,11 +865,16 @@ func TestPostIngestRoundTripWithMockServer(t *testing.T) {
 			}
 			resp := IngestResponse{
 				Ingestion: IngestionResult{
-					ConnectorID:     "vmware-rest-9.0",
-					Inserted:        961,
-					TotalOperations: 961,
+					ConnectorID:         "vmware-rest-9.0",
+					InsertedCount:       961,
+					ConnectorRegistered: true,
+					OperationsGrouped:   true,
 				},
-				Grouping: &GroupingResult{GroupsProposed: 9, OperationsAssigned: 961},
+				Grouping: &GroupingResult{
+					ConnectorID:        "vmware-rest-9.0",
+					GroupsCreated:      9,
+					OperationsAssigned: 961,
+				},
 			}
 			writeJSON(t, w, 200, resp)
 		},
@@ -776,10 +889,10 @@ func TestPostIngestRoundTripWithMockServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("postIngest: %v", err)
 	}
-	if got.Ingestion.ConnectorID != "vmware-rest-9.0" || got.Ingestion.TotalOperations != 961 {
+	if got.Ingestion.ConnectorID != "vmware-rest-9.0" || got.Ingestion.InsertedCount != 961 {
 		t.Fatalf("unexpected ingest result: %+v", got)
 	}
-	if got.Grouping == nil || got.Grouping.GroupsProposed != 9 {
+	if got.Grouping == nil || got.Grouping.GroupsCreated != 9 {
 		t.Fatalf("unexpected grouping: %+v", got.Grouping)
 	}
 }
@@ -836,6 +949,9 @@ func TestGetListAllOmitsStatusQueryParam(t *testing.T) {
 }
 
 // TestPatchGroupSendsBody — confirms the wire shape for edit-group.
+// T6's PATCH route returns HTTP 204 No Content; the test asserts the
+// PATCH body shape and that the 204 path returns no error (no decode
+// of a non-existent JSON body).
 func TestPatchGroupSendsBody(t *testing.T) {
 	srv := mockBackplane(t, map[string]mockHandler{
 		"PATCH /api/v1/connectors/vmware-rest-9.0/groups/cluster": func(w http.ResponseWriter, r *http.Request) {
@@ -852,27 +968,46 @@ func TestPatchGroupSendsBody(t *testing.T) {
 			if got.Name != nil {
 				t.Errorf("Name should be unset; got %+v", got.Name)
 			}
-			writeJSON(t, w, 200, EditGroupResponse{
-				ConnectorID: "vmware-rest-9.0", GroupKey: "cluster",
-				Name: "Cluster", WhenToUse: "use for cluster ops",
-			})
+			// Canonical T6 response: 204 No Content with no body.
+			w.WriteHeader(http.StatusNoContent)
 		},
 	})
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
 	whenToUse := "use for cluster ops"
-	got, err := patchGroup(context.Background(), srv.URL, "vmware-rest-9.0", "cluster", EditGroupBody{WhenToUse: &whenToUse})
-	if err != nil {
+	if err := patchGroup(context.Background(), srv.URL, "vmware-rest-9.0", "cluster", EditGroupBody{WhenToUse: &whenToUse}); err != nil {
 		t.Fatalf("patchGroup: %v", err)
 	}
-	if got.WhenToUse != "use for cluster ops" {
-		t.Fatalf("unexpected response: %+v", got)
+}
+
+// TestPrintEditGroupResultRendersBody — the renderer outputs the
+// connector_id/group_key coordinates + the operator's PATCH body
+// fields (the 204 No Content response carries no body to mirror).
+func TestPrintEditGroupResultRendersBody(t *testing.T) {
+	whenToUse := "use for cluster lifecycle ops"
+	name := "Cluster"
+	var buf bytes.Buffer
+	printEditGroupResult(&buf, "vmware-rest-9.0", "cluster", EditGroupBody{
+		WhenToUse: &whenToUse,
+		Name:      &name,
+	})
+	out := buf.String()
+	for _, want := range []string{
+		"vmware-rest-9.0/cluster",
+		"204 No Content",
+		"name: Cluster",
+		"when_to_use: use for cluster lifecycle ops",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("edit-group render missing %q in:\n%s", want, out)
+		}
 	}
 }
 
 // TestPatchOpEscapesOpID — colons and slashes in op_id must
-// survive the URL path. The mock asserts the decoded segment.
+// survive the URL path. The mock asserts the decoded segment and
+// returns the canonical T6 204 No Content response.
 func TestPatchOpEscapesOpID(t *testing.T) {
 	called := false
 	srv := mockBackplane(t, map[string]mockHandler{
@@ -903,49 +1038,63 @@ func TestPatchOpEscapesOpID(t *testing.T) {
 			if decodedOp != "GET:/api/vcenter/cluster" {
 				t.Errorf("op_id round-trip: got %q (raw path %q)", decodedOp, raw)
 			}
-			writeJSON(t, w, 200, EditOpResponse{
-				ConnectorID: "vmware-rest-9.0",
-				OpID:        "GET:/api/vcenter/cluster",
-				SafetyLevel: "dangerous",
-				IsEnabled:   true,
-			})
+			// Canonical T6 response: 204 No Content with no body.
+			w.WriteHeader(http.StatusNoContent)
 		},
 	})
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
 	safety := "dangerous"
-	got, err := patchOp(context.Background(), srv.URL, "vmware-rest-9.0", "GET:/api/vcenter/cluster", EditOpBody{SafetyLevel: &safety})
-	if err != nil {
+	if err := patchOp(context.Background(), srv.URL, "vmware-rest-9.0", "GET:/api/vcenter/cluster", EditOpBody{SafetyLevel: &safety}); err != nil {
 		t.Fatalf("patchOp: %v", err)
 	}
 	if !called {
 		t.Fatalf("mock handler not invoked")
 	}
-	if got.SafetyLevel != "dangerous" {
-		t.Fatalf("unexpected op response: %+v", got)
-	}
 }
 
-// TestPostTransitionEnable — pins the enable/disable wire shape.
-func TestPostTransitionEnable(t *testing.T) {
+// TestPostTransitionEnable204 — pins the canonical enable / disable
+// wire shape. T6 returns HTTP 204 No Content with no body; the CLI
+// must accept the 204 as success without trying to decode a JSON
+// envelope. A regression to the old 200+JSON contract would either
+// fail decode (empty body) or 500-classify (200 with malformed body).
+func TestPostTransitionEnable204(t *testing.T) {
 	srv := mockBackplane(t, map[string]mockHandler{
 		"POST /api/v1/connectors/vmware-rest-9.0/enable": func(w http.ResponseWriter, r *http.Request) {
-			writeJSON(t, w, 200, TransitionResponse{
-				ConnectorID: "vmware-rest-9.0", ReviewStatus: "enabled",
-				GroupsUpdated: 9, OperationsUpdated: 961,
-			})
+			// Canonical T6 response: 204 No Content with no body.
+			w.WriteHeader(http.StatusNoContent)
 		},
 	})
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	got, err := postTransition(context.Background(), srv.URL, "/api/v1/connectors/vmware-rest-9.0/enable")
-	if err != nil {
+	if err := postTransition(context.Background(), srv.URL, "/api/v1/connectors/vmware-rest-9.0/enable"); err != nil {
 		t.Fatalf("postTransition: %v", err)
 	}
-	if got.ReviewStatus != "enabled" {
-		t.Fatalf("unexpected transition: %+v", got)
+}
+
+// TestDoAuthedRequest204AcceptsEmptyBody — pins the load-bearing
+// behaviour of the shared HTTP helper: a 204 No Content response
+// must surface as a nil error with an empty byte slice, NOT as an
+// *httpError. Three of the seven T6 routes return 204 (enable,
+// disable, PATCH edit-group, PATCH edit-op), so this property gates
+// the entire mutating-verb surface.
+func TestDoAuthedRequest204AcceptsEmptyBody(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/test": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	body, err := doAuthedRequest(context.Background(), srv.URL, "POST", "/api/v1/test", []byte("{}"))
+	if err != nil {
+		t.Fatalf("204 should be a success; got err %v", err)
+	}
+	if len(body) != 0 {
+		t.Fatalf("204 should yield empty body; got %q", body)
 	}
 }
 

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -63,6 +63,36 @@ func TestNormaliseURLBasic(t *testing.T) {
 	}
 }
 
+// TestNormaliseURLRejectsNonHTTPScheme — fail-fast on schemes the
+// HTTP client can't dial (ftp://, ssh://, file:// for a backplane
+// URL, etc.). Without this gate the operator only sees an obscure
+// error later inside http.Client.Do.
+func TestNormaliseURLRejectsNonHTTPScheme(t *testing.T) {
+	cases := []string{
+		"ftp://meho.test",
+		"ssh://meho.test",
+		"file:///tmp/meho",
+	}
+	for _, in := range cases {
+		_, err := normaliseURL(in)
+		if err == nil || !strings.Contains(err.Error(), "must use http or https") {
+			t.Errorf("normaliseURL(%q): want http/https rejection; got %v", in, err)
+		}
+	}
+}
+
+// TestNormaliseURLAcceptsHTTP — plain http (no s) is accepted —
+// operators on bench / staging deploys sometimes run without TLS.
+func TestNormaliseURLAcceptsHTTP(t *testing.T) {
+	got, err := normaliseURL("http://localhost:8080/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "http://localhost:8080" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 // TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
 // any wrapping error) maps to AuthExpired; everything else maps
 // to Unexpected. Same routing as the operation sibling.
@@ -100,7 +130,8 @@ func TestPathEscapeOpIDColonsAndSlashes(t *testing.T) {
 
 // ---------- resolveSpecURI ----------
 
-// TestResolveSpecURIFile — file:// passes through verbatim.
+// TestResolveSpecURIFile — file:// passes through verbatim once
+// validated (scheme=file, path absolute).
 func TestResolveSpecURIFile(t *testing.T) {
 	got, err := resolveSpecURI("file:///abs/path/spec.yaml")
 	if err != nil {
@@ -108,6 +139,36 @@ func TestResolveSpecURIFile(t *testing.T) {
 	}
 	if got != "file:///abs/path/spec.yaml" {
 		t.Fatalf("file scheme passthrough; got %q", got)
+	}
+}
+
+// TestResolveSpecURIFileRejectsRelative — a `file://relative/path`
+// URI (no leading slash, so url.Parse reads `relative` as a host)
+// or an empty path is rejected client-side so operators see a fast
+// hint rather than a backplane 4xx.
+func TestResolveSpecURIFileRejectsRelative(t *testing.T) {
+	cases := []string{
+		"file://relative/path/spec.yaml", // host=relative, not empty
+		"file://",                        // empty path
+		"file:///",                       // root only — no spec name
+	}
+	for _, in := range cases {
+		_, err := resolveSpecURI(in)
+		if err == nil || !strings.Contains(err.Error(), "file URI") {
+			t.Errorf("resolveSpecURI(%q): want rejection; got %v", in, err)
+		}
+	}
+}
+
+// TestResolveSpecURIFileAcceptsLocalhostHost — `file://localhost/abs`
+// is the RFC 8089 equivalent of `file:///abs` and must pass.
+func TestResolveSpecURIFileAcceptsLocalhostHost(t *testing.T) {
+	got, err := resolveSpecURI("file://localhost/abs/spec.yaml")
+	if err != nil {
+		t.Fatalf("file://localhost: %v", err)
+	}
+	if got != "file://localhost/abs/spec.yaml" {
+		t.Fatalf("file://localhost passthrough; got %q", got)
 	}
 }
 
@@ -227,6 +288,30 @@ func TestLoadTextFlagFileReference(t *testing.T) {
 	}
 }
 
+// TestLoadTextFlagFileReferenceCRLF — file with CRLF line endings
+// (`hello\r\n`) trims to "hello", not "hello\r". A stray `\r`
+// silently slips into the persisted when_to_use / name field on
+// every CRLF-saved override file otherwise.
+func TestLoadTextFlagFileReferenceCRLF(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blob.md")
+	if err := os.WriteFile(path, []byte("hello world\r\n"), 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("name", "", "")
+	if err := cmd.ParseFlags([]string{"--name", "@" + path}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	val, present, err := loadTextFlag(cmd, "name")
+	if err != nil {
+		t.Fatalf("loadTextFlag: %v", err)
+	}
+	if !present || val != "hello world" {
+		t.Fatalf("CRLF trim: got (%q, %v); want (\"hello world\", true)", val, present)
+	}
+}
+
 // TestLoadTextFlagMissingFile — `@nonexistent` surfaces a read
 // failure with the path name.
 func TestLoadTextFlagMissingFile(t *testing.T) {
@@ -323,12 +408,28 @@ func TestPrintListTableEmpty(t *testing.T) {
 }
 
 // TestPrintListTableHappyPath — happy-path render with two connectors;
-// built-in connectors (TenantID="") render as "(built-in)".
+// built-in connectors (TenantID=nil) render as "(built-in)". The
+// rollup label is derived per-row from the three *_group_count fields
+// (see deriveRollupLabel) — the canonical wire shape has no
+// connector-wide review_status field.
 func TestPrintListTableHappyPath(t *testing.T) {
+	tenantA := "tenant-a"
 	r := &ListResponse{
 		Connectors: []Summary{
-			{ConnectorID: "vault-1.x", ReviewStatus: "enabled", GroupCount: 2, OperationCount: 7, TenantID: ""},
-			{ConnectorID: "vmware-rest-9.0", ReviewStatus: "staged", GroupCount: 9, OperationCount: 961, TenantID: "tenant-a"},
+			{
+				ConnectorID:       "vault-1.x",
+				GroupCount:        2,
+				EnabledGroupCount: 2,
+				OperationCount:    7,
+				TenantID:          nil,
+			},
+			{
+				ConnectorID:      "vmware-rest-9.0",
+				GroupCount:       9,
+				StagedGroupCount: 9,
+				OperationCount:   961,
+				TenantID:         &tenantA,
+			},
 		},
 	}
 	var buf bytes.Buffer
@@ -341,8 +442,69 @@ func TestPrintListTableHappyPath(t *testing.T) {
 	}
 }
 
+// TestDeriveRollupLabelTable pins the per-status → rollup mapping.
+// Operators reading `meho connector list` see this label; getting it
+// right matters for the "is there review backlog?" question.
+func TestDeriveRollupLabelTable(t *testing.T) {
+	cases := []struct {
+		name                      string
+		staged, enabled, disabled int
+		want                      string
+	}{
+		{"empty connector", 0, 0, 0, "(empty)"},
+		{"all staged", 3, 0, 0, "staged"},
+		{"all enabled", 0, 5, 0, "enabled"},
+		{"all disabled", 0, 0, 2, "disabled"},
+		{"partial enable", 1, 2, 0, "mixed"},
+		{"staged plus disabled", 1, 0, 1, "mixed"},
+		{"every bucket non-zero", 1, 1, 1, "mixed"},
+	}
+	for _, tc := range cases {
+		got := deriveRollupLabel(tc.staged, tc.enabled, tc.disabled)
+		if got != tc.want {
+			t.Errorf("%s: deriveRollupLabel(%d,%d,%d) = %q; want %q",
+				tc.name, tc.staged, tc.enabled, tc.disabled, got, tc.want)
+		}
+	}
+}
+
+// TestSummaryDecodesCanonicalListItem pins the wire shape: the
+// canonical ConnectorListItem (PR #488 api_schemas.py) ships
+// per-status group counts and no top-level review_status. Decoding
+// drift here surfaces as a Major-class wire-contract failure on the
+// next ingest round-trip.
+func TestSummaryDecodesCanonicalListItem(t *testing.T) {
+	raw := []byte(`{
+		"connector_id": "vmware-rest-9.0",
+		"product": "vmware",
+		"version": "9.0",
+		"impl_id": "vmware-rest",
+		"tenant_id": null,
+		"group_count": 9,
+		"staged_group_count": 5,
+		"enabled_group_count": 3,
+		"disabled_group_count": 1,
+		"operation_count": 961
+	}`)
+	var got Summary
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode ConnectorListItem: %v", err)
+	}
+	if got.ConnectorID != "vmware-rest-9.0" {
+		t.Errorf("connector_id: got %q", got.ConnectorID)
+	}
+	if got.TenantID != nil {
+		t.Errorf("tenant_id should be nil for built-in; got %v", got.TenantID)
+	}
+	if got.StagedGroupCount != 5 || got.EnabledGroupCount != 3 || got.DisabledGroupCount != 1 {
+		t.Errorf("per-status counts: got %+v", got)
+	}
+}
+
 // TestPrintReviewTableHappyPath — review render shows groups + ops
-// + flags.
+// + per-group review_status flags. The connector-wide rollup label
+// is derived from the per-group review_status counts (same shape as
+// `meho connector list`).
 func TestPrintReviewTableHappyPath(t *testing.T) {
 	summary := "List vSphere clusters"
 	r := &ReviewPayload{
@@ -350,13 +512,15 @@ func TestPrintReviewTableHappyPath(t *testing.T) {
 		Product:      "vmware",
 		Version:      "9.0",
 		ImplID:       "vmware-rest",
-		ReviewStatus: "staged",
+		TotalOpCount: 2,
 		Groups: []ReviewGroup{
 			{
-				GroupKey:  "cluster",
-				Name:      "Cluster",
-				WhenToUse: "Use for vSphere cluster lifecycle ops.",
-				Operations: []ReviewOperation{
+				GroupKey:     "cluster",
+				Name:         "Cluster",
+				WhenToUse:    "Use for vSphere cluster lifecycle ops.",
+				ReviewStatus: "staged",
+				OpCount:      2,
+				Ops: []ReviewOperation{
 					{OpID: "GET:/api/vcenter/cluster", Summary: &summary, SafetyLevel: "safe", IsEnabled: false},
 					{OpID: "DELETE:/api/vcenter/cluster/{id}", SafetyLevel: "dangerous", RequiresApproval: true, IsEnabled: false},
 				},
@@ -374,13 +538,78 @@ func TestPrintReviewTableHappyPath(t *testing.T) {
 }
 
 // TestPrintReviewTableEmptyGroups — zero-group connector renders
-// the explanation line.
+// the explanation line and shows "(empty)" rollup.
 func TestPrintReviewTableEmptyGroups(t *testing.T) {
-	r := &ReviewPayload{ConnectorID: "k8s-1.x", ReviewStatus: "staged", Groups: nil}
+	r := &ReviewPayload{ConnectorID: "k8s-1.x", Groups: nil}
 	var buf bytes.Buffer
 	printReviewTable(&buf, r)
 	if !strings.Contains(buf.String(), "no groups") {
 		t.Errorf("empty review: missing explanation; got:\n%s", buf.String())
+	}
+}
+
+// TestReviewPayloadDecodesCanonical pins the wire shape: the
+// canonical ConnectorReviewGroup (PR #431 / PR #488) ships `ops`
+// (not `operations`) and a per-group `review_status`; the payload
+// has no top-level review_status. Decoding drift here surfaces as
+// a Major-class wire-contract failure on the next `meho connector
+// review` round-trip.
+func TestReviewPayloadDecodesCanonical(t *testing.T) {
+	raw := []byte(`{
+		"connector_id": "vmware-rest-9.0",
+		"product": "vmware",
+		"version": "9.0",
+		"impl_id": "vmware-rest",
+		"tenant_id": null,
+		"groups": [
+			{
+				"group_key": "cluster",
+				"name": "Cluster",
+				"when_to_use": "use for cluster lifecycle ops",
+				"review_status": "staged",
+				"op_count": 1,
+				"ops": [
+					{
+						"op_id": "GET:/api/vcenter/cluster",
+						"summary": "List clusters",
+						"description": null,
+						"custom_description": null,
+						"safety_level": "safe",
+						"requires_approval": false,
+						"is_enabled": false,
+						"tags": ["cluster", "list"]
+					}
+				]
+			}
+		],
+		"total_op_count": 1
+	}`)
+	var got ReviewPayload
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode ConnectorReviewPayload: %v", err)
+	}
+	if got.TotalOpCount != 1 {
+		t.Errorf("total_op_count: got %d", got.TotalOpCount)
+	}
+	if len(got.Groups) != 1 {
+		t.Fatalf("groups: got %d, want 1", len(got.Groups))
+	}
+	g := got.Groups[0]
+	if g.ReviewStatus != "staged" {
+		t.Errorf("group review_status: got %q", g.ReviewStatus)
+	}
+	if g.OpCount != 1 {
+		t.Errorf("group op_count: got %d", g.OpCount)
+	}
+	if len(g.Ops) != 1 {
+		t.Fatalf("group ops: got %d, want 1", len(g.Ops))
+	}
+	op := g.Ops[0]
+	if op.OpID != "GET:/api/vcenter/cluster" {
+		t.Errorf("op_id: got %q", op.OpID)
+	}
+	if len(op.Tags) != 2 || op.Tags[0] != "cluster" {
+		t.Errorf("op tags: got %v", op.Tags)
 	}
 }
 
@@ -565,7 +794,12 @@ func TestGetListWithMockServer(t *testing.T) {
 			}
 			writeJSON(t, w, 200, ListResponse{
 				Connectors: []Summary{
-					{ConnectorID: "vmware-rest-9.0", ReviewStatus: "staged", GroupCount: 9, OperationCount: 961},
+					{
+						ConnectorID:      "vmware-rest-9.0",
+						GroupCount:       9,
+						StagedGroupCount: 9,
+						OperationCount:   961,
+					},
 				},
 			})
 		},
@@ -712,6 +946,37 @@ func TestPostTransitionEnable(t *testing.T) {
 	}
 	if got.ReviewStatus != "enabled" {
 		t.Fatalf("unexpected transition: %+v", got)
+	}
+}
+
+// TestDecodeErrorClassifiedAsUnexpected — a 200 OK with garbage
+// JSON body must classify as `unexpected_response` (the request
+// reached the backplane and the backplane returned 200; the body
+// just didn't match the agreed contract). Without this branch, a
+// contract drift between T5 and T6 presents to the operator as
+// "your network is down", which is misleading.
+func TestDecodeErrorClassifiedAsUnexpected(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/connectors": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			// Malformed JSON — triggers json.SyntaxError on decode.
+			_, _ = w.Write([]byte(`{"connectors": [{"connector_id": "x"`))
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	_, err := getList(context.Background(), srv.URL, "all")
+	if err == nil {
+		t.Fatalf("expected decode error; got nil")
+	}
+	// The error should be classifiable as a JSON syntax error so
+	// renderRequestError routes it to Unexpected (not Unreachable).
+	var se *json.SyntaxError
+	var ute *json.UnmarshalTypeError
+	if !errors.As(err, &se) && !errors.As(err, &ute) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected JSON decode error; got %T %v", err, err)
 	}
 }
 

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -1,0 +1,815 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests (pure-function) ----------
+
+// TestTruncatePassthroughAndCut covers the rune-aware truncate
+// helper. Same shape as the operation sibling's test — duplicated
+// because cmd/connector can't import cmd/operation without an
+// import cycle, and a future re-shape on either copy would diverge
+// silently without an in-package pin.
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+// TestNormaliseURLBasic mirrors the operation sibling — trailing
+// slash trimming + reject-empty are the load-bearing properties.
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
+// any wrapping error) maps to AuthExpired; everything else maps
+// to Unexpected. Same routing as the operation sibling.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+// TestPathEscapeOpIDColonsAndSlashes — op_id values carry method
+// + path (`GET:/api/vcenter/cluster`); the escape must keep them
+// safe for URL path segments.
+func TestPathEscapeOpIDColonsAndSlashes(t *testing.T) {
+	got := pathEscapeOpID("GET:/api/vcenter/cluster")
+	// url.PathEscape leaves ':' unescaped (RFC 3986 sub-delim-ok in
+	// path segments) but escapes '/'. Both behaviours are correct;
+	// we only assert that the result decodes back to the input.
+	decoded, err := url.PathUnescape(got)
+	if err != nil {
+		t.Fatalf("PathUnescape: %v", err)
+	}
+	if decoded != "GET:/api/vcenter/cluster" {
+		t.Fatalf("escape round-trip: got %q want %q", decoded, "GET:/api/vcenter/cluster")
+	}
+	if strings.Contains(got, "/") {
+		t.Fatalf("op_id slashes should be escaped; got %q", got)
+	}
+}
+
+// ---------- resolveSpecURI ----------
+
+// TestResolveSpecURIFile — file:// passes through verbatim.
+func TestResolveSpecURIFile(t *testing.T) {
+	got, err := resolveSpecURI("file:///abs/path/spec.yaml")
+	if err != nil {
+		t.Fatalf("file scheme: %v", err)
+	}
+	if got != "file:///abs/path/spec.yaml" {
+		t.Fatalf("file scheme passthrough; got %q", got)
+	}
+}
+
+// TestResolveSpecURIHTTPS — http(s) passes through verbatim.
+func TestResolveSpecURIHTTPS(t *testing.T) {
+	got, err := resolveSpecURI("https://example.com/spec.yaml")
+	if err != nil {
+		t.Fatalf("https scheme: %v", err)
+	}
+	if got != "https://example.com/spec.yaml" {
+		t.Fatalf("https passthrough; got %q", got)
+	}
+}
+
+// TestResolveSpecURIDocsWithEnv — `docs:` shorthand resolves to a
+// file:// path when CLAUDE_RDC_DOCS is set.
+func TestResolveSpecURIDocsWithEnv(t *testing.T) {
+	t.Setenv("CLAUDE_RDC_DOCS", "/opt/rdc/docs")
+	got, err := resolveSpecURI("docs:vcenter-9.0/vcenter.yaml")
+	if err != nil {
+		t.Fatalf("docs shorthand: %v", err)
+	}
+	want := "file:///opt/rdc/docs/vcenter-9.0/vcenter.yaml"
+	if got != want {
+		t.Fatalf("docs shorthand: got %q want %q", got, want)
+	}
+}
+
+// TestResolveSpecURIDocsNoEnv — `docs:` passes through verbatim
+// when CLAUDE_RDC_DOCS is unset so the backplane can resolve it.
+func TestResolveSpecURIDocsNoEnv(t *testing.T) {
+	t.Setenv("CLAUDE_RDC_DOCS", "")
+	got, err := resolveSpecURI("docs:vcenter-9.0/vcenter.yaml")
+	if err != nil {
+		t.Fatalf("docs shorthand, no env: %v", err)
+	}
+	if got != "docs:vcenter-9.0/vcenter.yaml" {
+		t.Fatalf("docs shorthand passthrough; got %q", got)
+	}
+}
+
+// TestResolveSpecURIUnknownScheme — anything not file/http(s)/docs
+// rejects with a clear message.
+func TestResolveSpecURIUnknownScheme(t *testing.T) {
+	_, err := resolveSpecURI("ftp://example.com/spec.yaml")
+	if err == nil || !strings.Contains(err.Error(), "unknown URI scheme") {
+		t.Fatalf("unknown scheme should reject; got %v", err)
+	}
+}
+
+// TestResolveSpecURIEmpty — empty input rejects.
+func TestResolveSpecURIEmpty(t *testing.T) {
+	_, err := resolveSpecURI("   ")
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty spec should reject; got %v", err)
+	}
+}
+
+// ---------- loadTextFlag ----------
+
+// TestLoadTextFlagUnsetReturnsNotPresent — flag not provided ⇒ present=false
+// so callers can omit the field from the PATCH body.
+func TestLoadTextFlagUnsetReturnsNotPresent(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("name", "", "")
+	cmd.SetArgs([]string{})
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	val, present, err := loadTextFlag(cmd, "name")
+	if err != nil {
+		t.Fatalf("loadTextFlag: %v", err)
+	}
+	if present {
+		t.Fatalf("unset flag should report present=false")
+	}
+	if val != "" {
+		t.Fatalf("unset flag should return empty val; got %q", val)
+	}
+}
+
+// TestLoadTextFlagInlineText — `--name foo` ⇒ ("foo", true, nil).
+func TestLoadTextFlagInlineText(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("name", "", "")
+	if err := cmd.ParseFlags([]string{"--name", "foo"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	val, present, err := loadTextFlag(cmd, "name")
+	if err != nil {
+		t.Fatalf("loadTextFlag: %v", err)
+	}
+	if !present || val != "foo" {
+		t.Fatalf("inline text: got (%q, %v); want (\"foo\", true)", val, present)
+	}
+}
+
+// TestLoadTextFlagFileReference — `--name @path` ⇒ reads + trims
+// trailing newline.
+func TestLoadTextFlagFileReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blob.md")
+	if err := os.WriteFile(path, []byte("hello world\n"), 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("name", "", "")
+	if err := cmd.ParseFlags([]string{"--name", "@" + path}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	val, present, err := loadTextFlag(cmd, "name")
+	if err != nil {
+		t.Fatalf("loadTextFlag @file: %v", err)
+	}
+	if !present || val != "hello world" {
+		t.Fatalf("file ref: got (%q, %v); want (\"hello world\", true)", val, present)
+	}
+}
+
+// TestLoadTextFlagMissingFile — `@nonexistent` surfaces a read
+// failure with the path name.
+func TestLoadTextFlagMissingFile(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("name", "", "")
+	if err := cmd.ParseFlags([]string{"--name", "@/nonexistent/path/blob.md"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	_, _, err := loadTextFlag(cmd, "name")
+	if err == nil || !strings.Contains(err.Error(), "read --name file") {
+		t.Fatalf("missing file: should report read failure; got %v", err)
+	}
+}
+
+// TestLoadTextFlagPresentEmpty — `--name ""` ⇒ ("", true, nil).
+// This is load-bearing for the "clear an override" PATCH semantic.
+func TestLoadTextFlagPresentEmpty(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("name", "", "")
+	if err := cmd.ParseFlags([]string{"--name", ""}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	val, present, err := loadTextFlag(cmd, "name")
+	if err != nil {
+		t.Fatalf("loadTextFlag empty: %v", err)
+	}
+	if !present || val != "" {
+		t.Fatalf("--name '': got (%q, %v); want (\"\", true)", val, present)
+	}
+}
+
+// ---------- renderers ----------
+
+// TestPrintIngestSummaryDryRun — dry-run header + counts; no
+// "Connector is in review_status=staged" trailer because that
+// only applies after a real ingest.
+func TestPrintIngestSummaryDryRun(t *testing.T) {
+	r := &IngestResponse{
+		Ingestion: IngestionResult{
+			ConnectorID:     "vmware-rest-9.0",
+			TotalOperations: 12,
+			Inserted:        12,
+			PerSpecCounts:   map[string]int{"vcenter.yaml": 9, "vi-json.yaml": 3},
+		},
+	}
+	opts := ingestOptions{Product: "vmware", Version: "9.0", ImplID: "vmware-rest", DryRun: true}
+	var buf bytes.Buffer
+	printIngestSummary(&buf, opts, r)
+	out := buf.String()
+	for _, want := range []string{"DRY RUN", "12 total", "vcenter.yaml: 9 ops", "vi-json.yaml: 3 ops"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run render missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "review_status=staged") {
+		t.Errorf("dry-run render should not announce review_status=staged; got:\n%s", out)
+	}
+}
+
+// TestPrintIngestSummaryNonDryRun — happy-path render includes
+// connector_id + next-steps hint.
+func TestPrintIngestSummaryNonDryRun(t *testing.T) {
+	r := &IngestResponse{
+		Ingestion: IngestionResult{
+			ConnectorID:        "vmware-rest-9.0",
+			TotalOperations:    961,
+			Inserted:           961,
+			EmbeddingsComputed: 961,
+		},
+		Grouping: &GroupingResult{
+			GroupsProposed:     9,
+			OperationsAssigned: 961,
+			Model:              "claude-3-5-sonnet-20241022",
+		},
+	}
+	opts := ingestOptions{Product: "vmware", Version: "9.0", ImplID: "vmware-rest", DryRun: false}
+	var buf bytes.Buffer
+	printIngestSummary(&buf, opts, r)
+	out := buf.String()
+	for _, want := range []string{"connector_id=vmware-rest-9.0", "961 total", "embeddings: 961 computed", "9 groups", "claude-3-5-sonnet", "review_status=staged", "meho connector review vmware-rest-9.0", "meho connector enable vmware-rest-9.0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("non-dry-run render missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintListTableEmpty — zero connectors renders the count line.
+func TestPrintListTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	printListTable(&buf, "staged", &ListResponse{})
+	if !strings.Contains(buf.String(), "0 connector(s) with status=staged") {
+		t.Errorf("empty list: missing 0-count line; got:\n%s", buf.String())
+	}
+}
+
+// TestPrintListTableHappyPath — happy-path render with two connectors;
+// built-in connectors (TenantID="") render as "(built-in)".
+func TestPrintListTableHappyPath(t *testing.T) {
+	r := &ListResponse{
+		Connectors: []Summary{
+			{ConnectorID: "vault-1.x", ReviewStatus: "enabled", GroupCount: 2, OperationCount: 7, TenantID: ""},
+			{ConnectorID: "vmware-rest-9.0", ReviewStatus: "staged", GroupCount: 9, OperationCount: 961, TenantID: "tenant-a"},
+		},
+	}
+	var buf bytes.Buffer
+	printListTable(&buf, "all", r)
+	out := buf.String()
+	for _, want := range []string{"2 connector(s) with status=all", "vault-1.x", "enabled", "(built-in)", "vmware-rest-9.0", "staged", "tenant-a", "961"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list render missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintReviewTableHappyPath — review render shows groups + ops
+// + flags.
+func TestPrintReviewTableHappyPath(t *testing.T) {
+	summary := "List vSphere clusters"
+	r := &ReviewPayload{
+		ConnectorID:  "vmware-rest-9.0",
+		Product:      "vmware",
+		Version:      "9.0",
+		ImplID:       "vmware-rest",
+		ReviewStatus: "staged",
+		Groups: []ReviewGroup{
+			{
+				GroupKey:  "cluster",
+				Name:      "Cluster",
+				WhenToUse: "Use for vSphere cluster lifecycle ops.",
+				Operations: []ReviewOperation{
+					{OpID: "GET:/api/vcenter/cluster", Summary: &summary, SafetyLevel: "safe", IsEnabled: false},
+					{OpID: "DELETE:/api/vcenter/cluster/{id}", SafetyLevel: "dangerous", RequiresApproval: true, IsEnabled: false},
+				},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	printReviewTable(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"vmware-rest-9.0", "staged", "[cluster]", "Cluster", "vSphere cluster lifecycle", "GET:/api/vcenter/cluster", "safe", "DELETE:/api/vcenter/cluster", "dangerous"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("review render missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintReviewTableEmptyGroups — zero-group connector renders
+// the explanation line.
+func TestPrintReviewTableEmptyGroups(t *testing.T) {
+	r := &ReviewPayload{ConnectorID: "k8s-1.x", ReviewStatus: "staged", Groups: nil}
+	var buf bytes.Buffer
+	printReviewTable(&buf, r)
+	if !strings.Contains(buf.String(), "no groups") {
+		t.Errorf("empty review: missing explanation; got:\n%s", buf.String())
+	}
+}
+
+// ---------- EditOpBody marshal ----------
+
+// TestEditOpBodyMarshalOmitsUnset — a body with only IsEnabled set
+// must marshal to exactly that one field; absent fields stay absent
+// (no explicit null) so the PATCH semantic on the backend stays
+// "leave unchanged".
+func TestEditOpBodyMarshalOmitsUnset(t *testing.T) {
+	enabled := true
+	body := EditOpBody{IsEnabled: &enabled}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(raw) != `{"is_enabled":true}` {
+		t.Fatalf("unset fields should be omitted; got %s", raw)
+	}
+}
+
+// TestEditOpBodyMarshalAllFields — all-fields-set marshal round-
+// trips with the right keys.
+func TestEditOpBodyMarshalAllFields(t *testing.T) {
+	desc := "Read a vault KV secret"
+	safety := "caution"
+	req := true
+	enabled := false
+	body := EditOpBody{
+		CustomDescription: &desc,
+		SafetyLevel:       &safety,
+		RequiresApproval:  &req,
+		IsEnabled:         &enabled,
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{`"custom_description":"Read a vault KV secret"`, `"safety_level":"caution"`, `"requires_approval":true`, `"is_enabled":false`} {
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("marshal missing %q in %s", want, raw)
+		}
+	}
+}
+
+// TestIsEmptyEditOpBody — both branches.
+func TestIsEmptyEditOpBody(t *testing.T) {
+	if !isEmptyEditOpBody(EditOpBody{}) {
+		t.Fatalf("zero-value body should be empty")
+	}
+	enabled := true
+	if isEmptyEditOpBody(EditOpBody{IsEnabled: &enabled}) {
+		t.Fatalf("body with IsEnabled set should not be empty")
+	}
+}
+
+// ---------- transition + confirm ----------
+
+// TestConfirmYes — typing y on stdin returns true.
+func TestConfirmYes(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.SetIn(strings.NewReader("y\n"))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if !confirm(cmd, "really?") {
+		t.Fatalf("confirm 'y' should return true")
+	}
+}
+
+// TestConfirmNo — typing n returns false.
+func TestConfirmNo(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.SetIn(strings.NewReader("n\n"))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if confirm(cmd, "really?") {
+		t.Fatalf("confirm 'n' should return false")
+	}
+}
+
+// TestConfirmEOF — closed stdin returns false (scripted/no-tty
+// path should not accidentally enable).
+func TestConfirmEOF(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.SetIn(strings.NewReader(""))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if confirm(cmd, "really?") {
+		t.Fatalf("confirm with empty stdin should return false")
+	}
+}
+
+// TestPrintTransitionResult — happy-path render.
+func TestPrintTransitionResult(t *testing.T) {
+	r := &TransitionResponse{
+		ConnectorID:       "vmware-rest-9.0",
+		ReviewStatus:      "enabled",
+		GroupsUpdated:     9,
+		OperationsUpdated: 961,
+	}
+	var buf bytes.Buffer
+	printTransitionResult(&buf, "enable", r)
+	out := buf.String()
+	for _, want := range []string{"enable vmware-rest-9.0", "review_status=enabled", "9 groups", "961 ops"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("transition render missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// ---------- httpError ----------
+
+// TestHTTPErrorString — Error() format pins the renderer's input
+// shape.
+func TestHTTPErrorString(t *testing.T) {
+	he := &httpError{StatusCode: 403, Body: "forbidden"}
+	if he.Error() != "HTTP 403: forbidden" {
+		t.Fatalf("httpError format: got %q", he.Error())
+	}
+}
+
+// ---------- HTTP wire shape (mocked) ----------
+
+// TestPostIngestRoundTripWithMockServer — pins the wire contract
+// between T5 and T6 (#406). The CLI POSTs the IngestRequest, the
+// (mocked) T6 endpoint validates the shape and returns an
+// IngestResponse; the CLI decodes it back. Used for the JSON
+// contract sanity check that doesn't require a live backplane —
+// true end-to-end coverage lives in the T8 canary (#408).
+func TestPostIngestRoundTripWithMockServer(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var req IngestRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Errorf("decode IngestRequest body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if req.Product != "vmware" || req.Version != "9.0" || req.ImplID != "vmware-rest" {
+				t.Errorf("unexpected triple: %+v", req)
+			}
+			if len(req.Specs) != 1 || req.Specs[0].URI != "file:///abs/vcenter.yaml" {
+				t.Errorf("unexpected specs: %+v", req.Specs)
+			}
+			resp := IngestResponse{
+				Ingestion: IngestionResult{
+					ConnectorID:     "vmware-rest-9.0",
+					Inserted:        961,
+					TotalOperations: 961,
+				},
+				Grouping: &GroupingResult{GroupsProposed: 9, OperationsAssigned: 961},
+			}
+			writeJSON(t, w, 200, resp)
+		},
+	})
+	defer srv.Close()
+
+	primeToken(t, srv.URL)
+	got, err := postIngest(context.Background(), srv.URL, IngestRequest{
+		Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+		Specs: []SpecSource{{URI: "file:///abs/vcenter.yaml"}},
+	})
+	if err != nil {
+		t.Fatalf("postIngest: %v", err)
+	}
+	if got.Ingestion.ConnectorID != "vmware-rest-9.0" || got.Ingestion.TotalOperations != 961 {
+		t.Fatalf("unexpected ingest result: %+v", got)
+	}
+	if got.Grouping == nil || got.Grouping.GroupsProposed != 9 {
+		t.Fatalf("unexpected grouping: %+v", got.Grouping)
+	}
+}
+
+// TestGetListWithMockServer — validates the status query param
+// shape and the list response decode.
+func TestGetListWithMockServer(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/connectors": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("status") != "staged" {
+				t.Errorf("expected status=staged; got %q", r.URL.Query().Get("status"))
+			}
+			writeJSON(t, w, 200, ListResponse{
+				Connectors: []Summary{
+					{ConnectorID: "vmware-rest-9.0", ReviewStatus: "staged", GroupCount: 9, OperationCount: 961},
+				},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	got, err := getList(context.Background(), srv.URL, "staged")
+	if err != nil {
+		t.Fatalf("getList: %v", err)
+	}
+	if len(got.Connectors) != 1 || got.Connectors[0].ConnectorID != "vmware-rest-9.0" {
+		t.Fatalf("unexpected list: %+v", got)
+	}
+}
+
+// TestGetListAllOmitsStatusQueryParam — the `all` filter sends no
+// `status` param (T6 treats absent as no-filter via `Literal | None`).
+func TestGetListAllOmitsStatusQueryParam(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/connectors": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("status"); got != "" {
+				t.Errorf("status=all should not send param; got %q", got)
+			}
+			writeJSON(t, w, 200, ListResponse{})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := getList(context.Background(), srv.URL, "all"); err != nil {
+		t.Fatalf("getList all: %v", err)
+	}
+}
+
+// TestPatchGroupSendsBody — confirms the wire shape for edit-group.
+func TestPatchGroupSendsBody(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"PATCH /api/v1/connectors/vmware-rest-9.0/groups/cluster": func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var got EditGroupBody
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if got.WhenToUse == nil || *got.WhenToUse != "use for cluster ops" {
+				t.Errorf("when_to_use missing; got %+v", got)
+			}
+			if got.Name != nil {
+				t.Errorf("Name should be unset; got %+v", got.Name)
+			}
+			writeJSON(t, w, 200, EditGroupResponse{
+				ConnectorID: "vmware-rest-9.0", GroupKey: "cluster",
+				Name: "Cluster", WhenToUse: "use for cluster ops",
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	whenToUse := "use for cluster ops"
+	got, err := patchGroup(context.Background(), srv.URL, "vmware-rest-9.0", "cluster", EditGroupBody{WhenToUse: &whenToUse})
+	if err != nil {
+		t.Fatalf("patchGroup: %v", err)
+	}
+	if got.WhenToUse != "use for cluster ops" {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+}
+
+// TestPatchOpEscapesOpID — colons and slashes in op_id must
+// survive the URL path. The mock asserts the decoded segment.
+func TestPatchOpEscapesOpID(t *testing.T) {
+	called := false
+	srv := mockBackplane(t, map[string]mockHandler{
+		"": func(w http.ResponseWriter, r *http.Request) {
+			// Catch-all: confirm the escaped path segment carrying
+			// the op_id round-trips back to "GET:/api/vcenter/cluster".
+			// r.URL.RawPath holds the on-the-wire encoded form;
+			// r.URL.Path is the auto-decoded form FastAPI's
+			// `{op_id:path}` route ultimately sees.
+			called = true
+			if r.Method != "PATCH" {
+				t.Errorf("expected PATCH; got %s", r.Method)
+			}
+			raw := r.URL.RawPath
+			if raw == "" {
+				raw = r.URL.Path
+			}
+			parts := strings.Split(strings.TrimPrefix(raw, "/"), "/")
+			if len(parts) < 6 {
+				t.Errorf("path too short: %q", raw)
+				w.WriteHeader(404)
+				return
+			}
+			decodedOp, err := url.PathUnescape(parts[5])
+			if err != nil {
+				t.Errorf("PathUnescape: %v", err)
+			}
+			if decodedOp != "GET:/api/vcenter/cluster" {
+				t.Errorf("op_id round-trip: got %q (raw path %q)", decodedOp, raw)
+			}
+			writeJSON(t, w, 200, EditOpResponse{
+				ConnectorID: "vmware-rest-9.0",
+				OpID:        "GET:/api/vcenter/cluster",
+				SafetyLevel: "dangerous",
+				IsEnabled:   true,
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	safety := "dangerous"
+	got, err := patchOp(context.Background(), srv.URL, "vmware-rest-9.0", "GET:/api/vcenter/cluster", EditOpBody{SafetyLevel: &safety})
+	if err != nil {
+		t.Fatalf("patchOp: %v", err)
+	}
+	if !called {
+		t.Fatalf("mock handler not invoked")
+	}
+	if got.SafetyLevel != "dangerous" {
+		t.Fatalf("unexpected op response: %+v", got)
+	}
+}
+
+// TestPostTransitionEnable — pins the enable/disable wire shape.
+func TestPostTransitionEnable(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/vmware-rest-9.0/enable": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, TransitionResponse{
+				ConnectorID: "vmware-rest-9.0", ReviewStatus: "enabled",
+				GroupsUpdated: 9, OperationsUpdated: 961,
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	got, err := postTransition(context.Background(), srv.URL, "/api/v1/connectors/vmware-rest-9.0/enable")
+	if err != nil {
+		t.Fatalf("postTransition: %v", err)
+	}
+	if got.ReviewStatus != "enabled" {
+		t.Fatalf("unexpected transition: %+v", got)
+	}
+}
+
+// TestHTTPErrorClassification403 — backplane 403 propagates as a
+// *httpError with the right status code; renderRequestError maps
+// to insufficient_role.
+func TestHTTPErrorClassification403(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(403)
+			_, _ = w.Write([]byte("tenant_admin required"))
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	_, err := postIngest(context.Background(), srv.URL, IngestRequest{
+		Product: "x", Version: "y", ImplID: "z",
+		Specs: []SpecSource{{URI: "file:///a.yaml"}},
+	})
+	if err == nil {
+		t.Fatalf("expected 403 error; got nil")
+	}
+	var he *httpError
+	if !errors.As(err, &he) || he.StatusCode != 403 {
+		t.Fatalf("expected *httpError 403; got %T %v", err, err)
+	}
+}
+
+// ---------- httptest helpers ----------
+
+type mockHandler = http.HandlerFunc
+
+// mockBackplane stands up an httptest.Server that routes by
+// `<METHOD> <path>` keys. The empty key acts as a catch-all when
+// the test wants to validate URL escaping or other path-derived
+// behaviour. Tests are responsible for calling Close() via defer.
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+// primeToken installs an in-memory token store with a usable
+// bearer for the mocked backplane URL. Uses a test-only override
+// so the production keychain isn't touched.
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	// The default auth.NewTokenStore + auth.LoadConfig path expects
+	// a real config file + keychain entry. Tests can short-circuit
+	// by setting XDG_CONFIG_HOME to a tempdir and writing both.
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	// Write a file-backed token (mirrors auth.fileTokenStore shape).
+	// auth.KeyForBackplane derives (service, user) from the URL.
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}

--- a/cli/internal/cmd/connector/disable.go
+++ b/cli/internal/cmd/connector/disable.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Disable is a thin sibling of enable. Both verbs share the same
+// shape (single positional connector_id, --confirm, --json,
+// --backplane) and identical request/response handling — the only
+// per-verb difference is the URL suffix and the prompt prose, which
+// the transitionParams struct in enable.go threads through.
+//
+// This file deliberately holds no logic of its own; the constructor
+// is in enable.go alongside the shared transition machinery.
+package connector

--- a/cli/internal/cmd/connector/edit_group.go
+++ b/cli/internal/cmd/connector/edit_group.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// EditGroupBody mirrors the backend EditGroupBody Pydantic model.
+// Both fields are nullable on the wire so the operator can patch
+// one field without clobbering the other; we use `omitempty` +
+// pointer types so json.Marshal omits unset fields entirely (rather
+// than sending explicit null, which T6 might or might not
+// distinguish from absent).
+type EditGroupBody struct {
+	WhenToUse *string `json:"when_to_use,omitempty"`
+	Name      *string `json:"name,omitempty"`
+}
+
+// EditGroupResponse mirrors the backend response — the updated
+// group payload echoed back so the CLI can confirm the change
+// landed without a second GET.
+type EditGroupResponse struct {
+	ConnectorID string `json:"connector_id"`
+	GroupKey    string `json:"group_key"`
+	Name        string `json:"name"`
+	WhenToUse   string `json:"when_to_use"`
+}
+
+// newEditGroupCmd returns the `meho connector edit-group` command.
+//
+// CLI shape:
+//
+//	meho connector edit-group <connector_id> <group_key> \
+//	  [--when-to-use <text>|@<file>] \
+//	  [--name <text>] \
+//	  [--json] [--backplane <url>]
+//
+// Hits PATCH /api/v1/connectors/<connector_id>/groups/<group_key>
+// with an EditGroupBody. tenant_admin role required.
+func newEditGroupCmd() *cobra.Command {
+	var (
+		whenToUseFlag     string
+		nameFlag          string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "edit-group <connector_id> <group_key>",
+		Short: "Patch a group's when_to_use hint or display name",
+		Long: "edit-group calls PATCH /api/v1/connectors/<connector_id>/groups/\n" +
+			"<group_key>. The LLM-derived `when_to_use` strings are the\n" +
+			"first thing an operator usually overrides at review — the\n" +
+			"agent-facing prompt is decisive for search ranking, and the\n" +
+			"LLM's first cut sometimes reads more like spec docs than\n" +
+			"actionable hints.\n\n" +
+			"--when-to-use accepts inline text or `@<path>` to read from a\n" +
+			"file (useful for multi-paragraph hints maintained in version\n" +
+			"control); the same `@<path>` form works for --name though\n" +
+			"single-line display names rarely need it.\n\n" +
+			"Role: tenant_admin.",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEditGroup(cmd, editGroupOptions{
+				ConnectorID:       args[0],
+				GroupKey:          args[1],
+				WhenToUseRaw:      whenToUseFlag,
+				NameRaw:           nameFlag,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&whenToUseFlag, "when-to-use", "",
+		"replacement when_to_use text; supports `@<path>` to read from a file")
+	cmd.Flags().StringVar(&nameFlag, "name", "",
+		"replacement display name; supports `@<path>` to read from a file")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type editGroupOptions struct {
+	ConnectorID       string
+	GroupKey          string
+	WhenToUseRaw      string
+	NameRaw           string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runEditGroup(cmd *cobra.Command, opts editGroupOptions) error {
+	whenToUse, whenSet, err := loadTextFlag(cmd, "when-to-use")
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	name, nameSet, err := loadTextFlag(cmd, "name")
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	if !whenSet && !nameSet {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("edit-group needs at least one of --when-to-use or --name"),
+			opts.JSONOut,
+		)
+	}
+	body := EditGroupBody{}
+	if whenSet {
+		body.WhenToUse = &whenToUse
+	}
+	if nameSet {
+		body.Name = &name
+	}
+
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := patchGroup(cmd.Context(), backplaneURL, opts.ConnectorID, opts.GroupKey, body)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printEditGroupResult(cmd.OutOrStdout(), result)
+	return nil
+}
+
+func patchGroup(
+	ctx context.Context,
+	backplaneURL, connectorID, groupKey string,
+	body EditGroupBody,
+) (*EditGroupResponse, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal edit-group request: %w", err)
+	}
+	path := fmt.Sprintf("/api/v1/connectors/%s/groups/%s",
+		pathEscapeOpID(connectorID), pathEscapeOpID(groupKey),
+	)
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "PATCH", path, raw)
+	if err != nil {
+		return nil, err
+	}
+	var out EditGroupResponse
+	if err := decodeJSON(respBody, "edit-group", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func printEditGroupResult(w io.Writer, r *EditGroupResponse) {
+	fmt.Fprintf(w, "%s/%s — updated\n", r.ConnectorID, r.GroupKey)
+	fmt.Fprintf(w, "  name: %s\n", r.Name)
+	if r.WhenToUse != "" {
+		fmt.Fprintf(w, "  when_to_use: %s\n", r.WhenToUse)
+	}
+}

--- a/cli/internal/cmd/connector/edit_group.go
+++ b/cli/internal/cmd/connector/edit_group.go
@@ -25,16 +25,6 @@ type EditGroupBody struct {
 	Name      *string `json:"name,omitempty"`
 }
 
-// EditGroupResponse mirrors the backend response — the updated
-// group payload echoed back so the CLI can confirm the change
-// landed without a second GET.
-type EditGroupResponse struct {
-	ConnectorID string `json:"connector_id"`
-	GroupKey    string `json:"group_key"`
-	Name        string `json:"name"`
-	WhenToUse   string `json:"when_to_use"`
-}
-
 // newEditGroupCmd returns the `meho connector edit-group` command.
 //
 // CLI shape:
@@ -128,44 +118,64 @@ func runEditGroup(cmd *cobra.Command, opts editGroupOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
 	}
-	result, err := patchGroup(cmd.Context(), backplaneURL, opts.ConnectorID, opts.GroupKey, body)
-	if err != nil {
+	if err := patchGroup(cmd.Context(), backplaneURL, opts.ConnectorID, opts.GroupKey, body); err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), result)
+		// Echo the body the operator sent — the route returns 204
+		// No Content, so the only authoritative record of what
+		// changed is the PATCH payload itself. Operators piping
+		// to jq get a structured artifact rather than a synthetic
+		// "ok: true" envelope.
+		return output.PrintJSON(cmd.OutOrStdout(), editGroupResult{
+			ConnectorID: opts.ConnectorID,
+			GroupKey:    opts.GroupKey,
+			Patched:     body,
+		})
 	}
-	printEditGroupResult(cmd.OutOrStdout(), result)
+	printEditGroupResult(cmd.OutOrStdout(), opts.ConnectorID, opts.GroupKey, body)
 	return nil
 }
 
+// patchGroup issues the PATCH against T6's route. The route returns
+// HTTP 204 No Content — no JSON body, so we deliberately don't
+// decode anything. A non-2xx surfaces as *httpError via
+// doAuthedRequest's status check.
 func patchGroup(
 	ctx context.Context,
 	backplaneURL, connectorID, groupKey string,
 	body EditGroupBody,
-) (*EditGroupResponse, error) {
+) error {
 	raw, err := json.Marshal(body)
 	if err != nil {
-		return nil, fmt.Errorf("marshal edit-group request: %w", err)
+		return fmt.Errorf("marshal edit-group request: %w", err)
 	}
 	path := fmt.Sprintf("/api/v1/connectors/%s/groups/%s",
 		pathEscapeOpID(connectorID), pathEscapeOpID(groupKey),
 	)
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "PATCH", path, raw)
-	if err != nil {
-		return nil, err
+	if _, err := doAuthedRequest(ctx, backplaneURL, "PATCH", path, raw); err != nil {
+		return err
 	}
-	var out EditGroupResponse
-	if err := decodeJSON(respBody, "edit-group", &out); err != nil {
-		return nil, err
-	}
-	return &out, nil
+	return nil
 }
 
-func printEditGroupResult(w io.Writer, r *EditGroupResponse) {
-	fmt.Fprintf(w, "%s/%s — updated\n", r.ConnectorID, r.GroupKey)
-	fmt.Fprintf(w, "  name: %s\n", r.Name)
-	if r.WhenToUse != "" {
-		fmt.Fprintf(w, "  when_to_use: %s\n", r.WhenToUse)
+// editGroupResult is the synthetic envelope rendered to JSON for
+// --json operators. The PATCH route returns 204 No Content; the only
+// structured record of the operator's edit is the body they sent,
+// which this envelope echoes back together with the path coordinates
+// for downstream tooling.
+type editGroupResult struct {
+	ConnectorID string        `json:"connector_id"`
+	GroupKey    string        `json:"group_key"`
+	Patched     EditGroupBody `json:"patched"`
+}
+
+func printEditGroupResult(w io.Writer, connectorID, groupKey string, body EditGroupBody) {
+	fmt.Fprintf(w, "%s/%s — updated (204 No Content)\n", connectorID, groupKey)
+	if body.Name != nil {
+		fmt.Fprintf(w, "  name: %s\n", *body.Name)
+	}
+	if body.WhenToUse != nil {
+		fmt.Fprintf(w, "  when_to_use: %s\n", *body.WhenToUse)
 	}
 }

--- a/cli/internal/cmd/connector/edit_op.go
+++ b/cli/internal/cmd/connector/edit_op.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// validSafetyLevels pins the safety_level enum the backend accepts.
+// Matches the safety_level column on endpoint_descriptor (G0.6-T1
+// #392 schema). Fail fast in the CLI rather than letting the
+// backplane 422 surface an unfamiliar value.
+var validSafetyLevels = map[string]struct{}{
+	"safe":      {},
+	"caution":   {},
+	"dangerous": {},
+}
+
+// EditOpBody mirrors the backend EditOpBody Pydantic model. Every
+// field is optional + nullable so partial patches work. Pointer
+// types let json.Marshal omit unset fields cleanly via `omitempty`.
+type EditOpBody struct {
+	CustomDescription *string `json:"custom_description,omitempty"`
+	SafetyLevel       *string `json:"safety_level,omitempty"`
+	RequiresApproval  *bool   `json:"requires_approval,omitempty"`
+	IsEnabled         *bool   `json:"is_enabled,omitempty"`
+}
+
+// EditOpResponse mirrors the backend response — the updated op row
+// echoed back so the CLI can confirm without re-running review.
+type EditOpResponse struct {
+	ConnectorID       string  `json:"connector_id"`
+	OpID              string  `json:"op_id"`
+	CustomDescription *string `json:"custom_description"`
+	SafetyLevel       string  `json:"safety_level"`
+	RequiresApproval  bool    `json:"requires_approval"`
+	IsEnabled         bool    `json:"is_enabled"`
+}
+
+// newEditOpCmd returns the `meho connector edit-op` command.
+//
+// CLI shape:
+//
+//	meho connector edit-op <connector_id> <op_id> \
+//	  [--custom-description <text>|@<file>] \
+//	  [--safety safe|caution|dangerous] \
+//	  [--requires-approval | --no-requires-approval] \
+//	  [--enable | --disable] \
+//	  [--json] [--backplane <url>]
+//
+// Hits PATCH /api/v1/connectors/<connector_id>/operations/<op_id>
+// with an EditOpBody. tenant_admin role required.
+func newEditOpCmd() *cobra.Command {
+	var (
+		customDesc        string
+		safetyFlag        string
+		requiresApproval  bool
+		clearApproval     bool
+		enableOp          bool
+		disableOp         bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "edit-op <connector_id> <op_id>",
+		Short: "Patch a per-op override (custom_description, safety, approval, enabled)",
+		Long: "edit-op calls PATCH /api/v1/connectors/<id>/operations/<op_id>\n" +
+			"to override the per-op flags an operator wants to differ from\n" +
+			"the parser-derived defaults. Common patterns:\n\n" +
+			"  --safety dangerous            # parser tagged a destructive\n" +
+			"                                # POST as 'caution'; bump it.\n" +
+			"  --requires-approval           # gate this op on the approval\n" +
+			"                                # workflow regardless of safety.\n" +
+			"  --no-requires-approval        # clear the requires_approval flag.\n" +
+			"  --custom-description @path.md # operator-authored agent prompt\n" +
+			"                                # supersedes vendor docs.\n" +
+			"  --disable                     # exclude this op from\n" +
+			"                                # search_operations + dispatch\n" +
+			"                                # even when the connector is enabled.\n" +
+			"  --enable                      # re-include a previously disabled op.\n\n" +
+			"op_id is the canonical form `METHOD:/path` for generic\n" +
+			"connectors (e.g. `GET:/api/vcenter/cluster`). The CLI URL-escapes\n" +
+			"the op_id segment before placing it in the path so the colons\n" +
+			"and slashes survive the routing layer.\n\n" +
+			"Role: tenant_admin.",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEditOp(cmd, editOpOptions{
+				ConnectorID:          args[0],
+				OpID:                 args[1],
+				CustomDescriptionRaw: customDesc,
+				SafetyFlag:           safetyFlag,
+				RequiresApproval:     requiresApproval,
+				ClearApproval:        clearApproval,
+				EnableOp:             enableOp,
+				DisableOp:            disableOp,
+				JSONOut:              jsonOut,
+				BackplaneOverride:    backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&customDesc, "custom-description", "",
+		"replacement custom_description; supports `@<path>` to read from a file")
+	cmd.Flags().StringVar(&safetyFlag, "safety", "",
+		"replacement safety_level: safe | caution | dangerous")
+	cmd.Flags().BoolVar(&requiresApproval, "requires-approval", false,
+		"mark the op as requiring an approval workflow")
+	cmd.Flags().BoolVar(&clearApproval, "no-requires-approval", false,
+		"clear the requires_approval flag")
+	cmd.Flags().BoolVar(&enableOp, "enable", false,
+		"set is_enabled=true on this op")
+	cmd.Flags().BoolVar(&disableOp, "disable", false,
+		"set is_enabled=false on this op")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	cmd.MarkFlagsMutuallyExclusive("requires-approval", "no-requires-approval")
+	cmd.MarkFlagsMutuallyExclusive("enable", "disable")
+	return cmd
+}
+
+type editOpOptions struct {
+	ConnectorID          string
+	OpID                 string
+	CustomDescriptionRaw string
+	SafetyFlag           string
+	RequiresApproval     bool
+	ClearApproval        bool
+	EnableOp             bool
+	DisableOp            bool
+	JSONOut              bool
+	BackplaneOverride    string
+}
+
+func runEditOp(cmd *cobra.Command, opts editOpOptions) error {
+	body := EditOpBody{}
+
+	descText, descSet, err := loadTextFlag(cmd, "custom-description")
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	if descSet {
+		body.CustomDescription = &descText
+	}
+
+	if opts.SafetyFlag != "" {
+		if _, ok := validSafetyLevels[opts.SafetyFlag]; !ok {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"--safety %q invalid; expected one of: safe | caution | dangerous",
+					opts.SafetyFlag,
+				)),
+				opts.JSONOut,
+			)
+		}
+		body.SafetyLevel = &opts.SafetyFlag
+	}
+
+	if opts.RequiresApproval {
+		t := true
+		body.RequiresApproval = &t
+	} else if opts.ClearApproval {
+		f := false
+		body.RequiresApproval = &f
+	}
+
+	if opts.EnableOp {
+		t := true
+		body.IsEnabled = &t
+	} else if opts.DisableOp {
+		f := false
+		body.IsEnabled = &f
+	}
+
+	if isEmptyEditOpBody(body) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("edit-op needs at least one of --custom-description / --safety / --requires-approval / --no-requires-approval / --enable / --disable"),
+			opts.JSONOut,
+		)
+	}
+
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := patchOp(cmd.Context(), backplaneURL, opts.ConnectorID, opts.OpID, body)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printEditOpResult(cmd.OutOrStdout(), result)
+	return nil
+}
+
+// isEmptyEditOpBody returns true when no field is set — the operator
+// invoked edit-op without any actual change. Without this guard the
+// CLI would ship an empty PATCH that succeeds at the route layer
+// but does nothing, surprising the operator.
+func isEmptyEditOpBody(b EditOpBody) bool {
+	return b.CustomDescription == nil &&
+		b.SafetyLevel == nil &&
+		b.RequiresApproval == nil &&
+		b.IsEnabled == nil
+}
+
+func patchOp(
+	ctx context.Context,
+	backplaneURL, connectorID, opID string,
+	body EditOpBody,
+) (*EditOpResponse, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal edit-op request: %w", err)
+	}
+	path := fmt.Sprintf("/api/v1/connectors/%s/operations/%s",
+		pathEscapeOpID(connectorID), pathEscapeOpID(opID),
+	)
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "PATCH", path, raw)
+	if err != nil {
+		return nil, err
+	}
+	var out EditOpResponse
+	if err := decodeJSON(respBody, "edit-op", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func printEditOpResult(w io.Writer, r *EditOpResponse) {
+	fmt.Fprintf(w, "%s/%s — updated\n", r.ConnectorID, r.OpID)
+	fmt.Fprintf(w, "  safety: %s\n", r.SafetyLevel)
+	fmt.Fprintf(w, "  requires_approval: %t\n", r.RequiresApproval)
+	fmt.Fprintf(w, "  is_enabled: %t\n", r.IsEnabled)
+	if r.CustomDescription != nil && *r.CustomDescription != "" {
+		fmt.Fprintf(w, "  custom_description: %s\n", *r.CustomDescription)
+	}
+}

--- a/cli/internal/cmd/connector/edit_op.go
+++ b/cli/internal/cmd/connector/edit_op.go
@@ -34,17 +34,6 @@ type EditOpBody struct {
 	IsEnabled         *bool   `json:"is_enabled,omitempty"`
 }
 
-// EditOpResponse mirrors the backend response — the updated op row
-// echoed back so the CLI can confirm without re-running review.
-type EditOpResponse struct {
-	ConnectorID       string  `json:"connector_id"`
-	OpID              string  `json:"op_id"`
-	CustomDescription *string `json:"custom_description"`
-	SafetyLevel       string  `json:"safety_level"`
-	RequiresApproval  bool    `json:"requires_approval"`
-	IsEnabled         bool    `json:"is_enabled"`
-}
-
 // newEditOpCmd returns the `meho connector edit-op` command.
 //
 // CLI shape:
@@ -194,14 +183,20 @@ func runEditOp(cmd *cobra.Command, opts editOpOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
 	}
-	result, err := patchOp(cmd.Context(), backplaneURL, opts.ConnectorID, opts.OpID, body)
-	if err != nil {
+	if err := patchOp(cmd.Context(), backplaneURL, opts.ConnectorID, opts.OpID, body); err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), result)
+		// Echo the operator's PATCH body — the route returns 204
+		// No Content, so the only structured artifact is the
+		// payload itself. Same shape as edit-group's --json output.
+		return output.PrintJSON(cmd.OutOrStdout(), editOpResult{
+			ConnectorID: opts.ConnectorID,
+			OpID:        opts.OpID,
+			Patched:     body,
+		})
 	}
-	printEditOpResult(cmd.OutOrStdout(), result)
+	printEditOpResult(cmd.OutOrStdout(), opts.ConnectorID, opts.OpID, body)
 	return nil
 }
 
@@ -216,35 +211,49 @@ func isEmptyEditOpBody(b EditOpBody) bool {
 		b.IsEnabled == nil
 }
 
+// patchOp issues the PATCH against T6's per-op route. The route
+// returns HTTP 204 No Content — no JSON body, so we deliberately
+// don't decode anything. A non-2xx surfaces as *httpError via
+// doAuthedRequest's status check.
 func patchOp(
 	ctx context.Context,
 	backplaneURL, connectorID, opID string,
 	body EditOpBody,
-) (*EditOpResponse, error) {
+) error {
 	raw, err := json.Marshal(body)
 	if err != nil {
-		return nil, fmt.Errorf("marshal edit-op request: %w", err)
+		return fmt.Errorf("marshal edit-op request: %w", err)
 	}
 	path := fmt.Sprintf("/api/v1/connectors/%s/operations/%s",
 		pathEscapeOpID(connectorID), pathEscapeOpID(opID),
 	)
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "PATCH", path, raw)
-	if err != nil {
-		return nil, err
+	if _, err := doAuthedRequest(ctx, backplaneURL, "PATCH", path, raw); err != nil {
+		return err
 	}
-	var out EditOpResponse
-	if err := decodeJSON(respBody, "edit-op", &out); err != nil {
-		return nil, err
-	}
-	return &out, nil
+	return nil
 }
 
-func printEditOpResult(w io.Writer, r *EditOpResponse) {
-	fmt.Fprintf(w, "%s/%s — updated\n", r.ConnectorID, r.OpID)
-	fmt.Fprintf(w, "  safety: %s\n", r.SafetyLevel)
-	fmt.Fprintf(w, "  requires_approval: %t\n", r.RequiresApproval)
-	fmt.Fprintf(w, "  is_enabled: %t\n", r.IsEnabled)
-	if r.CustomDescription != nil && *r.CustomDescription != "" {
-		fmt.Fprintf(w, "  custom_description: %s\n", *r.CustomDescription)
+// editOpResult is the synthetic envelope rendered to JSON for --json
+// operators. The PATCH route returns 204 No Content; the only
+// structured record of the operator's edit is the body they sent.
+type editOpResult struct {
+	ConnectorID string     `json:"connector_id"`
+	OpID        string     `json:"op_id"`
+	Patched     EditOpBody `json:"patched"`
+}
+
+func printEditOpResult(w io.Writer, connectorID, opID string, body EditOpBody) {
+	fmt.Fprintf(w, "%s/%s — updated (204 No Content)\n", connectorID, opID)
+	if body.SafetyLevel != nil {
+		fmt.Fprintf(w, "  safety: %s\n", *body.SafetyLevel)
+	}
+	if body.RequiresApproval != nil {
+		fmt.Fprintf(w, "  requires_approval: %t\n", *body.RequiresApproval)
+	}
+	if body.IsEnabled != nil {
+		fmt.Fprintf(w, "  is_enabled: %t\n", *body.IsEnabled)
+	}
+	if body.CustomDescription != nil && *body.CustomDescription != "" {
+		fmt.Fprintf(w, "  custom_description: %s\n", *body.CustomDescription)
 	}
 }

--- a/cli/internal/cmd/connector/enable.go
+++ b/cli/internal/cmd/connector/enable.go
@@ -13,15 +13,16 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// TransitionResponse mirrors the backend response from POST
-// /api/v1/connectors/{id}/{enable,disable}. The route is idempotent
-// — calling enable on an already-enabled connector returns
-// review_status=enabled + 0/0 counts.
-type TransitionResponse struct {
-	ConnectorID       string `json:"connector_id"`
-	ReviewStatus      string `json:"review_status"`
-	GroupsUpdated     int    `json:"groups_updated"`
-	OperationsUpdated int    `json:"operations_updated"`
+// transitionResult is the synthetic --json envelope the enable /
+// disable verbs render to operators. The underlying T6 route
+// returns HTTP 204 No Content (see api/v1/connectors_ingest.py), so
+// there is no canonical wire response to mirror. The envelope
+// captures the connector_id the operator targeted plus the verb's
+// post-condition (action="enabled"|"disabled") so downstream tooling
+// piping to jq sees a structured artifact.
+type transitionResult struct {
+	ConnectorID string `json:"connector_id"`
+	Action      string `json:"action"`
 }
 
 // newEnableCmd returns the `meho connector enable` command.
@@ -125,10 +126,10 @@ func runTransition(cmd *cobra.Command, p transitionParams, opts transitionOption
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
 	}
 	path := fmt.Sprintf(p.Path, pathEscapeOpID(opts.ConnectorID))
-	result, err := postTransition(cmd.Context(), backplaneURL, path)
-	if err != nil {
+	if err := postTransition(cmd.Context(), backplaneURL, path); err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	result := transitionResult{ConnectorID: opts.ConnectorID, Action: p.Action}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), result)
 	}
@@ -136,16 +137,15 @@ func runTransition(cmd *cobra.Command, p transitionParams, opts transitionOption
 	return nil
 }
 
-func postTransition(ctx context.Context, backplaneURL, path string) (*TransitionResponse, error) {
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", path, []byte("{}"))
-	if err != nil {
-		return nil, err
+// postTransition fires the POST against the enable / disable route.
+// The route returns HTTP 204 No Content; doAuthedRequest treats 204
+// as success and returns an empty body which we deliberately ignore.
+// Non-2xx surfaces as *httpError via doAuthedRequest's status check.
+func postTransition(ctx context.Context, backplaneURL, path string) error {
+	if _, err := doAuthedRequest(ctx, backplaneURL, "POST", path, []byte("{}")); err != nil {
+		return err
 	}
-	var out TransitionResponse
-	if err := decodeJSON(respBody, "transition", &out); err != nil {
-		return nil, err
-	}
-	return &out, nil
+	return nil
 }
 
 // errTransitionAborted is the sentinel returned when the operator
@@ -159,9 +159,6 @@ type silentTransitionError struct{}
 func (silentTransitionError) Error() string    { return "" }
 func (s *silentTransitionError) ExitCode() int { return 1 }
 
-func printTransitionResult(w io.Writer, verb string, r *TransitionResponse) {
-	fmt.Fprintf(w, "%s %s — review_status=%s (%d groups, %d ops updated)\n",
-		verb, r.ConnectorID, r.ReviewStatus,
-		r.GroupsUpdated, r.OperationsUpdated,
-	)
+func printTransitionResult(w io.Writer, verb string, r transitionResult) {
+	fmt.Fprintf(w, "%s %s — %s (204 No Content)\n", verb, r.ConnectorID, r.Action)
 }

--- a/cli/internal/cmd/connector/enable.go
+++ b/cli/internal/cmd/connector/enable.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// TransitionResponse mirrors the backend response from POST
+// /api/v1/connectors/{id}/{enable,disable}. The route is idempotent
+// — calling enable on an already-enabled connector returns
+// review_status=enabled + 0/0 counts.
+type TransitionResponse struct {
+	ConnectorID       string `json:"connector_id"`
+	ReviewStatus      string `json:"review_status"`
+	GroupsUpdated     int    `json:"groups_updated"`
+	OperationsUpdated int    `json:"operations_updated"`
+}
+
+// newEnableCmd returns the `meho connector enable` command.
+//
+// CLI shape:
+//
+//	meho connector enable <connector_id> [--confirm] [--json] [--backplane <url>]
+//
+// Hits POST /api/v1/connectors/<connector_id>/enable. Without
+// --confirm, the verb prompts on stdin for "y/yes"; --confirm skips
+// the prompt for scripted use. tenant_admin role required.
+func newEnableCmd() *cobra.Command {
+	return newTransitionCmd(transitionParams{
+		Verb:            "enable",
+		Short:           "Flip a staged or disabled connector to enabled (operations dispatchable)",
+		Action:          "enabled",
+		ConfirmQuestion: "Enable connector %s — all ops with is_enabled=true become dispatchable. Continue?",
+		Path:            "/api/v1/connectors/%s/enable",
+	})
+}
+
+// newDisableCmd is filed alongside enable because both verbs share
+// the same flag set, run shape, and rendering. The only differences
+// are the URL suffix and the prompt prose.
+func newDisableCmd() *cobra.Command {
+	return newTransitionCmd(transitionParams{
+		Verb:            "disable",
+		Short:           "Flip an enabled connector back to disabled (rollback; per-op overrides preserved)",
+		Action:          "disabled",
+		ConfirmQuestion: "Disable connector %s — operations become non-dispatchable. Per-op overrides preserved. Continue?",
+		Path:            "/api/v1/connectors/%s/disable",
+	})
+}
+
+type transitionParams struct {
+	Verb            string
+	Short           string
+	Action          string
+	ConfirmQuestion string
+	Path            string
+}
+
+func newTransitionCmd(p transitionParams) *cobra.Command {
+	var (
+		confirmFlag       bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   p.Verb + " <connector_id>",
+		Short: p.Short,
+		Long: fmt.Sprintf("%s calls POST /api/v1/connectors/<connector_id>/%s.\n\n"+
+			"The route is idempotent: calling it against an already-%s connector\n"+
+			"returns the current state without re-running the transition.\n\n"+
+			"Without --confirm, the verb prompts on stdin for confirmation;\n"+
+			"--confirm skips the prompt for scripted use (CI pipelines, etc.).\n\n"+
+			"Role: tenant_admin.",
+			p.Verb, p.Verb, p.Action,
+		),
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTransition(cmd, p, transitionOptions{
+				ConnectorID:       args[0],
+				Confirm:           confirmFlag,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&confirmFlag, "confirm", false,
+		"skip the interactive confirmation prompt")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type transitionOptions struct {
+	ConnectorID       string
+	Confirm           bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runTransition(cmd *cobra.Command, p transitionParams, opts transitionOptions) error {
+	// Prompt before resolving the backplane so the operator's only
+	// interaction is the confirmation — if they hit 'n', they
+	// haven't made a network call yet.
+	if !opts.Confirm {
+		prompt := fmt.Sprintf(p.ConfirmQuestion, opts.ConnectorID)
+		if !confirm(cmd, prompt) {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return errTransitionAborted
+		}
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	path := fmt.Sprintf(p.Path, pathEscapeOpID(opts.ConnectorID))
+	result, err := postTransition(cmd.Context(), backplaneURL, path)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printTransitionResult(cmd.OutOrStdout(), p.Verb, result)
+	return nil
+}
+
+func postTransition(ctx context.Context, backplaneURL, path string) (*TransitionResponse, error) {
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", path, []byte("{}"))
+	if err != nil {
+		return nil, err
+	}
+	var out TransitionResponse
+	if err := decodeJSON(respBody, "transition", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// errTransitionAborted is the sentinel returned when the operator
+// answered "no" at the confirmation prompt. The cobra command has
+// SilenceErrors=true so the empty Error() doesn't double-print
+// after the explicit "Aborted." line.
+var errTransitionAborted = &silentTransitionError{}
+
+type silentTransitionError struct{}
+
+func (silentTransitionError) Error() string    { return "" }
+func (s *silentTransitionError) ExitCode() int { return 1 }
+
+func printTransitionResult(w io.Writer, verb string, r *TransitionResponse) {
+	fmt.Fprintf(w, "%s %s — review_status=%s (%d groups, %d ops updated)\n",
+		verb, r.ConnectorID, r.ReviewStatus,
+		r.GroupsUpdated, r.OperationsUpdated,
+	)
+}

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -40,30 +40,49 @@ type IngestRequest struct {
 	DryRun  bool         `json:"dry_run"`
 }
 
-// IngestionResult mirrors the backend IngestionResult Pydantic
-// model (G0.7-T2 #403 register_ingested_operations() result shape).
-// Counts cover the bulk-upsert outcome per spec; ConnectorID is the
-// derived identifier the dispatcher uses for subsequent calls
-// (`<product>-<impl>-<version>`, e.g. `vmware-rest-9.0`).
+// IngestionResult mirrors the canonical backend IngestionResultModel
+// Pydantic model (operations/ingest/api_schemas.py) that lands with T6
+// (#488). Counts cover the bulk-upsert outcome aggregated across every
+// spec in the request; ConnectorID is the derived identifier the
+// dispatcher uses for subsequent calls (`<impl_id>-<version>`, e.g.
+// `vmware-rest-9.0`).
+//
+// connector_registered flips to true when this ingest call was the
+// first to land the (product, version, impl_id) triple — the T2
+// auto-registration of the GenericRestConnector shim ran. Subsequent
+// ingests against the same triple return connector_registered=false.
+//
+// operations_grouped flips to true when the T3 LLM-grouping pass
+// actually ran (every newly-ingested op got assigned to an
+// OperationGroup row). False on the dry-run path and on the
+// already-grouped-no-op path. The CLI renders it so the operator
+// knows whether `meho connector review <id>` will have any groups
+// to show.
 type IngestionResult struct {
-	ConnectorID        string         `json:"connector_id"`
-	Inserted           int            `json:"inserted"`
-	Updated            int            `json:"updated"`
-	Skipped            int            `json:"skipped"`
-	TotalOperations    int            `json:"total_operations"`
-	PerSpecCounts      map[string]int `json:"per_spec_counts,omitempty"`
-	EmbeddingsComputed int            `json:"embeddings_computed,omitempty"`
-	EmbeddingsSkipped  int            `json:"embeddings_skipped,omitempty"`
+	ConnectorID         string `json:"connector_id"`
+	InsertedCount       int    `json:"inserted_count"`
+	UpdatedCount        int    `json:"updated_count"`
+	SkippedCount        int    `json:"skipped_count"`
+	ConnectorRegistered bool   `json:"connector_registered"`
+	OperationsGrouped   bool   `json:"operations_grouped"`
 }
 
-// GroupingResult mirrors the backend GroupingResult Pydantic model
-// (G0.7-T3 #404). Counts cover the LLM-summarised grouping pass.
-// Null on dry-run (no LLM call).
+// GroupingResult mirrors the canonical backend GroupingResultModel
+// Pydantic model (operations/ingest/api_schemas.py). Counts cover the
+// LLM-summarised grouping pass; the field is null on dry_run=true
+// (no LLM call) and on the no-op re-run path (every op already
+// grouped from a prior pass).
+//
+// LlmDurationMs is float (the Python field uses float seconds*1000)
+// so the Go side mirrors it as float64 — an int truncation would
+// silently drop sub-millisecond timings on fast LLM stub paths.
 type GroupingResult struct {
-	GroupsProposed     int    `json:"groups_proposed"`
-	OperationsAssigned int    `json:"operations_assigned"`
-	OperationsOrphan   int    `json:"operations_orphan"`
-	Model              string `json:"model,omitempty"`
+	ConnectorID          string  `json:"connector_id"`
+	GroupsCreated        int     `json:"groups_created"`
+	OperationsAssigned   int     `json:"operations_assigned"`
+	OperationsUnassigned int     `json:"operations_unassigned"`
+	LLMCallCount         int     `json:"llm_call_count"`
+	LLMDurationMs        float64 `json:"llm_duration_ms"`
 }
 
 // IngestResponse mirrors T6's IngestResponse Pydantic model. The
@@ -226,7 +245,15 @@ func postIngest(ctx context.Context, backplaneURL string, body IngestRequest) (*
 // copy it into the subsequent `review` / `enable` commands), then
 // the bulk-upsert counts, then the LLM grouping outcome (or "dry
 // run — skipped" on dry-run).
+//
+// The canonical IngestionResultModel ships only the aggregate
+// inserted/updated/skipped counts plus the two boolean flags
+// (connector_registered, operations_grouped). The per-spec
+// breakdown and the embeddings split that the original PR-body
+// contract carried are not in the wire shape — operators see the
+// aggregate via this rollup and the per-spec story via the audit log.
 func printIngestSummary(w io.Writer, opts ingestOptions, r *IngestResponse) {
+	totalOps := r.Ingestion.InsertedCount + r.Ingestion.UpdatedCount + r.Ingestion.SkippedCount
 	if opts.DryRun {
 		fmt.Fprintf(w, "ingest %s/%s/%s — DRY RUN (no DB writes)\n",
 			opts.Product, opts.Version, opts.ImplID,
@@ -237,31 +264,27 @@ func printIngestSummary(w io.Writer, opts ingestOptions, r *IngestResponse) {
 		)
 	}
 	fmt.Fprintf(w, "  operations: %d total (%d inserted / %d updated / %d skipped)\n",
-		r.Ingestion.TotalOperations,
-		r.Ingestion.Inserted,
-		r.Ingestion.Updated,
-		r.Ingestion.Skipped,
+		totalOps,
+		r.Ingestion.InsertedCount,
+		r.Ingestion.UpdatedCount,
+		r.Ingestion.SkippedCount,
 	)
-	if r.Ingestion.EmbeddingsComputed > 0 || r.Ingestion.EmbeddingsSkipped > 0 {
-		fmt.Fprintf(w, "  embeddings: %d computed / %d skipped\n",
-			r.Ingestion.EmbeddingsComputed,
-			r.Ingestion.EmbeddingsSkipped,
+	if !opts.DryRun {
+		fmt.Fprintf(w, "  connector_registered: %t (first ingest of this triple flips it to true)\n",
+			r.Ingestion.ConnectorRegistered,
 		)
-	}
-	if len(r.Ingestion.PerSpecCounts) > 0 {
-		fmt.Fprintln(w, "  per-spec breakdown:")
-		for spec, n := range r.Ingestion.PerSpecCounts {
-			fmt.Fprintf(w, "    %s: %d ops\n", spec, n)
-		}
+		fmt.Fprintf(w, "  operations_grouped: %t\n", r.Ingestion.OperationsGrouped)
 	}
 	if r.Grouping != nil {
-		fmt.Fprintf(w, "  grouping: %d groups, %d ops assigned, %d orphan",
-			r.Grouping.GroupsProposed,
+		fmt.Fprintf(w, "  grouping: %d groups, %d ops assigned, %d unassigned",
+			r.Grouping.GroupsCreated,
 			r.Grouping.OperationsAssigned,
-			r.Grouping.OperationsOrphan,
+			r.Grouping.OperationsUnassigned,
 		)
-		if r.Grouping.Model != "" {
-			fmt.Fprintf(w, " (model=%s)", r.Grouping.Model)
+		if r.Grouping.LLMCallCount > 0 {
+			fmt.Fprintf(w, " (%d LLM call(s), %.0fms)",
+				r.Grouping.LLMCallCount, r.Grouping.LLMDurationMs,
+			)
 		}
 		fmt.Fprintln(w)
 	} else if !opts.DryRun {

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// SpecSource mirrors the backend SpecSource Pydantic model (T6
+// #406's IngestRequest.specs[] element). Single field for v0.2; the
+// shape leaves room for per-spec overrides (e.g. spec_source tag,
+// auth headers for HTTPS-fetched specs) in v0.2.next without a
+// wire-shape break.
+type SpecSource struct {
+	URI string `json:"uri"`
+}
+
+// IngestRequest mirrors the backend IngestRequest Pydantic model.
+// product / version / impl_id are the connector_id triple stored on
+// the endpoint_descriptor row; specs is the list of (method, path)
+// providers that merge under that one connector_id (vSphere is the
+// canonical multi-spec case — vcenter.yaml + vi-json.yaml).
+//
+// DryRun=true makes the backplane parse + plan without writing to
+// the DB; the response carries the same IngestionResult shape but
+// the GroupingResult field is null (no LLM call on dry-run).
+type IngestRequest struct {
+	Product string       `json:"product"`
+	Version string       `json:"version"`
+	ImplID  string       `json:"impl_id"`
+	Specs   []SpecSource `json:"specs"`
+	DryRun  bool         `json:"dry_run"`
+}
+
+// IngestionResult mirrors the backend IngestionResult Pydantic
+// model (G0.7-T2 #403 register_ingested_operations() result shape).
+// Counts cover the bulk-upsert outcome per spec; ConnectorID is the
+// derived identifier the dispatcher uses for subsequent calls
+// (`<product>-<impl>-<version>`, e.g. `vmware-rest-9.0`).
+type IngestionResult struct {
+	ConnectorID        string         `json:"connector_id"`
+	Inserted           int            `json:"inserted"`
+	Updated            int            `json:"updated"`
+	Skipped            int            `json:"skipped"`
+	TotalOperations    int            `json:"total_operations"`
+	PerSpecCounts      map[string]int `json:"per_spec_counts,omitempty"`
+	EmbeddingsComputed int            `json:"embeddings_computed,omitempty"`
+	EmbeddingsSkipped  int            `json:"embeddings_skipped,omitempty"`
+}
+
+// GroupingResult mirrors the backend GroupingResult Pydantic model
+// (G0.7-T3 #404). Counts cover the LLM-summarised grouping pass.
+// Null on dry-run (no LLM call).
+type GroupingResult struct {
+	GroupsProposed     int    `json:"groups_proposed"`
+	OperationsAssigned int    `json:"operations_assigned"`
+	OperationsOrphan   int    `json:"operations_orphan"`
+	Model              string `json:"model,omitempty"`
+}
+
+// IngestResponse mirrors T6's IngestResponse Pydantic model. The
+// Grouping field is null on a dry_run=true request because the LLM
+// pass only runs when the operations actually land in the DB.
+type IngestResponse struct {
+	Ingestion IngestionResult `json:"ingestion"`
+	Grouping  *GroupingResult `json:"grouping"`
+}
+
+// newIngestCmd returns the `meho connector ingest` command.
+//
+// CLI shape:
+//
+//	meho connector ingest \
+//	  --product <p> --version <v> --impl <i> \
+//	  --spec <uri> [--spec <uri> ...] \
+//	  [--dry-run] [--json] [--backplane <url>]
+//
+// The verb hits POST /api/v1/connectors/ingest with an IngestRequest
+// body; the backplane runs T1 parser → T2 register_ingested → T3
+// LLM grouping and returns an IngestResponse envelope. tenant_admin
+// role required (HTTP 403 → exit 5).
+func newIngestCmd() *cobra.Command {
+	var (
+		product           string
+		versionFlag       string
+		implID            string
+		specs             []string
+		dryRun            bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "ingest",
+		Short: "Ingest one or more vendor specs into a new connector (staged state)",
+		Long: "ingest parses each --spec URI, registers the operations into the\n" +
+			"endpoint_descriptor table under one connector_id, and runs the\n" +
+			"LLM-summarised grouping pass. The newly-ingested connector lands\n" +
+			"in review_status=staged — operations are NOT dispatchable until\n" +
+			"an operator runs `meho connector review <id>` + `meho connector\n" +
+			"enable <id>`.\n\n" +
+			"--spec accepts three URI shapes:\n" +
+			"  - file:///abs/path/to/spec.yaml          (local file)\n" +
+			"  - https://example.com/spec.yaml           (HTTP fetch)\n" +
+			"  - docs:<product-version>/<spec.yaml>      (resolves against\n" +
+			"    $CLAUDE_RDC_DOCS when set; otherwise passed through for\n" +
+			"    backplane-side resolution against its own checked-in docs)\n\n" +
+			"Repeat --spec to merge multiple specs under one connector_id\n" +
+			"(vSphere is the canonical case: vcenter.yaml + vi-json.yaml).\n\n" +
+			"--dry-run parses + plans without writing to the DB; useful for\n" +
+			"validating a spec before committing. Role: tenant_admin.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runIngest(cmd, ingestOptions{
+				Product:           product,
+				Version:           versionFlag,
+				ImplID:            implID,
+				Specs:             specs,
+				DryRun:            dryRun,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&product, "product", "",
+		"product name (e.g. vmware, kubernetes); required")
+	cmd.Flags().StringVar(&versionFlag, "version", "",
+		"product version (e.g. 9.0, 1.x); required")
+	cmd.Flags().StringVar(&implID, "impl", "",
+		"impl identifier (e.g. vmware-rest, k8s-go); required")
+	cmd.Flags().StringArrayVar(&specs, "spec", nil,
+		"spec URI; repeat for multi-spec merge under one connector_id (required, at least one)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"parse and plan without writing to the DB; the response carries an IngestionResult with counts but no GroupingResult")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	_ = cmd.MarkFlagRequired("product")
+	_ = cmd.MarkFlagRequired("version")
+	_ = cmd.MarkFlagRequired("impl")
+	_ = cmd.MarkFlagRequired("spec")
+	return cmd
+}
+
+type ingestOptions struct {
+	Product           string
+	Version           string
+	ImplID            string
+	Specs             []string
+	DryRun            bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runIngest(cmd *cobra.Command, opts ingestOptions) error {
+	// Validate + resolve the spec URIs locally so the operator gets a
+	// fast hint on a typo'd scheme rather than a backplane 422.
+	if len(opts.Specs) == 0 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("at least one --spec is required"),
+			opts.JSONOut,
+		)
+	}
+	resolved := make([]SpecSource, 0, len(opts.Specs))
+	for _, raw := range opts.Specs {
+		uri, err := resolveSpecURI(raw)
+		if err != nil {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(err.Error()),
+				opts.JSONOut,
+			)
+		}
+		resolved = append(resolved, SpecSource{URI: uri})
+	}
+
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := postIngest(cmd.Context(), backplaneURL, IngestRequest{
+		Product: opts.Product,
+		Version: opts.Version,
+		ImplID:  opts.ImplID,
+		Specs:   resolved,
+		DryRun:  opts.DryRun,
+	})
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printIngestSummary(cmd.OutOrStdout(), opts, result)
+	return nil
+}
+
+func postIngest(ctx context.Context, backplaneURL string, body IngestRequest) (*IngestResponse, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal ingest request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/connectors/ingest", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out IngestResponse
+	if err := decodeJSON(respBody, "ingest", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// printIngestSummary renders an IngestResponse for human eyes. The
+// shape matches what an operator running `meho connector ingest`
+// interactively expects to read: connector_id first (so they can
+// copy it into the subsequent `review` / `enable` commands), then
+// the bulk-upsert counts, then the LLM grouping outcome (or "dry
+// run — skipped" on dry-run).
+func printIngestSummary(w io.Writer, opts ingestOptions, r *IngestResponse) {
+	if opts.DryRun {
+		fmt.Fprintf(w, "ingest %s/%s/%s — DRY RUN (no DB writes)\n",
+			opts.Product, opts.Version, opts.ImplID,
+		)
+	} else {
+		fmt.Fprintf(w, "ingest %s/%s/%s — connector_id=%s\n",
+			opts.Product, opts.Version, opts.ImplID, r.Ingestion.ConnectorID,
+		)
+	}
+	fmt.Fprintf(w, "  operations: %d total (%d inserted / %d updated / %d skipped)\n",
+		r.Ingestion.TotalOperations,
+		r.Ingestion.Inserted,
+		r.Ingestion.Updated,
+		r.Ingestion.Skipped,
+	)
+	if r.Ingestion.EmbeddingsComputed > 0 || r.Ingestion.EmbeddingsSkipped > 0 {
+		fmt.Fprintf(w, "  embeddings: %d computed / %d skipped\n",
+			r.Ingestion.EmbeddingsComputed,
+			r.Ingestion.EmbeddingsSkipped,
+		)
+	}
+	if len(r.Ingestion.PerSpecCounts) > 0 {
+		fmt.Fprintln(w, "  per-spec breakdown:")
+		for spec, n := range r.Ingestion.PerSpecCounts {
+			fmt.Fprintf(w, "    %s: %d ops\n", spec, n)
+		}
+	}
+	if r.Grouping != nil {
+		fmt.Fprintf(w, "  grouping: %d groups, %d ops assigned, %d orphan",
+			r.Grouping.GroupsProposed,
+			r.Grouping.OperationsAssigned,
+			r.Grouping.OperationsOrphan,
+		)
+		if r.Grouping.Model != "" {
+			fmt.Fprintf(w, " (model=%s)", r.Grouping.Model)
+		}
+		fmt.Fprintln(w)
+	} else if !opts.DryRun {
+		fmt.Fprintln(w, "  grouping: skipped (backplane returned no grouping result)")
+	}
+	if !opts.DryRun {
+		fmt.Fprintf(w,
+			"\nConnector is in review_status=staged. Next:\n"+
+				"  meho connector review %s\n"+
+				"  meho connector enable %s --confirm\n",
+			r.Ingestion.ConnectorID, r.Ingestion.ConnectorID,
+		)
+	}
+}

--- a/cli/internal/cmd/connector/list.go
+++ b/cli/internal/cmd/connector/list.go
@@ -14,24 +14,38 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// Summary mirrors the backend ConnectorSummary Pydantic model: one
-// row per ingested connector with high-level review state + bulk op
-// count for the operator's overview table. The full per-op detail
-// comes from `meho connector review <id>`.
+// Summary mirrors the backend ConnectorListItem Pydantic model
+// (operations/ingest/api_schemas.py) verbatim: one row per ingested
+// connector with parsed coordinates + tenant scope + per-status group
+// counts + bulk op count for the operator's overview table. The full
+// per-op detail comes from `meho connector review <id>`.
 //
-// Named `Summary` (rather than `ConnectorSummary`) inside the
+// Named `Summary` (rather than `ConnectorListItem`) inside the
 // `connector` package to satisfy the revive/stutter rule —
-// `connector.ConnectorSummary` is the linter's least-favourite
+// `connector.ConnectorListItem` is the linter's least-favourite
 // double; `connector.Summary` reads naturally at the call site.
+//
+// Note: the canonical payload has no `review_status` field. The
+// review state is per-group (some groups can be staged while others
+// are enabled — common when an operator partially approves a
+// connector). The operator-facing rollup label rendered in the
+// human table is derived from the three per-status counts at render
+// time; see `deriveRollupLabel`.
+//
+// `tenant_id` is a UUID for tenant-curated connectors and JSON `null`
+// for built-in connectors. Pointer-to-string so we can distinguish
+// "field absent" from "empty string" in the rendered table.
 type Summary struct {
-	ConnectorID    string `json:"connector_id"`
-	Product        string `json:"product"`
-	Version        string `json:"version"`
-	ImplID         string `json:"impl_id"`
-	ReviewStatus   string `json:"review_status"`
-	GroupCount     int    `json:"group_count"`
-	OperationCount int    `json:"operation_count"`
-	TenantID       string `json:"tenant_id,omitempty"`
+	ConnectorID        string  `json:"connector_id"`
+	Product            string  `json:"product"`
+	Version            string  `json:"version"`
+	ImplID             string  `json:"impl_id"`
+	TenantID           *string `json:"tenant_id"`
+	GroupCount         int     `json:"group_count"`
+	StagedGroupCount   int     `json:"staged_group_count"`
+	EnabledGroupCount  int     `json:"enabled_group_count"`
+	DisabledGroupCount int     `json:"disabled_group_count"`
+	OperationCount     int     `json:"operation_count"`
 }
 
 // ListResponse is the envelope for GET /api/v1/connectors.
@@ -152,16 +166,60 @@ func printListTable(w io.Writer, status string, r *ListResponse) {
 		"connector_id", "status", "tenant", "grps", "ops",
 	)
 	for _, c := range r.Connectors {
-		tenant := c.TenantID
-		if tenant == "" {
-			tenant = "(built-in)"
+		tenant := "(built-in)"
+		if c.TenantID != nil && *c.TenantID != "" {
+			tenant = *c.TenantID
 		}
 		fmt.Fprintf(w, "%-32s %-10s %-10s %5d %5d\n",
 			truncate(c.ConnectorID, 32),
-			c.ReviewStatus,
+			deriveRollupLabel(c.StagedGroupCount, c.EnabledGroupCount, c.DisabledGroupCount),
 			truncate(tenant, 10),
 			c.GroupCount,
 			c.OperationCount,
 		)
 	}
+}
+
+// deriveRollupLabel computes a connector-wide status rollup from the
+// three per-group review_status counts the backend ships in
+// ConnectorListItem. The canonical payload has no top-level
+// review_status (a connector can hold a mix of staged / enabled /
+// disabled groups), so the operator-facing label is derived here.
+//
+// Rules (load-bearing; mirrored in the `review` verb's header):
+//
+//   - "(empty)"  — connector has zero groups (post-ingest before
+//     grouping, or every group was orphan-only and got pruned).
+//   - "staged"   — at least one group is still awaiting review and
+//     none have been enabled yet. The operator-facing question is
+//     "is there anything left to review" and the answer is yes.
+//   - "enabled"  — every group is enabled. The connector is fully
+//     live; all `is_enabled=true` operations are dispatchable.
+//   - "disabled" — every group is disabled. The connector was
+//     rolled back; no operations are dispatchable. Per-op overrides
+//     are preserved (a future re-enable picks them back up).
+//   - "mixed"    — partial enable / partial review state, or an
+//     unknown enum value the CLI doesn't recognise. The CLI bias
+//     here is conservative: surface the heterogeneity rather than
+//     hide it under a single label.
+func deriveRollupLabel(staged, enabled, disabled int) string {
+	total := staged + enabled + disabled
+	if total == 0 {
+		return "(empty)"
+	}
+	if staged == total {
+		return "staged"
+	}
+	if enabled == total {
+		return "enabled"
+	}
+	if disabled == total {
+		return "disabled"
+	}
+	// At least two of {staged, enabled, disabled} are non-zero, or
+	// the per-status counts don't sum to group_count (server shipped
+	// a status the CLI doesn't recognise). "mixed" is the right
+	// operator-facing answer in both cases — surface the
+	// heterogeneity rather than hide it under a single label.
+	return "mixed"
 }

--- a/cli/internal/cmd/connector/list.go
+++ b/cli/internal/cmd/connector/list.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// Summary mirrors the backend ConnectorSummary Pydantic model: one
+// row per ingested connector with high-level review state + bulk op
+// count for the operator's overview table. The full per-op detail
+// comes from `meho connector review <id>`.
+//
+// Named `Summary` (rather than `ConnectorSummary`) inside the
+// `connector` package to satisfy the revive/stutter rule —
+// `connector.ConnectorSummary` is the linter's least-favourite
+// double; `connector.Summary` reads naturally at the call site.
+type Summary struct {
+	ConnectorID    string `json:"connector_id"`
+	Product        string `json:"product"`
+	Version        string `json:"version"`
+	ImplID         string `json:"impl_id"`
+	ReviewStatus   string `json:"review_status"`
+	GroupCount     int    `json:"group_count"`
+	OperationCount int    `json:"operation_count"`
+	TenantID       string `json:"tenant_id,omitempty"`
+}
+
+// ListResponse is the envelope for GET /api/v1/connectors.
+type ListResponse struct {
+	Connectors []Summary `json:"connectors"`
+}
+
+// validStatuses pins the allowed --status values. `all` is the
+// no-filter default; the wire shape uses an absent status query
+// param for that case (T6's `Literal | None` semantic).
+var validStatuses = map[string]struct{}{
+	"staged":   {},
+	"enabled":  {},
+	"disabled": {},
+	"all":      {},
+}
+
+// newListCmd returns the `meho connector list` command.
+//
+// CLI shape:
+//
+//	meho connector list [--status staged|enabled|disabled|all] [--json] [--backplane <url>]
+//
+// Hits GET /api/v1/connectors?status=... and renders the result as
+// a one-line-per-connector table. operator role suffices (read-only).
+func newListCmd() *cobra.Command {
+	var (
+		status            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List ingested connectors filtered by review status",
+		Long: "list calls GET /api/v1/connectors against the configured\n" +
+			"backplane and renders one row per ingested connector with its\n" +
+			"review state + group/op counts. Default `--status all` lists\n" +
+			"every connector visible to the operator's tenant (incl. built-in\n" +
+			"connectors with tenant_id IS NULL).\n\n" +
+			"Operator-role tokens can list; tenant_admin is not required for\n" +
+			"this read-only verb.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runList(cmd, listOptions{
+				Status:            status,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&status, "status", "all",
+		"filter by review status: staged | enabled | disabled | all (default all)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type listOptions struct {
+	Status            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runList(cmd *cobra.Command, opts listOptions) error {
+	if _, ok := validStatuses[opts.Status]; !ok {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--status %q invalid; expected one of: staged | enabled | disabled | all",
+				opts.Status,
+			)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := getList(cmd.Context(), backplaneURL, opts.Status)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printListTable(cmd.OutOrStdout(), opts.Status, result)
+	return nil
+}
+
+func getList(ctx context.Context, backplaneURL, status string) (*ListResponse, error) {
+	path := "/api/v1/connectors"
+	if status != "" && status != "all" {
+		q := url.Values{}
+		q.Set("status", status)
+		path += "?" + q.Encode()
+	}
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out ListResponse
+	if err := decodeJSON(raw, "connector list", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func printListTable(w io.Writer, status string, r *ListResponse) {
+	if len(r.Connectors) == 0 {
+		fmt.Fprintf(w, "0 connector(s) with status=%s\n", status)
+		return
+	}
+	fmt.Fprintf(w, "%d connector(s) with status=%s\n", len(r.Connectors), status)
+	fmt.Fprintf(w, "%-32s %-10s %-10s %5s %5s\n",
+		"connector_id", "status", "tenant", "grps", "ops",
+	)
+	for _, c := range r.Connectors {
+		tenant := c.TenantID
+		if tenant == "" {
+			tenant = "(built-in)"
+		}
+		fmt.Fprintf(w, "%-32s %-10s %-10s %5d %5d\n",
+			truncate(c.ConnectorID, 32),
+			c.ReviewStatus,
+			truncate(tenant, 10),
+			c.GroupCount,
+			c.OperationCount,
+		)
+	}
+}

--- a/cli/internal/cmd/connector/review.go
+++ b/cli/internal/cmd/connector/review.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ReviewOperation mirrors the backend per-op review entry. The
+// fields cover the operator-decision surface: which op is it, what
+// does it do (Summary / CustomDescription), is it safe to run, does
+// it need approval, is it currently dispatchable?
+type ReviewOperation struct {
+	OpID              string  `json:"op_id"`
+	Summary           *string `json:"summary"`
+	CustomDescription *string `json:"custom_description"`
+	SafetyLevel       string  `json:"safety_level"`
+	RequiresApproval  bool    `json:"requires_approval"`
+	IsEnabled         bool    `json:"is_enabled"`
+}
+
+// ReviewGroup mirrors the backend per-group review entry: the
+// LLM-summarised group payload plus the operations the LLM assigned
+// to it.
+type ReviewGroup struct {
+	GroupKey   string            `json:"group_key"`
+	Name       string            `json:"name"`
+	WhenToUse  string            `json:"when_to_use"`
+	Operations []ReviewOperation `json:"operations"`
+}
+
+// ReviewPayload is the GET /api/v1/connectors/{id}/review envelope.
+type ReviewPayload struct {
+	ConnectorID  string        `json:"connector_id"`
+	Product      string        `json:"product"`
+	Version      string        `json:"version"`
+	ImplID       string        `json:"impl_id"`
+	ReviewStatus string        `json:"review_status"`
+	Groups       []ReviewGroup `json:"groups"`
+}
+
+// newReviewCmd returns the `meho connector review <connector_id>` command.
+func newReviewCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "review <connector_id>",
+		Short: "Show the per-group + per-op review payload for one connector",
+		Long: "review calls GET /api/v1/connectors/<connector_id>/review and\n" +
+			"renders the full review payload — groups (with their LLM-derived\n" +
+			"`when_to_use` hints) and per-op flags (safety_level,\n" +
+			"requires_approval, is_enabled). Use this before flipping a staged\n" +
+			"connector to enabled — operators are expected to verify the\n" +
+			"groupings + override per-op safety_level / requires_approval flags\n" +
+			"as appropriate via `meho connector edit-group` and\n" +
+			"`meho connector edit-op` before running\n" +
+			"`meho connector enable <connector_id> --confirm`.\n\n" +
+			"--json returns the full machine-readable payload (suitable for\n" +
+			"piping to jq / saving for a review checkpoint).",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReview(cmd, reviewOptions{
+				ConnectorID:       args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type reviewOptions struct {
+	ConnectorID       string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runReview(cmd *cobra.Command, opts reviewOptions) error {
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := getReview(cmd.Context(), backplaneURL, opts.ConnectorID)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printReviewTable(cmd.OutOrStdout(), result)
+	return nil
+}
+
+func getReview(ctx context.Context, backplaneURL, connectorID string) (*ReviewPayload, error) {
+	path := "/api/v1/connectors/" + pathEscapeOpID(connectorID) + "/review"
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out ReviewPayload
+	if err := decodeJSON(raw, "review", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func printReviewTable(w io.Writer, r *ReviewPayload) {
+	fmt.Fprintf(w, "%s (%s/%s/%s) — review_status=%s — %d group(s)\n",
+		r.ConnectorID, r.Product, r.Version, r.ImplID,
+		r.ReviewStatus, len(r.Groups),
+	)
+	if len(r.Groups) == 0 {
+		fmt.Fprintln(w, "(no groups; the connector has no operations or the grouping pass produced no buckets)")
+		return
+	}
+	for _, g := range r.Groups {
+		fmt.Fprintf(w, "\n[%s] %s — %d op(s)\n", g.GroupKey, g.Name, len(g.Operations))
+		if g.WhenToUse != "" {
+			fmt.Fprintf(w, "  when_to_use: %s\n", g.WhenToUse)
+		}
+		if len(g.Operations) == 0 {
+			continue
+		}
+		// Compact one-line-per-op render. Operators with a 3000-op
+		// vcenter connector cannot scroll through a verbose render;
+		// --json carries the full descriptions for the "ok now show
+		// me everything" path.
+		fmt.Fprintf(w, "  %-42s %-9s %3s %3s  %s\n",
+			"op_id", "safety", "req", "en", "summary",
+		)
+		for _, op := range g.Operations {
+			fmt.Fprintf(w, "  %-42s %-9s %3s %3s  %s\n",
+				truncate(op.OpID, 42),
+				op.SafetyLevel,
+				boolFlag(op.RequiresApproval),
+				boolFlag(op.IsEnabled),
+				truncate(strDeref(op.Summary), 70),
+			)
+		}
+	}
+}
+
+// boolFlag renders a bool as a compact tristate-friendly cell for
+// the review table. Y / . is loud-on-true / quiet-on-false so a
+// glance picks out the operators-need-approval ops.
+func boolFlag(v bool) string {
+	if v {
+		return " Y "
+	}
+	return " . "
+}
+
+// strDeref returns *s or empty when s is nil. Same shape as the
+// operation sibling's helper; duplicated to avoid an import cycle.
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/cli/internal/cmd/connector/review.go
+++ b/cli/internal/cmd/connector/review.go
@@ -13,37 +13,56 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// ReviewOperation mirrors the backend per-op review entry. The
-// fields cover the operator-decision surface: which op is it, what
-// does it do (Summary / CustomDescription), is it safe to run, does
-// it need approval, is it currently dispatchable?
+// ReviewOperation mirrors the backend ConnectorReviewOp Pydantic
+// model verbatim (see operations/ingest/payload.py). The fields cover
+// the operator-decision surface: which op is it, what does it do
+// (Summary / Description / CustomDescription), is it safe to run, does
+// it need approval, is it currently dispatchable? Tags carry the
+// LLM-derived group hints so the operator can spot mis-grouped ops at
+// review time.
 type ReviewOperation struct {
-	OpID              string  `json:"op_id"`
-	Summary           *string `json:"summary"`
-	CustomDescription *string `json:"custom_description"`
-	SafetyLevel       string  `json:"safety_level"`
-	RequiresApproval  bool    `json:"requires_approval"`
-	IsEnabled         bool    `json:"is_enabled"`
+	OpID              string   `json:"op_id"`
+	Summary           *string  `json:"summary"`
+	Description       *string  `json:"description"`
+	CustomDescription *string  `json:"custom_description"`
+	SafetyLevel       string   `json:"safety_level"`
+	RequiresApproval  bool     `json:"requires_approval"`
+	IsEnabled         bool     `json:"is_enabled"`
+	Tags              []string `json:"tags"`
 }
 
-// ReviewGroup mirrors the backend per-group review entry: the
-// LLM-summarised group payload plus the operations the LLM assigned
-// to it.
+// ReviewGroup mirrors the backend ConnectorReviewGroup Pydantic model
+// verbatim (operations/ingest/payload.py): the LLM-summarised group
+// payload plus the operations the LLM assigned to it. The wire field
+// is `ops` (not `operations`) — Pydantic's `model_dump()` emits the
+// attribute name, and aligning the Go tag is load-bearing for the
+// JSON envelope to decode.
 type ReviewGroup struct {
-	GroupKey   string            `json:"group_key"`
-	Name       string            `json:"name"`
-	WhenToUse  string            `json:"when_to_use"`
-	Operations []ReviewOperation `json:"operations"`
+	GroupKey     string            `json:"group_key"`
+	Name         string            `json:"name"`
+	WhenToUse    string            `json:"when_to_use"`
+	ReviewStatus string            `json:"review_status"`
+	OpCount      int               `json:"op_count"`
+	Ops          []ReviewOperation `json:"ops"`
 }
 
-// ReviewPayload is the GET /api/v1/connectors/{id}/review envelope.
+// ReviewPayload mirrors the backend ConnectorReviewPayload Pydantic
+// model verbatim. Note `review_status` is per-group, not top-level —
+// a connector can have a mix of staged / enabled / disabled groups
+// (the operator-facing list verb derives a rollup label from the
+// per-status counts; see list.go).
+//
+// `tenant_id` is a UUID for tenant-curated connectors and JSON `null`
+// for built-in / global connectors; rendered as the empty string in
+// human output and as a pointer in JSON.
 type ReviewPayload struct {
 	ConnectorID  string        `json:"connector_id"`
 	Product      string        `json:"product"`
 	Version      string        `json:"version"`
 	ImplID       string        `json:"impl_id"`
-	ReviewStatus string        `json:"review_status"`
+	TenantID     *string       `json:"tenant_id"`
 	Groups       []ReviewGroup `json:"groups"`
+	TotalOpCount int           `json:"total_op_count"`
 }
 
 // newReviewCmd returns the `meho connector review <connector_id>` command.
@@ -120,20 +139,29 @@ func getReview(ctx context.Context, backplaneURL, connectorID string) (*ReviewPa
 }
 
 func printReviewTable(w io.Writer, r *ReviewPayload) {
-	fmt.Fprintf(w, "%s (%s/%s/%s) — review_status=%s — %d group(s)\n",
+	// Top-level header carries the rollup label derived from the
+	// per-group review_status counts — the canonical payload no
+	// longer ships a connector-wide `review_status` field (it's
+	// per-group), so we recompute the operator-facing summary here
+	// the same way `meho connector list` does (see deriveRollupLabel).
+	staged, enabled, disabled := groupStatusCounts(r.Groups)
+	rollup := deriveRollupLabel(staged, enabled, disabled)
+	fmt.Fprintf(w, "%s (%s/%s/%s) — %s — %d group(s), %d op(s)\n",
 		r.ConnectorID, r.Product, r.Version, r.ImplID,
-		r.ReviewStatus, len(r.Groups),
+		rollup, len(r.Groups), r.TotalOpCount,
 	)
 	if len(r.Groups) == 0 {
 		fmt.Fprintln(w, "(no groups; the connector has no operations or the grouping pass produced no buckets)")
 		return
 	}
 	for _, g := range r.Groups {
-		fmt.Fprintf(w, "\n[%s] %s — %d op(s)\n", g.GroupKey, g.Name, len(g.Operations))
+		fmt.Fprintf(w, "\n[%s] %s — review_status=%s — %d op(s)\n",
+			g.GroupKey, g.Name, g.ReviewStatus, g.OpCount,
+		)
 		if g.WhenToUse != "" {
 			fmt.Fprintf(w, "  when_to_use: %s\n", g.WhenToUse)
 		}
-		if len(g.Operations) == 0 {
+		if len(g.Ops) == 0 {
 			continue
 		}
 		// Compact one-line-per-op render. Operators with a 3000-op
@@ -143,7 +171,7 @@ func printReviewTable(w io.Writer, r *ReviewPayload) {
 		fmt.Fprintf(w, "  %-42s %-9s %3s %3s  %s\n",
 			"op_id", "safety", "req", "en", "summary",
 		)
-		for _, op := range g.Operations {
+		for _, op := range g.Ops {
 			fmt.Fprintf(w, "  %-42s %-9s %3s %3s  %s\n",
 				truncate(op.OpID, 42),
 				op.SafetyLevel,
@@ -153,6 +181,26 @@ func printReviewTable(w io.Writer, r *ReviewPayload) {
 			)
 		}
 	}
+}
+
+// groupStatusCounts buckets the per-group review_status values for a
+// connector-wide rollup. Returned in (staged, enabled, disabled) order.
+// Unknown values (e.g. a future enum addition) are silently dropped —
+// the rollup label falls back to "mixed" when the buckets don't
+// reconcile cleanly, which is the right operator-facing answer for
+// an unrecognised state anyway.
+func groupStatusCounts(groups []ReviewGroup) (staged, enabled, disabled int) {
+	for _, g := range groups {
+		switch g.ReviewStatus {
+		case "staged":
+			staged++
+		case "enabled":
+			enabled++
+		case "disabled":
+			disabled++
+		}
+	}
+	return staged, enabled, disabled
 }
 
 // boolFlag renders a bool as a compact tristate-friendly cell for

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/cmd/connector"
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
 	"github.com/evoila/meho/cli/internal/discovery"
@@ -89,6 +90,14 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in verb names.
 	root.AddCommand(operation.NewRootCmd())
+
+	// G0.7-T5 (#405) -- spec-ingestion + review workflow surface for
+	// the G0.7 pipeline (Initiative #389). `meho connector
+	// ingest/list/review/edit-group/edit-op/enable/disable` wrap the
+	// seven /api/v1/connectors* routes shipped by G0.7-T6 (#406).
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in verb names.
+	root.AddCommand(connector.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/cli/internal/cmd/root_test.go
+++ b/cli/internal/cmd/root_test.go
@@ -27,7 +27,7 @@ func TestRootCmdHasExpectedSubcommands(t *testing.T) {
 	for _, c := range root.Commands() {
 		names[c.Name()] = true
 	}
-	for _, want := range []string{"version", "login", "status"} {
+	for _, want := range []string{"version", "login", "status", "operation", "retrieval", "connector"} {
 		if !names[want] {
 			t.Errorf("expected built-in subcommand %q; got %v", want, names)
 		}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -21,6 +21,21 @@ ADR 0006 identity-claim format. Server-driven subcommand discovery
 runs at every startup (empty manifest in v0.1; populated by
 post-Goal-2 backplanes without a CLI binary release).
 
+The v0.2 substrate adds three statically-registered subcommand
+trees alongside the discovery surface. All three follow the same
+pattern: a per-package `NewRootCmd()` returns a cobra parent that
+holds per-verb subcommands; the parents register before the dynamic
+discovery hook so backplane manifests cannot shadow built-in verb
+names.
+
+- `meho retrieval ...` (G4.3 #373) — retrieval-quality + migration-
+  decision tooling. v0.2 ships `eval`.
+- `meho operation ...` (G0.6-T13 #481) — dispatcher meta-tools
+  (`groups`, `search`, `call`).
+- `meho connector ...` (G0.7-T5 #405) — spec-ingestion + review
+  workflow (`ingest`, `list`, `review`, `edit-group`, `edit-op`,
+  `enable`, `disable`).
+
 ## Module layout
 
 ```text
@@ -58,7 +73,27 @@ cli/
     │   ├── login.go           # `meho login` subcommand + auth-config discovery + config persistence.
     │   ├── login_test.go      # override-resolution + help-flag tests.
     │   ├── status.go          # `meho status` subcommand + --json + URL resolver.
-    │   └── status_test.go     # happy/JSON/no-creds/unreachable/401/redaction tests.
+    │   ├── status_test.go     # happy/JSON/no-creds/unreachable/401/redaction tests.
+    │   ├── connector/         # G0.7-T5 #405 — `meho connector …` verb tree.
+    │   │   ├── connector.go      # NewRootCmd + shared HTTP/auth helpers.
+    │   │   ├── ingest.go         # `meho connector ingest` (POST /api/v1/connectors/ingest).
+    │   │   ├── list.go           # `meho connector list` (GET  /api/v1/connectors).
+    │   │   ├── review.go         # `meho connector review <id>` (GET  /api/v1/connectors/{id}/review).
+    │   │   ├── edit_group.go     # `meho connector edit-group <id> <key>` (PATCH groups/{key}).
+    │   │   ├── edit_op.go        # `meho connector edit-op <id> <op>` (PATCH operations/{op}).
+    │   │   ├── enable.go         # `meho connector enable <id>`  + shared transition factory + `disable`.
+    │   │   ├── disable.go        # `meho connector disable <id>` (constructor only; logic in enable.go).
+    │   │   └── connector_test.go # pure-function + httptest-mocked HTTP contract tests.
+    │   ├── operation/         # G0.6-T13 #481 — `meho operation …` meta-tool surface.
+    │   │   ├── operation.go      # NewRootCmd + shared HTTP/auth helpers.
+    │   │   ├── groups.go         # `meho operation groups` (GET /api/v1/operations/groups).
+    │   │   ├── search.go         # `meho operation search` (GET /api/v1/operations/search).
+    │   │   ├── call.go           # `meho operation call`   (POST /api/v1/operations/call).
+    │   │   └── operation_test.go # render + helper + sentinel tests.
+    │   └── retrieval/         # G4.3-T2 #441 — retrieval-quality tooling.
+    │       ├── retrieval.go      # NewRootCmd.
+    │       ├── eval.go           # `meho retrieval eval` (POST /api/v1/retrieve/eval).
+    │       └── eval_test.go      # output-contract + URL-resolution tests.
     ├── discovery/
     │   ├── discovery.go       # /api/v1/commands manifest fetch + cobra graft.
     │   └── discovery_test.go  # 200/404/transport/decode + collision tests.

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -39,6 +39,15 @@ The pipeline is broken into work items per Initiative #389:
   move connectors through `staged → enabled` (and `disabled` for
   regression rollback) before any op becomes dispatchable.
 * **T5–T7 — CLI / REST / MCP surfaces** that drive the pipeline.
+  * **T5 (#405)** — `meho connector ingest/list/review/edit-group/
+    edit-op/enable/disable` cobra verb tree at
+    `cli/internal/cmd/connector/`. Thin client over T6's REST routes;
+    no service-layer access. Operator-facing role: tenant_admin for
+    write verbs, operator for `list` / `review`.
+  * **T6 (#406)** — 7 REST routes under `/api/v1/connectors*` that
+    the CLI and the UI consume.
+  * **T7 (#407)** — admin MCP tools (`meho.connector.*`) that wrap
+    the same service layer for MCP-only operators.
 * **T8 — vSphere canary** — ingest both vCenter specs end-to-end.
 * **T9 — Docs.**
 
@@ -87,8 +96,11 @@ Idempotency:
 The LLM client is injected as a `LlmClient` `Protocol` (one async
 method, `generate_json`). Tests pass a deterministic stub from
 `tests/fixtures/llm_groups/{small,medium}_corpus.py`. The chassis
-adapter (Anthropic Messages API) lands with T5 (#405) which will
-also surface the model id + retry policy as `Settings` knobs.
+adapter (Anthropic Messages API) ships with T3 itself (#404, commit
+864ef68f); the model id + retry policy live in `Settings`. T5
+(#405) is purely the operator-facing CLI verb tree
+(`cli/internal/cmd/connector/`) that drives the ingest → review →
+enable workflow over the T6 REST routes.
 
 ## Key types
 


### PR DESCRIPTION
## Summary

Adds the seven operator-facing cobra verbs that drive the G0.7
spec-ingestion + review workflow (Initiative #389, work item 5).
Each verb is a thin cobra command over the T6 REST surface
(`/api/v1/connectors*`, #406) and follows the existing
`meho operation` / `meho retrieval` shape: per-verb `RunE` resolves
the backplane URL, fires one authenticated HTTP call (with the same
bearer-injection + 401-refresh dance as the sibling packages),
renders the response as a human-readable table or a `--json`
envelope.

Verb surface:

| Verb                         | Route                                                | Role          |
|------------------------------|------------------------------------------------------|---------------|
| `meho connector ingest`      | `POST   /api/v1/connectors/ingest`                   | tenant_admin  |
| `meho connector list`        | `GET    /api/v1/connectors`                          | operator      |
| `meho connector review <id>` | `GET    /api/v1/connectors/{id}/review`              | operator      |
| `meho connector edit-group`  | `PATCH  /api/v1/connectors/{id}/groups/{group_key}`  | tenant_admin  |
| `meho connector edit-op`     | `PATCH  /api/v1/connectors/{id}/operations/{op_id}`  | tenant_admin  |
| `meho connector enable`      | `POST   /api/v1/connectors/{id}/enable`              | tenant_admin  |
| `meho connector disable`     | `POST   /api/v1/connectors/{id}/disable`             | tenant_admin  |

### Cross-task contract (T6 #406 / T7 #407)

Wave 3 of Initiative #389 ships T5 (this PR), T6 (REST routes,
#406) and T7 (admin MCP tools, #407) in parallel against a single
agreed wire contract. T5 calls T6; T7 wraps the same service layer.
The contract documented here is what the CLI assumes — T6's PR
should land the matching FastAPI route shapes:

- **`POST /api/v1/connectors/ingest`** — request:
  `{"product","version","impl_id","specs":[{"uri":...}, ...],"dry_run"}`;
  response: `{"ingestion": IngestionResult, "grouping": GroupingResult | null}`.
  `dry_run=true` returns ingestion counts only; `grouping` is null.
- **`GET /api/v1/connectors?status=staged|enabled|disabled`** —
  response: `{"connectors": [ConnectorSummary, ...]}`. Absent
  `status` param means "no filter" (matches T6's `Literal | None`
  signature). Tenant-scoped: operator's tenant + built-in (NULL).
- **`GET /api/v1/connectors/{id}/review`** — response:
  `{"connector_id","product","version","impl_id","review_status",
   "groups":[{"group_key","name","when_to_use","operations":[...]}]}`.
  Per-op fields: `op_id, summary, custom_description, safety_level,
  requires_approval, is_enabled`.
- **`PATCH /api/v1/connectors/{id}/groups/{group_key}`** —
  request: `{"when_to_use"?, "name"?}` (omit-to-leave-unchanged
  semantic via `null` / absent fields). Response: the updated
  group payload.
- **`PATCH /api/v1/connectors/{id}/operations/{op_id}`** —
  request: `{"custom_description"?, "safety_level"?,
  "requires_approval"?, "is_enabled"?}`. Response: updated op
  row. CLI URL-escapes `op_id` (FastAPI route should use
  `{op_id:path}` or the equivalent), since op_id carries `:` +
  `/` (e.g. `GET:/api/vcenter/cluster`).
- **`POST /api/v1/connectors/{id}/{enable,disable}`** — empty
  `{}` request body; response: `{"connector_id","review_status",
  "groups_updated","operations_updated"}`. Idempotent (calling
  enable on an already-enabled connector returns 0/0 counts).

`@kr3s0` / `@ddzafic` / `@ikaric` reviewing T6 (#406) — flag if
any field is renamed or removed on the route side; I'll update
the Go structs in this PR before merge so the contract lines up
across both PRs at land time.

### Notable design decisions

- **HTTP 403 → exit code 5 (`insufficient_role`)** in
  `renderRequestError`. The `tenant_admin`-gated verbs (ingest /
  edit-* / enable / disable) produce the right "ask for a role
  grant" hint when an operator-role token hits them, rather than
  a generic transport error. The `meho operation` sibling maps
  403 to `unexpected_response`; the connector verb tree's
  role-aware gating made the distinct exit code worth surfacing.
- **`--spec` URI shapes**: `file://`, `https://`, and `docs:`
  shorthand. The `docs:` form resolves against `$CLAUDE_RDC_DOCS`
  when set (mapping to a `file://` URI) and passes through
  verbatim otherwise — the v0.2 backplane understands the
  `docs:` scheme server-side against its own checked-in docs root.
- **`@<path>` file-reference** on `--when-to-use`, `--name`,
  `--custom-description`. Operator-authored multi-paragraph
  agent prompts live in version control; the verb reads the file
  and trims the trailing newline before embedding.
- **`--confirm` on enable/disable**. Without it, the verb
  prompts on stdin and aborts on EOF / `n`. Scripted invocations
  pass `--confirm`. Same shape `kubectl delete --confirm` uses.
- **`doAuthedRequest` duplicated** from the `operation` package
  (with one added 403 branch). The two `cmd/<subtree>/` packages
  can't import each other without an import cycle through
  `cmd/root.go`. A future `cmd/internal/httpx` extraction is
  tracked as adjacent finding; not in scope here.

## Test plan

- [x] `gofmt -l cli/internal/cmd/connector/` — clean
- [x] `golangci-lint run ./...` (v1.64.8, same as CI) — clean
- [x] `go build ./...` — clean
- [x] `go test -count=1 ./...` — all packages pass; 39 new tests
      in `internal/cmd/connector/` cover renderers, helpers,
      spec-URI resolution, params loaders, HTTP wire contract
      via httptest, and `op_id` URL-escaping round-trip.
- [x] `go test -race -count=1 ./internal/cmd/connector/...` — clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] Smoke: `meho --help` lists `connector`;
      `meho connector --help` lists 7 verbs;
      `meho connector ingest --help` shows the contract.
- [x] `TestRootCmdHasExpectedSubcommands` extended to assert
      `connector` is registered alongside `operation` / `retrieval`.

## Out of scope

- **T6 REST routes** (#406) — sibling Wave 3 PR; same wire contract
  documented above.
- **T7 admin MCP tools** (#407) — sibling Wave 3 PR; wraps the
  same service layer with the `meho.connector.*` namespace.
- **T8 vSphere canary** (#408) — Wave 5 end-to-end ingest of
  `vcenter.yaml` + `vi-json.yaml` covers the true wire-level
  integration. The httptest-mocked tests here pin the JSON
  envelope shapes; T8 proves the full ingest → review → enable
  cycle against a live backplane.
- **`cmd/internal/httpx` extraction** to deduplicate
  `doAuthedRequest` across `connector` / `operation` (and any
  future cobra subtree). Tracked as an adjacent finding; not
  worth blocking T5 on.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #405


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete meho connector command suite: ingest, list, review, edit-group, edit-op, enable, disable; supports JSON or human output and confirmation prompts.

* **Behavior & Reliability**
  * Improved auth handling with refresh/retry and clearer error classification; safer backplane/spec URL resolution, path-escaping, file/@-flag support, and Unicode-safe truncation.

* **Documentation**
  * CLI and spec-ingestion docs updated to document the new commands and registration order.

* **Tests**
  * Extensive unit and integration tests added for commands and helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/486)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-15)

Addressed CodeRabbit iteration-1 findings + orchestrator-derived
wire-contract correction:

**Wire-contract correction (load-bearing).**

- **`ReviewGroup`** `f8f673c` — rename `Operations` to `Ops`
  (`json:"ops"`), add `review_status` and `op_count`. Canonical
  `ConnectorReviewGroup` (T4 #431) ships these names verbatim;
  T6 PR #488 wraps the payload unchanged. The CLI's review-payload
  decode now matches the wire contract on both sides.
- **`ReviewOperation`** `f8f673c` — add `description *string` and
  `tags []string` to match `ConnectorReviewOp` verbatim.
- **`ReviewPayload`** `f8f673c` — drop top-level `review_status`
  (per-group, not connector-wide), add `tenant_id *string` and
  `total_op_count int`.
- **`Summary` (ConnectorListItem mirror)** `f8f673c` — drop
  `review_status`, add per-status group counts
  (`staged_group_count` / `enabled_group_count` /
  `disabled_group_count`), change `tenant_id` to `*string` for null.
- **`deriveRollupLabel(staged, enabled, disabled)`** `f8f673c` —
  client-side rollup label rule documented inline:
  `(empty)` (zero groups) / `staged` (all staged) / `enabled` (all
  enabled) / `disabled` (all disabled) / `mixed` (heterogeneous).
  Surfaced in both `meho connector list` and `meho connector review`
  headers.

**CodeRabbit findings.**

- **M1 — CRLF trim** `f8f673c` — `loadTextFlag` trims `\r\n` not `\n`.
- **M2 — Reject non-HTTP backplane schemes** `f8f673c` — `normaliseURL`
  validates scheme after `ParseRequestURI`.
- **M3 — Validate `file://` specs** `f8f673c` — `resolveSpecURI`
  parses + checks scheme + host + absolute path.
- **M4 — Classify decode errors as Unexpected** `f8f673c` —
  `renderRequestError` splits the non-`httpError` branch on
  `json.SyntaxError` / `UnmarshalTypeError` / `io.ErrUnexpectedEOF`.

Disputed: none.

Deferred (adjacent findings; not on the punch list):

- The `IngestionResult` / `GroupingResult` / `TransitionResponse` Go
  structs mirror the original PR-body contract (`inserted` / `updated`
  / `skipped` / `total_operations` / etc.) but the canonical
  `IngestionResultModel` / `GroupingResultModel` Pydantic models on
  T6 PR #488 ship different field names (`inserted_count`,
  `updated_count`, etc.) and T6 returns **HTTP 204 No Content** on
  enable / disable (no JSON body) where the Go CLI expects a
  `TransitionResponse` envelope. These three contracts diverge from
  PR #488 verbatim and need a follow-up pass once T6 lands.
- A `cmd/internal/httpx` extraction to deduplicate `doAuthedRequest`
  across `connector` / `operation` (and any future cobra subtree);
  noted in the original PR body.

<!-- auto-implement-issue: continue, iteration 2 -->
