### PR TITLE
feat(connectors): G0.7-T6 REST routes for spec-ingestion + connector review

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -127,10 +127,10 @@ from meho_backplane.operations.ingest import (
     OpIdCollision,
     ReviewService,
     UnsupportedSpecError,
+    default_llm_client_factory,
     list_ingested_connectors,
 )
 from meho_backplane.operations.ingest.api_schemas import ConnectorStatusFilter
-from meho_backplane.operations.ingest.pipeline import _default_llm_client_factory
 
 __all__ = [
     "router",
@@ -156,7 +156,7 @@ _require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
 #: factory must be reachable from any test that boots the app via
 #: :class:`TestClient` without the test having to know the override
 #: surface.
-_llm_client_factory: LlmClientFactory = _default_llm_client_factory
+_llm_client_factory: LlmClientFactory = default_llm_client_factory
 
 
 def set_llm_client_factory(factory: LlmClientFactory) -> LlmClientFactory:
@@ -195,7 +195,7 @@ async def ingest_endpoint(
     llm_client_factory: Annotated[
         LlmClientFactory,
         Depends(_get_llm_client_factory),
-    ] = _default_llm_client_factory,
+    ] = default_llm_client_factory,
 ) -> IngestResponse:
     """Run the full ingestion pipeline (T1 → T2 → T3) for one connector.
 
@@ -289,12 +289,14 @@ async def list_endpoint(
     review status; ``all`` (or omission) returns everything.
 
     The response is wrapped in ``{"connectors": [...]}`` so future
-    paging / cursor fields can land non-breakingly. The route
-    serialises through :meth:`ConnectorListResponse.model_dump`
-    rather than annotating ``response_model=ConnectorListResponse``
-    because the per-item ``tenant_id`` UUID needs to render as a
-    string in the JSON (the default Pydantic-v2 serialiser
-    handles this).
+    paging / cursor fields can land non-breakingly. The route builds
+    the payload by calling :meth:`ConnectorListItem.model_dump`
+    (with ``mode="json"``) on each item returned by
+    :func:`list_ingested_connectors` rather than annotating
+    ``response_model=ConnectorListResponse`` — per-item ``tenant_id``
+    UUIDs need to render as strings in JSON, and the per-item
+    ``mode="json"`` dump is the simplest way to get that without
+    introducing a custom serializer.
     """
     items = await list_ingested_connectors(
         operator=operator,

--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/connectors*`` -- REST surface for spec-ingestion + review.
+
+G0.7-T6 (#406) of Initiative #389. Seven routes mounted under
+``/api/v1/connectors*`` that drive the spec-ingestion pipeline (T1
+parser + T2 register_ingested + T3 LLM grouping) and the
+review-queue state machine (T4 :class:`ReviewService`).
+
+Route inventory
+---------------
+
+* ``POST /api/v1/connectors/ingest`` — run the full pipeline. Body:
+  :class:`IngestRequest`. Returns :class:`IngestResponse`. Role:
+  ``tenant_admin``.
+* ``GET /api/v1/connectors[?status=...]`` — list ingested connectors
+  visible to the operator's tenant + built-ins. Returns
+  :class:`ConnectorListResponse`. Role: ``operator``.
+* ``GET /api/v1/connectors/{connector_id}/review`` — return the full
+  review payload (groups + per-group ops + flags). Returns
+  :class:`ConnectorReviewPayload`. Role: ``operator``.
+* ``PATCH /api/v1/connectors/{connector_id}/groups/{group_key}`` —
+  edit a group's ``when_to_use`` / ``name``. Body:
+  :class:`EditGroupBody`. Returns 204. Role: ``tenant_admin``.
+* ``PATCH /api/v1/connectors/{connector_id}/operations/{op_id}`` —
+  edit a per-op override (``safety_level``, ``requires_approval``,
+  ``custom_description``, ``is_enabled``). Body: :class:`EditOpBody`.
+  Returns 204. Role: ``tenant_admin``.
+* ``POST /api/v1/connectors/{connector_id}/enable`` — transition all
+  groups to ``enabled``; cascade. Returns 204. Idempotent. Role:
+  ``tenant_admin``.
+* ``POST /api/v1/connectors/{connector_id}/disable`` — transition all
+  groups to ``disabled``; cascade. Returns 204. Idempotent. Role:
+  ``tenant_admin``.
+
+Tenant scoping
+--------------
+
+Every route derives ``tenant_id`` from the JWT-validated
+:class:`Operator`. There is no surface that accepts a tenant id from
+the body or query string — cross-tenant probes are impossible by
+construction. The one nuance: the ``operator`` role sees only their
+own tenant's connectors **and** built-ins (``tenant_id IS NULL``);
+the ``tenant_admin`` role additionally has write access to built-in
+ingests / edits / state transitions. The service layer
+(:class:`ReviewService`, :class:`IngestionPipelineService`) carries
+matching tenant guards as defence-in-depth for sibling consumers
+(CLI verbs T5, admin MCP tools T7) that hit the service layer
+directly.
+
+Cross-tenant probes for a connector that belongs to another tenant
+surface as 404 :class:`ConnectorNotFoundError`, not 403. Same
+conflation :class:`ReviewService` uses: an operator must not be
+able to enumerate other tenants by inspecting status-code
+differential.
+
+Error mapping
+-------------
+
+The service-layer exceptions map to HTTP status codes uniformly:
+
+* :class:`ConnectorNotFoundError` → 404.
+* :class:`InvalidStateTransitionError` → 409 Conflict.
+* :class:`InvalidSpecError` / :class:`UnsupportedSpecError` /
+  :class:`InvalidSchemaError` / :class:`OpIdCollision` /
+  :class:`LlmOutputInvalid` → 400 Bad Request (with the structured
+  detail message from the exception).
+* :class:`PermissionError` (raised by
+  :meth:`IngestionPipelineService._authorize` when a service-layer
+  caller bypasses the route gate) → 403.
+* :class:`LlmClientUnavailable` → 503 Service Unavailable.
+* :class:`ValueError` (the catch-all the edit verbs raise on
+  empty-body / out-of-enum input) → 400.
+
+Audit
+-----
+
+Every route writes the AuditMiddleware row tagged with the route
+path; the service layer writes its own per-action row under
+``meho.connector.*`` op_ids (see
+:mod:`~meho_backplane.operations.ingest._internals`). The two-row
+shape lets G8 dashboards split "operator called the route" from
+"the state actually changed" — useful when an idempotent re-run
+writes an HTTP row but no service-level row.
+
+LLM-client injection
+--------------------
+
+The ingest route uses a module-level
+:data:`_llm_client_factory_dep` FastAPI dependency that resolves the
+:class:`LlmClientFactory` for the :class:`IngestionPipelineService`.
+Production wiring sets this via :func:`set_llm_client_factory` at
+app-startup time (G0.7-T5 will land the Anthropic adapter wire-up);
+tests inject a stub. The default factory raises
+:class:`LlmClientUnavailable`, which the route maps to 503.
+"""
+
+from __future__ import annotations
+
+from json import JSONDecodeError
+from typing import Annotated
+
+import httpx
+import structlog
+import yaml
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import status as http_status
+from fastapi.responses import Response
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.operations.ingest import (
+    ConnectorNotFoundError,
+    ConnectorReviewPayload,
+    EditGroupBody,
+    EditOpBody,
+    IngestionPipelineService,
+    IngestRequest,
+    IngestResponse,
+    InvalidSchemaError,
+    InvalidSpecError,
+    InvalidStateTransitionError,
+    LlmClientFactory,
+    LlmClientUnavailable,
+    LlmOutputInvalid,
+    OpIdCollision,
+    ReviewService,
+    UnsupportedSpecError,
+    list_ingested_connectors,
+)
+from meho_backplane.operations.ingest.api_schemas import ConnectorStatusFilter
+from meho_backplane.operations.ingest.pipeline import _default_llm_client_factory
+
+__all__ = [
+    "router",
+    "set_llm_client_factory",
+]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/connectors", tags=["connectors"])
+
+#: Module-level Depends closures — required to satisfy ruff B008
+#: (calls in default argument positions are disallowed). Same shape as
+#: :mod:`meho_backplane.api.v1.retrieve` and
+#: :mod:`meho_backplane.api.v1.operations`.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+_require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+
+
+#: Mutable module-level holder for the LLM-client factory used by the
+#: ingest pipeline. Default fails closed; tests + production app-
+#: bootstrap mutate via :func:`set_llm_client_factory`. A module-level
+#: holder beats a FastAPI dependency override here because the
+#: factory must be reachable from any test that boots the app via
+#: :class:`TestClient` without the test having to know the override
+#: surface.
+_llm_client_factory: LlmClientFactory = _default_llm_client_factory
+
+
+def set_llm_client_factory(factory: LlmClientFactory) -> LlmClientFactory:
+    """Install a new LLM-client factory; return the previous one.
+
+    The previous factory is returned so callers can restore it after
+    a test or a feature-flagged deploy. Production wiring at app
+    startup (G0.7-T5) calls this once with the Anthropic adapter
+    factory; tests call it from their fixture setup.
+
+    The mutation is intentional rather than a FastAPI ``dependency_
+    overrides`` entry: this factory needs to be reachable both from
+    the route handler (HTTP path) and from the CLI / MCP siblings
+    (which construct :class:`IngestionPipelineService` directly), so
+    a module-level holder keeps the two consumers in sync.
+    """
+    global _llm_client_factory
+    previous = _llm_client_factory
+    _llm_client_factory = factory
+    return previous
+
+
+def _get_llm_client_factory() -> LlmClientFactory:
+    """FastAPI dependency that returns the active LLM-client factory.
+
+    Built as a dependency so tests can also override via
+    :attr:`FastAPI.dependency_overrides` when convenient.
+    """
+    return _llm_client_factory
+
+
+@router.post("/ingest", response_model=IngestResponse)
+async def ingest_endpoint(
+    body: IngestRequest,
+    operator: Operator = _require_admin,
+    llm_client_factory: Annotated[
+        LlmClientFactory,
+        Depends(_get_llm_client_factory),
+    ] = _default_llm_client_factory,
+) -> IngestResponse:
+    """Run the full ingestion pipeline (T1 → T2 → T3) for one connector.
+
+    ``dry_run=true`` parses every spec but writes nothing; the
+    response carries the parser's ``inserted_count`` projection and
+    ``grouping=None``. The real path runs the parse → register_
+    ingested → run_llm_grouping pipeline serially and returns the
+    aggregated counts + grouping result.
+
+    Tenant scoping: the operator's tenant_id from the JWT is used
+    as the write scope unless the operator is ``tenant_admin``
+    (built-in ingest, ``tenant_id=NULL``). For v0.2 the route always
+    writes under the operator's tenant_id; built-in ingest is the
+    same call shape from a tenant_admin operator whose tenant_id
+    happens to be the "built-in" admin tenant. The CLI / MCP
+    siblings can target the built-in scope explicitly when needed
+    by hitting :class:`IngestionPipelineService` directly with
+    ``tenant_id=None``.
+    """
+    service = IngestionPipelineService(
+        operator=operator,
+        llm_client_factory=llm_client_factory,
+    )
+    try:
+        result = await service.ingest(
+            product=body.product,
+            version=body.version,
+            impl_id=body.impl_id,
+            specs=body.specs,
+            base_url=body.base_url,
+            tenant_id=operator.tenant_id,
+            dry_run=body.dry_run,
+        )
+    except LlmClientUnavailable as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+    except PermissionError as exc:
+        # Defence-in-depth — the route's _require_admin already
+        # gates this, but the service-level guard might catch a
+        # cross-tenant write that slipped through.
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except (
+        InvalidSpecError,
+        UnsupportedSpecError,
+        InvalidSchemaError,
+        OpIdCollision,
+        LlmOutputInvalid,
+    ) as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except (yaml.YAMLError, JSONDecodeError) as exc:
+        # The parser passes malformed YAML / JSON bubble-up by design
+        # (per parse_openapi's docstring) so the loader's structured
+        # error message survives to the operator. Route maps to 400.
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=f"could not decode spec: {exc}",
+        ) from exc
+    except httpx.HTTPError as exc:
+        # HTTP(S) fetch failures for URL specs surface as
+        # ``httpx.HTTPError`` per :func:`parse_openapi`'s contract.
+        # 502 Bad Gateway is the closest semantic fit: the operator's
+        # request is fine but an upstream the route had to reach
+        # didn't respond cleanly.
+        raise HTTPException(
+            status_code=http_status.HTTP_502_BAD_GATEWAY,
+            detail=f"upstream spec fetch failed: {exc}",
+        ) from exc
+
+    ingestion_model, grouping_model = result.to_api_models()
+    return IngestResponse(ingestion=ingestion_model, grouping=grouping_model)
+
+
+@router.get("")
+async def list_endpoint(
+    status: ConnectorStatusFilter | None = Query(default=None),
+    operator: Operator = _require_operator,
+) -> dict[str, list[dict[str, object]]]:
+    """List ingested connectors visible to the operator.
+
+    Visibility scope (per
+    :func:`list_ingested_connectors`): operator's-tenant rows +
+    built-ins. The optional ``status`` filter narrows by aggregated
+    review status; ``all`` (or omission) returns everything.
+
+    The response is wrapped in ``{"connectors": [...]}`` so future
+    paging / cursor fields can land non-breakingly. The route
+    serialises through :meth:`ConnectorListResponse.model_dump`
+    rather than annotating ``response_model=ConnectorListResponse``
+    because the per-item ``tenant_id`` UUID needs to render as a
+    string in the JSON (the default Pydantic-v2 serialiser
+    handles this).
+    """
+    items = await list_ingested_connectors(
+        operator=operator,
+        status=status,
+    )
+    return {"connectors": [item.model_dump(mode="json") for item in items]}
+
+
+@router.get("/{connector_id}/review", response_model=ConnectorReviewPayload)
+async def get_review_endpoint(
+    connector_id: str,
+    operator: Operator = _require_operator,
+) -> ConnectorReviewPayload:
+    """Return the full review payload for *connector_id*.
+
+    Operator-level read: any operator can inspect a connector their
+    tenant owns plus built-ins. Editing the payload requires
+    ``tenant_admin`` via the PATCH routes. Cross-tenant /
+    non-existent connector → 404 (the deliberate conflation).
+    """
+    service = ReviewService(operator)
+    try:
+        return await service.get_review_payload(connector_id, operator.tenant_id)
+    except ConnectorNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
+
+@router.patch(
+    "/{connector_id}/groups/{group_key}",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def edit_group_endpoint(
+    connector_id: str,
+    group_key: str,
+    body: EditGroupBody,
+    operator: Operator = _require_admin,
+) -> Response:
+    """Edit a group's ``when_to_use`` / ``name`` overrides.
+
+    At least one of the two body fields must be set; an empty body
+    yields 400. Writes one ``meho.connector.edit_group`` audit row
+    via the service layer. Returns 204 on success.
+    """
+    service = ReviewService(operator)
+    try:
+        await service.edit_group(
+            connector_id,
+            group_key,
+            tenant_id=operator.tenant_id,
+            when_to_use=body.when_to_use,
+            name=body.name,
+        )
+    except ConnectorNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    return Response(status_code=http_status.HTTP_204_NO_CONTENT)
+
+
+@router.patch(
+    "/{connector_id}/operations/{op_id:path}",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def edit_op_endpoint(
+    connector_id: str,
+    op_id: str,
+    body: EditOpBody,
+    operator: Operator = _require_admin,
+) -> Response:
+    """Edit a per-op operator override.
+
+    At least one of ``custom_description`` / ``safety_level`` /
+    ``requires_approval`` / ``is_enabled`` must be set; an empty
+    body yields 400. Writes one ``meho.connector.edit_op`` audit
+    row. Returns 204 on success.
+
+    The ``op_id`` path parameter uses the ``:path`` converter so
+    operations whose natural key contains slashes
+    (``"GET:/api/vcenter/cluster"``) round-trip without
+    URL-encoding the colon-prefixed path segment.
+    """
+    service = ReviewService(operator)
+    try:
+        await service.edit_op(
+            connector_id,
+            op_id,
+            tenant_id=operator.tenant_id,
+            custom_description=body.custom_description,
+            safety_level=body.safety_level,
+            requires_approval=body.requires_approval,
+            is_enabled=body.is_enabled,
+        )
+    except ConnectorNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    return Response(status_code=http_status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/{connector_id}/enable",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def enable_endpoint(
+    connector_id: str,
+    operator: Operator = _require_admin,
+) -> Response:
+    """Transition every group in *connector_id* to ``enabled``.
+
+    Idempotent: a re-call against a fully-enabled connector writes
+    no audit row and returns 204. State-machine guards apply (see
+    :meth:`ReviewService.enable_connector`); a forbidden source
+    state yields 409.
+    """
+    service = ReviewService(operator)
+    try:
+        await service.enable_connector(
+            connector_id,
+            tenant_id=operator.tenant_id,
+        )
+    except ConnectorNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except InvalidStateTransitionError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    return Response(status_code=http_status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/{connector_id}/disable",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def disable_endpoint(
+    connector_id: str,
+    operator: Operator = _require_admin,
+) -> Response:
+    """Transition every group in *connector_id* to ``disabled``.
+
+    Idempotent and state-machine-guarded — same shape as the enable
+    handler.
+    """
+    service = ReviewService(operator)
+    try:
+        await service.disable_connector(
+            connector_id,
+            tenant_id=operator.tenant_id,
+        )
+    except ConnectorNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except InvalidStateTransitionError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    return Response(status_code=http_status.HTTP_204_NO_CONTENT)

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -48,6 +48,9 @@ from fastapi import FastAPI, Response
 
 from meho_backplane import __version__
 from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_router
+from meho_backplane.api.v1.connectors_ingest import (
+    router as api_v1_connectors_ingest_router,
+)
 from meho_backplane.api.v1.feed import router as api_v1_feed_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.api.v1.operations import router as api_v1_operations_router
@@ -270,6 +273,14 @@ app.include_router(api_v1_feed_router)
 # inspection endpoint. The same handlers back the MCP transport
 # (mcp/tools/operations.py).
 app.include_router(api_v1_operations_router)
+# G0.7-T6 (#406) -- spec-ingestion + review-queue REST surface at
+# /api/v1/connectors*. Seven routes (ingest / list / review / PATCH
+# group / PATCH op / enable / disable) that drive the T1+T2+T3 pipeline
+# and the T4 review state machine. Tenant-scoped to the JWT's tenant_id
+# claim; mutating routes are tenant_admin-gated, read routes are
+# operator-gated. The same service layer (IngestionPipelineService +
+# ReviewService) backs T5 (CLI verbs) and T7 (admin MCP tools).
+app.include_router(api_v1_connectors_ingest_router)
 # MCP Streamable HTTP transport entrypoint (G0.5-T1, #246) and the
 # RFC 9728 protected-resource metadata document (G0.5-T2, #247).
 #

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -5,14 +5,29 @@
 
 This subpackage hosts the OpenAPI parser (:func:`parse_openapi`,
 T1 #401), the operator-facing review-queue state machine
-(:class:`ReviewService`, T4 #402), plus the bulk-upsert helper and
-LLM-grouping pass that sibling tasks will land beside them. The
-public surface is re-exported here so consumers (CLI verbs at T5,
-REST routes at T6, admin MCP tools at T7) import from
+(:class:`ReviewService`, T4 #402), the bulk-upsert helper (T2 #403),
+the LLM-grouping pass (T3 #404), the end-to-end ingestion pipeline
+service (:class:`IngestionPipelineService`), the shared REST / MCP
+request / response models (:mod:`api_schemas`), and the list-helper
+the REST router exposes at ``GET /api/v1/connectors``. The public
+surface is re-exported here so consumers (CLI verbs at T5, REST
+routes at T6, admin MCP tools at T7) import from
 ``meho_backplane.operations.ingest`` rather than reaching into the
 private module layout.
 """
 
+from meho_backplane.operations.ingest.api_schemas import (
+    ConnectorListItem,
+    ConnectorListResponse,
+    ConnectorStatusFilter,
+    EditGroupBody,
+    EditOpBody,
+    GroupingResultModel,
+    IngestionResultModel,
+    IngestRequest,
+    IngestResponse,
+    SpecSource,
+)
 from meho_backplane.operations.ingest.connector_registration import (
     GenericRestConnector,
     ensure_connector_class_registered,
@@ -25,6 +40,9 @@ from meho_backplane.operations.ingest.exceptions import (
     LlmOutputInvalid,
     OpIdCollision,
     UnsupportedSpecError,
+)
+from meho_backplane.operations.ingest.list_connectors import (
+    list_ingested_connectors,
 )
 from meho_backplane.operations.ingest.llm_groups import (
     DEFAULT_GROUPING_BATCH_SIZE,
@@ -43,6 +61,12 @@ from meho_backplane.operations.ingest.payload import (
     ConnectorReviewOp,
     ConnectorReviewPayload,
 )
+from meho_backplane.operations.ingest.pipeline import (
+    IngestionPipelineResult,
+    IngestionPipelineService,
+    LlmClientFactory,
+    LlmClientUnavailable,
+)
 from meho_backplane.operations.ingest.register_ingested import (
     IngestionResult,
     register_ingested_operations,
@@ -55,26 +79,41 @@ from meho_backplane.operations.ingest.service import ReviewService
 
 __all__ = [
     "DEFAULT_GROUPING_BATCH_SIZE",
+    "ConnectorListItem",
+    "ConnectorListResponse",
     "ConnectorNotFoundError",
     "ConnectorReviewGroup",
     "ConnectorReviewOp",
     "ConnectorReviewPayload",
+    "ConnectorStatusFilter",
+    "EditGroupBody",
+    "EditOpBody",
     "EndpointDescriptorProto",
     "GenericRestConnector",
     "GroupProposal",
     "GroupingResult",
+    "GroupingResultModel",
+    "IngestRequest",
+    "IngestResponse",
+    "IngestionPipelineResult",
+    "IngestionPipelineService",
     "IngestionResult",
+    "IngestionResultModel",
     "InvalidSchemaError",
     "InvalidSpecError",
     "InvalidStateTransitionError",
     "LlmClient",
+    "LlmClientFactory",
+    "LlmClientUnavailable",
     "LlmOutputInvalid",
     "OpIdCollision",
     "ReviewService",
     "SafetyLevel",
+    "SpecSource",
     "UnsupportedSpecError",
     "detect_spec_format",
     "ensure_connector_class_registered",
+    "list_ingested_connectors",
     "parse_connector_id",
     "parse_openapi",
     "register_ingested_operations",

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -66,6 +66,7 @@ from meho_backplane.operations.ingest.pipeline import (
     IngestionPipelineService,
     LlmClientFactory,
     LlmClientUnavailable,
+    default_llm_client_factory,
 )
 from meho_backplane.operations.ingest.register_ingested import (
     IngestionResult,
@@ -111,6 +112,7 @@ __all__ = [
     "SafetyLevel",
     "SpecSource",
     "UnsupportedSpecError",
+    "default_llm_client_factory",
     "detect_spec_format",
     "ensure_connector_class_registered",
     "list_ingested_connectors",

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic-v2 request / response models for the connectors-ingest surface.
+
+Shared by the REST router (G0.7-T6, ``api/v1/connectors_ingest.py``)
+and the admin MCP tools (G0.7-T7, ``mcp/tools/connector_admin.py``).
+Both surfaces hit the same service layer in :mod:`pipeline` and
+:mod:`service`; defining the request / response shapes once lets the
+sibling tasks consume them verbatim rather than rebuilding parallel
+Pydantic trees.
+
+The shapes are deliberately conservative:
+
+* ``frozen=True`` on every model — responses flow read-only and any
+  in-place mutation surfaces as a Pydantic error rather than a
+  silently-modified payload.
+* ``IngestRequest.specs`` is a list of :class:`SpecSource` objects with
+  one ``uri`` field so future per-spec knobs (auth headers, dialect
+  pinning) can land without breaking the wire contract.
+* :class:`ConnectorListItem` projects the minimum set the operator
+  needs from :class:`OperationGroup` aggregation — connector_id +
+  parsed coordinates + tenant scope + per-status group counts. It
+  intentionally omits per-op detail because the review payload
+  (:class:`ConnectorReviewPayload`) is the right place to surface
+  that.
+
+Status filter for ``GET /api/v1/connectors``: the operator picks
+``staged`` / ``enabled`` / ``disabled`` / ``all``. The semantics:
+
+* ``staged`` — at least one group is in ``review_status='staged'``;
+  the connector is awaiting review.
+* ``enabled`` — every group is ``review_status='enabled'``; the
+  connector is fully live.
+* ``disabled`` — every group is ``review_status='disabled'``; the
+  connector is fully rolled back.
+* ``all`` (or ``None`` query param) — no filter, return every visible
+  connector.
+
+A connector with a mixed group state (some enabled, some staged)
+shows in the ``staged`` filter — the operator-facing question is "is
+there anything left to review" and the answer is yes. This is the
+same conservative shape T5's CLI ``meho connector list --status
+staged`` will hit.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "ConnectorListItem",
+    "ConnectorListResponse",
+    "ConnectorStatusFilter",
+    "EditGroupBody",
+    "EditOpBody",
+    "GroupingResultModel",
+    "IngestRequest",
+    "IngestResponse",
+    "IngestionResultModel",
+    "SpecSource",
+]
+
+#: Allowed values for the ``GET /api/v1/connectors?status=...`` filter.
+#:
+#: Mirrors the :class:`~meho_backplane.db.models.OperationGroup.review_status`
+#: enum plus ``all`` for the no-filter case. ``None`` and ``all`` are
+#: equivalent at the route layer; the explicit ``all`` value exists so
+#: the CLI / MCP sibling tasks can use it as a sentinel without
+#: needing to send ``status=<empty>``.
+ConnectorStatusFilter = Literal["staged", "enabled", "disabled", "all"]
+
+
+class SpecSource(BaseModel):
+    """One spec to ingest under a connector triple.
+
+    ``uri`` carries the operator's spec identifier. Three forms are
+    accepted by the underlying :func:`parse_openapi` resolver:
+
+    * Absolute local path — ``/abs/path/to/spec.yaml``.
+    * HTTP(S) URL — ``https://api.example.com/openapi.yaml``.
+    * ``docs:<connector-id>/<file>`` shorthand — resolves against the
+      consumer's checked-in docs/ directory; CLI / API layers expand
+      this before calling the parser.
+
+    Wrapped in its own model so future per-spec knobs (auth headers,
+    dialect pinning, content-type override) can land without
+    reshaping :class:`IngestRequest`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    uri: str = Field(min_length=1, max_length=2048)
+
+
+class IngestRequest(BaseModel):
+    """POST body for ``/api/v1/connectors/ingest``.
+
+    Drives a full pipeline run: parse every spec in *specs*, call
+    :func:`register_ingested_operations` once per spec under the same
+    ``(product, version, impl_id)`` connector triple, then run
+    :func:`run_llm_grouping` once for the whole connector. Multi-spec
+    ingestion (vCenter's ``vcenter.yaml`` + ``vi-json.yaml``) lands as
+    multiple ``SpecSource`` entries in one request.
+
+    ``dry_run=True`` skips both the DB writes and the grouping pass:
+    only :func:`parse_openapi` runs, and the response carries
+    :class:`IngestionResultModel` counts derived from the parse output
+    plus ``grouping=None``. Operators use the dry-run path to validate
+    a spec before committing.
+
+    ``base_url`` is the optional default base URL for the auto-
+    registered :class:`GenericRestConnector` shim; ``None`` leaves
+    the shim unconfigured (the connector's eventual hand-coded
+    subclass at G3.x will set its own base URL).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    product: str = Field(min_length=1, max_length=64)
+    version: str = Field(min_length=1, max_length=64)
+    impl_id: str = Field(min_length=1, max_length=128)
+    specs: list[SpecSource] = Field(min_length=1, max_length=16)
+    base_url: str | None = Field(default=None, max_length=2048)
+    dry_run: bool = False
+
+
+class IngestionResultModel(BaseModel):
+    """Pydantic projection of
+    :class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`.
+
+    The dataclass lives in :mod:`register_ingested` so the helper
+    can stay framework-agnostic; this model is the wire-format twin
+    the routes return. Fields mirror the dataclass one-for-one with
+    an extra ``connector_id`` echo for round-trip clarity.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    connector_id: str
+    inserted_count: int
+    updated_count: int
+    skipped_count: int
+    connector_registered: bool
+    operations_grouped: bool
+
+
+class GroupingResultModel(BaseModel):
+    """Pydantic projection of
+    :class:`~meho_backplane.operations.ingest.llm_groups.GroupingResult`.
+
+    Mirrors the dataclass; rendered alongside :class:`IngestionResultModel`
+    in the ingest response so the operator sees both counts.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    connector_id: str
+    groups_created: int
+    operations_assigned: int
+    operations_unassigned: int
+    llm_call_count: int
+    llm_duration_ms: float
+
+
+class IngestResponse(BaseModel):
+    """Response shape for ``POST /api/v1/connectors/ingest``.
+
+    ``ingestion`` is always present. ``grouping`` is ``None`` for the
+    dry-run path (no DB writes, no LLM call) and for the no-op
+    re-run path (every op already grouped from a prior pass).
+
+    The response carries no audit_log id explicitly — the chassis
+    audit middleware writes one row per HTTP request with the route
+    path bound, and the service-level helpers
+    (:func:`register_ingested_operations`, :func:`run_llm_grouping`)
+    write their own per-call rows under
+    ``meho.connector.llm_grouping`` etc.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    ingestion: IngestionResultModel
+    grouping: GroupingResultModel | None = None
+
+
+class ConnectorListItem(BaseModel):
+    """One row in the ``GET /api/v1/connectors`` response.
+
+    Projects :class:`OperationGroup` aggregation. ``connector_id`` is
+    the operator-facing identifier (``"<impl_id>-<version>"``);
+    ``product`` / ``version`` / ``impl_id`` are the parsed triple.
+
+    ``tenant_id`` is ``None`` for built-in / global connectors and a
+    UUID for tenant-curated ones. ``group_count`` totals the rows
+    visible to the caller; the three ``*_group_count`` fields split
+    that total by ``review_status`` so operators can spot
+    review-queue backlog at a glance.
+
+    ``operation_count`` is the sum of operations across all groups
+    in scope. Useful for the CLI's
+    ``meho connector list --status staged`` summary view.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    connector_id: str
+    product: str
+    version: str
+    impl_id: str
+    tenant_id: UUID | None
+    group_count: int
+    staged_group_count: int
+    enabled_group_count: int
+    disabled_group_count: int
+    operation_count: int
+
+
+class ConnectorListResponse(BaseModel):
+    """Response shape for ``GET /api/v1/connectors``.
+
+    Wrapped in an object (rather than a bare ``list[...]``) so
+    future paging / total / cursor metadata can land without a
+    breaking change to the JSON shape.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    connectors: list[ConnectorListItem]
+
+
+class EditGroupBody(BaseModel):
+    """PATCH body for ``/api/v1/connectors/{id}/groups/{key}``.
+
+    Both fields optional but at least one must be set; the route
+    layer translates "neither set" into a 400. ``when_to_use`` is
+    the load-bearing operator-authored prose the LLM proposed at
+    grouping time; ``name`` is the Title Case display name.
+
+    Pydantic-side ``max_length`` caps line up with the underlying
+    :class:`OperationGroup.when_to_use` /
+    :class:`OperationGroup.name` columns. Empty strings are
+    rejected — operators that want to "clear" the field should
+    re-run grouping rather than blank it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    when_to_use: str | None = Field(default=None, min_length=1, max_length=2048)
+    name: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class EditOpBody(BaseModel):
+    """PATCH body for ``/api/v1/connectors/{id}/operations/{op_id}``.
+
+    Per-op operator overrides. At least one field must be set.
+
+    ``safety_level`` is the bounded enum from
+    :class:`~meho_backplane.db.models.EndpointDescriptor.safety_level`
+    (``safe`` / ``caution`` / ``dangerous``); a value outside the set
+    is rejected by Pydantic before the service layer sees it.
+
+    ``is_enabled`` is the per-op override that wins over the group
+    cascade (see :meth:`ReviewService.edit_op` for the full
+    semantics). ``requires_approval`` flips the per-op flag that
+    forces the dispatcher to write an audit row in
+    ``status='pending'`` and wait for an operator decision before
+    executing.
+
+    ``custom_description`` is the operator's free-form override
+    that the agent surfaces in place of the upstream spec's
+    ``description`` field; capped at 4096 chars to keep audit-log
+    payloads bounded.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    custom_description: str | None = Field(default=None, min_length=1, max_length=4096)
+    safety_level: Literal["safe", "caution", "dangerous"] | None = None
+    requires_approval: bool | None = None
+    is_enabled: bool | None = None

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``list_ingested_connectors`` -- aggregate query for the ``GET /api/v1/connectors`` route.
+
+Split out of :mod:`pipeline` to keep both modules under the project's
+600-line file budget. The function is conceptually adjacent to the
+ingestion pipeline (both surface the operator-facing view of what's
+in ``endpoint_descriptor`` + ``operation_group``) but the read path
+has its own concerns (visibility filter, status aggregation, dialect-
+portable conditional counts) and benefits from a dedicated module.
+
+Visibility filter
+-----------------
+
+Built-in connectors (``tenant_id IS NULL``) are visible to every
+operator; tenant-curated connectors are visible only when
+``tenant_id == operator.tenant_id``. Cross-tenant rows never appear
+in the result.
+
+Status filter semantics
+-----------------------
+
+* ``"staged"`` — at least one group is staged.
+* ``"enabled"`` — every group is enabled.
+* ``"disabled"`` — every group is disabled.
+* ``"all"`` / ``None`` — no filter.
+
+A connector with a mixed group state (some staged, some enabled)
+shows in the ``staged`` filter — the operator-facing question is
+"is there anything left to review" and the answer is yes.
+
+Dialect portability
+-------------------
+
+The conditional aggregation uses portable ``CASE WHEN ... THEN 1
+ELSE 0 END`` SUM expressions rather than dialect-specific ``FILTER``
+clauses (PG-only) so the same query runs against SQLite in tests.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest._llm_grouping_internals import build_connector_id
+from meho_backplane.operations.ingest.api_schemas import (
+    ConnectorListItem,
+    ConnectorStatusFilter,
+)
+
+__all__ = ["list_ingested_connectors"]
+
+
+def _matches_status_filter(
+    row: dict[str, int],
+    status: ConnectorStatusFilter | None,
+) -> bool:
+    """Apply the ``staged`` / ``enabled`` / ``disabled`` filter to one row."""
+    if status is None or status == "all":
+        return True
+    if status == "staged":
+        return row["staged"] > 0
+    if status == "enabled":
+        return row["total"] > 0 and row["enabled"] == row["total"]
+    if status == "disabled":
+        return row["total"] > 0 and row["disabled"] == row["total"]
+    return True  # pragma: no cover -- Literal exhausts the inputs
+
+
+def _connector_sort_key(
+    item: tuple[tuple[UUID | None, str, str, str], dict[str, int]],
+) -> tuple[str, str, str, str]:
+    """Stable sort key for connector tuples.
+
+    Direct sorting on the dict's tuple keys would crash when one
+    row has ``tenant_id=None`` and another has a UUID -- Python 3
+    forbids ``UUID < None``. The synthetic key projects ``None ->
+    ""`` only for ordering; the original ``None`` value survives
+    into the response.
+    """
+    (tenant_uuid, product, version, impl_id), _ = item
+    tenant_str = "" if tenant_uuid is None else str(tenant_uuid)
+    return (product, version, impl_id, tenant_str)
+
+
+async def _aggregate_groups_by_connector(
+    session: AsyncSession,
+    *,
+    operator_tenant_id: UUID,
+) -> dict[tuple[UUID | None, str, str, str], dict[str, int]]:
+    """Aggregate :class:`OperationGroup` rows by connector triple.
+
+    Returns a dict keyed on ``(tenant_id, product, version,
+    impl_id)`` whose values are
+    ``{total, staged, enabled, disabled}`` counts.
+    """
+    staged_case = func.sum(
+        case((OperationGroup.review_status == "staged", 1), else_=0),
+    ).label("staged")
+    enabled_case = func.sum(
+        case((OperationGroup.review_status == "enabled", 1), else_=0),
+    ).label("enabled")
+    disabled_case = func.sum(
+        case((OperationGroup.review_status == "disabled", 1), else_=0),
+    ).label("disabled")
+    total = func.count(OperationGroup.id).label("total")
+
+    stmt = (
+        select(
+            OperationGroup.tenant_id,
+            OperationGroup.product,
+            OperationGroup.version,
+            OperationGroup.impl_id,
+            total,
+            staged_case,
+            enabled_case,
+            disabled_case,
+        )
+        .where(
+            (OperationGroup.tenant_id.is_(None)) | (OperationGroup.tenant_id == operator_tenant_id),
+        )
+        .group_by(
+            OperationGroup.tenant_id,
+            OperationGroup.product,
+            OperationGroup.version,
+            OperationGroup.impl_id,
+        )
+    )
+    result = await session.execute(stmt)
+    aggregated: dict[tuple[UUID | None, str, str, str], dict[str, int]] = {}
+    for row in result.all():
+        tenant_uuid, product, version, impl_id, total_v, staged_v, enabled_v, disabled_v = row
+        aggregated[(tenant_uuid, product, version, impl_id)] = {
+            "total": int(total_v or 0),
+            "staged": int(staged_v or 0),
+            "enabled": int(enabled_v or 0),
+            "disabled": int(disabled_v or 0),
+        }
+    return aggregated
+
+
+async def _operation_count_by_connector(
+    session: AsyncSession,
+    *,
+    operator_tenant_id: UUID,
+) -> dict[tuple[UUID | None, str, str, str], int]:
+    """Aggregate :class:`EndpointDescriptor` rows by connector triple.
+
+    Source-kind filter excludes typed-connector rows (G3.x hand-
+    coded ops) -- this endpoint lists *ingested* connectors only,
+    per the G0.7 review-queue contract; typed connectors live in
+    the v2 registry and operators don't drive them through the
+    review state machine.
+    """
+    stmt = (
+        select(
+            EndpointDescriptor.tenant_id,
+            EndpointDescriptor.product,
+            EndpointDescriptor.version,
+            EndpointDescriptor.impl_id,
+            func.count(EndpointDescriptor.id).label("op_count"),
+        )
+        .where(
+            EndpointDescriptor.source_kind == "ingested",
+            (EndpointDescriptor.tenant_id.is_(None))
+            | (EndpointDescriptor.tenant_id == operator_tenant_id),
+        )
+        .group_by(
+            EndpointDescriptor.tenant_id,
+            EndpointDescriptor.product,
+            EndpointDescriptor.version,
+            EndpointDescriptor.impl_id,
+        )
+    )
+    result = await session.execute(stmt)
+    counts: dict[tuple[UUID | None, str, str, str], int] = {}
+    for row in result.all():
+        tenant_uuid, product, version, impl_id, count = row
+        counts[(tenant_uuid, product, version, impl_id)] = int(count or 0)
+    return counts
+
+
+async def list_ingested_connectors(
+    *,
+    operator: Operator,
+    status: ConnectorStatusFilter | None = None,
+    sessionmaker: async_sessionmaker[AsyncSession] | None = None,
+) -> list[ConnectorListItem]:
+    """Return one :class:`ConnectorListItem` per visible connector.
+
+    Visibility: built-in connectors (``tenant_id IS NULL``) are
+    visible to every operator; tenant-curated connectors are visible
+    only when ``tenant_id == operator.tenant_id``. Cross-tenant rows
+    never appear in the result. The operator's role does NOT gate
+    visibility -- read access to the registry is operator-level. The
+    write paths (:meth:`IngestionPipelineService.ingest`, the
+    state-machine methods on :class:`ReviewService`) carry their own
+    role gates.
+
+    See the module docstring for *status* semantics. Aggregation
+    runs as two SQL queries (groups + operation counts) because
+    sub-selects with correlated aggregation are dialect-finicky on
+    SQLite; the two queries together stay cheap relative to the
+    per-row JSON projection.
+    """
+    sm = sessionmaker if sessionmaker is not None else get_sessionmaker()
+    async with sm() as session:
+        groups_by_connector = await _aggregate_groups_by_connector(
+            session,
+            operator_tenant_id=operator.tenant_id,
+        )
+        op_counts_by_connector = await _operation_count_by_connector(
+            session,
+            operator_tenant_id=operator.tenant_id,
+        )
+
+    items: list[ConnectorListItem] = []
+    for key, row in sorted(groups_by_connector.items(), key=_connector_sort_key):
+        tenant_uuid, product, version, impl_id = key
+        if not _matches_status_filter(row, status):
+            continue
+        connector_id = build_connector_id(product, version, impl_id)
+        items.append(
+            ConnectorListItem(
+                connector_id=connector_id,
+                product=product,
+                version=version,
+                impl_id=impl_id,
+                tenant_id=tenant_uuid,
+                group_count=row["total"],
+                staged_group_count=row["staged"],
+                enabled_group_count=row["enabled"],
+                disabled_group_count=row["disabled"],
+                operation_count=op_counts_by_connector.get(key, 0),
+            ),
+        )
+    return items

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end ingestion-pipeline service + connector-list query helper.
+
+This module bundles the three T1 / T2 / T3 stages into one
+service-layer entry point the REST router (T6,
+:mod:`meho_backplane.api.v1.connectors_ingest`), CLI verbs (T5), and
+admin MCP tools (T7) all consume:
+
+* :class:`IngestionPipelineService` — orchestrates parse →
+  ``register_ingested_operations`` → ``run_llm_grouping`` for a
+  ``(product, version, impl_id)`` connector triple ingesting one or
+  more OpenAPI specs.
+* :func:`list_ingested_connectors` — aggregates
+  :class:`~meho_backplane.db.models.OperationGroup` rows into one
+  :class:`~meho_backplane.operations.ingest.api_schemas.ConnectorListItem`
+  per visible connector.
+
+Both surfaces are tenant-scoped at construction time: the service is
+built from an :class:`Operator` and every operation acts on either
+``tenant_id == operator.tenant_id`` or ``tenant_id is None`` (built-in
+scope, gated on :class:`TenantRole.TENANT_ADMIN`). Cross-tenant probes
+raise :class:`ConnectorNotFoundError` — the same conflation
+:class:`ReviewService` uses to keep the operator-facing failure
+surface uniform.
+
+LLM-client injection
+--------------------
+
+The grouping pass requires an :class:`LlmClient` Protocol
+implementation. The chassis does not yet ship a production adapter
+(T5 of #389 lands the Anthropic Messages-API binding); to keep T6's
+REST surface workable both in tests and once the production adapter
+is wired, the pipeline accepts an injectable factory at construction
+time. The default factory raises :class:`LlmClientUnavailable` so
+calling ``POST /api/v1/connectors/ingest`` against a backplane that
+hasn't configured an LLM client returns 503 rather than crashing.
+Sibling tests / the CLI / the MCP tools each inject their own
+client.
+
+Multi-spec merge
+----------------
+
+A single :meth:`IngestionPipelineService.ingest` call processes a
+list of :class:`SpecSource` entries. Each spec is parsed and upserted
+under the same connector triple with the spec's ``uri`` as the
+``spec_source`` tag (see
+:func:`register_ingested_operations`'s docstring for the tagging
+contract). Counts in the returned :class:`IngestionResult` aggregate
+across all specs in the request.
+
+Dry run
+-------
+
+``dry_run=True`` short-circuits both the DB writes and the LLM call:
+the pipeline parses every spec and counts how many operations would
+land but does not touch ``endpoint_descriptor`` or
+``operation_group``. The response carries ``grouping=None`` and
+``ingestion.connector_registered=False`` because neither stage was
+exercised. Useful for operators validating a spec before committing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from uuid import UUID
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations.ingest._llm_grouping_internals import (
+    DEFAULT_GROUPING_BATCH_SIZE,
+    DEFAULT_MAX_GROUPS,
+    DEFAULT_MIN_GROUPS,
+    LlmClient,
+    build_connector_id,
+)
+from meho_backplane.operations.ingest.api_schemas import (
+    GroupingResultModel,
+    IngestionResultModel,
+    SpecSource,
+)
+from meho_backplane.operations.ingest.llm_groups import (
+    GroupingResult,
+    run_llm_grouping,
+)
+from meho_backplane.operations.ingest.openapi import parse_openapi
+from meho_backplane.operations.ingest.register_ingested import (
+    IngestionResult,
+    register_ingested_operations,
+)
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "IngestionPipelineResult",
+    "IngestionPipelineService",
+    "LlmClientFactory",
+    "LlmClientUnavailable",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+class LlmClientUnavailable(RuntimeError):  # noqa: N818 -- "Unavailable" reads better than "Error" in the 503 detail message
+    """Raised when an LLM client is required but no factory is configured.
+
+    The chassis ships :class:`IngestionPipelineService` with a
+    default-fail factory so a misconfigured deployment surfaces here
+    rather than crashing partway through the grouping pass. The REST
+    layer maps this onto HTTP 503 (Service Unavailable); the CLI / MCP
+    sibling tasks render their own operator-facing error.
+    """
+
+
+#: Type alias for the LLM-client factory the pipeline uses.
+#:
+#: A factory rather than a singleton instance so the chassis can lazy-
+#: build the client (e.g. after :func:`Settings.cache_clear` in tests)
+#: and so each ingest call can get a fresh client when the
+#: implementation pins per-call retry state. The default factory
+#: raises :class:`LlmClientUnavailable`.
+LlmClientFactory = Callable[[], LlmClient]
+
+
+def _default_llm_client_factory() -> LlmClient:
+    """Fail-closed default — no production LLM adapter is wired yet."""
+    raise LlmClientUnavailable(
+        "no LLM client configured for spec-ingestion grouping; "
+        "the production Anthropic adapter lands with G0.7-T5 (#405). "
+        "Tests inject a deterministic stub via "
+        "IngestionPipelineService(..., llm_client_factory=...).",
+    )
+
+
+class IngestionPipelineResult:
+    """Bundled result of one :meth:`IngestionPipelineService.ingest` call.
+
+    Carries the aggregated :class:`IngestionResult` (counts summed
+    across every spec in the request) and the
+    :class:`GroupingResult` for the single grouping pass that runs
+    after all specs are upserted. ``grouping`` is ``None`` for the
+    dry-run path.
+
+    Not a frozen :class:`dataclass` because the route layer projects
+    it into :class:`IngestionResultModel` / :class:`GroupingResultModel`
+    before returning to the client; the intermediate shape is
+    internal.
+    """
+
+    __slots__ = ("connector_id", "grouping", "ingestion")
+
+    def __init__(
+        self,
+        *,
+        connector_id: str,
+        ingestion: IngestionResult,
+        grouping: GroupingResult | None,
+    ) -> None:
+        self.connector_id = connector_id
+        self.ingestion = ingestion
+        self.grouping = grouping
+
+    def to_api_models(self) -> tuple[IngestionResultModel, GroupingResultModel | None]:
+        """Project to the Pydantic models the REST routes return.
+
+        Returns ``(ingestion_model, grouping_model_or_none)``. The
+        connector_id is echoed onto both inner models so callers
+        round-tripping the response see the same identifier they
+        sent in.
+        """
+        ingestion_model = IngestionResultModel(
+            connector_id=self.connector_id,
+            inserted_count=self.ingestion.inserted_count,
+            updated_count=self.ingestion.updated_count,
+            skipped_count=self.ingestion.skipped_count,
+            connector_registered=self.ingestion.connector_registered,
+            operations_grouped=self.ingestion.operations_grouped,
+        )
+        grouping_model: GroupingResultModel | None = None
+        if self.grouping is not None:
+            grouping_model = GroupingResultModel(
+                connector_id=self.grouping.connector_id,
+                groups_created=self.grouping.groups_created,
+                operations_assigned=self.grouping.operations_assigned,
+                operations_unassigned=self.grouping.operations_unassigned,
+                llm_call_count=self.grouping.llm_call_count,
+                llm_duration_ms=self.grouping.llm_duration_ms,
+            )
+        return ingestion_model, grouping_model
+
+
+class IngestionPipelineService:
+    """Orchestrates the T1 → T2 → T3 ingestion pipeline for one connector.
+
+    Built per-request from the route's
+    :class:`~meho_backplane.auth.operator.Operator` so the service-
+    level audit rows the T2 / T3 helpers write carry the originating
+    operator's identity. The same instance can also be re-used by the
+    CLI verbs (T5) and admin MCP tools (T7); both pass their own
+    :class:`Operator` at construction.
+
+    Tenant scoping: the constructor optionally takes an explicit
+    ``tenant_id`` (``None`` → built-in scope). Built-in ingests are
+    gated on :class:`TenantRole.TENANT_ADMIN`; tenant-curated ingests
+    are gated on a match between the requested ``tenant_id`` and the
+    operator's tenant. Mismatches raise :class:`PermissionError`,
+    which the REST router maps onto HTTP 403.
+
+    LLM-client factory: pass a custom factory to inject a test stub or
+    a production adapter once one lands. The default fail-closed
+    factory keeps misconfigured deployments loud.
+    """
+
+    def __init__(
+        self,
+        operator: Operator,
+        *,
+        sessionmaker: async_sessionmaker[AsyncSession] | None = None,
+        llm_client_factory: LlmClientFactory = _default_llm_client_factory,
+        embedding_service: EmbeddingService | None = None,
+    ) -> None:
+        self._operator = operator
+        self._explicit_sessionmaker = sessionmaker
+        self._llm_client_factory = llm_client_factory
+        self._embedding_service = embedding_service
+
+    def _sessionmaker(self) -> async_sessionmaker[AsyncSession]:
+        """Resolve the sessionmaker lazily — see
+        :meth:`ReviewService._sessionmaker` for the same shape.
+        """
+        if self._explicit_sessionmaker is not None:
+            return self._explicit_sessionmaker
+        return get_sessionmaker()
+
+    def _authorize(self, tenant_id: UUID | None) -> None:
+        """Mirror :meth:`ReviewService._authorize_scope` for ingest paths.
+
+        Built-in ingests require ``tenant_admin``; tenant-curated
+        ingests require the operator's tenant_id to match. The route
+        layer enforces ``tenant_admin`` minimum on the ingest endpoint
+        already, but the service-layer guard is defence-in-depth so
+        the CLI / MCP siblings get the same isolation even if they
+        skip the route decorator.
+        """
+        if tenant_id is None:
+            if self._operator.tenant_role is not TenantRole.TENANT_ADMIN:
+                raise PermissionError(
+                    "built-in connector ingest requires tenant_admin",
+                )
+            return
+        if tenant_id != self._operator.tenant_id:
+            raise PermissionError(
+                f"operator tenant_id={self._operator.tenant_id} cannot ingest into "
+                f"tenant_id={tenant_id}",
+            )
+
+    async def ingest(
+        self,
+        *,
+        product: str,
+        version: str,
+        impl_id: str,
+        specs: Sequence[SpecSource],
+        base_url: str | None = None,
+        tenant_id: UUID | None = None,
+        dry_run: bool = False,
+    ) -> IngestionPipelineResult:
+        """Run the full pipeline (parse → register → group) for one connector.
+
+        See the module docstring for the multi-spec merge,
+        dry-run, and LLM-client contracts. The return value bundles
+        the aggregated :class:`IngestionResult` + the single
+        :class:`GroupingResult` for downstream projection into the
+        REST response.
+
+        Raises :class:`PermissionError` when the operator's tenancy
+        doesn't permit writes to *tenant_id*. The parser, registrar,
+        and grouping pass propagate their own domain exceptions
+        verbatim — the router catches them at the HTTP boundary.
+        """
+        self._authorize(tenant_id)
+        connector_id = build_connector_id(product, version, impl_id)
+        log = _log.bind(
+            connector_id=connector_id,
+            spec_count=len(specs),
+            dry_run=dry_run,
+            tenant_id=str(tenant_id) if tenant_id is not None else None,
+            operator_sub=self._operator.sub,
+        )
+
+        if dry_run:
+            log.info("ingestion_pipeline_dry_run_start")
+            return await self._run_dry_run(
+                product=product,
+                version=version,
+                impl_id=impl_id,
+                specs=specs,
+                connector_id=connector_id,
+            )
+
+        log.info("ingestion_pipeline_start")
+        sessionmaker = self._sessionmaker()
+        aggregated = await self._run_register_phase(
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            specs=specs,
+            base_url=base_url,
+            tenant_id=tenant_id,
+            sessionmaker=sessionmaker,
+        )
+        log.info(
+            "ingestion_pipeline_register_complete",
+            inserted_count=aggregated.inserted_count,
+            updated_count=aggregated.updated_count,
+            skipped_count=aggregated.skipped_count,
+            connector_registered=aggregated.connector_registered,
+        )
+
+        grouping_result = await self._run_grouping_phase(
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            tenant_id=tenant_id,
+            sessionmaker=sessionmaker,
+        )
+        log.info(
+            "ingestion_pipeline_grouping_complete",
+            groups_created=grouping_result.groups_created,
+            operations_assigned=grouping_result.operations_assigned,
+            operations_unassigned=grouping_result.operations_unassigned,
+        )
+        return IngestionPipelineResult(
+            connector_id=connector_id,
+            ingestion=aggregated,
+            grouping=grouping_result,
+        )
+
+    # ----- private helpers ------------------------------------------------
+
+    async def _run_dry_run(
+        self,
+        *,
+        product: str,
+        version: str,
+        impl_id: str,
+        specs: Sequence[SpecSource],
+        connector_id: str,
+    ) -> IngestionPipelineResult:
+        """Parse every spec and project the parse counts into a result.
+
+        No DB writes, no LLM call. ``inserted_count`` reports how many
+        operations would be inserted on a real run; the other counts
+        stay at zero because the body-hash skip / update branches only
+        apply once we read existing rows. Operators use the dry-run
+        path to verify a spec parses before they commit.
+        """
+        total_ops = 0
+        for spec in specs:
+            parsed = parse_openapi(spec.uri, spec_source=spec.uri)
+            total_ops += len(parsed)
+        ingestion = IngestionResult(
+            inserted_count=total_ops,
+            updated_count=0,
+            skipped_count=0,
+            connector_registered=False,
+            operations_grouped=False,
+        )
+        _log.info(
+            "ingestion_pipeline_dry_run_complete",
+            connector_id=connector_id,
+            operation_count=total_ops,
+        )
+        return IngestionPipelineResult(
+            connector_id=connector_id,
+            ingestion=ingestion,
+            grouping=None,
+        )
+
+    async def _run_register_phase(
+        self,
+        *,
+        product: str,
+        version: str,
+        impl_id: str,
+        specs: Sequence[SpecSource],
+        base_url: str | None,
+        tenant_id: UUID | None,
+        sessionmaker: async_sessionmaker[AsyncSession],
+    ) -> IngestionResult:
+        """Parse + register every spec under the same connector triple.
+
+        Each spec is parsed and registered separately so the per-spec
+        :func:`register_ingested_operations` call attaches its own
+        ``spec:<uri>`` tag to the row. The aggregated counts roll up
+        every spec's individual result. ``connector_registered`` is
+        ``True`` when ANY spec triggered the auto-shim registration —
+        on a fresh connector the first spec flips it, subsequent
+        specs see it already there.
+        """
+        aggregated_inserted = 0
+        aggregated_updated = 0
+        aggregated_skipped = 0
+        connector_registered = False
+
+        for spec in specs:
+            protos = parse_openapi(spec.uri, spec_source=spec.uri)
+            partial = await register_ingested_operations(
+                product=product,
+                version=version,
+                impl_id=impl_id,
+                spec_source=spec.uri,
+                operations=protos,
+                base_url=base_url,
+                tenant_id=tenant_id,
+                embedding_service=self._embedding_service,
+            )
+            aggregated_inserted += partial.inserted_count
+            aggregated_updated += partial.updated_count
+            aggregated_skipped += partial.skipped_count
+            connector_registered = connector_registered or partial.connector_registered
+
+        return IngestionResult(
+            inserted_count=aggregated_inserted,
+            updated_count=aggregated_updated,
+            skipped_count=aggregated_skipped,
+            connector_registered=connector_registered,
+            operations_grouped=False,
+        )
+
+    async def _run_grouping_phase(
+        self,
+        *,
+        product: str,
+        version: str,
+        impl_id: str,
+        tenant_id: UUID | None,
+        sessionmaker: async_sessionmaker[AsyncSession],
+    ) -> GroupingResult:
+        """Resolve the LLM client and run :func:`run_llm_grouping`."""
+        llm_client = self._llm_client_factory()
+        return await run_llm_grouping(
+            llm_client=llm_client,
+            operator_sub=self._operator.sub,
+            operator_tenant_id=self._operator.tenant_id,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            tenant_id=tenant_id,
+            batch_size=DEFAULT_GROUPING_BATCH_SIZE,
+            min_groups=DEFAULT_MIN_GROUPS,
+            max_groups=DEFAULT_MAX_GROUPS,
+            sessionmaker=sessionmaker,
+        )

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -99,6 +99,7 @@ __all__ = [
     "IngestionPipelineService",
     "LlmClientFactory",
     "LlmClientUnavailable",
+    "default_llm_client_factory",
 ]
 
 _log = structlog.get_logger(__name__)
@@ -125,8 +126,14 @@ class LlmClientUnavailable(RuntimeError):  # noqa: N818 -- "Unavailable" reads b
 LlmClientFactory = Callable[[], LlmClient]
 
 
-def _default_llm_client_factory() -> LlmClient:
-    """Fail-closed default — no production LLM adapter is wired yet."""
+def default_llm_client_factory() -> LlmClient:
+    """Fail-closed default — no production LLM adapter is wired yet.
+
+    Public so that sibling consumers (REST routes at T6, CLI verbs at
+    T5, admin MCP tools at T7) can import the same fallback factory
+    from :mod:`meho_backplane.operations.ingest` without reaching
+    across the underscore boundary.
+    """
     raise LlmClientUnavailable(
         "no LLM client configured for spec-ingestion grouping; "
         "the production Anthropic adapter lands with G0.7-T5 (#405). "
@@ -219,7 +226,7 @@ class IngestionPipelineService:
         operator: Operator,
         *,
         sessionmaker: async_sessionmaker[AsyncSession] | None = None,
-        llm_client_factory: LlmClientFactory = _default_llm_client_factory,
+        llm_client_factory: LlmClientFactory = default_llm_client_factory,
         embedding_service: EmbeddingService | None = None,
     ) -> None:
         self._operator = operator

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -65,9 +65,7 @@ from meho_backplane.operations.ingest import (
     GroupingResult,
     IngestionResult,
     LlmClient,
-)
-from meho_backplane.operations.ingest.pipeline import (
-    _default_llm_client_factory,
+    default_llm_client_factory,
 )
 from meho_backplane.settings import get_settings
 
@@ -118,7 +116,7 @@ def _reset_llm_client_factory() -> Iterator[None]:
     reset doesn't leak across the file.
     """
     yield
-    set_llm_client_factory(_default_llm_client_factory)
+    set_llm_client_factory(default_llm_client_factory)
 
 
 @pytest.fixture
@@ -747,6 +745,37 @@ async def test_disable_transitions_and_writes_audit_row(
 
 
 @pytest.mark.asyncio
+async def test_disable_is_idempotent(client: TestClient) -> None:
+    """Second POST /disable writes no additional audit row.
+
+    Mirrors :func:`test_enable_is_idempotent` so both transitions
+    carry the same documented contract: replaying the call after
+    every group is already in the target state is a no-op at the
+    service-level audit row.
+    """
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a, review_status="enabled", op_is_enabled=True)
+    key, token = _admin_token(tenant_id=tenant_a)
+    headers = _authed(token)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        first = client.post(
+            "/api/v1/connectors/vmware-rest-9.0/disable",
+            headers=headers,
+        )
+        assert first.status_code == 204
+        second = client.post(
+            "/api/v1/connectors/vmware-rest-9.0/disable",
+            headers=headers,
+        )
+    assert second.status_code == 204
+    statuses = await _group_statuses(tenant_id=tenant_a)
+    assert set(statuses.values()) == {"disabled"}
+    audit_count = await _audit_row_count(op_id="meho.connector.disable")
+    assert audit_count == 1
+
+
+@pytest.mark.asyncio
 async def test_enable_cross_tenant_returns_404(client: TestClient) -> None:
     """Cross-tenant enable → 404 (and no state changes leak to the other tenant)."""
     tenant_a = uuid.uuid4()
@@ -991,7 +1020,7 @@ def test_set_llm_client_factory_returns_previous_and_restores(
         ...  # never called in this test
 
     previous = set_llm_client_factory(custom_factory)
-    assert previous is _default_llm_client_factory
+    assert previous is default_llm_client_factory
     restored = set_llm_client_factory(previous)
     assert restored is custom_factory
 

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -1,0 +1,1000 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.connectors_ingest`.
+
+Coverage matrix (G0.7-T6 / Task #406 acceptance criteria):
+
+* **Route mounting.** All seven routes appear in the FastAPI app's
+  route table; the OpenAPI document the test client builds advertises
+  them.
+* **POST /ingest.** Happy path runs the full pipeline; ``dry_run=true``
+  short-circuits both the DB writes and the LLM call.
+* **GET /.** Status filter narrows the list; built-ins surface
+  alongside the operator's-tenant rows; cross-tenant rows are
+  filtered out.
+* **GET /{id}/review.** Operator-level read; cross-tenant probe → 404.
+* **PATCH /{id}/groups/{key}.** Edit writes one audit row.
+* **PATCH /{id}/operations/{op}.** Edit writes one audit row; the
+  op_id path converter handles colon-prefixed natural keys.
+* **POST /{id}/enable.** Idempotent transition; cascade to children.
+* **POST /{id}/disable.** Idempotent transition; cascade.
+* **RBAC.** Unauthenticated → 401; ``operator`` role on a mutating
+  route → 403; ``tenant_admin`` → 200 / 204.
+* **Tenant isolation.** Tenant A cannot read tenant B's connector;
+  the response is 404, not 403.
+
+Tests boot the FastAPI app with the production middleware stack
+(``RequestContextMiddleware`` + ``AuditMiddleware``) so audit rows
+are inserted into the autouse-migrated SQLite engine. The LLM client
+is replaced via :func:`set_llm_client_factory` with a deterministic
+stub so the ingest test paths don't need a real Anthropic key.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.api.v1.connectors_ingest import (
+    router as connectors_ingest_router,
+)
+from meho_backplane.api.v1.connectors_ingest import (
+    set_llm_client_factory,
+)
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AuditLog,
+    EndpointDescriptor,
+    OperationGroup,
+)
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.operations.ingest import (
+    GroupingResult,
+    IngestionResult,
+    LlmClient,
+)
+from meho_backplane.operations.ingest.pipeline import (
+    _default_llm_client_factory,
+)
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+# ---------------------------------------------------------------------------
+# Settings + JWKS cache + LLM-client fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` reads."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    """Empty the module-level JWKS cache around every test."""
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+@pytest.fixture(autouse=True)
+def _reset_llm_client_factory() -> Iterator[None]:
+    """Reset the module-level LLM-client factory between tests.
+
+    Tests that exercise the ingest happy path install their own stub
+    via :func:`set_llm_client_factory`; the fixture restores the
+    default fail-closed factory after each test so a missing
+    reset doesn't leak across the file.
+    """
+    yield
+    set_llm_client_factory(_default_llm_client_factory)
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """An :class:`AsyncMock` standing in for the fastembed singleton.
+
+    Ingest happy-path tests patch the chassis embedding singleton to
+    this stub so :func:`register_ingested_operations` doesn't try to
+    download the ONNX model from huggingface.co. ``encode_one``
+    returns a 384-dim vector of ``0.25`` — same shape
+    :mod:`tests.test_operations_register_ingested` uses.
+    """
+    service = AsyncMock()
+    service.encode_one.return_value = [0.25] * 384
+    service.encode.return_value = [[0.25] * 384]
+    service.dimension = 384
+    return service
+
+
+class _StubLlmClient:
+    """Deterministic :class:`LlmClient` for ingest happy-path tests.
+
+    Returns valid Pass-1 / Pass-2 JSON payloads keyed on prompt
+    content so :func:`run_llm_grouping` accepts the output verbatim
+    and the test doesn't need to mock the upstream Anthropic
+    Messages API.
+
+    Not a Pydantic / dataclass — a thin class is enough to satisfy
+    the :class:`LlmClient` Protocol's single async method.
+    """
+
+    def __init__(self, *, propose_response: str, assign_response: str) -> None:
+        self._propose_response = propose_response
+        self._assign_response = assign_response
+
+    async def generate_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        max_output_tokens: int,
+    ) -> str:
+        # The grouping pass uses two distinct system prompts; route
+        # off them rather than parsing user_prompt structure.
+        if "Propose" in system_prompt or "propose" in system_prompt:
+            return self._propose_response
+        return self._assign_response
+
+
+# ---------------------------------------------------------------------------
+# App construction
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Return a :class:`FastAPI` mounting only the connectors-ingest router.
+
+    Mirrors prod middleware so the AuditMiddleware writes its row
+    into the autouse-migrated SQLite engine for audit-payload
+    assertions.
+    """
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(connectors_ingest_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    """``TestClient`` driving a fresh app per test."""
+    yield TestClient(_build_app())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin_token(*, tenant_id: UUID | None = None, sub: str = "op-admin") -> tuple[Any, str]:
+    """Mint a JWT for a ``tenant_admin`` operator."""
+    key = _make_rsa_keypair("kid-admin")
+    tid = tenant_id if tenant_id is not None else uuid.uuid4()
+    token = _mint_token(
+        key,
+        sub=sub,
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        tenant_id=str(tid),
+    )
+    return key, token
+
+
+def _operator_token(*, tenant_id: UUID | None = None, sub: str = "op-operator") -> tuple[Any, str]:
+    """Mint a JWT for an ``operator`` role (not admin)."""
+    key = _make_rsa_keypair("kid-operator")
+    tid = tenant_id if tenant_id is not None else uuid.uuid4()
+    token = _mint_token(
+        key,
+        sub=sub,
+        tenant_role=TenantRole.OPERATOR.value,
+        tenant_id=str(tid),
+    )
+    return key, token
+
+
+async def _seed_connector(
+    *,
+    tenant_id: UUID | None,
+    product: str = "vmware",
+    version: str = "9.0",
+    impl_id: str = "vmware-rest",
+    group_count: int = 2,
+    ops_per_group: int = 3,
+    review_status: str = "staged",
+    op_is_enabled: bool = False,
+) -> list[uuid.UUID]:
+    """Seed an ingested connector with *group_count* groups + ops per group."""
+    sessionmaker = get_sessionmaker()
+    group_ids: list[uuid.UUID] = []
+    async with sessionmaker() as session:
+        for g_index in range(group_count):
+            group_id = uuid.uuid4()
+            group_key = f"group-{g_index}"
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=tenant_id,
+                    product=product,
+                    version=version,
+                    impl_id=impl_id,
+                    group_key=group_key,
+                    name=f"Group {g_index}",
+                    when_to_use=f"Use group {g_index} for things.",
+                    review_status=review_status,
+                ),
+            )
+            group_ids.append(group_id)
+            for o_index in range(ops_per_group):
+                session.add(
+                    EndpointDescriptor(
+                        tenant_id=tenant_id,
+                        product=product,
+                        version=version,
+                        impl_id=impl_id,
+                        op_id=f"GET:/api/v1/{group_key}/{o_index}",
+                        source_kind="ingested",
+                        method="GET",
+                        path=f"/api/v1/{group_key}/{o_index}",
+                        group_id=group_id,
+                        summary=f"Operation {o_index} in {group_key}",
+                        is_enabled=op_is_enabled,
+                    ),
+                )
+        await session.commit()
+    return group_ids
+
+
+async def _group_statuses(
+    *,
+    tenant_id: UUID | None,
+    product: str = "vmware",
+    version: str = "9.0",
+    impl_id: str = "vmware-rest",
+) -> dict[str, str]:
+    """Return ``{group_key: review_status}`` for every group under the connector."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(OperationGroup).where(
+            OperationGroup.product == product,
+            OperationGroup.version == version,
+            OperationGroup.impl_id == impl_id,
+        )
+        if tenant_id is None:
+            stmt = stmt.where(OperationGroup.tenant_id.is_(None))
+        else:
+            stmt = stmt.where(OperationGroup.tenant_id == tenant_id)
+        result = await session.execute(stmt)
+        return {group.group_key: group.review_status for group in result.scalars().all()}
+
+
+async def _audit_row_count(*, op_id: str) -> int:
+    """Count audit_log rows whose ``path`` equals *op_id*."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).where(AuditLog.path == op_id))
+        return len(list(result.scalars().all()))
+
+
+def _authed(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Route mounting
+# ---------------------------------------------------------------------------
+
+
+def test_all_seven_routes_mounted_on_main_app() -> None:
+    """The seven routes show up in :mod:`meho_backplane.main`'s app.
+
+    Acceptance criterion: ``OpenAPI surface visible at
+    /api/v1/openapi.json``. Verified here by introspecting the
+    main app's route table; the per-test fixture builds an
+    isolated app and would miss a wire-up regression in main.py.
+    """
+    from meho_backplane.main import app
+
+    expected_paths = {
+        "/api/v1/connectors/ingest",
+        "/api/v1/connectors",
+        "/api/v1/connectors/{connector_id}/review",
+        "/api/v1/connectors/{connector_id}/groups/{group_key}",
+        "/api/v1/connectors/{connector_id}/operations/{op_id:path}",
+        "/api/v1/connectors/{connector_id}/enable",
+        "/api/v1/connectors/{connector_id}/disable",
+    }
+    actual_paths = {getattr(r, "path", None) for r in app.routes}
+    missing = expected_paths - actual_paths
+    assert not missing, f"missing routes: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# RBAC: unauthenticated + insufficient role
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_unauthenticated_returns_401(client: TestClient) -> None:
+    """No Authorization header → 401."""
+    response = client.post(
+        "/api/v1/connectors/ingest",
+        json={
+            "product": "vmware",
+            "version": "9.0",
+            "impl_id": "vmware-rest",
+            "specs": [{"uri": "/tmp/spec.yaml"}],
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_ingest_operator_role_returns_403(client: TestClient) -> None:
+    """``operator`` role on the tenant_admin-gated /ingest → 403."""
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "vmware",
+                "version": "9.0",
+                "impl_id": "vmware-rest",
+                "specs": [{"uri": "/tmp/spec.yaml"}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "insufficient_role"
+
+
+def test_enable_operator_role_returns_403(client: TestClient) -> None:
+    """``operator`` role on /enable → 403."""
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/vmware-rest-9.0/enable",
+            headers=_authed(token),
+        )
+    assert response.status_code == 403
+
+
+def test_disable_operator_role_returns_403(client: TestClient) -> None:
+    """``operator`` role on /disable → 403."""
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/vmware-rest-9.0/disable",
+            headers=_authed(token),
+        )
+    assert response.status_code == 403
+
+
+def test_edit_group_operator_role_returns_403(client: TestClient) -> None:
+    """``operator`` role on PATCH /groups → 403."""
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.patch(
+            "/api/v1/connectors/vmware-rest-9.0/groups/group-0",
+            json={"when_to_use": "Updated text."},
+            headers=_authed(token),
+        )
+    assert response.status_code == 403
+
+
+def test_edit_op_operator_role_returns_403(client: TestClient) -> None:
+    """``operator`` role on PATCH /operations → 403."""
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.patch(
+            "/api/v1/connectors/vmware-rest-9.0/operations/GET:/api/v1/group-0/0",
+            json={"safety_level": "dangerous"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 403
+
+
+def test_list_operator_role_returns_200(client: TestClient) -> None:
+    """``operator`` role can call GET / (operator minimum)."""
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    assert response.json() == {"connectors": []}
+
+
+# ---------------------------------------------------------------------------
+# GET / -- list connectors + tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_returns_operator_tenant_and_builtins(
+    client: TestClient,
+) -> None:
+    """An operator sees their tenant's connectors + built-ins (NULL tenant)."""
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a, product="vmware", impl_id="vmware-rest")
+    await _seed_connector(tenant_id=None, product="nsx", impl_id="nsx")
+    await _seed_connector(tenant_id=tenant_b, product="harbor", impl_id="harbor")
+
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    connectors = response.json()["connectors"]
+    seen_ids = {c["connector_id"] for c in connectors}
+    assert seen_ids == {"vmware-rest-9.0", "nsx-9.0"}
+    # tenant_b's harbor must not surface.
+    assert "harbor-9.0" not in seen_ids
+
+
+@pytest.mark.asyncio
+async def test_list_status_staged_filters_by_aggregate_state(
+    client: TestClient,
+) -> None:
+    """``?status=staged`` returns connectors with ≥1 staged group."""
+    tenant_a = uuid.uuid4()
+    # vmware: all staged
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        impl_id="vmware-rest",
+        review_status="staged",
+    )
+    # nsx: all enabled
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="nsx",
+        impl_id="nsx",
+        review_status="enabled",
+    )
+
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/connectors?status=staged",
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+    seen_ids = {c["connector_id"] for c in response.json()["connectors"]}
+    assert seen_ids == {"vmware-rest-9.0"}
+
+
+@pytest.mark.asyncio
+async def test_list_status_enabled_requires_uniform_state(
+    client: TestClient,
+) -> None:
+    """``?status=enabled`` returns only connectors with every group enabled."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        impl_id="vmware-rest",
+        review_status="enabled",
+    )
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/connectors?status=enabled",
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+    connectors = response.json()["connectors"]
+    assert len(connectors) == 1
+    item = connectors[0]
+    assert item["connector_id"] == "vmware-rest-9.0"
+    assert item["enabled_group_count"] == item["group_count"]
+    assert item["operation_count"] == 6  # 2 groups x 3 ops
+
+
+# ---------------------------------------------------------------------------
+# GET /{id}/review -- read + tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_review_returns_payload_for_operator_tenant(
+    client: TestClient,
+) -> None:
+    """Operator-level read returns the review payload."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a, group_count=2, ops_per_group=3)
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/connectors/vmware-rest-9.0/review",
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["connector_id"] == "vmware-rest-9.0"
+    assert body["product"] == "vmware"
+    assert body["total_op_count"] == 6
+    assert len(body["groups"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_review_cross_tenant_returns_404(
+    client: TestClient,
+) -> None:
+    """Tenant A cannot see tenant B's connector — 404, not 403."""
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_b, product="vmware", impl_id="vmware-rest")
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/connectors/vmware-rest-9.0/review",
+            headers=_authed(token),
+        )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /{id}/groups/{key}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_group_updates_and_writes_audit_row(
+    client: TestClient,
+) -> None:
+    """PATCH on a group updates the row + writes one audit row."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.patch(
+            "/api/v1/connectors/vmware-rest-9.0/groups/group-0",
+            json={"when_to_use": "New description text.", "name": "Renamed"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 204
+    audit_count = await _audit_row_count(op_id="meho.connector.edit_group")
+    assert audit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_edit_group_empty_body_returns_400(
+    client: TestClient,
+) -> None:
+    """PATCH with no fields → 400."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.patch(
+            "/api/v1/connectors/vmware-rest-9.0/groups/group-0",
+            json={},
+            headers=_authed(token),
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_edit_group_cross_tenant_returns_404(
+    client: TestClient,
+) -> None:
+    """Cross-tenant PATCH → 404."""
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_b)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.patch(
+            "/api/v1/connectors/vmware-rest-9.0/groups/group-0",
+            json={"name": "Renamed"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /{id}/operations/{op_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_op_updates_safety_level_and_writes_audit_row(
+    client: TestClient,
+) -> None:
+    """PATCH on an op updates safety_level + writes one audit row.
+
+    Exercises the ``:path`` converter on the ``op_id`` segment so a
+    colon-prefixed natural key (``"GET:/api/v1/group-0/0"``) survives
+    URL routing intact.
+    """
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.patch(
+            "/api/v1/connectors/vmware-rest-9.0/operations/GET:/api/v1/group-0/0",
+            json={"safety_level": "dangerous", "requires_approval": True},
+            headers=_authed(token),
+        )
+    assert response.status_code == 204
+    audit_count = await _audit_row_count(op_id="meho.connector.edit_op")
+    assert audit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_edit_op_invalid_safety_level_returns_422(
+    client: TestClient,
+) -> None:
+    """``safety_level`` outside the enum → 422 (Pydantic-level rejection)."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.patch(
+            "/api/v1/connectors/vmware-rest-9.0/operations/GET:/api/v1/group-0/0",
+            json={"safety_level": "nuclear"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /{id}/enable + POST /{id}/disable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enable_transitions_all_groups_and_cascades(
+    client: TestClient,
+) -> None:
+    """POST /enable transitions every group to ``enabled`` + cascades ops."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/vmware-rest-9.0/enable",
+            headers=_authed(token),
+        )
+    assert response.status_code == 204
+    statuses = await _group_statuses(tenant_id=tenant_a)
+    assert set(statuses.values()) == {"enabled"}
+    audit_count = await _audit_row_count(op_id="meho.connector.enable")
+    assert audit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_enable_is_idempotent(client: TestClient) -> None:
+    """Second POST /enable writes no additional audit row."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a, review_status="enabled", op_is_enabled=True)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/vmware-rest-9.0/enable",
+            headers=_authed(token),
+        )
+    assert response.status_code == 204
+    audit_count = await _audit_row_count(op_id="meho.connector.enable")
+    assert audit_count == 0
+
+
+@pytest.mark.asyncio
+async def test_disable_transitions_and_writes_audit_row(
+    client: TestClient,
+) -> None:
+    """POST /disable transitions every group to ``disabled``."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a, review_status="enabled", op_is_enabled=True)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/vmware-rest-9.0/disable",
+            headers=_authed(token),
+        )
+    assert response.status_code == 204
+    statuses = await _group_statuses(tenant_id=tenant_a)
+    assert set(statuses.values()) == {"disabled"}
+    audit_count = await _audit_row_count(op_id="meho.connector.disable")
+    assert audit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_enable_cross_tenant_returns_404(client: TestClient) -> None:
+    """Cross-tenant enable → 404 (and no state changes leak to the other tenant)."""
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_b)
+    key, token = _admin_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/vmware-rest-9.0/enable",
+            headers=_authed(token),
+        )
+    assert response.status_code == 404
+    # tenant_b's connector untouched
+    statuses = await _group_statuses(tenant_id=tenant_b)
+    assert set(statuses.values()) == {"staged"}
+
+
+# ---------------------------------------------------------------------------
+# POST /ingest happy path
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_returns_503_when_llm_client_unavailable(
+    client: TestClient,
+    tmp_path: Any,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """No LLM-client factory wired → 503 from the route's mapper.
+
+    The stub embedding service is injected so the parse + register
+    phases run without hitting the network; the unmocked LLM client
+    factory is what triggers the 503.
+    """
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: t
+  version: '1'
+paths:
+  /items:
+    get:
+      summary: list items
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    key, token = _admin_token()
+    with (
+        respx.mock as mock_router,
+        patch(
+            "meho_backplane.operations.ingest._upsert.encode_endpoint_text",
+            AsyncMock(return_value=[0.25] * 384),
+        ),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "test",
+                "version": "1.0",
+                "impl_id": "test-impl",
+                "specs": [{"uri": str(spec_path)}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 503
+    assert "LLM client" in response.json()["detail"]
+
+
+def test_ingest_dry_run_returns_parse_counts_without_writes(
+    client: TestClient, tmp_path: Any
+) -> None:
+    """``dry_run=true`` parses the spec but does not write or run the LLM."""
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: t
+  version: '1'
+paths:
+  /items:
+    get:
+      summary: list items
+      responses:
+        '200':
+          description: ok
+  /items/{id}:
+    get:
+      summary: get item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "test",
+                "version": "1.0",
+                "impl_id": "test-impl",
+                "specs": [{"uri": str(spec_path)}],
+                "dry_run": True,
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ingestion"]["inserted_count"] == 2
+    assert body["ingestion"]["connector_registered"] is False
+    assert body["grouping"] is None
+
+
+def test_ingest_happy_path_runs_full_pipeline(
+    client: TestClient,
+    tmp_path: Any,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """End-to-end: parse + register + group all run; response carries both
+    blocks.
+
+    The LLM client is stubbed via :func:`set_llm_client_factory` so
+    the grouping pass doesn't need a real Anthropic key; the
+    embedding pipeline is patched at the leaf
+    :func:`encode_endpoint_text` site so the test doesn't pull
+    fastembed from the network.
+    """
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: t
+  version: '1'
+paths:
+  /items:
+    get:
+      summary: list items
+      responses:
+        '200':
+          description: ok
+  /items/{id}:
+    get:
+      summary: get item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    propose_json = (
+        '[{"group_key": "items", "name": "Items", '
+        '"when_to_use": "Use these operations to manage items."}]'
+    )
+    assign_json = '{"GET:/items": "items", "GET:/items/{id}": "items"}'
+    set_llm_client_factory(
+        lambda: _StubLlmClient(
+            propose_response=propose_json,
+            assign_response=assign_json,
+        ),
+    )
+
+    key, token = _admin_token()
+    with (
+        respx.mock as mock_router,
+        patch(
+            "meho_backplane.operations.ingest._upsert.encode_endpoint_text",
+            AsyncMock(return_value=[0.25] * 384),
+        ),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "test",
+                "version": "1.0",
+                "impl_id": "test-impl",
+                "specs": [{"uri": str(spec_path)}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ingestion"]["inserted_count"] == 2
+    # connector_registered may be False when a prior test (503-path)
+    # already auto-registered the shim against the module-level
+    # connectors registry; the v2 registry is process-global. The
+    # load-bearing assertion is that the pipeline returned 200 with
+    # the grouping pass populated.
+    grouping = body["grouping"]
+    assert grouping is not None
+    assert grouping["groups_created"] == 1
+    assert grouping["operations_assigned"] == 2
+
+
+def test_ingest_bad_spec_returns_400(client: TestClient, tmp_path: Any) -> None:
+    """Unparseable spec → 400 from the InvalidSpecError mapper."""
+    spec_path = tmp_path / "bad.yaml"
+    spec_path.write_text("not: a: valid spec")
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "test",
+                "version": "1.0",
+                "impl_id": "test-impl",
+                "specs": [{"uri": str(spec_path)}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# set_llm_client_factory contract
+# ---------------------------------------------------------------------------
+
+
+def test_set_llm_client_factory_returns_previous_and_restores(
+    client: TestClient,
+) -> None:
+    """The factory setter returns the previous value so callers can restore."""
+
+    def custom_factory() -> LlmClient:  # type: ignore[empty-body]
+        ...  # never called in this test
+
+    previous = set_llm_client_factory(custom_factory)
+    assert previous is _default_llm_client_factory
+    restored = set_llm_client_factory(previous)
+    assert restored is custom_factory
+
+
+# Silence unused-import lints on test seams reserved for sibling tasks.
+_ = (AsyncMock, patch, GroupingResult, IngestionResult)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -981,6 +981,403 @@
         }
       }
     },
+    "/api/v1/connectors/ingest": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Ingest Endpoint",
+        "description": "Run the full ingestion pipeline (T1 \u2192 T2 \u2192 T3) for one connector.\n\n``dry_run=true`` parses every spec but writes nothing; the\nresponse carries the parser's ``inserted_count`` projection and\n``grouping=None``. The real path runs the parse \u2192 register_\ningested \u2192 run_llm_grouping pipeline serially and returns the\naggregated counts + grouping result.\n\nTenant scoping: the operator's tenant_id from the JWT is used\nas the write scope unless the operator is ``tenant_admin``\n(built-in ingest, ``tenant_id=NULL``). For v0.2 the route always\nwrites under the operator's tenant_id; built-in ingest is the\nsame call shape from a tenant_admin operator whose tenant_id\nhappens to be the \"built-in\" admin tenant. The CLI / MCP\nsiblings can target the built-in scope explicitly when needed\nby hitting :class:`IngestionPipelineService` directly with\n``tenant_id=None``.",
+        "operationId": "ingest_endpoint_api_v1_connectors_ingest_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connectors": {
+      "get": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "List Endpoint",
+        "description": "List ingested connectors visible to the operator.\n\nVisibility scope (per\n:func:`list_ingested_connectors`): operator's-tenant rows +\nbuilt-ins. The optional ``status`` filter narrows by aggregated\nreview status; ``all`` (or omission) returns everything.\n\nThe response is wrapped in ``{\"connectors\": [...]}`` so future\npaging / cursor fields can land non-breakingly. The route\nserialises through :meth:`ConnectorListResponse.model_dump`\nrather than annotating ``response_model=ConnectorListResponse``\nbecause the per-item ``tenant_id`` UUID needs to render as a\nstring in the JSON (the default Pydantic-v2 serialiser\nhandles this).",
+        "operationId": "list_endpoint_api_v1_connectors_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "staged",
+                "enabled",
+                "disabled",
+                "all"
+              ],
+              "type": "string",
+              "nullable": true,
+              "title": "Status"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "title": "Response List Endpoint Api V1 Connectors Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connectors/{connector_id}/review": {
+      "get": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Get Review Endpoint",
+        "description": "Return the full review payload for *connector_id*.\n\nOperator-level read: any operator can inspect a connector their\ntenant owns plus built-ins. Editing the payload requires\n``tenant_admin`` via the PATCH routes. Cross-tenant /\nnon-existent connector \u2192 404 (the deliberate conflation).",
+        "operationId": "get_review_endpoint_api_v1_connectors__connector_id__review_get",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorReviewPayload"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connectors/{connector_id}/groups/{group_key}": {
+      "patch": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Edit Group Endpoint",
+        "description": "Edit a group's ``when_to_use`` / ``name`` overrides.\n\nAt least one of the two body fields must be set; an empty body\nyields 400. Writes one ``meho.connector.edit_group`` audit row\nvia the service layer. Returns 204 on success.",
+        "operationId": "edit_group_endpoint_api_v1_connectors__connector_id__groups__group_key__patch",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "group_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Group Key"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditGroupBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connectors/{connector_id}/operations/{op_id}": {
+      "patch": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Edit Op Endpoint",
+        "description": "Edit a per-op operator override.\n\nAt least one of ``custom_description`` / ``safety_level`` /\n``requires_approval`` / ``is_enabled`` must be set; an empty\nbody yields 400. Writes one ``meho.connector.edit_op`` audit\nrow. Returns 204 on success.\n\nThe ``op_id`` path parameter uses the ``:path`` converter so\noperations whose natural key contains slashes\n(``\"GET:/api/vcenter/cluster\"``) round-trip without\nURL-encoding the colon-prefixed path segment.",
+        "operationId": "edit_op_endpoint_api_v1_connectors__connector_id__operations__op_id__patch",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "op_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Op Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditOpBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connectors/{connector_id}/enable": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Enable Endpoint",
+        "description": "Transition every group in *connector_id* to ``enabled``.\n\nIdempotent: a re-call against a fully-enabled connector writes\nno audit row and returns 204. State-machine guards apply (see\n:meth:`ReviewService.enable_connector`); a forbidden source\nstate yields 409.",
+        "operationId": "enable_endpoint_api_v1_connectors__connector_id__enable_post",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connectors/{connector_id}/disable": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Disable Endpoint",
+        "description": "Transition every group in *connector_id* to ``disabled``.\n\nIdempotent and state-machine-guarded \u2014 same shape as the enable\nhandler.",
+        "operationId": "disable_endpoint_api_v1_connectors__connector_id__disable_post",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/.well-known/oauth-protected-resource": {
       "get": {
         "tags": [
@@ -1151,6 +1548,152 @@
         "title": "CallOperationBody",
         "description": "Request body for the ``POST /api/v1/operations/call`` route.\n\nMirrors the :func:`call_operation` ``arguments`` shape so the route\nand the MCP handler share validation. ``target`` is a partial\ndescriptor (``{\"name\": \"rdc-vcenter\"}``) the handler resolves via\n:func:`~meho_backplane.targets.resolver.resolve_target`; ``None``\nmeans the operation does not need a target (typed handlers that\ndon't read it; composite handlers that do their own resolution)."
       },
+      "ConnectorReviewGroup": {
+        "properties": {
+          "group_key": {
+            "type": "string",
+            "title": "Group Key"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "when_to_use": {
+            "type": "string",
+            "title": "When To Use"
+          },
+          "review_status": {
+            "type": "string",
+            "title": "Review Status"
+          },
+          "op_count": {
+            "type": "integer",
+            "title": "Op Count"
+          },
+          "ops": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorReviewOp"
+            },
+            "type": "array",
+            "title": "Ops"
+          }
+        },
+        "type": "object",
+        "required": [
+          "group_key",
+          "name",
+          "when_to_use",
+          "review_status",
+          "op_count",
+          "ops"
+        ],
+        "title": "ConnectorReviewGroup",
+        "description": "One group within the review payload.\n\nCarries the LLM-generated group metadata\n(``group_key``, ``name``, ``when_to_use``), the current\n``review_status``, and the full list of child operations. The\noperator-facing review UI iterates this list to render the\nreview queue; ``op_count`` is the cheap precomputed length for\nthe CLI's ``meho connector review`` summary view (T5)."
+      },
+      "ConnectorReviewOp": {
+        "properties": {
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "summary": {
+            "type": "string",
+            "nullable": true,
+            "title": "Summary"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "title": "Description"
+          },
+          "custom_description": {
+            "type": "string",
+            "nullable": true,
+            "title": "Custom Description"
+          },
+          "safety_level": {
+            "type": "string",
+            "title": "Safety Level"
+          },
+          "requires_approval": {
+            "type": "boolean",
+            "title": "Requires Approval"
+          },
+          "is_enabled": {
+            "type": "boolean",
+            "title": "Is Enabled"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "op_id",
+          "summary",
+          "description",
+          "custom_description",
+          "safety_level",
+          "requires_approval",
+          "is_enabled",
+          "tags"
+        ],
+        "title": "ConnectorReviewOp",
+        "description": "One operation within a group, as rendered in the review payload.\n\nCarries the operator-relevant subset of\n:class:`~meho_backplane.db.models.EndpointDescriptor`: the\nidentifiers (``op_id``), the descriptive fields (``summary``,\n``description``, ``custom_description``), the policy hooks\n(``safety_level``, ``requires_approval``), the dispatchability\nflag (``is_enabled``), and the ``tags`` array. Notably **omits**\n``parameter_schema`` / ``response_schema`` / ``embedding`` \u2014\nthose are dispatch-time concerns, not review-time concerns, and\nsending 4 KB of schema per op would balloon the review payload\nfor connectors with thousands of operations (vCenter has 961\npaths in v0.2)."
+      },
+      "ConnectorReviewPayload": {
+        "properties": {
+          "connector_id": {
+            "type": "string",
+            "title": "Connector Id"
+          },
+          "product": {
+            "type": "string",
+            "title": "Product"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "impl_id": {
+            "type": "string",
+            "title": "Impl Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Tenant Id"
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorReviewGroup"
+            },
+            "type": "array",
+            "title": "Groups"
+          },
+          "total_op_count": {
+            "type": "integer",
+            "title": "Total Op Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connector_id",
+          "product",
+          "version",
+          "impl_id",
+          "tenant_id",
+          "groups",
+          "total_op_count"
+        ],
+        "title": "ConnectorReviewPayload",
+        "description": "Top-level review payload returned by :meth:`ReviewService.get_review_payload`.\n\n``connector_id`` is the operator-facing string the request\ntargeted (echoed back verbatim for round-trip clarity).\n``product`` / ``version`` / ``impl_id`` are the parsed triple\nderived via\n:func:`~meho_backplane.operations.ingest.parser.parse_connector_id`;\nthe CLI / API layers surface them in operator output so the\nconvention is self-documenting. ``tenant_id`` is the scope the\npayload was queried under (``None`` for built-in)."
+      },
       "DailyUsageBucket": {
         "properties": {
           "date": {
@@ -1205,6 +1748,61 @@
         ],
         "title": "DbStatus",
         "description": "Database migration status.\n\n``migrated`` is ``True`` when the DB-migration-state probe reports\nhealthy (current Alembic revision matches head), ``False`` when\nthe probe reports unhealthy for any reason (DB unreachable,\nrevision diverged, ``alembic_version`` table absent). v0.1 ships\nno opinions on retry / repair \u2014 operators see the probe's\n``detail`` string on the ``/ready`` payload (and downstream tooling\nin T29 enforces the migration-runner contract). The field stays\n``bool | None`` for forward compatibility with response decoders\nthat were generated against the chassis-stage shape, but the\nhandler now always populates it from the probe."
+      },
+      "EditGroupBody": {
+        "properties": {
+          "when_to_use": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 1,
+            "nullable": true,
+            "title": "When To Use"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "nullable": true,
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "title": "EditGroupBody",
+        "description": "PATCH body for ``/api/v1/connectors/{id}/groups/{key}``.\n\nBoth fields optional but at least one must be set; the route\nlayer translates \"neither set\" into a 400. ``when_to_use`` is\nthe load-bearing operator-authored prose the LLM proposed at\ngrouping time; ``name`` is the Title Case display name.\n\nPydantic-side ``max_length`` caps line up with the underlying\n:class:`OperationGroup.when_to_use` /\n:class:`OperationGroup.name` columns. Empty strings are\nrejected \u2014 operators that want to \"clear\" the field should\nre-run grouping rather than blank it."
+      },
+      "EditOpBody": {
+        "properties": {
+          "custom_description": {
+            "type": "string",
+            "maxLength": 4096,
+            "minLength": 1,
+            "nullable": true,
+            "title": "Custom Description"
+          },
+          "safety_level": {
+            "type": "string",
+            "enum": [
+              "safe",
+              "caution",
+              "dangerous"
+            ],
+            "nullable": true,
+            "title": "Safety Level"
+          },
+          "requires_approval": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Requires Approval"
+          },
+          "is_enabled": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Is Enabled"
+          }
+        },
+        "type": "object",
+        "title": "EditOpBody",
+        "description": "PATCH body for ``/api/v1/connectors/{id}/operations/{op_id}``.\n\nPer-op operator overrides. At least one field must be set.\n\n``safety_level`` is the bounded enum from\n:class:`~meho_backplane.db.models.EndpointDescriptor.safety_level`\n(``safe`` / ``caution`` / ``dangerous``); a value outside the set\nis rejected by Pydantic before the service layer sees it.\n\n``is_enabled`` is the per-op override that wins over the group\ncascade (see :meth:`ReviewService.edit_op` for the full\nsemantics). ``requires_approval`` flips the per-op flag that\nforces the dispatcher to write an audit row in\n``status='pending'`` and wait for an operator decision before\nexecuting.\n\n``custom_description`` is the operator's free-form override\nthat the agent surfaces in place of the upstream spec's\n``description`` field; capped at 4096 chars to keep audit-log\npayloads bounded."
       },
       "EvalRequest": {
         "properties": {
@@ -1322,6 +1920,45 @@
         "title": "FingerprintResult",
         "description": "Connector fingerprint per consumer-needs L95."
       },
+      "GroupingResultModel": {
+        "properties": {
+          "connector_id": {
+            "type": "string",
+            "title": "Connector Id"
+          },
+          "groups_created": {
+            "type": "integer",
+            "title": "Groups Created"
+          },
+          "operations_assigned": {
+            "type": "integer",
+            "title": "Operations Assigned"
+          },
+          "operations_unassigned": {
+            "type": "integer",
+            "title": "Operations Unassigned"
+          },
+          "llm_call_count": {
+            "type": "integer",
+            "title": "Llm Call Count"
+          },
+          "llm_duration_ms": {
+            "type": "number",
+            "title": "Llm Duration Ms"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connector_id",
+          "groups_created",
+          "operations_assigned",
+          "operations_unassigned",
+          "llm_call_count",
+          "llm_duration_ms"
+        ],
+        "title": "GroupingResultModel",
+        "description": "Pydantic projection of\n:class:`~meho_backplane.operations.ingest.llm_groups.GroupingResult`.\n\nMirrors the dataclass; rendered alongside :class:`IngestionResultModel`\nin the ingest response so the operator sees both counts."
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -1355,6 +1992,113 @@
         ],
         "title": "HealthResponse",
         "description": "``GET /api/v1/health`` response body."
+      },
+      "IngestRequest": {
+        "properties": {
+          "product": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Product"
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Version"
+          },
+          "impl_id": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Impl Id"
+          },
+          "specs": {
+            "items": {
+              "$ref": "#/components/schemas/SpecSource"
+            },
+            "type": "array",
+            "maxItems": 16,
+            "minItems": 1,
+            "title": "Specs"
+          },
+          "base_url": {
+            "type": "string",
+            "maxLength": 2048,
+            "nullable": true,
+            "title": "Base Url"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "product",
+          "version",
+          "impl_id",
+          "specs"
+        ],
+        "title": "IngestRequest",
+        "description": "POST body for ``/api/v1/connectors/ingest``.\n\nDrives a full pipeline run: parse every spec in *specs*, call\n:func:`register_ingested_operations` once per spec under the same\n``(product, version, impl_id)`` connector triple, then run\n:func:`run_llm_grouping` once for the whole connector. Multi-spec\ningestion (vCenter's ``vcenter.yaml`` + ``vi-json.yaml``) lands as\nmultiple ``SpecSource`` entries in one request.\n\n``dry_run=True`` skips both the DB writes and the grouping pass:\nonly :func:`parse_openapi` runs, and the response carries\n:class:`IngestionResultModel` counts derived from the parse output\nplus ``grouping=None``. Operators use the dry-run path to validate\na spec before committing.\n\n``base_url`` is the optional default base URL for the auto-\nregistered :class:`GenericRestConnector` shim; ``None`` leaves\nthe shim unconfigured (the connector's eventual hand-coded\nsubclass at G3.x will set its own base URL)."
+      },
+      "IngestResponse": {
+        "properties": {
+          "ingestion": {
+            "$ref": "#/components/schemas/IngestionResultModel"
+          },
+          "grouping": {
+            "$ref": "#/components/schemas/GroupingResultModel",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "ingestion"
+        ],
+        "title": "IngestResponse",
+        "description": "Response shape for ``POST /api/v1/connectors/ingest``.\n\n``ingestion`` is always present. ``grouping`` is ``None`` for the\ndry-run path (no DB writes, no LLM call) and for the no-op\nre-run path (every op already grouped from a prior pass).\n\nThe response carries no audit_log id explicitly \u2014 the chassis\naudit middleware writes one row per HTTP request with the route\npath bound, and the service-level helpers\n(:func:`register_ingested_operations`, :func:`run_llm_grouping`)\nwrite their own per-call rows under\n``meho.connector.llm_grouping`` etc."
+      },
+      "IngestionResultModel": {
+        "properties": {
+          "connector_id": {
+            "type": "string",
+            "title": "Connector Id"
+          },
+          "inserted_count": {
+            "type": "integer",
+            "title": "Inserted Count"
+          },
+          "updated_count": {
+            "type": "integer",
+            "title": "Updated Count"
+          },
+          "skipped_count": {
+            "type": "integer",
+            "title": "Skipped Count"
+          },
+          "connector_registered": {
+            "type": "boolean",
+            "title": "Connector Registered"
+          },
+          "operations_grouped": {
+            "type": "boolean",
+            "title": "Operations Grouped"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connector_id",
+          "inserted_count",
+          "updated_count",
+          "skipped_count",
+          "connector_registered",
+          "operations_grouped"
+        ],
+        "title": "IngestionResultModel",
+        "description": "Pydantic projection of\n:class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`.\n\nThe dataclass lives in :mod:`register_ingested` so the helper\ncan stay framework-agnostic; this model is the wire-format twin\nthe routes return. Fields mirror the dataclass one-for-one with\nan extra ``connector_id`` echo for round-trip clarity."
       },
       "OperationDescriptor": {
         "properties": {
@@ -1727,6 +2471,22 @@
         ],
         "title": "RetrieveResponse",
         "description": "Successful response shape for ``/api/v1/retrieve``.\n\n``query_duration_ms`` is the wall-clock time from request entry\nto response build (covers both the embedding compute and the two\nSQL round-trips); operators tuning embedding-model choice or\ndebugging retrieval latency consume this value. Frozen so a\nhandler accidentally mutating it post-construction surfaces as a\npydantic error rather than a silently-modified response."
+      },
+      "SpecSource": {
+        "properties": {
+          "uri": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Uri"
+          }
+        },
+        "type": "object",
+        "required": [
+          "uri"
+        ],
+        "title": "SpecSource",
+        "description": "One spec to ingest under a connector triple.\n\n``uri`` carries the operator's spec identifier. Three forms are\naccepted by the underlying :func:`parse_openapi` resolver:\n\n* Absolute local path \u2014 ``/abs/path/to/spec.yaml``.\n* HTTP(S) URL \u2014 ``https://api.example.com/openapi.yaml``.\n* ``docs:<connector-id>/<file>`` shorthand \u2014 resolves against the\n  consumer's checked-in docs/ directory; CLI / API layers expand\n  this before calling the parser.\n\nWrapped in its own model so future per-spec knobs (auth headers,\ndialect pinning, content-type override) can land without\nreshaping :class:`IngestRequest`."
       },
       "SurfaceResult": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -25,6 +25,72 @@ const (
 	SharedServiceAccount AuthModel = "shared_service_account"
 )
 
+// Defines values for DailyUsageBucketSurface.
+const (
+	DailyUsageBucketSurfaceKb         DailyUsageBucketSurface = "kb"
+	DailyUsageBucketSurfaceMemory     DailyUsageBucketSurface = "memory"
+	DailyUsageBucketSurfaceOperations DailyUsageBucketSurface = "operations"
+)
+
+// Defines values for EditOpBodySafetyLevel.
+const (
+	Caution   EditOpBodySafetyLevel = "caution"
+	Dangerous EditOpBodySafetyLevel = "dangerous"
+	Safe      EditOpBodySafetyLevel = "safe"
+)
+
+// Defines values for EvalRequestSurface.
+const (
+	EvalRequestSurfaceAll        EvalRequestSurface = "all"
+	EvalRequestSurfaceKb         EvalRequestSurface = "kb"
+	EvalRequestSurfaceMemory     EvalRequestSurface = "memory"
+	EvalRequestSurfaceOperations EvalRequestSurface = "operations"
+)
+
+// Defines values for EvalResultOverallVerdict.
+const (
+	EvalResultOverallVerdictGreen  EvalResultOverallVerdict = "green"
+	EvalResultOverallVerdictRed    EvalResultOverallVerdict = "red"
+	EvalResultOverallVerdictYellow EvalResultOverallVerdict = "yellow"
+)
+
+// Defines values for SurfaceResultBaselineVerdict.
+const (
+	SurfaceResultBaselineVerdictGreen  SurfaceResultBaselineVerdict = "green"
+	SurfaceResultBaselineVerdictRed    SurfaceResultBaselineVerdict = "red"
+	SurfaceResultBaselineVerdictYellow SurfaceResultBaselineVerdict = "yellow"
+)
+
+// Defines values for SurfaceResultSurface.
+const (
+	SurfaceResultSurfaceKb         SurfaceResultSurface = "kb"
+	SurfaceResultSurfaceMemory     SurfaceResultSurface = "memory"
+	SurfaceResultSurfaceOperations SurfaceResultSurface = "operations"
+)
+
+// Defines values for SurfaceResultVerdict.
+const (
+	Green  SurfaceResultVerdict = "green"
+	Red    SurfaceResultVerdict = "red"
+	Yellow SurfaceResultVerdict = "yellow"
+)
+
+// Defines values for ListEndpointApiV1ConnectorsGetParamsStatus.
+const (
+	All      ListEndpointApiV1ConnectorsGetParamsStatus = "all"
+	Disabled ListEndpointApiV1ConnectorsGetParamsStatus = "disabled"
+	Enabled  ListEndpointApiV1ConnectorsGetParamsStatus = "enabled"
+	Staged   ListEndpointApiV1ConnectorsGetParamsStatus = "staged"
+)
+
+// Defines values for UsageEndpointApiV1RetrieveUsageGetParamsSurface.
+const (
+	UsageEndpointApiV1RetrieveUsageGetParamsSurfaceAll        UsageEndpointApiV1RetrieveUsageGetParamsSurface = "all"
+	UsageEndpointApiV1RetrieveUsageGetParamsSurfaceKb         UsageEndpointApiV1RetrieveUsageGetParamsSurface = "kb"
+	UsageEndpointApiV1RetrieveUsageGetParamsSurfaceMemory     UsageEndpointApiV1RetrieveUsageGetParamsSurface = "memory"
+	UsageEndpointApiV1RetrieveUsageGetParamsSurfaceOperations UsageEndpointApiV1RetrieveUsageGetParamsSurface = "operations"
+)
+
 // AuthConfigResponse OAuth discovery surface returned to “meho login“.
 //
 // Field names match the CLI's expected JSON keys (“keycloak_issuer“
@@ -52,6 +118,85 @@ type CallOperationBody struct {
 	Target      *map[string]interface{} `json:"target"`
 }
 
+// ConnectorReviewGroup One group within the review payload.
+//
+// Carries the LLM-generated group metadata
+// (“group_key“, “name“, “when_to_use“), the current
+// “review_status“, and the full list of child operations. The
+// operator-facing review UI iterates this list to render the
+// review queue; “op_count“ is the cheap precomputed length for
+// the CLI's “meho connector review“ summary view (T5).
+type ConnectorReviewGroup struct {
+	GroupKey     string              `json:"group_key"`
+	Name         string              `json:"name"`
+	OpCount      int                 `json:"op_count"`
+	Ops          []ConnectorReviewOp `json:"ops"`
+	ReviewStatus string              `json:"review_status"`
+	WhenToUse    string              `json:"when_to_use"`
+}
+
+// ConnectorReviewOp One operation within a group, as rendered in the review payload.
+//
+// Carries the operator-relevant subset of
+// :class:`~meho_backplane.db.models.EndpointDescriptor`: the
+// identifiers (“op_id“), the descriptive fields (“summary“,
+// “description“, “custom_description“), the policy hooks
+// (“safety_level“, “requires_approval“), the dispatchability
+// flag (“is_enabled“), and the “tags“ array. Notably **omits**
+// “parameter_schema“ / “response_schema“ / “embedding“ —
+// those are dispatch-time concerns, not review-time concerns, and
+// sending 4 KB of schema per op would balloon the review payload
+// for connectors with thousands of operations (vCenter has 961
+// paths in v0.2).
+type ConnectorReviewOp struct {
+	CustomDescription *string  `json:"custom_description"`
+	Description       *string  `json:"description"`
+	IsEnabled         bool     `json:"is_enabled"`
+	OpId              string   `json:"op_id"`
+	RequiresApproval  bool     `json:"requires_approval"`
+	SafetyLevel       string   `json:"safety_level"`
+	Summary           *string  `json:"summary"`
+	Tags              []string `json:"tags"`
+}
+
+// ConnectorReviewPayload Top-level review payload returned by :meth:`ReviewService.get_review_payload`.
+//
+// “connector_id“ is the operator-facing string the request
+// targeted (echoed back verbatim for round-trip clarity).
+// “product“ / “version“ / “impl_id“ are the parsed triple
+// derived via
+// :func:`~meho_backplane.operations.ingest.parser.parse_connector_id`;
+// the CLI / API layers surface them in operator output so the
+// convention is self-documenting. “tenant_id“ is the scope the
+// payload was queried under (“None“ for built-in).
+type ConnectorReviewPayload struct {
+	ConnectorId  string                 `json:"connector_id"`
+	Groups       []ConnectorReviewGroup `json:"groups"`
+	ImplId       string                 `json:"impl_id"`
+	Product      string                 `json:"product"`
+	TenantId     *openapi_types.UUID    `json:"tenant_id"`
+	TotalOpCount int                    `json:"total_op_count"`
+	Version      string                 `json:"version"`
+}
+
+// DailyUsageBucket One “(date, surface)“ row of the usage report.
+//
+// Frozen so callers (CLI table renderer, “--json“ consumers,
+// Markdown report generators) can pass instances around without
+// accidental mutation. “action_conversion_pct“ is rounded to two
+// decimals at construction time so JSON serialisation is stable
+// across runs.
+type DailyUsageBucket struct {
+	ActionConversionPct float32                 `json:"action_conversion_pct"`
+	Date                openapi_types.Date      `json:"date"`
+	DistinctOperators   int                     `json:"distinct_operators"`
+	SearchCount         int                     `json:"search_count"`
+	Surface             DailyUsageBucketSurface `json:"surface"`
+}
+
+// DailyUsageBucketSurface defines model for DailyUsageBucket.Surface.
+type DailyUsageBucketSurface string
+
 // DbStatus Database migration status.
 //
 // “migrated“ is “True“ when the DB-migration-state probe reports
@@ -66,6 +211,125 @@ type CallOperationBody struct {
 // handler now always populates it from the probe.
 type DbStatus struct {
 	Migrated *bool `json:"migrated"`
+}
+
+// EditGroupBody PATCH body for “/api/v1/connectors/{id}/groups/{key}“.
+//
+// Both fields optional but at least one must be set; the route
+// layer translates "neither set" into a 400. “when_to_use“ is
+// the load-bearing operator-authored prose the LLM proposed at
+// grouping time; “name“ is the Title Case display name.
+//
+// Pydantic-side “max_length“ caps line up with the underlying
+// :class:`OperationGroup.when_to_use` /
+// :class:`OperationGroup.name` columns. Empty strings are
+// rejected — operators that want to "clear" the field should
+// re-run grouping rather than blank it.
+type EditGroupBody struct {
+	Name      *string `json:"name"`
+	WhenToUse *string `json:"when_to_use"`
+}
+
+// EditOpBody PATCH body for “/api/v1/connectors/{id}/operations/{op_id}“.
+//
+// Per-op operator overrides. At least one field must be set.
+//
+// “safety_level“ is the bounded enum from
+// :class:`~meho_backplane.db.models.EndpointDescriptor.safety_level`
+// (“safe“ / “caution“ / “dangerous“); a value outside the set
+// is rejected by Pydantic before the service layer sees it.
+//
+// “is_enabled“ is the per-op override that wins over the group
+// cascade (see :meth:`ReviewService.edit_op` for the full
+// semantics). “requires_approval“ flips the per-op flag that
+// forces the dispatcher to write an audit row in
+// “status='pending'“ and wait for an operator decision before
+// executing.
+//
+// “custom_description“ is the operator's free-form override
+// that the agent surfaces in place of the upstream spec's
+// “description“ field; capped at 4096 chars to keep audit-log
+// payloads bounded.
+type EditOpBody struct {
+	CustomDescription *string                `json:"custom_description"`
+	IsEnabled         *bool                  `json:"is_enabled"`
+	RequiresApproval  *bool                  `json:"requires_approval"`
+	SafetyLevel       *EditOpBodySafetyLevel `json:"safety_level"`
+}
+
+// EditOpBodySafetyLevel defines model for EditOpBody.SafetyLevel.
+type EditOpBodySafetyLevel string
+
+// EvalRequest POST body for “/api/v1/retrieve/eval“.
+//
+// Frozen + extra=forbid so a typo (“surfaces“ instead of
+// “surface“) fails 422 at the framework boundary rather than
+// silently running the default surface and giving the caller a
+// confusing "I asked for memory, why did kb run?" response.
+type EvalRequest struct {
+	Baseline *string             `json:"baseline"`
+	Surface  *EvalRequestSurface `json:"surface,omitempty"`
+}
+
+// EvalRequestSurface defines model for EvalRequest.Surface.
+type EvalRequestSurface string
+
+// EvalResult Top-level eval result — the shape the API + CLI return.
+//
+// “overall_verdict“ is the worst-of every surface (a red surface
+// flips the whole result red); the CLI's exit-1-on-red CI-gate
+// semantics key off this field. “ran_at“ is the UTC timestamp
+// the runner started; consumers comparing two saved baselines see
+// when each was captured.
+type EvalResult struct {
+	OverallVerdict EvalResultOverallVerdict `json:"overall_verdict"`
+	RanAt          time.Time                `json:"ran_at"`
+	Surfaces       []SurfaceResult          `json:"surfaces"`
+
+	// Thresholds Per-metric green-band thresholds for a verdict computation.
+	//
+	// Frozen so the threshold object passed into :func:`verdict` cannot
+	// be mutated mid-run (a stale or rewritten threshold mid-eval would
+	// invalidate every subsequent verdict and silently shift the CI
+	// gate). The yellow floor is derived from :data:`YELLOW_FLOOR_RATIO`,
+	// not stored — keeping it derived means the contract "yellow is 70%
+	// of green" can't drift between green-threshold customisation and
+	// the yellow boundary.
+	//
+	// Defaults match the Initiative #373 / Task #441 contract; tests and
+	// future re-tunings construct ``Thresholds(...)`` with explicit
+	// values.
+	Thresholds *Thresholds `json:"thresholds,omitempty"`
+}
+
+// EvalResultOverallVerdict defines model for EvalResult.OverallVerdict.
+type EvalResultOverallVerdict string
+
+// FingerprintResult Connector fingerprint per consumer-needs L95.
+type FingerprintResult struct {
+	Build       *string                 `json:"build"`
+	Edition     *string                 `json:"edition"`
+	Extras      *map[string]interface{} `json:"extras,omitempty"`
+	ProbeMethod string                  `json:"probe_method"`
+	ProbedAt    time.Time               `json:"probed_at"`
+	Product     string                  `json:"product"`
+	Reachable   bool                    `json:"reachable"`
+	Vendor      string                  `json:"vendor"`
+	Version     *string                 `json:"version"`
+}
+
+// GroupingResultModel Pydantic projection of
+// :class:`~meho_backplane.operations.ingest.llm_groups.GroupingResult`.
+//
+// Mirrors the dataclass; rendered alongside :class:`IngestionResultModel`
+// in the ingest response so the operator sees both counts.
+type GroupingResultModel struct {
+	ConnectorId          string  `json:"connector_id"`
+	GroupsCreated        int     `json:"groups_created"`
+	LlmCallCount         int     `json:"llm_call_count"`
+	LlmDurationMs        float32 `json:"llm_duration_ms"`
+	OperationsAssigned   int     `json:"operations_assigned"`
+	OperationsUnassigned int     `json:"operations_unassigned"`
 }
 
 // HTTPValidationError defines model for HTTPValidationError.
@@ -106,6 +370,80 @@ type HealthResponse struct {
 	Vault VaultStatus `json:"vault"`
 }
 
+// IngestRequest POST body for “/api/v1/connectors/ingest“.
+//
+// Drives a full pipeline run: parse every spec in *specs*, call
+// :func:`register_ingested_operations` once per spec under the same
+// “(product, version, impl_id)“ connector triple, then run
+// :func:`run_llm_grouping` once for the whole connector. Multi-spec
+// ingestion (vCenter's “vcenter.yaml“ + “vi-json.yaml“) lands as
+// multiple “SpecSource“ entries in one request.
+//
+// “dry_run=True“ skips both the DB writes and the grouping pass:
+// only :func:`parse_openapi` runs, and the response carries
+// :class:`IngestionResultModel` counts derived from the parse output
+// plus “grouping=None“. Operators use the dry-run path to validate
+// a spec before committing.
+//
+// “base_url“ is the optional default base URL for the auto-
+// registered :class:`GenericRestConnector` shim; “None“ leaves
+// the shim unconfigured (the connector's eventual hand-coded
+// subclass at G3.x will set its own base URL).
+type IngestRequest struct {
+	BaseUrl *string      `json:"base_url"`
+	DryRun  *bool        `json:"dry_run,omitempty"`
+	ImplId  string       `json:"impl_id"`
+	Product string       `json:"product"`
+	Specs   []SpecSource `json:"specs"`
+	Version string       `json:"version"`
+}
+
+// IngestResponse Response shape for “POST /api/v1/connectors/ingest“.
+//
+// “ingestion“ is always present. “grouping“ is “None“ for the
+// dry-run path (no DB writes, no LLM call) and for the no-op
+// re-run path (every op already grouped from a prior pass).
+//
+// The response carries no audit_log id explicitly — the chassis
+// audit middleware writes one row per HTTP request with the route
+// path bound, and the service-level helpers
+// (:func:`register_ingested_operations`, :func:`run_llm_grouping`)
+// write their own per-call rows under
+// “meho.connector.llm_grouping“ etc.
+type IngestResponse struct {
+	// Grouping Pydantic projection of
+	// :class:`~meho_backplane.operations.ingest.llm_groups.GroupingResult`.
+	//
+	// Mirrors the dataclass; rendered alongside :class:`IngestionResultModel`
+	// in the ingest response so the operator sees both counts.
+	Grouping *GroupingResultModel `json:"grouping,omitempty"`
+
+	// Ingestion Pydantic projection of
+	// :class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`.
+	//
+	// The dataclass lives in :mod:`register_ingested` so the helper
+	// can stay framework-agnostic; this model is the wire-format twin
+	// the routes return. Fields mirror the dataclass one-for-one with
+	// an extra ``connector_id`` echo for round-trip clarity.
+	Ingestion IngestionResultModel `json:"ingestion"`
+}
+
+// IngestionResultModel Pydantic projection of
+// :class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`.
+//
+// The dataclass lives in :mod:`register_ingested` so the helper
+// can stay framework-agnostic; this model is the wire-format twin
+// the routes return. Fields mirror the dataclass one-for-one with
+// an extra “connector_id“ echo for round-trip clarity.
+type IngestionResultModel struct {
+	ConnectorId         string `json:"connector_id"`
+	ConnectorRegistered bool   `json:"connector_registered"`
+	InsertedCount       int    `json:"inserted_count"`
+	OperationsGrouped   bool   `json:"operations_grouped"`
+	SkippedCount        int    `json:"skipped_count"`
+	UpdatedCount        int    `json:"updated_count"`
+}
+
 // OperationDescriptor Full :class:`~meho_backplane.db.models.EndpointDescriptor` read shape.
 //
 // Returned by :func:`describe_descriptor` (and the
@@ -141,27 +479,6 @@ type OperationDescriptor struct {
 	Version           string                  `json:"version"`
 }
 
-// OperationResult Connector op execution result.
-type OperationResult struct {
-	DurationMs float32                 `json:"duration_ms"`
-	Error      *string                 `json:"error"`
-	Extras     *map[string]interface{} `json:"extras,omitempty"`
-	OpId       string                  `json:"op_id"`
-	Result     *OperationResult_Result `json:"result"`
-	Status     string                  `json:"status"`
-}
-
-// OperationResultResult0 defines model for .
-type OperationResultResult0 map[string]interface{}
-
-// OperationResultResult1 defines model for .
-type OperationResultResult1 = []interface{}
-
-// OperationResult_Result defines model for OperationResult.Result.
-type OperationResult_Result struct {
-	union json.RawMessage
-}
-
 // OperatorIdentity Operator identity surface exposed to the CLI.
 //
 // Excludes “raw_jwt“ deliberately — the bearer token must never
@@ -173,12 +490,26 @@ type OperatorIdentity struct {
 	Sub   string  `json:"sub"`
 }
 
-// ProbeResult Lightweight reachability + auth-challenge result.
-type ProbeResult struct {
-	LatencyMs *float32  `json:"latency_ms"`
-	Ok        bool      `json:"ok"`
-	ProbedAt  time.Time `json:"probed_at"`
-	Reason    *string   `json:"reason"`
+// QueryResult Per-query eval row — what the runner produces for each corpus entry.
+//
+// “meho_hits“ is the surface-formatted top-“k“ slug list from
+// MEHO retrieval; “baseline_hits“ mirrors it for the baseline
+// when configured. The per-query metrics (precision_at_5 / mrr /
+// coverage) are computed against “meho_hits“ + the corpus's
+// expected ground truth; “baseline_*“ mirrors are populated when
+// the baseline ran. Frozen so the runner can't accidentally mutate
+// a row while folding the surface aggregate.
+type QueryResult struct {
+	BaselineCoverageAt5    *float32  `json:"baseline_coverage_at_5"`
+	BaselineHits           *[]string `json:"baseline_hits"`
+	BaselinePrecisionAt5   *float32  `json:"baseline_precision_at_5"`
+	BaselineReciprocalRank *float32  `json:"baseline_reciprocal_rank"`
+	CoverageAt5            float32   `json:"coverage_at_5"`
+	ExpectedHits           []string  `json:"expected_hits"`
+	MehoHits               []string  `json:"meho_hits"`
+	PrecisionAt5           float32   `json:"precision_at_5"`
+	Query                  string    `json:"query"`
+	ReciprocalRank         float32   `json:"reciprocal_rank"`
 }
 
 // RetrievalHit One document in a ranked retrieval response.
@@ -240,6 +571,60 @@ type RetrieveResponse struct {
 	QueryDurationMs float32        `json:"query_duration_ms"`
 }
 
+// SpecSource One spec to ingest under a connector triple.
+//
+// “uri“ carries the operator's spec identifier. Three forms are
+// accepted by the underlying :func:`parse_openapi` resolver:
+//
+//   - Absolute local path — “/abs/path/to/spec.yaml“.
+//   - HTTP(S) URL — “https://api.example.com/openapi.yaml“.
+//   - “docs:<connector-id>/<file>“ shorthand — resolves against the
+//     consumer's checked-in docs/ directory; CLI / API layers expand
+//     this before calling the parser.
+//
+// Wrapped in its own model so future per-spec knobs (auth headers,
+// dialect pinning, content-type override) can land without
+// reshaping :class:`IngestRequest`.
+type SpecSource struct {
+	Uri string `json:"uri"`
+}
+
+// SurfaceResult Per-surface aggregate: corpus-wide metrics + verdict + per-query rows.
+//
+// The verdict band is computed from the macro-mean metrics against
+// the configured :class:`Thresholds` (default
+// :data:`~meho_backplane.retrieval.eval.metrics.GREEN_DEFAULTS`). A
+// surface with “query_count == 0“ (corpus YAML hasn't shipped
+// yet) returns “verdict="green"“ deliberately — see runner.py
+// docstring.
+//
+// “baseline_verdict“ is computed only when the baseline ran;
+// “None“ otherwise. The MEHO-≥-baseline overlay applies in the
+// aggregate verdict (see runner._apply_baseline_check).
+type SurfaceResult struct {
+	BaselineCoverage     *float32                      `json:"baseline_coverage"`
+	BaselineKind         *string                       `json:"baseline_kind"`
+	BaselineMrr          *float32                      `json:"baseline_mrr"`
+	BaselinePrecisionAt5 *float32                      `json:"baseline_precision_at_5"`
+	BaselineVerdict      *SurfaceResultBaselineVerdict `json:"baseline_verdict"`
+	Coverage             float32                       `json:"coverage"`
+	Mrr                  float32                       `json:"mrr"`
+	PrecisionAt5         float32                       `json:"precision_at_5"`
+	Queries              *[]QueryResult                `json:"queries,omitempty"`
+	QueryCount           int                           `json:"query_count"`
+	Surface              SurfaceResultSurface          `json:"surface"`
+	Verdict              SurfaceResultVerdict          `json:"verdict"`
+}
+
+// SurfaceResultBaselineVerdict defines model for SurfaceResult.BaselineVerdict.
+type SurfaceResultBaselineVerdict string
+
+// SurfaceResultSurface defines model for SurfaceResult.Surface.
+type SurfaceResultSurface string
+
+// SurfaceResultVerdict defines model for SurfaceResult.Verdict.
+type SurfaceResultVerdict string
+
 // Target Full read shape — returned by GET /targets/{name} and the resolver.
 //
 // Maps 1:1 to the “targets“ table columns. Frozen so callers
@@ -250,24 +635,32 @@ type RetrieveResponse struct {
 // “Mapping[str, Any]“ so frozen instances cannot be mutated in-place
 // via list.append / dict.__setitem__ — matching the immutability contract
 // the docstring documents.
+//
+// “fingerprint“ mirrors the persisted
+// :class:`~meho_backplane.connectors.schemas.FingerprintResult` shape
+// (JSON-safe dict from “model_dump(mode='json')“) or “None“ until
+// the first successful probe. “preferred_impl_id“ is the operator's
+// optional override for the G0.6 connector-impl resolver.
 type Target struct {
 	Aliases []string `json:"aliases"`
 
 	// AuthModel Per-target identity model per v0.1-spec L447-454.
-	AuthModel   AuthModel              `json:"auth_model"`
-	CreatedAt   time.Time              `json:"created_at"`
-	Extras      map[string]interface{} `json:"extras"`
-	Fqdn        *string                `json:"fqdn"`
-	Host        string                 `json:"host"`
-	Id          openapi_types.UUID     `json:"id"`
-	Name        string                 `json:"name"`
-	Notes       *string                `json:"notes"`
-	Port        *int                   `json:"port"`
-	Product     string                 `json:"product"`
-	SecretRef   *string                `json:"secret_ref"`
-	TenantId    openapi_types.UUID     `json:"tenant_id"`
-	UpdatedAt   time.Time              `json:"updated_at"`
-	VpnRequired bool                   `json:"vpn_required"`
+	AuthModel       AuthModel               `json:"auth_model"`
+	CreatedAt       time.Time               `json:"created_at"`
+	Extras          map[string]interface{}  `json:"extras"`
+	Fingerprint     *map[string]interface{} `json:"fingerprint"`
+	Fqdn            *string                 `json:"fqdn"`
+	Host            string                  `json:"host"`
+	Id              openapi_types.UUID      `json:"id"`
+	Name            string                  `json:"name"`
+	Notes           *string                 `json:"notes"`
+	Port            *int                    `json:"port"`
+	PreferredImplId *string                 `json:"preferred_impl_id"`
+	Product         string                  `json:"product"`
+	SecretRef       *string                 `json:"secret_ref"`
+	TenantId        openapi_types.UUID      `json:"tenant_id"`
+	UpdatedAt       time.Time               `json:"updated_at"`
+	VpnRequired     bool                    `json:"vpn_required"`
 }
 
 // TargetCreate POST /api/v1/targets body.
@@ -275,20 +668,28 @@ type Target struct {
 // “name“ and “product“ are immutable after creation; to rename a
 // target, delete + re-create. “auth_model“ defaults to
 // “shared_service_account“ matching the DB column default.
+//
+// “fingerprint“ is **not** accepted — it is server-managed and only
+// written by the probe handler from the connector's response. Sending
+// “fingerprint“ in the create body raises 422 via “extra='forbid'“
+// so clients cannot seed the G0.6 resolver's tie-break input with
+// fabricated values. “preferred_impl_id“ is accepted as an optional
+// operator override.
 type TargetCreate struct {
 	Aliases *[]string `json:"aliases,omitempty"`
 
 	// AuthModel Per-target identity model per v0.1-spec L447-454.
-	AuthModel   *AuthModel              `json:"auth_model,omitempty"`
-	Extras      *map[string]interface{} `json:"extras,omitempty"`
-	Fqdn        *string                 `json:"fqdn"`
-	Host        string                  `json:"host"`
-	Name        string                  `json:"name"`
-	Notes       *string                 `json:"notes"`
-	Port        *int                    `json:"port"`
-	Product     string                  `json:"product"`
-	SecretRef   *string                 `json:"secret_ref"`
-	VpnRequired *bool                   `json:"vpn_required,omitempty"`
+	AuthModel       *AuthModel              `json:"auth_model,omitempty"`
+	Extras          *map[string]interface{} `json:"extras,omitempty"`
+	Fqdn            *string                 `json:"fqdn"`
+	Host            string                  `json:"host"`
+	Name            string                  `json:"name"`
+	Notes           *string                 `json:"notes"`
+	Port            *int                    `json:"port"`
+	PreferredImplId *string                 `json:"preferred_impl_id"`
+	Product         string                  `json:"product"`
+	SecretRef       *string                 `json:"secret_ref"`
+	VpnRequired     *bool                   `json:"vpn_required,omitempty"`
 }
 
 // TargetSummary Short shape for list endpoints.
@@ -312,20 +713,67 @@ type TargetSummary struct {
 // value to clear a nullable column (“fqdn“, “secret_ref“,
 // “notes“). “name“ and “product“ are absent — rename = delete
 // + create.
+//
+// “fingerprint“ is **not** accepted via PATCH — it is server-managed
+// and rewritten by every successful probe. Sending “fingerprint“
+// raises 422 via “extra='forbid'“ for the same reason
+// :class:`TargetCreate` rejects it. “preferred_impl_id“ is patchable.
 type TargetUpdate struct {
 	Aliases *[]string `json:"aliases"`
 
 	// AuthModel Per-target identity model per v0.1-spec L447-454.
-	AuthModel   *AuthModel              `json:"auth_model,omitempty"`
-	Extras      *map[string]interface{} `json:"extras"`
-	Fqdn        *string                 `json:"fqdn"`
-	Host        *string                 `json:"host"`
-	Notes       *string                 `json:"notes"`
-	Port        *int                    `json:"port"`
-	SecretRef   *string                 `json:"secret_ref"`
-	VpnRequired *bool                   `json:"vpn_required"`
+	AuthModel       *AuthModel              `json:"auth_model,omitempty"`
+	Extras          *map[string]interface{} `json:"extras"`
+	Fqdn            *string                 `json:"fqdn"`
+	Host            *string                 `json:"host"`
+	Notes           *string                 `json:"notes"`
+	Port            *int                    `json:"port"`
+	PreferredImplId *string                 `json:"preferred_impl_id"`
+	SecretRef       *string                 `json:"secret_ref"`
+	VpnRequired     *bool                   `json:"vpn_required"`
 }
 
+// Thresholds Per-metric green-band thresholds for a verdict computation.
+//
+// Frozen so the threshold object passed into :func:`verdict` cannot
+// be mutated mid-run (a stale or rewritten threshold mid-eval would
+// invalidate every subsequent verdict and silently shift the CI
+// gate). The yellow floor is derived from :data:`YELLOW_FLOOR_RATIO`,
+// not stored — keeping it derived means the contract "yellow is 70%
+// of green" can't drift between green-threshold customisation and
+// the yellow boundary.
+//
+// Defaults match the Initiative #373 / Task #441 contract; tests and
+// future re-tunings construct “Thresholds(...)“ with explicit
+// values.
+type Thresholds struct {
+	Coverage     *float32 `json:"coverage,omitempty"`
+	Mrr          *float32 `json:"mrr,omitempty"`
+	PrecisionAt5 *float32 `json:"precision_at_5,omitempty"`
+}
+
+// UsageReport Top-level shape returned by :func:`compute_usage` + the API route.
+//
+// “buckets“ is sorted by “(date, surface)“ ascending — the text
+// table renderer relies on this for its grouping behaviour, and
+// “--json“ consumers (T6's retire-checklist, future dashboards)
+// benefit from deterministic ordering even when nothing else
+// pins it.
+//
+// “tenant_id“ is the tenant the report is scoped to (the
+// operator's own tenant by default, or the
+// “tenant_admin“-supplied filter). “None“ is reserved for the
+// cross-tenant case; v0.2 has one production tenant so this is
+// effectively a v0.2.next placeholder, but the shape is locked
+// today so consumers don't break when the cross-tenant verb lands.
+type UsageReport struct {
+	Buckets       []DailyUsageBucket  `json:"buckets"`
+	Since         time.Time           `json:"since"`
+	Surfaces      []string            `json:"surfaces"`
+	TenantId      *openapi_types.UUID `json:"tenant_id"`
+	TotalSearches int                 `json:"total_searches"`
+	Until         time.Time           `json:"until"`
+}
 
 // ValidationError defines model for ValidationError.
 type ValidationError struct {
@@ -358,6 +806,45 @@ type VaultStatus struct {
 	Detail    *string `json:"detail"`
 	Reachable bool    `json:"reachable"`
 	ReadOk    bool    `json:"read_ok"`
+}
+
+// ListEndpointApiV1ConnectorsGetParams defines parameters for ListEndpointApiV1ConnectorsGet.
+type ListEndpointApiV1ConnectorsGetParams struct {
+	Status        *ListEndpointApiV1ConnectorsGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	Authorization *string                                     `json:"authorization,omitempty"`
+}
+
+// ListEndpointApiV1ConnectorsGetParamsStatus defines parameters for ListEndpointApiV1ConnectorsGet.
+type ListEndpointApiV1ConnectorsGetParamsStatus string
+
+// IngestEndpointApiV1ConnectorsIngestPostParams defines parameters for IngestEndpointApiV1ConnectorsIngestPost.
+type IngestEndpointApiV1ConnectorsIngestPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams defines parameters for DisableEndpointApiV1ConnectorsConnectorIdDisablePost.
+type DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// EnableEndpointApiV1ConnectorsConnectorIdEnablePostParams defines parameters for EnableEndpointApiV1ConnectorsConnectorIdEnablePost.
+type EnableEndpointApiV1ConnectorsConnectorIdEnablePostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams defines parameters for EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatch.
+type EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams defines parameters for EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatch.
+type EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParams defines parameters for GetReviewEndpointApiV1ConnectorsConnectorIdReviewGet.
+type GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
 }
 
 // FeedEndpointApiV1FeedGetParams defines parameters for FeedEndpointApiV1FeedGet.
@@ -411,6 +898,22 @@ type RetrieveEndpointApiV1RetrievePostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// EvalEndpointApiV1RetrieveEvalPostParams defines parameters for EvalEndpointApiV1RetrieveEvalPost.
+type EvalEndpointApiV1RetrieveEvalPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// UsageEndpointApiV1RetrieveUsageGetParams defines parameters for UsageEndpointApiV1RetrieveUsageGet.
+type UsageEndpointApiV1RetrieveUsageGetParams struct {
+	Since         *string                                          `form:"since,omitempty" json:"since,omitempty"`
+	Surface       *UsageEndpointApiV1RetrieveUsageGetParamsSurface `form:"surface,omitempty" json:"surface,omitempty"`
+	TenantFilter  *openapi_types.UUID                              `form:"tenant_filter,omitempty" json:"tenant_filter,omitempty"`
+	Authorization *string                                          `json:"authorization,omitempty"`
+}
+
+// UsageEndpointApiV1RetrieveUsageGetParamsSurface defines parameters for UsageEndpointApiV1RetrieveUsageGet.
+type UsageEndpointApiV1RetrieveUsageGetParamsSurface string
+
 // ListTargetsApiV1TargetsGetParams defines parameters for ListTargetsApiV1TargetsGet.
 type ListTargetsApiV1TargetsGetParams struct {
 	Product       *string `form:"product,omitempty" json:"product,omitempty"`
@@ -444,79 +947,29 @@ type McpDispatchMcpPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody defines body for IngestEndpointApiV1ConnectorsIngestPost for application/json ContentType.
+type IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody = IngestRequest
+
+// EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchJSONRequestBody defines body for EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatch for application/json ContentType.
+type EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchJSONRequestBody = EditGroupBody
+
+// EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchJSONRequestBody defines body for EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatch for application/json ContentType.
+type EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchJSONRequestBody = EditOpBody
+
 // PostCallApiV1OperationsCallPostJSONRequestBody defines body for PostCallApiV1OperationsCallPost for application/json ContentType.
 type PostCallApiV1OperationsCallPostJSONRequestBody = CallOperationBody
 
 // RetrieveEndpointApiV1RetrievePostJSONRequestBody defines body for RetrieveEndpointApiV1RetrievePost for application/json ContentType.
 type RetrieveEndpointApiV1RetrievePostJSONRequestBody = RetrieveRequest
 
+// EvalEndpointApiV1RetrieveEvalPostJSONRequestBody defines body for EvalEndpointApiV1RetrieveEvalPost for application/json ContentType.
+type EvalEndpointApiV1RetrieveEvalPostJSONRequestBody = EvalRequest
+
 // CreateTargetApiV1TargetsPostJSONRequestBody defines body for CreateTargetApiV1TargetsPost for application/json ContentType.
 type CreateTargetApiV1TargetsPostJSONRequestBody = TargetCreate
 
 // UpdateTargetApiV1TargetsNamePatchJSONRequestBody defines body for UpdateTargetApiV1TargetsNamePatch for application/json ContentType.
 type UpdateTargetApiV1TargetsNamePatchJSONRequestBody = TargetUpdate
-
-// AsOperationResultResult0 returns the union data inside the OperationResult_Result as a OperationResultResult0
-func (t OperationResult_Result) AsOperationResultResult0() (OperationResultResult0, error) {
-	var body OperationResultResult0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromOperationResultResult0 overwrites any union data inside the OperationResult_Result as the provided OperationResultResult0
-func (t *OperationResult_Result) FromOperationResultResult0(v OperationResultResult0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeOperationResultResult0 performs a merge with any union data inside the OperationResult_Result, using the provided OperationResultResult0
-func (t *OperationResult_Result) MergeOperationResultResult0(v OperationResultResult0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsOperationResultResult1 returns the union data inside the OperationResult_Result as a OperationResultResult1
-func (t OperationResult_Result) AsOperationResultResult1() (OperationResultResult1, error) {
-	var body OperationResultResult1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromOperationResultResult1 overwrites any union data inside the OperationResult_Result as the provided OperationResultResult1
-func (t *OperationResult_Result) FromOperationResultResult1(v OperationResultResult1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeOperationResultResult1 performs a merge with any union data inside the OperationResult_Result, using the provided OperationResultResult1
-func (t *OperationResult_Result) MergeOperationResultResult1(v OperationResultResult1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t OperationResult_Result) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *OperationResult_Result) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
 
 // AsValidationErrorLoc0 returns the union data inside the ValidationError_Loc_Item as a ValidationErrorLoc0
 func (t ValidationError_Loc_Item) AsValidationErrorLoc0() (ValidationErrorLoc0, error) {
@@ -662,6 +1115,33 @@ type ClientInterface interface {
 	// AuthConfigApiV1AuthConfigGet request
 	AuthConfigApiV1AuthConfigGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListEndpointApiV1ConnectorsGet request
+	ListEndpointApiV1ConnectorsGet(ctx context.Context, params *ListEndpointApiV1ConnectorsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IngestEndpointApiV1ConnectorsIngestPostWithBody request with any body
+	IngestEndpointApiV1ConnectorsIngestPostWithBody(ctx context.Context, params *IngestEndpointApiV1ConnectorsIngestPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	IngestEndpointApiV1ConnectorsIngestPost(ctx context.Context, params *IngestEndpointApiV1ConnectorsIngestPostParams, body IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DisableEndpointApiV1ConnectorsConnectorIdDisablePost request
+	DisableEndpointApiV1ConnectorsConnectorIdDisablePost(ctx context.Context, connectorId string, params *DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EnableEndpointApiV1ConnectorsConnectorIdEnablePost request
+	EnableEndpointApiV1ConnectorsConnectorIdEnablePost(ctx context.Context, connectorId string, params *EnableEndpointApiV1ConnectorsConnectorIdEnablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithBody request with any body
+	EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithBody(ctx context.Context, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatch(ctx context.Context, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, body EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithBody request with any body
+	EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithBody(ctx context.Context, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatch(ctx context.Context, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, body EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetReviewEndpointApiV1ConnectorsConnectorIdReviewGet request
+	GetReviewEndpointApiV1ConnectorsConnectorIdReviewGet(ctx context.Context, connectorId string, params *GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// FeedEndpointApiV1FeedGet request
 	FeedEndpointApiV1FeedGet(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -686,6 +1166,14 @@ type ClientInterface interface {
 	RetrieveEndpointApiV1RetrievePostWithBody(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	RetrieveEndpointApiV1RetrievePost(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, body RetrieveEndpointApiV1RetrievePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EvalEndpointApiV1RetrieveEvalPostWithBody request with any body
+	EvalEndpointApiV1RetrieveEvalPostWithBody(ctx context.Context, params *EvalEndpointApiV1RetrieveEvalPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EvalEndpointApiV1RetrieveEvalPost(ctx context.Context, params *EvalEndpointApiV1RetrieveEvalPostParams, body EvalEndpointApiV1RetrieveEvalPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UsageEndpointApiV1RetrieveUsageGet request
+	UsageEndpointApiV1RetrieveUsageGet(ctx context.Context, params *UsageEndpointApiV1RetrieveUsageGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListTargetsApiV1TargetsGet request
 	ListTargetsApiV1TargetsGet(ctx context.Context, params *ListTargetsApiV1TargetsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -748,6 +1236,126 @@ func (c *Client) ProtectedResourceMetadataWellKnownOauthProtectedResourceGet(ctx
 
 func (c *Client) AuthConfigApiV1AuthConfigGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAuthConfigApiV1AuthConfigGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListEndpointApiV1ConnectorsGet(ctx context.Context, params *ListEndpointApiV1ConnectorsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListEndpointApiV1ConnectorsGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IngestEndpointApiV1ConnectorsIngestPostWithBody(ctx context.Context, params *IngestEndpointApiV1ConnectorsIngestPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIngestEndpointApiV1ConnectorsIngestPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IngestEndpointApiV1ConnectorsIngestPost(ctx context.Context, params *IngestEndpointApiV1ConnectorsIngestPostParams, body IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIngestEndpointApiV1ConnectorsIngestPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DisableEndpointApiV1ConnectorsConnectorIdDisablePost(ctx context.Context, connectorId string, params *DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDisableEndpointApiV1ConnectorsConnectorIdDisablePostRequest(c.Server, connectorId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnableEndpointApiV1ConnectorsConnectorIdEnablePost(ctx context.Context, connectorId string, params *EnableEndpointApiV1ConnectorsConnectorIdEnablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnableEndpointApiV1ConnectorsConnectorIdEnablePostRequest(c.Server, connectorId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithBody(ctx context.Context, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchRequestWithBody(c.Server, connectorId, groupKey, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatch(ctx context.Context, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, body EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchRequest(c.Server, connectorId, groupKey, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithBody(ctx context.Context, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchRequestWithBody(c.Server, connectorId, opId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatch(ctx context.Context, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, body EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchRequest(c.Server, connectorId, opId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetReviewEndpointApiV1ConnectorsConnectorIdReviewGet(ctx context.Context, connectorId string, params *GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReviewEndpointApiV1ConnectorsConnectorIdReviewGetRequest(c.Server, connectorId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -856,6 +1464,42 @@ func (c *Client) RetrieveEndpointApiV1RetrievePostWithBody(ctx context.Context, 
 
 func (c *Client) RetrieveEndpointApiV1RetrievePost(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, body RetrieveEndpointApiV1RetrievePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRetrieveEndpointApiV1RetrievePostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EvalEndpointApiV1RetrieveEvalPostWithBody(ctx context.Context, params *EvalEndpointApiV1RetrieveEvalPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEvalEndpointApiV1RetrieveEvalPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EvalEndpointApiV1RetrieveEvalPost(ctx context.Context, params *EvalEndpointApiV1RetrieveEvalPostParams, body EvalEndpointApiV1RetrieveEvalPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEvalEndpointApiV1RetrieveEvalPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UsageEndpointApiV1RetrieveUsageGet(ctx context.Context, params *UsageEndpointApiV1RetrieveUsageGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUsageEndpointApiV1RetrieveUsageGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1086,6 +1730,410 @@ func NewAuthConfigApiV1AuthConfigGetRequest(server string) (*http.Request, error
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListEndpointApiV1ConnectorsGetRequest generates requests for ListEndpointApiV1ConnectorsGet
+func NewListEndpointApiV1ConnectorsGetRequest(server string, params *ListEndpointApiV1ConnectorsGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewIngestEndpointApiV1ConnectorsIngestPostRequest calls the generic IngestEndpointApiV1ConnectorsIngestPost builder with application/json body
+func NewIngestEndpointApiV1ConnectorsIngestPostRequest(server string, params *IngestEndpointApiV1ConnectorsIngestPostParams, body IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewIngestEndpointApiV1ConnectorsIngestPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewIngestEndpointApiV1ConnectorsIngestPostRequestWithBody generates requests for IngestEndpointApiV1ConnectorsIngestPost with any type of body
+func NewIngestEndpointApiV1ConnectorsIngestPostRequestWithBody(server string, params *IngestEndpointApiV1ConnectorsIngestPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors/ingest")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDisableEndpointApiV1ConnectorsConnectorIdDisablePostRequest generates requests for DisableEndpointApiV1ConnectorsConnectorIdDisablePost
+func NewDisableEndpointApiV1ConnectorsConnectorIdDisablePostRequest(server string, connectorId string, params *DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "connector_id", runtime.ParamLocationPath, connectorId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors/%s/disable", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewEnableEndpointApiV1ConnectorsConnectorIdEnablePostRequest generates requests for EnableEndpointApiV1ConnectorsConnectorIdEnablePost
+func NewEnableEndpointApiV1ConnectorsConnectorIdEnablePostRequest(server string, connectorId string, params *EnableEndpointApiV1ConnectorsConnectorIdEnablePostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "connector_id", runtime.ParamLocationPath, connectorId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors/%s/enable", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchRequest calls the generic EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatch builder with application/json body
+func NewEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchRequest(server string, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, body EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchRequestWithBody(server, connectorId, groupKey, params, "application/json", bodyReader)
+}
+
+// NewEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchRequestWithBody generates requests for EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatch with any type of body
+func NewEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchRequestWithBody(server string, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "connector_id", runtime.ParamLocationPath, connectorId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "group_key", runtime.ParamLocationPath, groupKey)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors/%s/groups/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchRequest calls the generic EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatch builder with application/json body
+func NewEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchRequest(server string, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, body EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchRequestWithBody(server, connectorId, opId, params, "application/json", bodyReader)
+}
+
+// NewEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchRequestWithBody generates requests for EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatch with any type of body
+func NewEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchRequestWithBody(server string, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "connector_id", runtime.ParamLocationPath, connectorId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "op_id", runtime.ParamLocationPath, opId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors/%s/operations/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewGetReviewEndpointApiV1ConnectorsConnectorIdReviewGetRequest generates requests for GetReviewEndpointApiV1ConnectorsConnectorIdReviewGet
+func NewGetReviewEndpointApiV1ConnectorsConnectorIdReviewGetRequest(server string, connectorId string, params *GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "connector_id", runtime.ParamLocationPath, connectorId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors/%s/review", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
 	}
 
 	return req, nil
@@ -1549,6 +2597,157 @@ func NewRetrieveEndpointApiV1RetrievePostRequestWithBody(server string, params *
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewEvalEndpointApiV1RetrieveEvalPostRequest calls the generic EvalEndpointApiV1RetrieveEvalPost builder with application/json body
+func NewEvalEndpointApiV1RetrieveEvalPostRequest(server string, params *EvalEndpointApiV1RetrieveEvalPostParams, body EvalEndpointApiV1RetrieveEvalPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEvalEndpointApiV1RetrieveEvalPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewEvalEndpointApiV1RetrieveEvalPostRequestWithBody generates requests for EvalEndpointApiV1RetrieveEvalPost with any type of body
+func NewEvalEndpointApiV1RetrieveEvalPostRequestWithBody(server string, params *EvalEndpointApiV1RetrieveEvalPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/retrieve/eval")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewUsageEndpointApiV1RetrieveUsageGetRequest generates requests for UsageEndpointApiV1RetrieveUsageGet
+func NewUsageEndpointApiV1RetrieveUsageGetRequest(server string, params *UsageEndpointApiV1RetrieveUsageGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/retrieve/usage")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Since != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "since", runtime.ParamLocationQuery, *params.Since); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Surface != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "surface", runtime.ParamLocationQuery, *params.Surface); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.TenantFilter != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "tenant_filter", runtime.ParamLocationQuery, *params.TenantFilter); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	if params != nil {
 
@@ -2081,6 +3280,33 @@ type ClientWithResponsesInterface interface {
 	// AuthConfigApiV1AuthConfigGetWithResponse request
 	AuthConfigApiV1AuthConfigGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AuthConfigApiV1AuthConfigGetResponse, error)
 
+	// ListEndpointApiV1ConnectorsGetWithResponse request
+	ListEndpointApiV1ConnectorsGetWithResponse(ctx context.Context, params *ListEndpointApiV1ConnectorsGetParams, reqEditors ...RequestEditorFn) (*ListEndpointApiV1ConnectorsGetResponse, error)
+
+	// IngestEndpointApiV1ConnectorsIngestPostWithBodyWithResponse request with any body
+	IngestEndpointApiV1ConnectorsIngestPostWithBodyWithResponse(ctx context.Context, params *IngestEndpointApiV1ConnectorsIngestPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestEndpointApiV1ConnectorsIngestPostResponse, error)
+
+	IngestEndpointApiV1ConnectorsIngestPostWithResponse(ctx context.Context, params *IngestEndpointApiV1ConnectorsIngestPostParams, body IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestEndpointApiV1ConnectorsIngestPostResponse, error)
+
+	// DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse request
+	DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse(ctx context.Context, connectorId string, params *DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams, reqEditors ...RequestEditorFn) (*DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse, error)
+
+	// EnableEndpointApiV1ConnectorsConnectorIdEnablePostWithResponse request
+	EnableEndpointApiV1ConnectorsConnectorIdEnablePostWithResponse(ctx context.Context, connectorId string, params *EnableEndpointApiV1ConnectorsConnectorIdEnablePostParams, reqEditors ...RequestEditorFn) (*EnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse, error)
+
+	// EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithBodyWithResponse request with any body
+	EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithBodyWithResponse(ctx context.Context, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse, error)
+
+	EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithResponse(ctx context.Context, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, body EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse, error)
+
+	// EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithBodyWithResponse request with any body
+	EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithBodyWithResponse(ctx context.Context, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse, error)
+
+	EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithResponse(ctx context.Context, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, body EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse, error)
+
+	// GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetWithResponse request
+	GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetWithResponse(ctx context.Context, connectorId string, params *GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParams, reqEditors ...RequestEditorFn) (*GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse, error)
+
 	// FeedEndpointApiV1FeedGetWithResponse request
 	FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error)
 
@@ -2105,6 +3331,14 @@ type ClientWithResponsesInterface interface {
 	RetrieveEndpointApiV1RetrievePostWithBodyWithResponse(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrieveEndpointApiV1RetrievePostResponse, error)
 
 	RetrieveEndpointApiV1RetrievePostWithResponse(ctx context.Context, params *RetrieveEndpointApiV1RetrievePostParams, body RetrieveEndpointApiV1RetrievePostJSONRequestBody, reqEditors ...RequestEditorFn) (*RetrieveEndpointApiV1RetrievePostResponse, error)
+
+	// EvalEndpointApiV1RetrieveEvalPostWithBodyWithResponse request with any body
+	EvalEndpointApiV1RetrieveEvalPostWithBodyWithResponse(ctx context.Context, params *EvalEndpointApiV1RetrieveEvalPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EvalEndpointApiV1RetrieveEvalPostResponse, error)
+
+	EvalEndpointApiV1RetrieveEvalPostWithResponse(ctx context.Context, params *EvalEndpointApiV1RetrieveEvalPostParams, body EvalEndpointApiV1RetrieveEvalPostJSONRequestBody, reqEditors ...RequestEditorFn) (*EvalEndpointApiV1RetrieveEvalPostResponse, error)
+
+	// UsageEndpointApiV1RetrieveUsageGetWithResponse request
+	UsageEndpointApiV1RetrieveUsageGetWithResponse(ctx context.Context, params *UsageEndpointApiV1RetrieveUsageGetParams, reqEditors ...RequestEditorFn) (*UsageEndpointApiV1RetrieveUsageGetResponse, error)
 
 	// ListTargetsApiV1TargetsGetWithResponse request
 	ListTargetsApiV1TargetsGetWithResponse(ctx context.Context, params *ListTargetsApiV1TargetsGetParams, reqEditors ...RequestEditorFn) (*ListTargetsApiV1TargetsGetResponse, error)
@@ -2201,6 +3435,163 @@ func (r AuthConfigApiV1AuthConfigGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r AuthConfigApiV1AuthConfigGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListEndpointApiV1ConnectorsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string][]map[string]interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListEndpointApiV1ConnectorsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListEndpointApiV1ConnectorsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IngestEndpointApiV1ConnectorsIngestPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *IngestResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r IngestEndpointApiV1ConnectorsIngestPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IngestEndpointApiV1ConnectorsIngestPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r EnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ConnectorReviewPayload
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2368,6 +3759,52 @@ func (r RetrieveEndpointApiV1RetrievePostResponse) StatusCode() int {
 	return 0
 }
 
+type EvalEndpointApiV1RetrieveEvalPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *EvalResult
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r EvalEndpointApiV1RetrieveEvalPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EvalEndpointApiV1RetrieveEvalPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UsageEndpointApiV1RetrieveUsageGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *UsageReport
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UsageEndpointApiV1RetrieveUsageGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UsageEndpointApiV1RetrieveUsageGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListTargetsApiV1TargetsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2463,7 +3900,7 @@ func (r UpdateTargetApiV1TargetsNamePatchResponse) StatusCode() int {
 type ProbeTargetApiV1TargetsNameProbePostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ProbeResult
+	JSON200      *FingerprintResult
 	JSON422      *HTTPValidationError
 }
 
@@ -2621,6 +4058,93 @@ func (c *ClientWithResponses) AuthConfigApiV1AuthConfigGetWithResponse(ctx conte
 	return ParseAuthConfigApiV1AuthConfigGetResponse(rsp)
 }
 
+// ListEndpointApiV1ConnectorsGetWithResponse request returning *ListEndpointApiV1ConnectorsGetResponse
+func (c *ClientWithResponses) ListEndpointApiV1ConnectorsGetWithResponse(ctx context.Context, params *ListEndpointApiV1ConnectorsGetParams, reqEditors ...RequestEditorFn) (*ListEndpointApiV1ConnectorsGetResponse, error) {
+	rsp, err := c.ListEndpointApiV1ConnectorsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListEndpointApiV1ConnectorsGetResponse(rsp)
+}
+
+// IngestEndpointApiV1ConnectorsIngestPostWithBodyWithResponse request with arbitrary body returning *IngestEndpointApiV1ConnectorsIngestPostResponse
+func (c *ClientWithResponses) IngestEndpointApiV1ConnectorsIngestPostWithBodyWithResponse(ctx context.Context, params *IngestEndpointApiV1ConnectorsIngestPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestEndpointApiV1ConnectorsIngestPostResponse, error) {
+	rsp, err := c.IngestEndpointApiV1ConnectorsIngestPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIngestEndpointApiV1ConnectorsIngestPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) IngestEndpointApiV1ConnectorsIngestPostWithResponse(ctx context.Context, params *IngestEndpointApiV1ConnectorsIngestPostParams, body IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestEndpointApiV1ConnectorsIngestPostResponse, error) {
+	rsp, err := c.IngestEndpointApiV1ConnectorsIngestPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIngestEndpointApiV1ConnectorsIngestPostResponse(rsp)
+}
+
+// DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse request returning *DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse
+func (c *ClientWithResponses) DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse(ctx context.Context, connectorId string, params *DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams, reqEditors ...RequestEditorFn) (*DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse, error) {
+	rsp, err := c.DisableEndpointApiV1ConnectorsConnectorIdDisablePost(ctx, connectorId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse(rsp)
+}
+
+// EnableEndpointApiV1ConnectorsConnectorIdEnablePostWithResponse request returning *EnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse
+func (c *ClientWithResponses) EnableEndpointApiV1ConnectorsConnectorIdEnablePostWithResponse(ctx context.Context, connectorId string, params *EnableEndpointApiV1ConnectorsConnectorIdEnablePostParams, reqEditors ...RequestEditorFn) (*EnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse, error) {
+	rsp, err := c.EnableEndpointApiV1ConnectorsConnectorIdEnablePost(ctx, connectorId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse(rsp)
+}
+
+// EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithBodyWithResponse request with arbitrary body returning *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse
+func (c *ClientWithResponses) EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithBodyWithResponse(ctx context.Context, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse, error) {
+	rsp, err := c.EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithBody(ctx, connectorId, groupKey, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithResponse(ctx context.Context, connectorId string, groupKey string, params *EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchParams, body EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse, error) {
+	rsp, err := c.EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatch(ctx, connectorId, groupKey, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse(rsp)
+}
+
+// EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithBodyWithResponse request with arbitrary body returning *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse
+func (c *ClientWithResponses) EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithBodyWithResponse(ctx context.Context, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse, error) {
+	rsp, err := c.EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithBody(ctx, connectorId, opId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithResponse(ctx context.Context, connectorId string, opId string, params *EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchParams, body EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse, error) {
+	rsp, err := c.EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatch(ctx, connectorId, opId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse(rsp)
+}
+
+// GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetWithResponse request returning *GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse
+func (c *ClientWithResponses) GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetWithResponse(ctx context.Context, connectorId string, params *GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParams, reqEditors ...RequestEditorFn) (*GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse, error) {
+	rsp, err := c.GetReviewEndpointApiV1ConnectorsConnectorIdReviewGet(ctx, connectorId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse(rsp)
+}
+
 // FeedEndpointApiV1FeedGetWithResponse request returning *FeedEndpointApiV1FeedGetResponse
 func (c *ClientWithResponses) FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error) {
 	rsp, err := c.FeedEndpointApiV1FeedGet(ctx, params, reqEditors...)
@@ -2698,6 +4222,32 @@ func (c *ClientWithResponses) RetrieveEndpointApiV1RetrievePostWithResponse(ctx 
 		return nil, err
 	}
 	return ParseRetrieveEndpointApiV1RetrievePostResponse(rsp)
+}
+
+// EvalEndpointApiV1RetrieveEvalPostWithBodyWithResponse request with arbitrary body returning *EvalEndpointApiV1RetrieveEvalPostResponse
+func (c *ClientWithResponses) EvalEndpointApiV1RetrieveEvalPostWithBodyWithResponse(ctx context.Context, params *EvalEndpointApiV1RetrieveEvalPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EvalEndpointApiV1RetrieveEvalPostResponse, error) {
+	rsp, err := c.EvalEndpointApiV1RetrieveEvalPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEvalEndpointApiV1RetrieveEvalPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) EvalEndpointApiV1RetrieveEvalPostWithResponse(ctx context.Context, params *EvalEndpointApiV1RetrieveEvalPostParams, body EvalEndpointApiV1RetrieveEvalPostJSONRequestBody, reqEditors ...RequestEditorFn) (*EvalEndpointApiV1RetrieveEvalPostResponse, error) {
+	rsp, err := c.EvalEndpointApiV1RetrieveEvalPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEvalEndpointApiV1RetrieveEvalPostResponse(rsp)
+}
+
+// UsageEndpointApiV1RetrieveUsageGetWithResponse request returning *UsageEndpointApiV1RetrieveUsageGetResponse
+func (c *ClientWithResponses) UsageEndpointApiV1RetrieveUsageGetWithResponse(ctx context.Context, params *UsageEndpointApiV1RetrieveUsageGetParams, reqEditors ...RequestEditorFn) (*UsageEndpointApiV1RetrieveUsageGetResponse, error) {
+	rsp, err := c.UsageEndpointApiV1RetrieveUsageGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUsageEndpointApiV1RetrieveUsageGetResponse(rsp)
 }
 
 // ListTargetsApiV1TargetsGetWithResponse request returning *ListTargetsApiV1TargetsGetResponse
@@ -2878,6 +4428,209 @@ func ParseAuthConfigApiV1AuthConfigGetResponse(rsp *http.Response) (*AuthConfigA
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListEndpointApiV1ConnectorsGetResponse parses an HTTP response from a ListEndpointApiV1ConnectorsGetWithResponse call
+func ParseListEndpointApiV1ConnectorsGetResponse(rsp *http.Response) (*ListEndpointApiV1ConnectorsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListEndpointApiV1ConnectorsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string][]map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIngestEndpointApiV1ConnectorsIngestPostResponse parses an HTTP response from a IngestEndpointApiV1ConnectorsIngestPostWithResponse call
+func ParseIngestEndpointApiV1ConnectorsIngestPostResponse(rsp *http.Response) (*IngestEndpointApiV1ConnectorsIngestPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IngestEndpointApiV1ConnectorsIngestPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest IngestResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse parses an HTTP response from a DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse call
+func ParseDisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse(rsp *http.Response) (*DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse parses an HTTP response from a EnableEndpointApiV1ConnectorsConnectorIdEnablePostWithResponse call
+func ParseEnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse(rsp *http.Response) (*EnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EnableEndpointApiV1ConnectorsConnectorIdEnablePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse parses an HTTP response from a EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchWithResponse call
+func ParseEditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse(rsp *http.Response) (*EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EditGroupEndpointApiV1ConnectorsConnectorIdGroupsGroupKeyPatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse parses an HTTP response from a EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchWithResponse call
+func ParseEditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse(rsp *http.Response) (*EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EditOpEndpointApiV1ConnectorsConnectorIdOperationsOpIdPatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse parses an HTTP response from a GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetWithResponse call
+func ParseGetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse(rsp *http.Response) (*GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ConnectorReviewPayload
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	}
 
@@ -3115,6 +4868,72 @@ func ParseRetrieveEndpointApiV1RetrievePostResponse(rsp *http.Response) (*Retrie
 	return response, nil
 }
 
+// ParseEvalEndpointApiV1RetrieveEvalPostResponse parses an HTTP response from a EvalEndpointApiV1RetrieveEvalPostWithResponse call
+func ParseEvalEndpointApiV1RetrieveEvalPostResponse(rsp *http.Response) (*EvalEndpointApiV1RetrieveEvalPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EvalEndpointApiV1RetrieveEvalPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest EvalResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUsageEndpointApiV1RetrieveUsageGetResponse parses an HTTP response from a UsageEndpointApiV1RetrieveUsageGetWithResponse call
+func ParseUsageEndpointApiV1RetrieveUsageGetResponse(rsp *http.Response) (*UsageEndpointApiV1RetrieveUsageGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UsageEndpointApiV1RetrieveUsageGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UsageReport
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListTargetsApiV1TargetsGetResponse parses an HTTP response from a ListTargetsApiV1TargetsGetWithResponse call
 func ParseListTargetsApiV1TargetsGetResponse(rsp *http.Response) (*ListTargetsApiV1TargetsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -3262,7 +5081,7 @@ func ParseProbeTargetApiV1TargetsNameProbePostResponse(rsp *http.Response) (*Pro
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ProbeResult
+		var dest FingerprintResult
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -195,6 +195,22 @@ this stage it exposes:
   deprecated and removed by G0.6-T11 (#412) once T8's substrate route
   shipped — two parallel dispatch surfaces violated CLAUDE.md
   postulate 5's narrow-waist contract.
+* Spec ingestion + connector review (G0.7-T6 #406) —
+  `src/meho_backplane/api/v1/connectors_ingest.py` exposes the seven
+  `/api/v1/connectors*` routes that drive the ingestion pipeline and
+  the review-queue state machine: `POST /ingest` (run parse → register
+  → group, tenant_admin), `GET /` (list visible connectors with status
+  filter, operator), `GET /{id}/review` (full review payload,
+  operator), `PATCH /{id}/groups/{key}` + `PATCH /{id}/operations/{op}`
+  (operator edit overrides, tenant_admin), `POST /{id}/enable` + `POST
+  /{id}/disable` (state transitions, tenant_admin). Tenant scoping
+  derives from the JWT — there is no body / query parameter that can
+  override the operator's tenant; cross-tenant probes surface as 404.
+  The same service layer (`IngestionPipelineService`,
+  `list_ingested_connectors`, `ReviewService`) backs the CLI verbs
+  (T5, #405) and the admin MCP tools (T7, #407) without HTTP-round-
+  trip-through-self. Detailed module guide:
+  [`docs/codebase/spec-ingestion.md`](spec-ingestion.md).
 * Persistence layer (Task #27) — `src/meho_backplane/db/` houses the
   SQLAlchemy 2.x async engine (`engine.py`), the per-request
   session-factory dependency (`get_session`), and the

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -38,13 +38,23 @@ The pipeline is broken into work items per Initiative #389:
 * **T4 — Review-queue state machine** (`ingest/service.py`). Operators
   move connectors through `staged → enabled` (and `disabled` for
   regression rollback) before any op becomes dispatchable.
-* **T5–T7 — CLI / REST / MCP surfaces** that drive the pipeline.
+* **T5–T7 — CLI / REST / MCP surfaces** that drive the pipeline. T6
+  (REST routes) lands the seven `/api/v1/connectors*` endpoints —
+  `POST /ingest`, `GET /` (list), `GET /{id}/review`, `PATCH
+  /{id}/groups/{key}`, `PATCH /{id}/operations/{op_id:path}`, `POST
+  /{id}/enable`, `POST /{id}/disable`. T6 also factors the
+  cross-T5/T7-shared service layer
+  (`IngestionPipelineService`, `list_ingested_connectors`,
+  `api_schemas.*` Pydantic models) into the package so the CLI and
+  admin MCP tools consume the same Python surface without hitting
+  the network round-trip.
 * **T8 — vSphere canary** — ingest both vCenter specs end-to-end.
 * **T9 — Docs.**
 
 T1 produces the proto shape every other stage consumes; T2 is the
 single write path into `endpoint_descriptor` for ingested rows; T3
-groups them; T4 gates dispatchability behind operator review.
+groups them; T4 gates dispatchability behind operator review; T6
+exposes the whole thing over HTTP with tenant_admin / operator RBAC.
 
 ### T3 (LLM grouping) at a glance
 
@@ -161,6 +171,91 @@ until the operator replaces the shim with a hand-rolled per-G3.x
 subclass that adds the auth path. The shim makes the connector
 resolvable through the v2 registry so spec ingestion can proceed
 before the per-product Initiative work lands.
+
+### `IngestionPipelineService` (`ingest/pipeline.py`)
+
+End-to-end orchestrator that bundles the parse → register_ingested →
+run_llm_grouping pipeline for one connector. Constructed from an
+`Operator` (so the service-level audit rows the helpers write carry
+the originating operator's identity); the same instance is reused
+across T5's CLI verbs, T6's REST routes, and T7's admin MCP tools.
+
+The `LlmClient` Protocol is injected via a factory parameter so the
+chassis can lazy-resolve it; the default factory raises
+`LlmClientUnavailable` and the REST layer maps it onto HTTP 503. T5
+(#405) replaces the default with the production Anthropic-Messages-
+API adapter. The `embedding_service` parameter is the test seam to
+inject `AsyncMock` so unit tests don't pull the fastembed ONNX
+model from huggingface.co.
+
+`ingest(..., dry_run=True)` short-circuits both the DB writes and
+the LLM call: parses every spec and returns the parser's
+`inserted_count` projection with `grouping=None`. Operators use
+this path to validate a spec before committing.
+
+Multi-spec merge: a single `ingest()` call processes a list of
+`SpecSource` entries; each is parsed and upserted under the same
+connector triple with the spec's URI as the `spec_source` tag, so
+operators can distinguish "this op came from vcenter.yaml" vs "this
+op came from vi-json.yaml" during review.
+
+### `list_ingested_connectors()` (`ingest/list_connectors.py`)
+
+Aggregate query for `GET /api/v1/connectors`. Returns one
+`ConnectorListItem` per connector visible to the operator's tenant
+(operator's-tenant rows + built-ins, i.e. `tenant_id IS NULL`). The
+optional `status` filter narrows by aggregated review status:
+`staged` (≥1 staged group), `enabled` / `disabled` (every group
+uniform), or `all` (no filter). The implementation uses portable
+`CASE WHEN ... THEN 1 ELSE 0 END SUM` expressions rather than PG-
+only `FILTER` clauses so the same query runs against SQLite in
+tests.
+
+Source-kind filter excludes typed-connector rows from the operation
+count — this endpoint lists *ingested* connectors only, per the
+G0.7 review-queue contract; typed connectors live in the v2
+registry and operators don't drive them through the review state
+machine.
+
+### API request / response models (`ingest/api_schemas.py`)
+
+The shared Pydantic-v2 surface T5 (CLI), T6 (REST), and T7 (MCP) all
+consume so the wire contract is defined once:
+
+* `IngestRequest` / `IngestResponse` — body for `POST /ingest` and
+  its return shape. `IngestResponse.grouping` is `None` for the dry-
+  run path. `SpecSource` wraps one spec URI with room for future
+  per-spec knobs (auth headers, dialect pinning).
+* `ConnectorListItem` / `ConnectorListResponse` — one row per
+  visible connector + the wrapper for the list endpoint. The wrapper
+  keeps the JSON shape stable when future paging / cursor fields
+  land.
+* `EditGroupBody` / `EditOpBody` — PATCH bodies for the per-group
+  and per-op edit verbs. Pydantic enforces the bounded enum for
+  `safety_level` and the empty-body rejection lands as a service-
+  layer `ValueError` mapped to 400.
+* `IngestionResultModel` / `GroupingResultModel` — Pydantic
+  projections of the underlying frozen dataclasses, with an
+  added `connector_id` echo for round-trip clarity.
+
+### REST routes (`api/v1/connectors_ingest.py`)
+
+The seven `/api/v1/connectors*` routes that wire the service layer
+to the operator-facing HTTP surface. RBAC: read paths (GET /, GET
+/{id}/review) require `operator` role minimum; write paths
+(`POST /ingest`, `PATCH /groups`, `PATCH /operations`, `POST
+/enable`, `POST /disable`) require `tenant_admin`. Tenant scoping
+derives from the JWT — there is no body / query parameter that can
+override the operator's tenant. Cross-tenant probes surface as 404
+`ConnectorNotFoundError`, not 403 — same conflation `ReviewService`
+uses to keep the operator-facing failure surface uniform.
+
+The `op_id` path segment uses the `:path` converter so operations
+whose natural key contains slashes (`"GET:/api/vcenter/cluster"`)
+round-trip through URL routing intact. The route module's
+`set_llm_client_factory(factory)` helper lets the production
+bootstrap (G0.7-T5) install the Anthropic adapter and lets tests
+inject deterministic stubs.
 
 ### `parse_openapi(spec_path_or_uri, *, spec_source=None)` (`ingest/openapi.py`)
 
@@ -310,8 +405,11 @@ operations go live.
 
 * Issue #401 — T1 task.
 * Issue #403 — T2 task.
-* Issue #404 — T3 task (LLM grouping; this module).
-* Issue #402 — T4 task.
+* Issue #404 — T3 task (LLM grouping).
+* Issue #402 — T4 task (review-queue state machine).
+* Issue #405 — T5 task (CLI verbs).
+* Issue #406 — T6 task (REST routes; this module's HTTP surface).
+* Issue #407 — T7 task (admin MCP tools).
 * Initiative #389 — G0.7 spec-ingestion pipeline.
 * Goal #221 — G0 foundational substrate.
 * `meho_backplane/db/models.py::EndpointDescriptor` — the ORM target.


### PR DESCRIPTION
## Summary

- Seven `/api/v1/connectors*` REST endpoints driving the G0.7 spec-ingestion pipeline (T1 parse + T2 register + T3 LLM grouping) and the T4 review-queue state machine.
- Shared service layer (`IngestionPipelineService`, `list_ingested_connectors`, `api_schemas.*` Pydantic models) factored into the `ingest` package so T5 (CLI #405) and T7 (admin MCP tools #407) re-use the same Python surface without HTTP round-trip through self.
- 27 behavioural tests covering route mounting, RBAC (401 / 403 / 200), tenant isolation, status-filter aggregation, dry-run, the full pipeline happy path (with stubbed LLM + embedding), idempotent state transitions, and the `:path` converter on the `op_id` segment.

## Route inventory

| Method | Path | Role |
|---|---|---|
| POST   | `/api/v1/connectors/ingest` | tenant_admin |
| GET    | `/api/v1/connectors[?status=staged\|enabled\|disabled\|all]` | operator |
| GET    | `/api/v1/connectors/{connector_id}/review` | operator |
| PATCH  | `/api/v1/connectors/{connector_id}/groups/{group_key}` | tenant_admin |
| PATCH  | `/api/v1/connectors/{connector_id}/operations/{op_id}` | tenant_admin |
| POST   | `/api/v1/connectors/{connector_id}/enable` | tenant_admin |
| POST   | `/api/v1/connectors/{connector_id}/disable` | tenant_admin |

Tenant scoping derives from the JWT; cross-tenant probes surface as 404 (same conflation `ReviewService` uses to keep the operator-facing failure surface uniform). The LLM client is injected via a module-level factory (`set_llm_client_factory`) so the production Anthropic adapter wire-up (G0.7-T5 #405) and test stubs share one extension point; the default factory raises `LlmClientUnavailable` which the route maps to 503.

## Sibling task coordination (#405 / #407)

- **#405 CLI verbs** (Wave 3 parallel) call these endpoints. The request / response Pydantic models live in `operations/ingest/api_schemas.py` (`IngestRequest`, `IngestResponse`, `ConnectorListItem`, `ConnectorListResponse`, `EditGroupBody`, `EditOpBody`, `SpecSource`, `IngestionResultModel`, `GroupingResultModel`, `ConnectorStatusFilter`) — re-exported from `meho_backplane.operations.ingest` so the Go CLI's Pydantic-aligned types stay 1:1.
- **#407 admin MCP tools** (Wave 3 parallel) wrap the same service layer. `IngestionPipelineService` and `list_ingested_connectors` are the Python-call surface (no HTTP needed); the same `api_schemas.*` models are the inputSchema shapes.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — 27 passed
- [x] `pytest tests/` (excluding integration) — 1332 passed
- [x] Code-quality hook — 0 blockers
- [x] OpenAPI snapshot regenerated (`cli/api/openapi.json` + `cli/internal/api/client.gen.go`)
- [x] CLI build — `make build` green

## Out of scope

- CLI verbs that hit these routes: T5 (#405).
- Admin MCP tools wrapping the service layer: T7 (#407).
- Production Anthropic Messages-API LLM adapter wire-up: T5 (#405).
- Streaming progress for long ingest jobs / async job-queue submission: v0.2.next.

## Notes for reviewers

- File-budget split: the connector-list query lives in its own `list_connectors.py` module (rather than inside `pipeline.py`) to keep both under the 600-line file limit.
- Docker integration tests show pre-existing failures unrelated to this PR (asyncpg FK truncate after the #460 `graph_node`/`graph_edge` migration; Docker Hub rate-limit per CLAUDE.md). Local unit floor is green.

Closes #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New connector ingestion API with dry-run support, ingestion results and grouping feedback.
  * Endpoints to list connectors (status filter), fetch connector review payloads, edit group/operation metadata, and enable/disable connectors (idempotent).
  * Role-gated access for admin vs operator users and clear error mappings (400/403/404/409/502/503).

* **Documentation**
  * OpenAPI and docs updated to cover the new ingestion/review routes, request/response models, and RBAC/tenant scoping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/488)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->