### PR TITLE
fix(ci): inline Docker Hub credentials in security-scan.yml (regression from #447)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,53 +38,8 @@ permissions:
   security-events: write  # required for SARIF upload to Code Scanning
 
 jobs:
-  # Gate job: reads the optional Docker Hub secrets and surfaces their
-  # presence as a JSON-encoded container spec on a job output. This
-  # indirection is required because the `secrets` context is NOT
-  # available at `jobs.<job_id>.container` (top-level) per
-  # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-  # — only `github, inputs, matrix, needs, strategy, vars` are allowed
-  # there. `needs.<job>.outputs.*` IS available, so the gate publishes
-  # the full container map (with or without `credentials:`) and the
-  # consumer job parses it via `fromJSON()`.
-  #
-  # A previous iteration attempted `container: ${{ ... secrets.X ... }}`
-  # directly; actionlint correctly rejected the `secrets` references at
-  # that scope, and the bare `credentials: { username: ${{ secrets.X }} }`
-  # before that failed GH Actions template validation at parse time
-  # with "Unexpected value ''" (run 25864725292, 'Set up job'). The
-  # gate-job pattern is the documented workaround.
-  check-secrets:
-    name: Check Docker Hub credentials
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    outputs:
-      container_spec: ${{ steps.compute.outputs.container_spec }}
-    steps:
-      - id: compute
-        # Build the container spec as a JSON string. When both secrets
-        # are set, include `credentials`; otherwise emit the bare image
-        # spec so the downstream pull is anonymous. The JSON is emitted
-        # via the secret-aware shell (where `secrets` IS available) and
-        # passed to the consumer job through `outputs:` (allowed in
-        # `needs` context).
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
-            spec=$(jq -c -n \
-              --arg user "$DOCKERHUB_USERNAME" \
-              --arg pass "$DOCKERHUB_TOKEN" \
-              '{image: "semgrep/semgrep:1.160.0", credentials: {username: $user, password: $pass}}')
-          else
-            spec='{"image":"semgrep/semgrep:1.160.0"}'
-          fi
-          echo "container_spec=$spec" >> "$GITHUB_OUTPUT"
-
   semgrep:
     name: Semgrep SAST
-    needs: check-secrets
     runs-on: meho-runners
     timeout-minutes: 15
     # Authenticated Docker Hub pull. The ARC scale-set runs every job
@@ -93,17 +48,22 @@ jobs:
     # has tripped this Semgrep job in production. Authenticated
     # Personal-tier doubles the bucket to 200/6h
     # (https://docs.docker.com/docker-hub/usage/pulls/) — enough
-    # short-term while G2.9-T1..T3 stand up the in-cluster
-    # pull-through cache that retires this block.
+    # short-term while evoila-bosnia/claude-rdc-hetzner-dc#463 stands
+    # up the in-cluster pull-through cache that retires this block.
     #
     # `credentials:` is consumed by the runner BEFORE any step runs,
     # so `docker/login-action` cannot substitute. Secrets are
-    # provisioned at the `evoila` org level so all sibling repos
-    # inherit them without per-repo duplication.
-    #
-    # `container` is materialised from `check-secrets`' output (see the
-    # comment on that job). Bump cadence: monthly review or on advisory.
-    container: ${{ fromJSON(needs.check-secrets.outputs.container_spec) }}
+    # provisioned at the `evoila` org level (visibility `all`) so all
+    # sibling repos inherit them without per-repo duplication. If
+    # either secret is missing the workflow fails template-validation
+    # at "Set up job" — that's the intended loud-failure signal that
+    # someone deleted the org secret. Bump cadence: monthly review or
+    # on advisory.
+    container:
+      image: semgrep/semgrep:1.160.0
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 


### PR DESCRIPTION
## Summary

PR #447's `check-secrets` gate-job pattern was supposed to (a) work around GH Actions' context-availability restriction on `secrets` at `jobs.<job>.container` and (b) degrade gracefully to anonymous pull when secrets aren't set. (a) it does; (b) it does NOT — and GH's own safety machinery breaks (a) when secrets *are* present.

GH Actions strips job outputs that contain secret values:

```
##[warning]Skip output 'container_spec' since it may contain secret.
```

Observed empirically on run [25914436757](https://github.com/evoila/meho/actions/runs/25914436757). The consumer job reads empty string from `needs.check-secrets.outputs.container_spec`, and `fromJSON('')` fails template-validation:

```
##[error]The template is not valid. .github/workflows/security-scan.yml (Line: 106, Col: 16): Error reading JToken from JsonReader. Path '', line 0, position 0.
```

**Net regression after #447 merged:** workflow is GREEN when secrets are MISSING (anon fallback path works) and RED when secrets are PRESENT (secret-stripping breaks `fromJSON`). That's the opposite of what we want.

## Fix

Drop the gate job. Inline `${{ secrets.DOCKERHUB_USERNAME }}` / `${{ secrets.DOCKERHUB_TOKEN }}` directly in `container.credentials.{username,password}`. The `secrets` context IS allowed at `jobs.<job_id>.container.credentials.*` (only the top-level `jobs.<job>.container` map is restricted to `github, inputs, matrix, needs, strategy, vars` per the [context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability)).

## Trade-off accepted

PR #447's B1 review concern was: bare inline credentials fail template-validation when secrets evaluate to empty string. That concern is now mitigated organizationally — `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` are provisioned at the `evoila` org level (visibility `all`) with 1Password vault custody. If someone ever deletes them, the workflow fails template-validation at "Set up job" — that's the **correct** failure mode (loud, immediate, points at the cause) vs. the silent-rate-limit fallback the gate pattern attempted.

## Long-term

[evoila-bosnia/claude-rdc-hetzner-dc#463](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/463) stands up an in-cluster Docker Hub pull-through cache (Harbor or GAR). When that lands and ARC runners are wired to it, this `credentials:` block becomes redundant and can be removed in a follow-up PR.

## Test plan

- [x] `yaml.safe_load` parses
- [ ] Workflow re-runs on this branch's first push and succeeds at "Set up job" (the failure mode that #447's gate pattern surfaced)
- [ ] Workflow re-runs on `main` post-merge and the Semgrep job pulls authenticated (verifiable via Docker Hub Activity logs showing the access token's pulls)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning infrastructure configuration to use explicit credential handling for container registry access, improving workflow reliability and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/507)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->