### PR TITLE
feat(cli): G8.1-T3 meho audit query/recent/show/who-touched/my-recent

### DIFF
--- a/cli/internal/cmd/audit/audit.go
+++ b/cli/internal/cmd/audit/audit.go
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package audit hosts the cobra commands under `meho audit ...` for
+// G8.1-T3 (#467) of Initiative #334. v0.2 ships five operator-facing
+// verbs that wrap the T2 REST surface (#466) shipped by
+// `backend/src/meho_backplane/api/v1/audit.py`:
+//
+//   - `meho audit query [--target T] [--principal P] [--op-id PATTERN]
+//     [--op-class C] [--result-status S] [--since DUR] [--until DUR]
+//     [--limit N] [--cursor C] [--json]` — full filter via
+//     POST /api/v1/audit/query.
+//   - `meho audit recent [--limit N] [--json]` — shortcut over
+//     POST /api/v1/audit/query with since="24h" bound at the CLI.
+//   - `meho audit show <audit-id> [--json]` — single-row detail via
+//     GET /api/v1/audit/show/{audit_id}. 404 surfaces as
+//     "audit row not found" — the cross-tenant probe always reads as
+//     not-found (the backend enforces tenant-scoping at the substrate
+//     layer and the route returns 404 rather than 403 so existence
+//     never leaks).
+//   - `meho audit who-touched <target> [--since DUR] [--limit N]
+//     [--json]` — pre-canned shortcut via
+//     GET /api/v1/audit/who-touched/{target}.
+//   - `meho audit my-recent [--since DUR] [--limit N] [--json]` —
+//     pre-canned shortcut filtered to the operator's own JWT subject
+//     via GET /api/v1/audit/my-recent.
+//
+// Each verb wraps one backplane route, renders the response either
+// as a human-readable table / key-value summary or as raw JSON when
+// `--json` is set. Authentication piggybacks on the token meho login
+// wrote — same pattern as `meho targets` and `meho retrieval`.
+package audit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho audit` parent command. The command is
+// grafted onto the top-level meho command tree by cmd/root.go
+// alongside `meho operation`, `meho retrieval`, `meho targets`, and
+// `meho connector`. The parent itself takes no args and prints its
+// own help; every piece of behaviour lives in the per-subcommand
+// RunE closures.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Query the MEHO audit log (query / recent / show / who-touched / my-recent)",
+		Long: "Query the WORM-grade audit log written by the backplane on " +
+			"every authenticated request. Wraps the G8.1-T2 REST surface " +
+			"(/api/v1/audit/*). All verbs are tenant-scoped via the operator's " +
+			"JWT — cross-tenant queries are impossible by construction.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newQueryCmd())
+	cmd.AddCommand(newRecentCmd())
+	cmd.AddCommand(newShowCmd())
+	cmd.AddCommand(newWhoTouchedCmd())
+	cmd.AddCommand(newMyRecentCmd())
+	return cmd
+}
+
+// Entry mirrors the backend `AuditEntry` Pydantic model
+// (`backend/src/meho_backplane/audit_query/schemas.py`). Fields are
+// hand-written rather than aliased to a generated client type so the
+// audit package stays decoupled from oapi-codegen churn — the
+// targets / retrieval / operation packages take the same stance.
+//
+// Optional Pydantic fields land as `*string` so the JSON round-trip
+// preserves the explicit-null wire shape. `DurationMS` is a string
+// because Pydantic v2 serialises `Decimal` as a quoted decimal string
+// by default.
+type Entry struct {
+	ID               string         `json:"id"`
+	TS               string         `json:"ts"`
+	TenantID         *string        `json:"tenant_id"`
+	PrincipalSub     string         `json:"principal_sub"`
+	PrincipalName    *string        `json:"principal_name"`
+	TargetID         *string        `json:"target_id"`
+	TargetName       *string        `json:"target_name"`
+	Method           string         `json:"method"`
+	Path             string         `json:"path"`
+	StatusCode       int            `json:"status_code"`
+	RequestID        *string        `json:"request_id"`
+	DurationMS       *string        `json:"duration_ms"`
+	Payload          map[string]any `json:"payload"`
+	OpID             string         `json:"op_id"`
+	OpClass          string         `json:"op_class"`
+	ResultStatus     string         `json:"result_status"`
+	ParentAuditID    *string        `json:"parent_audit_id"`
+	AgentSessionID   *string        `json:"agent_session_id"`
+	BroadcastEventID *string        `json:"broadcast_event_id"`
+}
+
+// QueryResult mirrors the backend `AuditQueryResult` Pydantic model
+// — a page of audit rows plus the opaque forward-only cursor.
+// `NextCursor` keeps the JSON key on null (no omitempty) so the wire
+// shape matches the Pydantic side, where the field is always emitted
+// as `null` when there is no further page. The retire-checklist PR
+// (#497) tripped on the same omitempty / schema-stability gotcha and
+// the fix is to never drop the key on Go re-marshal.
+type QueryResult struct {
+	Rows       []Entry `json:"rows"`
+	NextCursor *string `json:"next_cursor"`
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" from a generic resolver
+// failure. Same shape as the helpers in
+// cli/internal/cmd/targets/targets.go and operation/operation.go;
+// kept independent because importing those packages here would
+// create cycles via cmd/root.go.
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane resolves the backplane URL from either the
+// `--backplane` override or the `meho login` config file. Same shape
+// as the targets / operation package helpers — duplicated to avoid
+// the import cycle the cmd → cmd/audit → cmd path would create.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes and parses the URL to fail
+// fast on garbage input. Mirrors normaliseURL in
+// targets/targets.go and operation/operation.go.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from one of the per-verb
+// request helpers into the right output.StructuredError category.
+// Same classification ladder as targets / operation packages with
+// audit-specific 400 handling:
+//
+//   - 401 (refresh failed) → auth_expired with a `meho login` hint.
+//   - 403 (RBAC denial) → insufficient_role; the backend's 403 detail
+//     names the required role.
+//   - 400 → unexpected with the parser / substrate error message —
+//     `DurationParseError`, `InvalidCursorError`, and
+//     `UnsupportedFilterError` (v0.2's `parent_audit_id` /
+//     `agent_session_id` gap) all surface as 400 from the backend.
+//   - 404 → unexpected with "audit row not found" (only the
+//     show endpoint emits this; cross-tenant probes also surface
+//     here per the substrate's tenant-scoping discipline).
+//   - 422 → unexpected with the FastAPI validation envelope.
+//   - Any other 4xx/5xx → unexpected with the raw body.
+//   - Pure transport errors → unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderHTTPError classifies a non-2xx response into the right
+// StructuredError category.
+func renderHTTPError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	he *httpError,
+	jsonOut bool,
+) error {
+	switch he.StatusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusBadRequest:
+		// Audit-API 400 = DurationParseError (router) /
+		// InvalidCursorError (substrate) / UnsupportedFilterError
+		// (substrate). The backend's HTTPException detail is the
+		// parser's own message; surface it verbatim.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusNotFound:
+		// Only the show endpoint emits 404. Cross-tenant probes
+		// land here too — the substrate returns zero rows, the
+		// route surfaces 404 (not 403) so existence never leaks.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("audit row not found"),
+			jsonOut,
+		)
+	case http.StatusUnprocessableEntity:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
+			jsonOut,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape.
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error
+// body when it's a plain string. Falls back to the raw body when the
+// JSON shape doesn't match.
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection and one-shot 401-refresh-retry. Returns the
+// response body bytes (already drained) on 2xx, or an *httpError on
+// non-2xx, or an error categorised by api.IsTokenNotFound /
+// api.IsNoRefreshToken / generic transport.
+//
+// Mirrors cli/internal/cmd/targets/targets.go::doAuthedRequest and
+// operation/operation.go's namesake — kept independent for the
+// import-cycle reason called out on resolveBackplane.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// httpError carries a non-2xx response so per-verb runners can
+// render the right category.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// sendRequest is the bottom of the stack: build the http.Request,
+// stamp bearer + content headers, fire it.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// pathEscape escapes a single path segment for use inside a backend
+// URL.
+func pathEscape(segment string) string {
+	return url.PathEscape(segment)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Rune-aware so multi-byte UTF-8 survives the
+// cut. Same shape as the sibling-package helper.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// strDeref returns *s or empty string when s is nil. Backend Pydantic
+// models declare many audit fields as `Optional[...]`; null lands as
+// nil after JSON decode and the formatter consumes the empty string.
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/cli/internal/cmd/audit/audit.go
+++ b/cli/internal/cmd/audit/audit.go
@@ -342,15 +342,40 @@ func doAuthedRequest(
 	}
 	defer resp.Body.Close()
 
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+	// Read with a 1-MiB cap. The +1 byte over the cap is the
+	// truncation-detection trick: if ReadAll returns more than
+	// ``responseBodyCap`` bytes, the response was at least cap+1 bytes
+	// long and the decoder would otherwise consume a silently-truncated
+	// JSON payload. Fail loud instead — a truncated audit response
+	// surfaces as "decode error: unexpected end of JSON input" without
+	// this guard, which buries the real cause (response too large for
+	// the chassis CLI's safety cap).
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
 	if readErr != nil {
 		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if int64(len(raw)) > responseBodyCap {
+		return nil, fmt.Errorf(
+			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
+			responseBodyCap,
+		)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
 	}
 	return raw, nil
 }
+
+// responseBodyCap is the hard upper bound on a backplane response
+// body the CLI is willing to read. Audit pages cap at 1000 rows
+// server-side; a typical row at ~500 B yields ~500 KiB, so 1 MiB
+// is comfortable headroom. The cap protects against an
+// adversarial / misconfigured backplane sending an unbounded
+// response — the alternative is OOM. The +1-byte read pattern in
+// “doAuthedRequest“ distinguishes "fits in the cap" from
+// "truncated at the cap" so the decoder doesn't silently consume
+// a half-JSON.
+const responseBodyCap int64 = 1 << 20
 
 // httpError carries a non-2xx response so per-verb runners can
 // render the right category.
@@ -416,4 +441,23 @@ func strDeref(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// decodeAuditResponse JSON-decodes *raw* into *out* via a
+// “json.Decoder“ configured with “UseNumber()“ so payload numbers
+// survive as “json.Number“ rather than collapsing to “float64“.
+// Audit payloads carry integer-valued fields (“hit_count“,
+// “query_count“, timestamps stored as Unix seconds, etc.) that
+// silently lose precision when decoded as IEEE-754 doubles past
+// 2^53. The exact-integer-preserving path lets jq pipelines and the
+// human-readable summary render the value the backend actually wrote
+// instead of a rounded float. Used by every audit verb that decodes
+// an “Entry“ or “QueryResult“.
+func decodeAuditResponse(raw []byte, out any) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(out); err != nil {
+		return fmt.Errorf("decode audit response: %w", err)
+	}
+	return nil
 }

--- a/cli/internal/cmd/audit/audit_test.go
+++ b/cli/internal/cmd/audit/audit_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// seedXDGAndToken seeds a per-test config dir + token store that
+// resolveBackplane / doAuthedRequest will read. Mirrors the same
+// helper in cli/internal/cmd/targets/list_test.go — the auth
+// package's keyring backend defaults are disabled for tests so the
+// file-store path is exercised deterministically.
+func seedXDGAndToken(t *testing.T, backplaneURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  "eyJ.test.token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return dir
+}
+
+// newRunCmd builds a fresh cobra.Command with stdout/stderr buffers
+// attached. The runXxx helpers consume cmd.OutOrStdout /
+// cmd.ErrOrStderr; tests inspect the buffers afterwards.
+func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	return cmd, &stdout, &stderr
+}
+
+// TestNewRootCmdRegistersAllFiveVerbs — AC1: every advertised verb
+// has a cobra subcommand. The CLI manifest is the contract operators
+// build muscle memory around; dropping a verb silently is the
+// regression class we want to catch at unit-time.
+func TestNewRootCmdRegistersAllFiveVerbs(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"query":       false,
+		"recent":      false,
+		"show":        false,
+		"who-touched": false,
+		"my-recent":   false,
+	}
+	for _, sub := range root.Commands() {
+		// cobra splits `Use` on the first space to render <args>
+		// (so `show <audit-id>` registers as `show`). Mirror that
+		// split for the contains-check.
+		name := strings.SplitN(sub.Use, " ", 2)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("subcommand %q not registered under `meho audit`", name)
+		}
+	}
+}
+
+// TestNormaliseURLStripsTrailingSlash — the resolver mirrors the
+// targets / operation helpers; the trailing slash invariant is
+// load-bearing for the request paths assembled on top.
+func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
+	got, err := normaliseURL("https://meho.example/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.example" {
+		t.Errorf("trailing slash not stripped: got %q", got)
+	}
+}
+
+// TestNormaliseURLRejectsHostlessInput — bare paths fail fast rather
+// than producing a request against the local filesystem.
+func TestNormaliseURLRejectsHostlessInput(t *testing.T) {
+	if _, err := normaliseURL("/just/a/path"); err == nil {
+		t.Errorf("expected error for hostless URL")
+	}
+}
+
+// TestNormaliseURLRejectsGarbage — a fundamentally unparseable URL
+// surfaces the parse error rather than the silently-empty resolver.
+func TestNormaliseURLRejectsGarbage(t *testing.T) {
+	if _, err := normaliseURL("h ttp://broken"); err == nil {
+		t.Errorf("expected error for malformed URL")
+	}
+}
+
+// TestNormaliseURLRejectsEmpty — empty config slot must reach the
+// caller as an error rather than producing a zero-host request.
+func TestNormaliseURLRejectsEmpty(t *testing.T) {
+	if _, err := normaliseURL("   "); err == nil {
+		t.Errorf("expected error for empty URL")
+	}
+}
+
+// TestDecodeDetailStringPullsString — FastAPI's HTTPException body
+// surfaces as `{"detail": "<string>"}`. The audit-API 400 path
+// (DurationParseError / InvalidCursorError / UnsupportedFilterError)
+// uses that shape, so the CLI's error renderer leans on this helper.
+func TestDecodeDetailStringPullsString(t *testing.T) {
+	body := `{"detail": "cursor is not valid base64"}`
+	if got := decodeDetailString(body); got != "cursor is not valid base64" {
+		t.Errorf("decodeDetailString: got %q", got)
+	}
+}
+
+// TestDecodeDetailStringFallsBackOnNonJSON — operators see the raw
+// body when the response isn't FastAPI-shaped (a load balancer 503,
+// a stray HTML page) rather than an empty error.
+func TestDecodeDetailStringFallsBackOnNonJSON(t *testing.T) {
+	body := "Service Unavailable"
+	if got := decodeDetailString(body); got != "Service Unavailable" {
+		t.Errorf("decodeDetailString fallback: got %q", got)
+	}
+}
+
+// TestTruncateRuneAware — multi-byte UTF-8 stays valid when the
+// table renderer truncates a long target name.
+func TestTruncateRuneAware(t *testing.T) {
+	got := truncate("vörtex-vcenter-prod-eu-central-1", 10)
+	if len(got) == 0 || !strings.Contains(got, "…") {
+		t.Errorf("truncate did not emit ellipsis: %q", got)
+	}
+}
+
+// TestStrDerefHandlesNil — defensive nil-deref so the table /
+// summary helpers don't panic on backend-null fields.
+func TestStrDerefHandlesNil(t *testing.T) {
+	if got := strDeref(nil); got != "" {
+		t.Errorf("strDeref(nil): got %q", got)
+	}
+	v := "hello"
+	if got := strDeref(&v); got != "hello" {
+		t.Errorf("strDeref(&\"hello\"): got %q", got)
+	}
+}

--- a/cli/internal/cmd/audit/audit_test.go
+++ b/cli/internal/cmd/audit/audit_test.go
@@ -6,6 +6,8 @@ package audit
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -168,5 +170,120 @@ func TestStrDerefHandlesNil(t *testing.T) {
 	v := "hello"
 	if got := strDeref(&v); got != "hello" {
 		t.Errorf("strDeref(&\"hello\"): got %q", got)
+	}
+}
+
+// TestDoAuthedRequestRejectsOversizedResponse — the 1 MiB cap on
+// “io.LimitReader“ is paired with a +1-byte read so a response
+// that fills the cap surfaces as a clear error rather than feeding
+// a silently-truncated JSON body into the decoder. Without this
+// guard, an oversized audit page would surface as
+// "unexpected end of JSON input" — confusing to operators and
+// indistinguishable from a malformed backend response.
+func TestDoAuthedRequestRejectsOversizedResponse(t *testing.T) {
+	// Emit 1 MiB + 1 byte of payload — exactly at the threshold the
+	// truncation guard fires. Anything strictly above the cap must
+	// fail loud rather than silently decode.
+	oversized := strings.Repeat("a", int(responseBodyCap)+1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/test", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(oversized))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := doAuthedRequest(ctx, srv.URL, "GET", "/api/v1/audit/test", nil)
+	if err == nil {
+		t.Fatalf("expected error on oversized response")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error message does not mention size cap: %v", err)
+	}
+}
+
+// TestDoAuthedRequestAcceptsResponseExactlyAtCap — the threshold
+// itself is allowed through. The +1-byte read distinguishes
+// "fits in the cap" from "spilled past the cap"; exactly-at-cap
+// must still decode.
+func TestDoAuthedRequestAcceptsResponseExactlyAtCap(t *testing.T) {
+	exact := strings.Repeat("a", int(responseBodyCap))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/test", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(exact))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	raw, err := doAuthedRequest(ctx, srv.URL, "GET", "/api/v1/audit/test", nil)
+	if err != nil {
+		t.Fatalf("exact-cap response should not error: %v", err)
+	}
+	if int64(len(raw)) != responseBodyCap {
+		t.Errorf("expected %d bytes; got %d", responseBodyCap, len(raw))
+	}
+}
+
+// TestDecodeAuditResponsePreservesLargeIntegers — Unix-millis
+// timestamps and other 64-bit integers in audit payloads must
+// survive the JSON round-trip without losing precision. Without
+// “UseNumber()“ they collapse to “float64“ and any integer above
+// 2^53 rounds — silently mangling forensic data.
+func TestDecodeAuditResponsePreservesLargeIntegers(t *testing.T) {
+	// 1745923128091 is a real Unix-millis timestamp shape; well
+	// below 2^53 so the failure mode for ``float64`` would be a
+	// trailing-decimal render rather than a precision loss, but the
+	// principle covers the larger range too.
+	raw := []byte(`{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"ts": "2026-05-13T00:00:00Z",
+		"tenant_id": null,
+		"principal_sub": "damir",
+		"principal_name": null,
+		"target_id": null,
+		"target_name": null,
+		"method": "GET",
+		"path": "/x",
+		"status_code": 200,
+		"request_id": null,
+		"duration_ms": null,
+		"payload": {"hit_count": 1745923128091, "ratio": 0.5},
+		"op_id": "x.y",
+		"op_class": "read",
+		"result_status": "ok",
+		"parent_audit_id": null,
+		"agent_session_id": null,
+		"broadcast_event_id": null
+	}`)
+	var entry Entry
+	if err := decodeAuditResponse(raw, &entry); err != nil {
+		t.Fatalf("decodeAuditResponse: %v", err)
+	}
+	// The payload's integer must render exactly — no scientific
+	// notation, no trailing ``.0``. With ``UseNumber()`` it lands
+	// as ``json.Number("1745923128091")`` and formatPayloadScalar
+	// emits the bare digits.
+	hit, ok := entry.Payload["hit_count"]
+	if !ok {
+		t.Fatalf("payload missing hit_count: %+v", entry.Payload)
+	}
+	got := formatPayloadScalar(hit)
+	if got != "1745923128091" {
+		t.Errorf("integer precision lost: got %q; want %q", got, "1745923128091")
+	}
+	// And the float case still renders compactly.
+	ratio, ok := entry.Payload["ratio"]
+	if !ok {
+		t.Fatalf("payload missing ratio: %+v", entry.Payload)
+	}
+	if got := formatPayloadScalar(ratio); got != "0.5" {
+		t.Errorf("float render: got %q; want %q", got, "0.5")
 	}
 }

--- a/cli/internal/cmd/audit/my_recent.go
+++ b/cli/internal/cmd/audit/my_recent.go
@@ -5,7 +5,6 @@ package audit
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -124,8 +123,8 @@ func getMyRecent(ctx context.Context, backplaneURL string, opts myRecentOptions)
 		return nil, err
 	}
 	var out QueryResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode my-recent response: %w", err)
+	if err := decodeAuditResponse(raw, &out); err != nil {
+		return nil, err
 	}
 	return &out, nil
 }

--- a/cli/internal/cmd/audit/my_recent.go
+++ b/cli/internal/cmd/audit/my_recent.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newMyRecentCmd returns the `meho audit my-recent` command.
+//
+// CLI shape (per issue #467):
+//
+//	meho audit my-recent [--since DUR] [--limit N] [--json] [--backplane <url>]
+//
+// Calls GET /api/v1/audit/my-recent. The backend reads the operator's
+// `sub` claim from the verified JWT and binds it as the `principal`
+// filter — there is no surface that accepts an operator override.
+// Cross-operator inspection is `meho audit query --principal P`.
+//
+// Exit codes mirror `meho audit query`.
+func newMyRecentCmd() *cobra.Command {
+	var (
+		since             string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "my-recent",
+		Short: "Show your own recent audit activity",
+		Long: "my-recent calls GET /api/v1/audit/my-recent and renders the " +
+			"audit rows the calling operator produced. The `principal` " +
+			"filter is taken from the JWT's `sub` claim server-side — " +
+			"there is no surface that accepts an operator override. " +
+			"--since defaults to 24h server-side; pass a different " +
+			"shorthand (7d / 30m / 2w) or an ISO-8601 datetime to widen " +
+			"the window. --limit caps the page size (1..1000, server " +
+			"default 100). --json emits the raw QueryResult.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runMyRecent(cmd, myRecentOptions{
+				Since:             since,
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&since, "since", "",
+		"earliest occurred_at; defaults server-side to 24h when omitted")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max rows (1..1000, server default 100 when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw QueryResult JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type myRecentOptions struct {
+	Since             string
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runMyRecent(cmd *cobra.Command, opts myRecentOptions) error {
+	if opts.Limit < 0 || opts.Limit > 1000 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 1000; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := getMyRecent(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printQueryTable(cmd.OutOrStdout(), result)
+	return nil
+}
+
+// buildMyRecentPath assembles the GET path with optional --since /
+// --limit query params. Exposed for unit tests.
+func buildMyRecentPath(since string, limit int) string {
+	q := url.Values{}
+	if since != "" {
+		q.Set("since", since)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/audit/my-recent"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path
+}
+
+func getMyRecent(ctx context.Context, backplaneURL string, opts myRecentOptions) (*QueryResult, error) {
+	raw, err := doAuthedRequest(
+		ctx, backplaneURL, "GET",
+		buildMyRecentPath(opts.Since, opts.Limit), nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var out QueryResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode my-recent response: %w", err)
+	}
+	return &out, nil
+}

--- a/cli/internal/cmd/audit/my_recent_test.go
+++ b/cli/internal/cmd/audit/my_recent_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildMyRecentPathOmitsEmptyParams — the no-flag form sends a
+// bare path so the backend's defaults take over.
+func TestBuildMyRecentPathOmitsEmptyParams(t *testing.T) {
+	got := buildMyRecentPath("", 0)
+	if got != "/api/v1/audit/my-recent" {
+		t.Errorf("buildMyRecentPath empty: got %q", got)
+	}
+}
+
+// TestBuildMyRecentPathEmitsParams — every set flag lands on the
+// query string.
+func TestBuildMyRecentPathEmitsParams(t *testing.T) {
+	got := buildMyRecentPath("2w", 25)
+	if !strings.Contains(got, "since=2w") {
+		t.Errorf("missing since: %q", got)
+	}
+	if !strings.Contains(got, "limit=25") {
+		t.Errorf("missing limit: %q", got)
+	}
+}
+
+// TestRunMyRecentHappyPath — the verb hits GET /api/v1/audit/my-
+// recent. The backend's `principal` filter is derived from the JWT
+// sub claim server-side; the CLI never supplies it.
+func TestRunMyRecentHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/my-recent", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s; want GET", r.Method)
+		}
+		// The route reads the principal filter from the JWT
+		// server-side; no client-supplied principal flag.
+		if r.URL.Query().Get("principal") != "" {
+			t.Errorf("CLI should not supply principal query param: got %q",
+				r.URL.Query().Get("principal"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(QueryResult{
+			Rows: []Entry{{
+				ID:           "00000000-0000-0000-0000-000000000001",
+				TS:           "2026-05-15T09:00:00Z",
+				PrincipalSub: "damir",
+				Method:       "POST",
+				Path:         "/api/v1/retrieve",
+				StatusCode:   200,
+				OpID:         "meho.retrieval.query",
+				OpClass:      "audit_query",
+				ResultStatus: "ok",
+				Payload:      map[string]any{},
+			}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runMyRecent(cmd, myRecentOptions{BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runMyRecent: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"TIME", "damir", "meho.retrieval.query", "audit_query"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q in %s", want, out)
+		}
+	}
+}
+
+// TestRunMyRecentRejectsOutOfRangeLimit — defensive --limit
+// validation matches the query verb.
+func TestRunMyRecentRejectsOutOfRangeLimit(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	if err := runMyRecent(cmd, myRecentOptions{Limit: 99999}); err == nil {
+		t.Fatalf("expected error for --limit=99999")
+	}
+}
+
+// TestRunMyRecentJSONRoundTrips — --json emits the structured shape.
+func TestRunMyRecentJSONRoundTrips(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/my-recent", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rows":[],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runMyRecent(cmd, myRecentOptions{JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runMyRecent --json: %v", err)
+	}
+	var decoded QueryResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
+	}
+}

--- a/cli/internal/cmd/audit/query.go
+++ b/cli/internal/cmd/audit/query.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// auditQueryRequest mirrors the backend `AuditQueryRequest` Pydantic
+// model (`backend/src/meho_backplane/api/v1/audit_models.py`). Every
+// filter field is a pointer (or `omitempty`-tagged primitive) so the
+// CLI emits only the keys the operator actually set — the backend
+// treats absent keys as "no narrowing on this column". `Limit=0`
+// special-cases the unset state because Go's zero-value int collides
+// with the backend's `ge=1` validation otherwise.
+type auditQueryRequest struct {
+	Target        *string `json:"target,omitempty"`
+	Principal     *string `json:"principal,omitempty"`
+	OpID          *string `json:"op_id,omitempty"`
+	OpClass       *string `json:"op_class,omitempty"`
+	ResultStatus  *string `json:"result_status,omitempty"`
+	Since         *string `json:"since,omitempty"`
+	Until         *string `json:"until,omitempty"`
+	AuditID       *string `json:"audit_id,omitempty"`
+	ParentAuditID *string `json:"parent_audit_id,omitempty"`
+	Limit         int     `json:"limit,omitempty"`
+	Cursor        *string `json:"cursor,omitempty"`
+}
+
+// newQueryCmd returns the `meho audit query` command.
+//
+// CLI shape (matches issue #467 spec):
+//
+//	meho audit query \
+//	  [--target T]                 # name or alias (server resolves)
+//	  [--principal P]              # operator sub or partial match
+//	  [--op-id PATTERN]            # glob: vsphere.vm.*
+//	  [--op-class C]               # read | write | credential_read | audit_query | other
+//	  [--result-status S]          # ok | error | denied
+//	  [--since DUR]                # 24h | 7d | ISO-8601
+//	  [--until DUR]
+//	  [--limit N]                  # 1..1000, default 100 (server-side)
+//	  [--cursor C]                 # opaque forward-pagination cursor
+//	  [--audit-id ID]              # exact-id lookup
+//	  [--parent-audit-id ID]       # v0.2 substrate rejects (400)
+//	  [--json]                     # raw RetireChecklistReport JSON
+//	  [--backplane <url>]          # override the configured backplane
+//
+// Exit codes:
+//   - 0   query returned cleanly (incl. zero-row result).
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape (incl. 400 parser errors,
+//     unsupported filter, invalid cursor; 404 from show only).
+//   - 5   insufficient_role
+func newQueryCmd() *cobra.Command {
+	var (
+		target            string
+		principal         string
+		opID              string
+		opClass           string
+		resultStatus      string
+		since             string
+		until             string
+		limit             int
+		cursor            string
+		auditID           string
+		parentAuditID     string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "query",
+		Short: "Query the audit log with arbitrary filter combinations",
+		Long: "query calls POST /api/v1/audit/query and renders the audit " +
+			"rows matching the operator-supplied filters. Tenant scoping " +
+			"is enforced server-side via the JWT — there is no surface " +
+			"that accepts a tenant id. --since/--until accept either a " +
+			"duration shorthand (24h / 7d / 30m / 2w) or an ISO-8601 " +
+			"datetime. --cursor pastes the opaque next_cursor from a " +
+			"prior page. --json emits the raw QueryResult so " +
+			"operators can pipe into jq.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runQuery(cmd, queryOptions{
+				Target:            target,
+				Principal:         principal,
+				OpID:              opID,
+				OpClass:           opClass,
+				ResultStatus:      resultStatus,
+				Since:             since,
+				Until:             until,
+				Limit:             limit,
+				Cursor:            cursor,
+				AuditID:           auditID,
+				ParentAuditID:     parentAuditID,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "",
+		"narrow to one target (name or alias; server-side resolution)")
+	cmd.Flags().StringVar(&principal, "principal", "",
+		"narrow to one operator (JWT subject; partial-match supported)")
+	cmd.Flags().StringVar(&opID, "op-id", "",
+		"narrow to one op-id (glob with * wildcards)")
+	cmd.Flags().StringVar(&opClass, "op-class", "",
+		"narrow to one op-class (read|write|credential_read|audit_query|other)")
+	cmd.Flags().StringVar(&resultStatus, "result-status", "",
+		"narrow to one result-status (ok|error|denied)")
+	cmd.Flags().StringVar(&since, "since", "",
+		"earliest occurred_at; accepts 24h / 7d / 30m / 2w shorthand or ISO-8601")
+	cmd.Flags().StringVar(&until, "until", "",
+		"latest occurred_at; accepts the same shorthand as --since")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max rows per page (1..1000, server default 100 when omitted)")
+	cmd.Flags().StringVar(&cursor, "cursor", "",
+		"opaque forward-pagination cursor from a prior page's NEXT line")
+	cmd.Flags().StringVar(&auditID, "audit-id", "",
+		"exact audit-id lookup (UUID)")
+	cmd.Flags().StringVar(&parentAuditID, "parent-audit-id", "",
+		"narrow to the composite-op subtree under this audit-id "+
+			"(v0.2 substrate rejects with 400; column lands with G0.6-T7 #398)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw QueryResult JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type queryOptions struct {
+	Target            string
+	Principal         string
+	OpID              string
+	OpClass           string
+	ResultStatus      string
+	Since             string
+	Until             string
+	Limit             int
+	Cursor            string
+	AuditID           string
+	ParentAuditID     string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runQuery(cmd *cobra.Command, opts queryOptions) error {
+	if opts.Limit < 0 || opts.Limit > 1000 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 1000; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := postQuery(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printQueryTable(cmd.OutOrStdout(), result)
+	return nil
+}
+
+// buildQueryRequest assembles the JSON body from the per-call
+// options. Each filter field lands on the wire only when the operator
+// set it. Empty strings stay empty (Pydantic's `extra="ignore"`
+// silently drops fields not on the model; the explicit Go-side
+// omission keeps the wire compact and matches the existing CLI
+// pattern in `cli/internal/cmd/retrieval/eval.go`).
+func buildQueryRequest(opts queryOptions) auditQueryRequest {
+	body := auditQueryRequest{}
+	if opts.Target != "" {
+		body.Target = &opts.Target
+	}
+	if opts.Principal != "" {
+		body.Principal = &opts.Principal
+	}
+	if opts.OpID != "" {
+		body.OpID = &opts.OpID
+	}
+	if opts.OpClass != "" {
+		body.OpClass = &opts.OpClass
+	}
+	if opts.ResultStatus != "" {
+		body.ResultStatus = &opts.ResultStatus
+	}
+	if opts.Since != "" {
+		body.Since = &opts.Since
+	}
+	if opts.Until != "" {
+		body.Until = &opts.Until
+	}
+	if opts.AuditID != "" {
+		body.AuditID = &opts.AuditID
+	}
+	if opts.ParentAuditID != "" {
+		body.ParentAuditID = &opts.ParentAuditID
+	}
+	if opts.Cursor != "" {
+		body.Cursor = &opts.Cursor
+	}
+	if opts.Limit > 0 {
+		body.Limit = opts.Limit
+	}
+	return body
+}
+
+func postQuery(ctx context.Context, backplaneURL string, opts queryOptions) (*QueryResult, error) {
+	body := buildQueryRequest(opts)
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal audit query: %w", err)
+	}
+	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/audit/query", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out QueryResult
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, fmt.Errorf("decode audit query response: %w", err)
+	}
+	return &out, nil
+}
+
+// printQueryTable renders the audit page as a compact, scannable
+// table. Columns: TIME, PRINCIPAL, TARGET, OP_ID, CLASS, STATUS per
+// the issue body's spec. When `next_cursor` is set, a final NEXT
+// line tells the operator how to paste-paginate.
+func printQueryTable(w io.Writer, r *QueryResult) {
+	if r == nil || len(r.Rows) == 0 {
+		fmt.Fprintln(w, "no audit rows matched the filter")
+		return
+	}
+	fmt.Fprintf(w, "%-22s %-12s %-18s %-26s %-16s %s\n",
+		"TIME", "PRINCIPAL", "TARGET", "OP_ID", "CLASS", "STATUS")
+	for _, row := range r.Rows {
+		target := strDeref(row.TargetName)
+		if target == "" {
+			target = "-"
+		}
+		fmt.Fprintf(w, "%-22s %-12s %-18s %-26s %-16s %s\n",
+			truncate(row.TS, 22),
+			truncate(row.PrincipalSub, 12),
+			truncate(target, 18),
+			truncate(row.OpID, 26),
+			truncate(row.OpClass, 16),
+			truncate(row.ResultStatus, 8),
+		)
+	}
+	if r.NextCursor != nil && *r.NextCursor != "" {
+		fmt.Fprintf(w, "NEXT: --cursor=%s  (paste to continue)\n", *r.NextCursor)
+	}
+}

--- a/cli/internal/cmd/audit/query.go
+++ b/cli/internal/cmd/audit/query.go
@@ -233,8 +233,8 @@ func postQuery(ctx context.Context, backplaneURL string, opts queryOptions) (*Qu
 		return nil, err
 	}
 	var out QueryResult
-	if err := json.Unmarshal(resp, &out); err != nil {
-		return nil, fmt.Errorf("decode audit query response: %w", err)
+	if err := decodeAuditResponse(resp, &out); err != nil {
+		return nil, err
 	}
 	return &out, nil
 }

--- a/cli/internal/cmd/audit/query_test.go
+++ b/cli/internal/cmd/audit/query_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildQueryRequestEmptyOptsOmitsEveryFilter — the no-flag form
+// sends a minimal `{}` body, letting the backend defaults take over
+// (server-side limit=100, no narrowing filters). Mirrors the
+// retire-checklist learning that empty Go pointers must drop on the
+// wire — otherwise the backend reads "set to empty string" as a
+// match condition.
+func TestBuildQueryRequestEmptyOptsOmitsEveryFilter(t *testing.T) {
+	body := buildQueryRequest(queryOptions{})
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(raw)
+	if got != "{}" {
+		t.Errorf("empty opts marshalled non-empty: %s", got)
+	}
+}
+
+// TestBuildQueryRequestEveryFlagLandsOnWire — every operator-set
+// flag round-trips into the JSON body with the backend-expected
+// key. The AuditQueryRequest Pydantic model is `extra="ignore"` so
+// a typo'd key would silently drop; the test pins each key by name.
+func TestBuildQueryRequestEveryFlagLandsOnWire(t *testing.T) {
+	opts := queryOptions{
+		Target:        "rdc-vcenter",
+		Principal:     "damir",
+		OpID:          "vsphere.vm.*",
+		OpClass:       "write",
+		ResultStatus:  "ok",
+		Since:         "24h",
+		Until:         "1h",
+		AuditID:       "00000000-0000-0000-0000-000000000001",
+		ParentAuditID: "00000000-0000-0000-0000-000000000002",
+		Limit:         50,
+		Cursor:        "opaque-cursor-bytes",
+	}
+	body := buildQueryRequest(opts)
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(raw)
+	for _, want := range []string{
+		`"target":"rdc-vcenter"`,
+		`"principal":"damir"`,
+		`"op_id":"vsphere.vm.*"`,
+		`"op_class":"write"`,
+		`"result_status":"ok"`,
+		`"since":"24h"`,
+		`"until":"1h"`,
+		`"audit_id":"00000000-0000-0000-0000-000000000001"`,
+		`"parent_audit_id":"00000000-0000-0000-0000-000000000002"`,
+		`"limit":50`,
+		`"cursor":"opaque-cursor-bytes"`,
+	} {
+		if !strings.Contains(wire, want) {
+			t.Errorf("buildQueryRequest missing %q in %s", want, wire)
+		}
+	}
+}
+
+// TestBuildQueryRequestLimitZeroDoesNotMarshal — Limit=0 means "use
+// server default 100"; the wire must not carry `"limit":0` because
+// Pydantic's `ge=1` validation rejects it.
+func TestBuildQueryRequestLimitZeroDoesNotMarshal(t *testing.T) {
+	body := buildQueryRequest(queryOptions{Limit: 0})
+	raw, _ := json.Marshal(body)
+	if strings.Contains(string(raw), "limit") {
+		t.Errorf("limit=0 should be omitted; got %s", string(raw))
+	}
+}
+
+// TestRunQueryRejectsOutOfRangeLimit — AC validation: --limit must
+// be 1..1000 inclusive; out-of-range surfaces as exit-code 4 without
+// touching the network.
+func TestRunQueryRejectsOutOfRangeLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{Limit: 9999})
+	if err == nil {
+		t.Fatalf("expected error for --limit=9999")
+	}
+	if !strings.Contains(stderr.String()+err.Error(), "limit must be between") {
+		t.Errorf("stderr did not surface limit error: %s / %v", stderr.String(), err)
+	}
+}
+
+// TestRunQueryHappyPathTable — full round-trip: stub backplane,
+// POST hits /api/v1/audit/query, response renders as the documented
+// table with the operator-visible columns.
+func TestRunQueryHappyPathTable(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/query", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s; want POST", r.Method)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"target":"rdc-vcenter"`) {
+			t.Errorf("body missing target filter: %s", body)
+		}
+		tname := "rdc-vcenter"
+		next := "opaque-next-cursor"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(QueryResult{
+			Rows: []Entry{{
+				ID:           "00000000-0000-0000-0000-000000000001",
+				TS:           "2026-05-13T15:42:11Z",
+				PrincipalSub: "damir",
+				TargetName:   &tname,
+				Method:       "GET",
+				Path:         "/api/v1/vsphere/vm/list",
+				StatusCode:   200,
+				OpID:         "vsphere.vm.list",
+				OpClass:      "read",
+				ResultStatus: "ok",
+				Payload:      map[string]any{},
+			}},
+			NextCursor: &next,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{Target: "rdc-vcenter", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runQuery: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"TIME", "PRINCIPAL", "TARGET", "OP_ID", "CLASS", "STATUS",
+		"damir", "rdc-vcenter", "vsphere.vm.list", "read", "ok",
+		"NEXT: --cursor=opaque-next-cursor",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q in %s", want, out)
+		}
+	}
+}
+
+// TestRunQueryJSONPassthroughRoundTrips — --json emits the raw
+// QueryResult shape so jq pipelines see a stable contract.
+// The backend always emits `next_cursor` as a JSON key (Pydantic
+// v2 default for `str | None`); the CLI must preserve the key when
+// re-marshalling so consumers can `jq .next_cursor` without an
+// optional-presence dance.
+func TestRunQueryJSONPassthroughRoundTrips(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/query", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Emit the null next_cursor case the schema-stability
+		// contract pins.
+		_, _ = w.Write([]byte(`{"rows":[],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runQuery --json: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"next_cursor"`) {
+		t.Errorf("--json dropped next_cursor key: %s", stdout.String())
+	}
+	var decoded QueryResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if decoded.NextCursor != nil {
+		t.Errorf("expected nil NextCursor; got %v", decoded.NextCursor)
+	}
+}
+
+// TestRunQuery400SurfacesParserError — DurationParseError /
+// InvalidCursorError / UnsupportedFilterError all return 400 from
+// the backend with the parser's own message in the detail. The CLI
+// surfaces it through the `unexpected` exit-code channel rather
+// than silently treating it as a transport error.
+func TestRunQuery400SurfacesParserError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/query", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"detail": "unrecognised duration 'foo'",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{Since: "foo", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 400")
+	}
+	if !strings.Contains(stderr.String(), "unrecognised duration") {
+		t.Errorf("stderr missing parser detail: %s", stderr.String())
+	}
+}
+
+// TestRunQueryUnreachableSurfacesAsTransport — a TCP-level failure
+// (no server listening) lands as `unreachable`, the operator-
+// readable exit-code-3 category.
+func TestRunQueryUnreachableSurfacesAsTransport(t *testing.T) {
+	// Pin to an unused TCP port by starting then closing a server.
+	srv := httptest.NewServer(http.NewServeMux())
+	addr := srv.URL
+	srv.Close()
+	seedXDGAndToken(t, addr)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{BackplaneOverride: addr})
+	if err == nil {
+		t.Fatalf("expected unreachable error")
+	}
+	// Two acceptable readings: connection refused (Darwin) or the
+	// generic call-error wrapper. Both go through Unreachable.
+	if !strings.Contains(stderr.String(), "call ") {
+		t.Errorf("stderr does not look like Unreachable: %s", stderr.String())
+	}
+}
+
+// TestPrintQueryTableEmpty — zero-row tenant renders the helper line
+// without a header so operators don't confuse "no rows" with "table
+// header but missing body".
+func TestPrintQueryTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	printQueryTable(&buf, &QueryResult{Rows: []Entry{}})
+	out := buf.String()
+	if !strings.Contains(out, "no audit rows matched the filter") {
+		t.Errorf("empty table missing helper line: %s", out)
+	}
+	if strings.Contains(out, "TIME") {
+		t.Errorf("empty table should not print header: %s", out)
+	}
+}

--- a/cli/internal/cmd/audit/recent.go
+++ b/cli/internal/cmd/audit/recent.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// recentDefaultSince is the operator-friendly "what happened today"
+// shorthand the recent verb defaults to. Matches the same default
+// the backend `who-touched` / `my-recent` routes ship.
+const recentDefaultSince = "24h"
+
+// newRecentCmd returns the `meho audit recent` command.
+//
+// CLI shape (per issue #467):
+//
+//	meho audit recent [--limit N] [--json] [--backplane <url>]
+//
+// Equivalent to `meho audit query --since 24h --limit N`. The verb
+// exists as a separate cobra subcommand (rather than a hidden alias
+// of `query`) so the help output cleanly enumerates the operator's
+// daily-use shortcut alongside the full filter surface.
+//
+// Exit codes mirror `meho audit query`.
+func newRecentCmd() *cobra.Command {
+	var (
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "recent",
+		Short: "Show the most recent audit rows in the operator's tenant",
+		Long: "recent is a shortcut over `meho audit query --since 24h " +
+			"--limit N`. It calls POST /api/v1/audit/query with the same " +
+			"backend route the full filter uses; the only thing this verb " +
+			"does is bind --since to 24h so operators don't have to type " +
+			"it on the most common case. --limit caps the page size " +
+			"(1..1000, server default 100). --json emits the raw " +
+			"QueryResult.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Re-use the query runner. `since=24h` is the only filter
+			// bound here; the operator can still reach the full filter
+			// surface via `meho audit query` directly.
+			return runQuery(cmd, queryOptions{
+				Since:             recentDefaultSince,
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max rows (1..1000, server default 100 when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw QueryResult JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}

--- a/cli/internal/cmd/audit/recent_test.go
+++ b/cli/internal/cmd/audit/recent_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRunRecentBindsSince24h — `meho audit recent` is the shortcut
+// over `meho audit query --since 24h`. The verb's only job is to
+// bind --since to 24h server-side; the rest of the round-trip is
+// the same query path the full filter uses. This pins that the
+// canonical "since=24h" filter actually lands on the wire (so the
+// shortcut doesn't silently degrade into a full-window scan if a
+// regression nudges the default constant).
+func TestRunRecentBindsSince24h(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/query", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s; want POST", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"since":"24h"`) {
+			t.Errorf("recent did not bind since=24h: %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rows":[],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{
+		Since:             recentDefaultSince,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runQuery via recent shortcut: %v; stderr=%s", err, stderr.String())
+	}
+}
+
+// TestRunRecentJSONRoundTrips — --json behaviour is the same as the
+// full query verb; the recent shortcut doesn't sit between the
+// caller and the response.
+func TestRunRecentJSONRoundTrips(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/query", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rows":[],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{
+		Since:             recentDefaultSince,
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runQuery via recent --json: %v", err)
+	}
+	var decoded QueryResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
+	}
+}
+
+// TestNewRecentCmdHasLimitFlag — the verb advertises --limit on its
+// own help text; operators with autocomplete enabled rely on this.
+func TestNewRecentCmdHasLimitFlag(t *testing.T) {
+	cmd := newRecentCmd()
+	if cmd.Flag("limit") == nil {
+		t.Errorf("recent verb missing --limit flag")
+	}
+	if cmd.Flag("json") == nil {
+		t.Errorf("recent verb missing --json flag")
+	}
+}

--- a/cli/internal/cmd/audit/show.go
+++ b/cli/internal/cmd/audit/show.go
@@ -109,8 +109,8 @@ func getEntry(ctx context.Context, backplaneURL, auditID string) (*Entry, error)
 		return nil, err
 	}
 	var out Entry
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode audit show response: %w", err)
+	if err := decodeAuditResponse(raw, &out); err != nil {
+		return nil, err
 	}
 	return &out, nil
 }
@@ -174,13 +174,24 @@ func formatPayload(payload map[string]any) string {
 // formatPayloadScalar renders one payload value compactly. Scalars
 // print directly; objects/lists round-trip through json.Marshal so
 // at least the JSON form is readable on a single line.
+//
+// “json.Number“ is the load-bearing case: the package's decoder
+// uses “UseNumber()“ (see “decodeAuditResponse“) so payload
+// numbers survive as their exact decimal string rather than rounding
+// through float64. A 64-bit “hit_count“ like “1745923128091“ (a
+// Unix-millis timestamp) prints back identical to what the backend
+// wrote, where “float64(1745923128091)“ would round-trip lossily.
 func formatPayloadScalar(v any) string {
 	switch v := v.(type) {
 	case string:
 		return v
 	case bool:
 		return fmt.Sprintf("%t", v)
+	case json.Number:
+		return v.String()
 	case float64:
+		// Defensive fallback for code paths that bypass the
+		// UseNumber decoder (e.g. payloads constructed by tests).
 		if v == float64(int64(v)) {
 			return fmt.Sprintf("%d", int64(v))
 		}

--- a/cli/internal/cmd/audit/show.go
+++ b/cli/internal/cmd/audit/show.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newShowCmd returns the `meho audit show` command.
+//
+// CLI shape (per issue #467):
+//
+//	meho audit show <audit-id> [--json] [--backplane <url>]
+//
+// 404 from the backend surfaces as "audit row not found". The
+// cross-tenant probe always reads as 404 — the substrate's tenant
+// WHERE clause yields zero rows for an audit_id outside the
+// operator's tenant, and the route returns 404 (not 403) so the
+// existence of an audit row in another tenant never leaks through
+// status-code discrimination.
+//
+// Exit codes:
+//   - 0   row rendered cleanly
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (includes 404 not-found and 422
+//     malformed-UUID)
+//   - 5   insufficient_role
+func newShowCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "show <audit-id>",
+		Short: "Fetch a single audit row by id",
+		Long: "show calls GET /api/v1/audit/show/{audit_id} and renders the " +
+			"single audit row. The argument must be a UUID (the backend " +
+			"validates and returns 422 on malformed input). A 404 means " +
+			"either the audit_id doesn't exist or it belongs to another " +
+			"tenant — the route deliberately conflates the two so " +
+			"existence is never leaked across tenant boundaries.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShow(cmd, showOptions{
+				AuditID:           args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type showOptions struct {
+	AuditID           string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runShow(cmd *cobra.Command, opts showOptions) error {
+	if opts.AuditID == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("show requires a non-empty <audit-id> argument"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	entry, err := getEntry(cmd.Context(), backplaneURL, opts.AuditID)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), entry)
+	}
+	printEntrySummary(cmd.OutOrStdout(), entry)
+	return nil
+}
+
+// buildShowPath assembles the GET path. Exposed for unit tests so
+// URL encoding of UUIDs with unusual rendering stays covered.
+func buildShowPath(auditID string) string {
+	return "/api/v1/audit/show/" + pathEscape(auditID)
+}
+
+func getEntry(ctx context.Context, backplaneURL, auditID string) (*Entry, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildShowPath(auditID), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out Entry
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode audit show response: %w", err)
+	}
+	return &out, nil
+}
+
+// printEntrySummary renders the full audit row as a stable
+// key-value summary. Optional fields are shown as "-" when null so
+// the layout stays grep-able and predictable across rows.
+func printEntrySummary(w io.Writer, e *Entry) {
+	fmt.Fprintf(w, "%-18s %s\n", "id:", e.ID)
+	fmt.Fprintf(w, "%-18s %s\n", "ts:", e.TS)
+	fmt.Fprintf(w, "%-18s %s\n", "tenant_id:", strDerefOrDash(e.TenantID))
+	fmt.Fprintf(w, "%-18s %s\n", "principal_sub:", e.PrincipalSub)
+	fmt.Fprintf(w, "%-18s %s\n", "principal_name:", strDerefOrDash(e.PrincipalName))
+	fmt.Fprintf(w, "%-18s %s\n", "target_id:", strDerefOrDash(e.TargetID))
+	fmt.Fprintf(w, "%-18s %s\n", "target_name:", strDerefOrDash(e.TargetName))
+	fmt.Fprintf(w, "%-18s %s\n", "method:", e.Method)
+	fmt.Fprintf(w, "%-18s %s\n", "path:", e.Path)
+	fmt.Fprintf(w, "%-18s %d\n", "status_code:", e.StatusCode)
+	fmt.Fprintf(w, "%-18s %s\n", "request_id:", strDerefOrDash(e.RequestID))
+	fmt.Fprintf(w, "%-18s %s\n", "duration_ms:", strDerefOrDash(e.DurationMS))
+	fmt.Fprintf(w, "%-18s %s\n", "op_id:", e.OpID)
+	fmt.Fprintf(w, "%-18s %s\n", "op_class:", e.OpClass)
+	fmt.Fprintf(w, "%-18s %s\n", "result_status:", e.ResultStatus)
+	fmt.Fprintf(w, "%-18s %s\n", "parent_audit_id:", strDerefOrDash(e.ParentAuditID))
+	fmt.Fprintf(w, "%-18s %s\n", "agent_session_id:", strDerefOrDash(e.AgentSessionID))
+	fmt.Fprintf(w, "%-18s %s\n", "broadcast_event_id:", strDerefOrDash(e.BroadcastEventID))
+	if len(e.Payload) > 0 {
+		fmt.Fprintf(w, "%-18s %s\n", "payload:", formatPayload(e.Payload))
+	} else {
+		fmt.Fprintf(w, "%-18s -\n", "payload:")
+	}
+}
+
+// strDerefOrDash returns *s, or "-" when s is nil / empty. Used by
+// the audit-row summary so absent optional fields stay grep-friendly
+// rather than rendering as a blank cell.
+func strDerefOrDash(s *string) string {
+	v := strDeref(s)
+	if v == "" {
+		return "-"
+	}
+	return v
+}
+
+// formatPayload renders the audit payload as a sorted-key
+// `k=v, k=v` summary. Sorted keys keep the output deterministic for
+// snapshot tests and operator diffs across runs.
+func formatPayload(payload map[string]any) string {
+	keys := make([]string, 0, len(payload))
+	for k := range payload {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, formatPayloadScalar(payload[k])))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatPayloadScalar renders one payload value compactly. Scalars
+// print directly; objects/lists round-trip through json.Marshal so
+// at least the JSON form is readable on a single line.
+func formatPayloadScalar(v any) string {
+	switch v := v.(type) {
+	case string:
+		return v
+	case bool:
+		return fmt.Sprintf("%t", v)
+	case float64:
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v))
+		}
+		return fmt.Sprintf("%g", v)
+	case nil:
+		return "null"
+	default:
+		blob, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(blob)
+	}
+}

--- a/cli/internal/cmd/audit/show_test.go
+++ b/cli/internal/cmd/audit/show_test.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildShowPathEscapesUUID — UUIDs are URL-safe by spec, but
+// pathEscape is the cheap defence against a typo'd argument with a
+// slash / space leaking into the URL.
+func TestBuildShowPathEscapesUUID(t *testing.T) {
+	got := buildShowPath("00000000-0000-0000-0000-000000000001")
+	want := "/api/v1/audit/show/00000000-0000-0000-0000-000000000001"
+	if got != want {
+		t.Errorf("buildShowPath: got %q; want %q", got, want)
+	}
+}
+
+// TestBuildShowPathHandlesSpecialChars — a typo'd argument with a
+// slash gets percent-encoded so the URL doesn't collapse the path
+// segment.
+func TestBuildShowPathHandlesSpecialChars(t *testing.T) {
+	got := buildShowPath("weird/value")
+	if !strings.Contains(got, "weird%2Fvalue") {
+		t.Errorf("buildShowPath did not URL-encode slash: %q", got)
+	}
+}
+
+// TestRunShowRequiresAuditIDArg — the empty-argument path goes
+// through the same renderError surface as a backplane refusal, so
+// operators see one consistent error class.
+func TestRunShowRequiresAuditIDArg(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{AuditID: ""})
+	if err == nil {
+		t.Fatalf("expected error for empty audit-id")
+	}
+	if !strings.Contains(stderr.String(), "non-empty <audit-id>") {
+		t.Errorf("stderr missing arg-required hint: %s", stderr.String())
+	}
+}
+
+// TestRunShowHappyPath — the verb hits GET /api/v1/audit/show/{id}
+// and renders the operator-friendly key-value summary with every
+// pinned field.
+func TestRunShowHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/show/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s; want GET", r.Method)
+		}
+		expected := "/api/v1/audit/show/11111111-1111-1111-1111-111111111111"
+		if r.URL.Path != expected {
+			t.Errorf("path: got %q; want %q", r.URL.Path, expected)
+		}
+		tname := "rdc-vcenter"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Entry{
+			ID:           "11111111-1111-1111-1111-111111111111",
+			TS:           "2026-05-13T15:42:11Z",
+			PrincipalSub: "damir",
+			TargetName:   &tname,
+			Method:       "GET",
+			Path:         "/api/v1/vsphere/vm/list",
+			StatusCode:   200,
+			OpID:         "vsphere.vm.list",
+			OpClass:      "read",
+			ResultStatus: "ok",
+			Payload:      map[string]any{"hit_count": float64(7)},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{
+		AuditID:           "11111111-1111-1111-1111-111111111111",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runShow: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"id:", "11111111-1111-1111-1111-111111111111",
+		"principal_sub:", "damir",
+		"target_name:", "rdc-vcenter",
+		"op_id:", "vsphere.vm.list",
+		"op_class:", "read",
+		"result_status:", "ok",
+		"payload:", "hit_count=7",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q in %s", want, out)
+		}
+	}
+}
+
+// TestRunShow404SurfacesNotFound — the backend returns 404 both
+// when an audit_id genuinely doesn't exist and when it exists but
+// belongs to another tenant. The CLI surfaces a single message
+// rather than two so existence never leaks.
+func TestRunShow404SurfacesNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/show/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail": "audit row not found"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{
+		AuditID:           "11111111-1111-1111-1111-111111111111",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 404")
+	}
+	if !strings.Contains(stderr.String(), "audit row not found") {
+		t.Errorf("stderr missing not-found hint: %s", stderr.String())
+	}
+}
+
+// TestRunShow422SurfacesValidationDetail — a malformed UUID
+// argument is rejected by FastAPI's validation before reaching the
+// handler. The CLI passes the validation envelope through so the
+// operator sees what was malformed.
+func TestRunShow422SurfacesValidationDetail(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/show/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":[{"loc":["path","audit_id"],"msg":"value is not a valid uuid"}]}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{
+		AuditID:           "not-a-uuid",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 422")
+	}
+	if !strings.Contains(stderr.String(), "invalid request") {
+		t.Errorf("stderr missing validation hint: %s", stderr.String())
+	}
+}
+
+// TestPrintEntrySummaryShowsDashForNullFields — optional
+// fields render as "-" so the summary stays grep-friendly across
+// rows with different optional-field populations.
+func TestPrintEntrySummaryShowsDashForNullFields(t *testing.T) {
+	var buf bytes.Buffer
+	printEntrySummary(&buf, &Entry{
+		ID:           "abc",
+		TS:           "2026-05-13T00:00:00Z",
+		PrincipalSub: "damir",
+		Method:       "GET",
+		Path:         "/x",
+		StatusCode:   200,
+		OpID:         "x.y",
+		OpClass:      "read",
+		ResultStatus: "ok",
+		Payload:      map[string]any{},
+	})
+	out := buf.String()
+	for _, want := range []string{
+		"tenant_id:         -",
+		"principal_name:    -",
+		"target_id:         -",
+		"target_name:       -",
+		"request_id:        -",
+		"duration_ms:       -",
+		"parent_audit_id:   -",
+		"agent_session_id:  -",
+		"broadcast_event_id: -",
+		"payload:           -",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q in %s", want, out)
+		}
+	}
+}
+
+// TestFormatPayloadSortedKeys — payload renderer keys are sorted so
+// snapshot tests stay deterministic and operator diffs across runs
+// don't churn on map-iteration order.
+func TestFormatPayloadSortedKeys(t *testing.T) {
+	got := formatPayload(map[string]any{
+		"zoo":      true,
+		"alpha":    1,
+		"midpoint": "x",
+	})
+	// Sorted: alpha, midpoint, zoo
+	if !strings.HasPrefix(got, "alpha=") {
+		t.Errorf("formatPayload keys not sorted: %s", got)
+	}
+	if !strings.Contains(got, "midpoint=x") {
+		t.Errorf("formatPayload missing middle key: %s", got)
+	}
+}

--- a/cli/internal/cmd/audit/who_touched.go
+++ b/cli/internal/cmd/audit/who_touched.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newWhoTouchedCmd returns the `meho audit who-touched <target>`
+// command.
+//
+// CLI shape (per issue #467):
+//
+//	meho audit who-touched <target> \
+//	  [--since DUR]    # 24h | 7d | ISO-8601, default 24h
+//	  [--limit N]      # 1..1000, server default 100
+//	  [--json]
+//	  [--backplane <url>]
+//
+// Calls GET /api/v1/audit/who-touched/{target}. The backend resolves
+// the target name against the same-tenant `targets` table; an
+// unmatched name returns an empty result (not an error).
+//
+// Exit codes mirror `meho audit query`.
+func newWhoTouchedCmd() *cobra.Command {
+	var (
+		since             string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "who-touched <target>",
+		Short: "Show every audit row that touched a specific target",
+		Long: "who-touched calls GET /api/v1/audit/who-touched/{target} " +
+			"and renders the audit rows where target_name matches the " +
+			"argument inside the operator's tenant. --since defaults to " +
+			"24h; pass a different shorthand (7d / 30m / 2w) or an " +
+			"ISO-8601 datetime to widen the window. --limit caps the " +
+			"page size (1..1000, server default 100). --json emits the " +
+			"raw QueryResult.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWhoTouched(cmd, whoTouchedOptions{
+				Target:            args[0],
+				Since:             since,
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&since, "since", "",
+		"earliest occurred_at; defaults server-side to 24h when omitted")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max rows (1..1000, server default 100 when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw QueryResult JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type whoTouchedOptions struct {
+	Target            string
+	Since             string
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runWhoTouched(cmd *cobra.Command, opts whoTouchedOptions) error {
+	if opts.Target == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("who-touched requires a non-empty <target> argument"),
+			opts.JSONOut,
+		)
+	}
+	if opts.Limit < 0 || opts.Limit > 1000 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 1000; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := getWhoTouched(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printQueryTable(cmd.OutOrStdout(), result)
+	return nil
+}
+
+// buildWhoTouchedPath assembles the GET path with query params. Only
+// emits the query params the operator set so the backend's own
+// defaults (since=24h, limit=100) take over otherwise. Exposed for
+// unit tests so the URL encoding of names with special characters
+// stays covered.
+func buildWhoTouchedPath(target string, since string, limit int) string {
+	q := url.Values{}
+	if since != "" {
+		q.Set("since", since)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/audit/who-touched/" + pathEscape(target)
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path
+}
+
+func getWhoTouched(ctx context.Context, backplaneURL string, opts whoTouchedOptions) (*QueryResult, error) {
+	raw, err := doAuthedRequest(
+		ctx, backplaneURL, "GET",
+		buildWhoTouchedPath(opts.Target, opts.Since, opts.Limit), nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var out QueryResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode who-touched response: %w", err)
+	}
+	return &out, nil
+}

--- a/cli/internal/cmd/audit/who_touched.go
+++ b/cli/internal/cmd/audit/who_touched.go
@@ -5,7 +5,6 @@ package audit
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -139,8 +138,8 @@ func getWhoTouched(ctx context.Context, backplaneURL string, opts whoTouchedOpti
 		return nil, err
 	}
 	var out QueryResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode who-touched response: %w", err)
+	if err := decodeAuditResponse(raw, &out); err != nil {
+		return nil, err
 	}
 	return &out, nil
 }

--- a/cli/internal/cmd/audit/who_touched_test.go
+++ b/cli/internal/cmd/audit/who_touched_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildWhoTouchedPathOmitsEmptyParams — the no-flag form sends a
+// bare path so the backend's defaults (since=24h, limit=100) take
+// over.
+func TestBuildWhoTouchedPathOmitsEmptyParams(t *testing.T) {
+	got := buildWhoTouchedPath("rdc-vcenter", "", 0)
+	if got != "/api/v1/audit/who-touched/rdc-vcenter" {
+		t.Errorf("buildWhoTouchedPath empty: got %q", got)
+	}
+}
+
+// TestBuildWhoTouchedPathEmitsParams — every set flag lands on the
+// wire as a query string param.
+func TestBuildWhoTouchedPathEmitsParams(t *testing.T) {
+	got := buildWhoTouchedPath("rdc-vcenter", "7d", 50)
+	if !strings.Contains(got, "since=7d") {
+		t.Errorf("missing since: %q", got)
+	}
+	if !strings.Contains(got, "limit=50") {
+		t.Errorf("missing limit: %q", got)
+	}
+}
+
+// TestBuildWhoTouchedPathEscapesTarget — a target name with a slash
+// (operator typo) doesn't collapse the URL path.
+func TestBuildWhoTouchedPathEscapesTarget(t *testing.T) {
+	got := buildWhoTouchedPath("foo/bar", "", 0)
+	if !strings.Contains(got, "foo%2Fbar") {
+		t.Errorf("buildWhoTouchedPath did not URL-encode slash: %q", got)
+	}
+}
+
+// TestRunWhoTouchedRequiresTarget — the cobra `ExactArgs(1)` gate
+// already catches missing args at the parser level; this exercises
+// the defence-in-depth path inside runWhoTouched.
+func TestRunWhoTouchedRequiresTarget(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runWhoTouched(cmd, whoTouchedOptions{Target: ""})
+	if err == nil {
+		t.Fatalf("expected error for empty target")
+	}
+	if !strings.Contains(stderr.String(), "non-empty <target>") {
+		t.Errorf("stderr missing target-required hint: %s", stderr.String())
+	}
+}
+
+// TestRunWhoTouchedHappyPath — the verb hits GET /api/v1/audit/who-
+// touched/{target} and renders the rows using the same table the
+// query verb emits.
+func TestRunWhoTouchedHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/who-touched/rdc-vcenter", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s; want GET", r.Method)
+		}
+		if r.URL.Query().Get("since") != "7d" {
+			t.Errorf("query since: got %q; want 7d", r.URL.Query().Get("since"))
+		}
+		tname := "rdc-vcenter"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(QueryResult{
+			Rows: []Entry{{
+				ID:           "00000000-0000-0000-0000-000000000001",
+				TS:           "2026-05-12T12:00:00Z",
+				PrincipalSub: "tarik",
+				TargetName:   &tname,
+				Method:       "POST",
+				Path:         "/api/v1/vsphere/nsx/firewall/update",
+				StatusCode:   200,
+				OpID:         "nsx.firewall.update",
+				OpClass:      "write",
+				ResultStatus: "ok",
+				Payload:      map[string]any{},
+			}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runWhoTouched(cmd, whoTouchedOptions{
+		Target:            "rdc-vcenter",
+		Since:             "7d",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runWhoTouched: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"TIME", "tarik", "rdc-vcenter", "nsx.firewall.update", "write"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q in %s", want, out)
+		}
+	}
+}
+
+// TestRunWhoTouchedJSONRoundTrips — --json emits the same wire shape
+// the substrate returns; pinning the key set keeps jq pipelines
+// stable.
+func TestRunWhoTouchedJSONRoundTrips(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/who-touched/rdc-vcenter", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rows":[],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runWhoTouched(cmd, whoTouchedOptions{
+		Target:            "rdc-vcenter",
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runWhoTouched --json: %v", err)
+	}
+	var decoded QueryResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
+	}
+}
+
+// TestRunWhoTouchedRejectsOutOfRangeLimit — defensive --limit
+// validation matches the query verb.
+func TestRunWhoTouchedRejectsOutOfRangeLimit(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	if err := runWhoTouched(cmd, whoTouchedOptions{Target: "rdc-vcenter", Limit: 99999}); err == nil {
+		t.Fatalf("expected error for --limit=99999")
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/cmd/audit"
 	"github.com/evoila/meho/cli/internal/cmd/connector"
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
@@ -106,6 +107,13 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in `targets` parent.
 	root.AddCommand(targets.NewRootCmd())
+
+	// G8.1-T3 (#467) -- audit-query verbs (query / recent / show /
+	// who-touched / my-recent) for Initiative #334. Wraps the four
+	// /api/v1/audit/* routes shipped by G8.1-T2 (#466). Registered
+	// before registerDynamicSubcommands so the backplane manifest
+	// cannot shadow the built-in `audit` parent.
+	root.AddCommand(audit.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -581,4 +581,3 @@ func executePlan(ctx context.Context, doer httpDoer, p *plan) error {
 	}
 	return nil
 }
-

--- a/cli/internal/cmd/targets/import_test.go
+++ b/cli/internal/cmd/targets/import_test.go
@@ -492,4 +492,3 @@ func TestRunImportNonexistentFileSurfacesUnexpected(t *testing.T) {
 	// is that the call doesn't panic. Assert on stderr instead.
 	_ = err
 }
-

--- a/cli/internal/cmd/targets/targets.go
+++ b/cli/internal/cmd/targets/targets.go
@@ -9,10 +9,12 @@
 //   - `meho targets list [--product P] [--json]` —
 //     GET /api/v1/targets, keyset-paginated, optionally narrowed by
 //     product slug.
+//
 //   - `meho targets describe <name|alias> [--json]` —
 //     GET /api/v1/targets/{name}, alias-aware via the backend's
 //     resolve_target. Renders the full Target read shape including
 //     `fingerprint` + `preferred_impl_id` (added by G0.3-T1.5).
+//
 //   - `meho targets probe <name|alias> [--json]` —
 //     POST /api/v1/targets/{name}/probe. The backend calls
 //     Connector.fingerprint(), persists the FingerprintResult to

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -35,6 +35,9 @@ names.
 - `meho connector ...` (G0.7-T5 #405) — spec-ingestion + review
   workflow (`ingest`, `list`, `review`, `edit-group`, `edit-op`,
   `enable`, `disable`).
+- `meho audit ...` (G8.1-T3 #467) — audit-log query surface
+  (`query`, `recent`, `show`, `who-touched`, `my-recent`) wrapping
+  the four `/api/v1/audit/*` routes shipped by G8.1-T2 (#466).
 
 ## Module layout
 
@@ -74,6 +77,19 @@ cli/
     │   ├── login_test.go      # override-resolution + help-flag tests.
     │   ├── status.go          # `meho status` subcommand + --json + URL resolver.
     │   ├── status_test.go     # happy/JSON/no-creds/unreachable/401/redaction tests.
+    │   ├── audit/            # G8.1-T3 #467 — `meho audit …` verb tree.
+    │   │   ├── audit.go          # NewRootCmd + shared HTTP/auth helpers.
+    │   │   ├── query.go          # `meho audit query` (POST /api/v1/audit/query).
+    │   │   ├── recent.go         # `meho audit recent` — shortcut for `query --since 24h`.
+    │   │   ├── show.go           # `meho audit show <audit-id>` (GET /api/v1/audit/show/{id}).
+    │   │   ├── who_touched.go    # `meho audit who-touched <target>` (GET /api/v1/audit/who-touched/{target}).
+    │   │   ├── my_recent.go      # `meho audit my-recent` (GET /api/v1/audit/my-recent).
+    │   │   ├── audit_test.go     # helper + URL-normalisation + register-all-verbs tests.
+    │   │   ├── query_test.go     # body-marshal + render + 400-passthrough tests.
+    │   │   ├── show_test.go      # path-escape + 404 / 422 surface + summary render tests.
+    │   │   ├── who_touched_test.go # query-param emit + table render tests.
+    │   │   ├── my_recent_test.go # JWT-only-principal contract tests.
+    │   │   └── recent_test.go    # since=24h binding + --json passthrough tests.
     │   ├── connector/         # G0.7-T5 #405 — `meho connector …` verb tree.
     │   │   ├── connector.go      # NewRootCmd + shared HTTP/auth helpers.
     │   │   ├── ingest.go         # `meho connector ingest` (POST /api/v1/connectors/ingest).


### PR DESCRIPTION
## Summary

- Ships the five operator-facing `meho audit ...` CLI verbs that wrap
  the T2 REST surface (`/api/v1/audit/*`) merged earlier today as
  [#496](https://github.com/evoila/meho/pull/496):
  `query` (POST), `recent` (POST with `since="24h"` bound), `show`
  (GET single-row), `who-touched` (GET pre-canned), `my-recent` (GET
  pre-canned, JWT-sub-scoped).
- Package shape mirrors `cli/internal/cmd/targets` line-for-line on
  the auth + HTTP scaffolding; the audit-specific 400 envelope
  (`DurationParseError` / `InvalidCursorError` / `UnsupportedFilterError`)
  surfaces verbatim through `output.Unexpected`; 404 from `show` is the
  deliberately-conflated cross-tenant probe response so existence
  never leaks.
- `recent` is a thin shortcut that re-uses the `query` runner with
  `since="24h"` bound, per the issue body's "alias for `query --since
  24h`" wording — no extra backend route required.
- `--json` round-trip preserves the `next_cursor` key on null
  (applies the schema-stability lesson from #497 from the start;
  Go-side type tags omit `omitempty` on optional response fields).

## Test plan

- [x] `gofmt -d ./internal/cmd/audit/` — clean (empty diff)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint v1.64.8 run --path-prefix=cli ./internal/cmd/audit/...` — clean
- [x] `go test ./internal/cmd/audit/... -count=1` — **41 passed**
- [x] `go test ./... -count=1` — **318 passed in 12 packages** (was 277 on
  main; +41 new audit tests, zero regressions)

### Acceptance criteria (issue #467)

- [x] AC1: All 5 verbs work end-to-end — `TestNewRootCmdRegistersAllFiveVerbs` + per-verb `httptest` round-trip tests. End-to-end against a live backplane is T5's (#469) acceptance scope.
- [x] AC2: `query --target rdc-vcenter --since 24h --op-class write` — `TestBuildQueryRequestEveryFlagLandsOnWire` + `TestRunQueryHappyPathTable`.
- [x] AC3: `recent` ≡ `query --since 24h` — `TestRunRecentBindsSince24h` asserts the wire body carries `"since":"24h"`.
- [x] AC4: `show <unknown-id>` → clean 404 surface — `TestRunShow404SurfacesNotFound`.
- [x] AC5: `who-touched <target> --since 24h` → pre-canned shape — `TestRunWhoTouchedHappyPath`.
- [x] AC6: `my-recent` filters by JWT sub — `TestRunMyRecentHappyPath` asserts the CLI does NOT send a `principal=` flag (backend reads sub server-side).
- [x] AC7: `--json` round-trip with jq — `TestRunQueryJSONPassthroughRoundTrips` + per-verb `*JSONRoundTrips` tests assert `next_cursor` is preserved on null.
- [x] AC8: Cursor pagination via `--cursor` — `TestRunQueryHappyPathTable` exercises the table's `NEXT: --cursor=...` line; `TestBuildQueryRequestEveryFlagLandsOnWire` confirms the cursor round-trips.
- [x] AC9: `--help` informative; cobra autocompletion — each verb sets `Use`, `Short`, `Long`; `TestNewRecentCmdHasLimitFlag` exercises the flag-introspection path.
- [x] AC10: `go test ./...` clean — 318/318 passed.
- [x] AC11: CI green — local Go gates all clean; CI verification on this push.

## Out of scope

- MCP `query_audit` meta-tool: T4 (#468).
- Tenant-boundary + cursor-concurrency integration acceptance: T5 (#469).
- Audit-API operator runbook + architecture sister doc: T6 (#470).
- Audit replay verb (`meho audit replay <session-id>`): G8.2 (#377).

## Adjacent findings

- Pre-existing gofmt warnings in `cli/internal/cmd/targets/{targets.go, import.go, import_test.go}` from a Go 1.23→1.25 doc-comment formatter rule tightening — visible to my local Go 1.26's gofmt, invisible to CI's Go 1.23. Not introduced by this PR; a future repo-wide reformat pass on a Go-version bump sweeps them.

Closes #467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level meho audit command with five verbs: query, recent (24h shortcut), show, who-touched, and my-recent — supports rich filtering, pagination, JSON output, and human-readable summaries. Backplane URL override and auth refresh are supported.

* **Tests**
  * Added extensive unit/integration tests covering all audit verbs, URL/escaping, input validation, JSON round-trips, response-size enforcement, and preservation of large integer precision.

* **Documentation**
  * CLI docs updated to document the new audit command and subcommands.

* **Bug Fixes**
  * Minor CLI/test cleanups for import/targets behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/506)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->