### PR TITLE
feat(mcp): G8.1-T4 query_audit MCP meta-tool — single agent surface for audit forensics

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/audit.py
+++ b/backend/src/meho_backplane/mcp/tools/audit.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``query_audit`` — single MCP meta-tool for forensic audit-log queries (G8.1-T4).
+
+The CLAUDE.md "narrow-waist agent surface" postulate (#5) says the agent
+sees ONE tool for audit data, not a per-shape family. The pre-canned
+shortcuts (``audit.show`` / ``audit.who_touched`` / ``audit.my_recent``)
+live in the CLI (T3) and the REST router (T2) only; on MCP the agent
+expresses every shape as a filter combination on ``query_audit``.
+
+Dispatches through the T1 :func:`~meho_backplane.audit_query.query_audit`
+substrate; tenant scope comes from the validated :class:`Operator`'s
+JWT — never from the arguments dict — so a cross-tenant agent probe is
+structurally impossible.
+
+``since`` / ``until`` accept either ISO-8601 absolute strings or the
+duration shorthand (``"24h"`` / ``"7d"`` / ``"30m"`` / ``"2w"``) the T2
+router introduced; parsing happens at the tool boundary via
+:func:`~meho_backplane.audit_query.parse_duration`, matching the REST
+surface's contract.
+
+Audit-on-audit-query
+====================
+
+The MCP dispatcher (``mcp/handlers.py``) writes one ``audit_log`` row
+per ``tools/call`` invocation. For this tool the row carries:
+
+* ``op_id = "query_audit"`` — the tool name verbatim (dispatcher
+  convention). Operators forensically searching ``audit_log`` for
+  "everyone who queried the audit log via MCP" filter on
+  ``payload->>'op_id' = 'query_audit'``. Note the REST surface emits
+  ``op_id = "meho.audit.query"`` — same logical operation, different
+  identifier per dispatch path; a v0.2.next unification surface.
+* ``op_class = "audit_query"`` — the declarative contract on the
+  :class:`ToolDefinition` below. The chassis broadcast classifier's
+  aggregate-only policy keys off this field per
+  ``broadcast/events.py::redact_payload``.
+
+inputSchema
+===========
+
+Hand-built JSON Schema 2020-12 rather than
+``AuditQueryFilters.model_json_schema()``: the substrate filter uses
+``datetime`` for ``since`` / ``until``, but agents pass duration
+shorthand (``"24h"``) which would fail jsonschema validation against a
+``format: date-time`` constraint. The hand-built schema accepts
+``string`` for both fields and the handler parses inside. Field
+``max_length`` mirrors :class:`AuditQueryRequest` in
+:mod:`~meho_backplane.api.v1.audit_models` so REST and MCP enforce the
+same per-field bounds.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Final
+
+from pydantic import ValidationError
+
+from meho_backplane.audit_query import (
+    AuditQueryFilters,
+    DurationParseError,
+    InvalidCursorError,
+    UnsupportedFilterError,
+    parse_duration,
+    query_audit,
+)
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+__all__: list[str] = []
+
+
+_TOOL_NAME: Final[str] = "query_audit"
+
+
+_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "target": {
+            "type": ["string", "null"],
+            "description": (
+                "Target name or alias. Substrate matches against "
+                "`targets.name` scoped to the operator's tenant; an "
+                "unknown name returns zero rows, not an error."
+            ),
+            "maxLength": 256,
+        },
+        "principal": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator sub or partial-name substring. Matches "
+                "`audit_log.operator_sub` via case-insensitive LIKE."
+            ),
+            "maxLength": 256,
+        },
+        "op_id": {
+            "type": ["string", "null"],
+            "description": (
+                "Glob pattern matched against the op_id (e.g. "
+                '"vsphere.vm.*"). Translates to SQL LIKE with `*` as the '
+                "wildcard."
+            ),
+            "maxLength": 256,
+        },
+        "op_class": {
+            "type": ["string", "null"],
+            "description": (
+                'One of "read" / "write" / "credential_read" / '
+                '"audit_query" / "other". Exact match.'
+            ),
+            "maxLength": 64,
+        },
+        "result_status": {
+            "type": ["string", "null"],
+            "description": (
+                'One of "ok" / "error" / "denied". Maps to status-code '
+                "ranges on the substrate side."
+            ),
+            "maxLength": 16,
+        },
+        "since": {
+            "type": ["string", "null"],
+            "description": (
+                "Window start. Either ISO-8601 absolute "
+                '("2026-05-14T00:00:00Z") or duration shorthand '
+                '("30s" / "5m" / "24h" / "7d" / "2w"). Resolved at '
+                "the tool boundary; substrate sees an absolute datetime."
+            ),
+            "maxLength": 32,
+        },
+        "until": {
+            "type": ["string", "null"],
+            "description": ("Window end. Same grammar as `since`."),
+            "maxLength": 32,
+        },
+        "audit_id": {
+            "type": ["string", "null"],
+            "format": "uuid",
+            "description": (
+                "Exact-id lookup. Combined with the tenant boundary, produces 0 or 1 row."
+            ),
+        },
+        "parent_audit_id": {
+            "type": ["string", "null"],
+            "format": "uuid",
+            "description": (
+                "Filter to one composite-operation subtree. NOT supported "
+                "in v0.2 — the substrate raises UnsupportedFilterError "
+                "(returned as -32602) until the column lands with G0.6-T7."
+            ),
+        },
+        "agent_session_id": {
+            "type": ["string", "null"],
+            "format": "uuid",
+            "description": (
+                "Filter to one agent session's audit trail. NOT supported "
+                "in v0.2 — returned as -32602 until a schema column lands."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 100,
+            "description": "Page size. Default 100; max 1000.",
+        },
+        "cursor": {
+            "type": ["string", "null"],
+            "description": (
+                "Opaque forward-pagination cursor from a previous result's "
+                "`next_cursor`. Tampered cursors return -32602."
+            ),
+            "maxLength": 512,
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+_TOOL_DESCRIPTION: Final[str] = (
+    "Query the audit log for forensic reconstruction. The canonical answer "
+    'to "who did X to Y and when?" — every authenticated operation against '
+    "the backplane (HTTP route, MCP tool call) writes one audit row, and "
+    "this tool is how an agent reads them back.\n\n"
+    "WHEN TO CALL: investigation flows — the operator asks 'who patched "
+    "rdc-vcenter on Tuesday', 'did someone read vault.kv before the outage', "
+    "'show me every denied request in the last 24h'. Pre-canned shortcut "
+    "shapes (`audit_id=<uuid>` for show, `target=<name>` for who-touched, "
+    "`principal=<operator.sub>` for my-recent) are filter combinations, not "
+    "separate tools.\n\n"
+    "WHEN NOT TO CALL: this is forensic reconstruction over the rolling "
+    "audit log, not live telemetry. For 'what is the system doing right "
+    "now' use the broadcast feed; for 'how often does retrieval happen' use "
+    "`meho.retrieval.usage`. Calling `query_audit` with no filters returns "
+    "the most recent 100 rows of the operator's tenant — not unbounded.\n\n"
+    "Tenant scoping is automatic — the operator's JWT determines the tenant "
+    "boundary; cross-tenant probes are impossible. Filter contents are "
+    "NEVER broadcast on the SSE feed (decision #3); only "
+    "`{op_id, result_status, row_count}` aggregate appears.\n\n"
+    "Returns `{rows: [AuditEntry, ...], next_cursor: <opaque|null>}` sorted "
+    "by timestamp descending. Use `next_cursor` (when non-null) to page "
+    "forward; `null` means the page is the end of the matching set under "
+    "the current filter."
+)
+
+
+async def _query_audit_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a ``query_audit`` MCP call through the T1 substrate.
+
+    The dispatcher has already jsonschema-validated *arguments* against
+    :data:`_INPUT_SCHEMA`, so every field is the right wire-shape (string
+    or null for the parser-bound ones, integer-in-range for ``limit``).
+    What still has to happen here:
+
+    1. Parse ``since`` / ``until`` shorthand via :func:`parse_duration`.
+       The schema accepts any string; runtime parsing surfaces the
+       parser's structured rejection message via
+       :class:`McpInvalidParamsError` (→ JSON-RPC ``-32602``).
+    2. Construct :class:`AuditQueryFilters` via
+       :meth:`pydantic.BaseModel.model_validate`. Pydantic coerces UUID
+       strings to :class:`uuid.UUID` automatically. A residual
+       :class:`pydantic.ValidationError` (e.g. malformed UUID slipping
+       past ``format: uuid``) surfaces as ``-32602``.
+    3. Open a session, call :func:`query_audit`. Substrate errors
+       (:class:`InvalidCursorError`, :class:`UnsupportedFilterError`)
+       are operator-actionable and surface as ``-32602``; anything else
+       propagates and the dispatcher turns it into ``-32603``.
+    4. Return the result as a JSON-safe dict via
+       :meth:`AuditQueryResult.model_dump`.
+    """
+    now = datetime.now(UTC)
+    materialized: dict[str, Any] = dict(arguments)
+    try:
+        if materialized.get("since") is not None:
+            materialized["since"] = parse_duration(materialized["since"], now=now)
+        if materialized.get("until") is not None:
+            materialized["until"] = parse_duration(materialized["until"], now=now)
+    except DurationParseError as exc:
+        raise McpInvalidParamsError(str(exc)) from exc
+
+    try:
+        filters = AuditQueryFilters.model_validate(materialized)
+    except ValidationError as exc:
+        raise McpInvalidParamsError(
+            f"query_audit: filter validation failed: {exc.error_count()} error(s)",
+        ) from exc
+
+    sessionmaker = get_sessionmaker()
+    try:
+        async with sessionmaker() as session:
+            result = await query_audit(
+                filters,
+                tenant_id=operator.tenant_id,
+                session=session,
+            )
+    except (InvalidCursorError, UnsupportedFilterError) as exc:
+        raise McpInvalidParamsError(str(exc)) from exc
+
+    return result.model_dump(mode="json")
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_TOOL_NAME,
+        description=_TOOL_DESCRIPTION,
+        inputSchema=_INPUT_SCHEMA,
+        outputSchema={
+            "type": "object",
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "AuditEntry rows sorted by timestamp descending. "
+                        "See `meho_backplane.audit_query.schemas.AuditEntry` "
+                        "for the per-row field set."
+                    ),
+                },
+                "next_cursor": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Opaque forward-pagination cursor. Null when the "
+                        "page is the end of the matching set."
+                    ),
+                },
+            },
+            "required": ["rows", "next_cursor"],
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class="audit_query",
+    ),
+    handler=_query_audit_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -130,12 +130,18 @@ def isolated_registry() -> Iterator[None]:
     runs.
     """
     from meho_backplane.mcp.resources import tenant_feed, tenant_info
-    from meho_backplane.mcp.tools import connector_admin, meho_status, operations
+    from meho_backplane.mcp.tools import (
+        audit,
+        connector_admin,
+        meho_status,
+        operations,
+    )
 
     clear_registries()
     importlib.reload(meho_status)
     importlib.reload(operations)
     importlib.reload(connector_admin)
+    importlib.reload(audit)
     importlib.reload(tenant_info)
     importlib.reload(tenant_feed)
     yield

--- a/backend/tests/test_mcp_tool_query_audit.py
+++ b/backend/tests/test_mcp_tool_query_audit.py
@@ -1,0 +1,543 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``query_audit`` MCP meta-tool (G8.1-T4 #468).
+
+Coverage matrix (issue #468 acceptance criteria):
+
+* AC1 — ``query_audit`` registered at MCP server startup; visible in
+  ``tools/list``.
+* AC2 — Tool description names what + when-to-call + when-NOT-to-call
+  (the load-bearing agent UX contract).
+* AC3 — ``tools/call query_audit {"target": "rdc-vcenter", "since": "24h"}``
+  dispatches through T1 with the right filter shape; ``since`` parses to
+  a tz-aware datetime at the tool boundary.
+* AC4 — Tenant scope injected from the operator's JWT, not the
+  arguments dict.
+* AC5 — ``op_class="audit_query"`` is the declarative contract on the
+  :class:`ToolDefinition`. End-to-end aggregate-only-broadcast
+  verification is T5's job (#469).
+* AC6 — ``tools/list`` schema validates as JSON-Schema-2020-12;
+  MEHO-internal fields stripped from the wire shape.
+* AC7 — (MCP-inspector smoke test) — out of scope here; T5 covers it.
+* AC8 — Per-shape conveniences (``audit.show`` / ``audit.who_touched`` /
+  ``audit.my_recent``) NOT registered against MCP — only ``query_audit``.
+* AC9 — ruff + mypy clean: Phase 7 verification, not a test here.
+
+The substrate (:func:`query_audit`) is patched at the tool's import
+site so route tests don't depend on PG/SQLite-seeded audit rows. The
+substrate has its own coverage in
+``tests/test_audit_query_handler.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.audit_query import (
+    AuditQueryResult,
+    InvalidCursorError,
+    UnsupportedFilterError,
+)
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import get_tool
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_PATCH_TARGET = "meho_backplane.mcp.tools.audit.query_audit"
+
+
+def _empty_result() -> AuditQueryResult:
+    return AuditQueryResult(rows=[], next_cursor=None)
+
+
+# ---------------------------------------------------------------------------
+# AC1 + AC6 — registration + wire shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_exposes_query_audit(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC1: ``query_audit`` appears in the MCP tool catalogue."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    names = {t["name"] for t in body["result"]["tools"]}
+    assert "query_audit" in names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_input_schema_is_strict_2020_12(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC6: inputSchema is JSON-Schema-2020-12 well-formed; wire fields stripped."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    )
+    tools = {t["name"]: t for t in response.json()["result"]["tools"]}
+    tool = tools["query_audit"]
+    schema = tool["inputSchema"]
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    # Every filter field is optional; no `required` array.
+    assert "required" not in schema or schema["required"] == []
+    # MEHO-internal fields stripped from the wire shape.
+    assert "required_role" not in tool
+    assert "op_class" not in tool
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_description_contains_when_to_call_guidance(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC2: description names WHAT + WHEN-TO + WHEN-NOT — agent UX contract."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 3, "method": "tools/list"},
+    )
+    tools = {t["name"]: t for t in response.json()["result"]["tools"]}
+    desc = tools["query_audit"]["description"].lower()
+    assert "audit" in desc
+    assert "when to call" in desc
+    assert "when not to call" in desc
+    # The narrow-waist call-out: the agent should know shortcuts are
+    # filter combinations, not separate tools.
+    assert "filter combinations" in desc or "filter combination" in desc
+
+
+def test_registered_definition_has_audit_query_op_class() -> None:
+    """AC5: ``op_class="audit_query"`` is the declarative contract.
+
+    The broadcast classifier reads this field via
+    :func:`~meho_backplane.broadcast.events.redact_payload` to switch to
+    aggregate-only mode for ``audit_query``. End-to-end verification
+    that the chain reaches the SSE feed correctly is T5's job (#469).
+    """
+    entry = get_tool("query_audit")
+    assert entry is not None
+    defn, _handler = entry
+    assert defn.op_class == "audit_query"
+    assert defn.required_role == TenantRole.OPERATOR
+
+
+def test_per_shape_shortcuts_not_registered_against_mcp() -> None:
+    """AC8: ``audit.show`` / ``audit.who_touched`` / ``audit.my_recent`` are CLI-only.
+
+    Per CLAUDE.md narrow-waist postulate (#5) the agent sees exactly
+    ONE audit tool; the shortcuts collapse into filter combinations on
+    ``query_audit``. Anyone registering a per-shape tool would defeat
+    the narrow-waist contract.
+    """
+    for shortcut in ("audit.show", "audit.who_touched", "audit.my_recent"):
+        assert get_tool(shortcut) is None, (
+            f"unexpected per-shape MCP tool registered: {shortcut!r} — "
+            "narrow-waist postulate (CLAUDE.md #5) requires only query_audit"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC3 + AC4 — handler dispatch + tenant scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_empty_arguments_dispatches_no_filter_query(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Empty arguments → substrate called with all-None filters + ``limit=100``."""
+    client, op = client_with_operator
+    mock_query = AsyncMock(return_value=_empty_result())
+    with patch(_PATCH_TARGET, new=mock_query):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {"name": "query_audit", "arguments": {}},
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload == {"rows": [], "next_cursor": None}
+    mock_query.assert_awaited_once()
+    filters = mock_query.await_args.args[0]
+    assert mock_query.await_args.kwargs["tenant_id"] == op.tenant_id
+    assert filters.target is None
+    assert filters.principal is None
+    assert filters.since is None
+    assert filters.until is None
+    assert filters.limit == 100
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_since_24h_parses_to_tz_aware_datetime(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC3: ``since="24h"`` resolves to ``now - 24h`` at the tool boundary."""
+    client, _op = client_with_operator
+    mock_query = AsyncMock(return_value=_empty_result())
+    with patch(_PATCH_TARGET, new=mock_query):
+        before = datetime.now(UTC)
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"target": "rdc-vcenter", "since": "24h"},
+                },
+            },
+        )
+        after = datetime.now(UTC)
+    assert response.status_code == 200
+    filters = mock_query.await_args.args[0]
+    assert filters.target == "rdc-vcenter"
+    assert filters.since is not None
+    assert filters.since.tzinfo is not None
+    # The handler subtracts 24h from `now`; the parsed value lands in
+    # the [before - 24h, after - 24h] band.
+    assert (before - timedelta(hours=24, seconds=1)) <= filters.since
+    assert filters.since <= (after - timedelta(hours=24) + timedelta(seconds=1))
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_tenant_id_taken_from_operator_jwt(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC4: tenant_id comes from the operator's JWT — never from arguments.
+
+    Because the inputSchema has ``additionalProperties: false``, an agent
+    that tries to smuggle ``tenant_id`` in the arguments dict gets a
+    -32602 from the dispatcher's jsonschema layer. This test pins both
+    sides of the invariant: legitimate calls are scoped to the JWT
+    tenant, and the smuggling vector is rejected.
+    """
+    client, op = client_with_operator
+    mock_query = AsyncMock(return_value=_empty_result())
+    with patch(_PATCH_TARGET, new=mock_query):
+        # Legitimate call — substrate receives JWT tenant_id.
+        post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "tools/call",
+                "params": {"name": "query_audit", "arguments": {}},
+            },
+        )
+    assert mock_query.await_args.kwargs["tenant_id"] == op.tenant_id
+    assert op.tenant_id == OPERATOR_TENANT_ID  # fixture sanity
+
+    # Smuggling attempt — `tenant_id` is not a schema field; the
+    # dispatcher rejects via additionalProperties: false.
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 13,
+            "method": "tools/call",
+            "params": {
+                "name": "query_audit",
+                "arguments": {
+                    "tenant_id": "11111111-1111-1111-1111-111111111111",
+                },
+            },
+        },
+    )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_handler_returns_result_model_dump(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The substrate's :class:`AuditQueryResult` round-trips through model_dump."""
+    from meho_backplane.audit_query import AuditEntry
+
+    client, _op = client_with_operator
+    entry = AuditEntry(
+        id=UUID("11111111-1111-1111-1111-111111111111"),
+        ts=datetime(2026, 5, 14, 12, 0, tzinfo=UTC),
+        tenant_id=OPERATOR_TENANT_ID,
+        principal_sub="op-1",
+        principal_name=None,
+        target_id=None,
+        target_name=None,
+        method="POST",
+        path="/api/v1/audit/query",
+        status_code=200,
+        request_id=None,
+        duration_ms=None,
+        payload={"op_id": "meho.audit.query", "op_class": "audit_query"},
+        op_id="meho.audit.query",
+        op_class="audit_query",
+        result_status="ok",
+        parent_audit_id=None,
+        agent_session_id=None,
+        broadcast_event_id=None,
+    )
+    mock_query = AsyncMock(
+        return_value=AuditQueryResult(rows=[entry], next_cursor="next-page-cursor"),
+    )
+    with patch(_PATCH_TARGET, new=mock_query):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 14,
+                "method": "tools/call",
+                "params": {"name": "query_audit", "arguments": {}},
+            },
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["next_cursor"] == "next-page-cursor"
+    assert len(payload["rows"]) == 1
+    assert payload["rows"][0]["id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["rows"][0]["op_id"] == "meho.audit.query"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping (DurationParseError / InvalidCursorError / UnsupportedFilterError)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_bad_duration_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A garbage ``since`` value surfaces as ``-32602`` with the parser message."""
+    client, _op = client_with_operator
+    mock_query = AsyncMock(return_value=_empty_result())
+    with patch(_PATCH_TARGET, new=mock_query):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 20,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"since": "twentyfour-hours"},
+                },
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "duration" in body["error"]["message"].lower()
+    mock_query.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_invalid_cursor_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Substrate-raised :class:`InvalidCursorError` maps to ``-32602``."""
+    client, _op = client_with_operator
+    mock_query = AsyncMock(side_effect=InvalidCursorError("cursor is not valid base64"))
+    with patch(_PATCH_TARGET, new=mock_query):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"cursor": "not-base64"},
+                },
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "cursor" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_unsupported_filter_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Substrate-raised :class:`UnsupportedFilterError` maps to ``-32602``."""
+    client, _op = client_with_operator
+    mock_query = AsyncMock(
+        side_effect=UnsupportedFilterError(
+            "parent_audit_id filter not supported in v0.2 — column lands with G0.6-T7 (#398)",
+        ),
+    )
+    with patch(_PATCH_TARGET, new=mock_query):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 22,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {
+                        "parent_audit_id": "11111111-1111-1111-1111-111111111111",
+                    },
+                },
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "parent_audit_id" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_rejects_additional_properties(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``additionalProperties: false`` blocks unknown fields at the schema layer."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 23,
+            "method": "tools/call",
+            "params": {
+                "name": "query_audit",
+                "arguments": {"unknown_field": "should be rejected"},
+            },
+        },
+    )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# RBAC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.READ_ONLY],
+    indirect=True,
+)
+def test_tools_call_read_only_role_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``read_only`` is below the operator gate — call is forbidden.
+
+    The RBAC list-time filter hides the tool from ``tools/list`` for
+    sub-operator roles; the per-call re-check in ``handle_tools_call``
+    surfaces a forbidden tool as ``INVALID_PARAMS`` (the JSON-RPC spec
+    lacks an HTTP-403 analogue, and the transport already 401s at the
+    JWT layer).
+    """
+    client, _op = client_with_operator
+    mock_query = AsyncMock(return_value=_empty_result())
+    with patch(_PATCH_TARGET, new=mock_query):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 30,
+                "method": "tools/call",
+                "params": {"name": "query_audit", "arguments": {}},
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+    mock_query.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_tools_call_tenant_admin_role_passes_gate(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``tenant_admin`` clears the operator gate — same tenant scope as operator."""
+    client, _op = client_with_operator
+    mock_query = AsyncMock(return_value=_empty_result())
+    with patch(_PATCH_TARGET, new=mock_query):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 31,
+                "method": "tools/call",
+                "params": {"name": "query_audit", "arguments": {}},
+            },
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    mock_query.assert_awaited_once()

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -137,6 +137,66 @@ Error mapping at the router boundary: `DurationParseError` (router-side),
 `InvalidCursorError` (substrate-side), `UnsupportedFilterError`
 (substrate-side) all surface as 400 with the underlying message.
 
+## MCP tool surface (G8.1-T4 #468)
+
+The agent-facing entry is a single tool — `query_audit` — registered in
+`backend/src/meho_backplane/mcp/tools/audit.py` against the G0.5 tool
+registry. The CLAUDE.md narrow-waist postulate (#5) says the agent
+sees exactly one audit tool; the REST per-shape shortcuts
+(`who-touched` / `my-recent` / `show`) collapse into filter
+combinations on `query_audit`.
+
+The handler:
+
+1. Receives the jsonschema-validated arguments dict.
+2. Parses `since` / `until` via the same
+   `meho_backplane.audit_query.parse_duration` the REST surface uses, so
+   the agent can pass either ISO-8601 or duration shorthand.
+3. Builds `AuditQueryFilters` via `model_validate` (Pydantic coerces
+   UUID strings; `additionalProperties: false` on the schema already
+   rejected unknown keys at the dispatcher).
+4. Calls `await query_audit(filters, tenant_id=operator.tenant_id,
+   session=session)`.
+5. Returns `result.model_dump(mode="json")` — the dispatcher wraps it
+   in the MCP `content` array.
+
+Tenant scoping mirrors the REST surface: `operator.tenant_id` comes
+from the validated JWT (resolved by `verify_mcp_jwt_and_bind`); the
+arguments dict never carries `tenant_id` (rejected by the schema).
+Cross-tenant probes are structurally impossible.
+
+Audit + broadcast contract:
+
+* The MCP dispatcher (`mcp/handlers.py`) writes one `audit_log` row
+  per `tools/call`. For this tool the row's `op_id` is the tool name
+  verbatim — `"query_audit"` — not the REST surface's
+  `"meho.audit.query"`. The asymmetry is the dispatcher's convention
+  (HTTP middleware reads a contextvar override; MCP dispatcher uses
+  the tool name). Unifying the two op_ids is a v0.2.next surface.
+* `op_class="audit_query"` on the `ToolDefinition` is the declarative
+  contract for the broadcast classifier's aggregate-only redaction
+  per `broadcast/events.py::redact_payload`. T5 (#469) is the
+  end-to-end acceptance gate for the wiring; T4 ships the declarative
+  registration only.
+
+Error mapping at the tool boundary:
+
+* `DurationParseError` (`since` / `until` shorthand) — caught in the
+  handler, raised as `McpInvalidParamsError` → JSON-RPC `-32602`.
+* `pydantic.ValidationError` (post-jsonschema, e.g. malformed UUID
+  slipping past `format: uuid`) — same mapping.
+* `InvalidCursorError` (substrate, tampered cursor) — same mapping.
+* `UnsupportedFilterError` (substrate, `parent_audit_id` /
+  `agent_session_id` in v0.2) — same mapping with the column-name
+  message.
+* Anything else propagates; the dispatcher's outer try/except turns
+  it into JSON-RPC `-32603` Internal Error.
+
+RBAC: `operator` role minimum. `read_only` callers find the tool
+absent from `tools/list` and get `-32602` on a direct `tools/call`
+attempt (the dispatcher's per-call RBAC re-check, not a transport
+401 — JSON-RPC has no 403 analogue).
+
 ## Dependencies
 
 * `meho_backplane.db.models.AuditLog` — read schema; this package never writes.
@@ -149,7 +209,10 @@ Reverse dependencies:
 
 * `meho_backplane.api.v1.audit` (T2 #466) — REST router for the four
   consumer-facing routes; dispatches every call through `query_audit`.
-* T3 #467 (CLI) and T4 #468 (MCP) follow.
+* `meho_backplane.mcp.tools.audit` (T4 #468) — single MCP meta-tool
+  registered against the G0.5 registry; dispatches every call through
+  `query_audit`.
+* T3 #467 (CLI) follows.
 
 ## Known issues / v0.2 gaps
 
@@ -195,7 +258,9 @@ Reverse dependencies:
 * Initiative: [G8.1 #334](https://github.com/evoila/meho/issues/334).
 * Tasks: [G8.1-T1 #465](https://github.com/evoila/meho/issues/465) (substrate),
   [G8.1-T2 #466](https://github.com/evoila/meho/issues/466) (REST routes +
-  duration parser).
+  duration parser),
+  [G8.1-T4 #468](https://github.com/evoila/meho/issues/468) (MCP
+  meta-tool).
 * Write paths: `backend/src/meho_backplane/audit.py`,
   `backend/src/meho_backplane/mcp/audit.py`.
 * Op-class classifier: `backend/src/meho_backplane/broadcast/events.py:172`


### PR DESCRIPTION
## Summary

- Ships the single `query_audit` MCP meta-tool — the agent-facing entry into the G8.1 audit-query substrate (T1, #465). Mounts in `backend/src/meho_backplane/mcp/tools/audit.py`, registers against the G0.5 tool registry, dispatches through the T1 `query_audit` handler.
- CLAUDE.md narrow-waist postulate (#5) demands one tool for audit data, not a per-shape family — the REST shortcuts (`who-touched` / `my-recent` / `show` shipped in #466) collapse into filter combinations on this tool, not separate MCP registrations.
- Tenant scope enforced by passing `operator.tenant_id` from the validated JWT into the substrate; `additionalProperties: false` on the `inputSchema` rejects any agent-supplied `tenant_id` smuggling.
- `since` / `until` accept duration shorthand (`"24h"` / `"7d"` / `"30m"` / `"2w"`) or ISO-8601; parsed via the same `parse_duration` helper the T2 router uses. Substrate / parser errors map to JSON-RPC `-32602`.
- `op_class="audit_query"` on the `ToolDefinition` is the declarative contract for the broadcast classifier's aggregate-only redaction. End-to-end wiring verification is T5's scope (#469).

## Test plan

- [x] `ruff check src/.../audit.py tests/test_mcp_tool_query_audit.py tests/mcp_test_fixtures.py` — clean.
- [x] `ruff format --check` — clean (8 files already formatted).
- [x] `mypy src/` — clean (132 source files).
- [x] `pytest tests/test_mcp_tool_query_audit.py` — **15 passed** in 11.5s.
- [x] `pytest tests/test_mcp_tool_meho_status.py tests/test_mcp_resource_tenant_info.py tests/test_mcp_resource_tenant_feed.py tests/test_mcp_audit.py tests/test_mcp_tools_operations.py tests/test_mcp_tools_connector_admin.py tests/test_app_starts.py` — **61 passed** (no MCP regression).
- [x] `pytest tests/test_audit_query_handler.py tests/test_audit_query_cursor.py tests/test_audit_query_schemas.py tests/test_audit_query_duration.py tests/test_api_audit_routes.py` — **79 passed** (no T1 / T2 regression).
- [x] **AC1** (`tools/list` exposes `query_audit`): `test_tools_list_exposes_query_audit`.
- [x] **AC2** (description names what + when-to + when-NOT): `test_tools_list_description_contains_when_to_call_guidance`.
- [x] **AC3** (`since="24h"` parses to tz-aware datetime; substrate gets the right filter): `test_tools_call_since_24h_parses_to_tz_aware_datetime`.
- [x] **AC4** (tenant scope from JWT; smuggled `tenant_id` rejected): `test_tools_call_tenant_id_taken_from_operator_jwt`.
- [x] **AC5** (`op_class="audit_query"` registered correctly — declarative): `test_registered_definition_has_audit_query_op_class`. End-to-end aggregate-only verification deferred to T5 (#469) per the AC's own scope punt.
- [x] **AC6** (`inputSchema` is JSON-Schema-2020-12; wire fields stripped): `test_tools_list_input_schema_is_strict_2020_12`.
- [x] **AC8** (per-shape conveniences NOT registered against MCP): `test_per_shape_shortcuts_not_registered_against_mcp`.
- [x] **AC9** (CI green; ruff + mypy clean): see above.

AC7 (MCP-inspector smoke test) is not testable in pytest; T5 covers it.

## Adjacent findings (NOT addressed here — recorded for follow-up)

1. **MCP broadcast publisher op_class override gap.** `mcp/handlers.py:548` (`_publish_mcp_event`) re-runs `classify_op(op_id)` instead of honoring `audit_payload["op_class"]` (which the dispatcher sets from `defn.op_class` at line 221). For `query_audit` with `op_id="query_audit"`, `classify_op` returns `"other"`, so the broadcast event ships with the full payload — not the aggregate-only `{op_id, result_status, row_count}` decision #3 requires for `op_class="audit_query"`. Fix is ~3 lines mirroring `audit.py:_publish_broadcast_event:346-357`; T5 (#469) is the natural place, or a separate small Task before T5.
2. **MCP audit-payload enrichment gap.** Handlers cannot surface `row_count` (or any other enrichment field) to the audit row or the broadcast event — the dispatcher builds `audit_payload` statically. For aggregate-only broadcasts to carry meaningful row counts, the dispatcher needs a contextvar-merge shim like `_resolve_audit_payload` from the HTTP path.
3. **op_id asymmetry.** REST audit-query rows: `op_id="meho.audit.query"`. MCP audit-query rows: `op_id="query_audit"` (the tool name; dispatcher convention). Operators forensically searching `audit_log` for "all audit-query calls" need to OR both. Unification via a `ToolDefinition.audit_op_id` override field or a tool rename — v0.2.next surface.

## Out of scope

- T3 (#467 CLI verbs).
- T5 (#469) — integration concurrency + aggregate-only broadcast verification + E2E CLI→REST→MCP.
- T6 (#470 docs/cross-repo + architecture).
- The three adjacent findings above.

Closes #468


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added forensic audit log query tool enabling operators to investigate system activities and events.
  * Supports timestamp-based filtering with intuitive duration shorthand syntax (e.g., "24h").
  * Enforces role-based access control to restrict queries to authorized operator accounts only.

* **Documentation**
  * Updated documentation describing the audit query tool's interface, validation, and error handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/505)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->