### PR TITLE
fix(ci): authenticate Docker Hub pulls in pytest job (DinD testcontainers path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      - name: Docker Hub login (for testcontainers pulls)
+        # Pulls inside the DinD daemon (testcontainers PostgresContainer
+        # spinning up pgvector/pgvector:pg16 for test_db_engine.py /
+        # test_migration_rollback.py / tests/integration/*) share the
+        # ARC cluster's NAT egress IP, which exhausts Docker Hub's
+        # 100/6h anonymous bucket. Authenticated Personal-tier doubles
+        # it to 200/6h
+        # (https://docs.docker.com/docker-hub/usage/pulls/). Same
+        # org-level secrets security-scan.yml uses, provisioned at
+        # the evoila org level (visibility `all`) with 1Password
+        # vault custody — see meho-internal#74 for the regression
+        # context this addresses. Long-term, the in-cluster proxy
+        # cache from claude-rdc-hetzner-dc#463 retires this step.
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Install uv
         # uv is the project's canonical Python toolchain (pyproject.toml
         # locks a uv.lock, not a requirements.txt). enable-cache: true


### PR DESCRIPTION
## Summary

The Python pytest job in \`ci.yml\` runs on \`meho-runners\` (the ARC scale-set), sharing the cluster NAT egress IP that Initiative #67 was originally about. Tests that spin up \`pgvector/pgvector:pg16\` via testcontainers (\`test_db_engine.py\`, \`test_migration_rollback.py\`, \`tests/integration/conftest.py\`) pull through the DinD sidecar's Docker daemon. That daemon counts against the cluster's shared 100/6h anonymous bucket and intermittently fails with \`ImageNotFound\` (the daemon's cached response after an upstream 429).

Reproduced empirically on run [25914436746](https://github.com/evoila/meho/actions/runs/25914436746):

\`\`\`
FAILED tests/test_db_engine.py::TestPostgresIntegration::test_alembic_upgrade_head_against_real_pg
- docker.errors.ImageNotFound: 404 Client Error
  ("No such image: pgvector/pgvector:pg16")
\`\`\`

## Fix

Add \`docker/login-action@v4.1.0\` step right after \`Checkout\` in the pytest job. Same org-level secrets PR #447 / #507 already use (\`DOCKERHUB_USERNAME\`, \`DOCKERHUB_TOKEN\`, provisioned at the \`evoila\` org level on 2026-05-15, visibility \`all\`, 1Password vault custody).

The login writes \`~/.docker/config.json\` for the rest of the job; the DinD daemon reads it on every subsequent pull. \`container.credentials:\` (the #447 / #507 mechanism) doesn't apply here because the pulls happen at runtime inside the test process via the docker-py SDK, not via GHA's \`container:\` / \`services:\` block.

## Why not \`container.credentials:\` like #447 / #507

The Semgrep job uses \`container:\` to run the Semgrep CLI inside a pre-pulled image. The pytest job runs natively on the runner and shells out to docker via testcontainers during test execution. Different code path, different fix mechanism.

## Long-term

[\`claude-rdc-hetzner-dc#463\`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/463) stands up an in-cluster Docker Hub pull-through cache. When that lands and ARC runners' DinD daemon config points at it via \`registry-mirrors\`, this login step becomes redundant and can be removed.

## Closes

Closes evoila-bosnia/meho-internal#74.

## Test plan

- [x] \`yaml.safe_load\` parses
- [ ] Workflow runs on this branch and passes the Pytest step (proving the auth mechanism works through DinD)
- [ ] Post-merge: \`tests/test_db_engine.py::TestPostgresIntegration::test_alembic_upgrade_head_against_real_pg\` passes consistently on main for 5+ runs (no \`ImageNotFound\` for pgvector)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline authentication to improve test reliability and stability during integration testing with external container services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/510)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->