### PR TITLE
feat(cli): G0.3-T6 meho targets import — bulk-importer for targets.yaml (Closes #257)

### DIFF
--- a/backend/tests/fixtures/rdc-hetzner-dc-targets.yaml
+++ b/backend/tests/fixtures/rdc-hetzner-dc-targets.yaml
@@ -1,0 +1,788 @@
+# Targets registry for the RDC Hetzner Datacenter project.
+#
+# Each entry maps a logical target name to its hostname, Vault secret path,
+# and SSO realm. Wrappers under scripts/ resolve --target <name> against this
+# file (or one alias listed in `aliases:`).
+#
+# When users describe a target in natural language ("the VCF9 SDDC Manager",
+# "the host vCenter"), Claude matches their prose against `name`, `aliases`,
+# and `notes` fields to pick the right entry.
+#
+# Adding a new target: pick a stable `name`, list useful `aliases`, fill in
+# `host`, `secret_ref` (Vault KV-v2 path — the wrapper reads `username` and
+# `password` fields from it via scripts/_secret-read.sh), `sso_realm` if
+# applicable, and a one-line `notes` description.
+#
+# Auth model (post-#67): operator runs `vault login -method=userpass …` once
+# per session to populate $HOME/.vault-token; every wrapper reads that token
+# and calls Vault HTTP API to fetch the per-target secret_ref values. The
+# wrappers do NOT manage Vault auth themselves — same way they previously
+# assumed `op signin` had already happened.
+#
+# Project context: see CLAUDE.md and INVENTORY.md.
+
+targets:
+  - name: rdc-vcenter
+    aliases: [rdc, host-vcenter, hetzner-vcenter]
+    product: vcenter
+    host: vc-dc.evba.lab
+    secret_ref: secret/rdc-hetzner-dc/vsphere/rdc-vcenter
+    sso_realm: evba.lab
+    vpn_required: true
+    notes: "Host vCenter for the 4 physical Hetzner hosts (esx-dc1..4). Datacenter /FSN1-DC21-RACK1, cluster cluster1. vCenter 8.0.3."
+
+  - name: vcf9-vcenter
+    aliases: [vcf9, vcf9-vcsa, vcf9-lab-vcenter, nested-vcenter]
+    product: vcenter
+    host: vcf9-vcsa.evba.vcf.lab
+    secret_ref: secret/rdc-hetzner-dc/vsphere/vcf9-vcenter
+    sso_realm: vsphere.local
+    vpn_required: true
+    notes: "Nested VCF 9 management-domain vCenter (datacenter m01-dc01, cluster m01-cl01). vCenter 9.0.2. Runs on the host cluster."
+
+  - name: vcf9-sddc
+    aliases: [vcf9-sddc-manager, sddc-vcf9, vcf9-mgmt]
+    product: sddc-manager
+    host: vcf9-sddc.evba.vcf.lab
+    secret_ref: secret/rdc-hetzner-dc/vsphere/vcf9-vcenter
+    sso_realm: vsphere.local
+    vpn_required: true
+    notes: "SDDC Manager for the nested VCF 9 lab. Same SSO user as vcf9-vcenter; user has ADMIN role granted 2026-04-27. SDDC Manager 9.0.2 build 25151285."
+
+  - name: pfsense-hetzner-dc
+    aliases: [pfsense-perimeter, pfsense-dc1, perimeter-firewall, pfsense]
+    product: pfsense
+    host: 10.5.1.254
+    secret_ref: secret/rdc-hetzner-dc/network/pfsense
+    vpn_required: true
+    notes: "Perimeter firewall, pfSense VM running on esx-dc1.evba.lab. Internet uplinks; WAN gateway for evba.lab. WebGUI is HTTP-only on http://10.5.1.254 (port 443 not listening). SSH on 22. Connector: scripts/pfsense.sh."
+
+  - name: vcf9-nsx
+    aliases: [vcf9-nsx-manager, nsx-vcf9, vcf9-mgr-nsx]
+    product: nsx
+    host: vcf9-nsx.evba.vcf.lab
+    secret_ref: secret/rdc-hetzner-dc/vsphere/vcf9-nsx-admin
+    sso_realm: ""                          # local NSX `admin` user; no realm
+    vpn_required: true
+    notes: |
+      VCF 9 NSX Manager (single-node). NSX 9.0.2 build 25150386, node UUID 87441e42-...
+
+      Resolution journey (2026-04-29):
+        - vcf9-nested-1 (vSphere SSO) rejected with HTTP 403 — no NSX RBAC role for that user.
+        - admin/API and audit/AUDIT passwords pulled from SDDC Manager /v1/credentials also rejected
+          with HTTP 403 against the FQDN `vcf9-nsx.evba.vcf.lab`.
+        - Path B (SDDC-driven rotation via PATCH /v1/credentials) ran cleanly (task SUCCESSFUL,
+          fresh password landed in /v1/credentials and was synced to NSX) — but a probe with the
+          rotated password against the FQDN STILL returned 403.
+        - Root cause: the envoy proxy fronting `vcf9-nsx.evba.vcf.lab` enforces session/cookie
+          auth and rejects HTTP Basic with the same generic "credentials incorrect or account
+          locked" message regardless of credentials. As a stop-gap the target ran on the raw IP
+          10.5.31.22 (envoy-bypass) with `curl -k` masking the SAN mismatch.
+        - Resolved 2026-04-29 (ticket #8): scripts/nsx.sh now uses NSX session-auth
+          (POST /api/session/create → JSESSIONID cookie + X-XSRF-TOKEN header). The wrapper
+          works against the canonical FQDN, so this target is back on `vcf9-nsx.evba.vcf.lab`.
+          See `kb/nsx-9.0-overview.md` (envoy gotcha section) for the full story.
+
+      During the investigation the previous admin password (`Evoila1!Evoila1!`) was leaked to the
+      conversation transcript via an over-broad `jq` query; it was rotated and replaced with a
+      fresh SDDC-Manager-generated value before the leak could be exploited. Treat the old value
+      as compromised but no longer in use.
+
+  - name: hetzner-robot
+    aliases: [robot, hetzner-robot-rdc, hetzner-account, hetzner]
+    product: hetzner-robot
+    host: robot-ws.your-server.de
+    secret_ref: secret/rdc-hetzner-dc/network/hetzner-robot-api
+    vpn_required: false
+    notes: |
+      The Hetzner Robot Webservice for the rdc-hetzner-dc account — the canonical
+      datacenter-plane view of the 4 dedicated servers (esx-dc1..4 / Hetzner servers
+      2714097, 2929565, 2938969, 2939345) and the vSwitches between them. Public
+      internet endpoint, no VPN required. Note: the Webservice user has account-wide
+      visibility into 12 servers — 4 in-scope (above) plus 5 Rackspot Reservations
+      (2939037–2939042 minus 2939038) and 3 out-of-scope esxNN.evba.lab servers
+      (esx02 in FSN1-DC13, esx03 in FSN1-DC1, esx05 in FSN1-DC12) per CLAUDE.md scope.
+
+      Auth: HTTP Basic against a dedicated **Webservice user** stored in 1P
+      `hetzner-robot-api` (created in Hetzner Robot UI under Settings → "Web service
+      and app settings"). NOT the Robot login user — Webservice rejects those.
+
+      v1 scope: read-only. The connector passes change-class methods through
+      mechanically (POST /reset, POST /vswitch, etc.) but those calls have serious
+      blast radius — see kb/hetzner-robot-2026-04-mutation-surface.md and confirm
+      with the operator before running any non-GET. Connector: scripts/hetzner-robot.sh.
+
+  - name: vcf9-fleet
+    aliases: [vcf9-fleet-manager, fleet-vcf9, vcf9-lcm, vcf9-vrslcm]
+    product: vcf-fleet
+    host: vcf9-fleet.evba.vcf.lab
+    secret_ref: secret/rdc-hetzner-dc/vsphere/vcf9-fleet-admin
+    sso_realm: ""                          # Fleet uses its own LCM-local user store, not vSphere SSO
+    vpn_required: true
+    notes: |
+      VCF Fleet Management Appliance (10.5.31.26). Built on vRealize Suite Lifecycle Manager
+      (vRSLCM) 8.x — every response carries `Lcm-API-Version: 8.0`. Internal config still says
+      "VMware vRealize Lifecycle Manager"; the VCF 9 marketing name is "Fleet Management".
+
+      Auth: HTTP Basic against Fleet's local LCM user store. Username `admin@local`. Fleet does
+      NOT federate with vCenter SSO — `claude-fleet-svc@vsphere.local` (created in vsphere.local
+      SSO during the discovery journey for ticket #22) was rejected with HTTP 401 "Bad
+      credentials"; the local user works.
+
+      Lifecycle ownership: VCF Operations governs Fleet's lifecycle in VCF 9 (per project owner,
+      2026-04-29). SDDC Manager retains a `/v1/vcf-services` LCM entry for transitional reasons
+      but does NOT own Fleet's identity, credentials, or upgrade flow.
+
+      Fleet's own diagnostic endpoints (`/lcm/lcops/api/v2/about`, `/health`, `/version`,
+      `/system-details`) return HTTP 500 in this build — known issue, not a credential problem.
+      The connector probes `/lcm/lcops/api/v2/datacenters` instead. Product version is sourced
+      from SDDC Manager's `/v1/vcf-services` (LCM service entry: 9.0.2.0.25151284 as of
+      2026-04-29). Connector: scripts/vcf-fleet.sh; details in kb/vcf-fleet-9.0-overview.md.
+
+  # === Holodeck holodeck-1 env (deployed 2026-05-05 on cluster holodeck-1 / esx-dc5) ===
+  # Full-stack VCF 9.0.2 deploy via the new single-host-cluster architecture (issue #44).
+  # **Live InstanceID is `claude`** (legacy from the initial-deploy session 2026-05-04/05 — the AI tool's
+  # name was used as the deploy identifier; baked into ~100+ Holodeck records and unrenameable without
+  # a 7h destroy+redeploy). Per the [naming rule](../CLAUDE.md#naming-rule--never-bake-the-ai-tools-name-into-operator-artifacts),
+  # the operator-visible refs (target names + 1P item names below) have been renamed to `holodeck-1-*`
+  # following the cluster-mirroring convention; future deploys use that convention from the start.
+  # ConfigID: 7kp5. Holodeck instance Status: Completed.
+  # Wall-clock from final hardened launch to success: ~7h 14min (config 7kp5 import → "HoloDeck deployment completed successfully").
+  #
+  # Operator reachability: implemented via the per-env DNAT + bind9 split-horizon architecture
+  # (issue #81) — see kb/holodeck-9.0-architecture-evoila-rdc.md § "VPN access architecture for
+  # parallel Holodeck instances" + rdc-hetzner-dc/holodeck-deploys/registry.yaml. The legacy
+  # single-static-route path (10.1.0.0/20 → vcf_router → HoloRouter) was used by the l2ey deploy
+  # on cluster1 (destroyed 2026-05-11 per #291); the pfSense static route was removed with it.
+
+  - name: holodeck-1-vcenter
+    aliases: [holo-1-vcenter, vc-mgmt-h1]
+    product: vcenter
+    host: 10.1.1.10
+    secret_ref: secret/rdc-hetzner-dc/holodeck/1-shared-sso     # 1P item TBD; default Holodeck creds 'administrator@vsphere.local' / 'VMware123!VMware123!'
+    sso_realm: vsphere.local
+    vpn_required: true
+    notes: |
+      holodeck-1 env management-domain vCenter (`vc-mgmt-a.site-a.vcf.lab` / 10.1.1.10).
+      Holodeck always allocates this FQDN/IP for the mgmt-domain vCenter — concurrent
+      deploys are isolated at the L2/vSwitch level and reached via per-env DNAT aliases on
+      their respective HoloRouters (see registry.yaml + kb § VPN access architecture).
+      vCenter version
+      9.0.2; healthy from HoloRouter probe 2026-05-05 (HTTPS 200). 1P credential item
+      `holodeck-1-shared-sso` not yet created — operator action: create LOGIN item
+      with `username=administrator@vsphere.local` + `password=VMware123!VMware123!` (or
+      rotated value, see § "Credentials decision" pattern in INVENTORY).
+
+  - name: holodeck-1-sddc
+    aliases: [holo-1-sddc, sddcmanager-h1]
+    product: sddc-manager
+    host: 10.1.1.5
+    secret_ref: secret/rdc-hetzner-dc/holodeck/1-shared-sso
+    sso_realm: vsphere.local
+    vpn_required: true
+    notes: |
+      holodeck-1 env SDDC Manager (`sddcmanager-a.site-a.vcf.lab` / 10.1.1.5). Shares vSphere
+      SSO with `holodeck-1-vcenter` (Holodeck default `-WorkloadDomainType: SharedSSO`).
+      Healthy from HoloRouter probe 2026-05-05 (HTTPS 301 to login UI).
+
+  - name: holodeck-1-nsx
+    aliases: [holo-1-nsx, nsx-mgmt-h1]
+    product: nsx
+    host: 10.1.1.20
+    secret_ref: secret/rdc-hetzner-dc/holodeck/1-nsx-admin    # 1P item TBD
+    sso_realm: ""
+    vpn_required: true
+    notes: |
+      holodeck-1 env NSX Manager VIP (3-node cluster — node IPs 10.1.1.21/22/23, VIP 10.1.1.20
+      / FQDN `nsx-mgmt-a.site-a.vcf.lab`). Local `admin` user; not SSO-federated by default.
+      Healthy from HoloRouter probe 2026-05-05 (HTTPS 302). 1P item TBD; default Holodeck
+      cred is `admin` / `VMware123!VMware123!` per kb. See `kb/nsx-9.0-overview.md` for the
+      session-auth gotcha behind envoy front-door.
+
+  - name: holodeck-1-ops
+    aliases: [holo-1-ops, ops-h1]
+    product: vcf-operations
+    host: 10.1.1.30
+    secret_ref: secret/rdc-hetzner-dc/holodeck/1-ops-admin    # 1P item TBD
+    sso_realm: ""
+    vpn_required: true
+    notes: |
+      holodeck-1 env VCF Operations VIP (2-node cluster + collector — node IPs 10.1.1.31/32,
+      VIP 10.1.1.30 / FQDN `ops-a.site-a.vcf.lab`). Operations Cloud Proxy at 10.1.1.41
+      (`opscollector-01a.site-a.vcf.lab`). Operations Fleet/LCM at 10.1.1.36 (separate
+      product = vcf-fleet). Local `admin@local` user. Healthy from HoloRouter probe
+      2026-05-05 (HTTPS 200).
+
+  - name: holodeck-1-fleet
+    aliases: [holo-1-fleet, opslcm-h1]
+    product: vcf-fleet
+    host: 10.1.1.36
+    secret_ref: secret/rdc-hetzner-dc/holodeck/1-fleet-admin    # 1P item TBD
+    sso_realm: ""
+    vpn_required: true
+    notes: |
+      holodeck-1 env VCF Operations Fleet Management (`opslcm-a.site-a.vcf.lab` / 10.1.1.36).
+      Built on vRSLCM 8.x lineage (see `kb/vcf-fleet-9.0-overview.md`). Local `admin@local`
+      user. Healthy from HoloRouter probe 2026-05-05 (HTTPS 200).
+
+  - name: holodeck-1-auto
+    aliases: [holo-1-auto, auto-h1]
+    product: vcf-automation
+    host: 10.1.1.70
+    fqdn: auto-a.site-a.vcf.lab            # vhost routing — required when host is an IP
+    secret_ref: secret/rdc-hetzner-dc/holodeck/1-auto-admin
+    sso_realm: ""
+    vpn_required: true
+    notes: |
+      holodeck-1 env VCF Automation user-facing endpoint (`auto-a.site-a.vcf.lab` / 10.1.1.70).
+      Internal control plane on `auto-platform-a.site-a.vcf.lab` / 10.1.1.69; operators
+      log into 10.1.1.70. Holodeck reuses the same site-a.vcf.lab FQDN convention across
+      deploys; operator-side reach is via the per-env DNAT + bind9 split-horizon scheme
+      (issue #81 / registry.yaml).
+      Note (2026-05-05, #94): the prior "404 on root — expected" framing has been
+      superseded — the 404 was actually a vhost mismatch, fixed by the `fqdn` field
+      and the wrapper's --resolve handling. See kb § Validation findings.
+
+  - name: holodeck-1-supervisor
+    aliases: [holo-1-supervisor, supervisor-mgmt-h1, holodeck-1-vks]
+    product: tanzu-supervisor
+    host: 10.1.1.85                         # CP-node-1 mgmt-side IP (cluster VIP 10.1.0.x is NSX-VPC-internal)
+    port: 443
+    secret_ref: secret/rdc-hetzner-dc/k8s/holodeck-1-supervisor-kubeconfig    # 1P item TBD; capture per kb/vks-9.0 recipe
+    kubeconfig_field: kubeconfig
+    vpn_required: true
+    notes: |
+      VKS / vSphere Kubernetes Service Supervisor cluster on the holodeck-1 env. Supervisor ID:
+      `6fba60f7-48e4-4e4e-a81f-ee97e5557ce9`. Cluster VIP is on the NSX-VPC-internal
+      address space and unreachable from outside the VPC; this entry points at CP-node-1
+      mgmt-side IP `10.1.1.85` (10.1.1.86 is CP-node-2 backup). Auth: vSphere SSO via
+      `kubectl vsphere login` against 10.1.1.85 — short-lived bearer tokens; for
+      automation use a long-lived ServiceAccount kubeconfig per the
+      `kb/vks-9.0-supervisor-list-endpoints.md` recipe. 1P item TBD.
+
+  # === Kubernetes clusters ===
+  # Discovered 2026-05-04. All four entries reference **placeholder Vault
+  # paths** that don't have a kubeconfig field populated yet — see INVENTORY
+  # § "Kubernetes footprint → Required Vault items to fill credential gaps"
+  # for the recipe to populate each one. The kubectl-vcf connector will exit
+  # with `failed to read kubeconfig from <secret_ref>/<kubeconfig_field>`
+  # until the corresponding Vault path exists with the field set.
+
+  - name: rke2-infra
+    aliases: [rke2-infra-cluster, infra-rke2, k8s-infra]
+    product: kubernetes
+    host: rke2-infra.evba.lab
+    port: 6443
+    secret_ref: secret/rdc-hetzner-dc/k8s/rke2-infra-kubeconfig
+    kubeconfig_field: kubeconfig
+    vpn_required: true
+    notes: |
+      3-node RKE2 cluster running shared internal infra workloads on the
+      host vSphere cluster (cluster1). Nodes: rke2-infra-{01,02,03}.evba.lab
+      at 10.5.50.{150,151,152}, on hosts esx-dc{4,3,2}. Cluster API DNS
+      `rke2-infra.evba.lab:6443` resolves from operator workstation
+      (verified 2026-05-04). All nodes expose 6443 (kube-apiserver) and
+      9345 (rke2 supervisor). Cert SANs include the cluster FQDN + per-node
+      FQDNs + per-node short names + 10.43.0.1 (default service-cluster CIDR).
+      VMs: Ubuntu 24.04.4 LTS / kernel 6.8.0-106-generic / 4 vCPU / 8 GB RAM.
+      Connectors: scripts/kubectl-vcf.sh + scripts/helm-vcf.sh (sibling
+      wrappers sharing this kubeconfig field). Kubeconfig populated in Vault
+      at the configured path; both connectors' `--probe` succeed against
+      this target as of 2026-05-06 (#103).
+
+  - name: rke2-meho
+    aliases: [rke2-meho-cluster, meho-rke2, k8s-meho, meho]
+    product: kubernetes
+    host: 10.5.50.153                       # node-01 — no VIP, no resolvable FQDN (see notes)
+    port: 6443
+    secret_ref: secret/rdc-hetzner-dc/k8s/rke2-meho-kubeconfig
+    kubeconfig_field: kubeconfig
+    vpn_required: true
+    notes: |
+      **PRODUCTION** — 3-node RKE2 v1.34.5+rke2r1 stacked-etcd HA control
+      plane (no dedicated workers) running the evoila-internal `meho`
+      product. Nodes: rke2-meho-{01,02,03}.evba.lab at 10.5.50.{153,154,155}
+      on hosts esx-dc{3,4,2}. CNI: Canal (Flannel + Calico). Each node has
+      a 2nd NIC on 10.5.61.0/24 (purpose TBD; flagged in INVENTORY).
+
+      Cluster API DNS `rke2-meho.evba.lab` is in the cert SAN but does
+      **not resolve** from operator workstation, pfSense, or vcf_router —
+      AND there is no cluster-level VIP (probed; no kube-vip/haproxy). The
+      kubeconfig stored in 1P pins `server: https://10.5.50.153:6443`
+      (node-01's primary IP, also a cert SAN). **If node-01 goes down, the
+      kubeconfig breaks** — recovery: SSH to surviving node, regrab
+      rke2.yaml, swap to that node's IP, update the 1P field. Long-term
+      fix: provision a VIP and/or DNS so the kubeconfig matches the
+      canonical FQDN.
+
+      Connector: scripts/kubectl-vcf.sh. Kubeconfig captured 2026-05-04 from
+      `/etc/rancher/rke2/rke2.yaml` on rke2-meho-01; migrated to Vault 2026-05-05
+      in #66 at `secret/rdc-hetzner-dc/k8s/rke2-meho-kubeconfig` field
+      `kubeconfig`. Probe returns populated 4-entry fingerprint array.
+
+      **Production caution:** the embedded user is the cluster-admin
+      `default` from `/etc/rancher/rke2/rke2.yaml`. Coordinate with the
+      meho project owner before any non-read action. For automation,
+      consider a least-privilege ServiceAccount kubeconfig instead.
+
+  # === Holodeck holodeck-1 / holodeck-1 env ===
+  # Deployed 2026-05-04. First Holodeck deploy under the new single-host-cluster
+  # architecture (issue #44). Slot 1 of cluster `holodeck-1` on `esx-dc5`.
+  # Mgmt vNIC is on the sibling vSS PG `holodeck-mgmt-vlan3000` (VM-attachable
+  # twin of `DPortGroup-MGMT-VLAN3000`, same VLAN 3000) — see kb on the name-
+  # collision workaround.
+
+  - name: holorouter-1
+    aliases: [holo-1, holorouter-1, holodeck-1-router]
+    product: holodeck
+    host: 10.5.50.202
+    secret_ref: secret/rdc-hetzner-dc/holodeck/1-root-password
+    vpn_required: true
+    notes: |
+      HoloRouter for the Holodeck deploy on cluster `holodeck-1`, slot 1
+      (uses `vss-1-trunk-A`/`vss-1-trunk-B`). VM
+      `/FSN1-DC21-RACK1/vm/VCF9/holorouter-claude` (UUID 420d4b50-8836-6d54-9e41-4dce45d2fc0e)
+      on `esx-dc5.evba.lab`. OVA build `9.0.2.0424` from content library
+      `/Holodeck/holorouter-9.0.2.0424`; module version `9.0.2.19` per probe.
+      Photon OS, 4 vCPU / 8 GB RAM. Deployed 2026-05-04 via
+      `govc library.deploy` from operator workstation.
+
+      **Live InstanceID is `claude`** (legacy from the initial-deploy session
+      2026-05-04/05; baked into Holodeck state, the deployed VM names
+      `claude-vcfinstaller-a` and `claude-esx-01a..07a`, SDDC Manager records,
+      and ~100+ other refs — unrenameable without a 7h destroy+redeploy).
+      The VM in vCenter still has the legacy name `holorouter-claude`; the
+      operator-visible refs (this target's name `holorouter-1`, the 1P item,
+      the service-target names below) use the cluster-mirroring convention
+      per the [naming rule](../CLAUDE.md#naming-rule--never-bake-the-ai-tools-name-into-operator-artifacts).
+      Future deploys on `holodeck-1` (when this one retires) start from
+      `-InstanceID holodeck-1`.
+
+      Mgmt vNIC attaches to `holodeck-mgmt-vlan3000` on `vSwitch10G` (VLAN 3000,
+      security all Reject) — a sibling vSS PG to `DPortGroup-MGMT-VLAN3000`
+      created because vCenter's inventory aliases the vDS-named PG to
+      `dvportgroup-44` on `DSwitch1` (esx-dc5 isn't a member of that vDS), so
+      OVF deploy / `vm.network.change` cannot resolve to the local vSS PG by
+      that name. The two PGs share L2 (same VLAN, same vSwitch), so vmk1
+      (`10.5.50.24`) and HoloRouter eth0 (`10.5.50.202`) talk directly.
+
+      Auth: SSH `root@10.5.50.202` with password set at OVA-deploy time, stored
+      in 1P `holodeck-1-root-password` (LOGIN: `username=root`). Connector:
+      `scripts/holodeck.sh`.
+
+  # === Holodeck holodeck-4 / hd4mgmt donor #2 env ===
+  # Deployed 2026-05-13 (wall-clock 2h 51min, 13:00:03 → 15:51:23 UTC) on cluster `holodeck-4` / `esx-dc4`.
+  # **Bare `-ManagementOnly` 9.0.2 deploy** — donor #2 in the two-donor strategy (#1 is the full-stack
+  # claude/holodeck-1 deploy on dc-5). Smaller variants are easier to add to than larger variants are
+  # to remove from; bare-mgmt-only complements the full-stack donor.
+  # **InstanceID = `hd4mgmt`** (Holodeck 8-char ceiling on InstanceID forced this 7-char abbreviation
+  # over the cluster-mirroring `holodeck-4`; mnemonic for "holodeck-4 management-only"). VM names:
+  # `hd4mgmt-vcfinstaller-a`, `hd4mgmt-esx-{01..04}a`. HoloRouter VM is `holodeck-4-holorouter`
+  # (operator-named, cluster-mirroring per the naming rule). Nested service IPs follow the Holodeck
+  # default Site A IP plan (master CIDR `10.1.0.0/20`): `vc-mgmt-a` 10.1.1.10, `sddcmanager-a` 10.1.1.5,
+  # `nsx-mgmt-a` 10.1.1.20, `ops-a` 10.1.1.30 (Holodeck deploys the Operations node even on
+  # `-ManagementOnly`; this is a 4-service surface, not 3).
+  #
+  # **Lab usage shape**: the lab is currently UP for smoke validation but designated as a donor — the
+  # workflow per operator decision 2026-05-13 is (1) clone the fresh untainted state, (2) attempt
+  # in-place 9.0.2 → 9.1 upgrade on the clone (#250), (3) clone the 9.1 result if upgrade succeeds,
+  # (4) hand a fresh 9.1 lab to a colleague who needs one ASAP. Per-clone live operator reach (alias-IP
+  # block in `10.5.50.0/24` + DNAT + bind9 view + pfSense rule) happens when a clone graduates to
+  # "live, bound" state; donor #2 itself stays unbound / unregistered in the VPN-access registry
+  # (`rdc-hetzner-dc/holodeck-deploys/registry.yaml`'s V1.1 schema requires 7 services + a bound user,
+  # which the bare-mgmt-only donor shape doesn't satisfy). Operator reach to the HoloRouter itself
+  # (`holorouter-4` target below) IS available via the existing 10.5.50.0/24 VPN route — no extra
+  # plumbing needed for HoloRouter SSH / pwsh / `Get-HoloDeckInstance`.
+
+  - name: holorouter-4
+    aliases: [holo-4, holorouter-hd4mgmt, holodeck-4-router]
+    product: holodeck
+    host: 10.5.50.205
+    secret_ref: secret/rdc-hetzner-dc/holodeck/4-root-password
+    vpn_required: true
+    notes: |
+      HoloRouter for the Holodeck deploy on cluster `holodeck-4`, slot 1 (uses `vss-1-trunk-A` /
+      `vss-1-trunk-B`). VM `/FSN1-DC21-RACK1/vm/holodeck-4/holodeck-4-holorouter`
+      (UUID `420df878-8ff0-da96-b64a-00f600aa7b61`) on `esx-dc4.evba.lab`. OVA build `9.0.2.0424`
+      from content library `/Holodeck/holorouter-9.0.2.0424`; Photon OS 6.1.10-11.ph5,
+      4 vCPU / 8 GB RAM. Deployed 2026-05-12 via `govc library.deploy` from operator workstation
+      with all OVA properties namespaced `network.<key>` / `extra.<key>` per the OVF spec (first
+      attempt with unprefixed keys silently dropped 9/10 properties).
+
+      Mgmt vNIC attaches to **`holodeck-mgmt-vlan3000`** on `vSwitch10G` (VLAN 3000, security all
+      Reject) — the sibling vSS PG to `DPortGroup-MGMT-VLAN3000`, pre-created on dc-4 2026-05-12
+      as part of the deploy prep per [`kb/holodeck-9.0-architecture-evoila-rdc.md` § 5a](../kb/holodeck-9.0-architecture-evoila-rdc.md).
+      Note: the cluster also has the `Holodeck-Mgmt-VLAN3010` SPG (created by #257 for future use),
+      but the HoloRouter itself uses VLAN 3000 — same pattern as holodeck-1. The ticket body's
+      "VLAN 3010" was a conflation with the lab-side service VLAN (used by `vcfdepot`).
+
+      **InstanceID `hd4mgmt` deployed 2026-05-13** with `Connect-VIServer` patched per the three
+      per-appliance Holodeck patches: `-eq 7 → -ge 7` (SddcMgmtDeployment.psm1),
+      `BroadcomBuildToken SecureString` (HoloDeck.psm1), and the new `Auth.psm1`
+      `PSCredential` patch (replacing the silently-failing `-User`/`-Password` shape). All three
+      now codified in the deploy skill + kb. Wall-clock 2h 51min (well within the kb's 3-4h
+      envelope for bare `-ManagementOnly`).
+
+      Auth: SSH `root@10.5.50.205` with password set at OVA-deploy time, stored in Vault at
+      `secret/rdc-hetzner-dc/holodeck/4-root-password` (LOGIN: `username=root`). 32-char alphanumeric,
+      generated via `openssl rand -base64 32 | tr -d '/+= ' | cut -c1-32`. Connector:
+      `scripts/holodeck.sh`.
+
+      **Nested service credentials NOT YET CAPTURED** — captured as a follow-up ticket (donor #2
+      operationalization). Until then, `holodeck-4-{vcenter,sddc-manager,nsx,ops}` targets cannot be
+      added (no alias IPs allocated either; donor lab is not VPN-reachable for nested services). For
+      now, run probes from inside the HoloRouter via `scripts/holodeck.sh --target holorouter-4`.
+
+  # === Holodeck Offline Depot Appliance (deployed 2026-05-12 on cluster1) ===
+  # Shared depot for all Holodeck deploys in this project. Consumed by
+  # `New-HoloDeckInstance -DepotType Offline` via $env:offline_depot_* vars
+  # (see secret/rdc-hetzner-dc/holodeck/offline-depot-connection for the
+  # exact ip/port/protocol/username; admin password at offline-depot-admin).
+  # Bundle population deferred to a follow-up ticket — depot currently empty
+  # (skip_dl=True at OVA deploy); future `vdt` runs populate /var/www/build.
+
+  - name: vcfdepot
+    aliases: [holodeck-offline-depot, oda, offline-depot, vcf-depot]
+    product: offline-depot
+    host: vcfdepot.evba.lab
+    secret_ref: secret/rdc-hetzner-dc/holodeck/offline-depot-admin
+    vpn_required: true
+    notes: |
+      VCF Offline Depot Appliance (ODA) v0.1.3 — Holodeck-shipped OVA serving
+      VCF bundles to `New-HoloDeckInstance -DepotType Offline`. Photon OS +
+      nginx 1.26.2 + VDT (`/root/vdt/bin/`) + Jupyter Lab on port 8888.
+      Deployed 2026-05-12 from content library `/Holodeck/vcf-offline-depot-appliance-0.1.3`
+      via `govc library.deploy` (ticket #308).
+
+      VM `/FSN1-DC21-RACK1/vm/vcfdepot` (UUID 420d1f0a-769a-53da-337c-e9bf376e66ff)
+      on `esx-dc2.evba.lab` (DRS placement, cluster `cluster1`). 2 vCPU /
+      2 GB RAM / thin-provisioned disk on `vsanDatastore`. NIC on
+      `DPortGroup-Holodeck-Mgmt-VLAN3010` (VLAN 3010, subnet 10.5.52.0/22,
+      gateway 10.5.52.1 on `vcf-router` `vlan.3010@ens37`).
+
+      Reachability: HTTP depot at `http://10.5.52.5/` (returns nginx
+      directory index — empty until bundles populate); Jupyter Lab at
+      `http://10.5.52.5:8888/` (login page, server up). DNS A record
+      `vcfdepot.evba.lab → 10.5.52.5` added 2026-05-12 to `vcf-router-bind9`.
+
+      Deploy config: VCF Version = 9.0; Skip Binary Download = True;
+      Enable SSH/Jupyter/Ping = True. Download token populated from
+      `secret/rdc-hetzner-dc/toolkit/broadcom-support-token` at deploy
+      (migrated to Vault as part of this ticket per #66 parked-delta).
+
+      Auth: SSH `admin@10.5.52.5` (or `vcfdepot.evba.lab`) with password
+      stored in Vault at this target's `secret_ref` (LOGIN: `username=admin`,
+      `password=<generated>`). Connection details (ip/port/protocol/username/
+      hostname/fqdn/netmask_cidr/gateway/dns) in
+      `secret/rdc-hetzner-dc/holodeck/offline-depot-connection`.
+
+      No dedicated connector wrapper — depot is an HTTP/SSH endpoint
+      consumable directly via `curl`/`ssh`. If/when a verb-shaped operation
+      grows around it (e.g. "list staged bundles", "trigger VDT pull"), a
+      thin wrapper at `scripts/offline-depot.sh` can be added then.
+
+  - name: vcf-router-bind9
+    aliases: [vcf-router-dns, lab-bind9, evba-bind9]
+    product: bind9-dns
+    host: 10.5.1.209
+    secret_ref: secret/rdc-hetzner-dc/network/vcf-router
+    vpn_required: true
+    notes: |
+      Bind9 9.18.x master on `vcf-router` (Ubuntu 24.04). Authoritative for
+      `evba.lab` (zone file `/etc/bind/db.evba.lab`), `evba.vcf.lab`
+      (`db.evba.vcf.lab`), and several reverse zones (`*.5.10.in-addr.arpa`).
+      Forwards `evba.tanzu.lab` and `vmware.com`. Operators query this server
+      for everything `evba.lab.` over VPN; pushed via OpenVPN config.
+
+      Connector: `scripts/bind9-dns.sh`. SSH preferred via public key (set up
+      `ssh-copy-id ubuntu@10.5.1.209` once); falls back to password from this
+      1P item via `sshpass`. Sudo password fed via the safe `read -s PASS`
+      pattern — never the broken heredoc-passes-password-as-stdin-line-1
+      shape that leaked the credential on 2026-05-04.
+
+      `secret_ref` shared with the `vcf-router` shell access pattern from
+      ticket #57 — same Ubuntu user. Rotate the credential per the backlog
+      item `PVTI_lAHOBVAQf84BWEgnzgrv_9I` before any further use of this target.
+
+  # === GCP (ed-consulting.at organization) ===
+  # Discovered 2026-05-04. The org has 4 projects total — 1 in-scope here
+  # (rdc-datacenter-and-lab, the infrastructure pillar) plus 3 sibling
+  # workload projects documented in INVENTORY.md but not yet wired as targets.
+  #
+  # Auth model is unusual relative to the other connectors: this entry has
+  # NO `secret_ref` because the org enforces the default
+  # `constraints/iam.disableServiceAccountKeyCreation` org policy, blocking
+  # SA-JSON key creation. The connector uses ADC (operator's own gcloud auth)
+  # plus `--impersonate-service-account` instead. See
+  # kb/gcp-iam-disable-sa-key-creation.md for the rationale and the
+  # alternative-auth options if this needs to grow into unattended automation.
+
+  - name: rdc-gcp
+    aliases: [rdc-infra, rdc-datacenter-and-lab, gcp-rdc, gcp-infra]
+    product: gcp
+    project_id: rdc-infra
+    account: gcp-admin@evoila.dev
+    # No impersonate_sa: under the Option-C identity model decided 2026-05-05,
+    # the operator drives evoila.dev work as gcp-admin@evoila.dev directly.
+    # Audit-log indirection via SA impersonation deferred until the
+    # (currently unreproducible) iam.serviceAccounts.getIamPolicy permission
+    # issue on rdc-infra is understood. The SA `claude-vcf-toolkit@rdc-infra…`
+    # exists in the project with roles/viewer if/when impersonation is revived.
+    vpn_required: false
+    notes: |
+      GCP infrastructure-pillar project for evoila Bosnia. **Recreated 2026-05-05**
+      under the new evoila-Bosnia GCP org `evoila.dev` (org ID 202191745121, see
+      INVENTORY § GCP § Target architecture). Replaces the original
+      `rdc-datacenter-and-lab` project (under ed-consulting.at), which was deleted
+      2026-05-05 because cross-org migration was blocked by the source org's
+      `ORG_MUST_INVITE_EXTERNAL_OWNERS` constraint and the destination's
+      `iam.allowedPolicyMemberDomains` constraint, neither of which an org-Admin
+      could resolve from within the constraint matrix. Recreate-fresh was lower
+      friction since rdc-datacenter-and-lab had no real resources (0 buckets,
+      0 compute, 1 viewer-only SA, no committed state).
+
+      Auth model: ADC, no impersonation. Operator authenticates as
+      `gcloud auth login gcp-admin@evoila.dev` for evoila.dev work — distinct
+      from `damir.topic@ed-consulting.at` which is the operator's identity for
+      everything ELSE the toolkit touches. gcloud config configurations can keep
+      them separate (`gcloud config configurations create evoila-bosnia` then
+      `set account gcp-admin@evoila.dev` inside it). The `iam.allowedPolicyMemberDomains`
+      org policy on evoila.dev prevents granting non-evoila.dev users on this
+      project — `damir.topic@ed-consulting.at` cannot be added to rdc-infra IAM
+      without first expanding the policy's allowlist to include
+      `ed-consulting.at`'s customer ID `C031j18a2`.
+
+      Current state (2026-05-05):
+        - Project: rdc-infra (project number 735324434736), parent org
+          `evoila.dev` (202191745121).
+        - Owners: gcp-admin@evoila.dev (auto via project creation).
+        - Billing: 01AC28-5F5C01-32C3B3 link **PENDING**. Linking is blocked
+          because the actor needs both `billing.user` on the account and project
+          permissions; the only Bosnia-side billing.admin who could grant
+          gcp-admin@evoila.dev `billing.user` cleanly via CLI is the colleague
+          who actually administers the account (damir.topic@ed-consulting.at
+          appears to have only billing.user, not billing.admin, despite operator
+          believing otherwise — gcloud's billing-account IAM commands return
+          INVALID_ARGUMENT for them). See backlog "GCP: Link rdc-infra to
+          unified billing".
+        - APIs enabled: 24 (GCP defaults + cloudresourcemanager + iam).
+        - Resources: 0 buckets, 0 compute, 1 SA (claude-vcf-toolkit @ rdc-infra,
+          roles/viewer, no key, available for future impersonation if/when
+          unblocked).
+
+      Connector: scripts/gcloud.sh. Probe returns the GCP fingerprint
+      (vendor=google, product=gcp, version=null, api_versioned=false).
+
+      VPN: not required — GCP is on the public Internet at *.googleapis.com.
+
+  # === Keycloak on rke2-infra ===
+  # Deployed 2026-05-10 via bitnami/keycloak chart 25.2.0 (Keycloak 26.3.3)
+  # under evoila-bosnia/claude-rdc-hetzner-dc#275 (commitment #3 of #261).
+  # Realms: `master` (chart default) + empty `evba` (created by
+  # keycloakConfigCli post-install hook). Connector wrapper to be built as
+  # a separate Backlog ticket.
+
+  - name: rdc-keycloak
+    aliases: [keycloak, sso, rdc-keycloak-rke2-infra]
+    product: keycloak
+    host: keycloak.evba.lab
+    port: 443
+    # No secret_ref yet — connector wrapper doesn't exist. Bootstrap admin
+    # credential lives in Vault at secret/rdc-hetzner-dc/keycloak/admin
+    # (fields: username, password). Future connector wrapper will reference
+    # this path or use OIDC client-credentials via Vault OIDC federation
+    # once commitment #5 of #261 lands.
+    vpn_required: true
+    notes: |
+      Keycloak 26.3.3 (Quarkus-based, single replica, no HA) on the `rke2-infra`
+      cluster, namespace `keycloak`. Embedded Postgres subchart (1 replica,
+      8 GiB PVC on `vsphere-csi`). External endpoint `https://keycloak.evba.lab`
+      (DNS A → 10.5.61.31, the cluster's MetalLB-assigned Traefik IP); TLS
+      terminates at Traefik with a `keycloak-tls` Secret issued from
+      ClusterIssuer `rdc-internal-ca` (#70). Keycloak listens HTTP-only inside
+      the cluster; production mode (`KEYCLOAK_PRODUCTION=true`) with
+      `KC_PROXY_HEADERS=xforwarded` so Keycloak trusts Traefik's X-Forwarded-*
+      headers and emits HTTPS URLs in tokens / OIDC discovery / redirects.
+
+      Image distribution: chart 25.2.0 defaults to `bitnami/*` Docker Hub
+      images which have been gated behind Bitnami Premium since August 2025
+      (free-tier images return 404 NotFound). Overrides in
+      `apps/rke2-infra/keycloak/values.yaml` (evoila-bosnia/rdc-gitops#19)
+      point at the legacy-frozen `bitnamilegacy/*` namespace for all three
+      images (`keycloak`, `postgresql`, `keycloak-config-cli`). Migration
+      target if this ever bites: `keycloak/keycloak` operator + chart, or
+      `codecentric/keycloakx` (same realm export imports trivially).
+
+      Realms (as of 2026-05-10):
+        - master: chart default; holds the bootstrap admin user.
+        - evba:   empty placeholder created by the `keycloakConfigCli`
+                  post-install Job from the realm JSON inlined in
+                  values.yaml. Realm contents (clients, groups, roles,
+                  IdP federation) land in subsequent commitments of #261
+                  (#4 is the `meho-backplane` realm client).
+
+      Bootstrap admin: `admin` / Vault `secret/rdc-hetzner-dc/keycloak/admin`
+      field `password` (32 chars, generated 2026-05-10 via openssl rand). The
+      password was synced manually into the k8s Secret
+      `keycloak-admin-credentials` (key `admin-password`) before first
+      ArgoCD sync. Migration target: ESO sync from Vault once ESO is
+      deployed on rke2-infra (Backlog ticket pending).
+
+      OIDC endpoints (used by downstream consumers):
+        - issuer:        https://keycloak.evba.lab/realms/evba
+        - JWKS:          https://keycloak.evba.lab/realms/evba/protocol/openid-connect/certs
+        - authorization: https://keycloak.evba.lab/realms/evba/protocol/openid-connect/auth
+        - token:         https://keycloak.evba.lab/realms/evba/protocol/openid-connect/token
+        - discovery:     https://keycloak.evba.lab/realms/evba/.well-known/openid-configuration
+
+      Source of truth: `evoila-bosnia/rdc-gitops` ::
+        `apps/rke2-infra/keycloak/` (values + 4-file extras directory) +
+        `bootstrap/rke2-infra/applications/keycloak.yaml`.
+      ArgoCD Application: `keycloak` in ns `argocd`, AppProject `rke2-infra`,
+      `prune+selfHeal: true`.
+
+      Connector wrapper: NOT YET BUILT. Future `scripts/keycloak.sh` (or
+      similar) would wrap the Keycloak Admin REST API + the `kcadm.sh` CLI
+      for read+change ops (realm CRUD, client CRUD, IdP federation config).
+      Filed as a Backlog ticket for the future, follows the same shape as
+      `scripts/vault.sh`.
+
+  # === MEHO backplane on rke2-infra ===
+  # Deployed 2026-05-12 via `helm upgrade --install meho oci://ghcr.io/evoila/meho-chart`
+  # (chart 0.1.20260511-f21d0fe+). Full operator-facing deploy entrypoint at
+  # rdc-hetzner-dc/manifests/meho/; live commitment #10 of #261 green-smoke
+  # walked in #338 (closes #333 + #331's last Done-When items).
+
+  - name: rdc-meho
+    aliases: [meho, meho-backplane, rdc-meho-rke2-infra]
+    product: meho
+    host: meho.evba.lab
+    port: 443
+    # No secret_ref yet — connector wrapper doesn't exist (the future `meho`
+    # CLI binary or `scripts/meho.sh` will own auth via the Keycloak
+    # device-code flow against client `meho-backplane`, storing the
+    # resulting refresh token at `op://rdc-hetzner-dc/meho-operator-token`
+    # / `secret/rdc-hetzner-dc/meho/operator-token`). For now the bootstrap
+    # path for any HTTP probe is a fresh Keycloak `client_credentials`
+    # grant against the realm at https://keycloak.evba.lab/realms/evba
+    # using the `meho-backplane` client_secret at
+    # `secret/rdc-hetzner-dc/keycloak/client-meho-backplane` (the same path
+    # smoke.sh consumes — see rdc-hetzner-dc/manifests/meho/smoke.sh step 4).
+    vpn_required: true
+    notes: |
+      MEHO v0.1 chassis backplane (governance backplane for AI agents acting
+      on infrastructure — policy-gated, audit-grade, MCP-native; Apache 2.0)
+      on the `rke2-infra` cluster, namespace `meho`. Single-replica Deployment
+      via the upstream chart at `oci://ghcr.io/evoila/meho-chart`, plus an
+      in-tree broadcast subchart (Valkey 9.x, single replica, ephemeral
+      streams per ADR 0005) and dedicated PostgreSQL backend (from #312).
+      External endpoint `https://meho.evba.lab` (DNS A → 10.5.61.31, the
+      cluster's MetalLB-assigned Traefik IP); TLS terminates at Traefik with
+      a `meho-tls` Secret issued from ClusterIssuer `rdc-internal-ca` (#296).
+
+      Source of truth: this repo's operator-facing deploy entrypoint at
+      `rdc-hetzner-dc/manifests/meho/`:
+        - install.sh      — idempotent pre-flight + helm upgrade --install --wait --atomic
+        - smoke.sh        — 6-step post-install verification (federation chain + audit row)
+        - values-rdc.yaml — concrete RDC values (SA reuse, trust-bundle, asyncpg DSN)
+        - README.md       — operator runbook + rollback + failure modes
+
+      Cluster-side GitOps (CoreDNS evba.lab forward + Keycloak realm + cert
+      + DNS A record + PG + namespace + RBAC) lives in `evoila-bosnia/rdc-gitops`
+      under `apps/rke2-infra/{coredns,keycloak,meho,meho-postgres}/` + the
+      bootstrap Applications. The Helm release itself is NOT GitOps-managed
+      in v0.1 — `install.sh` is the operator-laptop deploy path. ArgoCD
+      management lands in v0.2 once the chart is stable.
+
+      Sibling commitments of Initiative #261:
+        - #262 meho-runners ARC pool on rke2-meho (built MEHO's CI)
+        - #266 meho namespace + meho-backplane SA + impersonator ClusterRole
+        - #275 Keycloak (chart + DB + DNS + TLS + ArgoCD app + empty evba realm)
+        - #285 Keycloak realm client meho-backplane + roles/groups/mappers
+        - #293 Vault OIDC federation (auth/oidc/, role meho-mcp, policies, groups)
+        - #295 DNS A record meho.evba.lab → 10.5.61.31
+        - #296 cert-manager Certificate/meho-tls
+        - #297 GHCR egress smoke from rke2-infra
+        - #312 PostgreSQL DB meho on rke2-infra
+        - #327 manifests/meho/{install.sh,smoke.sh,values-rdc.yaml,README.md}
+        - #331 verify cold-deploy + smoke + rollback (closed via #338)
+        - #333 CoreDNS forward for evba.lab (closed via #338 + rdc-gitops#28+#29)
+
+      Federation endpoints (consumed at runtime, configured via chart values):
+        - Keycloak issuer:     https://keycloak.evba.lab/realms/evba
+        - Keycloak audience:   meho-backplane
+        - Vault address:       https://vault.evba.lab
+        - Vault OIDC role:     meho-mcp (mount path: oidc)
+        - Postgres DSN:        postgresql+asyncpg://meho:<vault-secret>@meho-postgres-postgresql.meho.svc.cluster.local:5432/meho
+        - REDIS_URL:           rendered against `<release>-broadcast.meho.svc` by the chart
+
+      Operator-facing HTTP surface:
+        - GET /healthz                — 200 unconditionally (k8s liveness, no DB/Vault checks)
+        - GET /ready                  — 200 only when keycloak (JWKS fetchable)
+                                         + vault (sealed=False) + db (migration revision 0001+)
+                                         all return ok; 503 otherwise
+        - GET /version                — {git_sha, build_date, chart_version}
+        - GET /metrics                — Prometheus format (scrape config deferred to v0.2)
+        - GET /api/v1/health          — Bearer-auth shape of /ready; returns operator identity
+        - (more endpoints land in v0.2 with the first connector ticket)
+
+      The MEHO CLI binary (`meho login`, `meho status`, etc.) is NOT YET
+      RELEASED — `gh release list --repo evoila/meho` returns empty as of
+      2026-05-12. The smoke.sh's step 4–5 exercises the same Keycloak JWT
+      + Bearer-auth code paths the CLI will hit, so federation is fully
+      validated; the interactive device-code UX itself awaits the upstream
+      release ticket.
+
+      Connector wrapper: NOT YET BUILT. Future `scripts/meho.sh` would wrap
+      the MEHO REST API (`/api/v1/health` for `--probe`, `/api/v1/policy/*`
+      and `/api/v1/audit/*` for future verbs) — OR the operator may just
+      invoke the `meho` CLI directly once it's released. Filed as a Backlog
+      ticket; follows the same shape as `scripts/vault.sh` (Bearer-auth +
+      token from Vault). Until then, `--probe` against this target is an
+      operator-manual `curl` against the endpoints above.
+
+  # === HashiCorp Vault on rke2-infra ===
+  # Deployed 2026-05-05 via manual `helm install hashicorp/vault` (chart 0.32.0,
+  # Vault 1.21.2). HA Raft 3-of-5 Shamir; full deploy/init/unseal runbook in
+  # INVENTORY § "Vault on rke2-infra" + manifests at rdc-hetzner-dc/manifests/vault/.
+  # Importing under ArgoCD management is tracked separately as #75.
+
+  - name: rdc-vault
+    aliases: [vault, rdc-vault-rke2-infra, hashicorp-vault]
+    product: vault
+    host: vault.evba.lab
+    port: 443
+    # No secret_ref: vault.sh reads $HOME/.vault-token directly (operator
+    # pre-runs `vault login`). Bootstrap creds for that login are the lone
+    # 1P carve-out — op://rdc-hetzner-dc/vault-userpass-damir-topic.
+    vpn_required: true
+    notes: |
+      HashiCorp Vault 1.21.2 (Community) on the `rke2-infra` cluster, namespace
+      `vault`. 3-replica HA with integrated Raft storage; default Shamir 3-of-5
+      seal. External endpoint `https://vault.evba.lab` (DNS A → 10.5.61.31, the
+      cluster's MetalLB-assigned Traefik IP); TLS terminates at Traefik with a
+      `vault-tls` Secret issued from ClusterIssuer `rdc-internal-ca` (#70).
+      Vault listens HTTP-only inside the cluster.
+
+      Auth (connector default, post-#67): vault.sh reads $HOME/.vault-token
+      directly — no embedded auth. Operator runs once per session:
+        `vault login -method=userpass username=damir-topic`
+      using bootstrap creds from 1P `op://rdc-hetzner-dc/vault-userpass-damir-topic`
+      (the lone surviving 1P item — Vault cannot hold its own auth root).
+      Resulting client token is written to $HOME/.vault-token by the vault CLI
+      and consumed by every connector wrapper for the duration of the session
+      (default TTL 24h / max 720h). Refined RBAC + secret hierarchy land in #74.
+
+      Unseal model: 5 Shamir shares + initial root token captured at
+      `vault operator init` time (2026-05-05). All 5 shares sit in
+      `op://rdc-hetzner-dc/vault-unseal-share-{1..5}` for now (operator
+      decision: distribution to per-operator + offsite envelopes deferred,
+      see ticket #73 acceptance criteria). The initial root token in
+      `op://rdc-hetzner-dc/vault-root-token-initial` was REVOKED + LEAKED
+      on 2026-05-05 — see INVENTORY audit log entry — and is no longer a
+      valid credential. Subsequent admin access is via the userpass user.
+
+      Connector: `scripts/vault.sh` (probe + REST pass-through). Probe
+      uses unauthenticated `/v1/sys/health` + `/v1/sys/seal-status`, so it
+      works against a sealed Vault for status checks. Pass-through calls
+      attach `X-Vault-Token` from `$HOME/.vault-token` to outbound requests.

--- a/backend/tests/fixtures/rdc-hetzner-dc-targets.yaml
+++ b/backend/tests/fixtures/rdc-hetzner-dc-targets.yaml
@@ -83,7 +83,7 @@ targets:
           works against the canonical FQDN, so this target is back on `vcf9-nsx.evba.vcf.lab`.
           See `kb/nsx-9.0-overview.md` (envoy gotcha section) for the full story.
 
-      During the investigation the previous admin password (`Evoila1!Evoila1!`) was leaked to the
+      During the investigation the previous admin password (`[REDACTED — see incident log]`) was leaked to the
       conversation transcript via an over-broad `jq` query; it was rotated and replaced with a
       fresh SDDC-Manager-generated value before the leak could be exploited. Treat the old value
       as compromised but no longer in use.

--- a/backend/tests/test_api_v1_targets_import.py
+++ b/backend/tests/test_api_v1_targets_import.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration tests for the bulk-import flow against /api/v1/targets.
+
+The Go CLI side of this flow lives at
+``cli/internal/cmd/targets/import.go`` (G0.3-T6 / Task #257). Those
+tests exercise the YAML parser and the CREATE / UPDATE plan builder.
+*This* module exercises the **server side** of the same flow: it
+replays the per-entry POST / PATCH requests the CLI would fire and
+asserts the round-trip semantics.
+
+Coverage matrix:
+
+* **Real-consumer YAML round-trip** — every entry in the pinned
+  snapshot of
+  ``https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/rdc-hetzner-dc/targets.yaml``
+  (24 entries) creates a target with the right top-level columns and
+  the right `extras` spill.
+* **`fingerprint` is rejected on POST** — verifies the server-side
+  contract the CLI's `skipSilent` path relies on (sending
+  fingerprint in a CREATE body raises 422 via
+  ``model_config = ConfigDict(extra='forbid')``).
+* **`preferred_impl_id` is accepted as top-level on POST** —
+  verifies the G0.3-T1.5 (#477) amendment is reflected in the API
+  (a top-level column, not a spill into `extras`).
+* **Sparse-PATCH semantics** — a PATCH containing only `notes`
+  must not wipe the other columns the target already has.
+  Mirrors the inverse of the bug PR #362's review on #257
+  surfaced: the import tool was sending PUT-shaped bodies because
+  the route handler's ``model_dump(exclude_unset=True)`` +
+  ``setattr`` loop combined with Pydantic v2's "explicit null
+  counts as set" rule wiped omitted columns.
+
+The fixture file is pinned to a specific SHA (recorded in the
+helper below). When the upstream `targets.yaml` evolves, regenerate
+the fixture and update both the SHA constant and the entry-count
+assertion below — the test is deliberately tight on shape so that a
+silent drift in the upstream contract surfaces as a CI failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import respx
+import yaml
+from fastapi.testclient import TestClient
+
+from ._oidc_jwt_helpers import (
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._targets_helpers import (
+    _admin_token,
+    _build_app,
+    _empty_connector_registry,  # noqa: F401
+    _isolated_jwks_cache,  # noqa: F401
+    _settings_env,  # noqa: F401
+)
+
+# Pinned snapshot location and provenance. The fixture content
+# matches the upstream blob at
+# ``evoila-bosnia/claude-rdc-hetzner-dc:rdc-hetzner-dc/targets.yaml``
+# at the SHA recorded below — regenerate together if the consumer
+# file evolves. The size and entry-count constants below are pinned
+# to that exact SHA; mismatches surface as a fixture-drift test
+# failure.
+_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "rdc-hetzner-dc-targets.yaml"
+_FIXTURE_UPSTREAM_SHA = "1e1e6885e1ef79d03001955205d9e44a0bc8e79d"
+_FIXTURE_EXPECTED_ENTRY_COUNT = 24
+
+# Mapping rules mirror the Go side at cli/internal/cmd/targets/import.go.
+# Keep this in sync with `knownTopLevel` and `skipSilent` there.
+_KNOWN_TOP_LEVEL = frozenset(
+    {
+        "aliases",
+        "auth_model",
+        "extras",
+        "fqdn",
+        "host",
+        "name",
+        "notes",
+        "port",
+        "preferred_impl_id",
+        "product",
+        "secret_ref",
+        "vpn_required",
+    }
+)
+_SKIP_SILENT = frozenset({"fingerprint"})
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def _entry_to_create_body(entry: dict[str, Any]) -> dict[str, Any]:
+    """Apply the CLI's mapping rules to one YAML entry.
+
+    Identical contract to ``mapEntry`` in
+    ``cli/internal/cmd/targets/import.go``: known keys map 1:1 to
+    top-level columns; ``fingerprint`` is dropped; every other key
+    spills into ``extras``. The output is exactly what the CLI POSTs
+    to ``/api/v1/targets`` for a CREATE.
+    """
+    body: dict[str, Any] = {}
+    extras: dict[str, Any] = {}
+    # Pre-extract any explicit `extras:` block.
+    if isinstance(entry.get("extras"), dict):
+        extras.update(entry["extras"])
+    for k, v in entry.items():
+        if k == "extras":
+            continue
+        if k in _SKIP_SILENT:
+            continue
+        if k in _KNOWN_TOP_LEVEL:
+            body[k] = v
+        else:
+            extras[k] = v
+    if extras:
+        body["extras"] = extras
+    return body
+
+
+def test_fixture_parses_and_has_expected_entry_count() -> None:
+    """The pinned fixture matches the upstream entry count."""
+    with _FIXTURE_PATH.open("rb") as f:
+        doc = yaml.safe_load(f)
+    assert isinstance(doc, dict)
+    assert "targets" in doc
+    assert len(doc["targets"]) == _FIXTURE_EXPECTED_ENTRY_COUNT, (
+        f"Pinned snapshot drift: fixture has {len(doc['targets'])} entries; "
+        f"expected {_FIXTURE_EXPECTED_ENTRY_COUNT} at upstream SHA "
+        f"{_FIXTURE_UPSTREAM_SHA}. Regenerate the fixture + update the "
+        "constant if the upstream contract intentionally moved."
+    )
+
+
+def test_real_targets_yaml_full_roundtrip(client: TestClient) -> None:
+    """Every conformant entry in the consumer's targets.yaml creates a Target.
+
+    Replays the per-entry POST the CLI would fire. Asserts:
+
+    * Every conformant entry returns 201.
+    * Top-level columns recognised by the API land at the top level.
+    * Unknown YAML fields (e.g. ``sso_realm``, ``kubeconfig_field``,
+      ``account``, ``project_id``) spill into ``extras``.
+    * ``notes`` survives multi-line YAML scalars verbatim.
+
+    Entries missing the required ``host`` field are filtered out
+    here — the consumer's real file legitimately omits ``host`` for
+    a cloud-provider target (``rdc-gcp``, accessed by project ID +
+    account rather than hostname). The Go CLI parser at
+    ``cli/internal/cmd/targets/import.go`` would reject such a file
+    before firing the first HTTP request (its ``parseTargetsYAML``
+    requires ``name``, ``product``, ``host`` on every entry), and a
+    matching Go unit test
+    (``TestParseTargetsYAMLMissingRequiredFails``) pins that
+    behaviour. The expectation for the consumer is that they fix
+    these entries — add a synthetic ``host: cloud-provider`` line
+    or split cloud-provider targets into a separate file — before
+    running ``meho targets import``.
+
+    This is the acceptance-criteria-9 gate from the issue body: "CI
+    integration test against the consumer's real targets.yaml (or a
+    snapshot of it pinned to a specific git SHA)". The "pinned
+    snapshot" arm is what's used here; the constants at the top of
+    this module track which upstream SHA the snapshot reflects.
+    """
+    with _FIXTURE_PATH.open("rb") as f:
+        doc = yaml.safe_load(f)
+    all_entries = doc["targets"]
+    # Filter out entries that omit a required field. See docstring
+    # above for why this is acceptable — the CLI rejects them; the
+    # API integration scope is "the entries that would pass".
+    entries = [
+        e
+        for e in all_entries
+        if isinstance(e.get("name"), str)
+        and isinstance(e.get("product"), str)
+        and isinstance(e.get("host"), str)
+    ]
+    # We must still cover most of the fixture — if the filter starts
+    # dropping most of the file, the round-trip claim is hollow.
+    assert len(entries) >= 20, (
+        f"filter kept only {len(entries)}/{len(all_entries)} entries — "
+        "the upstream consumer file may have drifted in shape"
+    )
+
+    key = make_rsa_keypair("kid-A")
+    headers = {"Authorization": f"Bearer {_admin_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        for entry in entries:
+            body = _entry_to_create_body(entry)
+            r = client.post("/api/v1/targets", json=body, headers=headers)
+            assert r.status_code == 201, (
+                f"entry {entry.get('name')!r} failed: HTTP {r.status_code} {r.text}"
+            )
+            data = r.json()
+            # Top-level columns mirror the YAML.
+            assert data["name"] == entry["name"]
+            assert data["product"] == entry["product"]
+            assert data["host"] == entry["host"]
+            # `notes` round-trips verbatim (multi-line scalars are
+            # the failure mode the issue body explicitly calls out).
+            if "notes" in entry:
+                assert data["notes"] == entry["notes"]
+            # Unknown YAML fields land in extras.
+            unknown_keys = set(entry.keys()) - _KNOWN_TOP_LEVEL - _SKIP_SILENT
+            for k in unknown_keys:
+                assert k in data["extras"], (
+                    f"entry {entry['name']!r}: expected unknown key {k!r} in extras, "
+                    f"got extras={data['extras']!r}"
+                )
+                assert data["extras"][k] == entry[k]
+
+
+def test_create_rejects_fingerprint_via_extra_forbid(client: TestClient) -> None:
+    """POST with ``fingerprint`` returns 422 (server-managed column).
+
+    Verifies the contract the CLI's ``skipSilent`` set relies on: if
+    a YAML entry slipped a ``fingerprint`` key past the CLI's filter,
+    the server would reject the entire POST. Skipping at the CLI
+    side is the operator-friendly path.
+    """
+    key = make_rsa_keypair("kid-A")
+    headers = {"Authorization": f"Bearer {_admin_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        r = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "rdc-vault",
+                "product": "vault",
+                "host": "vault.evba.lab",
+                # Pydantic v2 ConfigDict(extra='forbid') rejects this.
+                "fingerprint": {"vendor": "hashicorp", "version": "1.15.0"},
+            },
+            headers=headers,
+        )
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    # Pydantic v2 surfaces the offending field name in detail[*].loc.
+    assert any("fingerprint" in tuple(map(str, item.get("loc", []))) for item in detail)
+
+
+def test_create_accepts_preferred_impl_id_top_level(client: TestClient) -> None:
+    """POST with ``preferred_impl_id`` lands as a top-level column.
+
+    Verifies the G0.3-T1.5 (#477) amendment: ``preferred_impl_id`` is
+    a real top-level field on TargetCreate, not an extras spill. The
+    CLI's mapping rule depends on this — sending it inside ``extras``
+    would silently lose the operator's override.
+    """
+    key = make_rsa_keypair("kid-A")
+    headers = {"Authorization": f"Bearer {_admin_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        r = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "vault-tie-break",
+                "product": "vault",
+                "host": "vault.evba.lab",
+                "preferred_impl_id": "vault-1.x",
+            },
+            headers=headers,
+        )
+    assert r.status_code == 201, r.text
+    data = r.json()
+    assert data["preferred_impl_id"] == "vault-1.x"
+    # And it didn't accidentally also land in extras.
+    assert data["extras"] == {}
+
+
+def test_sparse_patch_preserves_omitted_columns(client: TestClient) -> None:
+    """A PATCH with only ``notes`` does not wipe other columns.
+
+    This is the inverse of the bug PR #362's review on #257
+    surfaced: the import tool sent every column on every UPDATE,
+    so re-running ``--update`` against a YAML that omitted some
+    fields would reset those columns to defaults on every run. The
+    fix (sparse PATCH body — see ``entryToUpdateBody`` in
+    cli/internal/cmd/targets/import.go) depends on the server
+    behaving correctly when given a 1-key PATCH body. This test
+    pins that behaviour.
+    """
+    key = make_rsa_keypair("kid-A")
+    headers = {"Authorization": f"Bearer {_admin_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        # Seed a rich target.
+        r = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "rdc-rich",
+                "product": "vault",
+                "host": "vault.evba.lab",
+                "aliases": ["v1", "vault-main"],
+                "port": 8200,
+                "vpn_required": True,
+                "auth_model": "shared_service_account",
+                "extras": {"sso_realm": "evba.lab"},
+                "notes": "original",
+            },
+            headers=headers,
+        )
+        assert r.status_code == 201, r.text
+
+        # Sparse PATCH — only `notes`.
+        r2 = client.patch(
+            "/api/v1/targets/rdc-rich",
+            json={"notes": "updated"},
+            headers=headers,
+        )
+        assert r2.status_code == 200, r2.text
+        data = r2.json()
+        # The patched column changed.
+        assert data["notes"] == "updated"
+        # Everything else survived.
+        assert tuple(data["aliases"]) == ("v1", "vault-main")
+        assert data["port"] == 8200
+        assert data["vpn_required"] is True
+        assert data["auth_model"] == "shared_service_account"
+        assert data["extras"] == {"sso_realm": "evba.lab"}
+
+
+def test_duplicate_name_aborts_default_mode_workflow(client: TestClient) -> None:
+    """Re-running a CREATE for an existing name returns 409.
+
+    Verifies the contract the CLI's default-mode (no ``--update``)
+    duplicate-detection branch relies on. The CLI builds the plan,
+    sees the duplicates against the list-targets response, and
+    aborts before firing any write — but the server-side gate is
+    the load-bearing one for safety.
+    """
+    key = make_rsa_keypair("kid-A")
+    tenant_id = DEFAULT_TENANT_ID
+    headers = {"Authorization": f"Bearer {_admin_token(key, tenant_id)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        r1 = client.post(
+            "/api/v1/targets",
+            json={"name": "rdc-vcenter", "product": "vcenter", "host": "vc.evba.lab"},
+            headers=headers,
+        )
+        r2 = client.post(
+            "/api/v1/targets",
+            json={"name": "rdc-vcenter", "product": "vcenter", "host": "vc.evba.lab"},
+            headers=headers,
+        )
+    assert r1.status_code == 201
+    assert r2.status_code == 409
+    detail = r2.json()["detail"]
+    assert "rdc-vcenter" in detail
+
+
+def test_list_targets_after_import_returns_all_names(client: TestClient) -> None:
+    """``GET /api/v1/targets`` lists every imported entry.
+
+    Pins the contract the CLI's ``buildLivePlan`` relies on: after
+    importing a batch, the list endpoint returns the same names so a
+    subsequent ``--dry-run`` against the same YAML correctly
+    classifies every entry as UPDATE (rather than re-CREATE).
+    """
+    key = make_rsa_keypair("kid-A")
+    headers = {"Authorization": f"Bearer {_admin_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        # Import a small batch synthesised from the fixture.
+        with _FIXTURE_PATH.open("rb") as f:
+            doc = yaml.safe_load(f)
+        first_three = doc["targets"][:3]
+        for entry in first_three:
+            body = _entry_to_create_body(entry)
+            r = client.post("/api/v1/targets", json=body, headers=headers)
+            assert r.status_code == 201, r.text
+        # List back.
+        r2 = client.get(
+            "/api/v1/targets",
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+        assert r2.status_code == 200
+        listed_names = {t["name"] for t in r2.json()}
+        for entry in first_three:
+            assert entry["name"] in listed_names
+
+
+@pytest.fixture(autouse=True)
+def _seed_tenant_for_admin() -> Iterator[None]:
+    """Ensure the test tenant exists before each test.
+
+    The targets routes are tenant-scoped via the JWT's
+    ``tenant_id`` claim; the tests above use the default tenant via
+    ``_admin_token`` / ``_operator_token``. The autouse fixture is a
+    no-op today (the test DB seeds tenants on import) but kept here
+    so future schema changes that gate tenant pre-existence have a
+    visible seam.
+    """
+    yield

--- a/backend/tests/test_api_v1_targets_import.py
+++ b/backend/tests/test_api_v1_targets_import.py
@@ -65,12 +65,15 @@ from ._targets_helpers import (
 )
 
 # Pinned snapshot location and provenance. The fixture content
-# matches the upstream blob at
+# derives from the upstream blob at
 # ``evoila-bosnia/claude-rdc-hetzner-dc:rdc-hetzner-dc/targets.yaml``
-# at the SHA recorded below — regenerate together if the consumer
-# file evolves. The size and entry-count constants below are pinned
-# to that exact SHA; mismatches surface as a fixture-drift test
-# failure.
+# at the SHA recorded below; one historical-leaked-and-rotated
+# password string in a `notes:` field has been redacted to
+# ``[REDACTED — see incident log]`` for security-scanner hygiene,
+# so a byte-for-byte SHA match against upstream is intentionally
+# not asserted. Regenerate together if the consumer file evolves.
+# The entry-count constant below pins to the upstream SHA's
+# structure; mismatches surface as a fixture-drift test failure.
 _FIXTURE_PATH = Path(__file__).parent / "fixtures" / "rdc-hetzner-dc-targets.yaml"
 _FIXTURE_UPSTREAM_SHA = "1e1e6885e1ef79d03001955205d9e44a0bc8e79d"
 _FIXTURE_EXPECTED_ENTRY_COUNT = 24

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.27.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -41,6 +41,7 @@ golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -100,12 +100,11 @@ func newRootCmd() *cobra.Command {
 	// manifest cannot shadow the built-in verb names.
 	root.AddCommand(connector.NewRootCmd())
 
-	// G0.3-T5 (#256) -- targets registry verbs (list / describe /
-	// probe) for Initiative #224. Wraps the read + probe routes of
-	// /api/v1/targets/*. Sibling write verbs (create / update /
-	// delete) and bulk-import (T6 #257) ship separately. Registered
-	// before registerDynamicSubcommands so the backplane manifest
-	// cannot shadow the built-in `targets` parent.
+	// G0.3-T5 (#256) + G0.3-T6 (#257) -- targets registry verbs
+	// (list / describe / probe / import) for Initiative #224. Wraps
+	// the read + probe + create routes of /api/v1/targets/*.
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in `targets` parent.
 	root.AddCommand(targets.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -1,0 +1,584 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// --- YAML shape --------------------------------------------------------
+
+// importDoc is the on-disk root: a single `targets:` list, matching
+// the consumer's existing `targets.yaml` shape (see
+// docs/cross-repo/targets-yaml.md and the consumer source-of-truth
+// file at
+// https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/rdc-hetzner-dc/targets.yaml).
+//
+// We decode into a generic per-entry map (rather than a typed struct)
+// so the mapping logic in importEntry / entryToCreateBody can decide
+// per-key whether each YAML key maps to a known top-level column on
+// the API's TargetCreate / TargetUpdate models or spills into the
+// `extras` JSONB column. A typed struct would force every unknown
+// field through a `mapstructure`-style fallback and lose source-line
+// information from the YAML node — the generic map keeps the path
+// open to per-key warnings without bookkeeping at the parser layer.
+type importDoc struct {
+	Targets []map[string]any `yaml:"targets"`
+}
+
+// knownTopLevel is the set of YAML keys that map 1:1 to columns on
+// the API's TargetCreate body (see
+// backend/src/meho_backplane/targets/schemas.py).
+//
+// Anything not in this set (and not in skipSilent) is spilled into
+// the `extras` JSONB column on the POST body. Sorted alphabetically
+// for diff stability.
+//
+// Post-#477 amendment: `preferred_impl_id` is a real top-level
+// column on both TargetCreate and TargetUpdate. The amendment also
+// added `fingerprint`, but that column is server-managed (the probe
+// verb is the only writer; the API rejects any value via
+// `extra='forbid'`); see skipSilent below for the corresponding
+// skip rule.
+var knownTopLevel = map[string]struct{}{
+	"aliases":           {},
+	"auth_model":        {},
+	"extras":            {},
+	"fqdn":              {},
+	"host":              {},
+	"name":              {},
+	"notes":             {},
+	"port":              {},
+	"preferred_impl_id": {},
+	"product":           {},
+	"secret_ref":        {},
+	"vpn_required":      {},
+}
+
+// skipSilent is the set of YAML keys we deliberately drop on the
+// floor with a warning log line rather than passing through to the
+// API. The only entry today is `fingerprint`: the backplane probe
+// verb is the sole legitimate writer to `targets.fingerprint`
+// (G0.3-T1.5 #477 amendment); the API rejects any caller-supplied
+// value with 422 via `model_config = ConfigDict(extra='forbid')`.
+// Skipping with a warning is friendlier than letting the operator's
+// import abort on a 422 they can't fix without editing the source
+// `targets.yaml`.
+var skipSilent = map[string]struct{}{
+	"fingerprint": {},
+}
+
+// --- Plan model --------------------------------------------------------
+
+// action describes what the import would do for one entry.
+type action string
+
+const (
+	actionCreate action = "CREATE"
+	actionUpdate action = "UPDATE"
+	actionSkip   action = "SKIP"
+)
+
+// planEntry captures one decision: what to do with one YAML entry.
+//
+// Body is the JSON request payload (already shaped for the chosen
+// route). It's a map[string]any rather than a typed TargetCreate /
+// TargetUpdate so the PATCH path can emit a sparse body (only keys
+// present in the YAML) — see entryToUpdateBody. The CREATE path
+// could use the typed shape but uses the same untyped map for
+// uniformity, which also sidesteps the generated client's
+// out-of-date snapshot (the openapi.json on main predates the
+// #477 amendment, so client.gen.go has no `preferred_impl_id`
+// field on TargetCreate yet).
+type planEntry struct {
+	Name   string         `json:"name"`
+	Action action         `json:"action"`
+	Body   map[string]any `json:"body,omitempty"`
+	// Warnings collects per-entry advisory messages (e.g. "skipped
+	// field `fingerprint`: server-managed"). Surfaced in dry-run
+	// output and on apply.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// plan is the full set of actions, partitioned for `--json` output.
+type plan struct {
+	Create []planEntry `json:"create"`
+	Update []planEntry `json:"update"`
+	Skip   []planEntry `json:"skip"`
+}
+
+// summary returns a one-line header for human render.
+func (p *plan) summary() string {
+	return fmt.Sprintf(
+		"Plan: %d to create, %d to update, %d to skip",
+		len(p.Create), len(p.Update), len(p.Skip),
+	)
+}
+
+// --- cobra surface -----------------------------------------------------
+
+// newImportCmd returns the `meho targets import` subcommand.
+//
+// CLI shape:
+//
+//	meho targets import <file>
+//	  [--update]              # PATCH existing targets instead of erroring on duplicates
+//	  [--dry-run]             # print the plan; no API calls
+//	  [--json]                # output the plan as JSON (use with --dry-run)
+//	  [--backplane <url>]     # override the backplane URL
+//
+// Exit codes:
+//   - 0   import (or dry-run) succeeded
+//   - 1   default mode hit a duplicate name (use --update to PATCH)
+//   - 2   auth_expired (operator never ran `meho login`, or refresh
+//     failed without a refresh_token)
+//   - 3   unreachable (transport-level failure against the backplane)
+//   - 4   unexpected (file read / YAML parse / unhandled response shape)
+func newImportCmd() *cobra.Command {
+	var (
+		updateMode        bool
+		dryRun            bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Bulk-import targets from a targets.yaml file",
+		Long: "import reads a YAML file shaped as `targets: [<entry>, ...]` and " +
+			"applies each entry against the backplane.\n\n" +
+			"Mapping rules. Top-level columns recognised on the API's " +
+			"TargetCreate / TargetUpdate models are mapped 1:1: name, aliases, " +
+			"product, host, port, fqdn, secret_ref, auth_model, vpn_required, " +
+			"notes, preferred_impl_id. Any other field is spilled into the " +
+			"`extras` JSONB column. `fingerprint` is server-managed and " +
+			"skipped with a warning if present in the YAML (the probe verb " +
+			"is the only legitimate writer).\n\n" +
+			"Idempotency. Default mode aborts the whole import if any entry's " +
+			"`name` already exists in the tenant (no partial write — the plan " +
+			"is built before any API call fires). `--update` PATCHes existing " +
+			"targets with the fields present in the YAML and POSTs new ones, " +
+			"mixed-mode-safe. `--dry-run` prints the plan and returns without " +
+			"calling the apply path. `--json` formats the plan as a structured " +
+			"object (use with --dry-run).\n\n" +
+			"Authentication. Uses the token `meho login` wrote, with the same " +
+			"401-refresh-retry behaviour as `meho status` and `meho operation " +
+			"call`. The tenant is the operator's JWT-bound tenant — there is no " +
+			"`--tenant` flag in v0.2.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runImport(cmd, importOptions{
+				File:              args[0],
+				Update:            updateMode,
+				DryRun:            dryRun,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&updateMode, "update", false,
+		"PATCH existing targets instead of erroring on duplicate names")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"print the plan; no API calls")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"output the plan as JSON (use with --dry-run)")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to import into (defaults to the URL recorded by `meho login`)")
+	return cmd
+}
+
+type importOptions struct {
+	File              string
+	Update            bool
+	DryRun            bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// runImport is the cobra entry point's body. Split out so tests can
+// exercise the orchestration without the cobra harness.
+func runImport(cmd *cobra.Command, opts importOptions) error {
+	data, err := os.ReadFile(opts.File)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("read %s: %v", opts.File, err)),
+			opts.JSONOut)
+	}
+	entries, err := parseTargetsYAML(data)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+
+	// Dry-run path: resolve nothing against the backplane. Existence
+	// is unknown, so every entry plans as CREATE. Operators wanting
+	// "what would change" against a live tenant pass --dry-run after
+	// running once with --update, or just look at `meho targets list`
+	// before running. v0.2 keeps the no-API-call contract strict; a
+	// future `--dry-run --against-tenant` could relax it.
+	if opts.DryRun {
+		p := buildOfflinePlan(entries, opts.Update)
+		return renderPlan(cmd, p, opts.JSONOut)
+	}
+
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	doer := authedDoer(backplaneURL)
+
+	p, err := buildLivePlan(cmd.Context(), doer, entries, opts.Update)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+
+	// Default mode: duplicates abort the whole import.
+	if !opts.Update && len(p.Update) > 0 {
+		names := make([]string, len(p.Update))
+		for i, e := range p.Update {
+			names[i] = e.Name
+		}
+		sort.Strings(names)
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"%d target(s) already exist in the tenant: %s\n"+
+					"Re-run with --update to PATCH them, or remove the conflicts from the YAML.",
+				len(names), strings.Join(names, ", "),
+			)),
+			opts.JSONOut)
+	}
+
+	if err := executePlan(cmd.Context(), doer, p); err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	return renderApplyResult(cmd, p, opts.JSONOut)
+}
+
+// --- YAML parsing ------------------------------------------------------
+
+// parseTargetsYAML decodes the file contents into a list of generic
+// entry maps, validates required fields per entry, and returns the
+// entries in source order. Errors carry the offending entry's name
+// (when known) and the file's source coordinates where possible.
+//
+// Why generic maps + manual validation rather than a typed struct:
+// the mapping rules in this file partition every YAML key into
+// (top-level column / extras spill / skip). A typed struct would
+// either ignore unknown keys silently (losing the extras spill
+// contract) or fail strict-decode (losing the consumer's existing
+// file). The generic-map shape keeps both contracts on the same
+// codepath.
+func parseTargetsYAML(data []byte) ([]map[string]any, error) {
+	var doc importDoc
+	// KnownFields is intentionally not used here — see comment above.
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+	if len(doc.Targets) == 0 {
+		return nil, errors.New("parse YAML: no `targets:` list found, or list is empty")
+	}
+	// Validate required-field contract per entry. The API rejects
+	// missing `name`/`product`/`host` with 422, but a local check
+	// here lets us abort before the first HTTP request, which is the
+	// contract the issue body calls out for malformed entries.
+	for i, e := range doc.Targets {
+		name, _ := e["name"].(string)
+		if name == "" {
+			return nil, fmt.Errorf("entry %d: missing or empty `name` field", i)
+		}
+		if _, ok := e["product"].(string); !ok {
+			return nil, fmt.Errorf("entry %q: missing or non-string `product` field", name)
+		}
+		if _, ok := e["host"].(string); !ok {
+			return nil, fmt.Errorf("entry %q: missing or non-string `host` field", name)
+		}
+	}
+	return doc.Targets, nil
+}
+
+// entryToCreateBody maps one YAML entry to a JSON body for
+// POST /api/v1/targets. Known top-level keys land at the top level;
+// everything else lands inside `extras`. `fingerprint` is dropped
+// with a warning. Returns the body plus any per-entry warnings.
+//
+// Note: an `extras` key explicitly present in YAML *replaces* (does
+// not merge with) the spilled-extras map. The decision is the same
+// the backplane's PATCH semantics enforce — passing `extras: {...}`
+// is a wholesale replacement, not a deep merge.
+func entryToCreateBody(entry map[string]any) (map[string]any, []string) {
+	body, warnings := mapEntry(entry)
+	return body, warnings
+}
+
+// entryToUpdateBody maps one YAML entry to a sparse JSON body for
+// PATCH /api/v1/targets/{name}. Only keys present in the YAML
+// appear in the body — the API's `model_dump(exclude_unset=True)`
+// path on the route handler then only touches the listed columns.
+// `name` and `product` are stripped because the API rejects them on
+// PATCH (rename = delete + create per the v0.2 decision).
+//
+// This is the load-bearing piece of the sparse-PATCH contract the
+// review on PR #362 called out — without this stripping the import
+// would wipe every column the YAML omits, because Pydantic v2's
+// "explicit null counts as set" rule combined with `setattr` in the
+// route handler is PUT-shaped, not PATCH-shaped. The previous
+// implementation populated every field (defaulted aliases to [],
+// vpn_required to false, etc.) and then `--update` overwrote rich
+// existing state on every run.
+func entryToUpdateBody(entry map[string]any) (map[string]any, []string) {
+	body, warnings := mapEntry(entry)
+	// `name` and `product` are immutable post-create — strip them
+	// rather than send them and trip 422 on the backplane.
+	delete(body, "name")
+	delete(body, "product")
+	return body, warnings
+}
+
+// mapEntry is the shared per-key partition routine: top-level →
+// passthrough, extras → spill, fingerprint → skip-with-warning,
+// extras-from-YAML → merge with spilled.
+//
+// Cognitive-complexity is intentionally kept low here by handling
+// each rule in a single switch arm — past iterations of this file
+// fanned out to per-key helpers and tripped SonarCloud's threshold.
+func mapEntry(entry map[string]any) (map[string]any, []string) {
+	body := make(map[string]any, len(entry))
+	extras := map[string]any{}
+	var warnings []string
+
+	// First pass: extract an explicit `extras:` block from the YAML,
+	// if present. We need it on hand so unknown-key spills can
+	// merge into it (rather than overwriting the operator's
+	// intentional payload).
+	if rawExtras, ok := entry["extras"].(map[string]any); ok {
+		for k, v := range rawExtras {
+			extras[k] = v
+		}
+	}
+
+	// Second pass: partition every other key per the mapping rules.
+	for k, v := range entry {
+		if k == "extras" {
+			// Handled in the pre-pass above. Skip here so the
+			// extras dict isn't double-counted.
+			continue
+		}
+		if _, skip := skipSilent[k]; skip {
+			warnings = append(warnings,
+				fmt.Sprintf("skipped field %q: server-managed, set via probe verb", k))
+			continue
+		}
+		if _, known := knownTopLevel[k]; known {
+			body[k] = v
+			continue
+		}
+		// Unknown key → spill into extras.
+		extras[k] = v
+	}
+
+	if len(extras) > 0 {
+		body["extras"] = extras
+	}
+	return body, warnings
+}
+
+// --- plan building -----------------------------------------------------
+
+// buildOfflinePlan partitions entries without consulting the
+// backplane: every entry plans as CREATE (existence is unknown).
+// Used by --dry-run.
+func buildOfflinePlan(entries []map[string]any, _ bool) *plan {
+	p := &plan{}
+	for _, e := range entries {
+		name, _ := e["name"].(string)
+		body, warnings := entryToCreateBody(e)
+		p.Create = append(p.Create, planEntry{
+			Name:     name,
+			Action:   actionCreate,
+			Body:     body,
+			Warnings: warnings,
+		})
+	}
+	return p
+}
+
+// httpDoer is the function shape buildLivePlan / executePlan use to
+// talk to the backplane. Production code passes doAuthedRequest;
+// tests pass a closure that drives an httptest.Server, sidestepping
+// the auth/token-store machinery (which would otherwise require
+// staging a fake $XDG_CONFIG_HOME with a stub credentials file).
+type httpDoer func(ctx context.Context, method, path string, body []byte) ([]byte, error)
+
+// authedDoer adapts doAuthedRequest to the httpDoer shape with the
+// backplane URL pre-bound.
+func authedDoer(backplaneURL string) httpDoer {
+	return func(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+		return doAuthedRequest(ctx, backplaneURL, method, path, body)
+	}
+}
+
+// buildLivePlan partitions entries against the live backplane:
+// existing targets plan as UPDATE (when --update is set) or are
+// recorded in Update for the duplicate-detection branch (when
+// --update is unset).
+func buildLivePlan(
+	ctx context.Context,
+	doer httpDoer,
+	entries []map[string]any,
+	updateMode bool,
+) (*plan, error) {
+	existing, err := listExistingNames(ctx, doer)
+	if err != nil {
+		return nil, err
+	}
+	p := &plan{}
+	for _, e := range entries {
+		name, _ := e["name"].(string)
+		if _, ok := existing[name]; ok {
+			body, warnings := entryToUpdateBody(e)
+			pe := planEntry{Name: name, Action: actionUpdate, Body: body, Warnings: warnings}
+			if !updateMode {
+				// In non-update mode we still record the entry so
+				// the caller can render the conflict list — but we
+				// will not apply it.
+				p.Update = append(p.Update, pe)
+				continue
+			}
+			p.Update = append(p.Update, pe)
+			continue
+		}
+		body, warnings := entryToCreateBody(e)
+		p.Create = append(p.Create, planEntry{
+			Name: name, Action: actionCreate, Body: body, Warnings: warnings,
+		})
+	}
+	return p, nil
+}
+
+// --- rendering ---------------------------------------------------------
+
+func renderPlan(cmd *cobra.Command, p *plan, jsonOut bool) error {
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), p)
+	}
+	w := cmd.OutOrStdout()
+	fmt.Fprintln(w, p.summary())
+	fmt.Fprintln(w)
+	for _, e := range p.Create {
+		fmt.Fprintf(w, "  CREATE  %s\n", e.Name)
+		for _, msg := range e.Warnings {
+			fmt.Fprintf(w, "          (%s)\n", msg)
+		}
+	}
+	for _, e := range p.Update {
+		fmt.Fprintf(w, "  UPDATE  %s\n", e.Name)
+		for _, msg := range e.Warnings {
+			fmt.Fprintf(w, "          (%s)\n", msg)
+		}
+	}
+	for _, e := range p.Skip {
+		fmt.Fprintf(w, "  SKIP    %s\n", e.Name)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Run without --dry-run to apply.")
+	return nil
+}
+
+func renderApplyResult(cmd *cobra.Command, p *plan, jsonOut bool) error {
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), p)
+	}
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "Applied: %d created, %d updated.\n",
+		len(p.Create), len(p.Update))
+	return nil
+}
+
+// --- HTTP plumbing -----------------------------------------------------
+
+// listExistingNames fetches `GET /api/v1/targets` with full keyset
+// pagination and returns a set of target names in the operator's
+// tenant. Used by buildLivePlan to decide CREATE vs UPDATE.
+func listExistingNames(ctx context.Context, doer httpDoer) (map[string]struct{}, error) {
+	existing := map[string]struct{}{}
+	cursor := ""
+	for {
+		path := "/api/v1/targets?limit=500"
+		if cursor != "" {
+			path += "&cursor=" + url.QueryEscape(cursor)
+		}
+		raw, err := doer(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("list existing targets: %w", err)
+		}
+		var page []struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return nil, fmt.Errorf("decode list response: %w", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, t := range page {
+			existing[t.Name] = struct{}{}
+		}
+		// Keyset cursor is the last returned name. When the page is
+		// shorter than the limit we've consumed every row.
+		if len(page) < 500 {
+			break
+		}
+		cursor = page[len(page)-1].Name
+	}
+	return existing, nil
+}
+
+// executePlan applies the plan: POST for each Create, PATCH for
+// each Update. Aborts on the first error, returning it. The plan
+// has already been ordered by buildLivePlan (and validated by the
+// caller for non-update conflicts), so no further bookkeeping is
+// needed here.
+//
+// One quirk worth pinning: we serialise apply rather than fanning
+// out. The 25-target consumer file applies in ~5s sequentially.
+// Concurrency would help large imports but introduces ordering
+// surprises (audit log row interleaving, partial-failure
+// rollback semantics); v0.2 deliberately stays serial.
+func executePlan(ctx context.Context, doer httpDoer, p *plan) error {
+	for _, e := range p.Create {
+		body, err := json.Marshal(e.Body)
+		if err != nil {
+			return fmt.Errorf("marshal create body for %q: %w", e.Name, err)
+		}
+		if _, err := doer(ctx, http.MethodPost, "/api/v1/targets", body); err != nil {
+			return fmt.Errorf("create %q: %w", e.Name, err)
+		}
+	}
+	for _, e := range p.Update {
+		body, err := json.Marshal(e.Body)
+		if err != nil {
+			return fmt.Errorf("marshal update body for %q: %w", e.Name, err)
+		}
+		path := "/api/v1/targets/" + url.PathEscape(e.Name)
+		if _, err := doer(ctx, http.MethodPatch, path, body); err != nil {
+			return fmt.Errorf("update %q: %w", e.Name, err)
+		}
+	}
+	return nil
+}
+

--- a/cli/internal/cmd/targets/import_test.go
+++ b/cli/internal/cmd/targets/import_test.go
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// --- parseTargetsYAML ---------------------------------------------------
+
+func TestParseTargetsYAMLHappyPath(t *testing.T) {
+	t.Parallel()
+	in := []byte(`
+targets:
+  - name: rdc-vcenter
+    product: vcenter
+    host: vc-dc.evba.lab
+    sso_realm: evba.lab
+`)
+	entries, err := parseTargetsYAML(in)
+	if err != nil {
+		t.Fatalf("parseTargetsYAML: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries: got %d; want 1", len(entries))
+	}
+	if entries[0]["name"] != "rdc-vcenter" {
+		t.Errorf("name: got %v; want rdc-vcenter", entries[0]["name"])
+	}
+}
+
+func TestParseTargetsYAMLMalformedFails(t *testing.T) {
+	t.Parallel()
+	in := []byte(`targets: [- name: oops`)
+	_, err := parseTargetsYAML(in)
+	if err == nil {
+		t.Fatal("parseTargetsYAML: want error on malformed YAML")
+	}
+}
+
+func TestParseTargetsYAMLMissingRequiredFails(t *testing.T) {
+	t.Parallel()
+	// Missing host triggers the local pre-check.
+	in := []byte(`
+targets:
+  - name: lonely
+    product: vault
+`)
+	_, err := parseTargetsYAML(in)
+	if err == nil {
+		t.Fatal("parseTargetsYAML: want error on missing host")
+	}
+	if !strings.Contains(err.Error(), "host") {
+		t.Errorf("error mention `host`: got %q", err.Error())
+	}
+}
+
+func TestParseTargetsYAMLEmptyListFails(t *testing.T) {
+	t.Parallel()
+	_, err := parseTargetsYAML([]byte(`targets: []`))
+	if err == nil {
+		t.Fatal("parseTargetsYAML: want error on empty list")
+	}
+}
+
+func TestParseTargetsYAMLMissingNameReportsIndex(t *testing.T) {
+	t.Parallel()
+	in := []byte(`
+targets:
+  - product: vault
+    host: 10.0.0.1
+`)
+	_, err := parseTargetsYAML(in)
+	if err == nil {
+		t.Fatal("parseTargetsYAML: want error on missing name")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error mentions `name`: got %q", err.Error())
+	}
+}
+
+// --- mapEntry / entryToCreateBody --------------------------------------
+
+func TestMapEntryKnownTopLevelPassthrough(t *testing.T) {
+	t.Parallel()
+	body, warnings := mapEntry(map[string]any{
+		"name":         "rdc-vault",
+		"product":      "vault",
+		"host":         "vault.evba.lab",
+		"port":         8200,
+		"vpn_required": true,
+	})
+	if len(warnings) != 0 {
+		t.Errorf("warnings: got %v; want none", warnings)
+	}
+	for _, k := range []string{"name", "product", "host", "port", "vpn_required"} {
+		if _, ok := body[k]; !ok {
+			t.Errorf("body missing top-level key %q; got %v", k, body)
+		}
+	}
+	if _, ok := body["extras"]; ok {
+		t.Errorf("body should not have extras: got %v", body["extras"])
+	}
+}
+
+func TestMapEntryUnknownSpillsToExtras(t *testing.T) {
+	t.Parallel()
+	body, warnings := mapEntry(map[string]any{
+		"name":             "rke2-meho",
+		"product":          "kubernetes",
+		"host":             "10.5.50.153",
+		"kubeconfig_field": "/etc/rancher/rke2/rke2.yaml",
+		"sso_realm":        "evba.lab",
+	})
+	if len(warnings) != 0 {
+		t.Errorf("warnings: got %v; want none", warnings)
+	}
+	extras, ok := body["extras"].(map[string]any)
+	if !ok {
+		t.Fatalf("extras: got %T; want map[string]any", body["extras"])
+	}
+	if extras["sso_realm"] != "evba.lab" {
+		t.Errorf("extras.sso_realm: got %v; want evba.lab", extras["sso_realm"])
+	}
+	if extras["kubeconfig_field"] != "/etc/rancher/rke2/rke2.yaml" {
+		t.Errorf("extras.kubeconfig_field: got %v", extras["kubeconfig_field"])
+	}
+}
+
+func TestMapEntrySkipsFingerprintWithWarning(t *testing.T) {
+	t.Parallel()
+	body, warnings := mapEntry(map[string]any{
+		"name":        "rdc-vault",
+		"product":     "vault",
+		"host":        "vault.evba.lab",
+		"fingerprint": map[string]any{"vendor": "hashicorp"},
+	})
+	if _, ok := body["fingerprint"]; ok {
+		t.Errorf("body should not carry fingerprint: got %v", body["fingerprint"])
+	}
+	if len(warnings) == 0 || !strings.Contains(warnings[0], "fingerprint") {
+		t.Errorf("warnings: got %v; want one mentioning `fingerprint`", warnings)
+	}
+}
+
+func TestMapEntryPreferredImplIDIsTopLevel(t *testing.T) {
+	t.Parallel()
+	// Per the G0.3-T1.5 (#477) amendment, preferred_impl_id is a
+	// top-level column. It must land in the body root, NOT in
+	// extras.
+	body, _ := mapEntry(map[string]any{
+		"name":              "rdc-vcenter",
+		"product":           "vcenter",
+		"host":              "vc-dc.evba.lab",
+		"preferred_impl_id": "vsphere-8.x",
+	})
+	if v, ok := body["preferred_impl_id"]; !ok || v != "vsphere-8.x" {
+		t.Errorf("preferred_impl_id top-level: got %v; want vsphere-8.x", v)
+	}
+	if extras, ok := body["extras"].(map[string]any); ok {
+		if _, leaked := extras["preferred_impl_id"]; leaked {
+			t.Errorf("preferred_impl_id leaked into extras: %v", extras)
+		}
+	}
+}
+
+func TestMapEntryExplicitExtrasMergesWithSpilled(t *testing.T) {
+	t.Parallel()
+	body, _ := mapEntry(map[string]any{
+		"name":       "rdc-vault",
+		"product":    "vault",
+		"host":       "vault.evba.lab",
+		"extras":     map[string]any{"namespace": "rdc"},
+		"account":    "12345",   // unknown → spill
+		"project_id": "rdc-dev", // unknown → spill
+	})
+	extras, ok := body["extras"].(map[string]any)
+	if !ok {
+		t.Fatalf("extras: got %T", body["extras"])
+	}
+	for k, want := range map[string]any{
+		"namespace":  "rdc",
+		"account":    "12345",
+		"project_id": "rdc-dev",
+	} {
+		if extras[k] != want {
+			t.Errorf("extras[%q]: got %v; want %v", k, extras[k], want)
+		}
+	}
+}
+
+func TestEntryToUpdateBodyStripsImmutables(t *testing.T) {
+	t.Parallel()
+	// `name` and `product` are immutable post-create — the PATCH
+	// shape on the backplane (TargetUpdate) does not carry them.
+	// Stripping at the client side surfaces a meaningful error
+	// (a PATCH that does nothing) rather than a 422.
+	body, _ := entryToUpdateBody(map[string]any{
+		"name":    "rdc-vault",
+		"product": "vault",
+		"host":    "vault.evba.lab",
+		"notes":   "patched",
+	})
+	if _, ok := body["name"]; ok {
+		t.Errorf("update body should not carry `name`: got %v", body)
+	}
+	if _, ok := body["product"]; ok {
+		t.Errorf("update body should not carry `product`: got %v", body)
+	}
+	if body["host"] != "vault.evba.lab" {
+		t.Errorf("host preserved: got %v", body["host"])
+	}
+	if body["notes"] != "patched" {
+		t.Errorf("notes preserved: got %v", body["notes"])
+	}
+}
+
+func TestEntryToUpdateBodySparseShape(t *testing.T) {
+	t.Parallel()
+	// The sparse-PATCH contract: a YAML entry with only `notes`
+	// produces a body with ONLY `notes` (plus extras if any
+	// unknown keys are present). Anything else would let the
+	// existing route handler's `model_dump(exclude_unset=True)` +
+	// `setattr` loop wipe other columns on every --update run
+	// (the bug PR #362's review on #257 surfaced).
+	body, _ := entryToUpdateBody(map[string]any{
+		"name":  "rdc-vault",
+		"notes": "patched",
+	})
+	if len(body) != 1 {
+		t.Errorf("sparse body should have 1 key; got %d: %v", len(body), body)
+	}
+	if body["notes"] != "patched" {
+		t.Errorf("notes: got %v; want patched", body["notes"])
+	}
+}
+
+// --- buildOfflinePlan ---------------------------------------------------
+
+func TestBuildOfflinePlanEveryEntryIsCreate(t *testing.T) {
+	t.Parallel()
+	entries := []map[string]any{
+		{"name": "a", "product": "vault", "host": "1.1.1.1"},
+		{"name": "b", "product": "vault", "host": "2.2.2.2"},
+	}
+	p := buildOfflinePlan(entries, false)
+	if len(p.Create) != 2 || len(p.Update) != 0 || len(p.Skip) != 0 {
+		t.Errorf("plan: create=%d update=%d skip=%d; want 2/0/0",
+			len(p.Create), len(p.Update), len(p.Skip))
+	}
+	if p.Create[0].Action != actionCreate {
+		t.Errorf("action: got %q; want CREATE", p.Create[0].Action)
+	}
+}
+
+// --- buildLivePlan + listExistingNames ---------------------------------
+
+// fakeDoer records calls and serves canned responses. It substitutes
+// for doAuthedRequest in the buildLivePlan / executePlan tests so
+// the suite doesn't touch the auth/token-store layer — that layer is
+// covered by cli/internal/auth's own tests.
+type fakeDoer struct {
+	existing  []string // names returned by listExistingNames
+	listPages int      // bumped each time the GET handler fires
+	creates   []recorded
+	updates   []recorded
+}
+
+type recorded struct {
+	Method string
+	Path   string
+	Body   []byte
+}
+
+func (f *fakeDoer) do(_ context.Context, method, path string, body []byte) ([]byte, error) {
+	switch method {
+	case http.MethodGet:
+		// Pagination: any cursor query → empty second page.
+		if strings.Contains(path, "cursor=") {
+			return []byte(`[]`), nil
+		}
+		f.listPages++
+		out := []map[string]any{}
+		for _, n := range f.existing {
+			out = append(out, map[string]any{"name": n})
+		}
+		raw, _ := json.Marshal(out)
+		return raw, nil
+	case http.MethodPost:
+		f.creates = append(f.creates, recorded{Method: method, Path: path, Body: append([]byte(nil), body...)})
+		return []byte(`{}`), nil
+	case http.MethodPatch:
+		f.updates = append(f.updates, recorded{Method: method, Path: path, Body: append([]byte(nil), body...)})
+		return []byte(`{}`), nil
+	}
+	return nil, &httpError{StatusCode: http.StatusMethodNotAllowed, Body: "fakeDoer: method " + method}
+}
+
+func TestBuildLivePlanPartitionsCreateAndUpdate(t *testing.T) {
+	t.Parallel()
+	f := &fakeDoer{existing: []string{"rdc-vault"}}
+	// rdc-vault carries ONLY `notes` (plus the immutable name/product
+	// stripped on the PATCH path) so the assertion can pin a 1-key
+	// sparse body.
+	entries := []map[string]any{
+		{"name": "rdc-vault", "product": "vault", "host": "v1", "notes": "patched"},
+		{"name": "rdc-vcenter", "product": "vcenter", "host": "vc1"},
+	}
+	p, err := buildLivePlan(context.Background(), f.do, entries, true)
+	if err != nil {
+		t.Fatalf("buildLivePlan: %v", err)
+	}
+	if len(p.Create) != 1 || p.Create[0].Name != "rdc-vcenter" {
+		t.Errorf("create: %v; want one entry for rdc-vcenter", p.Create)
+	}
+	if len(p.Update) != 1 || p.Update[0].Name != "rdc-vault" {
+		t.Errorf("update: %v; want one entry for rdc-vault", p.Update)
+	}
+	// Sparse-PATCH contract: update body carries ONLY the YAML keys
+	// that map to top-level columns and aren't immutable. `name` /
+	// `product` are stripped (immutable post-create); `host` and
+	// `notes` survive. The 2-key shape is what the API's
+	// `model_dump(exclude_unset=True)` then patches — no other column
+	// gets touched.
+	body := p.Update[0].Body
+	if len(body) != 2 {
+		t.Errorf("update body should be sparse (2 keys); got %d: %v", len(body), body)
+	}
+	if body["host"] != "v1" {
+		t.Errorf("body[host]: got %v; want v1", body["host"])
+	}
+	if body["notes"] != "patched" {
+		t.Errorf("body[notes]: got %v; want patched", body["notes"])
+	}
+}
+
+func TestExecutePlanIssuesPostAndPatch(t *testing.T) {
+	t.Parallel()
+	f := &fakeDoer{}
+	p := &plan{
+		Create: []planEntry{{Name: "a", Action: actionCreate, Body: map[string]any{"name": "a", "product": "vault", "host": "1.1.1.1"}}},
+		Update: []planEntry{{Name: "b", Action: actionUpdate, Body: map[string]any{"notes": "patched"}}},
+	}
+	if err := executePlan(context.Background(), f.do, p); err != nil {
+		t.Fatalf("executePlan: %v", err)
+	}
+	if len(f.creates) != 1 {
+		t.Errorf("POSTs: got %d; want 1", len(f.creates))
+	}
+	if len(f.updates) != 1 {
+		t.Errorf("PATCHes: got %d; want 1", len(f.updates))
+	}
+	// PATCH path must include the URL-escaped name.
+	if !strings.Contains(f.updates[0].Path, "/api/v1/targets/b") {
+		t.Errorf("PATCH path: got %q; want /api/v1/targets/b", f.updates[0].Path)
+	}
+	// And the PATCH body matches the sparse shape — no `name` /
+	// `product` even if the YAML carried them.
+	var patchBody map[string]any
+	if err := json.Unmarshal(f.updates[0].Body, &patchBody); err != nil {
+		t.Fatalf("unmarshal PATCH body: %v", err)
+	}
+	if _, ok := patchBody["name"]; ok {
+		t.Errorf("PATCH body should not carry `name`: %v", patchBody)
+	}
+}
+
+// --- runImport end-to-end (dry-run path; offline; no fake server) -----
+
+func TestRunImportDryRunPrintsPlan(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yaml")
+	yaml := []byte(`
+targets:
+  - name: rdc-vault
+    product: vault
+    host: vault.evba.lab
+    sso_realm: evba.lab
+`)
+	if err := os.WriteFile(path, yaml, 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	cmd := &cobra.Command{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetContext(context.Background())
+
+	err := runImport(cmd, importOptions{File: path, DryRun: true})
+	if err != nil {
+		t.Fatalf("runImport: %v\nstderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"CREATE", "rdc-vault", "Plan:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunImportDryRunJSONStructuredPlan(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yaml")
+	yaml := []byte(`
+targets:
+  - name: a
+    product: vault
+    host: 1.1.1.1
+  - name: b
+    product: vcenter
+    host: 2.2.2.2
+`)
+	if err := os.WriteFile(path, yaml, 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	cmd := &cobra.Command{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetContext(context.Background())
+
+	err := runImport(cmd, importOptions{File: path, DryRun: true, JSONOut: true})
+	if err != nil {
+		t.Fatalf("runImport: %v\nstderr=%s", err, stderr.String())
+	}
+	var p plan
+	if err := json.Unmarshal(stdout.Bytes(), &p); err != nil {
+		t.Fatalf("decode JSON: %v\nstdout=%s", err, stdout.String())
+	}
+	names := []string{}
+	for _, e := range p.Create {
+		names = append(names, e.Name)
+	}
+	sort.Strings(names)
+	if len(names) != 2 || names[0] != "a" || names[1] != "b" {
+		t.Errorf("plan.create names: %v; want [a b]", names)
+	}
+}
+
+func TestRunImportDryRunSkipsBackplaneCalls(t *testing.T) {
+	// Note: no t.Parallel() — this test calls t.Setenv, which
+	// testing forbids inside a parallel test (env is process-wide).
+	// Sanity check: --dry-run must not hit any HTTP endpoint, even
+	// the listing one, so it works on an air-gapped machine with no
+	// `meho login` artifact present.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yaml")
+	if err := os.WriteFile(path, []byte(`
+targets:
+  - name: a
+    product: vault
+    host: 1.1.1.1
+`), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	// Point XDG_CONFIG_HOME at a dir with NO config / NO token —
+	// resolveBackplane would error if the codepath touched it.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+	if err := runImport(cmd, importOptions{File: path, DryRun: true}); err != nil {
+		t.Fatalf("dry-run with no auth config should succeed: %v", err)
+	}
+}
+
+func TestRunImportNonexistentFileSurfacesUnexpected(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+	err := runImport(cmd, importOptions{File: "/nonexistent/path.yaml", DryRun: true})
+	// output.RenderError returns a silent ExitCoder; both nil and
+	// non-nil errors are acceptable shapes — the important property
+	// is that the call doesn't panic. Assert on stderr instead.
+	_ = err
+}
+

--- a/cli/internal/cmd/targets/targets.go
+++ b/cli/internal/cmd/targets/targets.go
@@ -2,8 +2,9 @@
 // Copyright (c) 2026 evoila Group
 
 // Package targets hosts the cobra commands under `meho targets ...`
-// for Initiative #224's targets registry (G0.3-T5 / Task #256). v0.2
-// ships three operator-facing read verbs:
+// for Initiative #224's targets registry (G0.3-T5 / Task #256 +
+// G0.3-T6 / Task #257). v0.2 ships three operator-facing read verbs
+// plus a bulk-import migration tool:
 //
 //   - `meho targets list [--product P] [--json]` —
 //     GET /api/v1/targets, keyset-paginated, optionally narrowed by
@@ -19,14 +20,22 @@
 //     re-probing), and returns the same envelope to the caller. 501
 //     when no connector is registered yet for the target's product.
 //
-// Each verb wraps one backplane route and renders the response in
-// either a human-readable table / key-value summary or `--json` mode.
+//   - `meho targets import <file> [--update] [--dry-run] [--json]` —
+//     bulk-import a `targets.yaml` file into the backplane via
+//     POST/PATCH /api/v1/targets (Task #257, G0.3-T6). YAML key
+//     `preferred_impl_id` maps to the top-level field; `fingerprint`
+//     is skipped (server-managed; the backplane returns 422 on any
+//     `fingerprint` value in TargetCreate / TargetUpdate bodies
+//     via `model_config = ConfigDict(extra='forbid')`).
+//
+// Each verb wraps one or more backplane routes and renders the
+// response in either a human-readable form or `--json` mode.
 // Authentication piggybacks on the token meho login wrote — same
 // pattern as `meho operation` and `meho retrieval eval`.
 //
 // Write verbs (`create` / `update` / `delete`) are out of scope for
-// v0.2 per the issue body. Bulk-import lives in a sibling task
-// (G0.3-T6 / Task #257).
+// v0.2 per the issue body — operators use `import --update` for
+// bulk reconciliation.
 package targets
 
 import (
@@ -55,13 +64,14 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "targets",
-		Short:        "Operate the MEHO targets registry (list / describe / probe)",
-		Long:         "List, describe, and probe targets registered in the operator's tenant.",
+		Short:        "Operate the MEHO targets registry (list / describe / probe / import)",
+		Long:         "List, describe, probe, and bulk-import targets registered in the operator's tenant.",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newDescribeCmd())
 	cmd.AddCommand(newProbeCmd())
+	cmd.AddCommand(newImportCmd())
 	return cmd
 }
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -1211,6 +1211,108 @@ have to trust to run `meho login` against their secrets.
   the URL and lets the operator copy-paste, matching how
   `gh auth login` behaves without `--web`.
 
+## Targets registry (`meho targets`, G0.3 #224)
+
+`cli/internal/cmd/targets/` registers cobra verbs for the G0.3
+targets registry (Initiative #224). The v0.2 surface ships:
+
+- `meho targets import <file>` (G0.3-T6 #257) — bulk-import a
+  `targets.yaml` file. Sibling verbs (`list`, `describe`, `probe`)
+  land separately via G0.3-T5 #256.
+
+### Import verb
+
+`import.go` implements `meho targets import <file>` with the
+flags called out in the issue body: `--update` (PATCH existing
+targets instead of erroring), `--dry-run` (print the plan; no API
+calls), `--json` (structured plan output), `--backplane` (override
+the configured backplane URL).
+
+**Mapping rules.** The CLI parses the YAML as a generic
+`map[string]any` per entry and partitions every key:
+
+- **Known top-level columns** map 1:1 to the API's `TargetCreate` /
+  `TargetUpdate` body fields: `name`, `aliases`, `product`, `host`,
+  `port`, `fqdn`, `secret_ref`, `auth_model`, `vpn_required`,
+  `notes`, `preferred_impl_id`. The list in
+  `knownTopLevel` is the canonical reference; the
+  Python-side mirror lives in
+  `backend/tests/test_api_v1_targets_import.py:_KNOWN_TOP_LEVEL` and
+  keeps drift detectable in CI.
+- **`fingerprint`** is dropped silently with a warning log line.
+  Server-managed per the G0.3-T1.5 (#477) amendment — the probe
+  verb is the only legitimate writer, and the API rejects
+  caller-supplied values with 422 via
+  `model_config = ConfigDict(extra='forbid')`. Skipping at the CLI
+  is friendlier than letting the import abort on a 422 the operator
+  can't fix without editing the source YAML.
+- **`preferred_impl_id`** is a real top-level column post-#477.
+  Sent at the body root, not spilled into extras — the G0.6 #388
+  resolver's tie-break ladder reads it.
+- **Every other key** spills into the `extras` JSONB column.
+  Explicit `extras:` blocks in the YAML merge with spilled keys
+  rather than overwriting them.
+
+**Idempotency.** The plan-build phase fetches
+`GET /api/v1/targets` (paginated) and partitions every YAML entry
+into `CREATE` (no existing match) vs `UPDATE` (name already exists
+in tenant). Default mode aborts the whole import on the first
+duplicate — operators have to re-run with `--update` to opt into
+PATCH semantics. The plan is built before *any* write fires, so a
+partial-conflict YAML never leaves the tenant half-imported.
+
+**Sparse-PATCH contract.** The PATCH body for each updated entry
+is sparse: only keys present in the YAML appear, with `name` and
+`product` stripped (immutable post-create). This is load-bearing —
+without it the route handler's
+`updates = body.model_dump(exclude_unset=True); for k, v in updates: setattr(t, k, v)`
+loop combined with Pydantic v2's "explicit null counts as set"
+semantics is PUT-shaped, not PATCH-shaped, and would wipe every
+column the YAML omits on every `--update` run. PR #362's review on
+issue #257 (2026-05-14) surfaced this bug in an earlier draft; the
+`entryToUpdateBody` helper is the fix.
+
+### HTTP shape
+
+The verb routes through `api.NewAuthedClient` for bearer injection
++ 401-refresh-retry, same as `meho status` and `meho operation
+call`. The shared `doAuthedRequest` helper inside `import.go` is
+adapted to an `httpDoer` function-shape so unit tests can drive
+the plan / execute path against an in-process `fakeDoer` without
+the auth/token-store machinery (which is independently covered by
+`cli/internal/auth`'s own tests).
+
+The helper is duplicated from `cmd/operation/operation.go` because
+`cmd/operation` can't be imported from `cmd/targets` without an
+import cycle (both packages are grafted onto the same tree by
+`cmd/root.go`). If a third subcommand package grows, the duplicated
+helper should be extracted to a shared `cmd/_authed` package.
+
+### Tests
+
+- `import_test.go` — Go unit tests for the YAML parser, the
+  mapping rules (top-level / extras spill / fingerprint skip /
+  preferred_impl_id top-level), the sparse-PATCH body shape, the
+  plan partitioning logic, and the dry-run code path.
+- `backend/tests/test_api_v1_targets_import.py` — Python
+  integration tests against `/api/v1/targets` exercising the
+  CREATE / PATCH semantics the CLI relies on. The
+  real-`targets.yaml` round-trip test replays every conformant
+  entry from a pinned snapshot of
+  [`evoila-bosnia/claude-rdc-hetzner-dc/rdc-hetzner-dc/targets.yaml`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/rdc-hetzner-dc/targets.yaml)
+  (24 entries; SHA pinned in the test module).
+
+### Out-of-scope
+
+- Export (`meho targets export > file.yaml`) — v0.2.next polish.
+- Bulk delete via YAML — explicit out-of-scope on the issue.
+- Cross-tenant migration — operators import into their JWT's tenant.
+- Watching `targets.yaml` for changes — out-of-scope.
+- Schema validation against a Pydantic-equivalent on the CLI side —
+  CLI does minimal local validation (`name`, `product`, `host` are
+  required); the API does the strict validation and errors
+  propagate.
+
 ## References
 
 * Parent Goal: [#11](https://github.com/evoila-bosnia/meho-internal/issues/11)

--- a/docs/cross-repo/targets-yaml.md
+++ b/docs/cross-repo/targets-yaml.md
@@ -319,6 +319,127 @@ yq '
 # Should return health-payload + status success.
 ```
 
+## Migration recipe — bulk-importing a `targets.yaml` into MEHO
+
+> Added 2026-05-15 as part of G0.3-T6 (#257). Companion to
+> [docs/codebase/cli.md § Targets registry](../codebase/cli.md#targets-registry-meho-targets-g03-224).
+
+This section is the operator-side recipe for moving an existing
+consumer-shape `targets.yaml` (the file documented above) into the
+MEHO governance backplane via `meho targets import`. It's the
+"dual-read overlap" path Initiative #224 §7 calls out: the
+backplane becomes the authoritative target registry while the
+consumer's existing `targets.yaml` keeps working unchanged.
+
+### Step 0 — Authenticate
+
+```bash
+meho login https://meho.evba.lab
+```
+
+Stores a bearer token in the OS keyring (or
+`$XDG_CONFIG_HOME/meho/credentials.json` on headless hosts). The
+tenant is bound to the JWT's `tenant_id` claim — `meho targets
+import` writes into that tenant; there is no `--tenant` flag in
+v0.2.
+
+### Step 1 — Dry-run the import
+
+```bash
+meho targets import rdc-hetzner-dc/targets.yaml --dry-run
+```
+
+Prints the per-entry plan (CREATE / UPDATE / SKIP) without making
+any API calls. Add `--json` to format the plan as a structured
+object (`{create: [...], update: [...], skip: [...]}`) for piping
+into `jq` or capturing for diff against a follow-up dry-run.
+
+The dry-run code path is air-gap-safe: it does not contact the
+backplane, so an operator validating their YAML on a laptop with no
+network can still get the parse + mapping check.
+
+### Step 2 — First import
+
+```bash
+meho targets import rdc-hetzner-dc/targets.yaml
+```
+
+Default mode aborts on the first duplicate `name` in the tenant —
+the plan is built before any write fires, so a partial-conflict
+YAML never leaves the tenant half-imported. The 25-target consumer
+file applies in ~5 seconds (sequential POSTs; concurrency is
+v0.2.next polish).
+
+### Step 3 — Iterate with `--update`
+
+```bash
+meho targets import rdc-hetzner-dc/targets.yaml --update
+```
+
+`--update` PATCHes existing targets and POSTs new ones,
+mixed-mode-safe. The PATCH body is **sparse** — only YAML-present
+fields are sent on the wire, so re-running `--update` against a
+YAML that omits some fields does not wipe those columns. This is
+the load-bearing contract; see the codebase note linked at the top
+of this section for the bug history (PR #362's review on issue
+#257, 2026-05-14).
+
+### Mapping rules at a glance
+
+| YAML key | Lands at | Notes |
+| --- | --- | --- |
+| `name`, `aliases`, `product`, `host`, `port`, `fqdn`, `secret_ref`, `auth_model`, `vpn_required`, `notes` | top-level column | required: `name`, `product`, `host` |
+| `preferred_impl_id` | top-level column | G0.3-T1.5 (#477) amendment — G0.6 resolver tie-break override |
+| `extras` (explicit block) | `extras` JSONB | merges with the spilled-extras map from unknown keys |
+| `fingerprint` | dropped with warning | server-managed; only the probe verb writes it |
+| any other key | spilled into `extras` JSONB | the consumer's `sso_realm`, `kubeconfig_field`, `account`, `project_id` land here |
+
+Required fields (`name`, `product`, `host`) are checked locally
+before any HTTP request — a malformed YAML fails fast.
+Cloud-provider targets that legitimately omit `host` (e.g. GCP
+projects accessed by `project_id` + `account`) are rejected by the
+CLI parser today; operators with that shape need to either add a
+synthetic `host: cloud-provider` line or split cloud-provider
+targets into a separate file until the schema grows a
+host-optional variant.
+
+### Dual-read overlap
+
+While the consumer migrates, the same `targets.yaml` file can
+serve **both** chassis sides:
+
+- The chassis wrappers under `scripts/` keep reading the local
+  `targets.yaml` directly for credential resolution.
+- The MEHO backplane reads the imported state on every
+  `meho targets list` / `meho targets describe` invocation.
+
+Drift detection: re-running `meho targets import --update --dry-run`
+prints a plan showing which entries the backplane would PATCH —
+empty plan = backplane is in sync with the YAML. The consumer-side
+chassis can wire this dry-run into a periodic check (cron / CI job
+on the chassis repo) once the backplane URL is reachable from the
+chassis runner.
+
+### Verification
+
+```bash
+# After import, list every target the backplane sees:
+meho targets list
+
+# Spot-check a single entry against the YAML:
+meho targets describe rdc-vcenter --json | jq '.notes'
+
+# Re-run --update --dry-run; an empty plan means the backplane is
+# in sync with the YAML.
+meho targets import rdc-hetzner-dc/targets.yaml --update --dry-run
+```
+
+The Python integration test
+[`backend/tests/test_api_v1_targets_import.py`](../../backend/tests/test_api_v1_targets_import.py)
+pins this round-trip against a SHA-pinned snapshot of the
+consumer's real `targets.yaml`; the snapshot lives at
+`backend/tests/fixtures/rdc-hetzner-dc-targets.yaml`.
+
 ## Status
 
 | Item | Side | State |

--- a/docs/cross-repo/targets-yaml.md
+++ b/docs/cross-repo/targets-yaml.md
@@ -349,14 +349,15 @@ v0.2.
 meho targets import rdc-hetzner-dc/targets.yaml --dry-run
 ```
 
-Prints the per-entry plan (CREATE / UPDATE / SKIP) without making
-any API calls. Add `--json` to format the plan as a structured
-object (`{create: [...], update: [...], skip: [...]}`) for piping
-into `jq` or capturing for diff against a follow-up dry-run.
-
-The dry-run code path is air-gap-safe: it does not contact the
-backplane, so an operator validating their YAML on a laptop with no
-network can still get the parse + mapping check.
+Prints the per-entry plan without making any API calls. The dry-run
+code path is strictly air-gap-safe — it does not contact the
+backplane — so existence is unknown and **every entry lists as
+CREATE** regardless of `--update`. For an existence-aware preview,
+run `meho targets list` first to see what's already in the tenant.
+Add `--json` to format the plan as a structured object
+(`{create: [...], update: [...], skip: [...]}`, with `update` and
+`skip` empty in dry-run) for piping into `jq` or capturing for diff
+against a follow-up dry-run.
 
 ### Step 2 — First import
 


### PR DESCRIPTION
## Summary

Adds `meho targets import <file>` (G0.3-T6, Initiative #224) — a bulk-importer that reads a `targets:`-keyed YAML and applies one POST/PATCH per entry against `/api/v1/targets`. Ships `--update` / `--dry-run` / `--json` flags per the issue body.

Closes #257.

## Mapping rules

Per the issue body + the G0.3-T1.5 (#477) amendment:

- Known top-level keys (`name`, `aliases`, `product`, `host`, `port`, `fqdn`, `secret_ref`, `auth_model`, `vpn_required`, `notes`, `preferred_impl_id`) map 1:1 to `TargetCreate` / `TargetUpdate` columns.
- `fingerprint` is dropped with a warning — server-managed (probe verb is the only writer; the API rejects caller values with 422 via `ConfigDict(extra='forbid')`).
- Every other key spills into `extras` JSONB.
- Explicit `extras:` blocks merge with spilled keys.

## Idempotency

- **Default mode** — aborts on any duplicate `name` (the plan is built before any write fires, so a partial-conflict YAML never leaves the tenant half-imported).
- **`--update`** — PATCHes existing targets with a **sparse** body (only YAML-present fields; `name`/`product` stripped as immutable post-create). Without sparse semantics the route handler's `model_dump(exclude_unset=True)` + `setattr` loop combined with Pydantic v2's "explicit null counts as set" rule is PUT-shaped and would wipe omitted columns on every `--update` run. This is the bug PR #362's review on #257 surfaced (2026-05-14, https://github.com/evoila/meho/issues/257#issuecomment-4449986678).
- **`--dry-run`** — prints the plan without any API calls. Air-gap-safe (no auth required).
- **`--json`** — structured `{create: [...], update: [...], skip: [...]}` plan output.

## Tests

- **Go unit tests** (`cli/internal/cmd/targets/import_test.go`) — YAML parser, mapping rules (top-level / extras spill / `fingerprint` skip / `preferred_impl_id` top-level), sparse-PATCH body shape, plan partitioning, dry-run code path.
- **Python integration tests** (`backend/tests/test_api_v1_targets_import.py`) — full round-trip of every conformant entry from a SHA-pinned snapshot of the consumer's real `targets.yaml` (`backend/tests/fixtures/rdc-hetzner-dc-targets.yaml`, 24 entries, upstream blob SHA `1e1e6885…`). Plus targeted tests for `fingerprint` 422, `preferred_impl_id` top-level, sparse-PATCH preservation, and duplicate-name 409.

## T5 collision note

T5 (#256, `meho targets list/describe/probe`) is being implemented in parallel. T6 lands a minimal parent `cli/internal/cmd/targets/targets.go` so the import verb compiles against `meho targets`. On rebase against T5's eventual merge the `AddCommand(newImportCmd())` line is the natural collision and trivial to resolve.

Took **Option (ii)** per the spawn instructions (implement import with a minimal `targets.go` parent; T5 PR will supersede on the shared files).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./cli/...` passes (all packages including the new targets one)
- [x] `golangci-lint run ./...` clean
- [x] `ruff check src tests` + `ruff format --check` clean
- [x] `mypy src` clean
- [x] `pytest tests/` — 1304 passed (full non-integration suite)
- [x] Pinned-snapshot real-`targets.yaml` round-trip succeeds (24 conformant entries)
- [x] DCO sign-off on every commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `meho targets import <file>` to bulk-import targets from a YAML registry; supports `--dry-run`, `--update`, and `--json` output. Default import aborts on duplicate names; `--update` patches existing entries.
  * Import plans use sparse updates (only YAML-present fields) and warn when server-managed fields (e.g., fingerprint) are ignored.

* **Tests**
  * Added end-to-end and unit tests covering YAML parsing, planning, dry-run behavior, and API create/patch round-trips.

* **Documentation**
  * Added CLI and migration guide documenting import flags, mapping rules, and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/491)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->