### PR TITLE
docs(architecture): G0.7-T9 spec-ingestion.md + connector-ingestion runbook

### DIFF
--- a/docs/architecture/connectors.md
+++ b/docs/architecture/connectors.md
@@ -6,7 +6,7 @@
 >
 > - **[operations-substrate.md](operations-substrate.md)** — canonical reference for the G0.6 substrate as-shipped: `endpoint_descriptor` + `operation_group` tables, the v2 connector registry, the dispatcher's eight-phase pipeline, composite recursion + audit-tree linkage, the JSONFlux reducer Protocol, and the three operation meta-tools. Read this first; the content below remains as historical baseline.
 > - **[connector-resolution.md](connector-resolution.md)** — the resolver's tie-break ladder with three worked examples.
-> - **[#389 G0.7 Spec ingestion pipeline](https://github.com/evoila/meho/issues/389)** — OpenAPI 3.0/3.1 parser + vi-json multi-spec merge + LLM-summarised operation groups + operator review queue. Architecture doc lands separately.
+> - **[spec-ingestion.md](spec-ingestion.md)** — canonical reference for the G0.7 spec-ingestion pipeline as-shipped: OpenAPI 3.0/3.1 parser, `register_ingested_operations()` upsert + multi-spec merge + body-hash skip, two-pass LLM-summarised operation groups (`1 + ceil(N/50)` call budget), operator review-queue state machine (`staged → enabled → disabled`), the seven `meho connector ...` CLI verbs, `/api/v1/connectors*` REST routes, and the `meho.connector.*` admin MCP tools. Companion operator runbook: [`docs/cross-repo/connector-ingestion.md`](../cross-repo/connector-ingestion.md).
 >
 > Connector kinds (three, all first-class, all versioned, multi-impl per product):
 > - **Generic (ingested) connectors** — operations auto-derived from a vendor OpenAPI spec by G0.7 into `endpoint_descriptor` rows (`source_kind='ingested'`). Examples planned: `vmware-rest-9.0`, `nsx-4.2`, `harbor-2.x`, `hetzner-robot-2026-04`.

--- a/docs/architecture/spec-ingestion.md
+++ b/docs/architecture/spec-ingestion.md
@@ -1,0 +1,332 @@
+# Spec ingestion (G0.7)
+
+> Read [CLAUDE.md](../../CLAUDE.md) first for the postulates that scope this pipeline. Sister doc to [operations-substrate.md](operations-substrate.md) (G0.6) — that doc owns the destination tables and dispatcher; this one owns the pipeline that *populates* them from vendor specs. Covers the implementation that landed under [Initiative #389 G0.7](https://github.com/evoila/meho/issues/389).
+
+How MEHO turns a vendor OpenAPI document into rows in `endpoint_descriptor` + `operation_group` that the agent's [`search_operations`](operations-substrate.md#search_operationsconnector_id-query-groupnone-limit10) and [`call_operation`](operations-substrate.md#call_operationconnector_id-op_id-targetnone-params) meta-tools can resolve — without ever exposing a per-op MCP tool ([CLAUDE.md](../../CLAUDE.md) postulate 5).
+
+## What this pipeline does
+
+One sentence: take an OpenAPI 3.0/3.1 spec, parse it into `EndpointDescriptorProto` rows, ask an LLM to propose 8–15 operation groups + per-group `when_to_use` hints, stage the connector for operator review (`review_status='staged'`, every op `is_enabled=False`), and let the operator enable it once they have polished the LLM output and stamped per-op overrides.
+
+The pipeline operationalises [CLAUDE.md](../../CLAUDE.md) postulate 4 (operation grouping + LLM hints, operator-reviewable) and the v0.1-spec's "auto-derive is the primary operation source" mandate ([v0.1-spec §3 L289–313](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/docs/meho-coordination/v0.1-spec.md)).
+
+### Supported spec formats
+
+**v0.2 ships OpenAPI 3.0/3.1 only.** The parser ([`ingest/openapi.py`](../../backend/src/meho_backplane/operations/ingest/openapi.py)) accepts either YAML or JSON, sniffed at decode time. Both `3.0.x` and `3.1.x` are first-class; the parser rejects every other spec version with `UnsupportedSpecError`.
+
+Deferred to v0.2.next:
+
+- **GraphQL SDL / introspection** — no GraphQL surfaces in the v0.2 connector inventory.
+- **WSDL** — no SOAP-without-REST-overlay surfaces in v0.2.
+- **proto / gRPC** — no gRPC surfaces in v0.2.
+- **Google discovery doc** — defer until G3.7 (gcloud); the call there is "extend G0.7 with an adapter" vs "wrap `google-cloud-python` as a typed connector".
+
+## The five-step pipeline
+
+```mermaid
+flowchart LR
+    A[OpenAPI spec<br>file:// or https://]
+    A --> B[T1<br>parse_openapi]
+    B -->|EndpointDescriptorProto list| C[T2<br>register_ingested_operations]
+    C -->|DB rows + embeddings<br>+ GenericRestConnector shim| D[T3<br>run_llm_grouping]
+    D -->|operation_group + group_id| E[T4<br>ReviewService]
+    E -->|staged → enabled| F[T8<br>vSphere canary]
+    F -->|search_operations<br>top-3 hits OK| G[Live for agents]
+```
+
+Each step is an isolated function with its own audit row. The pipeline composes through [`IngestionPipelineService`](../../backend/src/meho_backplane/operations/ingest/pipeline.py) which the CLI (T5), REST (T6), and admin MCP (T7) surfaces all share.
+
+The five-step labels:
+
+- **Parse** — T1 ([`ingest/openapi.py`](../../backend/src/meho_backplane/operations/ingest/openapi.py)) — pure-function YAML/JSON → `EndpointDescriptorProto`. No DB session, no LLM call. Issue [#401](https://github.com/evoila/meho/issues/401).
+- **Register** — T2 ([`ingest/register_ingested.py`](../../backend/src/meho_backplane/operations/ingest/register_ingested.py)) — DB upsert + embedding compute + multi-spec merge + auto-registration of a `GenericRestConnector` shim against the v2 connector registry + body-hash skip-re-embed. Issue [#403](https://github.com/evoila/meho/issues/403).
+- **Group** — T3 ([`ingest/llm_groups.py`](../../backend/src/meho_backplane/operations/ingest/llm_groups.py)) — two-pass LLM (propose groups, then assign each op to a group). Issue [#404](https://github.com/evoila/meho/issues/404).
+- **Review** — T4 ([`ingest/service.py`](../../backend/src/meho_backplane/operations/ingest/service.py)) — `staged → enabled → disabled` state machine + per-op overrides + audit emission per transition. Issue [#402](https://github.com/evoila/meho/issues/402).
+- **Verify** — T8 ([`tests/acceptance/test_g07_vsphere_canary.py`](../../backend/tests/acceptance/test_g07_vsphere_canary.py)) — the govc-parity benchmark: ingest the vSphere REST spec, enable, then assert 10 representative queries return the canonical operation in the top-3 hits of `search_operations`. Issue [#408](https://github.com/evoila/meho/issues/408). Operator-facing runbook: [g07-vsphere-canary.md](../cross-repo/g07-vsphere-canary.md).
+
+Operator-facing surfaces — CLI (T5, [#405](https://github.com/evoila/meho/issues/405)), REST (T6, [#406](https://github.com/evoila/meho/issues/406)), admin MCP (T7, [#407](https://github.com/evoila/meho/issues/407)) — all wrap the same `IngestionPipelineService` + `ReviewService` so the wire contract is defined once. See [Operator surfaces](#operator-surfaces) below.
+
+## T1 — the parser
+
+[`parse_openapi(spec_path_or_uri, *, spec_source=None) -> list[EndpointDescriptorProto]`](../../backend/src/meho_backplane/operations/ingest/openapi.py) is the only public entry point. The function is synchronous because callers are CLI / one-shot ingestion endpoints with no event-loop concern, and the surface stays trivially testable.
+
+### Inputs
+
+- `spec_path_or_uri` — a `file://` path or an `http(s)://` URL. Local files read with stdlib; remote files fetched via [`httpx`](https://www.python-httpx.org/) with a 30 s timeout. YAML decoded via PyYAML's `CSafeLoader` (with a pure-Python `SafeLoader` fallback for platforms lacking LibYAML); JSON decoded via stdlib.
+- `spec_source` — optional tag string (e.g. `"vcenter.yaml"`) the parser stamps onto every row as a `spec:<source>` entry in `tags`. The downstream T2 merge path keys collision detection off this tag.
+
+### Per-operation output
+
+One `EndpointDescriptorProto` per `(method, path)` entry under `paths`:
+
+| Proto field | Source | Notes |
+|---|---|---|
+| `op_id` | `f"{METHOD}:{path}"` | Connector-side natural key (e.g. `"GET:/api/vcenter/cluster"`). |
+| `method`, `path` | OpenAPI path entry | `method` upper-cased. `path` keeps `{var}` templating verbatim. |
+| `summary`, `description` | OpenAPI operation object | Verbatim. Feed the BM25 + cosine retrieval text. |
+| `tags` | OpenAPI `tags[]` + `spec:<source>` | Spec tags plus the per-spec marker. |
+| `parameter_schema` | Merged path + query + header + body | Flattened JSON Schema 2020-12; properties carry an `x-meho-param-loc` extension (`"path"` / `"query"` / `"header"` / `"body"`) the dispatcher reads to split incoming `params` into four buckets. |
+| `response_schema` | Success-response schema | Picks `200 > 201 > 202 > ... > 2XX`. |
+| `safety_level` | HTTP-verb heuristic | `safe` for GET/HEAD/OPTIONS; `caution` for POST/PUT/PATCH; `dangerous` for DELETE. Operator overrides at review time. |
+| `requires_approval` | Always `False` at parse time | Operator flips for known-destructive ops via `edit-op`. |
+
+### `$ref` resolution — intentionally shallow
+
+[`refs.py::_resolve_shallow_ref`](../../backend/src/meho_backplane/operations/ingest/refs.py) inlines exactly one level of `$ref` into each parameter / response / body schema and leaves nested `$ref` strings verbatim. The parameter_schema is self-contained enough for the dispatcher's `jsonschema.Draft202012Validator` to validate the immediate parameter shape; deeper schema dereferencing (chasing nested `$ref`s through `components.schemas`) is the dispatcher's concern.
+
+Three classes of `$ref` are explicitly rejected with `UnsupportedSpecError` so the operator sees the problem at ingest time rather than at dispatch time:
+
+- **Non-schema component refs.** `$ref: "#/components/parameters/..."`, `$ref: "#/components/requestBodies/..."`, etc. vCenter's `vcenter.yaml` doesn't use these; **`vi-json.yaml` does** (every op references `#/components/parameters/moId`). See [Future work](#future-work) below — this is the load-bearing extension that unblocks vi-json ingestion.
+- **Cross-document refs.** `$ref: "other.yaml#/..."`. External files require either a pre-process pass or a v0.2.next resolver extension.
+- **`$ref` drill-down.** Refs that walk into a component's sub-tree (`#/components/schemas/X/properties/y`) raise `InvalidSchemaError`.
+
+## T2 — register_ingested_operations
+
+[`register_ingested_operations(session, protos, *, product, version, impl_id, tenant_id, spec_source, embedding_service) -> IngestionResult`](../../backend/src/meho_backplane/operations/ingest/register_ingested.py) is the single write path for ingested rows. Mirrors the typed-connector helper [`register_typed_operation()`](../../backend/src/meho_backplane/operations/typed_register.py) for embedding-text composition and body-hash idempotence.
+
+### Per-call flow
+
+1. **Within-batch collision check.** Set scan over the proto list; any `op_id` appearing twice raises `OpIdCollision` before any DB write.
+2. **Auto-register a `GenericRestConnector` subclass.** First ingest of a `(product, version, impl_id)` triple synthesises a class via `type(...)` and registers it through [`register_connector_v2()`](operations-substrate.md#the-connector-registry-v2). The shim's concrete `auth_headers` raises `NotImplementedError` with operator-readable guidance; the review-queue gate keeps every ingested op `is_enabled=False` until the operator replaces the shim with a hand-rolled per-G3.x subclass that adds the auth path.
+3. **Per-proto upsert** (delegated to [`_upsert.py`](../../backend/src/meho_backplane/operations/ingest/_upsert.py)):
+   - Compose the embedding text from `summary + description + custom_description + tags` and SHA-256 it.
+   - Natural-key lookup on `(product, version, impl_id, op_id)` plus a partial-index match on `tenant_id`.
+   - **Cross-call collision check.** If a persisted row's `spec:<source>` tag differs from the incoming `spec_source`, raise `OpIdCollision` with both spec sources named (so the operator-facing error names the two colliding specs).
+   - **Skip-re-embed path** — persisted row's recomposed embedding-text hash matches → no embedding inference; row's `updated_at` advances, embedding stays.
+   - **Re-embed path** — row exists but the embedding text changed → embedding recomputed; row updated.
+   - **First-register path** — brand-new row; embedding computed; row inserted.
+
+`IngestionResult` carries per-call counts (`inserted_count`, `updated_count`, `skipped_count`) plus two flags (`connector_registered`, `operations_grouped`). `operations_grouped` is always `False` from T2 alone; T3 flips it when the grouping pass runs.
+
+### Multi-spec merge
+
+A single `IngestionPipelineService.ingest(...)` call processes a list of `SpecSource` entries. Each is parsed and upserted under the **same** connector triple with that spec's URI as the `spec_source` tag. Operators can then distinguish "this op came from `vcenter.yaml`" vs "this op came from `vi-json.yaml`" during review.
+
+The same-`spec_source` re-ingest of an unchanged spec stays on the skip-re-embed path — the cross-call check only fires on a true mismatch. The operationally critical scenario this protects: an unchanged 3,000-op vCenter spec must not re-embed 3,000 operations on every re-ingest.
+
+## T3 — LLM-summarised grouping
+
+[`run_llm_grouping(session, *, product, version, impl_id, tenant_id, llm_client, config, embedding_service) -> GroupingResult`](../../backend/src/meho_backplane/operations/ingest/llm_groups.py) opens its own transaction and runs two passes.
+
+### Pass 1 — propose groups
+
+Runs only when no `operation_group` rows yet exist for the connector triple. Sends every unassigned op's `(op_id, summary, tags)` to the LLM with the system prompt at [`ingest/prompts/propose_groups.md.j2`](../../backend/src/meho_backplane/operations/ingest/prompts/propose_groups.md.j2) and asks for an array of `{group_key, name, when_to_use}` proposals.
+
+Output is validated against `GroupProposal` (snake_case key, non-empty fields, bounded `max_length` on prose, no duplicate keys). Validation failure raises `LlmOutputInvalid` carrying `pass_name="propose_groups"`, the verbatim model response (capped in the message preview), and the underlying `ValidationError` / `JSONDecodeError`. The transaction rolls back; the connector stays in whatever state preceded the call.
+
+Persisted rows land `review_status='staged'`.
+
+### Pass 2 — assign each op to a group
+
+Splits the unassigned-op set into batches of `batch_size` (default `50`). Each batch renders the system prompt at [`ingest/prompts/assign_op_to_group.md.j2`](../../backend/src/meho_backplane/operations/ingest/prompts/assign_op_to_group.md.j2) and asks for a JSON object mapping `op_id` to `group_key`, where `group_key` is either one of the Pass-1 keys or the sentinel `"none"`. Each row's `EndpointDescriptor.group_id` is set to the matching group's UUID; sentinel and unknown-key entries leave `group_id=NULL`.
+
+### Call-budget formula
+
+```
+llm_call_count = 1 + ceil(op_count / batch_size)
+```
+
+One Pass-1 call plus `ceil(N / batch_size)` Pass-2 calls. For vCenter's `vcenter.yaml` (~1,275 ops at `batch_size=50`) that's `1 + 26 = 27` calls per fresh ingest. The audit row T3 writes (`meho.connector.llm_grouping`) records the actual count for cost tracking.
+
+### Two distinct system prompts
+
+Each pass uses its own static system-prompt template so the Anthropic Messages API's cacheable prefix stays stable across batches — the prompt prefix is identical between every Pass-2 batch, only the user-prompt body (rendered from the Jinja template with the batch's ops) changes. This keeps prompt-caching effective on long ingests.
+
+### Idempotency
+
+- **No unassigned ops** → true no-op, zero LLM calls, no audit row.
+- **Existing groups present but some ops still unassigned** → Pass 1 skipped, Pass 2 only runs against the unassigned-op subset using the existing groups verbatim. The "partial-regrouping" branch.
+- **Fully fresh connector** → both passes run, all groups + assignments persist in one transaction.
+
+### The `LlmClient` Protocol seam
+
+The LLM client is injected as a `Protocol` with one async method, `generate_json(*, system_prompt, user_prompt, response_schema) -> dict`. Production wires the chassis Anthropic-Messages adapter; tests inject a deterministic stub from [`tests/fixtures/llm_groups/`](../../backend/tests/fixtures/llm_groups/). The `IngestionPipelineService` receives the client via a factory parameter so the chassis can lazy-resolve it; the default factory raises `LlmClientUnavailable` and the REST layer maps the exception onto HTTP 503.
+
+## T4 — review queue
+
+[`ReviewService(operator)`](../../backend/src/meho_backplane/operations/ingest/service.py) is the state-machine API every operator surface (T5 CLI, T6 REST, T7 admin MCP) routes write paths through.
+
+### State machine
+
+`OperationGroup.review_status` is a bounded enum enforced via a DB-layer CHECK constraint (migration in [`db/models.py::OperationGroup`](../../backend/src/meho_backplane/db/models.py)). The state transitions:
+
+```text
+   ┌──────────┐  enable_connector  ┌──────────┐
+   │  staged  │ ───────────────────▶ enabled  │
+   └────┬─────┘                    └────┬─────┘
+        │                               │ disable_connector
+        │                               ▼
+        │                          ┌──────────┐
+        └─────────────────────────▶│ disabled │
+              disable_connector    └──────────┘
+                                        │
+                                        │ enable_connector
+                                        ▼
+                                   (back to enabled)
+```
+
+- **`staged`** — fresh out of ingest. Every group rendered to the operator for review; every op `is_enabled=False`. Connector does NOT show up in `search_connectors`; operations are NOT dispatchable.
+- **`enabled`** — `enable_connector` cascade: every group → `enabled`, every op the operator approved → `is_enabled=True`. Operations become dispatchable; connector surfaces through the agent meta-tools.
+- **`disabled`** — `disable_connector` rollback: every group → `disabled`, every op → `is_enabled=False`. Per-op operator overrides (`custom_description`, `safety_level`, `requires_approval`) are **preserved** so a future `enable` resurfaces them verbatim.
+
+### Per-op overrides
+
+Operator edits routed through `ReviewService.edit_op(...)` set columns the parser leaves untouched:
+
+| Column | Operator intent |
+|---|---|
+| `custom_description` | Replacement agent-facing description that masks the vendor's spec wording. The retrieval text recomposes from this when set. |
+| `safety_level` | Override the HTTP-verb heuristic. Bounded enum `safe` / `caution` / `dangerous`. |
+| `requires_approval` | Forces `status='pending'` on dispatch + an explicit operator approval before execution. Orthogonal to `safety_level`. |
+| `is_enabled` | Re-enable / disable a single op without flipping the whole connector. |
+
+`ReviewService.edit_group(...)` mirrors the same shape for the group's `name` and `when_to_use` hint. Each edit writes a single `meho.connector.edit_op` / `meho.connector.edit_group` audit row in the same transaction as the column update. Operator-edit audit emission means [G8 audit replay](https://github.com/evoila/meho/issues/218) can reconstruct exactly which operator polished which group's `when_to_use` at which time.
+
+### PATCH semantics
+
+`edit_group` and `edit_op` use HTTP PATCH semantics: only fields the operator explicitly named are forwarded to the service. The REST router builds the service-call kwargs via `if "field" in body` key-presence checks so an omitted field never reaches `ReviewService` (an explicit `null` would otherwise be indistinguishable from an omission with `arguments.get(...)`). Same discipline applies to the MCP admin tool handlers.
+
+### Audit emission
+
+Every transition writes exactly one `audit_log` row with an `op_id` from the `meho.connector.*` namespace:
+
+| Action | `op_id` | Op-class |
+|---|---|---|
+| `ingest()` | `meho.connector.ingest` | write |
+| `edit_group()` | `meho.connector.edit_group` | write |
+| `edit_op()` | `meho.connector.edit_op` | write |
+| `enable_connector()` | `meho.connector.enable` | write |
+| `disable_connector()` | `meho.connector.disable` | write |
+| `run_llm_grouping()` | `meho.connector.llm_grouping` | write |
+
+Read paths (`list_ingested_connectors`, `get_review_payload`) follow the chassis convention of not emitting an audit row — list queries are too noisy to audit per-call. The G8 audit-replay surface reconstructs the connector's review history by walking the write-side rows.
+
+## Operator surfaces
+
+Three surfaces wrap the same `IngestionPipelineService` + `ReviewService` so the wire contract is defined once. The CLI verb tree (T5), the REST router (T6), and the admin MCP tool set (T7) consume the same shared Pydantic models in [`ingest/api_schemas.py`](../../backend/src/meho_backplane/operations/ingest/api_schemas.py) (`IngestRequest`, `IngestResponse`, `ConnectorListItem`, `EditGroupBody`, `EditOpBody`).
+
+### T5 — CLI verbs (`meho connector ...`)
+
+Cobra verb tree at [`cli/internal/cmd/connector/`](../../cli/internal/cmd/connector/). Thin client over T6's REST routes — no direct service-layer access.
+
+| Verb | Role | Wraps |
+|---|---|---|
+| `meho connector ingest --product <p> --version <v> --impl <i> --spec <uri> [--spec <uri>...] [--dry-run] [--json]` | `tenant_admin` | `POST /api/v1/connectors/ingest` |
+| `meho connector list [--status staged\|enabled\|disabled\|all] [--json]` | `operator` | `GET /api/v1/connectors` |
+| `meho connector review <connector_id> [--json]` | `operator` | `GET /api/v1/connectors/{id}/review` |
+| `meho connector edit-group <connector_id> <group_key> [--when-to-use <text>\|@file] [--name <text>]` | `tenant_admin` | `PATCH /api/v1/connectors/{id}/groups/{group_key}` |
+| `meho connector edit-op <connector_id> <op_id> [--custom-description ...] [--safety ...] [--requires-approval\|--no-requires-approval] [--enable\|--disable]` | `tenant_admin` | `PATCH /api/v1/connectors/{id}/operations/{op_id}` |
+| `meho connector enable <connector_id> [--confirm]` | `tenant_admin` | `POST /api/v1/connectors/{id}/enable` |
+| `meho connector disable <connector_id> [--confirm]` | `tenant_admin` | `POST /api/v1/connectors/{id}/disable` |
+
+Enable / disable are gated on an interactive confirmation prompt by default; `--confirm` skips it for CI / scripted use. `--json` on every read verb emits machine-readable JSON. The `@<file>` suffix on `--when-to-use` and `--custom-description` reads the value from a file so longer prose stays out of shell history.
+
+### T6 — REST routes (`/api/v1/connectors*`)
+
+Defined in [`api/v1/connectors_ingest.py`](../../backend/src/meho_backplane/api/v1/connectors_ingest.py). Seven endpoints; RBAC enforced by FastAPI dependency injection via [`auth.rbac.require_role`](../../backend/src/meho_backplane/auth/rbac.py).
+
+| Route | Method | Role | Returns |
+|---|---|---|---|
+| `/api/v1/connectors/ingest` | `POST` | `tenant_admin` | `IngestResponse` (200) |
+| `/api/v1/connectors` | `GET` | `operator` | `ConnectorListResponse` (200) |
+| `/api/v1/connectors/{id}/review` | `GET` | `operator` | `ConnectorReviewPayload` (200) |
+| `/api/v1/connectors/{id}/groups/{group_key}` | `PATCH` | `tenant_admin` | 204 No Content |
+| `/api/v1/connectors/{id}/operations/{op_id:path}` | `PATCH` | `tenant_admin` | 204 No Content |
+| `/api/v1/connectors/{id}/enable` | `POST` | `tenant_admin` | 204 No Content |
+| `/api/v1/connectors/{id}/disable` | `POST` | `tenant_admin` | 204 No Content |
+
+**Tenant scoping** derives from the JWT; there is no body or query parameter that can override the operator's tenant. Cross-tenant probes surface as 404 `ConnectorNotFoundError`, not 403 — same conflation [`operations-substrate.md`](operations-substrate.md#tenant-scoping-rules) uses to keep the operator-facing failure surface uniform.
+
+**The `op_id:path` converter** on `edit_op` is load-bearing: operation natural keys carry colons and slashes (`"GET:/api/vcenter/cluster"`) and the default FastAPI path converter would split on them. The `:path` converter preserves the full segment.
+
+### T7 — admin MCP tools (`meho.connector.*`)
+
+Defined in [`mcp/tools/connector_admin.py`](../../backend/src/meho_backplane/mcp/tools/connector_admin.py). Seven tools registered at module import:
+
+| Tool | `required_role` | Wraps |
+|---|---|---|
+| `meho.connector.ingest` | `tenant_admin` | `IngestionPipelineService.ingest()` |
+| `meho.connector.list` | `operator` | `list_ingested_connectors()` |
+| `meho.connector.review` | `operator` | `ReviewService.get_review_payload()` |
+| `meho.connector.edit_group` | `tenant_admin` | `ReviewService.edit_group()` |
+| `meho.connector.edit_op` | `tenant_admin` | `ReviewService.edit_op()` |
+| `meho.connector.enable` | `tenant_admin` | `ReviewService.enable_connector()` |
+| `meho.connector.disable` | `tenant_admin` | `ReviewService.disable_connector()` |
+
+These are **administrative** MCP tools per [CLAUDE.md](../../CLAUDE.md)'s "What MEHO is NOT" note — distinct from the agent-surface meta-tools. The registry's `all_tools_for(operator)` filter hides them from `tools/list` for operators whose role doesn't meet `required_role`, and the `handle_tools_call` dispatcher re-checks the rank at invocation so a client that guesses a hidden tool name is still rejected.
+
+There is **no parallel admin service class**; each handler converts the JSON-Schema-validated `arguments` dict into the canonical Pydantic model from `api_schemas` and calls the service directly. Responses are `model_dump(mode="json")`-ed onto the wire.
+
+## The vSphere canary (T8)
+
+End-to-end verification that the pipeline produces an agent-usable connector against a real ~1,275-operation spec corpus. Acceptance test at [`tests/acceptance/test_g07_vsphere_canary.py`](../../backend/tests/acceptance/test_g07_vsphere_canary.py); operator-facing runbook at [g07-vsphere-canary.md](../cross-repo/g07-vsphere-canary.md).
+
+### The 10-query govc-parity benchmark
+
+The canary ingests `vcenter.yaml`, drives the operator workflow (review → edit one group → enable), then runs ten representative operator queries through `search_operations`. The acceptance bar is **"the canonical operation appears in the top-3 hits"** for at least 8 of the 10 queries.
+
+The 10 (query, canonical-op) pairs are documented verbatim in the [canary runbook](../cross-repo/g07-vsphere-canary.md#test-variant). Three currently fail (`list virtual machines`, `power on virtual machine`, `power off virtual machine`) for the retrieval-quality reasons captured under [Future work](#future-work) — those three are marked `xfail` so the suite detects when description quality improves enough to flip them.
+
+### Rollback when a canary regresses
+
+`meho connector disable <connector_id> --confirm` cascades every group to `review_status='disabled'` and every op to `is_enabled=False`. The agent meta-tools stop surfacing the connector immediately; no in-flight dispatches will route to it. Per-op overrides (`custom_description`, `safety_level`, `requires_approval`) are preserved against a future re-enable.
+
+After fix → re-run `meho connector ingest`. Body-hash idempotence on T2 means rows whose parser output didn't change stay untouched (no re-embed cost); only the changed rows get an updated revision. After `review` + `enable`, the agent path re-warms.
+
+## Anti-patterns
+
+The pipeline operationalises load-bearing CLAUDE.md postulates. The patterns below are **NOT** acceptable in post-G0.7 code:
+
+- **Wholesale auto-enable without operator review** — violates postulate 4 (operator-reviewable). An ingest pass that lands `review_status='enabled'` directly defeats the gate's purpose. The only legitimate path from `staged` to `enabled` is `enable_connector(...)` after the operator has reviewed groups + per-op overrides.
+- **Adding to the agent meta-tool surface** — violates postulate 5. The agent surface is the ~17 meta-tools in [CLAUDE.md](../../CLAUDE.md). T7 ships seven *administrative* MCP tools under `meho.connector.*` for operators with `tenant_admin` role — never visible to the agent's daily `tools/list`.
+- **Hand-coding per-op MCP tools per ingested connector** — also violates postulate 5. A vCenter `vsphere.vm.list` tool registered as its own MCP tool is wrong; vendor operations reach the agent through `search_operations` + `call_operation` against the ingested rows.
+- **Embedding LLM prompts inline instead of as reviewable templates** — the two prompts live at [`ingest/prompts/propose_groups.md.j2`](../../backend/src/meho_backplane/operations/ingest/prompts/propose_groups.md.j2) and [`ingest/prompts/assign_op_to_group.md.j2`](../../backend/src/meho_backplane/operations/ingest/prompts/assign_op_to_group.md.j2) so prompt iterations are reviewable diffs. Inline string literals defeat that discipline.
+- **Bypassing the review-queue audit trail** — direct UPDATEs to `operation_group.review_status` or `endpoint_descriptor.is_enabled` outside `ReviewService` lose the `meho.connector.*` audit emission and break G8 replay.
+- **Stripping `spec:<source>` tags** — the multi-spec merge identifier is how operators tell `vcenter.yaml` ops apart from `vi-json.yaml` ops at review time. Code that filters or rewrites tags during ingestion must preserve the `spec:` marker.
+
+## Connecting to G0.6 (operations-substrate.md)
+
+The two Initiatives interlock as producer / consumer:
+
+- **G0.6's `endpoint_descriptor` and `operation_group` tables** are the destination. G0.7 writes; G0.6 reads.
+- **G0.6's dispatcher** invokes the handlers G0.7 ingests. The `source_kind='ingested'` branch in [`operations/_branches.py`](../../backend/src/meho_backplane/operations/_branches.py) reads `method` + `path` + the per-parameter `x-meho-param-loc` extension to route the call through the `GenericRestConnector` shim's HTTP transport.
+- **G0.6's three operation meta-tools** ([`list_operation_groups`](operations-substrate.md#list_operation_groupsconnector_id), [`search_operations`](operations-substrate.md#search_operationsconnector_id-query-groupnone-limit10), [`call_operation`](operations-substrate.md#call_operationconnector_id-op_id-targetnone-params)) consume what G0.7 produces. The retrieval algorithm (BM25 + cosine + RRF) operates over the rows G0.7 inserted; group-level filtering uses the LLM-summarised `operation_group.when_to_use` hints.
+- **G0.6's v2 connector registry** receives the `GenericRestConnector` shim G0.7's T2 synthesises. The shim makes the connector resolvable through `resolve_connector(target)` so spec ingestion can proceed before the per-product Initiative work (G3.1 vSphere, G3.4 NSX, etc.) replaces the shim with a hand-rolled subclass that supplies the auth path.
+
+The G0.7 pipeline is unblocked the moment G0.6 lands its T1 (tables) + T2 (registry v2) + T8 (meta-tools). All three landed on `main` before G0.7's first T1 PR, per the dependency DAG in Initiative #389.
+
+## Future work
+
+The vSphere canary surfaced three gaps that are real but out of G0.7's v0.2 scope. Document inline; file as separate Tasks when they become blockers for a specific consumer.
+
+### Gap 1 — T1 `$ref` extension for `vi-json.yaml`
+
+Every operation in `vi-json.yaml` references `$ref: "#/components/parameters/moId"`. The current T1 parser explicitly rejects non-schema component refs (`refs.py::resolve_shallow_ref` raises `UnsupportedSpecError`). Extending the resolver to inline `#/components/parameters/*` is ~40 LoC plus tests but lives in T1's scope, not T9's docs work. **Block on G0.7 quality if vi-json coverage is required for an early operator**; the canary covers `vcenter.yaml` alone today.
+
+### Gap 2 — T3 `llm_instructions` per-op enhancement
+
+Three of the 10 canary queries (`list virtual machines`, `power on virtual machine`, `power off virtual machine`) `xfail`. The drivers:
+
+- The vCenter spec's cardinal-op descriptions carry vendor-schema prose ("Vcenter.VM.FilterSpec", "Powers on a powered-off or suspended virtual machine") rather than natural-operator-language summaries.
+- T3's LLM-grouping pass produces per-group `when_to_use` hints but does **not** yet generate per-op `llm_instructions` or rewrite `summary`. Both would lift retrieval quality for cardinal ops with weak upstream descriptions.
+
+Resolution path: add a T3 enhancement pass that generates per-op `llm_instructions` from the spec body (one LLM call per op, batched), then re-bench. The `endpoint_descriptor.llm_instructions` column already exists ([G0.6-T1 #392](https://github.com/evoila/meho/issues/392)) so the storage shape is settled.
+
+### Gap 3 — live-LLM canary validation
+
+The G0.7 canary is currently stub-LLM-only — the acceptance test ships a deterministic path-prefix classifier so the suite stays reproducible and fast (~5 s ingest + ~1–2 s per benchmark query). A live-LLM variant gated on `MEHO_G07_CANARY_LIVE_LLM=1` is reserved for the day [Task #467](https://github.com/evoila/meho/issues/467) (Anthropic chassis adapter) lands. Once #467 ships, re-run the canary against harder queries (snapshot revert, performance-metrics query, host-network atomic mutation) that the path-prefix stub cannot trivially classify.
+
+## References
+
+- **Parent Initiative:** [#389 G0.7 Spec ingestion pipeline](https://github.com/evoila/meho/issues/389).
+- **Parent Goal:** [#221 G0 foundational substrate](https://github.com/evoila/meho/issues/221).
+- **Prerequisite tasks (all merged on `main`):** [#401 T1 parser](https://github.com/evoila/meho/issues/401); [#403 T2 register_ingested_operations](https://github.com/evoila/meho/issues/403); [#404 T3 LLM grouping](https://github.com/evoila/meho/issues/404); [#402 T4 review-queue state machine](https://github.com/evoila/meho/issues/402); [#405 T5 CLI verbs](https://github.com/evoila/meho/issues/405); [#406 T6 REST routes](https://github.com/evoila/meho/issues/406); [#407 T7 admin MCP tools](https://github.com/evoila/meho/issues/407); [#408 T8 vSphere canary](https://github.com/evoila/meho/issues/408).
+- **Companion Initiative:** [#388 G0.6 Operation registry + dispatcher](https://github.com/evoila/meho/issues/388) — the substrate this pipeline populates. See [operations-substrate.md](operations-substrate.md).
+- **Operator runbook:** [connector-ingestion.md](../cross-repo/connector-ingestion.md) — how to drive the pipeline end-to-end against a new vendor surface.
+- **vSphere canary runbook:** [g07-vsphere-canary.md](../cross-repo/g07-vsphere-canary.md) — the worked example operators reproduce locally.
+- **Codebase doc:** [docs/codebase/spec-ingestion.md](../codebase/spec-ingestion.md) — internal symbol-level map; updated in lock-step with code changes.
+- **CLAUDE.md postulates:** postulate 1 (two connector kinds, both first-class); postulate 4 (operation grouping + LLM hints, operator-reviewable); postulate 5 (agent surface is meta-tools).
+- **v0.1-spec anchors:** [§3 Operations L289–313](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/docs/meho-coordination/v0.1-spec.md) (auto-derive primary); [§4 JSONFlux](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/docs/meho-coordination/v0.1-spec.md) (set-shaped result discipline the dispatcher applies after this pipeline produces the operation).
+- **ADR:** [v0.2-decisions.md](../planning/v0.2-decisions.md) — locked architecture decisions.
+- **OpenAPI specifications:** [OpenAPI 3.0.3](https://spec.openapis.org/oas/v3.0.3.html); [OpenAPI 3.1.1](https://spec.openapis.org/oas/v3.1.1.html).
+- **Best-practices anchors:** `.claude/skills/implement-issue/ai_engineering_best_practices.md` (LLM prompt discipline, output-schema validation, operator-review gate before LLM-summarised content reaches agents); `.claude/skills/implement-issue/devops_best_practices.md` (architecture docs reflect shipped code; mermaid diagrams for control flow).

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -62,8 +62,27 @@ The pipeline is broken into work items per Initiative #389:
     `meho.connector.*` namespace and only `tenant_admin` operators
     (plus the two read tools at `operator` role) see them in
     `tools/list`.
-* **T8 — vSphere canary** — ingest both vCenter specs end-to-end.
-* **T9 — Docs.**
+* **T8 — vSphere canary** (`tests/acceptance/test_g07_vsphere_canary.py`).
+  Acceptance test that drives the full pipeline against the consumer's
+  vCenter REST spec (~1,275 ops): parse → register → group → review →
+  enable → 10-query govc-parity benchmark over `search_operations`.
+  Ships with `vcenter.yaml` only; `vi-json.yaml` ingestion is blocked
+  on a T1 parser extension for `#/components/parameters/*` (~40 LoC).
+  Three of 10 queries currently `xfail` pending a T3 per-op
+  `llm_instructions` enhancement. See the [vSphere canary
+  runbook](../cross-repo/g07-vsphere-canary.md) for the operator
+  procedure.
+* **T9 — Docs** (#409). Two new docs:
+  [docs/architecture/spec-ingestion.md](../architecture/spec-ingestion.md)
+  (canonical architecture reference) and
+  [docs/cross-repo/connector-ingestion.md](../cross-repo/connector-ingestion.md)
+  (operator runbook for adding a new vendor surface). Cross-link
+  updates to `connectors.md` correction header and this codebase
+  doc.
+
+All T1–T8 substrate work merged to `main` before T9 (#409); the
+pipeline is shipped and ready for per-G3.x consumer Initiatives
+to drive ingestion against their target vendor surfaces.
 
 T1 produces the proto shape every other stage consumes; T2 is the
 single write path into `endpoint_descriptor` for ingested rows; T3
@@ -467,8 +486,16 @@ operations go live.
 * Issue #405 — T5 task (CLI verbs).
 * Issue #406 — T6 task (REST routes; this module's HTTP surface).
 * Issue #407 — T7 task (admin MCP tools).
+* Issue #408 — T8 task (vSphere canary).
+* Issue #409 — T9 task (this doc + the architecture / operator-runbook pair).
 * Initiative #389 — G0.7 spec-ingestion pipeline.
 * Goal #221 — G0 foundational substrate.
+* [docs/architecture/spec-ingestion.md](../architecture/spec-ingestion.md) —
+  canonical architecture doc; companion to this codebase map.
+* [docs/cross-repo/connector-ingestion.md](../cross-repo/connector-ingestion.md) —
+  operator runbook for adding a new vendor surface end-to-end.
+* [docs/cross-repo/g07-vsphere-canary.md](../cross-repo/g07-vsphere-canary.md) —
+  the worked-example canary procedure operators reproduce locally.
 * `meho_backplane/db/models.py::EndpointDescriptor` — the ORM target.
 * `meho_backplane/operations/typed_register.py` — typed-connector
   parallel pathway; same body-hash skip-re-embed contract.

--- a/docs/cross-repo/README.md
+++ b/docs/cross-repo/README.md
@@ -51,10 +51,28 @@ If the cross-repo edge is a single comment in code or a single field in
 a values file, put the note next to the code instead. This directory is
 for the contracts substantial enough to need their own page.
 
+## Operator-facing runbooks (not handshakes — recipes)
+
+`docs/cross-repo/` also hosts the operator runbooks that span the
+consumer-MEHO boundary even when there's no protocol contract to spec
+— same audience (the operator deploying MEHO), same one-stop landing
+shape (prerequisites + step-by-step + rollback), no consumer-side
+implementation to track separately:
+
+| Doc | Purpose |
+| --- | --- |
+| [`broadcast-onboarding.md`](./broadcast-onboarding.md) | How to subscribe to the per-tenant Valkey broadcast stream from `meho status --watch`, an MCP client, or a custom downstream subscriber. |
+| [`connector-ingestion.md`](./connector-ingestion.md) | How to add a new vendor surface to MEHO via the G0.7 spec-ingestion pipeline — `meho connector ingest/review/edit/enable/disable`. Companion architecture: [`docs/architecture/spec-ingestion.md`](../architecture/spec-ingestion.md). |
+| [`g07-vsphere-canary.md`](./g07-vsphere-canary.md) | The worked-example canary procedure: ingest the vCenter REST spec, drive the operator workflow, run the 10-query govc-parity benchmark. |
+| [`mcp-client-setup.md`](./mcp-client-setup.md) | How to wire an MCP client (Claude.ai Custom Connector, MCP Inspector, Cline, Continue) to a running MEHO backplane, plus the Keycloak realm-side audience configuration. |
+
 ## Related
 
 - `docs/codebase/` — durable internal architecture docs (per area:
   backend, cli, devops). These describe what's inside `evoila/meho`;
   `cross-repo/` describes what crosses out of it.
+- `docs/architecture/` — canonical architecture references for shipped
+  substrates. The cross-repo runbooks above link to their architecture
+  companion when one exists.
 - Each handshake doc carries a status table that this README does not
   duplicate — drift between the two would be a bug.

--- a/docs/cross-repo/connector-ingestion.md
+++ b/docs/cross-repo/connector-ingestion.md
@@ -1,0 +1,323 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Adding a new vendor surface to MEHO — operator runbook
+
+> Operator-facing runbook for the G0.7 spec-ingestion pipeline. The architecture sits in [`docs/architecture/spec-ingestion.md`](../architecture/spec-ingestion.md); this doc is the cookbook every operator reads when standing up a new vendor connector from an OpenAPI spec.
+
+## When to use this
+
+You want operators on a tenant to dispatch operations against a vendor API that isn't yet a MEHO connector, and the vendor publishes an OpenAPI 3.0/3.1 spec. The ingestion pipeline parses the spec, computes embeddings, asks an LLM to propose 8–15 operation groups with `when_to_use` hints, and stages the result for your review before any operation becomes dispatchable.
+
+**Use the typed-connector runbook instead** when:
+
+- The vendor publishes no usable OpenAPI spec (SSH-only, raw SOAP, proto/gRPC).
+- The spec is published but materially incomplete (legacy `pyvmomi`-only ops).
+- A higher-level composite is the right agent UX (e.g. "create a VM end-to-end with networking attached").
+
+Typed connectors and ingested connectors are both first-class ([CLAUDE.md](../../CLAUDE.md) postulate 1) — same `endpoint_descriptor` table, same dispatcher, same agent meta-tools. The choice between them is driven by spec availability, not by preference.
+
+## Prerequisites
+
+- **Role.** Write verbs (`ingest`, `edit-group`, `edit-op`, `enable`, `disable`) require `tenant_admin`. Read verbs (`list`, `review`) require `operator`. The backplane returns HTTP 403 with the CLI exit code 5 if the wrong role tries a write verb.
+- **A running backplane.** `meho login <backplane-url>` writes a session token the CLI reuses across every verb. Override per-call with `--backplane <url>` when needed.
+- **The OpenAPI spec.** A path to a local file (`file:///abs/path/spec.yaml`) or an HTTPS URL the backplane can fetch (`https://vendor.example.com/openapi.yaml`). The CLI also accepts the `docs:<product>-<version>/<spec>.yaml` shorthand that resolves against `$CLAUDE_RDC_DOCS` when set; otherwise the shorthand is passed through for the backplane to resolve against its own checked-in docs corpus.
+- **An LLM client configured for the grouping pass.** Production deploys wire the Anthropic Messages-API adapter via [`IngestionPipelineService(..., llm_client_factory=...)`](../../backend/src/meho_backplane/operations/ingest/pipeline.py). If the adapter is unwired, the ingest REST route returns HTTP 503 `LlmClientUnavailable` and the CLI prints the structured error.
+- **Postgres with pgvector + FTS extensions.** v0.2 ships the `pgvector/pgvector:pg16`-derived chart image; local development uses the testcontainers fixture.
+
+## Step-by-step
+
+The workflow walks the [five-step pipeline](../architecture/spec-ingestion.md#the-five-step-pipeline) in operator-visible order: ingest → review → polish → enable → verify.
+
+### Step 1 — find the spec
+
+Vendor specs live in one of three places, in priority order:
+
+1. **The consumer's checked-in docs corpus** (e.g. `claude-rdc-hetzner-dc/docs/<product>-<version>/`). The maintainer's local clone is the conventional source. Use the `docs:<product>-<version>/<spec>.yaml` shorthand when this applies.
+2. **The vendor's published URL** (e.g. `https://developer.vmware.com/.../vcenter-rest-9.0.yaml`). Use a full `https://` URL.
+3. **A local download.** Use a full `file:///` path.
+
+Validate the spec before committing to a tenant-wide ingestion:
+
+```bash
+meho connector ingest \
+  --product <product> --version <version> --impl <impl> \
+  --spec <spec-uri> \
+  --dry-run
+```
+
+`--dry-run` parses each spec, surfaces parser-rejected `$ref` shapes, and returns the bulk-upsert plan **without** writing to the DB or making any LLM calls. The CLI prints inserted/updated/skipped counts so you can sanity-check that the parser found roughly the operation count the vendor advertises.
+
+### Step 2 — ingest the spec
+
+```bash
+meho connector ingest \
+  --product vmware --version 9.0 --impl vmware-rest \
+  --spec docs:vcenter-9.0/vcenter.yaml \
+  --json
+```
+
+The connector lands `review_status='staged'` with every operation `is_enabled=false`. The expected human-readable output:
+
+```
+ingest vmware/9.0/vmware-rest — connector_id=vmware-rest-9.0
+  operations: 1275 total (1275 inserted / 0 updated / 0 skipped)
+  connector_registered: true (first ingest of this triple flips it to true)
+  operations_grouped: true
+  grouping: 8 groups, 1100 ops assigned, 175 unassigned (27 LLM call(s), 45000ms)
+
+Connector is in review_status=staged. Next:
+  meho connector review vmware-rest-9.0
+  meho connector enable vmware-rest-9.0 --confirm
+```
+
+The LLM-call cost follows the formula `1 + ceil(op_count / batch_size)` (1 Pass-1 + N Pass-2 batches, default `batch_size=50`).
+
+### Step 3 — multi-spec ingest
+
+When one product publishes multiple specs that need to land under the same connector triple (vSphere's `vcenter.yaml` + `vi-json.yaml` is the canonical case), repeat `--spec`:
+
+```bash
+meho connector ingest \
+  --product vmware --version 9.0 --impl vmware-rest \
+  --spec docs:vcenter-9.0/vcenter.yaml \
+  --spec docs:vcenter-9.0/vi-json.yaml \
+  --json
+```
+
+Every row from the first spec carries a `spec:vcenter.yaml` tag; every row from the second carries `spec:vi-json.yaml`. The review payload (Step 4) renders the source tag so you can audit per spec.
+
+> **Caveat — vi-json blocked on a T1 parser extension.** The T1 parser currently rejects `$ref: "#/components/parameters/moId"`, which appears on every `vi-json.yaml` operation. The vSphere canary ([#408](https://github.com/evoila/meho/issues/408)) ships with `vcenter.yaml` only. Multi-spec ingest works end-to-end the moment the parser gains a `#/components/parameters/*` resolver (see [Known gaps](#known-gaps) below). Until then, run the second spec only against a parser branch that resolves non-schema component refs.
+
+### Step 4 — review the LLM-summarised groups
+
+```bash
+meho connector review vmware-rest-9.0
+```
+
+The review payload renders:
+
+- Every `operation_group` row (`group_key`, `name`, `when_to_use`, `review_status`).
+- Per-group operation count.
+- Per-op flags (`safety_level`, `requires_approval`, `is_enabled`, the parser-set vs operator-set distinction for each).
+- The `spec:<source>` tag distribution when multi-spec.
+
+Inspect each group's `when_to_use` carefully — this is the verbatim text the agent reads before deciding which group to search within. A `when_to_use` like "Use these operations for VM lifecycle workflows: list, inspect, power on/off, clone, snapshot, migrate" is actionable; "Operations related to virtual machines" is not.
+
+Use `--json` for machine-readable output suited to scripted post-processing (e.g. diffing the LLM's groups against a hand-curated reference).
+
+### Step 5 — polish weak group hints
+
+```bash
+meho connector edit-group vmware-rest-9.0 vm \
+  --when-to-use "Use these operations for any virtual-machine workflow: list, inspect, power on/off, clone, snapshot, migrate, or otherwise manage a VM."
+```
+
+Inline text up to ~2 KB works directly on the command line. For longer prose, use the `@<path>` form:
+
+```bash
+meho connector edit-group vmware-rest-9.0 storage --when-to-use @/tmp/storage_when_to_use.md
+```
+
+`edit-group` also accepts `--name` to override the LLM's group display name. Each edit writes a `meho.connector.edit_group` audit row in the same transaction as the column update so [G8 audit replay](https://github.com/evoila/meho/issues/218) can reconstruct exactly which operator polished which group at which time.
+
+Most operators polish 2–4 groups per ingest; the LLM's output is usable for the rest.
+
+### Step 6 — mark per-op safety overrides
+
+The parser defaults `DELETE` verbs to `safety_level='dangerous'` but leaves `requires_approval=false`. Flip `requires_approval` on any op whose execution should block on the approval queue:
+
+```bash
+meho connector edit-op vmware-rest-9.0 'DELETE:/vcenter/vm/{vm}' \
+  --safety dangerous --requires-approval
+```
+
+Other per-op overrides:
+
+```bash
+# Replace the agent-facing description (operator wins over vendor prose).
+meho connector edit-op vmware-rest-9.0 'POST:/vcenter/vm/{vm}/power?action=start' \
+  --custom-description @/tmp/vm_power_on_description.md
+
+# Re-enable a single op the connector was disabled with.
+meho connector edit-op vmware-rest-9.0 'GET:/vcenter/cluster' --enable
+
+# Disable a single op without disabling the whole connector.
+meho connector edit-op vmware-rest-9.0 'POST:/vcenter/legacy/deprecated-thing' --disable
+```
+
+`edit-op` requires at least one of `--custom-description`, `--safety`, `--requires-approval`, `--no-requires-approval`, `--enable`, `--disable`. An empty PATCH yields HTTP 400.
+
+Each edit writes a single `meho.connector.edit_op` audit row.
+
+### Step 7 — enable the connector
+
+```bash
+meho connector enable vmware-rest-9.0 --confirm
+```
+
+`enable` cascades every group to `review_status='enabled'` and every op to `is_enabled=true`. After this step:
+
+- The connector appears in `search_connectors` for every operator in the tenant.
+- Operations become dispatchable through `call_operation`.
+- The agent's `search_operations(connector_id="vmware-rest-9.0", query=...)` returns ranked results from the enabled rows.
+
+Without `--confirm`, the CLI prompts on stdin for `y/yes` — `--confirm` skips the prompt for scripted use (CI pipelines, etc.).
+
+### Step 8 — verify the agent path
+
+```bash
+meho operation groups vmware-rest-9.0
+meho operation search vmware-rest-9.0 "list virtual machines" --limit 10
+```
+
+The first command returns the 8–15 enabled groups with their `when_to_use` hints. The second returns ranked hits — the load-bearing acceptance bar from the vSphere canary is "the canonical operation appears in the top-3". See the canary's [10 (query, canonical-op) pairs](g07-vsphere-canary.md#test-variant) for the working examples.
+
+To verify dispatch end-to-end against a real target:
+
+```bash
+meho operation call vmware-rest-9.0 'GET:/vcenter/cluster' \
+  --target rdc-vcenter --json
+```
+
+The `--target` argument resolves against the tenant's [Target rows](targets-yaml.md); the call needs a reachable vCenter endpoint (a `vcsim` simulator suffices for read operations).
+
+## Rollback / disable
+
+```bash
+meho connector disable vmware-rest-9.0 --confirm
+```
+
+`disable` flips every group to `review_status='disabled'` and every op to `is_enabled=false`. The agent meta-tools stop surfacing the connector immediately; no in-flight dispatches will route to it.
+
+**Per-op operator overrides are preserved** (`custom_description`, `safety_level`, `requires_approval`) so a future `enable` resurfaces them verbatim. There is no `delete` verb — the rollback is reversible without losing operator work.
+
+The audit trail (`meho.connector.disable` row + the prior `meho.connector.enable` row) is sufficient to reconstruct what happened.
+
+After fix → re-run `meho connector ingest` against the corrected spec. T2's body-hash idempotence skips re-embedding rows whose parser output didn't change; only the changed rows take an embedding hit. After `review` + `enable`, the agent path re-warms.
+
+## Common operator gotchas
+
+### `op_id` carries `:` and `/`
+
+Operation natural keys for ingested rows look like `"GET:/api/vcenter/cluster"` — a method, a colon, and the OpenAPI path. The colon and slashes are part of the key.
+
+**In CLI commands**, quote the `op_id` to keep the shell from interpreting characters:
+
+```bash
+meho connector edit-op vmware-rest-9.0 'DELETE:/vcenter/vm/{vm}' --safety dangerous
+```
+
+**In REST calls**, the route uses FastAPI's `:path` converter so the full segment round-trips intact:
+
+```bash
+curl -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"safety_level": "dangerous"}' \
+  "https://meho.example.com/api/v1/connectors/vmware-rest-9.0/operations/DELETE:/vcenter/vm/{vm}"
+```
+
+URL-encoding the colon as `%3A` works but isn't required.
+
+### Multi-spec collisions
+
+If two specs publish the same `(method, path)` under the same connector triple, T2's per-row cross-call check raises `OpIdCollision` with both spec sources named:
+
+```
+OpIdCollision: 'GET:/vcenter/vm' already registered with spec_source='vcenter.yaml'; this call uses spec_source='vi-json.yaml'
+```
+
+The operator decides which spec wins. Re-running `ingest` with only the chosen spec for that op is one path; bumping `impl_id` to keep both as separate connectors is another.
+
+### Dry-run before committing
+
+Always pass `--dry-run` on the first ingest of a new spec. It surfaces parser-rejected `$ref` shapes, OpenAPI-version rejections, and per-spec op counts before any DB write or LLM call. Production ingests where the operator skipped `--dry-run` and the parser rejected the spec halfway through have walked back through `meho connector disable` more often than they should.
+
+### Tenant scope is JWT-derived
+
+There is no `--tenant` flag. The tenant the connector lands under derives from the JWT's `tenant_id` claim; cross-tenant probes surface as HTTP 404 `ConnectorNotFoundError`, not 403. Use a different login (different tenant_admin operator) to drive ingestion in a different tenant.
+
+### `--confirm` is required for `enable` and `disable`
+
+Both state-transition verbs prompt on stdin by default. CI pipelines and scripted operators pass `--confirm` to skip the prompt. The prompt is intentional — these verbs change every operator's view of the connector, and the consequence of an accidental enable on a partially-reviewed connector is dispatching against operations whose `safety_level` and `requires_approval` haven't been audited.
+
+### JSON output for everything
+
+Every read verb (`list`, `review`) accepts `--json`. Every write verb supporting `--json` emits the canonical response shape so scripted post-processing has a stable contract. Without `--json`, the CLI renders a human-readable summary.
+
+### `--backplane` overrides `meho login`
+
+By default the CLI reads the backplane URL from the most recent `meho login` session file. Pass `--backplane https://other.example.com` to point one call at a different deploy without re-logging-in.
+
+## RBAC notes
+
+The pipeline ships two roles. Both are realm roles on the Keycloak side; the chassis maps the realm role onto the `TenantRole` Python enum via [`auth.rbac`](../../backend/src/meho_backplane/auth/rbac.py).
+
+| Role | Sees | Can do |
+|---|---|---|
+| `operator` | `list_connectors`, `review_payload` for connectors in their tenant | Read-only. Cannot ingest, edit, enable, or disable. |
+| `tenant_admin` | Everything `operator` sees, plus every administrative MCP tool under `meho.connector.*` | Full ingest → review → enable → disable workflow. |
+
+Read paths require `operator`; write paths require `tenant_admin`. The REST router enforces this via FastAPI's `Depends(require_role(...))`; the admin MCP tools enforce it via the registry's `required_role` filter on `tools/list` plus a second-pass check in `handle_tools_call` so a client that guesses a hidden tool name is still rejected.
+
+**No cross-tenant write access.** The JWT carries exactly one `tenant_id`; the tenant the operator's session is bound to is the tenant the write lands under. A platform admin needing to drive ingestion across multiple tenants logs in once per tenant.
+
+## Known gaps
+
+Documented inline pending formal Task filing. The vSphere canary (see [g07-vsphere-canary.md](g07-vsphere-canary.md)) is the test bed that surfaced each.
+
+### Gap 1 — T1 `$ref` extension for `vi-json.yaml`
+
+**Status:** documented; no Task filed yet.
+
+The T1 parser rejects `$ref: "#/components/parameters/<name>"`. vSphere's `vi-json.yaml` references `#/components/parameters/moId` on every operation (~2,195 operations). The fix is small (~40 LoC in [`refs.py::_resolve_shallow_ref`](../../backend/src/meho_backplane/operations/ingest/refs.py) plus tests for the three additional ref shapes: `parameters`, `requestBodies`, `headers`) but the work belongs in T1's scope, not in T9's docs work.
+
+**File a Task** when an early operator needs vi-json coverage — e.g. when a govc-style workflow that fundamentally needs Performance Manager (`govc events`), snapshot revert (`govc snapshot.revert`), or host network atomic mutation (`govc host.evac`) becomes a blocker.
+
+### Gap 2 — T3 per-op `llm_instructions` enhancement
+
+**Status:** documented; no Task filed yet.
+
+The vSphere canary's 10-query benchmark currently `xfail`s on 3 queries:
+
+- `list virtual machines`
+- `power on virtual machine`
+- `power off virtual machine`
+
+The driver is description quality, not pipeline correctness. The vCenter spec's cardinal-op descriptions ("Vcenter.VM.FilterSpec", "Powers on a powered-off or suspended virtual machine") under-rank against sub-path operations that score higher on the BM25 + cosine fusion. T3's grouping pass produces per-group `when_to_use` hints but does NOT yet generate per-op `llm_instructions` or rewrite `summary`.
+
+Resolution path: extend T3 with a per-op `llm_instructions` generation pass that produces operator-friendly prose from the spec body, then re-bench. The `endpoint_descriptor.llm_instructions` column already exists ([G0.6-T1 #392](https://github.com/evoila/meho/issues/392)) so no schema work is needed.
+
+**File a Task** when the v0.2 retrieval-quality bar gates a downstream consumer.
+
+### Gap 3 — live-LLM canary validation
+
+**Status:** documented; gated on [Task #467](https://github.com/evoila/meho/issues/467).
+
+The canary's acceptance test ships a deterministic stub-LLM that classifies ops by URL-path prefix. The stub keeps the test reproducible and fast but doesn't exercise the production Anthropic adapter's prompt-engineering or retry-policy edges.
+
+A live-LLM variant exists at `MEHO_G07_CANARY_LIVE_LLM=1` but currently skips because [Task #467](https://github.com/evoila/meho/issues/467) (Anthropic chassis adapter) hasn't landed. Once #467 ships:
+
+1. Re-run the canary with the env var set.
+2. Pick harder queries the path-prefix stub can't trivially classify — snapshot revert, performance-metrics query, host-network atomic mutation.
+3. Compare top-3 hit rate against the stub baseline to verify the live LLM doesn't regress retrieval quality.
+
+**File a Task** in #467's wake; do not block #467 on it.
+
+## References
+
+- **Architecture doc:** [`docs/architecture/spec-ingestion.md`](../architecture/spec-ingestion.md) — the canonical reference for the pipeline's design.
+- **Sister architecture doc:** [`docs/architecture/operations-substrate.md`](../architecture/operations-substrate.md) — G0.6's substrate this pipeline writes into.
+- **vSphere canary runbook:** [`g07-vsphere-canary.md`](g07-vsphere-canary.md) — the worked example operators reproduce locally.
+- **Internal codebase map:** [`docs/codebase/spec-ingestion.md`](../codebase/spec-ingestion.md) — symbol-level map of `backend/src/meho_backplane/operations/ingest/`.
+- **CLAUDE.md postulates:** postulate 1 (two connector kinds, both first-class); postulate 4 (operation grouping + LLM hints, operator-reviewable); postulate 5 (agent surface is meta-tools).
+- **Parent Initiative:** [#389 G0.7 Spec ingestion pipeline](https://github.com/evoila/meho/issues/389).
+- **Parent Goal:** [#221 G0 foundational substrate](https://github.com/evoila/meho/issues/221).
+- **CLI source:** [`cli/internal/cmd/connector/`](../../cli/internal/cmd/connector/).
+- **Backend source:** [`backend/src/meho_backplane/operations/ingest/`](../../backend/src/meho_backplane/operations/ingest/).
+- **REST router:** [`backend/src/meho_backplane/api/v1/connectors_ingest.py`](../../backend/src/meho_backplane/api/v1/connectors_ingest.py).
+- **Admin MCP tools:** [`backend/src/meho_backplane/mcp/tools/connector_admin.py`](../../backend/src/meho_backplane/mcp/tools/connector_admin.py).
+- **OpenAPI specs:** [3.0.3](https://spec.openapis.org/oas/v3.0.3.html); [3.1.1](https://spec.openapis.org/oas/v3.1.1.html).


### PR DESCRIPTION
## Summary

- Ships the G0.7-T9 docs pair now that T1–T8 are merged: a canonical architecture doc at `docs/architecture/spec-ingestion.md` and an operator runbook at `docs/cross-repo/connector-ingestion.md`.
- Architecture doc covers the five-step pipeline (parse → register → group → review → verify), every load-bearing T1–T7 symbol with codebase links, the `1 + ceil(N/50)` LLM call-budget formula, the `staged → enabled → disabled` state machine, the three operator surfaces (CLI / REST / admin MCP), the vSphere canary's role as verification, anti-patterns enforcing CLAUDE.md postulates 4–5, and a Future work section.
- Runbook walks the operator end-to-end: prereqs → find spec → dry-run → multi-spec ingest → review → polish hints → per-op safety overrides → enable → verify → rollback. Plus an RBAC table, a Common gotchas section, and a Known gaps section documenting the three follow-ups inline.
- Cross-link updates: `docs/architecture/connectors.md` correction header now points the #389 bullet at the new architecture doc; `docs/codebase/spec-ingestion.md` flips T8 + T9 status from "in flight" to "shipped" and cross-links the operator runbook; `docs/cross-repo/README.md` adds an "Operator-facing runbooks" section listing the new doc alongside the three existing operator runbooks.

## Test plan

- [x] `pre-commit run --files <all 5 docs>` — every hook passes (trailing whitespace, EOF, gitleaks, conventional-commits).
- [x] `code-quality.py --diff` — passes (no Python/Go code touched).
- [x] Every named function/type/route in the docs maps to a real symbol — verified against the merged T1–T7 PRs (#401, #403, #404, #402, #486, #488, #487) and the T8 canary (#493).
- [x] Mermaid pipeline diagram matches the implemented flow (`IngestionPipelineService` → `parse_openapi` → `register_ingested_operations` → `run_llm_grouping` → `ReviewService`).
- [x] All in-document anchor links resolve (`#operator-surfaces`, `#future-work`, `#known-gaps`).
- [x] Cross-doc links resolve to real headings (`operations-substrate.md#search_operationsconnector_id-query-groupnone-limit10`, `g07-vsphere-canary.md#test-variant`).
- [x] Doc structure matches Initiative #389's "10. Docs" outline.

## Follow-ups documented inline

The vSphere canary surfaced three real gaps. All three are documented in the runbook's Known gaps section and in the architecture doc's Future work section — **not filed as separate GitHub Tasks yet**, with the rationale that the docs PR shouldn't carry scope creep and the orchestrator (or operator) can file them when they become consumer blockers:

1. **T1 `$ref` extension for `vi-json.yaml`** — ~40 LoC parser extension to resolve `#/components/parameters/*`. Blocks vi-json ingestion (~2,195 ops). File a Task when an early operator needs Performance Manager, snapshot revert, or host network atomic mutation coverage.
2. **T3 per-op `llm_instructions` enhancement** — generate operator-friendly prose from spec body to lift retrieval quality on cardinal ops with vendor-schema-heavy descriptions. Resolves the 3 currently-`xfail`ed canary queries. File a Task when the v0.2 retrieval-quality bar gates a downstream consumer.
3. **Live-LLM canary validation** — re-run the canary with `MEHO_G07_CANARY_LIVE_LLM=1` once Task #467 (Anthropic chassis adapter) lands; pick harder queries the path-prefix stub can't trivially classify. File a Task in #467's wake.

## Out of scope

- Filing follow-up Tasks for the three gaps above (documented inline; orchestrator/operator files when blocked).
- Goal #221 checklist tick for "G0.7 Spec ingestion pipeline" — Goal #221 body lives on `evoila-bosnia/meho-internal` project 19; this PR has no cross-repo write access. Note for the orchestrator to tick on merge.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a full architecture reference for the G0.7 spec-ingestion pipeline and updated connector architecture links.
  * Added a detailed spec-ingestion doc describing end-to-end ingestion, grouping, review, and canary expectations.
  * Added an operator runbook for connector ingestion with step-by-step procedures, prerequisites, RBAC notes, and known gaps.
  * Enhanced cross-repo README to list operator-facing runbooks and link to the new docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/495)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->