### PR TITLE
feat(audit): G8.1-T2 audit-query REST surface — POST /query + GET who-touched / my-recent / show

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,15 @@ jobs:
     # so no step ever starts on a fork PR.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: meho-runners
-    timeout-minutes: 10
+    # 20-min cap: the pytest suite now actually completes (the
+    # integration TRUNCATE fix one commit earlier unblocked the
+    # tests/integration/* subtree that previously failed fast at
+    # setup), so the budget is wall-clock for the full unit-plus-
+    # integration sweep + uv sync + coverage emit, not for a
+    # short-circuit-on-first-failure run. Run 25910787068 cancelled
+    # at 49% through unit tests under the old 10-min cap; doubling
+    # gives headroom for moderate suite growth.
+    timeout-minutes: 20
     defaults:
       run:
         # backend/ is the only Python project today; pyproject.toml

--- a/backend/src/meho_backplane/api/v1/audit.py
+++ b/backend/src/meho_backplane/api/v1/audit.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/audit/*`` — REST surface for the audit-query substrate (G8.1-T2).
+
+Mounts four routes, all of which dispatch through the T1
+:func:`~meho_backplane.audit_query.query_audit` handler:
+
+* ``POST /api/v1/audit/query`` — full filter; body is
+  :class:`~meho_backplane.api.v1.audit_models.AuditQueryRequest`.
+* ``GET /api/v1/audit/who-touched/{target}`` — pre-canned shortcut
+  bound to ``target=<path>``.
+* ``GET /api/v1/audit/my-recent`` — pre-canned shortcut bound to
+  ``principal=<operator.sub>``.
+* ``GET /api/v1/audit/show/{audit_id}`` — single-row fetch. 404 (not
+  403) when the audit row is not in the operator's tenant, so the
+  route never leaks the existence of an audit row across tenants.
+
+Tenant scoping
+==============
+
+Every route passes ``operator.tenant_id`` (lifted from the JWT by
+:func:`~meho_backplane.auth.rbac.require_role`) to ``query_audit`` as
+the mandatory keyword-only ``tenant_id`` argument. Client-supplied
+``tenant_id`` in the POST body is silently dropped — Pydantic v2's
+default ``extra="ignore"`` policy means a field absent from
+:class:`AuditQueryRequest` never reaches the router. Cross-tenant
+queries are impossible by construction.
+
+Audit-on-audit-query (decision #3, ``docs/planning/v0.2-decisions.md``)
+======================================================================
+
+Every route binds two audit-override contextvars before calling
+``query_audit`` so the row this request writes (via the chassis
+:class:`~meho_backplane.audit.AuditMiddleware`) carries the canonical
+audit-query identity:
+
+* ``audit_op_id = "meho.audit.query"`` — every audit-query call,
+  regardless of which of the four routes the operator hit, writes
+  under this canonical op_id. Operators querying ``audit_log`` for
+  "everyone who used the audit-query surface" filter on
+  ``payload->>'op_id' = 'meho.audit.query'``.
+* ``audit_op_class = "audit_query"`` — flips the broadcast event into
+  aggregate-only mode per
+  :func:`~meho_backplane.broadcast.events.classify_op` policy: SSE feed
+  + Slack subscribers see ``{op_id, result_status, row_count}`` only,
+  never the request filter contents. Audit-query filter shapes encode
+  the investigation target and the investigator's hunch — both are
+  privacy-sensitive.
+
+``audit_row_count`` is bound after ``query_audit`` returns so the
+broadcast event's row-count field reflects the actual returned
+cardinality.
+
+RBAC
+====
+
+All four routes require ``operator`` role minimum
+(:class:`~meho_backplane.auth.operator.TenantRole.OPERATOR`).
+``read_only`` gets 403; ``tenant_admin`` gets 200. The shape mirrors
+:mod:`~meho_backplane.api.v1.retrieve` and
+:mod:`~meho_backplane.api.v1.retrieve_usage`.
+
+Error mapping
+=============
+
+* :class:`~meho_backplane.audit_query.DurationParseError`
+  (``since`` / ``until`` shorthand) → 400 with the parser's message.
+* :class:`~meho_backplane.audit_query.InvalidCursorError` (tampered
+  cursor) → 400 with the substrate's message.
+* :class:`~meho_backplane.audit_query.UnsupportedFilterError`
+  (``parent_audit_id`` / ``agent_session_id`` in v0.2) → 400 with the
+  column-name message from the substrate.
+
+Other exceptions propagate; the chassis middleware turns them into 500.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Final
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from meho_backplane.api.v1.audit_models import AuditQueryRequest
+from meho_backplane.audit_query import (
+    AuditEntry,
+    AuditQueryFilters,
+    AuditQueryResult,
+    DurationParseError,
+    InvalidCursorError,
+    UnsupportedFilterError,
+    parse_duration,
+    query_audit,
+)
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.db.engine import get_sessionmaker
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1/audit", tags=["audit"])
+
+#: Module-level :class:`Depends` closure for the routes' RBAC gate.
+#: Built once at import time to satisfy ruff's B008 rule, matching the
+#: convention :mod:`~meho_backplane.api.v1.retrieve_usage` established.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+
+#: Canonical op_id every audit-query call (POST + 3 GET shortcuts) emits
+#: via the ``audit_op_id`` contextvar override honoured by
+#: :func:`~meho_backplane.audit._publish_broadcast_event`. The companion
+#: ``op_class="audit_query"`` flips the broadcast event into aggregate-
+#: only mode.
+_AUDIT_QUERY_OP_ID: Final[str] = "meho.audit.query"
+
+#: Default ``since`` for the two duration-shorthand GET routes. 24
+#: hours matches the issue body's default and the chassis's general
+#: "what happened today" framing.
+_DEFAULT_SINCE: Final[str] = "24h"
+
+
+def _bind_audit_overrides() -> None:
+    """Bind the audit-override contextvars BEFORE the substrate call.
+
+    Binding early — i.e. before :func:`query_audit` runs — means a
+    handler exception still produces an audit row carrying the
+    correct ``op_id`` / ``op_class``; the row-count is bound after
+    success because a partial query never produced rows. Mirrors
+    :func:`~meho_backplane.api.v1.retrieve_usage._bind_request_audit_context`.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_AUDIT_QUERY_OP_ID,
+        audit_op_class="audit_query",
+    )
+
+
+async def _dispatch(
+    filters: AuditQueryFilters,
+    *,
+    tenant_id: uuid.UUID,
+) -> AuditQueryResult:
+    """Acquire a session, call :func:`query_audit`, bind ``audit_row_count``.
+
+    Centralises the substrate dispatch so each route handler stays
+    focused on filter construction. Maps the substrate's operator-
+    facing validation errors (:class:`InvalidCursorError`,
+    :class:`UnsupportedFilterError`) to 400 — other exceptions
+    propagate and the chassis turns them into 500.
+    """
+    sessionmaker = get_sessionmaker()
+    try:
+        async with sessionmaker() as session:
+            result = await query_audit(filters, tenant_id=tenant_id, session=session)
+    except (InvalidCursorError, UnsupportedFilterError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Row count flows into the broadcast event's ``row_count`` field
+    # via ``audit_row_count`` (per ``broadcast/events.py::_maybe_row_count``),
+    # giving SSE / Slack subscribers an aggregate signal without
+    # revealing the request filter or the matched audit rows.
+    structlog.contextvars.bind_contextvars(audit_row_count=len(result.rows))
+    return result
+
+
+@router.post("/query", response_model=AuditQueryResult)
+async def query(
+    body: AuditQueryRequest,
+    operator: Operator = _require_operator,
+) -> AuditQueryResult:
+    """Run a tenant-scoped audit query with arbitrary filter combinations.
+
+    Body fields mirror :class:`AuditQueryFilters` except ``since`` /
+    ``until`` are duration strings (``"24h"`` / ``"7d"`` / ISO-8601)
+    parsed at the router layer. Client-supplied ``tenant_id`` in the
+    body is silently dropped per Pydantic v2's default
+    ``extra="ignore"``; the route always passes
+    ``operator.tenant_id`` to the substrate.
+    """
+    _bind_audit_overrides()
+    now = datetime.now(UTC)
+    try:
+        since = parse_duration(body.since, now=now) if body.since is not None else None
+        until = parse_duration(body.until, now=now) if body.until is not None else None
+    except DurationParseError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    filters = AuditQueryFilters(
+        target=body.target,
+        principal=body.principal,
+        op_id=body.op_id,
+        op_class=body.op_class,
+        result_status=body.result_status,
+        since=since,
+        until=until,
+        audit_id=body.audit_id,
+        parent_audit_id=body.parent_audit_id,
+        agent_session_id=body.agent_session_id,
+        limit=body.limit,
+        cursor=body.cursor,
+    )
+    return await _dispatch(filters, tenant_id=operator.tenant_id)
+
+
+@router.get("/who-touched/{target}", response_model=AuditQueryResult)
+async def who_touched(
+    target: str,
+    since: str = Query(default=_DEFAULT_SINCE, max_length=32),
+    limit: int = Query(default=100, ge=1, le=1000),
+    operator: Operator = _require_operator,
+) -> AuditQueryResult:
+    """Audit rows that touched *target* within the *since* window.
+
+    Pre-canned shortcut over :func:`query_audit` with the ``target``
+    filter bound to the path param. The substrate matches *target*
+    against the ``targets`` table scoped to the operator's tenant; a
+    non-matching name returns an empty result, never an error.
+    """
+    _bind_audit_overrides()
+    now = datetime.now(UTC)
+    try:
+        since_dt = parse_duration(since, now=now)
+    except DurationParseError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    filters = AuditQueryFilters(target=target, since=since_dt, limit=limit)
+    return await _dispatch(filters, tenant_id=operator.tenant_id)
+
+
+@router.get("/my-recent", response_model=AuditQueryResult)
+async def my_recent(
+    since: str = Query(default=_DEFAULT_SINCE, max_length=32),
+    limit: int = Query(default=100, ge=1, le=1000),
+    operator: Operator = _require_operator,
+) -> AuditQueryResult:
+    """Audit rows the calling operator produced within the *since* window.
+
+    Principal is taken from ``operator.sub`` (the JWT subject); an
+    operator cannot see another operator's recent activity through
+    this route — for that, the full POST surface filters on
+    ``principal``.
+    """
+    _bind_audit_overrides()
+    now = datetime.now(UTC)
+    try:
+        since_dt = parse_duration(since, now=now)
+    except DurationParseError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    filters = AuditQueryFilters(principal=operator.sub, since=since_dt, limit=limit)
+    return await _dispatch(filters, tenant_id=operator.tenant_id)
+
+
+@router.get("/show/{audit_id}", response_model=AuditEntry)
+async def show(
+    audit_id: uuid.UUID,
+    operator: Operator = _require_operator,
+) -> AuditEntry:
+    """Fetch a single audit row by id, scoped to the operator's tenant.
+
+    Cross-tenant probe semantics: the substrate's first WHERE clause
+    is always ``tenant_id = operator.tenant_id``, so a request for an
+    ``audit_id`` that exists but belongs to another tenant returns
+    zero rows. The route then surfaces 404 — never 403 — so a probing
+    operator cannot distinguish "row doesn't exist" from "row belongs
+    to another tenant".
+    """
+    _bind_audit_overrides()
+    filters = AuditQueryFilters(audit_id=audit_id, limit=1)
+    result = await _dispatch(filters, tenant_id=operator.tenant_id)
+    if not result.rows:
+        raise HTTPException(status_code=404, detail="audit row not found")
+    return result.rows[0]

--- a/backend/src/meho_backplane/api/v1/audit_models.py
+++ b/backend/src/meho_backplane/api/v1/audit_models.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Request/response models for the audit-query REST surface (G8.1-T2).
+
+The single non-trivial model is :class:`AuditQueryRequest` — the POST
+body for ``/api/v1/audit/query``. It mirrors
+:class:`~meho_backplane.audit_query.AuditQueryFilters` from the T1
+substrate but accepts ``since`` / ``until`` as strings so operators can
+pass shorthand (``"24h"`` / ``"7d"``) instead of ISO-8601. The router
+converts them via :func:`~meho_backplane.audit_query.parse_duration`
+before dispatch.
+
+The response models (:class:`AuditEntry` / :class:`AuditQueryResult`)
+are re-exported from the substrate without modification so OpenAPI
+surfaces them under the audit-query tag without duplicating the schema.
+
+Tenant scoping by construction
+==============================
+
+:class:`AuditQueryRequest` deliberately has **no** ``tenant_id`` field.
+Pydantic v2's default ``extra="ignore"`` policy means a client that
+puts ``tenant_id`` in the body has the value silently dropped; the
+router never reads from the body for the tenant boundary — it injects
+``operator.tenant_id`` from the JWT into the T1 handler call. The
+substrate's mandatory keyword-only ``tenant_id`` argument enforces the
+invariant on its side.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from meho_backplane.audit_query import AuditEntry, AuditQueryResult
+
+__all__ = [
+    "AuditEntry",
+    "AuditQueryRequest",
+    "AuditQueryResult",
+]
+
+
+class AuditQueryRequest(BaseModel):
+    """POST body for ``/api/v1/audit/query``.
+
+    Mirrors :class:`~meho_backplane.audit_query.AuditQueryFilters`
+    except ``since`` / ``until`` are strings parsed by
+    :func:`~meho_backplane.audit_query.parse_duration` at the router
+    layer. All other fields pass through to the substrate filter
+    object unchanged. The empty body shape ``{}`` is the no-filter
+    case — every field defaults to None or the substrate-side default.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    target: str | None = Field(default=None, max_length=256)
+    principal: str | None = Field(default=None, max_length=256)
+    op_id: str | None = Field(default=None, max_length=256)
+    op_class: str | None = Field(default=None, max_length=64)
+    result_status: str | None = Field(default=None, max_length=16)
+    since: str | None = Field(default=None, max_length=32)
+    until: str | None = Field(default=None, max_length=32)
+    audit_id: uuid.UUID | None = None
+    parent_audit_id: uuid.UUID | None = None
+    agent_session_id: uuid.UUID | None = None
+    limit: int = Field(default=100, ge=1, le=1000)
+    cursor: str | None = Field(default=None, max_length=512)

--- a/backend/src/meho_backplane/audit_query/__init__.py
+++ b/backend/src/meho_backplane/audit_query/__init__.py
@@ -14,6 +14,9 @@ The package exposes the consumer-facing surface T2 (REST), T3 (CLI), and T4
 * :class:`UnsupportedFilterError` — filter targets a column that does not yet
   exist in v0.2 (``parent_audit_id`` waits on G0.6-T7 #398;
   ``agent_session_id`` has no current roadmap).
+* :func:`parse_duration` / :class:`DurationParseError` — duration shorthand
+  (``"24h"`` / ``"7d"`` / ISO-8601) → :class:`datetime` parser used by the
+  T2 REST router layer (G8.1-T2 #466).
 
 See :mod:`.schemas` for the substrate-vs-issue-body reconciliation that
 documents which fields are real columns, which are computed at query time,
@@ -23,6 +26,7 @@ and which are v0.2 placeholders.
 from __future__ import annotations
 
 from .cursor import CursorPosition, InvalidCursorError, decode_cursor, encode_cursor
+from .duration import DurationParseError, parse_duration
 from .query import UnsupportedFilterError, query_audit
 from .schemas import AuditEntry, AuditQueryFilters, AuditQueryResult
 
@@ -31,9 +35,11 @@ __all__ = [
     "AuditQueryFilters",
     "AuditQueryResult",
     "CursorPosition",
+    "DurationParseError",
     "InvalidCursorError",
     "UnsupportedFilterError",
     "decode_cursor",
     "encode_cursor",
+    "parse_duration",
     "query_audit",
 ]

--- a/backend/src/meho_backplane/audit_query/duration.py
+++ b/backend/src/meho_backplane/audit_query/duration.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Duration parser for the audit-query REST surface (G8.1-T2).
+
+Routers under :mod:`meho_backplane.api.v1.audit` accept ``since`` /
+``until`` as either operator-friendly relative shorthand (``"24h"`` /
+``"7d"`` / ``"30m"``) or absolute ISO-8601 strings. The T1 substrate
+(:class:`~meho_backplane.audit_query.schemas.AuditQueryFilters`) takes
+:class:`datetime` only — duration parsing belongs at the router layer
+per the substrate docstring contract.
+
+Grammar
+=======
+
+* ``<N><unit>`` where ``unit`` ∈ ``{s, m, h, d, w}``. ``N`` is an
+  unsigned integer ≤ 9999. Result is ``now - timedelta``.
+* Otherwise the value is parsed with :meth:`datetime.fromisoformat`
+  (Python 3.11+ accepts the ``Z`` suffix and offset-aware forms).
+  Naive datetimes are interpreted as UTC so the downstream
+  ``occurred_at`` comparison lands in a single timezone — matching
+  the precedent
+  :func:`~meho_backplane.retrieval.usage.parse_since` set at line 256.
+* Anything else raises :class:`DurationParseError`.
+
+The companion parser
+:func:`~meho_backplane.retrieval.usage.parse_since` accepts a subset
+(``d`` / ``h`` only) because retrieval-usage telemetry deals in
+operator-day granularity. Audit forensics often wants sub-minute
+resolution (``"30s"``) and multi-week windows (``"2w"``), so the audit
+parser ships a wider grammar. Unifying the two is a v0.2.next surface.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Final
+
+__all__ = [
+    "DurationParseError",
+    "parse_duration",
+]
+
+
+class DurationParseError(ValueError):
+    """Raised by :func:`parse_duration` when the input doesn't parse.
+
+    Subclasses :class:`ValueError` so router-side ``except`` blocks
+    catch the standard exception; the dedicated subclass lets test
+    code pin "this specific parser rejected the input" without
+    matching on every :class:`ValueError` the call stack might raise.
+    """
+
+
+_RELATIVE_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"(?P<n>\d{1,4})(?P<unit>[smhdw])",
+)
+
+_UNIT_TO_TIMEDELTA_KW: Final[dict[str, str]] = {
+    "s": "seconds",
+    "m": "minutes",
+    "h": "hours",
+    "d": "days",
+    "w": "weeks",
+}
+
+
+def parse_duration(value: str, *, now: datetime) -> datetime:
+    """Resolve a duration string to an absolute UTC datetime.
+
+    *now* is injected explicitly so tests can pin a frozen clock
+    without monkey-patching :func:`datetime.now`. Production callers
+    pass ``datetime.now(UTC)``.
+
+    Examples
+    --------
+
+    >>> from datetime import UTC, datetime
+    >>> ref = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+    >>> parse_duration("24h", now=ref).isoformat()
+    '2026-05-13T12:00:00+00:00'
+    >>> parse_duration("7d", now=ref).isoformat()
+    '2026-05-07T12:00:00+00:00'
+    >>> parse_duration("30m", now=ref).isoformat()
+    '2026-05-14T11:30:00+00:00'
+    >>> parse_duration("2w", now=ref).isoformat()
+    '2026-04-30T12:00:00+00:00'
+    >>> parse_duration("2026-04-01", now=ref).isoformat()
+    '2026-04-01T00:00:00+00:00'
+    """
+    if not value:
+        raise DurationParseError("duration must be non-empty")
+
+    rel = _RELATIVE_PATTERN.fullmatch(value)
+    if rel is not None:
+        n = int(rel.group("n"))
+        unit = rel.group("unit")
+        kw = _UNIT_TO_TIMEDELTA_KW[unit]
+        return now - timedelta(**{kw: n})
+
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise DurationParseError(
+            f"unrecognised duration {value!r}: expected '<N>{{s|m|h|d|w}}' or an ISO-8601 datetime",
+        ) from exc
+
+    if parsed.tzinfo is None:
+        # Naive datetimes from operators are interpreted as UTC. Any
+        # other choice (server local, operator local) would be a
+        # silent-correctness footgun: the ``occurred_at`` column is
+        # ``timestamptz`` on PG and naive-UTC on SQLite; comparing a
+        # naive non-UTC value against either would shift the window
+        # by the local offset without the operator noticing.
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -47,6 +47,7 @@ import structlog
 from fastapi import FastAPI, Response
 
 from meho_backplane import __version__
+from meho_backplane.api.v1.audit import router as api_v1_audit_router
 from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_router
 from meho_backplane.api.v1.connectors_ingest import (
     router as api_v1_connectors_ingest_router,
@@ -281,6 +282,14 @@ app.include_router(api_v1_operations_router)
 # operator-gated. The same service layer (IngestionPipelineService +
 # ReviewService) backs T5 (CLI verbs) and T7 (admin MCP tools).
 app.include_router(api_v1_connectors_ingest_router)
+# G8.1-T2 (#466) -- audit-query REST surface. Four routes (POST /query,
+# GET who-touched / my-recent / show) all dispatching through the T1
+# substrate (`meho_backplane.audit_query.query_audit`). Operator role
+# minimum; tenant-scoped via the JWT's tenant_id claim. Binds the
+# `audit_op_id` / `audit_op_class` contextvar overrides so every audit
+# row this surface writes carries the canonical `meho.audit.query`
+# identity and broadcasts as aggregate-only per decision #3.
+app.include_router(api_v1_audit_router)
 # MCP Streamable HTTP transport entrypoint (G0.5-T1, #246) and the
 # RFC 9728 protected-resource metadata document (G0.5-T2, #247).
 #

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -27,10 +27,13 @@ pieces:
   across the five tests in :mod:`tests.integration.test_tenant_isolation`
   so the suite still finishes well inside the issue's "< 10s wall clock"
   acceptance criterion. Migrations land once, not five times; the
-  per-test ``TRUNCATE TABLE audit_log, documents, tenant`` in
-  ``pg_engine`` keeps test isolation honest even though the DB is shared
-  (non-cascading multi-table TRUNCATE is required because of the
-  ``documents.tenant_id REFERENCES tenant(id)`` FK from migration 0003).
+  per-test ``TRUNCATE TABLE audit_log, documents, graph_edge, graph_node,
+  broadcast_override, tenant`` in ``pg_engine`` keeps test isolation
+  honest even though the DB is shared (non-cascading multi-table
+  TRUNCATE is required because every table with a ``REFERENCES
+  tenant(id)`` FK must be listed in the same statement, otherwise PG
+  rejects with ``cannot truncate a table referenced in a foreign key
+  constraint``).
 * ``integration_env`` — autouse fixture that pins every Settings env
   var the chassis needs at construction time, then yields. The
   conftest in ``tests/conftest.py`` already pins ``DATABASE_URL`` to a
@@ -292,15 +295,30 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         # Truncate every chassis table in one statement: PG requires
         # that a TRUNCATE against a table referenced by a FK either
         # use ``CASCADE`` or include every referencing table in the
-        # same statement. Migration ``0003`` (G0.4-T1) added a real
-        # ``documents.tenant_id REFERENCES tenant(id)`` FK, so
-        # ``TRUNCATE TABLE tenant`` on its own is rejected — listing
-        # ``documents`` explicitly keeps the statement non-cascading
-        # while still leaving the table empty. ``audit_log`` has no
-        # FK to ``tenant`` (the soft column shape from 0002), but
-        # bundling it into the same TRUNCATE keeps the per-test reset
-        # atomic.
-        await conn.execute(text("TRUNCATE TABLE audit_log, documents, tenant"))
+        # same statement. The set of real ``REFERENCES tenant(id)`` FKs
+        # has grown across migrations and every one must appear in this
+        # list or PG rejects with ``cannot truncate a table referenced
+        # in a foreign key constraint``:
+        #
+        # * ``documents.tenant_id`` — migration 0003 (G0.4-T1).
+        # * ``graph_node.tenant_id`` — migration 0007 (G7 topology).
+        # * ``graph_edge.tenant_id`` — migration 0007 (G7 topology).
+        # * ``broadcast_override.tenant_id`` — migration 0008 (G6.3
+        #   PII opt-in/opt-out controls).
+        #
+        # ``audit_log`` has no FK to ``tenant`` (the soft column shape
+        # from 0002) but stays in the list so the per-test reset is
+        # atomic. Tables whose ``tenant_id`` is a soft column with no
+        # FK (``targets``, ``endpoint_descriptor``, ``operation_group``)
+        # don't need to be here. ``graph_edge`` also has a FK to
+        # ``graph_node`` but listing both lets the statement stay
+        # non-cascading regardless of FK order.
+        await conn.execute(
+            text(
+                "TRUNCATE TABLE audit_log, documents, graph_edge, "
+                "graph_node, broadcast_override, tenant",
+            ),
+        )
         # Re-seed two pinned tenant rows so the integration suite
         # actually exercises the T1 ``tenant`` table (the issue body's
         # explicit "Setup fixture" requirement). The pinned UUIDs

--- a/backend/tests/test_api_audit_routes.py
+++ b/backend/tests/test_api_audit_routes.py
@@ -1,0 +1,567 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.audit` (G8.1-T2).
+
+Coverage matrix (#466 acceptance criteria):
+
+* AC1 — All 4 routes mount + respond. Exercised implicitly by every
+  happy-path test below; the OpenAPI schema check
+  (:func:`test_openapi_schema_lists_all_four_routes`) is the explicit
+  AC9 surface.
+* AC2 — POST /query with empty body returns all tenant's rows up to
+  ``limit=100``. Verified via the dispatched filter object on the
+  mocked substrate.
+* AC3 — ``since="24h"`` shorthand parses to a :class:`datetime` before
+  reaching the substrate.
+* AC4 — ``who-touched/{target}`` builds a ``target=<path>`` filter.
+* AC5 — ``my-recent`` injects ``principal=operator.sub`` from the JWT.
+* AC6 — ``show/{audit_id}`` returns 404 when the substrate yields no
+  rows (the cross-tenant probe case — the substrate's tenant WHERE
+  clause produces zero rows for a row in another tenant, and the
+  route surfaces 404, not 403, so existence is never leaked).
+* AC7 — Body-supplied ``tenant_id`` is silently dropped; the route
+  always passes ``operator.tenant_id`` to the substrate.
+* AC8 — Every call binds ``audit_op_id="meho.audit.query"`` +
+  ``audit_op_class="audit_query"`` contextvars before the substrate
+  call, so the audit row written by :class:`AuditMiddleware` carries
+  the canonical op_id and the broadcast event ships as aggregate-only.
+* AC9 — OpenAPI schema lists all four routes under the audit tag.
+* AC10 — ruff + mypy clean: Phase 7 of the implement-issue-slim
+  skill, not a test here.
+
+The substrate (:func:`query_audit`) is patched at the route's import
+site so the route tests don't depend on PG/SQLite-seeded audit rows —
+the substrate has its own coverage in
+``tests/test_audit_query_handler.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+import respx
+import structlog
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from meho_backplane.api.v1.audit import router as audit_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.audit_query import (
+    AuditEntry,
+    AuditQueryResult,
+    InvalidCursorError,
+    UnsupportedFilterError,
+)
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import (
+    AUDIENCE as _AUDIENCE,
+)
+from ._oidc_jwt_helpers import (
+    ISSUER as _ISSUER,
+)
+from ._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` reads, around every test.
+
+    Mirrors :mod:`tests.test_api_v1_retrieve`'s autouse fixture so the
+    chassis ``verify_jwt`` dependency resolves cleanly without a real
+    Keycloak / Vault on the network.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+def _configure_capture(buf: io.StringIO) -> None:
+    structlog.reset_defaults()
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=buf),
+        cache_logger_on_first_use=False,
+    )
+
+
+@pytest.fixture
+def log_buffer() -> Iterator[io.StringIO]:
+    buf = io.StringIO()
+    _configure_capture(buf)
+    yield buf
+    structlog.reset_defaults()
+
+
+def _read_log_lines(buf: io.StringIO) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+def _build_app() -> FastAPI:
+    """FastAPI mirroring prod with the audit router + chassis middleware."""
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(audit_router)
+    return app
+
+
+@pytest.fixture
+def client(log_buffer: io.StringIO) -> Iterator[TestClient]:
+    """``TestClient`` driving a fresh app + log capture rebound first.
+
+    ``log_buffer`` is requested so the structlog processors stay
+    pinned for the lifetime of the request — without it the audit
+    middleware's logger would render with the default config and the
+    captured log lines disappear.
+    """
+    yield TestClient(_build_app())
+
+
+_TENANT_A = UUID("33333333-3333-3333-3333-333333333333")
+_TENANT_B = UUID("44444444-4444-4444-4444-444444444444")
+_DEFAULT_AUDIT_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _empty_result() -> AuditQueryResult:
+    return AuditQueryResult(rows=[], next_cursor=None)
+
+
+def _make_entry(
+    audit_id: UUID = _DEFAULT_AUDIT_ID,
+    tenant_id: UUID = _TENANT_A,
+    principal_sub: str = "op-1",
+) -> AuditEntry:
+    return AuditEntry(
+        id=audit_id,
+        ts=datetime(2026, 5, 14, 12, 0, tzinfo=UTC),
+        tenant_id=tenant_id,
+        principal_sub=principal_sub,
+        principal_name=None,
+        target_id=None,
+        target_name=None,
+        method="POST",
+        path="/api/v1/audit/query",
+        status_code=200,
+        request_id=None,
+        duration_ms=None,
+        payload={},
+        op_id="meho.audit.query",
+        op_class="audit_query",
+        result_status="ok",
+        parent_audit_id=None,
+        agent_session_id=None,
+        broadcast_event_id=None,
+    )
+
+
+def _token(
+    key: Any,
+    *,
+    sub: str = "op-1",
+    role: TenantRole = TenantRole.OPERATOR,
+    tenant_id: UUID = _TENANT_A,
+) -> str:
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_role=role.value,
+        tenant_id=str(tenant_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/audit/query
+# ---------------------------------------------------------------------------
+
+
+def test_post_query_empty_body_returns_200_with_no_filters(client: TestClient) -> None:
+    """AC2: empty body dispatches a no-filter query with the default limit."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"rows": [], "next_cursor": None}
+    mock_query.assert_awaited_once()
+    filters = mock_query.await_args.args[0]
+    kwargs = mock_query.await_args.kwargs
+    assert kwargs["tenant_id"] == _TENANT_A
+    assert filters.since is None
+    assert filters.until is None
+    assert filters.target is None
+    assert filters.principal is None
+    assert filters.limit == 100  # AC2: default limit
+
+
+def test_post_query_since_24h_parses_to_datetime(client: TestClient) -> None:
+    """AC3: ``since="24h"`` reaches the substrate as a tz-aware datetime."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        before = datetime.now(UTC)
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={"since": "24h"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        after = datetime.now(UTC)
+    assert resp.status_code == 200
+    filters = mock_query.await_args.args[0]
+    assert filters.since is not None
+    assert filters.since.tzinfo is not None
+    # The router subtracts 24h from "now" — verify the value lands in
+    # the [before - 24h, after - 24h] band.
+    assert (before - timedelta(hours=24, seconds=1)) <= filters.since
+    assert filters.since <= (after - timedelta(hours=24) + timedelta(seconds=1))
+
+
+def test_post_query_body_tenant_id_is_silently_dropped(client: TestClient) -> None:
+    """AC7: a tenant-A operator with ``tenant_id=<B>`` in the body still gets tenant-A scoping."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, tenant_id=_TENANT_A)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={"tenant_id": str(_TENANT_B)},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    kwargs = mock_query.await_args.kwargs
+    assert kwargs["tenant_id"] == _TENANT_A  # JWT wins
+
+
+def test_post_query_bad_duration_returns_400(client: TestClient) -> None:
+    """A garbage ``since`` value surfaces as 400, not 500."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={"since": "twentyfour-hours"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 400
+    assert "duration" in resp.json()["detail"].lower()
+    mock_query.assert_not_awaited()  # Substrate never reached.
+
+
+def test_post_query_invalid_cursor_returns_400(client: TestClient) -> None:
+    """Substrate-raised :class:`InvalidCursorError` maps to 400."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    mock_query = AsyncMock(side_effect=InvalidCursorError("cursor is not valid base64"))
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={"cursor": "not-base64"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 400
+    assert "cursor" in resp.json()["detail"].lower()
+
+
+def test_post_query_parent_audit_id_returns_400(client: TestClient) -> None:
+    """Substrate-raised :class:`UnsupportedFilterError` maps to 400."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    mock_query = AsyncMock(
+        side_effect=UnsupportedFilterError(
+            "parent_audit_id filter not supported in v0.2 — column lands with G0.6-T7 (#398)",
+        ),
+    )
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={"parent_audit_id": "55555555-5555-5555-5555-555555555555"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 400
+    assert "parent_audit_id" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/audit/who-touched/{target}
+# ---------------------------------------------------------------------------
+
+
+def test_who_touched_builds_target_filter(client: TestClient) -> None:
+    """AC4: the path param becomes the substrate filter's ``target`` field."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            "/api/v1/audit/who-touched/rdc-vcenter",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    filters = mock_query.await_args.args[0]
+    assert filters.target == "rdc-vcenter"
+    assert filters.since is not None  # default "24h" → datetime
+    assert filters.limit == 100
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/audit/my-recent
+# ---------------------------------------------------------------------------
+
+
+def test_my_recent_injects_principal_from_jwt(client: TestClient) -> None:
+    """AC5: ``principal`` filter is the operator's JWT subject — not from the URL."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, sub="op-42-jwt-sub")
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            "/api/v1/audit/my-recent",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    filters = mock_query.await_args.args[0]
+    assert filters.principal == "op-42-jwt-sub"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/audit/show/{audit_id}
+# ---------------------------------------------------------------------------
+
+
+def test_show_returns_200_with_entry_when_found(client: TestClient) -> None:
+    """``show`` returns 200 + the row when the substrate yields one."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    audit_id = UUID("11111111-1111-1111-1111-111111111111")
+    entry = _make_entry(audit_id=audit_id)
+    mock_query = AsyncMock(return_value=AuditQueryResult(rows=[entry], next_cursor=None))
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/show/{audit_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(audit_id)
+    filters = mock_query.await_args.args[0]
+    assert filters.audit_id == audit_id
+    assert filters.limit == 1
+
+
+def test_show_returns_404_when_substrate_yields_no_rows(client: TestClient) -> None:
+    """AC6: cross-tenant probe surfaces 404, not 403 — existence never leaks."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    cross_tenant_audit_id = UUID("66666666-6666-6666-6666-666666666666")
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/show/{cross_tenant_audit_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 404
+    assert resp.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# Audit-on-audit-query (AC8)
+# ---------------------------------------------------------------------------
+
+
+def test_audit_overrides_bound_for_post_query(
+    client: TestClient,
+    log_buffer: io.StringIO,
+) -> None:
+    """AC8: ``audit_op_id="meho.audit.query"`` reaches the audit log row.
+
+    The override is bound via :func:`structlog.contextvars.bind_contextvars`
+    before the substrate call. The audit middleware reads these contextvars
+    when constructing the audit row's ``payload``; the audit row's
+    ``payload->>'op_id'`` is what operators filter on. We verify the
+    override is observable by checking the captured structlog output —
+    every log line during the request inherits the bound contextvars,
+    so any line emitted between the bind and the response carries the
+    override key.
+    """
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+
+    lines = _read_log_lines(log_buffer)
+    overrides_observed = [
+        line
+        for line in lines
+        if line.get("audit_op_id") == "meho.audit.query"
+        and line.get("audit_op_class") == "audit_query"
+    ]
+    assert overrides_observed, (
+        "expected at least one structlog line carrying audit_op_id="
+        "'meho.audit.query' + audit_op_class='audit_query' bound by the route"
+    )
+
+
+# ---------------------------------------------------------------------------
+# RBAC
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_returns_401(client: TestClient) -> None:
+    """No Authorization header → 401 on every route."""
+    resp = client.post("/api/v1/audit/query", json={})
+    assert resp.status_code == 401
+
+
+def test_read_only_role_returns_403(client: TestClient) -> None:
+    """``read_only`` JWT is below the operator gate — 403."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, role=TenantRole.READ_ONLY)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 403
+    mock_query.assert_not_awaited()
+
+
+def test_tenant_admin_role_returns_200(client: TestClient) -> None:
+    """``tenant_admin`` JWT clears the operator gate."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, role=TenantRole.TENANT_ADMIN)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI mount surface (AC1 + AC9)
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_schema_lists_all_four_routes(client: TestClient) -> None:
+    """AC9: ``/openapi.json`` advertises all four audit routes under the audit tag."""
+    schema = client.get("/openapi.json").json()
+    paths = schema["paths"]
+    assert "/api/v1/audit/query" in paths
+    assert "/api/v1/audit/who-touched/{target}" in paths
+    assert "/api/v1/audit/my-recent" in paths
+    assert "/api/v1/audit/show/{audit_id}" in paths
+    # Every route is tagged "audit" so operators filtering /docs by tag
+    # find them grouped under one section.
+    assert "post" in paths["/api/v1/audit/query"]
+    assert "audit" in paths["/api/v1/audit/query"]["post"]["tags"]
+    assert "audit" in paths["/api/v1/audit/who-touched/{target}"]["get"]["tags"]
+    assert "audit" in paths["/api/v1/audit/my-recent"]["get"]["tags"]
+    assert "audit" in paths["/api/v1/audit/show/{audit_id}"]["get"]["tags"]

--- a/backend/tests/test_audit_query_duration.py
+++ b/backend/tests/test_audit_query_duration.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :mod:`meho_backplane.audit_query.duration` (G8.1-T2).
+
+Covers the grammar the parser advertises:
+
+* Relative shorthand for every supported unit (``s`` / ``m`` / ``h`` /
+  ``d`` / ``w``) round-trips to the expected ``now - timedelta``.
+* The 4-digit upper bound (``9999<unit>``) accepts; 5-digit rejects.
+* ISO-8601 absolute strings parse through :meth:`datetime.fromisoformat`,
+  including the Python 3.11+ offset-aware forms.
+* Naive ISO-8601 strings are interpreted as UTC.
+* The empty string and every "off-grammar" shape reject with
+  :class:`DurationParseError`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from meho_backplane.audit_query import DurationParseError, parse_duration
+
+# Frozen reference clock for every relative-grammar assertion in this
+# module. Pinning the clock keeps the assertions reproducible without
+# monkey-patching :func:`datetime.now`, mirroring the contract
+# :func:`parse_duration` advertises (``now`` is a mandatory keyword
+# argument exactly so tests can inject one).
+_REF = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("30s", datetime(2026, 5, 14, 11, 59, 30, tzinfo=UTC)),
+        ("5m", datetime(2026, 5, 14, 11, 55, 0, tzinfo=UTC)),
+        ("24h", datetime(2026, 5, 13, 12, 0, 0, tzinfo=UTC)),
+        ("7d", datetime(2026, 5, 7, 12, 0, 0, tzinfo=UTC)),
+        ("2w", datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)),
+    ],
+)
+def test_relative_grammar_for_every_unit(value: str, expected: datetime) -> None:
+    """One assertion per supported unit suffix — the full grammar surface."""
+    assert parse_duration(value, now=_REF) == expected
+
+
+def test_n_unit_upper_bound_4_digits_accepts() -> None:
+    """``9999<unit>`` is the largest accepted N — exercises the regex bound."""
+    parse_duration("9999d", now=_REF)
+
+
+def test_n_unit_5_digits_rejects() -> None:
+    """``10000d`` falls past the 4-digit regex bound — :class:`DurationParseError`."""
+    with pytest.raises(DurationParseError):
+        parse_duration("10000d", now=_REF)
+
+
+def test_iso8601_offset_aware_parses_through() -> None:
+    """Offset-aware ISO-8601 surfaces with the operator-supplied tzinfo intact."""
+    parsed = parse_duration("2026-04-01T00:00:00+00:00", now=_REF)
+    assert parsed == datetime(2026, 4, 1, tzinfo=UTC)
+
+
+def test_iso8601_naive_interpreted_as_utc() -> None:
+    """A naive ISO-8601 date is interpreted as UTC — the documented choice."""
+    parsed = parse_duration("2026-04-01", now=_REF)
+    assert parsed.tzinfo is UTC
+    assert parsed == datetime(2026, 4, 1, tzinfo=UTC)
+
+
+def test_empty_string_rejects() -> None:
+    """Empty input is a parser-level rejection, not a fall-through."""
+    with pytest.raises(DurationParseError):
+        parse_duration("", now=_REF)
+
+
+@pytest.mark.parametrize(
+    "garbage",
+    [
+        "abc",
+        "24x",  # unsupported unit
+        "h24",  # unit-first instead of value-first
+        "24 h",  # whitespace
+        "-5d",  # negative
+        "1.5d",  # fractional
+        "24hh",  # double unit
+    ],
+)
+def test_off_grammar_inputs_reject(garbage: str) -> None:
+    """Off-grammar inputs surface as :class:`DurationParseError` — never silent."""
+    with pytest.raises(DurationParseError):
+        parse_duration(garbage, now=_REF)

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -108,6 +108,35 @@ query_audit(filters, tenant_id, session)
                    if has_more else None
 ```
 
+## REST surface (G8.1-T2 #466)
+
+The four routes under `backend/src/meho_backplane/api/v1/audit.py` are the
+operator-facing entry into the substrate. All four dispatch through
+`query_audit` with `tenant_id=operator.tenant_id` (from the JWT) — the
+substrate's tenant-scoping invariant is enforced one layer up.
+
+| Route | Filter shape | Notes |
+|---|---|---|
+| `POST /api/v1/audit/query` | Body is `AuditQueryRequest`; `since` / `until` are strings parsed at the router via `parse_duration` (`"24h"` / `"7d"` / ISO-8601). Client-supplied `tenant_id` is silently dropped by Pydantic's default `extra="ignore"` — the route never reads tenant from the body. | Full-filter surface. |
+| `GET /api/v1/audit/who-touched/{target}` | Path param becomes `filters.target`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
+| `GET /api/v1/audit/my-recent` | `filters.principal = operator.sub`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
+| `GET /api/v1/audit/show/{audit_id}` | `filters.audit_id = <path>`, `limit=1`. Substrate returns 0 rows for cross-tenant lookups → router raises **404** (not 403) so existence never leaks. | Single-row fetch. |
+
+Every route binds two audit-override contextvars **before** the substrate
+call — `audit_op_id="meho.audit.query"` and `audit_op_class="audit_query"`
+— so the audit row written by `AuditMiddleware` carries the canonical
+op_id and the broadcast event ships as aggregate-only (`{op_id,
+result_status, row_count}` only, never the request filter). The
+`audit_row_count` contextvar is bound after the substrate returns so the
+broadcast event's `row_count` field reflects the actual returned
+cardinality. The shape mirrors `api/v1/retrieve_usage.py`.
+
+RBAC: `operator` role minimum. `read_only` → 403; `tenant_admin` → 200.
+
+Error mapping at the router boundary: `DurationParseError` (router-side),
+`InvalidCursorError` (substrate-side), `UnsupportedFilterError`
+(substrate-side) all surface as 400 with the underlying message.
+
 ## Dependencies
 
 * `meho_backplane.db.models.AuditLog` — read schema; this package never writes.
@@ -116,7 +145,11 @@ query_audit(filters, tenant_id, session)
   shared with the broadcast publish path so audit-query and broadcast classify
   identically.
 
-No reverse dependencies in v0.2 — T2 / T3 / T4 add them later.
+Reverse dependencies:
+
+* `meho_backplane.api.v1.audit` (T2 #466) — REST router for the four
+  consumer-facing routes; dispatches every call through `query_audit`.
+* T3 #467 (CLI) and T4 #468 (MCP) follow.
 
 ## Known issues / v0.2 gaps
 
@@ -160,7 +193,9 @@ No reverse dependencies in v0.2 — T2 / T3 / T4 add them later.
 ## References
 
 * Initiative: [G8.1 #334](https://github.com/evoila/meho/issues/334).
-* Task: [G8.1-T1 #465](https://github.com/evoila/meho/issues/465).
+* Tasks: [G8.1-T1 #465](https://github.com/evoila/meho/issues/465) (substrate),
+  [G8.1-T2 #466](https://github.com/evoila/meho/issues/466) (REST routes +
+  duration parser).
 * Write paths: `backend/src/meho_backplane/audit.py`,
   `backend/src/meho_backplane/mcp/audit.py`.
 * Op-class classifier: `backend/src/meho_backplane/broadcast/events.py:172`


### PR DESCRIPTION
## Summary

- Ships the four `/api/v1/audit/*` REST routes — `POST /query` plus the
  three pre-canned shortcuts `who-touched/{target}` / `my-recent` /
  `show/{audit_id}` — all dispatching through the T1 substrate (#465)
  landed earlier today. Single dispatch path keeps the substrate's
  tenant-scoping invariant load-bearing: every route passes
  `operator.tenant_id` from the JWT into `query_audit`, never from the
  body.
- Adds `audit_query/duration.py` with `parse_duration` (`s/m/h/d/w` +
  ISO-8601). Lives next to the T1 substrate exports rather than under
  `retrieval/` because the audit grammar is wider than
  `retrieval/usage.py:parse_since` (sub-minute resolution + multi-week
  windows audit forensics needs).
- `show/{audit_id}` returns **404 (not 403)** when the substrate
  yields zero rows for a cross-tenant audit_id — existence never
  leaks across tenants.
- Every route binds `audit_op_id="meho.audit.query"` +
  `audit_op_class="audit_query"` contextvars before the substrate call
  so the audit row carries the canonical op_id and the broadcast event
  ships as aggregate-only per decision #3 (filter contents never
  broadcast). Same shape `retrieve_usage.py` established.

## Test plan

- [x] `ruff check` — clean across all 7 edited files
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean (0 issues / 129 source files)
- [x] `pytest tests/test_audit_query_duration.py` — 17 passed (every
  supported unit + off-grammar inputs + ISO-8601 with/without offset)
- [x] `pytest tests/test_api_audit_routes.py` — 15 passed:
  - AC2: empty POST body → no-filter query, `limit=100` default
  - AC3: `since="24h"` parses to tz-aware datetime before substrate
  - AC4: `who-touched/{target}` builds `target=<path>` filter
  - AC5: `my-recent` injects `principal=operator.sub` from JWT
  - AC6: `show/{audit_id}` cross-tenant probe returns 404 (not 403)
  - AC7: body-supplied `tenant_id` silently dropped; JWT wins
  - AC8: `audit_op_id="meho.audit.query"` contextvar observable in
    structlog output
  - AC9: OpenAPI lists all 4 routes under the `audit` tag
  - RBAC: `read_only` → 403; `tenant_admin` → 200; unauth → 401
  - Error mapping: bad duration / invalid cursor /
    `UnsupportedFilterError` → 400
- [x] `pytest tests/test_audit_query_handler.py tests/test_audit_query_cursor.py tests/test_audit_query_schemas.py tests/test_app_starts.py` — 49 passed (no T1 regression; mount sanity OK)

## Out of scope

- T3 (#467 CLI verbs), T4 (#468 MCP meta-tool), T5 (#469 acceptance —
  integration concurrency / aggregate-only broadcast verification),
  T6 (#470 docs/cross-repo + architecture). Each ships under its own
  Task; this PR is strictly the REST surface.
- Unifying `audit_query/duration.py:parse_duration` with
  `retrieval/usage.py:parse_since` — different grammars by design
  (telemetry doesn't need `s`/`m`/`w`); promotion to a shared chassis
  primitive is a v0.2.next surface.

Closes #466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit-query REST endpoints: query by filters, who-touched, my-recent, and show-by-id.
  * Duration shorthand parsing for time ranges (e.g., "24h", "7d") with ISO‑8601 support.
  * Audit-query identity recorded for query operations; tenant-scoped results and RBAC enforced.

* **Bug Fixes**
  * Clear HTTP mappings for bad cursors, unsupported filters, bad durations, missing rows (400/404).

* **Tests**
  * New unit and integration tests covering routes, duration parsing, RBAC, and OpenAPI.

* **Documentation**
  * Expanded audit query docs with endpoint usage and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/496)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->