### PR TITLE
feat(cli): meho targets list/describe/probe (G0.3-T5 #256)

### DIFF
--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/connector"
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
+	"github.com/evoila/meho/cli/internal/cmd/targets"
 	"github.com/evoila/meho/cli/internal/discovery"
 )
 
@@ -98,6 +99,14 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in verb names.
 	root.AddCommand(connector.NewRootCmd())
+
+	// G0.3-T5 (#256) -- targets registry verbs (list / describe /
+	// probe) for Initiative #224. Wraps the read + probe routes of
+	// /api/v1/targets/*. Sibling write verbs (create / update /
+	// delete) and bulk-import (T6 #257) ship separately. Registered
+	// before registerDynamicSubcommands so the backplane manifest
+	// cannot shadow the built-in `targets` parent.
+	root.AddCommand(targets.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/cli/internal/cmd/root_test.go
+++ b/cli/internal/cmd/root_test.go
@@ -27,7 +27,7 @@ func TestRootCmdHasExpectedSubcommands(t *testing.T) {
 	for _, c := range root.Commands() {
 		names[c.Name()] = true
 	}
-	for _, want := range []string{"version", "login", "status", "operation", "retrieval", "connector"} {
+	for _, want := range []string{"version", "login", "status", "operation", "retrieval", "connector", "targets"} {
 		if !names[want] {
 			t.Errorf("expected built-in subcommand %q; got %v", want, names)
 		}

--- a/cli/internal/cmd/targets/describe.go
+++ b/cli/internal/cmd/targets/describe.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// Target mirrors the backend Target Pydantic model
+// (backend/src/meho_backplane/targets/schemas.py L75-112). The
+// shape includes the G0.3-T1.5 additions:
+//
+//   - Fingerprint — cached FingerprintResult from the last successful
+//     probe. Server-managed; only the probe handler writes it.
+//   - PreferredImplId — operator override for the G0.6 resolver's
+//     tie-break ladder.
+//
+// Fingerprint is typed as map[string]any rather than the concrete
+// FingerprintResult struct so the CLI surfaces every key the backend
+// persists without needing a Go regen each time
+// FingerprintResult's optional field set grows; --json round-trips
+// the wire shape verbatim.
+type Target struct {
+	ID              string         `json:"id"`
+	TenantID        string         `json:"tenant_id"`
+	Name            string         `json:"name"`
+	Aliases         []string       `json:"aliases"`
+	Product         string         `json:"product"`
+	Host            string         `json:"host"`
+	Port            *int           `json:"port"`
+	Fqdn            *string        `json:"fqdn"`
+	SecretRef       *string        `json:"secret_ref"`
+	AuthModel       string         `json:"auth_model"`
+	VpnRequired     bool           `json:"vpn_required"`
+	Extras          map[string]any `json:"extras"`
+	Notes           *string        `json:"notes"`
+	Fingerprint     map[string]any `json:"fingerprint"`
+	PreferredImplID *string        `json:"preferred_impl_id"`
+	CreatedAt       string         `json:"created_at"`
+	UpdatedAt       string         `json:"updated_at"`
+}
+
+// newDescribeCmd returns the `meho targets describe` command.
+//
+// CLI shape:
+//
+//	meho targets describe <name|alias> \
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// The query accepts either the target's canonical name or any of its
+// aliases — alias resolution happens server-side via the resolver
+// (backend/src/meho_backplane/targets/resolver.py).
+//
+// Exit codes:
+//   - 0   target rendered cleanly
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 404 "Target not found",
+//     409 "Ambiguous query")
+//   - 5   insufficient_role
+func newDescribeCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "describe <name-or-alias>",
+		Short: "Describe a single target (alias-aware)",
+		Long: "describe calls GET /api/v1/targets/{name} and renders the " +
+			"full Target row. The supplied argument can be the target's " +
+			"canonical name or any of its aliases — resolution happens " +
+			"server-side. On a 404 the CLI surfaces the near-miss " +
+			"suggestions the resolver computed so the operator can fix " +
+			"a typo in one shot. --json emits the raw API response.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDescribe(cmd, describeOptions{
+				Query:             args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type describeOptions struct {
+	Query             string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runDescribe(cmd *cobra.Command, opts describeOptions) error {
+	if opts.Query == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("describe requires a non-empty <name-or-alias> argument"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	t, err := getTarget(cmd.Context(), backplaneURL, opts.Query)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), t)
+	}
+	printTargetSummary(cmd.OutOrStdout(), t)
+	return nil
+}
+
+// buildDescribePath assembles the GET path. Exposed for unit tests
+// so the URL encoding of names with special characters stays
+// covered.
+func buildDescribePath(query string) string {
+	// PathEscape escapes path-segment-unsafe characters (spaces,
+	// slashes, ?, #). Operators routinely pick names with hyphens
+	// and dots; the unsafe set is rare but worth protecting.
+	return "/api/v1/targets/" + pathEscape(query)
+}
+
+func getTarget(ctx context.Context, backplaneURL, query string) (*Target, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildDescribePath(query), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out Target
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode target response: %w", err)
+	}
+	return &out, nil
+}
+
+// printTargetSummary renders the full Target as a stable, scannable
+// key-value summary. Keep output discipline: one fact per line, key
+// padded to a fixed width for vertical alignment. Fingerprint is
+// rendered as a compact one-liner with the high-signal fields; the
+// full structure is in --json.
+func printTargetSummary(w io.Writer, t *Target) {
+	fmt.Fprintf(w, "%-18s %s\n", "name:", t.Name)
+	fmt.Fprintf(w, "%-18s %s\n", "id:", t.ID)
+	fmt.Fprintf(w, "%-18s %s\n", "tenant_id:", t.TenantID)
+	if len(t.Aliases) > 0 {
+		fmt.Fprintf(w, "%-18s %s\n", "aliases:", strings.Join(t.Aliases, ", "))
+	} else {
+		fmt.Fprintf(w, "%-18s -\n", "aliases:")
+	}
+	fmt.Fprintf(w, "%-18s %s\n", "product:", t.Product)
+	fmt.Fprintf(w, "%-18s %s\n", "host:", t.Host)
+	if t.Port != nil {
+		fmt.Fprintf(w, "%-18s %d\n", "port:", *t.Port)
+	}
+	if t.Fqdn != nil && *t.Fqdn != "" {
+		fmt.Fprintf(w, "%-18s %s\n", "fqdn:", *t.Fqdn)
+	}
+	fmt.Fprintf(w, "%-18s %s\n", "auth_model:", t.AuthModel)
+	fmt.Fprintf(w, "%-18s %t\n", "vpn_required:", t.VpnRequired)
+	if t.SecretRef != nil && *t.SecretRef != "" {
+		fmt.Fprintf(w, "%-18s %s\n", "secret_ref:", *t.SecretRef)
+	}
+	if t.PreferredImplID != nil && *t.PreferredImplID != "" {
+		fmt.Fprintf(w, "%-18s %s\n", "preferred_impl_id:", *t.PreferredImplID)
+	} else {
+		fmt.Fprintf(w, "%-18s -\n", "preferred_impl_id:")
+	}
+	fmt.Fprintf(w, "%-18s %s\n", "fingerprint:", formatFingerprint(t.Fingerprint))
+	if t.Notes != nil && *t.Notes != "" {
+		fmt.Fprintf(w, "%-18s %s\n", "notes:", *t.Notes)
+	}
+	if len(t.Extras) > 0 {
+		fmt.Fprintf(w, "%-18s %s\n", "extras:", formatExtras(t.Extras))
+	}
+	fmt.Fprintf(w, "%-18s %s\n", "created_at:", t.CreatedAt)
+	fmt.Fprintf(w, "%-18s %s\n", "updated_at:", t.UpdatedAt)
+}
+
+// formatFingerprint renders the cached fingerprint as a one-line
+// summary "<vendor>/<product> <version> (probed_at <ts>, method <m>,
+// reachable=<bool>)" when set; "(none — never probed)" otherwise.
+// Full key set is in --json. Keep the high-signal fields visible
+// without overflowing the line width.
+func formatFingerprint(fp map[string]any) string {
+	if len(fp) == 0 {
+		return "(none — never probed)"
+	}
+	vendor, _ := fp["vendor"].(string)
+	product, _ := fp["product"].(string)
+	version, _ := fp["version"].(string)
+	probedAt, _ := fp["probed_at"].(string)
+	method, _ := fp["probe_method"].(string)
+	reachable, _ := fp["reachable"].(bool)
+	head := strings.TrimSpace(vendor + "/" + product)
+	if version != "" {
+		head = head + " " + version
+	}
+	return fmt.Sprintf("%s (probed_at=%s method=%s reachable=%t)",
+		head, probedAt, method, reachable)
+}
+
+// formatExtras renders the extras map as a `key=value, key=value`
+// list with keys sorted for deterministic output (tests + diffs).
+// Non-scalar values land as their JSON representation.
+func formatExtras(extras map[string]any) string {
+	if len(extras) == 0 {
+		return "-"
+	}
+	keys := make([]string, 0, len(extras))
+	for k := range extras {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, formatScalar(extras[k])))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatScalar renders an extras value compactly. Scalars print
+// directly; objects/lists round-trip through json.Marshal so a
+// pretty JSON form is at least readable on one line.
+func formatScalar(v any) string {
+	switch v := v.(type) {
+	case string:
+		return v
+	case bool:
+		return fmt.Sprintf("%t", v)
+	case float64:
+		// json.Unmarshal decodes JSON numbers to float64 by default.
+		// Render integers without trailing zeros so version-like keys
+		// (extras["build"]) don't surface as "12345.000000".
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v))
+		}
+		return fmt.Sprintf("%g", v)
+	default:
+		blob, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(blob)
+	}
+}

--- a/cli/internal/cmd/targets/describe_test.go
+++ b/cli/internal/cmd/targets/describe_test.go
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildDescribePathSimpleName — operator-typical names produce
+// a clean GET path without spurious encoding.
+func TestBuildDescribePathSimpleName(t *testing.T) {
+	if got := buildDescribePath("rdc-vcenter"); got != "/api/v1/targets/rdc-vcenter" {
+		t.Fatalf("describe path: got %q", got)
+	}
+}
+
+// TestBuildDescribePathEscapesSpecial — slash, hash, space all get
+// URL-encoded so the backplane sees a single path segment.
+func TestBuildDescribePathEscapesSpecial(t *testing.T) {
+	if got := buildDescribePath("name with/slash"); got != "/api/v1/targets/name%20with%2Fslash" {
+		t.Fatalf("describe path with special chars: got %q", got)
+	}
+}
+
+// TestRunDescribeRejectsEmptyQuery — cobra's ExactArgs(1) blocks the
+// command-line zero-arg case; the runner still must reject empty
+// strings (e.g. the operator wrote `meho targets describe ""`).
+func TestRunDescribeRejectsEmptyQuery(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runDescribe(cmd, describeOptions{Query: ""})
+	if err == nil {
+		t.Fatalf("expected error for empty query")
+	}
+	if !strings.Contains(stderr.String(), "non-empty") {
+		t.Errorf("stderr missing non-empty hint; got %q", stderr.String())
+	}
+}
+
+// TestPrintTargetSummaryHappyPath — full target with every optional
+// field set renders the canonical key-value summary.
+func TestPrintTargetSummaryHappyPath(t *testing.T) {
+	port := 443
+	fqdn := "vc.example.com"
+	secret := "vault://vsphere/rdc"
+	notes := "primary"
+	preferred := "vsphere-rest-9.0"
+	tgt := &Target{
+		ID:              "abc-id",
+		TenantID:        "tnt-id",
+		Name:            "rdc-vcenter",
+		Aliases:         []string{"vc-prod"},
+		Product:         "vcenter",
+		Host:            "vc.example",
+		Port:            &port,
+		Fqdn:            &fqdn,
+		SecretRef:       &secret,
+		AuthModel:       "shared_service_account",
+		VpnRequired:     true,
+		Notes:           &notes,
+		PreferredImplID: &preferred,
+		Fingerprint: map[string]any{
+			"vendor":       "vmware",
+			"product":      "vcenter",
+			"version":      "9.0.0",
+			"reachable":    true,
+			"probed_at":    "2026-05-15T08:00:00Z",
+			"probe_method": "rest",
+		},
+		Extras: map[string]any{
+			"region":   "eu-central",
+			"replicas": float64(3),
+		},
+		CreatedAt: "2026-05-01T00:00:00Z",
+		UpdatedAt: "2026-05-15T08:00:00Z",
+	}
+	var buf bytes.Buffer
+	printTargetSummary(&buf, tgt)
+	out := buf.String()
+	for _, want := range []string{
+		"name:", "rdc-vcenter",
+		"aliases:", "vc-prod",
+		"product:", "vcenter",
+		"host:", "vc.example",
+		"port:", "443",
+		"fqdn:", "vc.example.com",
+		"auth_model:", "shared_service_account",
+		"vpn_required:", "true",
+		"preferred_impl_id:", "vsphere-rest-9.0",
+		"fingerprint:", "vmware/vcenter", "9.0.0", "reachable=true",
+		"extras:", "region=eu-central", "replicas=3",
+		"notes:", "primary",
+		"created_at:", "2026-05-01T00:00:00Z",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printTargetSummary missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestPrintTargetSummaryNoFingerprint — never-probed target renders
+// the "(none — never probed)" placeholder for fingerprint and a
+// dashed placeholder for preferred_impl_id, so operators see the
+// difference between "field absent" and "field empty".
+func TestPrintTargetSummaryNoFingerprint(t *testing.T) {
+	tgt := &Target{
+		Name:        "fresh-target",
+		Aliases:     nil,
+		AuthModel:   "shared_service_account",
+		Fingerprint: nil,
+	}
+	var buf bytes.Buffer
+	printTargetSummary(&buf, tgt)
+	out := buf.String()
+	if !strings.Contains(out, "fingerprint:") {
+		t.Errorf("expected fingerprint line; got %q", out)
+	}
+	if !strings.Contains(out, "never probed") {
+		t.Errorf("expected never-probed hint; got %q", out)
+	}
+	if !strings.Contains(out, "preferred_impl_id:") || !strings.Contains(out, "preferred_impl_id: -") {
+		t.Errorf("expected dashed preferred_impl_id line; got %q", out)
+	}
+	if !strings.Contains(out, "aliases:") {
+		t.Errorf("expected aliases line; got %q", out)
+	}
+}
+
+// TestFormatFingerprintNilEmpty — nil / empty map renders the
+// no-probe placeholder; tests the boundary of the human render.
+func TestFormatFingerprintNilEmpty(t *testing.T) {
+	if got := formatFingerprint(nil); !strings.Contains(got, "never probed") {
+		t.Errorf("nil fp: got %q", got)
+	}
+	if got := formatFingerprint(map[string]any{}); !strings.Contains(got, "never probed") {
+		t.Errorf("empty fp: got %q", got)
+	}
+}
+
+// TestFormatExtrasSortedDeterministic — the renderer must produce
+// the same string for the same input map across runs (no map
+// iteration order leak).
+func TestFormatExtrasSortedDeterministic(t *testing.T) {
+	m := map[string]any{"b": 2, "a": 1, "c": "x"}
+	got := formatExtras(m)
+	if got != "a=1, b=2, c=x" {
+		t.Errorf("non-deterministic extras render: got %q", got)
+	}
+}
+
+// TestFormatScalarFloatVsInt — JSON decoded ints land as float64;
+// the formatter must surface 3 as "3", not "3.000000".
+func TestFormatScalarFloatVsInt(t *testing.T) {
+	if got := formatScalar(float64(3)); got != "3" {
+		t.Errorf("int-shaped float: got %q", got)
+	}
+	if got := formatScalar(float64(3.5)); got != "3.5" {
+		t.Errorf("fractional float: got %q", got)
+	}
+	if got := formatScalar(true); got != "true" {
+		t.Errorf("bool: got %q", got)
+	}
+	if got := formatScalar([]any{1, 2}); !strings.Contains(got, "[") {
+		t.Errorf("array: got %q", got)
+	}
+}
+
+// TestRunDescribeHappyPath — describe drives end-to-end through the
+// auth stack; backend returns a Target shape with fingerprint +
+// preferred_impl_id set.
+func TestRunDescribeHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/rdc-vcenter", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+		port := 443
+		preferred := "vsphere-rest-9.0"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Target{
+			ID:              "abc",
+			TenantID:        "tnt",
+			Name:            "rdc-vcenter",
+			Aliases:         []string{"vc-prod"},
+			Product:         "vcenter",
+			Host:            "vc.example",
+			Port:            &port,
+			AuthModel:       "shared_service_account",
+			VpnRequired:     false,
+			PreferredImplID: &preferred,
+			Fingerprint: map[string]any{
+				"vendor":       "vmware",
+				"product":      "vcenter",
+				"version":      "9.0.0",
+				"reachable":    true,
+				"probed_at":    "2026-05-15T08:00:00Z",
+				"probe_method": "rest",
+			},
+			CreatedAt: "2026-05-01T00:00:00Z",
+			UpdatedAt: "2026-05-15T08:00:00Z",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runDescribe(cmd, describeOptions{Query: "rdc-vcenter", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runDescribe: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"name:", "rdc-vcenter",
+		"aliases:", "vc-prod",
+		"fingerprint:", "vmware/vcenter", "9.0.0",
+		"preferred_impl_id:", "vsphere-rest-9.0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("describe output missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestRunDescribeAlias — describe accepts an alias and the backend's
+// resolver returns the canonical row. The CLI should treat the path
+// segment opaquely; resolution happens server-side.
+func TestRunDescribeAlias(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/vc-prod", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Target{
+			Name:      "rdc-vcenter",
+			Aliases:   []string{"vc-prod"},
+			Product:   "vcenter",
+			Host:      "vc.example",
+			AuthModel: "shared_service_account",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runDescribe(cmd, describeOptions{Query: "vc-prod", BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("describe alias: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "rdc-vcenter") {
+		t.Errorf("alias describe should return canonical name; got %q", stdout.String())
+	}
+}
+
+// TestRunDescribe404RendersNearMisses — 404 with structured detail
+// must surface the candidate names so the operator fixes a typo on
+// the next try.
+func TestRunDescribe404RendersNearMisses(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":{"error":"no_target","query":"rdc-vc","matches":[
+            {"id":"id1","name":"rdc-vcenter","aliases":["vc-prod"],"product":"vcenter","host":"vc.example"},
+            {"id":"id2","name":"rdc-vsphere","aliases":[],"product":"vcenter","host":"vs.example"}
+        ]}}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runDescribe(cmd, describeOptions{Query: "rdc-vc", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 404")
+	}
+	for _, want := range []string{"Target not found", "rdc-vcenter", "rdc-vsphere", "did you mean"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr missing %q in %q", want, stderr.String())
+		}
+	}
+}

--- a/cli/internal/cmd/targets/list.go
+++ b/cli/internal/cmd/targets/list.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// TargetSummary mirrors the backend TargetSummary Pydantic model
+// (backend/src/meho_backplane/targets/schemas.py L57-72). Hand-
+// written rather than aliased to the generated api.TargetSummary so
+// the targets package stays decoupled from the generated client's
+// type surface — the operation/retrieval packages take the same
+// stance for the same reason (generated types churn on every spec
+// re-snapshot).
+type TargetSummary struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Aliases []string `json:"aliases"`
+	Product string   `json:"product"`
+	Host    string   `json:"host"`
+}
+
+// newListCmd returns the `meho targets list` command.
+//
+// CLI shape (matches issue #256 spec):
+//
+//	meho targets list \
+//	  [--product P]                            # filter by product slug
+//	  [--limit N]                              # 1..500, default 100
+//	  [--cursor C]                             # keyset pagination cursor
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// Exit codes mirror sibling verbs:
+//   - 0   targets listed cleanly (including the empty-tenant case)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape
+//   - 5   insufficient_role
+func newListCmd() *cobra.Command {
+	var (
+		product           string
+		limit             int
+		cursor            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List targets in your tenant",
+		Long: "list calls GET /api/v1/targets and renders the targets " +
+			"registered in the operator's tenant. Optional --product " +
+			"narrows by product slug (exact match). Results are keyset-" +
+			"paginated by name; pass --cursor <last-name-seen> to fetch " +
+			"the next page. --limit caps the page size (1..500, default " +
+			"100). --json emits the raw API response so operators can " +
+			"pipe into jq.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runList(cmd, listOptions{
+				Product:           product,
+				Limit:             limit,
+				Cursor:            cursor,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVarP(&product, "product", "p", "",
+		"filter by product slug (exact match)")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max targets per page (1..500, server default 100 when omitted)")
+	cmd.Flags().StringVar(&cursor, "cursor", "",
+		"keyset pagination cursor (the last name from the previous page)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type listOptions struct {
+	Product           string
+	Limit             int
+	Cursor            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runList(cmd *cobra.Command, opts listOptions) error {
+	// Fail fast on out-of-range --limit. The API clamps internally
+	// (FastAPI Query(ge=1, le=500)) but explicit zero/negative would
+	// fall through with a 422 surprise. Surface the constraint here.
+	if opts.Limit < 0 || opts.Limit > 500 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 500; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	summaries, err := getTargets(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), summaries)
+	}
+	printTargetsTable(cmd.OutOrStdout(), summaries)
+	return nil
+}
+
+// buildListPath assembles the GET /api/v1/targets query string from
+// the per-call options. Exposed for tests so the URL construction
+// stays unit-checkable without standing up an httptest.Server.
+func buildListPath(opts listOptions) string {
+	q := url.Values{}
+	if opts.Product != "" {
+		q.Set("product", opts.Product)
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Cursor != "" {
+		q.Set("cursor", opts.Cursor)
+	}
+	path := "/api/v1/targets"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path
+}
+
+func getTargets(ctx context.Context, backplaneURL string, opts listOptions) ([]TargetSummary, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out []TargetSummary
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode targets response: %w", err)
+	}
+	return out, nil
+}
+
+// printTargetsTable renders the list as a compact, scannable table.
+// Columns: NAME, ALIASES, PRODUCT, HOST per the issue's acceptance
+// criterion 1. ID is omitted from the human view (operators rarely
+// need the UUID; --json surfaces it).
+func printTargetsTable(w io.Writer, summaries []TargetSummary) {
+	if len(summaries) == 0 {
+		fmt.Fprintln(w, "no targets registered in this tenant")
+		return
+	}
+	fmt.Fprintf(w, "%-30s %-30s %-20s %s\n", "NAME", "ALIASES", "PRODUCT", "HOST")
+	for _, s := range summaries {
+		aliases := "-"
+		if len(s.Aliases) > 0 {
+			aliases = strings.Join(s.Aliases, ",")
+		}
+		fmt.Fprintf(w, "%-30s %-30s %-20s %s\n",
+			truncate(s.Name, 30),
+			truncate(aliases, 30),
+			truncate(s.Product, 20),
+			truncate(s.Host, 80),
+		)
+	}
+}

--- a/cli/internal/cmd/targets/list_test.go
+++ b/cli/internal/cmd/targets/list_test.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// TestBuildListPathOmitsEmptyFilters — the empty options shape sends
+// no query string so the backplane sees a clean
+// /api/v1/targets.
+func TestBuildListPathOmitsEmptyFilters(t *testing.T) {
+	if got := buildListPath(listOptions{}); got != "/api/v1/targets" {
+		t.Fatalf("empty opts path: got %q; want %q", got, "/api/v1/targets")
+	}
+}
+
+// TestBuildListPathSetsProduct — --product P appends ?product=P.
+func TestBuildListPathSetsProduct(t *testing.T) {
+	got := buildListPath(listOptions{Product: "vcenter"})
+	if got != "/api/v1/targets?product=vcenter" {
+		t.Fatalf("product opt: got %q", got)
+	}
+}
+
+// TestBuildListPathSetsAllFilters — every option lands on the wire.
+func TestBuildListPathSetsAllFilters(t *testing.T) {
+	got := buildListPath(listOptions{Product: "k8s", Limit: 25, Cursor: "rke2-meho"})
+	for _, want := range []string{"product=k8s", "limit=25", "cursor=rke2-meho"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildListPath missing %q in %q", want, got)
+		}
+	}
+}
+
+// TestBuildListPathEncodesSpecialChars — operator-typical names with
+// hyphens stay alone; a cursor with a space gets URL-encoded.
+func TestBuildListPathEncodesSpecialChars(t *testing.T) {
+	got := buildListPath(listOptions{Cursor: "weird name"})
+	if !strings.Contains(got, "cursor=weird+name") {
+		t.Errorf("buildListPath did not URL-encode space; got %q", got)
+	}
+}
+
+// TestPrintTargetsTableEmpty — zero-target tenant renders the
+// no-targets line without the header row.
+func TestPrintTargetsTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	printTargetsTable(&buf, nil)
+	out := buf.String()
+	if !strings.Contains(out, "no targets registered") {
+		t.Errorf("empty render missing no-targets hint; got %q", out)
+	}
+	if strings.Contains(out, "NAME") {
+		t.Errorf("empty render should skip header; got %q", out)
+	}
+}
+
+// TestPrintTargetsTableRendersColumns — happy-path render with two
+// rows: header line + each target's name / aliases / product / host.
+func TestPrintTargetsTableRendersColumns(t *testing.T) {
+	rows := []TargetSummary{
+		{ID: "1", Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
+		{ID: "2", Name: "rke2-meho", Aliases: nil, Product: "k8s", Host: "k.example"},
+	}
+	var buf bytes.Buffer
+	printTargetsTable(&buf, rows)
+	out := buf.String()
+	for _, want := range []string{"NAME", "ALIASES", "PRODUCT", "HOST", "rdc-vcenter", "vc-prod", "vcenter", "vc.example", "rke2-meho", "k8s"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printTargetsTable missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestRunListRejectsOutOfRangeLimit — runList must fail fast on a
+// --limit outside the API's ge=1, le=500 contract so operators see
+// the CLI-side hint rather than a 422 round-trip.
+func TestRunListRejectsOutOfRangeLimit(t *testing.T) {
+	cmd := &cobra.Command{}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	err := runList(cmd, listOptions{Limit: 501})
+	if err == nil {
+		t.Fatalf("expected error for over-budget --limit")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 500") {
+		t.Errorf("stderr missing range hint; got %q", stderr.String())
+	}
+}
+
+// TestRunListRejectsNegativeLimit — symmetrical case for --limit=-1.
+func TestRunListRejectsNegativeLimit(t *testing.T) {
+	cmd := &cobra.Command{}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	err := runList(cmd, listOptions{Limit: -1})
+	if err == nil {
+		t.Fatalf("expected error for negative --limit")
+	}
+}
+
+// TestRunListHappyPath drives runList end-to-end through the auth
+// + transport stack against an httptest server. Mirrors the
+// retrieval / status sibling tests' file-fallback approach to
+// credential injection.
+func TestRunListHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("product"); got != "vcenter" {
+			t.Errorf("query product: got %q; want %q", got, "vcenter")
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]TargetSummary{
+			{ID: "1", Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{Product: "vcenter", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runList: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"NAME", "rdc-vcenter", "vcenter", "vc.example"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestRunListJSONHappyPath — --json round-trips the raw response
+// shape; operators piping through jq get a stable contract.
+func TestRunListJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]TargetSummary{
+			{ID: "deadbeef", Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runList --json: %v; stderr=%s", err, stderr.String())
+	}
+	// Parse stdout as JSON to confirm the operator sees a structured
+	// envelope, not the table.
+	var decoded []TargetSummary
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(decoded) != 1 || decoded[0].Name != "rdc-vcenter" {
+		t.Errorf("--json decode produced %+v", decoded)
+	}
+}
+
+// TestRunList401SurfacesAuthExpired — exhausting the refresh budget
+// (no refresh_token present) must render as auth_expired with the
+// `meho login` hint.
+func TestRunList401SurfacesAuthExpired(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"detail":"token expired"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL) // stored token has no refresh_token
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error; stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "auth_expired") {
+		t.Errorf("expected auth_expired in stderr; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected `meho login` hint in stderr; got %q", stderr.String())
+	}
+}
+
+// TestRunList403SurfacesInsufficientRole — RBAC denial renders with
+// the required-role string the backend supplied.
+func TestRunList403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: operator required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(stderr.String(), "insufficient_role") {
+		t.Errorf("expected insufficient_role in stderr; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "operator required") {
+		t.Errorf("expected backend role hint passed through; got %q", stderr.String())
+	}
+	// Check exit code lands at 5.
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+// ----- shared helpers below -----
+
+// seedXDGAndToken redirects XDG_CONFIG_HOME / MEHO_KEYRING_DISABLE
+// and seeds a token + config for the supplied backplane URL.
+// Mirrors withTempXDG + seedCreds from cmd/status_test.go; kept
+// independent because the cmd package can't be imported here.
+func seedXDGAndToken(t *testing.T, backplaneURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  "eyJ.test.token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return dir
+}
+
+// newRunCmd builds a fresh cobra.Command with stdout/stderr buffers
+// attached. The runXxx helpers consume cmd.OutOrStdout /
+// cmd.ErrOrStderr; tests inspect the buffers afterward.
+func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	return cmd, &stdout, &stderr
+}

--- a/cli/internal/cmd/targets/probe.go
+++ b/cli/internal/cmd/targets/probe.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// FingerprintResult mirrors the backend FingerprintResult Pydantic
+// model (backend/src/meho_backplane/connectors/schemas.py L96-118).
+// The shape matches the response of
+// POST /api/v1/targets/{name}/probe. Per the 2026-05-14 amendment to
+// Initiative #224 (G0.3-T1.5 / Task #477) the backend now returns
+// FingerprintResult (not ProbeResult) and persists it to
+// targets.fingerprint so the G0.6 resolver can read it without
+// re-probing.
+//
+// Optional fields (version / build / edition) are `*string` so the
+// CLI can distinguish "connector explicitly omitted the field" from
+// "connector reported an empty string".
+type FingerprintResult struct {
+	Vendor      string         `json:"vendor"`
+	Product     string         `json:"product"`
+	Version     *string        `json:"version"`
+	Build       *string        `json:"build"`
+	Edition     *string        `json:"edition"`
+	Reachable   bool           `json:"reachable"`
+	ProbedAt    string         `json:"probed_at"`
+	ProbeMethod string         `json:"probe_method"`
+	Extras      map[string]any `json:"extras,omitempty"`
+}
+
+// newProbeCmd returns the `meho targets probe` command.
+//
+// CLI shape:
+//
+//	meho targets probe <name|alias> \
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// The backend calls Connector.fingerprint(target) and persists the
+// result to `targets.fingerprint` on success — so a subsequent
+// `meho targets describe` surfaces the cached snapshot without
+// reprobing. On 501 (no connector registered for the target's
+// product yet) the column is *not* touched; any previously-cached
+// fingerprint survives.
+//
+// Exit codes:
+//   - 0   probe completed; FingerprintResult rendered
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 404 "Target not found",
+//     501 "no connector registered for product=X yet", and
+//     500s when the connector raised — the backend propagates
+//     the exception per #477's accepted trade-off)
+//   - 5   insufficient_role
+func newProbeCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "probe <name-or-alias>",
+		Short: "Probe a target's connector and refresh its fingerprint",
+		Long: "probe calls POST /api/v1/targets/{name}/probe. The " +
+			"backend invokes the connector registered for the target's " +
+			"product, returns the FingerprintResult, and persists it to " +
+			"`targets.fingerprint` for the G0.6 resolver to read later " +
+			"without re-probing. On 501 (no connector yet for the " +
+			"target's product) the CLI surfaces a friendly pointer to " +
+			"Goal G3 where the per-product connector work lives. On a " +
+			"connector exception the backend propagates a 500; the CLI " +
+			"renders it as unexpected_response with the underlying " +
+			"detail so operators can decide whether to retry, file a " +
+			"connector bug, or check connectivity.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProbe(cmd, probeOptions{
+				Query:             args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type probeOptions struct {
+	Query             string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runProbe(cmd *cobra.Command, opts probeOptions) error {
+	if opts.Query == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("probe requires a non-empty <name-or-alias> argument"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	fp, err := postProbe(cmd.Context(), backplaneURL, opts.Query)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), fp)
+	}
+	printFingerprint(cmd.OutOrStdout(), fp)
+	return nil
+}
+
+// buildProbePath assembles the POST path. Exposed for unit tests so
+// the URL encoding of names with special characters stays covered.
+func buildProbePath(query string) string {
+	return "/api/v1/targets/" + pathEscape(query) + "/probe"
+}
+
+func postProbe(ctx context.Context, backplaneURL, query string) (*FingerprintResult, error) {
+	// Empty body — the route reads only the path-param name + the
+	// authed operator. Pass nil so doAuthedRequest skips the
+	// Content-Type/Content-Length stamp and lets the server route
+	// see an actual zero-length body.
+	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", buildProbePath(query), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out FingerprintResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode fingerprint response: %w", err)
+	}
+	return &out, nil
+}
+
+// printFingerprint renders a FingerprintResult as a key-value
+// summary. Same shape as the describe command's fingerprint line,
+// but with full multi-line breakdown — operators run `probe` for
+// the explicit "what did this connector report just now?" answer
+// and want every field visible.
+func printFingerprint(w io.Writer, fp *FingerprintResult) {
+	fmt.Fprintf(w, "%-14s %s\n", "vendor:", fp.Vendor)
+	fmt.Fprintf(w, "%-14s %s\n", "product:", fp.Product)
+	if v := strDeref(fp.Version); v != "" {
+		fmt.Fprintf(w, "%-14s %s\n", "version:", v)
+	}
+	if b := strDeref(fp.Build); b != "" {
+		fmt.Fprintf(w, "%-14s %s\n", "build:", b)
+	}
+	if e := strDeref(fp.Edition); e != "" {
+		fmt.Fprintf(w, "%-14s %s\n", "edition:", e)
+	}
+	fmt.Fprintf(w, "%-14s %t\n", "reachable:", fp.Reachable)
+	fmt.Fprintf(w, "%-14s %s\n", "probed_at:", fp.ProbedAt)
+	fmt.Fprintf(w, "%-14s %s\n", "probe_method:", fp.ProbeMethod)
+	if len(fp.Extras) > 0 {
+		fmt.Fprintf(w, "%-14s %s\n", "extras:", formatProbeExtras(fp.Extras))
+	}
+}
+
+// formatProbeExtras renders the extras map deterministically. Same
+// shape as describe.go::formatExtras; duplicated here to avoid an
+// implicit coupling between the two verbs' rendering rules.
+func formatProbeExtras(extras map[string]any) string {
+	if len(extras) == 0 {
+		return "-"
+	}
+	keys := make([]string, 0, len(extras))
+	for k := range extras {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, formatScalar(extras[k])))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cli/internal/cmd/targets/probe_test.go
+++ b/cli/internal/cmd/targets/probe_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildProbePathSimpleName — operator-typical names produce a
+// clean POST path.
+func TestBuildProbePathSimpleName(t *testing.T) {
+	if got := buildProbePath("rdc-vcenter"); got != "/api/v1/targets/rdc-vcenter/probe" {
+		t.Fatalf("probe path: got %q", got)
+	}
+}
+
+// TestBuildProbePathEscapesSpecial — names with slashes / spaces are
+// path-escaped so the URL stays a single segment.
+func TestBuildProbePathEscapesSpecial(t *testing.T) {
+	if got := buildProbePath("a/b c"); got != "/api/v1/targets/a%2Fb%20c/probe" {
+		t.Fatalf("escape: got %q", got)
+	}
+}
+
+// TestRunProbeRejectsEmptyQuery — defensive guard against the
+// argv-empty case that ExactArgs(1) lets through.
+func TestRunProbeRejectsEmptyQuery(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runProbe(cmd, probeOptions{Query: ""})
+	if err == nil {
+		t.Fatalf("expected error for empty query")
+	}
+	if !strings.Contains(stderr.String(), "non-empty") {
+		t.Errorf("expected non-empty hint; got %q", stderr.String())
+	}
+}
+
+// TestPrintFingerprintRendersAllFields — happy-path render lays out
+// vendor / product / version / build / edition / reachable /
+// probed_at / probe_method on separate lines.
+func TestPrintFingerprintRendersAllFields(t *testing.T) {
+	ver := "9.0.0"
+	build := "12345"
+	edition := "enterprise"
+	fp := &FingerprintResult{
+		Vendor:      "vmware",
+		Product:     "vcenter",
+		Version:     &ver,
+		Build:       &build,
+		Edition:     &edition,
+		Reachable:   true,
+		ProbedAt:    "2026-05-15T08:00:00Z",
+		ProbeMethod: "rest",
+		Extras:      map[string]any{"datacenter_count": float64(2)},
+	}
+	var buf bytes.Buffer
+	printFingerprint(&buf, fp)
+	out := buf.String()
+	for _, want := range []string{
+		"vendor:", "vmware",
+		"product:", "vcenter",
+		"version:", "9.0.0",
+		"build:", "12345",
+		"edition:", "enterprise",
+		"reachable:", "true",
+		"probed_at:", "2026-05-15T08:00:00Z",
+		"probe_method:", "rest",
+		"extras:", "datacenter_count=2",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printFingerprint missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestPrintFingerprintOmitsNilOptionals — nil version / build /
+// edition lines should not appear so operators don't see a wall of
+// empty fields when the connector reported only the required set.
+func TestPrintFingerprintOmitsNilOptionals(t *testing.T) {
+	fp := &FingerprintResult{
+		Vendor:      "vmware",
+		Product:     "vcenter",
+		Reachable:   true,
+		ProbedAt:    "2026-05-15T08:00:00Z",
+		ProbeMethod: "rest",
+	}
+	var buf bytes.Buffer
+	printFingerprint(&buf, fp)
+	out := buf.String()
+	for _, mustNot := range []string{"version:", "build:", "edition:"} {
+		if strings.Contains(out, mustNot) {
+			t.Errorf("expected %q omitted when nil; got %q", mustNot, out)
+		}
+	}
+}
+
+// TestRunProbeHappyPath — backend returns a FingerprintResult; CLI
+// renders it. Confirms the post-#477 contract (FingerprintResult,
+// not ProbeResult).
+func TestRunProbeHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/rdc-vcenter/probe", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+		ver := "9.0.0"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(FingerprintResult{
+			Vendor:      "vmware",
+			Product:     "vcenter",
+			Version:     &ver,
+			Reachable:   true,
+			ProbedAt:    "2026-05-15T08:00:00Z",
+			ProbeMethod: "rest",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runProbe(cmd, probeOptions{Query: "rdc-vcenter", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runProbe: %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{"vendor:", "vmware", "product:", "vcenter", "9.0.0", "reachable:", "true"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("probe stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+// TestRunProbeJSONRoundTrip — --json emits the raw envelope; verify
+// it parses back to a FingerprintResult unchanged.
+func TestRunProbeJSONRoundTrip(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/rdc-vcenter/probe", func(w http.ResponseWriter, _ *http.Request) {
+		ver := "9.0.0"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(FingerprintResult{
+			Vendor:      "vmware",
+			Product:     "vcenter",
+			Version:     &ver,
+			Reachable:   true,
+			ProbedAt:    "2026-05-15T08:00:00Z",
+			ProbeMethod: "rest",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runProbe(cmd, probeOptions{Query: "rdc-vcenter", JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runProbe --json: %v", err)
+	}
+	var decoded FingerprintResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if decoded.Vendor != "vmware" || strDeref(decoded.Version) != "9.0.0" {
+		t.Errorf("--json decode produced %+v", decoded)
+	}
+}
+
+// TestRunProbe501RendersGracefulMessage — backend returns 501 when
+// the target's product has no connector yet; CLI must surface the
+// backend detail string + a G3 pointer so operators know what's
+// missing.
+func TestRunProbe501RendersGracefulMessage(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/rdc-vcenter/probe", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		fmt.Fprint(w, `{"detail":"no connector registered for product='vcenter'"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runProbe(cmd, probeOptions{Query: "rdc-vcenter", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 501")
+	}
+	for _, want := range []string{"no connector registered", "vcenter", "Goal G3", "unexpected_response"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("501 stderr missing %q in %q", want, stderr.String())
+		}
+	}
+}
+
+// TestRunProbe500SurfacesConnectorException — per #477's accepted
+// trade-off, a connector that raises propagates as a 500. CLI must
+// surface the underlying detail so the operator can act on it
+// (retry / file bug / check connectivity) rather than seeing an
+// opaque "something failed".
+func TestRunProbe500SurfacesConnectorException(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets/rdc-vcenter/probe", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"detail":"Internal Server Error"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runProbe(cmd, probeOptions{Query: "rdc-vcenter", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 500")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 500") {
+		t.Errorf("expected HTTP 500 surfaced in stderr; got %q", stderr.String())
+	}
+}

--- a/cli/internal/cmd/targets/targets.go
+++ b/cli/internal/cmd/targets/targets.go
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package targets hosts the cobra commands under `meho targets ...`
+// for Initiative #224's targets registry (G0.3-T5 / Task #256). v0.2
+// ships three operator-facing read verbs:
+//
+//   - `meho targets list [--product P] [--json]` —
+//     GET /api/v1/targets, keyset-paginated, optionally narrowed by
+//     product slug.
+//   - `meho targets describe <name|alias> [--json]` —
+//     GET /api/v1/targets/{name}, alias-aware via the backend's
+//     resolve_target. Renders the full Target read shape including
+//     `fingerprint` + `preferred_impl_id` (added by G0.3-T1.5).
+//   - `meho targets probe <name|alias> [--json]` —
+//     POST /api/v1/targets/{name}/probe. The backend calls
+//     Connector.fingerprint(), persists the FingerprintResult to
+//     targets.fingerprint (so the G0.6 resolver can read it without
+//     re-probing), and returns the same envelope to the caller. 501
+//     when no connector is registered yet for the target's product.
+//
+// Each verb wraps one backplane route and renders the response in
+// either a human-readable table / key-value summary or `--json` mode.
+// Authentication piggybacks on the token meho login wrote — same
+// pattern as `meho operation` and `meho retrieval eval`.
+//
+// Write verbs (`create` / `update` / `delete`) are out of scope for
+// v0.2 per the issue body. Bulk-import lives in a sibling task
+// (G0.3-T6 / Task #257).
+package targets
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho targets` parent command. The command
+// is grafted onto the top-level meho command tree by cmd/root.go
+// alongside `meho operation` and `meho retrieval`. The parent itself
+// takes no args and prints its own help; every piece of behaviour
+// lives in the per-subcommand RunE closures.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "targets",
+		Short:        "Operate the MEHO targets registry (list / describe / probe)",
+		Long:         "List, describe, and probe targets registered in the operator's tenant.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newDescribeCmd())
+	cmd.AddCommand(newProbeCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" (→ auth_expired exit
+// code 2 — the right fix is `meho login`) from URL-parse failures
+// (→ unexpected exit code 4 — the right fix is correcting argv).
+// Same shape as the helper in cli/internal/cmd/operation/operation.go;
+// kept independent because the cmd/operation package can't be
+// imported here without an import cycle.
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane re-implements the host-trimming + parsing rules
+// the cmd package's resolveBackplaneURL applies. We can't import cmd
+// from a subpackage without an import cycle (cmd/root.go grafts this
+// package onto the tree), so the resolution shape is mirrored here —
+// same shape as operation/operation.go's helper.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical contract to the
+// operation/operation.go sibling.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail
+// fast on garbage input. Mirrors normaliseURL in operation/operation.go.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from one of the per-verb
+// request helpers into the right output.StructuredError category.
+// Same classification ladder as operation/operation.go but with
+// extra dispatch for the target-specific 4xx envelopes:
+//
+//   - 401 (refresh failed / no_refresh_token / token_not_found) →
+//     auth_expired with a `meho login <url>` hint.
+//   - 403 (RBAC denial) → insufficient_role; the backend's 403
+//     detail string names the required role.
+//   - 404 with detail.error == "no_target" → unexpected_response,
+//     with the target query and any near-miss names surfaced in
+//     the detail for operator scannability.
+//   - 409 with detail.error == "ambiguous_target" → unexpected,
+//     listing the colliding names so the operator can disambiguate.
+//   - 501 → unexpected with the "no connector registered for
+//     product=X yet" string the operator needs to resolve the gap
+//     (file a Goal G3 connector task).
+//   - Any other 4xx/5xx → unexpected with the raw body.
+//   - Pure transport errors (timeouts, DNS, connection refused) →
+//     unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderHTTPError classifies a non-2xx response into the right
+// StructuredError category. Lifted into its own helper so per-verb
+// shims (probe wants the 501 message to point at G3) can wrap it.
+func renderHTTPError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	he *httpError,
+	jsonOut bool,
+) error {
+	switch he.StatusCode {
+	case http.StatusUnauthorized:
+		// The 401-refresh-retry path in doAuthedRequest already
+		// exhausted the refresh budget. The token is dead; the
+		// operator must rerun `meho login`.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		// 403 detail is FastAPI/Starlette's HTTPException shape
+		// ({"detail": "<string>"}). The backend's require_role helper
+		// writes the required role into the detail string; pass it
+		// through verbatim so the operator sees what role they need.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusNotFound:
+		// 404 carries either FastAPI's plain {"detail": "..."} or the
+		// targets resolver's structured {"detail": {"error":
+		// "no_target", "query": "...", "matches": [...]}}. Render
+		// near-miss suggestions when the structured form lands so the
+		// operator sees "did you mean rdc-vcenter? rdc-vsphere?".
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(formatNotFound(he.Body)),
+			jsonOut,
+		)
+	case http.StatusConflict:
+		// 409 from resolve_target = ambiguous_target. Surface the
+		// colliding names so the operator can re-issue with the
+		// disambiguated name.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(formatAmbiguous(he.Body)),
+			jsonOut,
+		)
+	case http.StatusNotImplemented:
+		// 501 from probe_target = "no connector registered for
+		// product=<X>". Pointer to G3 connector goals so operators
+		// know where to look for the work.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(formatNoConnector(he.Body)),
+			jsonOut,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape, with the
+// detail field accepting either a string (FastAPI's default) or the
+// targets resolver's nested object ({"error", "query", "matches"}).
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// resolverDetail mirrors the structured detail TargetNotFoundError
+// and AmbiguousTargetError raise (resolver.py L57-95).
+type resolverDetail struct {
+	Error   string                   `json:"error"`
+	Query   string                   `json:"query"`
+	Matches []resolverMatchOnTheWire `json:"matches"`
+}
+
+// resolverMatchOnTheWire mirrors TargetSummary.model_dump(mode='json')
+// — only the human-readable fields the CLI surfaces. The id/host/
+// product fields are present in the wire shape but the CLI summary
+// renders only `name` (with aliases as a parenthesised hint).
+type resolverMatchOnTheWire struct {
+	Name    string   `json:"name"`
+	Aliases []string `json:"aliases"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error
+// body when it's a plain string. Falls back to the raw body when the
+// JSON shape doesn't match — better to surface the raw error than to
+// swallow it.
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// formatNotFound renders a 404 envelope into a single operator-
+// readable line. Structured form (resolver) → "Target not found:
+// <q>; did you mean: <a, b, c>"; plain string fallback → raw detail.
+func formatNotFound(body string) string {
+	if matches, query, ok := parseResolverDetail(body); ok {
+		if len(matches) == 0 {
+			return fmt.Sprintf("Target not found: %q (no near-misses)", query)
+		}
+		names := make([]string, 0, len(matches))
+		for _, m := range matches {
+			names = append(names, m.Name)
+		}
+		return fmt.Sprintf("Target not found: %q; did you mean: %s",
+			query, strings.Join(names, ", "))
+	}
+	return "Target not found: " + decodeDetailString(body)
+}
+
+// formatAmbiguous renders a 409 envelope into a single line.
+func formatAmbiguous(body string) string {
+	if matches, query, ok := parseResolverDetail(body); ok {
+		names := make([]string, 0, len(matches))
+		for _, m := range matches {
+			names = append(names, m.Name)
+		}
+		return fmt.Sprintf("Ambiguous query %q matches: %s",
+			query, strings.Join(names, ", "))
+	}
+	return "Ambiguous query: " + decodeDetailString(body)
+}
+
+// formatNoConnector renders a 501 envelope. Detail looks like
+// `no connector registered for product='vcenter'` — append a G3
+// pointer so operators know where the connector work lives.
+func formatNoConnector(body string) string {
+	detail := decodeDetailString(body)
+	return detail + " — connector work tracks under Goal G3 (per-product connectors); try again after the relevant connector lands"
+}
+
+// parseResolverDetail attempts to decode the targets resolver's
+// structured detail. Returns (matches, query, true) on success;
+// (_, _, false) when the body isn't the structured shape (FastAPI
+// plain-string detail, or a totally different error envelope).
+func parseResolverDetail(body string) ([]resolverMatchOnTheWire, string, bool) {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		return nil, "", false
+	}
+	var detail resolverDetail
+	if err := json.Unmarshal(env.Detail, &detail); err != nil {
+		return nil, "", false
+	}
+	if detail.Error == "" {
+		return nil, "", false
+	}
+	return detail.Matches, detail.Query, true
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection + one-shot 401-refresh-retry. Returns the
+// response body bytes (already drained) on a 2xx outcome, or an
+// *httpError when the backplane returned a non-2xx, or an error
+// categorised by api.IsTokenNotFound / api.IsNoRefreshToken / generic
+// transport so renderRequestError can pick the right StructuredError
+// category.
+//
+// Mirrors cli/internal/cmd/operation/operation.go::doAuthedRequest.
+// Kept independent of the operation package for the import-cycle
+// reason called out on resolveBackplane.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		// One-shot refresh + retry, mirroring api.AuthedClient.GetHealth
+		// and operation/operation.go doAuthedRequest.
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// httpError carries a non-2xx response so per-verb runners can
+// render the right category (404 → not-found with near-misses, 501 →
+// no-connector pointer, etc.). Not an output.StructuredError directly
+// — renderHTTPError decides exit-code class based on status.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// sendRequest is the bottom of the stack: build the http.Request,
+// stamp bearer + content headers, fire it. Split out so the
+// 401-refresh-retry path in doAuthedRequest can reuse the same body
+// bytes without re-marshalling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// pathEscape escapes a single path segment for use inside a backend
+// URL. url.PathEscape escapes path-segment-unsafe characters
+// (spaces, slashes, ?, #) without touching the unreserved set.
+// Wrapped here to keep target verbs independent of net/url's
+// import-spread.
+func pathEscape(segment string) string {
+	return url.PathEscape(segment)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Rune-aware so multi-byte UTF-8 survives the
+// cut. Same shape as the operation-package helper; kept here to
+// avoid the import-cycle the cmd → cmd/operation → cmd path would
+// create.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// strDeref returns *s or empty string when s is nil. Backend Pydantic
+// models declare many fields as Optional[str]; null lands as nil
+// after JSON decode and the formatter consumes the empty string.
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/cli/internal/cmd/targets/targets_test.go
+++ b/cli/internal/cmd/targets/targets_test.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// TestRootCmdLists3Verbs pins the v0.2 verb set so a future split
+// (e.g. renaming `describe` to `show`) is caught at compile-test
+// time.
+func TestRootCmdLists3Verbs(t *testing.T) {
+	root := NewRootCmd()
+	names := map[string]bool{}
+	for _, c := range root.Commands() {
+		names[c.Name()] = true
+	}
+	for _, want := range []string{"list", "describe", "probe"} {
+		if !names[want] {
+			t.Errorf("expected subcommand %q on `meho targets`; got %v", want, names)
+		}
+	}
+}
+
+// TestRootCmdHelpListsAllVerbs — the parent's help text should list
+// the three verbs so operators new to the surface find them via
+// `meho targets --help`.
+func TestRootCmdHelpListsAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	var buf strings.Builder
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("`meho targets --help` failed: %v", err)
+	}
+	help := buf.String()
+	for _, want := range []string{"list", "describe", "probe", "operator's tenant"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("expected `meho targets --help` to mention %q; got:\n%s", want, help)
+		}
+	}
+}
+
+// TestNormaliseURLStripsTrailingSlash mirrors the contract the
+// sibling operation/retrieval packages enforce; trailing-slash
+// trimming is the v0.2 convention.
+func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+}
+
+// TestNormaliseURLRejectsEmpty — empty input returns the "empty"
+// error string callers depend on.
+func TestNormaliseURLRejectsEmpty(t *testing.T) {
+	_, err := normaliseURL("   ")
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected 'empty' error; got %v", err)
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
+// any error wrapping it) maps to AuthExpired; everything else maps
+// to Unexpected. Same routing ladder as the operation sibling.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrappedNotFound := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrappedNotFound)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("ErrConfigNotFound wrapper should classify as auth_expired; got %+v", se)
+	}
+	parseFailure := errors.New("invalid backplane URL")
+	se = classifyBackplaneError(parseFailure)
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected; got %+v", se)
+	}
+}
+
+// TestTruncateRuneSafe — multi-byte UTF-8 must not produce invalid
+// byte cuts. Pins the same contract the operation sibling pins.
+func TestTruncateRuneSafe(t *testing.T) {
+	if got := truncate("café world", 5); got != "café…" {
+		t.Fatalf("truncate multi-byte: got %q; want %q", got, "café…")
+	}
+	if got := truncate("hello", 10); got != "hello" {
+		t.Fatalf("truncate within budget: got %q; want %q", got, "hello")
+	}
+	if got := truncate("anything", 0); got != "" {
+		t.Fatalf("truncate maxLen=0 should be empty; got %q", got)
+	}
+}
+
+// TestStrDerefNilEmpty — nil pointer returns empty; pointer returns
+// underlying string.
+func TestStrDerefNilEmpty(t *testing.T) {
+	if got := strDeref(nil); got != "" {
+		t.Fatalf("strDeref(nil): got %q; want %q", got, "")
+	}
+	v := "x"
+	if got := strDeref(&v); got != "x" {
+		t.Fatalf("strDeref(&v): got %q; want %q", got, "x")
+	}
+}
+
+// TestPathEscapeRoundTrip — the helper must escape the FastAPI-
+// unsafe characters but leave the operator-typical characters
+// (hyphens, dots, alphanumerics) alone.
+func TestPathEscapeRoundTrip(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"rdc-vcenter", "rdc-vcenter"},
+		{"vc.prod", "vc.prod"},
+		{"weird name with space", "weird%20name%20with%20space"},
+		{"slash/in/name", "slash%2Fin%2Fname"},
+	}
+	for _, c := range cases {
+		if got := pathEscape(c.in); got != c.want {
+			t.Errorf("pathEscape(%q): got %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestDecodeDetailStringFromFastAPI — FastAPI's HTTPException body
+// is {"detail": "<string>"}; decodeDetailString must extract the
+// string. The raw-body fallback fires only on shape mismatch.
+func TestDecodeDetailStringFromFastAPI(t *testing.T) {
+	body := `{"detail": "Insufficient role: tenant_admin required"}`
+	if got := decodeDetailString(body); got != "Insufficient role: tenant_admin required" {
+		t.Errorf("decodeDetailString: got %q", got)
+	}
+}
+
+// TestDecodeDetailStringFallback — non-JSON body returns the raw
+// trimmed body rather than swallowing it.
+func TestDecodeDetailStringFallback(t *testing.T) {
+	body := "  plain text error\n"
+	if got := decodeDetailString(body); got != "plain text error" {
+		t.Errorf("decodeDetailString fallback: got %q", got)
+	}
+}
+
+// TestFormatNotFoundStructuredDetail — the resolver's structured
+// envelope ({"error": "no_target", "query": "X", "matches": [...]})
+// renders as a one-line "did you mean" hint listing near-miss names.
+func TestFormatNotFoundStructuredDetail(t *testing.T) {
+	body := `{"detail":{"error":"no_target","query":"rdc-vc","matches":[
+        {"id":"00000000-0000-0000-0000-000000000001","name":"rdc-vcenter","aliases":["vc-prod"],"product":"vcenter","host":"vc.example"},
+        {"id":"00000000-0000-0000-0000-000000000002","name":"rdc-vsphere","aliases":[],"product":"vcenter","host":"vs.example"}
+    ]}}`
+	got := formatNotFound(body)
+	for _, want := range []string{"Target not found", `"rdc-vc"`, "rdc-vcenter", "rdc-vsphere"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatNotFound missing %q in %q", want, got)
+		}
+	}
+}
+
+// TestFormatNotFoundEmptyMatches — query with zero near-misses
+// surfaces the "(no near-misses)" hint so operators don't expect
+// suggestions when there are none.
+func TestFormatNotFoundEmptyMatches(t *testing.T) {
+	body := `{"detail":{"error":"no_target","query":"totally-unknown","matches":[]}}`
+	got := formatNotFound(body)
+	if !strings.Contains(got, "no near-misses") {
+		t.Errorf("expected near-misses hint; got %q", got)
+	}
+	if !strings.Contains(got, `"totally-unknown"`) {
+		t.Errorf("expected query in detail; got %q", got)
+	}
+}
+
+// TestFormatNotFoundPlainStringFallback — FastAPI's plain-string
+// detail must still produce a "Target not found: ..." line.
+func TestFormatNotFoundPlainStringFallback(t *testing.T) {
+	body := `{"detail":"some other 404"}`
+	got := formatNotFound(body)
+	if !strings.Contains(got, "Target not found") || !strings.Contains(got, "some other 404") {
+		t.Errorf("plain-string 404 detail not surfaced; got %q", got)
+	}
+}
+
+// TestFormatAmbiguousStructuredDetail — 409 from resolve_target must
+// list the colliding names so the operator can pick one.
+func TestFormatAmbiguousStructuredDetail(t *testing.T) {
+	body := `{"detail":{"error":"ambiguous_target","query":"k8s","matches":[
+        {"id":"00000000-0000-0000-0000-000000000003","name":"rke2-meho","aliases":["k8s"],"product":"k8s","host":"a.example"},
+        {"id":"00000000-0000-0000-0000-000000000004","name":"rke2-infra","aliases":["k8s"],"product":"k8s","host":"b.example"}
+    ]}}`
+	got := formatAmbiguous(body)
+	for _, want := range []string{"Ambiguous", `"k8s"`, "rke2-meho", "rke2-infra"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatAmbiguous missing %q in %q", want, got)
+		}
+	}
+}
+
+// TestFormatNoConnectorAppendsG3Pointer — 501 detail string must
+// retain the backend's message and add the G3-goal pointer so
+// operators know where to look for the connector work.
+func TestFormatNoConnectorAppendsG3Pointer(t *testing.T) {
+	body := `{"detail":"no connector registered for product='vcenter'"}`
+	got := formatNoConnector(body)
+	if !strings.Contains(got, "no connector registered for product='vcenter'") {
+		t.Errorf("expected raw backend detail in %q", got)
+	}
+	if !strings.Contains(got, "Goal G3") {
+		t.Errorf("expected G3 pointer in %q", got)
+	}
+}
+
+// TestRenderHTTPErrorRoutesByStatus — each HTTP status the targets
+// surface produces lands in the right StructuredError category.
+func TestRenderHTTPErrorRoutesByStatus(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		wantCode string
+		wantExit int
+	}{
+		{
+			name:     "401 maps to auth_expired",
+			status:   http.StatusUnauthorized,
+			body:     `{"detail":"token rejected"}`,
+			wantCode: "auth_expired",
+			wantExit: 2,
+		},
+		{
+			name:     "403 maps to insufficient_role",
+			status:   http.StatusForbidden,
+			body:     `{"detail":"Insufficient role: tenant_admin required"}`,
+			wantCode: "insufficient_role",
+			wantExit: 5,
+		},
+		{
+			name:     "404 maps to unexpected_response",
+			status:   http.StatusNotFound,
+			body:     `{"detail":{"error":"no_target","query":"x","matches":[]}}`,
+			wantCode: "unexpected_response",
+			wantExit: 4,
+		},
+		{
+			name:     "409 maps to unexpected_response",
+			status:   http.StatusConflict,
+			body:     `{"detail":{"error":"ambiguous_target","query":"y","matches":[]}}`,
+			wantCode: "unexpected_response",
+			wantExit: 4,
+		},
+		{
+			name:     "501 maps to unexpected_response",
+			status:   http.StatusNotImplemented,
+			body:     `{"detail":"no connector registered for product='vault'"}`,
+			wantCode: "unexpected_response",
+			wantExit: 4,
+		},
+		{
+			name:     "500 falls through to unexpected_response",
+			status:   http.StatusInternalServerError,
+			body:     `internal server error`,
+			wantCode: "unexpected_response",
+			wantExit: 4,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			var stderr strings.Builder
+			cmd.SetErr(&stderr)
+			he := &httpError{StatusCode: c.status, Body: c.body}
+			err := renderHTTPError(cmd, "https://meho.test", he, false)
+			if err == nil {
+				t.Fatalf("expected non-nil error")
+			}
+			type ec interface{ ExitCode() int }
+			x, ok := err.(ec)
+			if !ok {
+				t.Fatalf("error %v should expose ExitCode", err)
+			}
+			if x.ExitCode() != c.wantExit {
+				t.Fatalf("exit code: got %d; want %d", x.ExitCode(), c.wantExit)
+			}
+			// The structured-error rendering writes the code into
+			// stderr (human path). Check the prefix lands so
+			// downstream `meho status` / `gh` scrapers stay
+			// reliable.
+			if !strings.Contains(stderr.String(), c.wantCode) {
+				t.Errorf("stderr missing %q; got %q", c.wantCode, stderr.String())
+			}
+		})
+	}
+}
+
+// TestHTTPErrorErrorString — the *httpError formatter must not lose
+// the underlying status / body so wrapping errors stays useful.
+func TestHTTPErrorErrorString(t *testing.T) {
+	he := &httpError{StatusCode: 418, Body: "i am a teapot"}
+	got := he.Error()
+	if !strings.Contains(got, "HTTP 418") || !strings.Contains(got, "i am a teapot") {
+		t.Errorf("httpError.Error() lost detail: %q", got)
+	}
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -659,6 +659,92 @@ The fourth route `GET /api/v1/operations/{descriptor_id}` (tenant-
 admin diagnostic for `llm_instructions` inspection) is deferred — the
 G0.6-T13 DoD was "three CLI verbs", not four.
 
+## Targets registry (`meho targets`, G0.3-T5 #256)
+
+`cli/internal/cmd/targets/` registers the three operator-facing verbs
+that wrap the targets registry routes from G0.3-T3 (#254) and the
+G0.3-T1.5 (#477) probe-persistence remediation. The verbs are the
+operator-side surface for the per-tenant `targets` table — a
+fingerprinted catalog of vendor systems the operator manages (vCenter
+hosts, Vault instances, k8s clusters, …) that the G0.6 dispatcher
+resolves at `call` time. Write verbs (`create` / `update` / `delete`)
+are deferred; bulk import lands under G0.3-T6 (#257).
+
+### Subcommands
+
+- `meho targets list [--product P] [--limit N] [--cursor C]` — calls
+  `GET /api/v1/targets`. Renders the operator's tenant-scoped targets
+  as a `NAME / ALIASES / PRODUCT / HOST` table. Results are keyset-
+  paginated by name; `--cursor <last-name-seen>` walks pages. `--limit`
+  is capped at 500 by the API; the CLI fails fast at the boundary so
+  operators see the constraint without a 422 round-trip.
+- `meho targets describe <name-or-alias>` — calls
+  `GET /api/v1/targets/{name}`. Renders the full `Target` read shape
+  as a stable key-value summary including the post-#477 fields
+  `fingerprint` (cached `FingerprintResult` from the last successful
+  probe) and `preferred_impl_id` (operator override for the G0.6
+  resolver's tie-break ladder). Alias resolution happens server-side
+  via `resolve_target`; a 404 surfaces the resolver's near-miss list
+  so operators can correct a typo in one shot.
+- `meho targets probe <name-or-alias>` — calls
+  `POST /api/v1/targets/{name}/probe`. Backend invokes the registered
+  `Connector.fingerprint(target)`, persists the `FingerprintResult` to
+  `targets.fingerprint` (so the G0.6 resolver reads it without
+  re-probing), and returns the envelope. On 501 (no connector
+  registered for the target's product yet) the CLI appends a pointer
+  to Goal G3 (per-product connectors) so operators know where the
+  work tracks; the DB row is **not** touched and any previously-
+  cached fingerprint survives. A connector that raises propagates as
+  a 500; per the #477 accepted trade-off the CLI surfaces the
+  underlying detail rather than masking it as a graceful failure.
+
+### Reserved flags (same shape across all three verbs)
+
+- `--json` — emit the raw JSON envelope to stdout instead of the human
+  render. Stable schemas: `list` → `[]TargetSummary`; `describe` →
+  full `Target` (including `fingerprint` + `preferred_impl_id`);
+  `probe` → `FingerprintResult`.
+- `--backplane <url>` — override the backplane URL (defaults to the
+  URL recorded by `meho login`).
+
+### HTTP shape + error envelopes
+
+All three verbs route through `api.NewAuthedClient(...)` for bearer
+injection + one-shot 401-refresh-retry, mirroring the
+`meho operation` sibling. The shared `doAuthedRequest` helper in
+`targets.go` builds the request manually (rather than using the
+generated `ClientWithResponses`) because the target verbs need
+fine-grained 4xx classification: 404 carries the resolver's
+structured `{"error": "no_target", "query": "...", "matches": [...]}`
+envelope, 409 carries `ambiguous_target` with colliding names, and
+501 carries the "no connector registered" detail. The hand-written
+`renderHTTPError` ladder classifies each status into the right
+`output.StructuredError` category.
+
+### Exit codes
+
+- `0` — verb ran cleanly. `list` exits 0 on an empty tenant
+  (operationally meaningful, never 404).
+- `2` — `auth_expired` (no stored credentials, refresh exhausted, or
+  401 after the one-shot retry).
+- `3` — `unreachable` (network / transport failure before the
+  backplane responded).
+- `4` — `unexpected_response` (404 not-found, 409 ambiguous, 501
+  no-connector, 500 connector exception, malformed JSON, etc.).
+- `5` — `insufficient_role` (403 RBAC denial; backend's detail string
+  names the required role).
+
+### Out of scope (v0.2)
+
+- Write verbs (`create` / `update` / `delete`). The API supports them
+  (require `tenant_admin`); the CLI surfaces them in a follow-up
+  task when operators ask. Bulk import via T6 (#257) lands in a
+  sibling PR.
+- Auto-completion of target names. Operators type names; tab-completion
+  would need a separate `cobra-complete`-style design pass.
+- Client-side caching. Every CLI invocation hits the API fresh — the
+  source of truth is the backplane, not a stale local copy.
+
 ## Server-driven discovery (`internal/discovery/`)
 
 Goal #11 §5 mandates server-driven `--help`: adding an operation to


### PR DESCRIPTION
## Summary

- Operator-facing CLI verbs (`meho targets list / describe / probe`) that wrap the G0.3 targets registry routes from T3 (#254) + the G0.3-T1.5 probe-persistence remediation (#477). Replaces the consumer's client-side `yq` resolution in `targets.yaml` with a server call.
- `describe` surfaces the post-#477 fields `fingerprint` and `preferred_impl_id` so operators see exactly what the G0.6 resolver will consume; `probe` shows the live FingerprintResult and triggers backend persistence to `targets.fingerprint`.
- Fine-grained 4xx classification: 404 with the resolver's structured envelope renders as "Target not found: <q>; did you mean: ..." (one-shot typo fixes); 409 surfaces colliding names; 501 appends a Goal G3 pointer for missing connectors; 500 surfaces the underlying detail per #477's accepted trade-off.

## Test plan

- [x] `go vet ./...` — clean
- [x] `gofmt`-clean
- [x] `golangci-lint run ./...` — clean
- [x] `go test -race -cover ./internal/cmd/targets/...` — pass, 87.5% coverage
- [x] `go test -race ./...` — full module passes
- [x] `go build ./cmd/meho` — binary builds; `meho targets --help` lists list/describe/probe with operator-friendly help text
- [x] Acceptance criteria verified:
  - [x] `meho targets list` renders NAME / ALIASES / PRODUCT / HOST table; `--json` returns raw `[]TargetSummary` (TestRunListHappyPath, TestRunListJSONHappyPath)
  - [x] `meho targets list --product vcenter` filters server-side (httptest assert in TestRunListHappyPath)
  - [x] `meho targets describe rdc-vcenter` returns the full Target with fingerprint + preferred_impl_id (TestRunDescribeHappyPath, TestPrintTargetSummaryHappyPath)
  - [x] Alias resolution works (TestRunDescribeAlias)
  - [x] 404 → exit non-zero with near-misses (TestRunDescribe404RendersNearMisses)
  - [x] `meho targets probe rdc-vcenter` returns FingerprintResult (TestRunProbeHappyPath)
  - [x] 501 → friendly message + G3 pointer (TestRunProbe501RendersGracefulMessage)
  - [x] 401 → suggests `meho login` (TestRunList401SurfacesAuthExpired)
  - [x] 403 → "Insufficient role: ..." (TestRunList403SurfacesInsufficientRole)
  - [x] `meho targets --help` lists the three verbs (TestRootCmdHelpListsAllVerbs)

## Out of scope (per issue body)

- Write verbs (`create` / `update` / `delete`) — operators write via API or the T6 bulk-import (#257).
- Auto-completion of target names (separate cobra-complete design pass).
- Client-side caching — every invocation hits the backplane fresh.

## Implementation notes

Follows the `meho operation` sibling pattern: raw HTTP via `doAuthedRequest` (one-shot 401-refresh-retry) rather than the generated `ClientWithResponses`, because the target verbs need fine-grained classification of the resolver's structured 404/409 detail envelopes. `cli/internal/api/client.gen.go` is regenerated against the current `cli/api/openapi.json` snapshot so the package compiles cleanly with the post-#477 `Target` shape (additive: `fingerprint` + `preferred_impl_id`).

Closes #256


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `meho targets list` command to display all targets with optional filtering by product and result limiting.
  * Added `meho targets describe` command to retrieve detailed information about a specific target by name or alias.
  * Added `meho targets probe` command to fingerprint and inspect target connectivity and system details.
  * All target commands support `--json` for machine-readable output and `--backplane` to override the server URL.

* **Documentation**
  * Added CLI command reference documentation for the new targets command suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/490)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->