### PR TITLE
feat(operations): G0.7-T2 register_ingested_operations() helper

### DIFF
--- a/backend/src/meho_backplane/operations/__init__.py
+++ b/backend/src/meho_backplane/operations/__init__.py
@@ -41,10 +41,15 @@ Sub-modules:
   :class:`HandlerRefError` for typed-connector init-time
   registration (re-exported at the package level for convenience).
 * :mod:`.ingest` — G0.7 spec-ingestion pipeline. Today:
-  :func:`~meho_backplane.operations.ingest.parse_openapi` (T1 #401)
-  + the :class:`~meho_backplane.operations.ingest.ReviewService`
-  state machine (T4 #402). Later: the bulk-upsert helper (T2 #403)
-  and the LLM-grouping pass (T3 #404).
+  :func:`~meho_backplane.operations.ingest.parse_openapi` (T1 #401),
+  the :class:`~meho_backplane.operations.ingest.ReviewService` state
+  machine (T4 #402), and
+  :func:`~meho_backplane.operations.ingest.register_ingested_operations`
+  (T2 #403) — the async bulk-upsert that takes parser output through
+  to ``endpoint_descriptor`` rows in ``staged`` state, auto-registers
+  an :class:`HttpConnector` shim for first-time triples, and supports
+  multi-spec merge under one connector_id. Later: the LLM-grouping
+  pass (T3 #404).
 
 The dispatcher reads ``endpoint_descriptor`` rows directly via the
 ORM; the meta-tools (T8, #399) will hit the same surface via the
@@ -65,6 +70,11 @@ from meho_backplane.operations.dispatcher import (
     reset_dispatcher_caches,
     set_default_reducer,
 )
+from meho_backplane.operations.ingest import (
+    IngestionResult,
+    OpIdCollision,
+    register_ingested_operations,
+)
 from meho_backplane.operations.reducer import (
     PassThroughReducer,
     Reducer,
@@ -81,6 +91,8 @@ __all__ = [
     "DispatchChild",
     "Dispatcher",
     "HandlerRefError",
+    "IngestionResult",
+    "OpIdCollision",
     "PassThroughReducer",
     "Reducer",
     "ResultHandle",
@@ -89,6 +101,7 @@ __all__ = [
     "dispatch",
     "import_handler",
     "parent_audit_id_var",
+    "register_ingested_operations",
     "register_typed_operation",
     "reset_dispatcher_caches",
     "set_default_reducer",

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -13,11 +13,15 @@ REST routes at T6, admin MCP tools at T7) import from
 private module layout.
 """
 
+from meho_backplane.operations.ingest.connector_registration import (
+    ensure_connector_class_registered,
+)
 from meho_backplane.operations.ingest.exceptions import (
     ConnectorNotFoundError,
     InvalidSchemaError,
     InvalidSpecError,
     InvalidStateTransitionError,
+    OpIdCollision,
     UnsupportedSpecError,
 )
 from meho_backplane.operations.ingest.openapi import (
@@ -29,6 +33,10 @@ from meho_backplane.operations.ingest.payload import (
     ConnectorReviewGroup,
     ConnectorReviewOp,
     ConnectorReviewPayload,
+)
+from meho_backplane.operations.ingest.register_ingested import (
+    IngestionResult,
+    register_ingested_operations,
 )
 from meho_backplane.operations.ingest.schemas import (
     EndpointDescriptorProto,
@@ -42,13 +50,17 @@ __all__ = [
     "ConnectorReviewOp",
     "ConnectorReviewPayload",
     "EndpointDescriptorProto",
+    "IngestionResult",
     "InvalidSchemaError",
     "InvalidSpecError",
     "InvalidStateTransitionError",
+    "OpIdCollision",
     "ReviewService",
     "SafetyLevel",
     "UnsupportedSpecError",
     "detect_spec_format",
+    "ensure_connector_class_registered",
     "parse_connector_id",
     "parse_openapi",
+    "register_ingested_operations",
 ]

--- a/backend/src/meho_backplane/operations/ingest/connector_registration.py
+++ b/backend/src/meho_backplane/operations/ingest/connector_registration.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Auto-register a minimal ``HttpConnector`` shim for a freshly-ingested connector.
+
+G0.7-T2 (#403) of Initiative #389. The first time an operator runs
+``meho connector ingest --product <p> --version <v> --impl <i>``
+against a triple that has no concrete connector class yet, T2 wires
+up a thin :class:`HttpConnector` subclass dynamically so the
+:func:`~meho_backplane.connectors.resolver.resolve_connector` tie-break
+ladder can route to the new connector for read operations the
+moment the operator flips the review queue to ``enabled``. Subsequent
+ingestions against the same ``(product, version, impl_id)`` skip
+this step — the registry is in-memory and the second call sees the
+shim already present.
+
+The shim is intentionally **minimal**:
+
+* It fixes the v2 registry-key attributes (``product``, ``version``,
+  ``impl_id``, ``supported_version_range``, ``priority``) so the
+  resolver picks it up.
+* It stashes ``base_url`` on the class for any future override (the
+  default :meth:`HttpConnector._base_url` reads from the target, but
+  some ingested connectors will need to override it; recording the
+  arg is harmless and avoids an inevitable follow-up).
+* It raises :class:`NotImplementedError` from :meth:`fingerprint`,
+  :meth:`probe`, :meth:`execute`, and :meth:`auth_headers` with a
+  message naming the G3.x Initiative responsible for replacing it.
+
+The motivation for "raise" rather than "guess" is operator clarity:
+a dispatch attempt against the auto-shim should produce a clear
+"this connector is registration-only; a per-product subclass must
+ship" error rather than a half-correct fingerprint that pretends
+the integration is live. Per-product auth divergence (vSphere's
+``POST /api/session``, NSX's XSRF token, vCF's dual-plane) is
+authored as a real subclass per G3.x Initiative; that subclass
+REPLACES this shim at code-merge time by registering the same
+``(product, version, impl_id)`` key.
+
+The dynamically-generated class name follows the pattern
+``GenericRest_<product>_<version>_<impl_id>`` (with ``.`` / ``-``
+replaced by ``_`` for Python identifier validity). The name is
+visible in startup-log ``connector_registered_v2`` events and in
+``list_connector_impls()`` diagnostic output so operators can
+identify auto-shims at a glance.
+
+Concurrency note: connector registration races (two ingestion calls
+against the same triple in flight at the same time) are caught by
+the registry's RuntimeError-on-duplicate. The helper checks the
+registry under no lock; if a race lands, the second call returns
+``False`` (the loser sees the registration as a no-op). v0.2
+ingestion is operator-triggered (single-shot CLI), so the race is
+theoretical — but the swallow-on-RuntimeError fallback keeps the
+helper robust against a future MCP-tool-driven trigger model where
+two operators might fire simultaneously.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import structlog
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    register_connector_v2,
+)
+
+__all__ = [
+    "ensure_connector_class_registered",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Match the leading "<major>.<minor>" portion of the version string.
+# Anything that isn't ``<int>.<int>`` (e.g. ``"1.x"``, ``"latest"``,
+# semver pre-releases) falls back to "any version" (None) so the
+# resolver doesn't over-constrain on a version shape it can't parse.
+_VERSION_PREFIX_RE = re.compile(r"^(\d+)\.(\d+)")
+
+
+def _derive_supported_version_range(version: str) -> str | None:
+    """Derive a PEP 440-style range from the version string.
+
+    ``"9.0"`` → ``">=9.0,<10.0"``. ``"9.0.1"`` → ``">=9.0,<10.0"``
+    (major.minor compatibility window). ``"1.x"`` / ``"latest"`` /
+    other non-numeric shapes → ``None`` (matches any version,
+    matching the v1 Connector default that empty / None
+    ``supported_version_range`` accepts any fingerprinted version).
+
+    Per-product connectors that ship as real subclasses (G3.x) will
+    set this attribute explicitly and override the auto-shim; the
+    derivation here is only ever load-bearing for the brief window
+    between first ingestion and the per-product subclass landing.
+    """
+    match = _VERSION_PREFIX_RE.match(version)
+    if match is None:
+        return None
+    major = int(match.group(1))
+    minor = int(match.group(2))
+    return f">={major}.{minor},<{major + 1}.0"
+
+
+def _identifier_safe_segment(value: str) -> str:
+    """Coerce *value* into a valid Python identifier segment.
+
+    Replaces non-alphanumeric characters with ``_`` and prefixes a
+    leading underscore when *value* starts with a digit. The result
+    is suitable for use as a class-name fragment passed to
+    :func:`type` — ``type()`` rejects names that aren't valid
+    Python identifiers at the syntactic level.
+    """
+    cleaned = re.sub(r"[^0-9A-Za-z_]", "_", value)
+    if not cleaned:
+        return "_"
+    if cleaned[0].isdigit():
+        cleaned = "_" + cleaned
+    return cleaned
+
+
+def _build_generic_rest_connector_class(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    base_url: str | None,
+) -> type[HttpConnector]:
+    """Dynamically construct a minimal :class:`HttpConnector` subclass.
+
+    The returned class is fully instantiable — every
+    :class:`~meho_backplane.connectors.base.Connector` abstract method
+    is overridden by a stub that raises :class:`NotImplementedError`
+    naming the G3.x Initiative responsible for shipping the real
+    implementation. The class itself can be registered immediately so
+    :func:`~meho_backplane.connectors.resolver.resolve_connector`
+    routes to it; the dispatch attempt against an uninhabited op is
+    what surfaces the "this connector needs a real subclass" message.
+    """
+
+    async def _fingerprint_stub(self: Any, target: Any) -> Any:
+        raise NotImplementedError(
+            f"GenericRestConnector shim for {self.product!r}/{self.version!r}"
+            f"/{self.impl_id!r} is registration-only; a per-product "
+            "connector subclass must ship via a G3.x Initiative before "
+            "fingerprint() is callable."
+        )
+
+    async def _probe_stub(self: Any, target: Any) -> Any:
+        raise NotImplementedError(
+            f"GenericRestConnector shim for {self.product!r}/{self.version!r}"
+            f"/{self.impl_id!r} is registration-only; a per-product "
+            "connector subclass must ship via a G3.x Initiative before "
+            "probe() is callable."
+        )
+
+    async def _execute_stub(
+        self: Any,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> Any:
+        raise NotImplementedError(
+            f"GenericRestConnector shim for {self.product!r}/{self.version!r}"
+            f"/{self.impl_id!r} is registration-only; a per-product "
+            "connector subclass must ship via a G3.x Initiative before "
+            "execute() is callable."
+        )
+
+    async def _auth_headers_stub(
+        self: Any,
+        target: Any,
+        raw_jwt: str,
+    ) -> dict[str, str]:
+        raise NotImplementedError(
+            f"GenericRestConnector shim for {self.product!r}/{self.version!r}"
+            f"/{self.impl_id!r} is registration-only; auth_headers() needs "
+            "a per-product override (session token, basic auth, XSRF, etc.) "
+            "shipped via a G3.x Initiative."
+        )
+
+    name_segments = "_".join(_identifier_safe_segment(seg) for seg in (product, version, impl_id))
+    cls_name = f"GenericRest_{name_segments}"
+    attrs: dict[str, Any] = {
+        "product": product,
+        "version": version,
+        "impl_id": impl_id,
+        "supported_version_range": _derive_supported_version_range(version),
+        "priority": 0,
+        # ``base_url`` is recorded on the class so a future G3.x
+        # subclass that wants to honour the operator-supplied base
+        # URL can read it without re-plumbing the ingestion call.
+        # ``HttpConnector._base_url`` reads from the target by
+        # default — the recorded value is informational in v0.2.
+        "_ingested_base_url": base_url,
+        # Repeat the docstring on the class so introspection /
+        # operator tooling explains the auto-shim shape.
+        "__doc__": (
+            f"Auto-registered HTTP connector shim for product={product!r} "
+            f"version={version!r} impl_id={impl_id!r}. Registration-only; "
+            "fingerprint/probe/execute raise NotImplementedError. Replaced "
+            "by a per-product subclass per the G3.x Initiative for this "
+            "connector."
+        ),
+        "fingerprint": _fingerprint_stub,
+        "probe": _probe_stub,
+        "execute": _execute_stub,
+        "auth_headers": _auth_headers_stub,
+    }
+    return type(cls_name, (HttpConnector,), attrs)
+
+
+def ensure_connector_class_registered(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    base_url: str | None = None,
+) -> bool:
+    """Register a :class:`HttpConnector` shim for *(product, version, impl_id)* if absent.
+
+    Returns ``True`` when a new shim was registered, ``False`` when
+    a class for the triple was already present in the v2 registry
+    (the typical second-ingestion path on the same connector).
+
+    The helper is intentionally idempotent on the registry side:
+    a same-process re-ingestion does no work, and a cross-process
+    re-ingestion (process restart) registers a fresh shim that
+    behaves identically. Real per-product subclasses that ship via
+    G3.x Initiatives MUST register at module-import time
+    (lifespan-startup ``_eager_import_connectors``) so the shim does
+    not paper over a real connector on cold start — the typical
+    deployment ordering is: G3.x lands → image rebuilds → process
+    restart → real subclass registers at import → ingestion runs
+    against the already-registered key and skips this helper.
+    """
+    key = (product, version, impl_id)
+    if key in all_connectors_v2():
+        _log.info(
+            "ingested_connector_already_registered",
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+        return False
+
+    cls = _build_generic_rest_connector_class(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        base_url=base_url,
+    )
+    try:
+        register_connector_v2(
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            cls=cls,
+        )
+    except RuntimeError:
+        # Concurrent ingestion against the same triple registered the
+        # class between our membership check and the register call.
+        # Treat as "already registered" rather than propagating —
+        # both calls produced the same observable end state.
+        _log.info(
+            "ingested_connector_race_registered_by_peer",
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+        return False
+
+    _log.info(
+        "ingested_connector_shim_registered",
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        cls=cls.__name__,
+        supported_version_range=cls.supported_version_range,
+    )
+    return True

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -3,9 +3,9 @@
 
 """Domain exceptions for the G0.7 spec-ingestion pipeline.
 
-Two unrelated families of failure modes share this module so T1
-(OpenAPI parser, #401) and T4 (review-queue state machine, #402)
-agree on an import path:
+Three families of failure modes share this module so the sibling
+tasks (parser T1 #401, register-ingested T2 #403, review-queue T4
+#402) agree on an import path:
 
 Parser failures (T1 #401) — raised from
 :func:`~meho_backplane.operations.ingest.parse_openapi`:
@@ -18,6 +18,17 @@ Parser failures (T1 #401) — raised from
 * :class:`InvalidSchemaError` — a referenced JSON Schema is
   structurally broken (dangling ``$ref``, component-path drill-down,
   non-list parameters).
+
+Bulk-upsert failures (T2 #403) — raised from
+:func:`~meho_backplane.operations.ingest.register_ingested_operations`:
+
+* :class:`OpIdCollision` — the incoming spec carries an ``op_id`` a
+  row already on the connector was ingested from a *different* spec
+  source. The natural key
+  ``(product, version, impl_id, op_id)`` is unique per row, so the
+  helper refuses to silently overlay one spec's payload onto another
+  spec's row; the operator picks the resolution (rename one op via
+  ``custom_description`` at T4 review, or skip the conflicting spec).
 
 Review-queue failures (T4 #402) — raised from
 :class:`~meho_backplane.operations.ingest.ReviewService`:
@@ -43,9 +54,11 @@ Review-queue failures (T4 #402) — raised from
 
 The parser classes inherit from :class:`ValueError` so callers that
 already catch parsing errors via ``except ValueError`` keep working;
-the review-queue classes inherit from :class:`Exception` directly so
-callers can ``except`` them precisely without catching unrelated
-runtime faults.
+:class:`OpIdCollision` inherits from :class:`ValueError` for the
+same reason (ingestion call sites already wrap ``parse_openapi`` in
+a ``except ValueError`` block). The review-queue classes inherit
+from :class:`Exception` directly so callers can ``except`` them
+precisely without catching unrelated runtime faults.
 """
 
 from __future__ import annotations
@@ -57,6 +70,7 @@ __all__ = [
     "InvalidSchemaError",
     "InvalidSpecError",
     "InvalidStateTransitionError",
+    "OpIdCollision",
     "UnsupportedSpecError",
 ]
 
@@ -89,6 +103,51 @@ class InvalidSchemaError(ValueError):
     a structurally unsupported shape (component-path drill-down
     refs, for example).
     """
+
+
+class OpIdCollision(ValueError):  # noqa: N818 -- name pinned by Task #403 contract
+    """An incoming op_id collides with an existing row from a different spec.
+
+    Raised by
+    :func:`~meho_backplane.operations.ingest.register_ingested_operations`
+    when the bulk upsert would overlay one spec's parsed operation
+    onto a row another spec already populated under the same
+    ``(product, version, impl_id, op_id)`` natural key.
+
+    Attributes
+    ----------
+    incoming_spec_source:
+        The ``spec_source`` value passed to the failing call (e.g.
+        ``"vi-json.yaml"``).
+    colliding_op_ids:
+        The list of ``op_id`` values the helper refused to overlay,
+        sorted alphabetically for stable error messages.
+    existing_spec_sources:
+        ``{op_id: spec_source}`` mapping of the spec-source tag
+        recovered from the existing row's ``tags`` column for each
+        colliding op-id. Empty string when the existing row has no
+        ``spec:*`` tag (legacy row predating multi-spec merge).
+
+    The exception is raised **before** any row is written, so a
+    collision aborts the entire batch — partial ingestion under
+    contention is not a supported state.
+    """
+
+    def __init__(
+        self,
+        *,
+        incoming_spec_source: str,
+        colliding_op_ids: list[str],
+        existing_spec_sources: dict[str, str],
+    ) -> None:
+        self.incoming_spec_source = incoming_spec_source
+        self.colliding_op_ids = sorted(colliding_op_ids)
+        self.existing_spec_sources = existing_spec_sources
+        joined = ", ".join(
+            f"{op_id!r} (existing spec={existing_spec_sources.get(op_id, '') or '<untagged>'!r})"
+            for op_id in self.colliding_op_ids
+        )
+        super().__init__(f"spec_source={incoming_spec_source!r} collides on op_id(s): {joined}")
 
 
 class InvalidStateTransitionError(Exception):

--- a/backend/src/meho_backplane/operations/ingest/register_ingested.py
+++ b/backend/src/meho_backplane/operations/ingest/register_ingested.py
@@ -1,0 +1,566 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``register_ingested_operations()`` — async bulk-upsert of parsed OpenAPI ops.
+
+G0.7-T2 (#403) of Initiative #389. The CLI verb
+``meho connector ingest`` (T5) and the REST route ``POST
+/api/v1/connectors/ingest`` (T6) both reduce to a single call to this
+helper after the parser (T1 #401) produces the
+:class:`EndpointDescriptorProto` list. Parallel pathway to
+:func:`~meho_backplane.operations.typed_register.register_typed_operation`:
+both write :class:`EndpointDescriptor` rows under the same natural
+key, but typed registration runs at connector-init time with a Python
+callable as the dispatch handle, whereas ingested registration runs
+at operator-triggered ingest time with ``method`` / ``path`` as the
+dispatch handles.
+
+Algorithm
+---------
+
+Per call (one ``spec_source`` worth of operations):
+
+1. **Validate the inputs.** ``spec_source`` non-empty; ``operations``
+   non-empty list of :class:`EndpointDescriptorProto`. ``op_id``
+   values within the batch must be unique — duplicates indicate a
+   parser bug and we refuse to silently clobber within a single call.
+2. **Auto-register the connector class** via
+   :func:`~meho_backplane.operations.ingest.connector_registration.ensure_connector_class_registered`.
+   First call lands a :class:`HttpConnector` shim;
+   :attr:`IngestionResult.connector_registered` reports whether a
+   new class was added (``True`` first time, ``False`` thereafter).
+3. **Look up existing rows** for the natural-key family
+   ``(product, version, impl_id, tenant_id, op_id IN incoming)`` in
+   one query.
+4. **Pre-detect op-id collisions** across spec sources by inspecting
+   each existing row's ``tags`` for a ``spec:<source>`` marker; a
+   different marker than the incoming ``spec_source`` is the
+   collision case. Raise :class:`OpIdCollision` with all offenders
+   in one shot so the operator sees the full punch list rather than
+   one error per re-run.
+5. **For each proto:**
+
+   * No existing row → INSERT a new descriptor with
+     ``source_kind='ingested'``, ``is_enabled=False`` (staged), the
+     parser-derived columns, the ``spec:<source>`` tag injected (if
+     not already present from the parser), and a fresh embedding
+     computed from ``summary + description + custom_description +
+     tags``.
+   * Existing row with matching embedding-text hash → skip-re-embed:
+     UPDATE the non-embedding-text columns (``method`` / ``path`` /
+     ``parameter_schema`` / ``response_schema`` / ``safety_level`` /
+     ``requires_approval``) and the ``spec:<source>`` tag, advance
+     ``updated_at``. Counts as ``skipped`` in the result. The
+     skip-re-embed branch is the operationally critical path for
+     repeated ingestion runs — re-ingesting vcenter.yaml's 961
+     operations without spec changes avoids 961 ONNX inferences.
+   * Existing row with different embedding-text hash → re-embed:
+     UPDATE every body-derived column plus ``embedding``, advance
+     ``updated_at``. Counts as ``updated``.
+
+6. **Commit** (helper-owned session) or **flush** (caller-owned
+   session). The caller-owned-session branch matches the
+   :func:`register_typed_operation` shape so the CLI verb / REST
+   route can stage ingestion inside a larger audit-emitting
+   transaction.
+
+Idempotency contract
+--------------------
+
+* Re-running with the same args produces no embedding service calls
+  for unchanged rows (verified via the call-count assertion in
+  tests) and leaves ``inserted_count=0``,
+  ``updated_count=0``, ``skipped_count=len(operations)``.
+* Re-running after a parser-side change to a single op triggers
+  exactly one re-embed for that op; the rest skip.
+* Re-running with a fresh ``spec_source`` against the same
+  connector merges: new op-ids land as inserts; pre-existing op-ids
+  whose ``spec:*`` marker came from the original spec raise
+  :class:`OpIdCollision` (multi-spec merge requires disjoint
+  op_ids in v0.2).
+
+Stale operations
+----------------
+
+Ops that exist in the DB under this connector but do NOT appear in
+the incoming ``operations`` list are NOT auto-deleted in v0.2.
+Operators handle obsolete ops via T4's per-op
+``edit_op(is_enabled=False)`` flow. Auto-deletion on re-ingest is
+v0.2.next once the audit story for "operator-disabled vs
+spec-removed" is settled.
+
+Connector class auto-registration
+---------------------------------
+
+See :mod:`.connector_registration` for the design notes. The auto-shim
+gets the connector resolvable + dispatchable for read-only ops with
+default auth; per-product auth quirks (G3.1 vSphere session creation,
+G3.5 NSX XSRF, G3.6 vCF dual-plane) ship as real subclasses per G3.x
+Initiative and REPLACE this shim at code-merge time.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from uuid import UUID
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations.embed import (
+    build_embedding_text,
+    compute_embedding_text_hash,
+    encode_endpoint_text,
+)
+from meho_backplane.operations.ingest.connector_registration import (
+    ensure_connector_class_registered,
+)
+from meho_backplane.operations.ingest.exceptions import OpIdCollision
+from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "IngestionResult",
+    "register_ingested_operations",
+]
+
+_SPEC_TAG_PREFIX = "spec:"
+
+
+class IngestionResult(BaseModel):
+    """Outcome of one :func:`register_ingested_operations` call.
+
+    Returned by the helper and surfaced verbatim by the CLI verb
+    ``meho connector ingest`` (T5) and the REST route
+    ``POST /api/v1/connectors/ingest`` (T6); both render the field
+    set as a JSON object so operators (and the test harness in T8)
+    can assert against counts without parsing prose.
+
+    Attributes
+    ----------
+    inserted_count, updated_count, skipped_count:
+        Per-op outcomes. ``inserted`` = new row; ``updated`` =
+        existing row, embedding text changed → re-embed; ``skipped``
+        = existing row, embedding text unchanged → no re-embed. The
+        sum is ``len(operations)`` on every successful call.
+    connector_registered:
+        ``True`` when this call was the first to ingest the
+        ``(product, version, impl_id)`` triple and registered a
+        :class:`HttpConnector` shim into the v2 registry. ``False``
+        on subsequent calls (the shim — or a real per-product
+        subclass — was already present).
+    operations_grouped:
+        Always ``False`` from this helper. T3 (LLM grouping)
+        flips groups onto rows in a follow-up pass; T2 leaves
+        ``group_id`` NULL.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    inserted_count: int = Field(ge=0)
+    updated_count: int = Field(ge=0)
+    skipped_count: int = Field(ge=0)
+    connector_registered: bool
+    operations_grouped: bool = False
+
+
+def _normalise_tags_for_persistence(
+    proto_tags: Sequence[str],
+    *,
+    spec_source: str,
+) -> list[str]:
+    """Return *proto_tags* with a single ``spec:<source>`` marker present.
+
+    The parser (T1) may already inject the ``spec:<source>`` tag when
+    callers passed ``spec_source`` through ``parse_openapi``; the
+    helper must still cope with callers (notably T8's vSphere canary
+    smoke harness) that parse first and pass the resulting protos
+    through ``register_ingested_operations`` with a different
+    ``spec_source`` argument. The function:
+
+    * Filters out **any** existing ``spec:*`` markers from the
+      incoming tags — they belong to whatever code path produced the
+      proto, not to this ingestion call.
+    * Appends ``spec:<source>`` at the end so the tag is
+      deterministically present.
+
+    Preserves the relative ordering of non-spec tags so the parser's
+    upstream tag list stays readable in the persisted column.
+    """
+    cleaned = [tag for tag in proto_tags if not tag.startswith(_SPEC_TAG_PREFIX)]
+    cleaned.append(f"{_SPEC_TAG_PREFIX}{spec_source}")
+    return cleaned
+
+
+def _extract_spec_source(tags: Sequence[str]) -> str | None:
+    """Return the ``spec_source`` value carried by *tags*, or ``None``.
+
+    Reads the first ``spec:<value>`` marker — there should only ever
+    be one (Tag normalisation above strips duplicates on every
+    upsert). A row without a ``spec:*`` tag pre-dates multi-spec
+    merge and is treated as "no spec source recorded" in collision
+    diagnostics.
+    """
+    for tag in tags:
+        if tag.startswith(_SPEC_TAG_PREFIX):
+            return tag[len(_SPEC_TAG_PREFIX) :]
+    return None
+
+
+def _validate_batch_unique_op_ids(operations: Sequence[EndpointDescriptorProto]) -> None:
+    """Reject a batch with duplicate ``op_id`` values across protos.
+
+    Parser-produced batches always have unique op-ids (one per
+    method+path tuple); a duplicate indicates a bug upstream of T2.
+    Failing fast here surfaces the parser regression at the
+    ingestion boundary rather than silently letting the second
+    duplicate clobber the first within the same call.
+    """
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for proto in operations:
+        if proto.op_id in seen:
+            duplicates.add(proto.op_id)
+        seen.add(proto.op_id)
+    if duplicates:
+        raise ValueError(
+            f"register_ingested_operations: duplicate op_id(s) within batch: {sorted(duplicates)!r}"
+        )
+
+
+def _detect_collisions(
+    existing_by_op_id: dict[str, EndpointDescriptor],
+    *,
+    spec_source: str,
+) -> dict[str, str]:
+    """Return ``{op_id: existing_spec_source}`` for any cross-spec collisions.
+
+    Empty dict when none — the caller treats that as the "no
+    collision" case and proceeds to upsert. A non-empty dict
+    triggers :class:`OpIdCollision`.
+    """
+    collisions: dict[str, str] = {}
+    for op_id, existing in existing_by_op_id.items():
+        existing_source = _extract_spec_source(existing.tags)
+        # Untagged legacy rows (existing_source is None) are NOT a
+        # collision — they pre-date multi-spec merge and the
+        # ingestion is allowed to claim them by stamping the spec
+        # marker on the row.
+        if existing_source is not None and existing_source != spec_source:
+            collisions[op_id] = existing_source
+    return collisions
+
+
+async def register_ingested_operations(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    spec_source: str,
+    operations: Sequence[EndpointDescriptorProto],
+    base_url: str | None = None,
+    tenant_id: UUID | None = None,
+    session: AsyncSession | None = None,
+    embedding_service: EmbeddingService | None = None,
+) -> IngestionResult:
+    """Bulk-upsert parsed operations into ``endpoint_descriptor`` for one spec.
+
+    Parameters
+    ----------
+    product, version, impl_id:
+        Natural-key coordinates for the connector
+        ``(product, version, impl_id)`` triple. The same triple is
+        used by typed registrations and by registry v2 routing.
+    spec_source:
+        Tag value identifying which upstream document the
+        ``operations`` came from (e.g. ``"vcenter.yaml"``,
+        ``"vi-json.yaml"``). Materialised as a ``spec:<value>`` tag
+        on every persisted row so the operator review queue (T4)
+        can browse per spec, and so multi-spec collisions can be
+        detected on subsequent ingestions. Must be a non-empty
+        string.
+    operations:
+        Parser-produced :class:`EndpointDescriptorProto` list. The
+        helper rejects empty batches and batches with duplicate
+        op-ids (parser regression guard).
+    base_url:
+        Optional default base URL for the auto-registered
+        :class:`HttpConnector` shim. Recorded as a class attribute
+        on the dynamically-created class so a future per-product
+        subclass can read it without re-plumbing ingestion. The
+        :meth:`HttpConnector._base_url` default reads from the
+        target's host/port — the recorded value is informational in
+        v0.2.
+    tenant_id:
+        ``None`` for built-in / global ingestion (shipped product
+        defaults); a UUID for tenant-curated ingestion. The
+        per-tenant scope writes rows under the
+        ``endpoint_descriptor_tenant_idx`` partial-unique index;
+        built-in rows write under
+        ``endpoint_descriptor_global_idx``.
+    session:
+        Caller-owned :class:`AsyncSession` for stage-in-larger-tx
+        callers (T5 CLI / T6 REST). When ``None`` the helper opens
+        its own session, commits, and closes.
+    embedding_service:
+        Test seam for the :class:`EmbeddingService`. Production
+        callers pass ``None`` so the helper resolves the
+        process-wide singleton.
+
+    Returns
+    -------
+    IngestionResult
+        Outcome counts plus the connector-registration flag. See
+        :class:`IngestionResult` for the field semantics.
+
+    Raises
+    ------
+    ValueError
+        ``spec_source`` empty / whitespace, ``operations`` empty, or
+        the batch contains duplicate ``op_id`` values.
+    OpIdCollision
+        One or more incoming op-ids collide with existing rows whose
+        ``spec:*`` tag names a *different* spec source. No rows are
+        written when this fires.
+    """
+    if not spec_source or not spec_source.strip():
+        raise ValueError(
+            "register_ingested_operations: spec_source must be a non-empty string "
+            f"(received {spec_source!r})"
+        )
+    if not operations:
+        raise ValueError("register_ingested_operations: operations list is empty")
+    _validate_batch_unique_op_ids(operations)
+
+    connector_registered = ensure_connector_class_registered(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        base_url=base_url,
+    )
+
+    if session is not None:
+        result = await _register_in_session(
+            session,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            spec_source=spec_source,
+            operations=operations,
+            tenant_id=tenant_id,
+            embedding_service=embedding_service,
+            commit=False,
+        )
+    else:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as owned_session:
+            result = await _register_in_session(
+                owned_session,
+                product=product,
+                version=version,
+                impl_id=impl_id,
+                spec_source=spec_source,
+                operations=operations,
+                tenant_id=tenant_id,
+                embedding_service=embedding_service,
+                commit=True,
+            )
+
+    return IngestionResult(
+        inserted_count=result["inserted_count"],
+        updated_count=result["updated_count"],
+        skipped_count=result["skipped_count"],
+        connector_registered=connector_registered,
+        operations_grouped=False,
+    )
+
+
+async def _register_in_session(
+    session: AsyncSession,
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    spec_source: str,
+    operations: Sequence[EndpointDescriptorProto],
+    tenant_id: UUID | None,
+    embedding_service: EmbeddingService | None,
+    commit: bool,
+) -> dict[str, int]:
+    """Inner upsert path — runs against *session* without owning its lifecycle.
+
+    Split out from :func:`register_ingested_operations` so the public
+    helper can branch on caller-owned-vs-helper-owned session without
+    duplicating the upsert loop. Returns the count breakdown
+    (inserted / updated / skipped) the outer helper folds into
+    :class:`IngestionResult` together with the connector-registration
+    flag.
+
+    Tenant-aware natural-key lookup: ``tenant_id IS NULL`` for
+    built-in ingestion, ``tenant_id = :uuid`` for tenant-curated.
+    The two paths share the same upsert logic but route the
+    descriptor INSERT to the matching partial-unique index.
+    """
+    log = structlog.get_logger(__name__)
+    now = datetime.now(UTC)
+
+    op_ids = [proto.op_id for proto in operations]
+    # ``IN (...)`` against the natural-key fields. SQLAlchemy emits
+    # a tuple expansion under PG and SQLite; for a batch of <=1000
+    # op-ids (vcenter.yaml's 961 paths, vi-json.yaml's 2,195) the
+    # round-trip is one query.
+    query = select(EndpointDescriptor).where(
+        EndpointDescriptor.product == product,
+        EndpointDescriptor.version == version,
+        EndpointDescriptor.impl_id == impl_id,
+        EndpointDescriptor.op_id.in_(op_ids),
+    )
+    if tenant_id is None:
+        query = query.where(EndpointDescriptor.tenant_id.is_(None))
+    else:
+        query = query.where(EndpointDescriptor.tenant_id == tenant_id)
+    result = await session.execute(query)
+    existing_by_op_id: dict[str, EndpointDescriptor] = {row.op_id: row for row in result.scalars()}
+
+    collisions = _detect_collisions(existing_by_op_id, spec_source=spec_source)
+    if collisions:
+        raise OpIdCollision(
+            incoming_spec_source=spec_source,
+            colliding_op_ids=list(collisions),
+            existing_spec_sources=collisions,
+        )
+
+    inserted_count = 0
+    updated_count = 0
+    skipped_count = 0
+
+    for proto in operations:
+        tags = _normalise_tags_for_persistence(proto.tags, spec_source=spec_source)
+        incoming_text = build_embedding_text(
+            summary=proto.summary or "",
+            description=proto.description or "",
+            custom_description=None,
+            tags=tags,
+        )
+        incoming_hash = compute_embedding_text_hash(incoming_text)
+
+        existing = existing_by_op_id.get(proto.op_id)
+        if existing is not None:
+            existing_text = build_embedding_text(
+                summary=existing.summary or "",
+                description=existing.description or "",
+                custom_description=existing.custom_description,
+                tags=existing.tags,
+            )
+            existing_hash = compute_embedding_text_hash(existing_text)
+
+            if existing_hash == incoming_hash:
+                # Skip-re-embed: parser output and persisted text
+                # match. Update the non-text columns (parameter
+                # schema, response schema, method, path, etc.) when
+                # they differ; advance ``updated_at``.
+                existing.method = proto.method
+                existing.path = proto.path
+                existing.parameter_schema = dict(proto.parameter_schema)
+                existing.response_schema = (
+                    dict(proto.response_schema) if proto.response_schema is not None else None
+                )
+                existing.safety_level = proto.safety_level
+                existing.requires_approval = proto.requires_approval
+                existing.tags = tags
+                existing.updated_at = now
+                skipped_count += 1
+                continue
+
+            # Re-embed: persisted text differs from parser output.
+            embedding = await encode_endpoint_text(
+                incoming_text,
+                service=embedding_service,
+            )
+            existing.method = proto.method
+            existing.path = proto.path
+            existing.summary = proto.summary
+            existing.description = proto.description
+            existing.parameter_schema = dict(proto.parameter_schema)
+            existing.response_schema = (
+                dict(proto.response_schema) if proto.response_schema is not None else None
+            )
+            existing.safety_level = proto.safety_level
+            existing.requires_approval = proto.requires_approval
+            existing.tags = tags
+            existing.embedding = embedding
+            existing.updated_at = now
+            updated_count += 1
+            continue
+
+        # First-register path: brand-new row in staged state.
+        embedding = await encode_endpoint_text(
+            incoming_text,
+            service=embedding_service,
+        )
+        descriptor = EndpointDescriptor(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            op_id=proto.op_id,
+            source_kind="ingested",
+            method=proto.method,
+            path=proto.path,
+            # ``handler_ref`` is the typed-op dispatch handle; ingested
+            # ops resolve their dispatch target via ``method`` + ``path``
+            # against the registered HttpConnector subclass.
+            handler_ref=None,
+            summary=proto.summary,
+            description=proto.description,
+            # Group assignment is T3's responsibility; T2 leaves NULL.
+            group_id=None,
+            tags=tags,
+            parameter_schema=dict(proto.parameter_schema),
+            response_schema=(
+                dict(proto.response_schema) if proto.response_schema is not None else None
+            ),
+            llm_instructions=None,
+            safety_level=proto.safety_level,
+            requires_approval=proto.requires_approval,
+            # Staged state: agent's search_operations (T8) must not
+            # surface this row until the operator review queue (T4)
+            # transitions it to enabled.
+            is_enabled=False,
+            embedding=embedding,
+            custom_description=None,
+            custom_notes=None,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(descriptor)
+        inserted_count += 1
+
+    await session.flush()
+    if commit:
+        await session.commit()
+
+    log.info(
+        "ingested_operations_registered",
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        spec_source=spec_source,
+        tenant_id=str(tenant_id) if tenant_id is not None else None,
+        inserted=inserted_count,
+        updated=updated_count,
+        skipped=skipped_count,
+    )
+
+    return {
+        "inserted_count": inserted_count,
+        "updated_count": updated_count,
+        "skipped_count": skipped_count,
+    }

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -1,0 +1,803 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.operations.ingest.register_ingested`.
+
+Coverage matrix (G0.7-T2 / Task #403 acceptance criteria):
+
+* First-call insert path: every parsed proto lands as a new
+  :class:`EndpointDescriptor` row with ``source_kind='ingested'``,
+  ``is_enabled=False`` (staged), ``group_id IS NULL``, ``tags``
+  carrying the ``spec:<source>`` marker, embedding computed once.
+* Body-hash skip: re-running with identical parser output produces
+  zero embedding service calls + the result counts ``skipped`` per
+  op.
+* Re-run with changed summary/description triggers re-embed and
+  counts ``updated`` per op.
+* Re-run with changed parameter_schema (non-embedding-text field)
+  does NOT trigger re-embed; counts ``skipped``; the parameter
+  schema is updated on the row.
+* Multi-spec merge: ingesting a second spec under the same
+  ``(product, version, impl_id)`` with disjoint op-ids produces
+  rows tagged distinctly via ``spec:<source>``.
+* Op-id collision detected: ingesting two specs with overlapping
+  op-ids raises :class:`OpIdCollision`; no rows are written from
+  the failing call.
+* Connector class auto-registration on first ingest: the v2
+  registry contains a :class:`HttpConnector` subclass keyed on the
+  triple; :attr:`IngestionResult.connector_registered` is ``True``.
+* Second ingest under the same triple does NOT re-register;
+  ``connector_registered=False``.
+* Tenant scoping: ``tenant_id`` argument routes rows to the
+  matching partial-unique index; built-in (``None``) and
+  tenant-scoped rows can coexist for the same op-id without
+  collision.
+* :class:`IngestionResult` shape: counts + flags as documented.
+* Caller-owned session: helper does not commit; caller controls
+  transaction boundaries.
+
+The embedding service is mocked via the explicit
+``embedding_service=`` parameter so tests don't pull fastembed or
+ONNX runtime, and the call count assertion is what proves the
+skip-re-embed branch.
+
+A fresh in-memory registry is installed for each test via the
+``_reset_connector_registry`` autouse fixture so connector
+auto-registration assertions don't leak across tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations.ingest import (
+    EndpointDescriptorProto,
+    IngestionResult,
+    OpIdCollision,
+    ensure_connector_class_registered,
+    register_ingested_operations,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_connector_registry() -> Iterator[None]:
+    """Empty the connector registry around every test.
+
+    The v2 registry is a module-level dict; auto-registrations from
+    one test leaking into another would make the
+    ``connector_registered=True`` assertion flaky. Pairs with the
+    documented test-only ``clear_registry`` escape hatch.
+    """
+    clear_registry()
+    yield
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic 384-dim embedding mock; call count proves skip-re-embed."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """An :class:`AsyncSession` against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _proto(
+    *,
+    op_id: str = "GET:/api/vcenter/cluster",
+    method: str = "GET",
+    path: str = "/api/vcenter/cluster",
+    summary: str | None = "List clusters",
+    description: str | None = "Return every vCenter cluster.",
+    tags: list[str] | None = None,
+    parameter_schema: dict[str, Any] | None = None,
+    response_schema: dict[str, Any] | None = None,
+    safety_level: str = "safe",
+    requires_approval: bool = False,
+) -> EndpointDescriptorProto:
+    """Build an :class:`EndpointDescriptorProto` with defaults filled in."""
+    return EndpointDescriptorProto(
+        op_id=op_id,
+        method=method,
+        path=path,
+        summary=summary,
+        description=description,
+        tags=tags if tags is not None else [],
+        parameter_schema=(
+            parameter_schema
+            if parameter_schema is not None
+            else {"type": "object", "properties": {}}
+        ),
+        response_schema=response_schema,
+        safety_level=safety_level,  # type: ignore[arg-type]
+        requires_approval=requires_approval,
+    )
+
+
+# ---------------------------------------------------------------------------
+# First-call insert path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_first_call_inserts_descriptor_in_staged_state(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """First call inserts every proto as a staged row with the spec tag."""
+    protos = [
+        _proto(
+            op_id="GET:/api/vcenter/cluster",
+            method="GET",
+            path="/api/vcenter/cluster",
+            tags=["cluster"],
+        ),
+        _proto(
+            op_id="DELETE:/api/vcenter/vm/{vm_id}",
+            method="DELETE",
+            path="/api/vcenter/vm/{vm_id}",
+            summary="Delete a VM",
+            description="Permanently delete the specified virtual machine.",
+            tags=["vm-lifecycle"],
+            safety_level="dangerous",
+        ),
+    ]
+
+    result = await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=protos,
+        embedding_service=stub_embedding_service,
+    )
+
+    assert isinstance(result, IngestionResult)
+    assert result.inserted_count == 2
+    assert result.updated_count == 0
+    assert result.skipped_count == 0
+    assert result.connector_registered is True
+    assert result.operations_grouped is False
+    assert stub_embedding_service.encode_one.call_count == 2
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor)
+                    .where(EndpointDescriptor.product == "vmware")
+                    .order_by(EndpointDescriptor.op_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(rows) == 2
+    cluster = next(row for row in rows if row.op_id == "GET:/api/vcenter/cluster")
+    delete_vm = next(row for row in rows if row.op_id == "DELETE:/api/vcenter/vm/{vm_id}")
+    assert cluster.tenant_id is None
+    assert cluster.source_kind == "ingested"
+    assert cluster.method == "GET"
+    assert cluster.path == "/api/vcenter/cluster"
+    assert cluster.handler_ref is None
+    assert cluster.is_enabled is False
+    assert cluster.group_id is None
+    assert cluster.safety_level == "safe"
+    assert "cluster" in cluster.tags
+    assert "spec:vcenter.yaml" in cluster.tags
+    assert cluster.embedding == [0.1] * 384
+    assert cluster.custom_description is None
+
+    assert delete_vm.safety_level == "dangerous"
+    assert "spec:vcenter.yaml" in delete_vm.tags
+
+
+@pytest.mark.asyncio
+async def test_register_first_call_registers_http_connector_shim(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """First ingestion against a triple registers a HttpConnector subclass."""
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto()],
+        embedding_service=stub_embedding_service,
+    )
+
+    registry = all_connectors_v2()
+    key = ("vmware", "9.0", "vmware-rest")
+    assert key in registry
+    cls = registry[key]
+    assert issubclass(cls, HttpConnector)
+    assert cls.product == "vmware"
+    assert cls.version == "9.0"
+    assert cls.impl_id == "vmware-rest"
+    # Derived range: same major.minor compatibility window.
+    assert cls.supported_version_range == ">=9.0,<10.0"
+
+
+@pytest.mark.asyncio
+async def test_register_second_call_does_not_re_register_connector(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Subsequent ingestions against the same triple report connector_registered=False."""
+    first = await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto(op_id="GET:/a")],
+        embedding_service=stub_embedding_service,
+    )
+    second = await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto(op_id="GET:/b")],
+        embedding_service=stub_embedding_service,
+    )
+    assert first.connector_registered is True
+    assert second.connector_registered is False
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — body-hash skip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_same_args_twice_skips_reembed(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Re-call with identical parser output produces one row + one embed call."""
+    protos = [_proto(op_id="GET:/api/vcenter/cluster", tags=["cluster"])]
+    args: dict[str, Any] = {
+        "product": "vmware",
+        "version": "9.0",
+        "impl_id": "vmware-rest",
+        "spec_source": "vcenter.yaml",
+        "operations": protos,
+        "embedding_service": stub_embedding_service,
+    }
+
+    first = await register_ingested_operations(**args)
+    assert first.inserted_count == 1 and first.skipped_count == 0
+    assert stub_embedding_service.encode_one.call_count == 1
+
+    second = await register_ingested_operations(**args)
+    assert second.inserted_count == 0
+    assert second.updated_count == 0
+    assert second.skipped_count == 1
+    assert stub_embedding_service.encode_one.call_count == 1, (
+        "Embedding service must not be invoked when parser output is unchanged"
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.op_id == "GET:/api/vcenter/cluster"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+
+
+@pytest.mark.parametrize(
+    "field,new_value",
+    [
+        ("summary", "Updated summary"),
+        ("description", "Updated description body."),
+    ],
+)
+@pytest.mark.asyncio
+async def test_register_changed_embedding_text_triggers_reembed(
+    stub_embedding_service: AsyncMock,
+    field: str,
+    new_value: Any,
+) -> None:
+    """Changing summary/description fields triggers a re-embed."""
+    baseline = _proto(op_id="GET:/api/vcenter/cluster", tags=["cluster"])
+    base_args: dict[str, Any] = {
+        "product": "vmware",
+        "version": "9.0",
+        "impl_id": "vmware-rest",
+        "spec_source": "vcenter.yaml",
+        "embedding_service": stub_embedding_service,
+    }
+    await register_ingested_operations(operations=[baseline], **base_args)
+    assert stub_embedding_service.encode_one.call_count == 1
+
+    updated = baseline.model_copy(update={field: new_value})
+    result = await register_ingested_operations(
+        operations=[updated],
+        **base_args,
+    )
+    assert result.updated_count == 1
+    assert result.skipped_count == 0
+    assert stub_embedding_service.encode_one.call_count == 2, (
+        f"Changing {field!r} must trigger a re-embed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_changed_parameter_schema_does_not_reembed(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Changing non-embedding-text fields updates the row without re-embed."""
+    baseline = _proto(
+        op_id="GET:/api/vcenter/cluster",
+        parameter_schema={"type": "object", "properties": {}},
+        tags=["cluster"],
+    )
+    base_args: dict[str, Any] = {
+        "product": "vmware",
+        "version": "9.0",
+        "impl_id": "vmware-rest",
+        "spec_source": "vcenter.yaml",
+        "embedding_service": stub_embedding_service,
+    }
+    await register_ingested_operations(operations=[baseline], **base_args)
+    assert stub_embedding_service.encode_one.call_count == 1
+
+    updated = baseline.model_copy(
+        update={
+            "parameter_schema": {
+                "type": "object",
+                "properties": {"filter": {"type": "string"}},
+            }
+        }
+    )
+    result = await register_ingested_operations(
+        operations=[updated],
+        **base_args,
+    )
+    assert result.skipped_count == 1
+    assert result.updated_count == 0
+    assert stub_embedding_service.encode_one.call_count == 1, (
+        "Changing parameter_schema must not trigger a re-embed"
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "GET:/api/vcenter/cluster"
+                )
+            )
+        ).scalar_one()
+    assert row.parameter_schema["properties"] == {"filter": {"type": "string"}}
+
+
+# ---------------------------------------------------------------------------
+# Multi-spec merge + collision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_multi_spec_merge_tags_per_spec(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Two spec ingestions under one connector tag rows distinctly via spec:*."""
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[
+            _proto(
+                op_id="GET:/api/vcenter/cluster",
+                method="GET",
+                path="/api/vcenter/cluster",
+                tags=["cluster"],
+            ),
+        ],
+        embedding_service=stub_embedding_service,
+    )
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vi-json.yaml",
+        operations=[
+            _proto(
+                op_id="POST:/ClusterComputeResource/{moId}/Method",
+                method="POST",
+                path="/ClusterComputeResource/{moId}/Method",
+                summary="Invoke a method",
+                description="Invoke a managed-object method.",
+                tags=["cluster"],
+                safety_level="caution",
+            ),
+        ],
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor)
+                    .where(EndpointDescriptor.product == "vmware")
+                    .order_by(EndpointDescriptor.op_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(rows) == 2
+    cluster = next(row for row in rows if row.op_id == "GET:/api/vcenter/cluster")
+    method = next(row for row in rows if row.op_id == "POST:/ClusterComputeResource/{moId}/Method")
+    assert "spec:vcenter.yaml" in cluster.tags
+    assert "spec:vi-json.yaml" not in cluster.tags
+    assert "spec:vi-json.yaml" in method.tags
+    assert "spec:vcenter.yaml" not in method.tags
+
+
+@pytest.mark.asyncio
+async def test_register_op_id_collision_across_specs_raises(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Ingesting the same op-id under a different spec_source raises OpIdCollision."""
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[
+            _proto(op_id="GET:/api/vcenter/cluster", tags=["cluster"]),
+            _proto(
+                op_id="GET:/api/vcenter/host",
+                method="GET",
+                path="/api/vcenter/host",
+                summary="List hosts",
+                description="Return every vCenter host.",
+                tags=["host"],
+            ),
+        ],
+        embedding_service=stub_embedding_service,
+    )
+
+    with pytest.raises(OpIdCollision) as excinfo:
+        await register_ingested_operations(
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            spec_source="vi-json.yaml",
+            operations=[
+                _proto(op_id="GET:/api/vcenter/cluster", tags=[]),
+                _proto(
+                    op_id="GET:/api/vcenter/host",
+                    method="GET",
+                    path="/api/vcenter/host",
+                    summary="List hosts",
+                    description="Return every vCenter host.",
+                    tags=[],
+                ),
+            ],
+            embedding_service=stub_embedding_service,
+        )
+
+    error = excinfo.value
+    assert error.incoming_spec_source == "vi-json.yaml"
+    assert "GET:/api/vcenter/cluster" in error.colliding_op_ids
+    assert "GET:/api/vcenter/host" in error.colliding_op_ids
+    assert error.existing_spec_sources["GET:/api/vcenter/cluster"] == "vcenter.yaml"
+
+    # No new rows from the failed call: still exactly the two from
+    # the first successful ingestion.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.product == "vmware")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 2
+    for row in rows:
+        assert "spec:vcenter.yaml" in row.tags
+        assert "spec:vi-json.yaml" not in row.tags
+
+
+# ---------------------------------------------------------------------------
+# Connector class auto-registration unit test
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_connector_class_registered_first_call_returns_true() -> None:
+    """Direct call to the helper registers a shim and reports True."""
+    registered = ensure_connector_class_registered(
+        product="acme",
+        version="1.0",
+        impl_id="acme-rest",
+        base_url="https://acme.test",
+    )
+    assert registered is True
+    cls = all_connectors_v2()[("acme", "1.0", "acme-rest")]
+    assert issubclass(cls, HttpConnector)
+    assert cls.product == "acme"
+    assert cls.supported_version_range == ">=1.0,<2.0"
+
+
+def test_ensure_connector_class_registered_idempotent() -> None:
+    """Second call against the same triple does NOT re-register."""
+    ensure_connector_class_registered(product="acme", version="1.0", impl_id="acme-rest")
+    second = ensure_connector_class_registered(product="acme", version="1.0", impl_id="acme-rest")
+    assert second is False
+
+
+def test_ensure_connector_class_non_numeric_version_no_range() -> None:
+    """Non-numeric version strings fall back to ``supported_version_range=None``."""
+    ensure_connector_class_registered(product="acme", version="latest", impl_id="acme-rest")
+    cls = all_connectors_v2()[("acme", "latest", "acme-rest")]
+    assert cls.supported_version_range is None
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_spec_source", ["", "   ", "\t"])
+@pytest.mark.asyncio
+async def test_register_rejects_invalid_spec_source(
+    stub_embedding_service: AsyncMock,
+    bad_spec_source: str,
+) -> None:
+    """Empty / whitespace ``spec_source`` raises :class:`ValueError`."""
+    with pytest.raises(ValueError, match="spec_source"):
+        await register_ingested_operations(
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            spec_source=bad_spec_source,
+            operations=[_proto()],
+            embedding_service=stub_embedding_service,
+        )
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_empty_operations_list(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Empty operations list raises :class:`ValueError`."""
+    with pytest.raises(ValueError, match="empty"):
+        await register_ingested_operations(
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            spec_source="vcenter.yaml",
+            operations=[],
+            embedding_service=stub_embedding_service,
+        )
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_duplicate_op_ids_in_batch(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Duplicate ``op_id`` values within a single batch raise :class:`ValueError`."""
+    with pytest.raises(ValueError, match="duplicate"):
+        await register_ingested_operations(
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            spec_source="vcenter.yaml",
+            operations=[
+                _proto(op_id="GET:/api/vcenter/cluster"),
+                _proto(op_id="GET:/api/vcenter/cluster"),
+            ],
+            embedding_service=stub_embedding_service,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tenant scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_tenant_scoped_rows_isolated_from_builtin(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Tenant-scoped and built-in rows can share an op-id without colliding."""
+    tenant_id = uuid.uuid4()
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto(op_id="GET:/api/vcenter/cluster", tags=["cluster"])],
+        embedding_service=stub_embedding_service,
+    )
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto(op_id="GET:/api/vcenter/cluster", tags=["cluster"])],
+        tenant_id=tenant_id,
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.op_id == "GET:/api/vcenter/cluster"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 2
+    by_scope = {row.tenant_id: row for row in rows}
+    assert None in by_scope and tenant_id in by_scope
+
+
+# ---------------------------------------------------------------------------
+# Caller-owned session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_caller_session_does_not_commit(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """When the caller passes a session, the helper does not commit."""
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto()],
+        session=session,
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        result = await fresh.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.product == "vmware")
+        )
+        assert result.scalar_one_or_none() is None
+
+    await session.commit()
+    async with sessionmaker() as fresh_after:
+        result = await fresh_after.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.product == "vmware")
+        )
+        assert result.scalar_one() is not None
+
+
+@pytest.mark.asyncio
+async def test_register_caller_session_rollback_discards_inserts(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """Caller rollback after the helper returns discards every inserted row."""
+    await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto()],
+        session=session,
+        embedding_service=stub_embedding_service,
+    )
+
+    await session.rollback()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        result = await fresh.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.product == "vmware")
+        )
+        assert result.scalar_one_or_none() is None
+
+
+# ---------------------------------------------------------------------------
+# 50-op integration smoke (acceptance: ingest a fixture spec; assert row count
+# + staged state + connector registered)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_50_op_batch_lands_staged_and_registered(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A 50-op batch lands as 50 staged rows; the connector class is registered."""
+    protos = [
+        _proto(
+            op_id=f"GET:/api/v1/resource/{i}",
+            method="GET",
+            path=f"/api/v1/resource/{i}",
+            summary=f"Get resource {i}",
+            description=f"Fetch resource number {i}.",
+            tags=["resource"],
+        )
+        for i in range(50)
+    ]
+    result = await register_ingested_operations(
+        product="acme",
+        version="1.0",
+        impl_id="acme-rest",
+        spec_source="acme.yaml",
+        operations=protos,
+        embedding_service=stub_embedding_service,
+    )
+    assert result.inserted_count == 50
+    assert result.connector_registered is True
+    assert stub_embedding_service.encode_one.call_count == 50
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.product == "acme")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 50
+    assert all(row.is_enabled is False for row in rows)
+    assert all(row.group_id is None for row in rows)
+    assert all(row.source_kind == "ingested" for row in rows)
+    assert ("acme", "1.0", "acme-rest") in all_connectors_v2()

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -67,6 +67,79 @@ The function is synchronous because callers are CLI / one-shot
 ingestion endpoints that have no in-flight event loop concern. It
 also keeps the surface trivially testable.
 
+### `register_ingested_operations(...)` (`ingest/register_ingested.py`)
+
+T2 (#403). Async bulk-upsert that takes the parser output through
+to `endpoint_descriptor` rows in **staged** state. Parallel pathway
+to `register_typed_operation()` (G0.6-T4); both write to the same
+table but differ in:
+
+| | `register_typed_operation` | `register_ingested_operations` |
+|---|---|---|
+| Trigger | Connector init (lifespan startup) | Operator command (`meho connector ingest`) |
+| Input | One proto per call | Batch of protos in one call |
+| `source_kind` | `'typed'` | `'ingested'` |
+| `handler_ref` | Dotted Python path | `NULL` (dispatch via `method` + `path`) |
+| `is_enabled` | `True` (built-in connectors trusted) | `False` (operator must enable per row via T4) |
+| `tenant_id` | Always `NULL` | `NULL` (built-in) or UUID (tenant-curated) |
+| `spec_source` tag | n/a | Required; written as `spec:<source>` |
+
+The helper returns an `IngestionResult` Pydantic model with
+inserted / updated / skipped counts, a `connector_registered` flag,
+and an `operations_grouped` flag (always `False` from T2 — T3 owns
+LLM grouping).
+
+**Body-hash skip.** Same algorithm as `register_typed_operation`:
+the embedding text is composed from `summary + description +
+custom_description + tags`; the SHA-256 hash of the composed text
+is recomputed for the persisted row and compared to the incoming
+hash. Match → skip-re-embed branch (update non-text columns,
+advance `updated_at`, count as `skipped`). Mismatch → re-embed and
+update every body-derived column (count as `updated`).
+
+**Multi-spec merge.** One `connector_id` (e.g. `vmware-rest-9.0`)
+accepts multiple specs ingested in separate calls, each with its
+own `spec_source` (`vcenter.yaml`, `vi-json.yaml`). Rows from each
+spec carry a `spec:<source>` marker in `tags` so operators can
+browse per spec. The natural key
+`(product, version, impl_id, op_id)` is unique per row, so:
+
+* **Disjoint op-ids across specs** (the typical vSphere case;
+  vcenter.yaml exposes `GET:/api/vcenter/...`, vi-json.yaml exposes
+  `POST:/ClusterComputeResource/{moId}/Method`) → both specs land
+  cleanly under one connector.
+* **Overlapping op-ids across specs** → `OpIdCollision` raised
+  before any row is written. Operator resolves manually (rename
+  one op via `custom_description` at T4 review, or skip the
+  conflicting spec).
+
+**Connector class auto-registration.** First ingestion of a
+`(product, version, impl_id)` triple registers a thin
+`HttpConnector` subclass via `register_connector_v2()` (G0.6-T2).
+The shim:
+
+* Fixes the v2 registry-key attributes so the resolver can route
+  to it.
+* Derives `supported_version_range` from the version's major.minor
+  prefix (e.g. `"9.0"` → `">=9.0,<10.0"`, `"9.0.1"` → same window;
+  `"latest"` → `None`).
+* Raises `NotImplementedError` from `fingerprint`, `probe`,
+  `execute`, and `auth_headers` with a message naming the G3.x
+  Initiative responsible for shipping the real subclass.
+
+Subsequent ingestions against the same triple skip registration
+(`connector_registered=False`). Per-product auth quirks (G3.1
+vSphere session creation, G3.5 NSX XSRF, G3.6 vCF dual-plane) ship
+as real subclasses per G3.x Initiative; that subclass REPLACES the
+auto-shim at code-merge time (real subclasses register at module
+import — lifespan startup runs before the operator can re-ingest).
+
+**Stale operations.** Ops that exist in the DB under this
+connector but do NOT appear in the incoming batch are NOT
+auto-deleted in v0.2. Operators handle obsolete ops via T4's per-op
+`edit_op(is_enabled=False)` flow. Auto-deletion on re-ingest is
+v0.2.next.
+
 ## Control flow
 
 ```text
@@ -128,9 +201,14 @@ operations go live.
 
 ## References
 
-* Issue #401 — T1 task.
+* Issue #401 — T1 task (OpenAPI parser).
+* Issue #403 — T2 task (`register_ingested_operations`).
 * Initiative #389 — G0.7 spec-ingestion pipeline.
 * Goal #221 — G0 foundational substrate.
 * `meho_backplane/db/models.py::EndpointDescriptor` — the ORM target.
+* `meho_backplane/operations/typed_register.py` — parallel pathway
+  for typed (hand-coded) connectors; same body-hash algorithm.
+* `meho_backplane/connectors/registry.py` — `register_connector_v2`
+  the auto-shim writes to.
 * OpenAPI 3.0.3 spec: https://spec.openapis.org/oas/v3.0.3.html
 * OpenAPI 3.1.1 spec: https://spec.openapis.org/oas/v3.1.1.html


### PR DESCRIPTION
## Summary

- Ships `register_ingested_operations()` — the async bulk-upsert helper that takes parser output (T1 #401) through to `endpoint_descriptor` rows in **staged** state. Parallel pathway to `register_typed_operation()` (G0.6-T4 #395); both write to the same table but ingested rows resolve dispatch via `method` + `path` instead of `handler_ref` and land with `is_enabled=False` until the operator review queue (T4 #402) flips them.
- Multi-spec merge under one `(product, version, impl_id)` via `spec:<source>` tag markers; cross-spec op-id collisions raise `OpIdCollision` before any row is written.
- Auto-registers a thin `HttpConnector` shim on first ingestion of a new triple so the v2 registry has a routable class between first ingestion and the G3.x per-product subclass landing. The shim raises `NotImplementedError` from `fingerprint` / `probe` / `execute` / `auth_headers` — auth quirks ship per-G3.x Initiative.
- Body-hash skip mirrors the typed-register pattern: re-ingesting unchanged parser output avoids the ONNX inference per row.

## Test plan

- [x] `ruff check` — clean across `operations/ingest/` + tests
- [x] `ruff format --check` — clean
- [x] `mypy` — no issues found in the 4 new/modified source files
- [x] `pytest tests/test_operations_register_ingested.py` — 21 passed (the new module)
- [x] `pytest tests/` (unit) — 994 passed, 11 skipped (no regressions in the existing ops suite)
- [x] Acceptance: `register_ingested_operations()` inserts rows with `source_kind='ingested'`
- [x] Acceptance: body-hash skip works (embedding service mock asserts call count)
- [x] Acceptance: multi-spec merge tags rows distinctly via `spec:<source>`
- [x] Acceptance: op-id collision raises `OpIdCollision` listing both op-ids
- [x] Acceptance: connector class auto-registration on first ingest; not re-registered on second
- [x] Acceptance: embeddings stored as 384-dim list (portable vector)
- [x] Acceptance: tenant scoping — built-in (`tenant_id=None`) and tenant-curated rows coexist
- [x] Acceptance: rows land in staged state (`is_enabled=False`); `group_id` stays `NULL` (T3 owns grouping)
- [x] Acceptance: `IngestionResult` shape matches the contract
- [x] Acceptance: 50-op fixture batch lands cleanly with `is_enabled=False` on every row

## Out of scope

- LLM grouping (assigning rows to groups): T3 (#404)
- Operator review state machine: T4 (#402) — already shipped
- CLI verbs invoking this helper: T5 (#405)
- REST routes invoking this helper: T6 (#406)
- Per-product auth overrides for the auto-registered shim: G3.x Initiative work
- Auto-deletion of stale ops on re-ingest: v0.2.next
- Real-PG `pgvector` integration test: T8 (#408) vSphere canary covers this end-to-end

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenAPI operation ingestion pipeline that registers specifications, stages operations for review, and reports insertion/update/skip counts.
  * Operations can now be ingested from multiple specification sources with automatic collision detection.

* **Tests**
  * Comprehensive test suite added for ingestion workflow covering multi-spec handling, collision detection, and idempotency.

* **Documentation**
  * Added detailed guide documenting the spec-ingestion pipeline, staged-operation workflow, and collision-handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/489)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->