### PR TITLE
feat(cli): G4.1-T4 meho kb ingest/search/list/show/add/delete (cobra over T2 API)

### DIFF
--- a/cli/internal/cmd/kb/add.go
+++ b/cli/internal/cmd/kb/add.go
@@ -101,7 +101,7 @@ func newAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&metadata, "metadata", "",
 		"comma-separated key=value pairs to attach as entry metadata (e.g. owner=ops,source=runbook)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw KbEntry JSON instead of the human summary")
+		"emit raw Entry JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -152,7 +152,7 @@ func postAdd(
 	ctx context.Context,
 	backplaneURL, slug, body string,
 	metadata map[string]any,
-) (*KbEntry, error) {
+) (*Entry, error) {
 	req := kbEntryCreateRequest{Slug: slug, Body: body, Metadata: metadata}
 	raw, err := json.Marshal(req)
 	if err != nil {
@@ -162,7 +162,7 @@ func postAdd(
 	if err != nil {
 		return nil, err
 	}
-	var out KbEntry
+	var out Entry
 	if err := json.Unmarshal(resp, &out); err != nil {
 		return nil, fmt.Errorf("decode kb add response: %w", err)
 	}
@@ -172,7 +172,7 @@ func postAdd(
 // printAddSummary renders the created entry as a compact one-line
 // confirmation plus the round-tripped slug / timestamps. Operators
 // who want the full body should chase with `meho kb show <slug>`.
-func printAddSummary(w io.Writer, e *KbEntry) {
+func printAddSummary(w io.Writer, e *Entry) {
 	if e == nil {
 		return
 	}

--- a/cli/internal/cmd/kb/add.go
+++ b/cli/internal/cmd/kb/add.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// kbEntryCreateRequest mirrors the backend KbEntryCreate pydantic
+// model. The `Metadata` field is sent only when non-nil so the
+// backend's default (`{}`) applies when the operator passes no
+// `--metadata`. `slug` and `body` are required by the substrate's
+// `min_length=1` constraint; the CLI rejects empty values before
+// the request goes out.
+type kbEntryCreateRequest struct {
+	Slug     string         `json:"slug"`
+	Body     string         `json:"body"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// newAddCmd returns the `meho kb add` command.
+//
+// CLI shape (per issue #418):
+//
+//	meho kb add <slug> \
+//	  --body @file.md|@-|<inline-text> \
+//	  [--metadata key=value,key=value] \
+//	  [--json] \
+//	  [--backplane <url>]
+//
+// Role: tenant_admin. Operator-role JWT lands as 403
+// insufficient_role.
+//
+// `--body @<path>` reads the named file; `--body @-` reads from
+// stdin; bare `--body "text"` accepts inline content. Trailing
+// newlines from file / stdin reads are stripped (a 1-line file
+// passed via @ doesn't carry a gratuitous final newline through
+// the JSON body); embedded newlines are preserved.
+//
+// `--metadata "k1=v1,k2=v2"` parses to a flat string-keyed map.
+// Comma + equals are not escapable in v0.2 — operators who need
+// commas / equals inside values should construct the JSON body via
+// the REST surface or wait for v0.2.next.
+//
+// Exit codes:
+//   - 0   entry created (201)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 422 invalid_slug / missing body)
+//   - 5   insufficient_role
+func newAddCmd() *cobra.Command {
+	var (
+		body              string
+		metadata          string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "add <slug>",
+		Short: "Create or re-index one kb entry (tenant_admin)",
+		Long: "add calls POST /api/v1/kb to create or re-index one " +
+			"kb entry under the operator's tenant. Tenant_admin only — " +
+			"operator-role JWT lands as 403 insufficient_role.\n\n" +
+			"--body accepts inline text, @<path> to read a file, or " +
+			"@- to read from stdin. Trailing newlines from file / " +
+			"stdin reads are stripped (a 1-line file passed via @ " +
+			"doesn't carry a gratuitous final newline through the " +
+			"JSON body); embedded newlines are preserved.\n\n" +
+			"--metadata accepts a comma-separated list of key=value " +
+			"pairs (`--metadata source=runbook,owner=ops`). Values " +
+			"are stored as strings; operators needing richer metadata " +
+			"types (lists, nested objects) should construct the JSON " +
+			"body via the REST surface directly.\n\n" +
+			"The substrate's body-hash short-circuit means re-creating " +
+			"an entry with an unchanged body pays only an updated_at " +
+			"bump — `meho kb add` against an existing slug with the " +
+			"same body is effectively a no-op.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAdd(cmd, addOptions{
+				Slug:              args[0],
+				BodyArg:           body,
+				MetadataArg:       metadata,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&body, "body", "",
+		"entry body: inline text, @<path> to read a file, or @- to read from stdin")
+	cmd.Flags().StringVar(&metadata, "metadata", "",
+		"comma-separated key=value pairs to attach as entry metadata (e.g. owner=ops,source=runbook)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw KbEntry JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type addOptions struct {
+	Slug              string
+	BodyArg           string
+	MetadataArg       string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runAdd(cmd *cobra.Command, opts addOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("add requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	body, err := loadBodyFlag(cmd, opts.BodyArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	metadata, err := parseMetadataFlag(opts.MetadataArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	entry, err := postAdd(cmd.Context(), backplaneURL, opts.Slug, body, metadata)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), entry)
+	}
+	printAddSummary(cmd.OutOrStdout(), entry)
+	return nil
+}
+
+func postAdd(
+	ctx context.Context,
+	backplaneURL, slug, body string,
+	metadata map[string]any,
+) (*KbEntry, error) {
+	req := kbEntryCreateRequest{Slug: slug, Body: body, Metadata: metadata}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal kb add request: %w", err)
+	}
+	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/kb", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out KbEntry
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, fmt.Errorf("decode kb add response: %w", err)
+	}
+	return &out, nil
+}
+
+// printAddSummary renders the created entry as a compact one-line
+// confirmation plus the round-tripped slug / timestamps. Operators
+// who want the full body should chase with `meho kb show <slug>`.
+func printAddSummary(w io.Writer, e *KbEntry) {
+	if e == nil {
+		return
+	}
+	fmt.Fprintf(w, "created kb entry %q\n", e.Slug)
+	fmt.Fprintf(w, "%-14s %s\n", "id:", e.ID)
+	fmt.Fprintf(w, "%-14s %s\n", "tenant_id:", e.TenantID)
+	fmt.Fprintf(w, "%-14s %s\n", "created_at:", e.CreatedAt)
+	fmt.Fprintf(w, "%-14s %s\n", "updated_at:", e.UpdatedAt)
+	fmt.Fprintf(w, "%-14s %d bytes\n", "body:", len(e.Body))
+}

--- a/cli/internal/cmd/kb/add_test.go
+++ b/cli/internal/cmd/kb/add_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRunAddRejectsEmptySlug — empty slug short-circuits before the
+// body parsing path so the operator sees the slug hint first.
+func TestRunAddRejectsEmptySlug(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runAdd(cmd, addOptions{Slug: "", BodyArg: "x"})
+	if err == nil {
+		t.Fatalf("expected error for empty slug")
+	}
+	if !strings.Contains(stderr.String(), "non-empty <slug>") {
+		t.Errorf("expected slug hint; got %q", stderr.String())
+	}
+}
+
+// TestRunAddRejectsEmptyBody — empty --body is caught at the runner.
+func TestRunAddRejectsEmptyBody(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runAdd(cmd, addOptions{Slug: "x", BodyArg: ""})
+	if err == nil {
+		t.Fatalf("expected error for empty body")
+	}
+	if !strings.Contains(stderr.String(), "--body") {
+		t.Errorf("expected --body hint; got %q", stderr.String())
+	}
+}
+
+// TestRunAddRejectsBadMetadata — malformed --metadata surfaces a
+// CLI-side error rather than a 422.
+func TestRunAddRejectsBadMetadata(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runAdd(cmd, addOptions{Slug: "x", BodyArg: "body", MetadataArg: "missing-equals"})
+	if err == nil {
+		t.Fatalf("expected error for malformed --metadata")
+	}
+	if !strings.Contains(stderr.String(), "metadata") {
+		t.Errorf("expected metadata hint; got %q", stderr.String())
+	}
+}
+
+// TestRunAddHappyPath — the runner POSTs the right body and renders
+// the success summary.
+func TestRunAddHappyPath(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &bodyJSON); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(KbEntry{
+			ID:        "00000000-0000-0000-0000-000000000001",
+			TenantID:  "00000000-0000-0000-0000-000000000002",
+			Slug:      "new-slug",
+			Body:      "body content",
+			Metadata:  map[string]any{"owner": "ops"},
+			CreatedAt: "2026-05-15T00:00:00Z",
+			UpdatedAt: "2026-05-15T00:00:00Z",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runAdd(cmd, addOptions{
+		Slug:              "new-slug",
+		BodyArg:           "body content",
+		MetadataArg:       "owner=ops",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runAdd: %v; stderr=%s", err, stderr.String())
+	}
+	if got := bodyJSON["slug"]; got != "new-slug" {
+		t.Errorf("expected slug in body; got %+v", bodyJSON)
+	}
+	if got := bodyJSON["body"]; got != "body content" {
+		t.Errorf("expected body in request; got %+v", bodyJSON)
+	}
+	md, ok := bodyJSON["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected metadata map; got %T", bodyJSON["metadata"])
+	}
+	if md["owner"] != "ops" {
+		t.Errorf("expected owner=ops in metadata; got %+v", md)
+	}
+	if !strings.Contains(stdout.String(), "created kb entry") {
+		t.Errorf("expected success line; got %q", stdout.String())
+	}
+}
+
+// TestRunAddOmitsMetadataWhenAbsent — without --metadata the JSON
+// body must not carry a metadata field (so the backend's default {}
+// applies).
+func TestRunAddOmitsMetadataWhenAbsent(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &bodyJSON); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(KbEntry{Slug: "x"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runAdd(cmd, addOptions{Slug: "x", BodyArg: "b", BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runAdd: %v", err)
+	}
+	if _, ok := bodyJSON["metadata"]; ok {
+		t.Errorf("expected metadata absent; got %+v", bodyJSON)
+	}
+}
+
+// TestRunAddJSONHappyPath — --json emits the round-tripped entry.
+func TestRunAddJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(KbEntry{Slug: "x", Body: "y"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runAdd(cmd, addOptions{Slug: "x", BodyArg: "y", JSONOut: true, BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runAdd --json: %v", err)
+	}
+	var decoded KbEntry
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.Slug != "x" || decoded.Body != "y" {
+		t.Errorf("decode: %+v", decoded)
+	}
+}
+
+// TestRunAdd403SurfacesInsufficientRole — operator-role JWT lands
+// as 403; the CLI must classify it as insufficient_role exit 5.
+func TestRunAdd403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runAdd(cmd, addOptions{Slug: "x", BodyArg: "y", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected required-role hint; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+// TestRunAdd422SurfacesValidationDetail — 422 from invalid_slug
+// must include the backend's detail string so operators see why.
+func TestRunAdd422SurfacesValidationDetail(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"detail":"slug 'BAD' does not match SLUG_PATTERN"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runAdd(cmd, addOptions{Slug: "BAD", BodyArg: "y", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(stderr.String(), "invalid request") {
+		t.Errorf("expected invalid request hint; got %q", stderr.String())
+	}
+}
+
+// TestRunAddReadsBodyFromStdin — --body @- pipes content through
+// cmd.InOrStdin().
+func TestRunAddReadsBodyFromStdin(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &bodyJSON)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(KbEntry{Slug: "x", Body: "from stdin"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString("from stdin\n"))
+	if err := runAdd(cmd, addOptions{Slug: "x", BodyArg: "@-", BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runAdd: %v", err)
+	}
+	if got := bodyJSON["body"]; got != "from stdin" {
+		t.Errorf("expected stdin body; got %+v", bodyJSON)
+	}
+}
+
+// TestAddCmdHelpMentionsBodyAndMetadata — the cobra help text must
+// surface --body and --metadata so operators discover the inputs.
+func TestAddCmdHelpMentionsBodyAndMetadata(t *testing.T) {
+	cmd := newAddCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--help"})
+	// --help short-circuits with err=nil per cobra's conventions.
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	// Case-insensitive checks — cobra renders "Tenant_admin only —
+	// operator-role JWT lands as 403"; the comparison reads through
+	// strings.ToLower so the test doesn't pin to the description's
+	// chosen capitalisation.
+	lower := strings.ToLower(buf.String())
+	for _, want := range []string{"--body", "--metadata", "tenant_admin"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("expected help to mention %q; got %q", want, buf.String())
+		}
+	}
+}

--- a/cli/internal/cmd/kb/add_test.go
+++ b/cli/internal/cmd/kb/add_test.go
@@ -69,7 +69,7 @@ func TestRunAddHappyPath(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(KbEntry{
+		_ = json.NewEncoder(w).Encode(Entry{
 			ID:        "00000000-0000-0000-0000-000000000001",
 			TenantID:  "00000000-0000-0000-0000-000000000002",
 			Slug:      "new-slug",
@@ -124,7 +124,7 @@ func TestRunAddOmitsMetadataWhenAbsent(t *testing.T) {
 			t.Fatalf("decode: %v", err)
 		}
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(KbEntry{Slug: "x"})
+		_ = json.NewEncoder(w).Encode(Entry{Slug: "x"})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -145,7 +145,7 @@ func TestRunAddJSONHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(KbEntry{Slug: "x", Body: "y"})
+		_ = json.NewEncoder(w).Encode(Entry{Slug: "x", Body: "y"})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -156,7 +156,7 @@ func TestRunAddJSONHappyPath(t *testing.T) {
 	if err := runAdd(cmd, addOptions{Slug: "x", BodyArg: "y", JSONOut: true, BackplaneOverride: srv.URL}); err != nil {
 		t.Fatalf("runAdd --json: %v", err)
 	}
-	var decoded KbEntry
+	var decoded Entry
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
 	}
@@ -213,6 +213,15 @@ func TestRunAdd422SurfacesValidationDetail(t *testing.T) {
 	if !strings.Contains(stderr.String(), "invalid request") {
 		t.Errorf("expected invalid request hint; got %q", stderr.String())
 	}
+	// Tighten the assertion: the CLI's value-add over a raw curl is
+	// surfacing the backend's `detail` payload so operators see *what*
+	// was wrong (which field, which pattern). A regression that
+	// swallows the detail would still pass the "invalid request"
+	// check alone — assert the substrate's pattern-mismatch string
+	// survives the round-trip into stderr.
+	if !strings.Contains(stderr.String(), "SLUG_PATTERN") {
+		t.Errorf("expected backend detail to survive into stderr; got %q", stderr.String())
+	}
 }
 
 // TestRunAddReadsBodyFromStdin — --body @- pipes content through
@@ -224,7 +233,7 @@ func TestRunAddReadsBodyFromStdin(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &bodyJSON)
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(KbEntry{Slug: "x", Body: "from stdin"})
+		_ = json.NewEncoder(w).Encode(Entry{Slug: "x", Body: "from stdin"})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/cli/internal/cmd/kb/delete.go
+++ b/cli/internal/cmd/kb/delete.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newDeleteCmd returns the `meho kb delete` command.
+//
+// CLI shape (per issue #418):
+//
+//	meho kb delete <slug> [--confirm] [--json] [--backplane <url>]
+//
+// Role: tenant_admin. Operator-role JWT lands as 403
+// insufficient_role.
+//
+// Default behaviour prompts for a y/N confirmation on stdin;
+// --confirm skips the prompt for scripted use (CI pipelines, etc.).
+// Delete is **idempotent** at the substrate: a delete against an
+// absent slug returns 204 (not 404), matching the kb route
+// contract. Output mentions idempotency so operators rerunning the
+// command after a previous successful run don't mistake the no-op
+// for an error.
+//
+// Exit codes:
+//   - 0   delete succeeded (204) or operator declined the prompt
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (a 404 here would signal contract
+//     drift since delete is idempotent server-side)
+//   - 5   insufficient_role
+func newDeleteCmd() *cobra.Command {
+	var (
+		confirm           bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "delete <slug>",
+		Short: "Delete one kb entry by slug (tenant_admin)",
+		Long: "delete calls DELETE /api/v1/kb/{slug}. Tenant_admin " +
+			"only — operator-role JWT lands as 403 insufficient_role. " +
+			"Delete is idempotent server-side: a delete against an " +
+			"absent slug returns 204 (the conflation prevents " +
+			"enumerating other tenants via status-code differential).\n\n" +
+			"Without --confirm, the verb prompts on stdin for a y/N " +
+			"confirmation; --confirm skips the prompt for scripted use " +
+			"(CI pipelines, etc.). Declining the prompt exits 0 without " +
+			"calling the backend.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDelete(cmd, deleteOptions{
+				Slug:              args[0],
+				Confirm:           confirm,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&confirm, "confirm", false,
+		"skip the stdin confirmation prompt")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit a machine-readable success envelope instead of the human line")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type deleteOptions struct {
+	Slug              string
+	Confirm           bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// deleteResult is the structure printed in --json mode. Kept small
+// (slug + status) so operators piping into jq get a stable envelope
+// regardless of whether the row existed server-side (the substrate
+// doesn't surface that distinction back to the CLI).
+type deleteResult struct {
+	Slug   string `json:"slug"`
+	Status string `json:"status"`
+}
+
+func runDelete(cmd *cobra.Command, opts deleteOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("delete requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	if !opts.Confirm {
+		prompt := fmt.Sprintf(
+			"Delete kb entry %q — idempotent (no-op if already absent). Continue?",
+			opts.Slug,
+		)
+		if !confirmPrompt(cmd, prompt) {
+			result := deleteResult{Slug: opts.Slug, Status: "declined"}
+			if opts.JSONOut {
+				return output.PrintJSON(cmd.OutOrStdout(), result)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "declined: kb entry %q not deleted\n", opts.Slug)
+			return nil
+		}
+	}
+	if err := callDelete(cmd.Context(), backplaneURL, opts.Slug); err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	result := deleteResult{Slug: opts.Slug, Status: "deleted"}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "deleted kb entry %q\n", opts.Slug)
+	return nil
+}
+
+// buildDeletePath assembles the DELETE path. Exposed for unit tests
+// so URL encoding of slugs with dots stays covered.
+func buildDeletePath(slug string) string {
+	return "/api/v1/kb/" + pathEscape(slug)
+}
+
+func callDelete(ctx context.Context, backplaneURL, slug string) error {
+	// doAuthedRequest returns (nil, nil) on a 204; the kb delete
+	// route emits an empty 204 body whether or not the row existed
+	// server-side. We discard the (nil) response — the success
+	// signal is the absence of an error.
+	_, err := doAuthedRequest(ctx, backplaneURL, "DELETE", buildDeletePath(slug), nil)
+	return err
+}

--- a/cli/internal/cmd/kb/delete.go
+++ b/cli/internal/cmd/kb/delete.go
@@ -99,10 +99,14 @@ func runDelete(cmd *cobra.Command, opts deleteOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
-	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
-	}
+	// Confirm BEFORE resolving the backplane so that an operator who
+	// declines (or hits ^D / EOF on a piped /dev/null) exits 0 with
+	// the declined-status envelope regardless of whether `meho login`
+	// has been run. Resolving first would surface an auth_expired
+	// error on a no-config workstation even when the operator was
+	// about to type `n` — the prompt would never appear, and the
+	// "ask before doing destructive things" promise in the docstring
+	// would be violated.
 	if !opts.Confirm {
 		prompt := fmt.Sprintf(
 			"Delete kb entry %q — idempotent (no-op if already absent). Continue?",
@@ -116,6 +120,10 @@ func runDelete(cmd *cobra.Command, opts deleteOptions) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "declined: kb entry %q not deleted\n", opts.Slug)
 			return nil
 		}
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
 	}
 	if err := callDelete(cmd.Context(), backplaneURL, opts.Slug); err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)

--- a/cli/internal/cmd/kb/delete_test.go
+++ b/cli/internal/cmd/kb/delete_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildDeletePathEscapesSlug — path encoding follows the same
+// contract as buildShowPath.
+func TestBuildDeletePathEscapesSlug(t *testing.T) {
+	if got := buildDeletePath("vcenter-9.0"); got != "/api/v1/kb/vcenter-9.0" {
+		t.Errorf("buildDeletePath: got %q", got)
+	}
+	if got := buildDeletePath("a b"); got != "/api/v1/kb/a%20b" {
+		t.Errorf("buildDeletePath space: got %q", got)
+	}
+}
+
+// TestRunDeleteRejectsEmptySlug — args[0] empty is caught.
+func TestRunDeleteRejectsEmptySlug(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := runDelete(cmd, deleteOptions{Slug: ""}); err == nil {
+		t.Fatalf("expected error for empty slug")
+	} else if !strings.Contains(stderr.String(), "non-empty <slug>") {
+		t.Errorf("expected slug hint; got %q", stderr.String())
+	}
+}
+
+// TestRunDeletePromptDeclined — when --confirm is not set and the
+// operator answers "n", the runner must NOT call the backplane.
+func TestRunDeletePromptDeclined(t *testing.T) {
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/", func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString("n\n"))
+	err := runDelete(cmd, deleteOptions{Slug: "x", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runDelete declined: %v", err)
+	}
+	if called {
+		t.Errorf("decline should not call backend; but DELETE was issued")
+	}
+	if !strings.Contains(stdout.String(), "declined") {
+		t.Errorf("expected declined line; got %q", stdout.String())
+	}
+}
+
+// TestRunDeleteWithConfirmSkipsPrompt — --confirm skips the prompt
+// and calls DELETE directly.
+func TestRunDeleteWithConfirmSkipsPrompt(t *testing.T) {
+	method := ""
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/", func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	// EOF stdin — if --confirm were ignored, confirmPrompt would
+	// return false and the backend wouldn't be called.
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runDelete(cmd, deleteOptions{Slug: "x", Confirm: true, BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runDelete --confirm: %v", err)
+	}
+	if method != http.MethodDelete {
+		t.Errorf("expected DELETE; got %s", method)
+	}
+	if !strings.Contains(stdout.String(), "deleted") {
+		t.Errorf("expected deleted line; got %q", stdout.String())
+	}
+}
+
+// TestRunDeleteIdempotent204 — the substrate returns 204 on a
+// missing slug; the CLI must surface that as success without
+// surfacing a not-found error.
+func TestRunDeleteIdempotent204(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString("y\n"))
+	err := runDelete(cmd, deleteOptions{Slug: "ghost", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runDelete: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "deleted") {
+		t.Errorf("expected deleted line; got %q", stdout.String())
+	}
+}
+
+// TestRunDeleteJSONHappyPath — --json emits the structured envelope.
+func TestRunDeleteJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runDelete(cmd, deleteOptions{
+		Slug: "x", Confirm: true, JSONOut: true, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runDelete --json: %v", err)
+	}
+	var decoded deleteResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.Status != "deleted" || decoded.Slug != "x" {
+		t.Errorf("--json: %+v", decoded)
+	}
+}
+
+// TestRunDelete403SurfacesInsufficientRole — operator-role JWT
+// surfaces with the required-role detail.
+func TestRunDelete403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runDelete(cmd, deleteOptions{Slug: "x", Confirm: true, BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected role hint; got %q", stderr.String())
+	}
+}

--- a/cli/internal/cmd/kb/delete_test.go
+++ b/cli/internal/cmd/kb/delete_test.go
@@ -34,6 +34,33 @@ func TestRunDeleteRejectsEmptySlug(t *testing.T) {
 	}
 }
 
+// TestRunDeleteDeclinedWithoutLoginConfig — the docstring's "ask
+// before doing destructive things" promise must hold even when the
+// operator has not yet run `meho login`. Without a backplane URL
+// configured, resolveBackplane would surface auth_expired; the
+// runner must reach the prompt first so a decline exits 0 with
+// status=declined and no backplane call is made.
+func TestRunDeleteDeclinedWithoutLoginConfig(t *testing.T) {
+	// Per-test XDG dir without seeding any config / token. This
+	// mirrors a fresh workstation where no `meho login` has run yet.
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString("n\n"))
+	err := runDelete(cmd, deleteOptions{Slug: "x"})
+	if err != nil {
+		t.Fatalf("decline without login should exit 0; got err=%v stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "declined") {
+		t.Errorf("expected declined line; got %q", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "auth_expired") {
+		t.Errorf("decline should not surface auth_expired; got stderr=%q", stderr.String())
+	}
+}
+
 // TestRunDeletePromptDeclined — when --confirm is not set and the
 // operator answers "n", the runner must NOT call the backplane.
 func TestRunDeletePromptDeclined(t *testing.T) {

--- a/cli/internal/cmd/kb/ingest.go
+++ b/cli/internal/cmd/kb/ingest.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ingestKbRequest mirrors the backend IngestKbRequest pydantic
+// model. The substrate's `@model_validator(mode="after")` enforces
+// "exactly one of `directory` / `tarball_url`"; the CLI only sets
+// `directory` because `tarball_url` ingest returns 501 from the
+// route in v0.2 (the substrate exposes only `ingest_directory`).
+type ingestKbRequest struct {
+	Directory string `json:"directory"`
+	DryRun    bool   `json:"dry_run,omitempty"`
+}
+
+// newIngestCmd returns the `meho kb ingest` command.
+//
+// CLI shape (per issue #418):
+//
+//	meho kb ingest <directory> [--dry-run] [--json] [--backplane <url>]
+//
+// Role: tenant_admin. Operator-role JWT lands as 403
+// insufficient_role.
+//
+// The directory path is **interpreted on the backplane host**, not
+// the operator's workstation — the substrate walks the supplied path
+// via `KbService.ingest_directory`. Operators running the CLI
+// against a remote backplane must therefore stage their kb/ tree on
+// the backplane host (or run the CLI on the backplane host
+// itself); the route does not accept tarball uploads in v0.2 (that
+// path is filed as v0.2.next under Initiative #331 and currently
+// returns 501 when `tarball_url` is set).
+//
+// `--dry-run` short-circuits the substrate's write path; the
+// counters in the returned `KbIngestionResult` reflect what _would_
+// have been inserted / updated / skipped / errored.
+//
+// Exit codes:
+//   - 0   ingest returned cleanly; counters rendered
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 400 directory_not_found /
+//     not_a_directory, 422 schema-violation, 501 tarball-not-supported)
+//   - 5   insufficient_role
+func newIngestCmd() *cobra.Command {
+	var (
+		dryRun            bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "ingest <directory>",
+		Short: "Bulk-ingest a kb/ directory on the backplane host (tenant_admin)",
+		Long: "ingest calls POST /api/v1/kb/ingest. Tenant_admin only — " +
+			"operator-role JWT lands as 403 insufficient_role.\n\n" +
+			"The directory path is interpreted on the backplane host, " +
+			"not the operator's workstation — the substrate walks the " +
+			"supplied path via KbService.ingest_directory. Operators " +
+			"running the CLI against a remote backplane must stage " +
+			"their kb/ tree on the backplane host (or run the CLI on " +
+			"the backplane host itself).\n\n" +
+			"--dry-run short-circuits the substrate's write path; the " +
+			"counters in the returned KbIngestionResult reflect what " +
+			"would have been inserted / updated / skipped / errored " +
+			"without actually writing.\n\n" +
+			"The substrate's body-hash short-circuit means re-ingesting " +
+			"an unchanged corpus only pays an updated_at bump per file; " +
+			"the skipped_count counter rises rather than updated_count.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runIngest(cmd, ingestOptions{
+				Directory:         args[0],
+				DryRun:            dryRun,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"resolve the plan without writing to the substrate (counters reflect intent only)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw KbIngestionResult JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type ingestOptions struct {
+	Directory         string
+	DryRun            bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runIngest(cmd *cobra.Command, opts ingestOptions) error {
+	if opts.Directory == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("ingest requires a non-empty <directory> argument"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := postIngest(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printIngestSummary(cmd.OutOrStdout(), result, opts.DryRun)
+	return nil
+}
+
+func postIngest(ctx context.Context, backplaneURL string, opts ingestOptions) (*KbIngestionResult, error) {
+	body := ingestKbRequest{Directory: opts.Directory, DryRun: opts.DryRun}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal kb ingest request: %w", err)
+	}
+	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/kb/ingest", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out KbIngestionResult
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, fmt.Errorf("decode kb ingest response: %w", err)
+	}
+	return &out, nil
+}
+
+// printIngestSummary renders the four-bucket counter result as a
+// stable key-value summary. Errors (if any) are appended one per
+// line so an operator triaging a partial-failure run sees every
+// file path that failed without needing --json.
+func printIngestSummary(w io.Writer, r *KbIngestionResult, dryRun bool) {
+	if r == nil {
+		return
+	}
+	if dryRun {
+		fmt.Fprintln(w, "dry-run: substrate write path skipped; counters reflect intent only")
+	}
+	fmt.Fprintf(w, "%-14s %d\n", "inserted:", r.InsertedCount)
+	fmt.Fprintf(w, "%-14s %d\n", "updated:", r.UpdatedCount)
+	fmt.Fprintf(w, "%-14s %d\n", "skipped:", r.SkippedCount)
+	fmt.Fprintf(w, "%-14s %d\n", "errored:", r.ErrorCount)
+	total := r.InsertedCount + r.UpdatedCount + r.SkippedCount + r.ErrorCount
+	fmt.Fprintf(w, "%-14s %d\n", "total:", total)
+	if len(r.Errors) > 0 {
+		fmt.Fprintln(w, "errors:")
+		for _, e := range r.Errors {
+			fmt.Fprintf(w, "  - %s\n", e)
+		}
+	}
+}

--- a/cli/internal/cmd/kb/ingest.go
+++ b/cli/internal/cmd/kb/ingest.go
@@ -43,7 +43,7 @@ type ingestKbRequest struct {
 // returns 501 when `tarball_url` is set).
 //
 // `--dry-run` short-circuits the substrate's write path; the
-// counters in the returned `KbIngestionResult` reflect what _would_
+// counters in the returned `IngestionResult` reflect what _would_
 // have been inserted / updated / skipped / errored.
 //
 // Exit codes:
@@ -71,7 +71,7 @@ func newIngestCmd() *cobra.Command {
 			"their kb/ tree on the backplane host (or run the CLI on " +
 			"the backplane host itself).\n\n" +
 			"--dry-run short-circuits the substrate's write path; the " +
-			"counters in the returned KbIngestionResult reflect what " +
+			"counters in the returned IngestionResult reflect what " +
 			"would have been inserted / updated / skipped / errored " +
 			"without actually writing.\n\n" +
 			"The substrate's body-hash short-circuit means re-ingesting " +
@@ -92,7 +92,7 @@ func newIngestCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
 		"resolve the plan without writing to the substrate (counters reflect intent only)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw KbIngestionResult JSON instead of the human summary")
+		"emit raw IngestionResult JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -128,7 +128,7 @@ func runIngest(cmd *cobra.Command, opts ingestOptions) error {
 	return nil
 }
 
-func postIngest(ctx context.Context, backplaneURL string, opts ingestOptions) (*KbIngestionResult, error) {
+func postIngest(ctx context.Context, backplaneURL string, opts ingestOptions) (*IngestionResult, error) {
 	body := ingestKbRequest{Directory: opts.Directory, DryRun: opts.DryRun}
 	raw, err := json.Marshal(body)
 	if err != nil {
@@ -138,7 +138,7 @@ func postIngest(ctx context.Context, backplaneURL string, opts ingestOptions) (*
 	if err != nil {
 		return nil, err
 	}
-	var out KbIngestionResult
+	var out IngestionResult
 	if err := json.Unmarshal(resp, &out); err != nil {
 		return nil, fmt.Errorf("decode kb ingest response: %w", err)
 	}
@@ -149,7 +149,7 @@ func postIngest(ctx context.Context, backplaneURL string, opts ingestOptions) (*
 // stable key-value summary. Errors (if any) are appended one per
 // line so an operator triaging a partial-failure run sees every
 // file path that failed without needing --json.
-func printIngestSummary(w io.Writer, r *KbIngestionResult, dryRun bool) {
+func printIngestSummary(w io.Writer, r *IngestionResult, dryRun bool) {
 	if r == nil {
 		return
 	}

--- a/cli/internal/cmd/kb/ingest_test.go
+++ b/cli/internal/cmd/kb/ingest_test.go
@@ -36,7 +36,7 @@ func TestRunIngestHappyPath(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &bodyJSON)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(KbIngestionResult{
+		_ = json.NewEncoder(w).Encode(IngestionResult{
 			InsertedCount: 5,
 			UpdatedCount:  2,
 			SkippedCount:  37,
@@ -74,7 +74,7 @@ func TestRunIngestDryRunBindsBody(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &bodyJSON)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(KbIngestionResult{Errors: []string{}})
+		_ = json.NewEncoder(w).Encode(IngestionResult{Errors: []string{}})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -97,7 +97,7 @@ func TestRunIngestJSONHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/kb/ingest", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(KbIngestionResult{
+		_ = json.NewEncoder(w).Encode(IngestionResult{
 			InsertedCount: 1, UpdatedCount: 2, SkippedCount: 3, ErrorCount: 0, Errors: []string{},
 		})
 	})
@@ -109,7 +109,7 @@ func TestRunIngestJSONHappyPath(t *testing.T) {
 	if err := runIngest(cmd, ingestOptions{Directory: "/x", JSONOut: true, BackplaneOverride: srv.URL}); err != nil {
 		t.Fatalf("runIngest --json: %v", err)
 	}
-	var decoded KbIngestionResult
+	var decoded IngestionResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
 	}
@@ -167,7 +167,7 @@ func TestRunIngest403SurfacesInsufficientRole(t *testing.T) {
 // line so partial-failure runs are visible without --json.
 func TestPrintIngestSummaryWithErrors(t *testing.T) {
 	var buf bytes.Buffer
-	printIngestSummary(&buf, &KbIngestionResult{
+	printIngestSummary(&buf, &IngestionResult{
 		InsertedCount: 1, UpdatedCount: 0, SkippedCount: 0, ErrorCount: 2,
 		Errors: []string{"foo.md: bad slug", "bar.md: unreadable"},
 	}, false)
@@ -182,7 +182,7 @@ func TestPrintIngestSummaryWithErrors(t *testing.T) {
 // TestPrintIngestSummaryDryRunBanner — --dry-run emits a banner.
 func TestPrintIngestSummaryDryRunBanner(t *testing.T) {
 	var buf bytes.Buffer
-	printIngestSummary(&buf, &KbIngestionResult{}, true)
+	printIngestSummary(&buf, &IngestionResult{}, true)
 	if !strings.Contains(buf.String(), "dry-run") {
 		t.Errorf("expected dry-run banner; got %q", buf.String())
 	}

--- a/cli/internal/cmd/kb/ingest_test.go
+++ b/cli/internal/cmd/kb/ingest_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRunIngestRejectsEmptyDirectory — empty arg is caught.
+func TestRunIngestRejectsEmptyDirectory(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := runIngest(cmd, ingestOptions{Directory: ""}); err == nil {
+		t.Fatalf("expected error for empty directory")
+	} else if !strings.Contains(stderr.String(), "non-empty <directory>") {
+		t.Errorf("expected hint; got %q", stderr.String())
+	}
+}
+
+// TestRunIngestHappyPath — POSTs the right body and renders the
+// four-bucket summary.
+func TestRunIngestHappyPath(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/ingest", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &bodyJSON)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(KbIngestionResult{
+			InsertedCount: 5,
+			UpdatedCount:  2,
+			SkippedCount:  37,
+			ErrorCount:    0,
+			Errors:        []string{},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runIngest(cmd, ingestOptions{Directory: "/srv/kb", BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runIngest: %v; stderr=%s", err, stderr.String())
+	}
+	if bodyJSON["directory"] != "/srv/kb" {
+		t.Errorf("expected directory in request; got %+v", bodyJSON)
+	}
+	if v, ok := bodyJSON["dry_run"].(bool); ok && v {
+		t.Errorf("dry_run should be omitted when false; got %+v", bodyJSON)
+	}
+	for _, want := range []string{"inserted:", "updated:", "skipped:", "errored:", "total:", "5", "2", "37", "44"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+// TestRunIngestDryRunBindsBody — --dry-run sets dry_run=true in
+// the body.
+func TestRunIngestDryRunBindsBody(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/ingest", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &bodyJSON)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(KbIngestionResult{Errors: []string{}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runIngest(cmd, ingestOptions{Directory: "/srv/kb", DryRun: true, BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runIngest --dry-run: %v", err)
+	}
+	if v, _ := bodyJSON["dry_run"].(bool); !v {
+		t.Errorf("expected dry_run=true; got %+v", bodyJSON)
+	}
+	if !strings.Contains(stdout.String(), "dry-run:") {
+		t.Errorf("expected dry-run banner; got %q", stdout.String())
+	}
+}
+
+// TestRunIngestJSONHappyPath — --json emits the raw result.
+func TestRunIngestJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/ingest", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(KbIngestionResult{
+			InsertedCount: 1, UpdatedCount: 2, SkippedCount: 3, ErrorCount: 0, Errors: []string{},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runIngest(cmd, ingestOptions{Directory: "/x", JSONOut: true, BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runIngest --json: %v", err)
+	}
+	var decoded KbIngestionResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.InsertedCount != 1 || decoded.UpdatedCount != 2 {
+		t.Errorf("decode produced %+v", decoded)
+	}
+}
+
+// TestRunIngest400SurfacesDirectoryNotFound — 400 from
+// directory_not_found / not_a_directory surfaces the substrate's
+// detail verbatim.
+func TestRunIngest400SurfacesDirectoryNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/ingest", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"detail":"directory_not_found: /no/such/path"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runIngest(cmd, ingestOptions{Directory: "/no/such/path", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(stderr.String(), "directory_not_found") {
+		t.Errorf("expected substrate detail; got %q", stderr.String())
+	}
+}
+
+// TestRunIngest403SurfacesInsufficientRole — operator-role JWT
+// surfaces with the role hint.
+func TestRunIngest403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/ingest", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runIngest(cmd, ingestOptions{Directory: "/srv/kb", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected role hint; got %q", stderr.String())
+	}
+}
+
+// TestPrintIngestSummaryWithErrors — errors are appended one per
+// line so partial-failure runs are visible without --json.
+func TestPrintIngestSummaryWithErrors(t *testing.T) {
+	var buf bytes.Buffer
+	printIngestSummary(&buf, &KbIngestionResult{
+		InsertedCount: 1, UpdatedCount: 0, SkippedCount: 0, ErrorCount: 2,
+		Errors: []string{"foo.md: bad slug", "bar.md: unreadable"},
+	}, false)
+	out := buf.String()
+	for _, want := range []string{"errors:", "foo.md: bad slug", "bar.md: unreadable", "total:", "3"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestPrintIngestSummaryDryRunBanner — --dry-run emits a banner.
+func TestPrintIngestSummaryDryRunBanner(t *testing.T) {
+	var buf bytes.Buffer
+	printIngestSummary(&buf, &KbIngestionResult{}, true)
+	if !strings.Contains(buf.String(), "dry-run") {
+		t.Errorf("expected dry-run banner; got %q", buf.String())
+	}
+}

--- a/cli/internal/cmd/kb/kb.go
+++ b/cli/internal/cmd/kb/kb.go
@@ -89,12 +89,15 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// KbEntryPreview mirrors the backend KbEntryPreview pydantic model
+// EntryPreview mirrors the backend KbEntryPreview pydantic model
 // (`backend/src/meho_backplane/api/v1/kb.py`). Hand-written rather
 // than aliased to the generated client type so the kb package stays
 // decoupled from oapi-codegen churn — the targets / retrieval /
 // audit / connector / operation packages take the same stance.
-type KbEntryPreview struct {
+// Unprefixed name follows the sibling-package convention
+// (`audit.Entry`, `connector.IngestionResult`, etc.) and avoids the
+// `revive` stutter rule (`kb.KbEntryPreview` → `kb.EntryPreview`).
+type EntryPreview struct {
 	Slug      string         `json:"slug"`
 	Preview   string         `json:"preview"`
 	Metadata  map[string]any `json:"metadata"`
@@ -102,20 +105,20 @@ type KbEntryPreview struct {
 	UpdatedAt string         `json:"updated_at"`
 }
 
-// KbListResponse mirrors the backend KbListResponse envelope.
-// Wrapped in `{"entries": [...]}` for forward-compat with future
-// paging fields — same shape connectors_ingest adopted for its
-// list response.
-type KbListResponse struct {
-	Entries []KbEntryPreview `json:"entries"`
+// ListResponse mirrors the backend KbListResponse envelope. Wrapped
+// in `{"entries": [...]}` for forward-compat with future paging
+// fields — same shape connectors_ingest adopted for its list
+// response.
+type ListResponse struct {
+	Entries []EntryPreview `json:"entries"`
 }
 
-// KbEntry mirrors the backend KbEntry pydantic model — the full
-// entry shape returned by GET /api/v1/kb/{slug} and POST /api/v1/kb.
+// Entry mirrors the backend KbEntry pydantic model — the full entry
+// shape returned by GET /api/v1/kb/{slug} and POST /api/v1/kb.
 // `Metadata` decodes as `map[string]any` so the CLI can re-emit it
-// in --json mode without re-typing every Markdown front-matter
-// shape the operator might store.
-type KbEntry struct {
+// in --json mode without re-typing every Markdown front-matter shape
+// the operator might store.
+type Entry struct {
 	ID        string         `json:"id"`
 	TenantID  string         `json:"tenant_id"`
 	Slug      string         `json:"slug"`
@@ -125,12 +128,12 @@ type KbEntry struct {
 	UpdatedAt string         `json:"updated_at"`
 }
 
-// KbIngestionResult mirrors the backend KbIngestionResult shape.
+// IngestionResult mirrors the backend KbIngestionResult shape.
 // Counters partition every discovered .md file into exactly one of
 // four buckets (inserted / updated / skipped / error); the substrate
 // invariant is `inserted + updated + skipped + error == total .md
 // files`. `Errors` carries per-file error strings (path + reason).
-type KbIngestionResult struct {
+type IngestionResult struct {
 	InsertedCount int      `json:"inserted_count"`
 	UpdatedCount  int      `json:"updated_count"`
 	SkippedCount  int      `json:"skipped_count"`
@@ -178,6 +181,16 @@ func (e *errNoBackplaneConfigured) Error() string {
 	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
 }
 func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// errMissingAccessToken is the sentinel doAuthedRequest returns
+// when the stored token row exists but its `access_token` field is
+// empty. It's a credential-state failure rather than a transport
+// failure, so renderRequestError maps it to auth_expired (exit 2)
+// with a `meho login` hint — not unreachable (exit 3). Pre-existing
+// sibling packages (audit/, targets/, etc.) emit a generic error
+// here that falls through to unreachable; the local fix here is
+// scoped to the kb package (m3 in the review punch list).
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
 
 // resolveBackplane resolves the backplane URL from either the
 // `--backplane` override or the `meho login` config file. Same shape
@@ -232,6 +245,9 @@ func normaliseURL(s string) (string, error) {
 // Same classification ladder as the audit / targets siblings with
 // kb-specific 4xx handling:
 //
+//   - empty stored bearer → auth_expired (the row exists but its
+//     access_token is empty, so the right fix is `meho login` even
+//     though there's no transport-level 401 yet).
 //   - 401 (refresh failed) → auth_expired with a `meho login` hint.
 //   - 403 (RBAC denial) → insufficient_role; the backend's 403 detail
 //     names the required role.
@@ -255,6 +271,15 @@ func renderRequestError(
 	err error,
 	jsonOut bool,
 ) error {
+	if errors.Is(err, errMissingAccessToken) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
 	if api.IsTokenNotFound(err) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -391,7 +416,7 @@ func doAuthedRequest(
 	httpClient := authed.HTTPClient()
 	bearer := authed.AccessToken()
 	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
+		return nil, errMissingAccessToken
 	}
 
 	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)

--- a/cli/internal/cmd/kb/kb.go
+++ b/cli/internal/cmd/kb/kb.go
@@ -1,0 +1,639 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package kb hosts the cobra commands under `meho kb ...` for
+// G4.1-T4 (#418) of Initiative #331. v0.2 ships six operator-facing
+// verbs that wrap the T2 REST surface (#416) shipped by
+// `backend/src/meho_backplane/api/v1/kb.py` plus the G0.4-T5
+// `/api/v1/retrieve` route for the search verb:
+//
+//   - `meho kb ingest <directory> [--dry-run] [--json]` — server-side
+//     bulk ingest via POST /api/v1/kb/ingest. Role: tenant_admin.
+//   - `meho kb search <query> [--limit N] [--json]` — kb-scoped
+//     hybrid retrieval via POST /api/v1/retrieve with source="kb".
+//     Role: operator.
+//   - `meho kb list [--filter P] [--limit N] [--offset N] [--json]` —
+//     paginated entry listing via GET /api/v1/kb. Role: operator.
+//   - `meho kb show <slug> [--json]` — single-entry fetch via
+//     GET /api/v1/kb/{slug}. Role: operator. Renders the body as
+//     plain Markdown unless --json is set.
+//   - `meho kb add <slug> --body @file.md [--metadata k=v,...]
+//     [--json]` — single-entry create/re-index via POST /api/v1/kb.
+//     Role: tenant_admin. The --body flag accepts inline text,
+//     @<path> file references, and @- for stdin.
+//   - `meho kb delete <slug> [--confirm] [--json]` — single-entry
+//     deletion via DELETE /api/v1/kb/{slug}. Role: tenant_admin.
+//     Prompts for confirmation on stdin unless --confirm is set;
+//     idempotent (delete-already-missing returns 204 from the
+//     backend).
+//
+// Each verb wraps one backplane route and renders the response
+// either as a human-readable form (text table, Markdown body,
+// key-value summary) or as `--json` mode. Authentication piggybacks
+// on the token meho login wrote — same pattern as `meho audit`,
+// `meho targets`, and `meho connector`.
+//
+// The implementation deliberately follows the in-package HTTP helper
+// pattern the sibling verb trees use (one resolveBackplane /
+// doAuthedRequest / renderRequestError trio per package) rather
+// than a shared cli/internal/api_client package. The reason is the
+// import-cycle one: each verb tree is registered onto the root
+// command, so a shared helper imported from cmd/* and from any
+// per-tree package would close the cycle. Duplicating the helpers
+// (a handful of small, stable functions) is the convention every
+// sibling package follows.
+package kb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho kb` parent command. The command is
+// grafted onto the top-level meho command tree by cmd/root.go
+// alongside `meho audit`, `meho targets`, `meho connector`,
+// `meho operation`, and `meho retrieval`. The parent itself takes
+// no args and prints its own help; every piece of behaviour lives
+// in the per-subcommand RunE closures.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kb",
+		Short: "Operate the MEHO knowledge base (ingest / search / list / show / add / delete)",
+		Long: "Operate the tenant-scoped knowledge base wired by G4.1. " +
+			"Ingest, search, list, show, add, and delete kb entries. " +
+			"Write verbs (ingest / add / delete) require tenant_admin; " +
+			"read verbs are operator-level. Tenant scoping is enforced " +
+			"server-side via the JWT — no surface accepts a tenant id.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newIngestCmd())
+	cmd.AddCommand(newSearchCmd())
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newShowCmd())
+	cmd.AddCommand(newAddCmd())
+	cmd.AddCommand(newDeleteCmd())
+	return cmd
+}
+
+// KbEntryPreview mirrors the backend KbEntryPreview pydantic model
+// (`backend/src/meho_backplane/api/v1/kb.py`). Hand-written rather
+// than aliased to the generated client type so the kb package stays
+// decoupled from oapi-codegen churn — the targets / retrieval /
+// audit / connector / operation packages take the same stance.
+type KbEntryPreview struct {
+	Slug      string         `json:"slug"`
+	Preview   string         `json:"preview"`
+	Metadata  map[string]any `json:"metadata"`
+	CreatedAt string         `json:"created_at"`
+	UpdatedAt string         `json:"updated_at"`
+}
+
+// KbListResponse mirrors the backend KbListResponse envelope.
+// Wrapped in `{"entries": [...]}` for forward-compat with future
+// paging fields — same shape connectors_ingest adopted for its
+// list response.
+type KbListResponse struct {
+	Entries []KbEntryPreview `json:"entries"`
+}
+
+// KbEntry mirrors the backend KbEntry pydantic model — the full
+// entry shape returned by GET /api/v1/kb/{slug} and POST /api/v1/kb.
+// `Metadata` decodes as `map[string]any` so the CLI can re-emit it
+// in --json mode without re-typing every Markdown front-matter
+// shape the operator might store.
+type KbEntry struct {
+	ID        string         `json:"id"`
+	TenantID  string         `json:"tenant_id"`
+	Slug      string         `json:"slug"`
+	Body      string         `json:"body"`
+	Metadata  map[string]any `json:"metadata"`
+	CreatedAt string         `json:"created_at"`
+	UpdatedAt string         `json:"updated_at"`
+}
+
+// KbIngestionResult mirrors the backend KbIngestionResult shape.
+// Counters partition every discovered .md file into exactly one of
+// four buckets (inserted / updated / skipped / error); the substrate
+// invariant is `inserted + updated + skipped + error == total .md
+// files`. `Errors` carries per-file error strings (path + reason).
+type KbIngestionResult struct {
+	InsertedCount int      `json:"inserted_count"`
+	UpdatedCount  int      `json:"updated_count"`
+	SkippedCount  int      `json:"skipped_count"`
+	ErrorCount    int      `json:"error_count"`
+	Errors        []string `json:"errors"`
+}
+
+// RetrievalHit mirrors the backend RetrievalHit pydantic model
+// (`backend/src/meho_backplane/retrieval/retriever.py`). Returned by
+// POST /api/v1/retrieve. `BM25Score`, `CosineScore`, `BM25Rank`, and
+// `CosineRank` are `*float64` / `*int` because the backend emits
+// `null` for documents that did not appear in that signal's top-K
+// candidate list.
+type RetrievalHit struct {
+	DocumentID  string         `json:"document_id"`
+	TenantID    string         `json:"tenant_id"`
+	Source      string         `json:"source"`
+	SourceID    string         `json:"source_id"`
+	Kind        string         `json:"kind"`
+	Body        string         `json:"body"`
+	DocMetadata map[string]any `json:"doc_metadata"`
+	FusedScore  float64        `json:"fused_score"`
+	BM25Score   *float64       `json:"bm25_score"`
+	CosineScore *float64       `json:"cosine_score"`
+	BM25Rank    *int           `json:"bm25_rank"`
+	CosineRank  *int           `json:"cosine_rank"`
+}
+
+// RetrieveResponse mirrors the backend RetrieveResponse envelope.
+type RetrieveResponse struct {
+	Hits            []RetrievalHit `json:"hits"`
+	QueryDurationMS float64        `json:"query_duration_ms"`
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" (→ auth_expired exit
+// code 2 — the right fix is `meho login`) from URL-parse failures
+// (→ unexpected exit code 4 — the right fix is correcting argv).
+// Same shape as the helper in cli/internal/cmd/audit/audit.go;
+// kept independent because importing those packages would create
+// cycles via cmd/root.go.
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane resolves the backplane URL from either the
+// `--backplane` override or the `meho login` config file. Same shape
+// as the audit / targets / operation package helpers — duplicated
+// to avoid the import cycle the cmd → cmd/kb → cmd path would
+// create.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical contract to the
+// audit / targets sibling.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes and parses the URL to fail
+// fast on garbage input. Mirrors normaliseURL in audit/audit.go and
+// targets/targets.go.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from one of the per-verb
+// request helpers into the right output.StructuredError category.
+// Same classification ladder as the audit / targets siblings with
+// kb-specific 4xx handling:
+//
+//   - 401 (refresh failed) → auth_expired with a `meho login` hint.
+//   - 403 (RBAC denial) → insufficient_role; the backend's 403 detail
+//     names the required role.
+//   - 404 → unexpected with the backend's detail (kb routes return
+//     `slug_not_found` for cross-tenant or absent slug — the
+//     conflation prevents enumerating other tenants via status-code
+//     differential).
+//   - 422 → unexpected with the FastAPI validation envelope (invalid
+//     slug, missing required field, both-or-neither directory and
+//     tarball_url).
+//   - 400 → unexpected with the backend's detail string
+//     (`directory_not_found` / `not_a_directory` from the ingest
+//     route).
+//   - 501 → unexpected with the backend's detail (tarball_url ingest
+//     is not implemented in v0.2).
+//   - Any other 4xx/5xx → unexpected with the raw body.
+//   - Pure transport errors → unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderHTTPError classifies a non-2xx response into the right
+// StructuredError category.
+func renderHTTPError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	he *httpError,
+	jsonOut bool,
+) error {
+	switch he.StatusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusBadRequest:
+		// Ingest 400 = directory_not_found / not_a_directory from the
+		// backplane substrate. Surface the detail verbatim so the
+		// operator sees the path the backplane failed to read.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusNotFound:
+		// `meho kb show <slug>` and `meho kb delete <slug>` on an
+		// absent slug surface here. The backend returns
+		// `slug_not_found` for both genuine absence and cross-tenant
+		// probes — the conflation prevents leaking tenant boundaries
+		// via status-code differential. Note that delete itself is
+		// idempotent (204 on missing) per the kb route contract; a
+		// 404 from delete therefore signals a contract drift worth
+		// surfacing rather than swallowing.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusUnprocessableEntity:
+		// 422 from invalid slug shape, missing required body field,
+		// or the exactly-one-of directory/tarball_url contract. The
+		// backend emits the FastAPI validation envelope.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
+			jsonOut,
+		)
+	case http.StatusNotImplemented:
+		// 501 from kb.ingest when the operator supplied
+		// `tarball_url`. The substrate exposes only ingest_directory
+		// in v0.2; the route surfaces a clear "not implemented" so
+		// callers don't silently lose work.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape.
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error
+// body when it's a plain string. Falls back to the raw body when the
+// JSON shape doesn't match.
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection and one-shot 401-refresh-retry. Returns the
+// response body bytes (already drained) on 2xx, or an *httpError on
+// non-2xx, or an error categorised by api.IsTokenNotFound /
+// api.IsNoRefreshToken / generic transport.
+//
+// Mirrors cli/internal/cmd/audit/audit.go::doAuthedRequest and its
+// targets / operation siblings.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	// Read with a 1-MiB cap. The +1 byte over the cap is the
+	// truncation-detection trick: if ReadAll returns more than
+	// responseBodyCap bytes, the response was at least cap+1 bytes
+	// long and the decoder would otherwise consume a silently-
+	// truncated JSON payload. Fail loud instead — a truncated kb
+	// response surfaces as "decode error: unexpected end of JSON
+	// input" without this guard, which buries the real cause
+	// (response too large for the chassis CLI's safety cap).
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if int64(len(raw)) > responseBodyCap {
+		return nil, fmt.Errorf(
+			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
+			responseBodyCap,
+		)
+	}
+	// DELETE returns 204 with no body — the substrate of kb.delete
+	// is idempotent and emits an empty body whether or not the row
+	// existed. Treat 204 as success even when the response body is
+	// empty so the verb's runner can render the success line without
+	// trying to decode JSON.
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// responseBodyCap is the hard upper bound on a backplane response
+// body the CLI is willing to read. Kb list pages cap at 500 rows
+// server-side and each row carries only a 200-char preview; a full
+// page is ~500 × 1 KB ≈ 500 KiB. 1 MiB is comfortable headroom.
+// `meho kb show` of a real-world Markdown entry tops out at ~50 KB.
+// The cap protects against an adversarial / misconfigured backplane
+// sending an unbounded response — the alternative is OOM. The
+// +1-byte read pattern in doAuthedRequest distinguishes "fits in
+// the cap" from "truncated at the cap".
+const responseBodyCap int64 = 1 << 20
+
+// httpError carries a non-2xx response so per-verb runners can
+// render the right category.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// sendRequest is the bottom of the stack: build the http.Request,
+// stamp bearer + content headers, fire it.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// pathEscape escapes a single path segment for use inside a backend
+// URL.
+func pathEscape(segment string) string {
+	return url.PathEscape(segment)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Rune-aware so multi-byte UTF-8 survives the
+// cut. Same shape as the sibling-package helpers.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// loadBodyFlag reads a flag value supporting inline text, `@<path>`
+// for file references, and `@-` for stdin. Returns the loaded body
+// or an error. The substrate's `body` field has a `min_length=1`
+// constraint, so an empty result is rejected at the CLI rather than
+// after a 422 round-trip.
+//
+// `@-` reads from cmd.InOrStdin() so tests can wire a bytes.Buffer;
+// the read is bounded by `loadBodyStdinCap` to protect against an
+// adversarial pipe (a runaway `tail -f` redirect, etc.).
+//
+// Trailing newlines (LF or CRLF) are stripped from file/stdin reads
+// so a 1-line file passed via `@` doesn't carry a gratuitous
+// trailing newline through the JSON body. Embedded newlines inside
+// the text are preserved; only the final CRLF / LF is stripped.
+// Inline text values pass through verbatim.
+func loadBodyFlag(cmd *cobra.Command, raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("--body is required (inline text, @<path>, or @-)")
+	}
+	if !strings.HasPrefix(raw, "@") {
+		return raw, nil
+	}
+	path := strings.TrimPrefix(raw, "@")
+	if path == "-" {
+		blob, err := io.ReadAll(io.LimitReader(cmd.InOrStdin(), loadBodyStdinCap+1))
+		if err != nil {
+			return "", fmt.Errorf("read --body from stdin: %w", err)
+		}
+		if int64(len(blob)) > loadBodyStdinCap {
+			return "", fmt.Errorf(
+				"--body from stdin exceeds %d-byte cap; pass a file with @<path> instead",
+				loadBodyStdinCap,
+			)
+		}
+		out := strings.TrimRight(string(blob), "\r\n")
+		if out == "" {
+			return "", errors.New("--body @- read empty input; cannot create kb entry with empty body")
+		}
+		return out, nil
+	}
+	blob, err := readBodyFile(path)
+	if err != nil {
+		return "", err
+	}
+	out := strings.TrimRight(string(blob), "\r\n")
+	if out == "" {
+		return "", fmt.Errorf("--body file %q is empty; cannot create kb entry with empty body", path)
+	}
+	return out, nil
+}
+
+// loadBodyStdinCap bounds the @- read so an adversarial / malformed
+// pipe can't pin a kb add verb in unbounded ReadAll. 1 MiB matches
+// the response-body cap and is generous for any realistic Markdown
+// entry (the consumer's longest entries are ~10 KB).
+const loadBodyStdinCap int64 = 1 << 20
+
+// readBodyFile is the file-read seam — split out so kb_test.go can
+// stub it (testing a real os.ReadFile path through a temp file is
+// fine, but the seam exists for cases where the underlying
+// filesystem error must be deterministic).
+var readBodyFile = func(path string) ([]byte, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --body file %q: %w", path, err)
+	}
+	return blob, nil
+}
+
+// parseMetadataFlag parses the --metadata "k=v,k=v" flag value into a
+// map. Returns nil for an empty value so the caller can omit the
+// "metadata" key from the JSON body (the backend defaults to {}
+// when the field is absent). Trims whitespace around keys + values
+// so `--metadata "k = v, x = y"` works. Keys must be non-empty;
+// values may be empty.
+//
+// Comma + equals are not escapable in v0.2 — operators who need
+// commas or equals inside a value should construct the JSON body
+// directly via the REST API or wait for v0.2.next. The CLI surface
+// is the convenience path; the full key/value-space lives behind
+// the REST route.
+func parseMetadataFlag(raw string) (map[string]any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	out := make(map[string]any)
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			return nil, fmt.Errorf("--metadata pair %q is missing '=' separator", pair)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return nil, fmt.Errorf("--metadata pair %q has empty key", pair)
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// confirmPrompt prompts on stdin/stdout with the given message and
+// returns true only when the operator types y/yes/Y. EOF (closed
+// stdin) is treated as a no — scripted use must pass --confirm.
+// Honours cmd.InOrStdin() so tests can wire a bytes.Buffer.
+// Mirrors `confirm` in cli/internal/cmd/connector/connector.go.
+func confirmPrompt(cmd *cobra.Command, prompt string) bool {
+	fmt.Fprintf(cmd.OutOrStdout(), "%s [y/N]: ", prompt)
+	var answer string
+	if _, err := fmt.Fscanln(cmd.InOrStdin(), &answer); err != nil {
+		// Most common error: io.EOF from a piped empty stdin.
+		// Treat as "no" so scripts that pipe /dev/null don't
+		// accidentally delete a kb entry.
+		return false
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
+}

--- a/cli/internal/cmd/kb/kb_test.go
+++ b/cli/internal/cmd/kb/kb_test.go
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// seedXDGAndToken seeds a per-test config dir + token store that
+// resolveBackplane / doAuthedRequest will read. Mirrors the same
+// helper in cli/internal/cmd/audit/audit_test.go.
+func seedXDGAndToken(t *testing.T, backplaneURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  "eyJ.test.token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return dir
+}
+
+// newRunCmd builds a fresh cobra.Command with stdout/stderr buffers
+// attached. The runXxx helpers consume cmd.OutOrStdout /
+// cmd.ErrOrStderr; tests inspect the buffers afterwards.
+func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	return cmd, &stdout, &stderr
+}
+
+// TestNewRootCmdRegistersAllSixVerbs — AC1: every advertised verb
+// has a cobra subcommand. The CLI manifest is the contract operators
+// build muscle memory around; dropping a verb silently is the
+// regression class we want to catch at unit-time.
+func TestNewRootCmdRegistersAllSixVerbs(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"ingest": false,
+		"search": false,
+		"list":   false,
+		"show":   false,
+		"add":    false,
+		"delete": false,
+	}
+	for _, sub := range root.Commands() {
+		name := strings.SplitN(sub.Use, " ", 2)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("subcommand %q not registered under `meho kb`", name)
+		}
+	}
+}
+
+// TestRootCmdHelpListsAllVerbs — the parent's help text should
+// mention every verb so operators new to the surface find them.
+func TestRootCmdHelpListsAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("`meho kb --help` failed: %v", err)
+	}
+	help := buf.String()
+	for _, want := range []string{"ingest", "search", "list", "show", "add", "delete", "tenant"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("expected `meho kb --help` to mention %q; got:\n%s", want, help)
+		}
+	}
+}
+
+// TestNormaliseURLStripsTrailingSlash — the resolver mirrors the
+// sibling packages; trailing-slash trimming is the v0.2 convention.
+func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Errorf("trailing slash not stripped: got %q", got)
+	}
+}
+
+// TestNormaliseURLRejectsHostless — bare paths fail fast rather
+// than producing a request against the local filesystem.
+func TestNormaliseURLRejectsHostless(t *testing.T) {
+	if _, err := normaliseURL("/just/a/path"); err == nil {
+		t.Errorf("expected error for hostless URL")
+	}
+}
+
+// TestNormaliseURLRejectsEmpty — empty input returns the "empty"
+// error string callers depend on.
+func TestNormaliseURLRejectsEmpty(t *testing.T) {
+	if _, err := normaliseURL("   "); err == nil {
+		t.Errorf("expected error for empty URL")
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
+// any error wrapping it) maps to AuthExpired; everything else maps
+// to Unexpected. Same routing ladder as the audit / targets
+// siblings.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrappedNotFound := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrappedNotFound)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("ErrConfigNotFound wrapper should classify as auth_expired; got %+v", se)
+	}
+	parseFailure := errors.New("invalid URL")
+	se = classifyBackplaneError(parseFailure)
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected; got %+v", se)
+	}
+}
+
+// TestDecodeDetailStringFromFastAPI — FastAPI's HTTPException body
+// is {"detail": "<string>"}; decodeDetailString must extract it.
+func TestDecodeDetailStringFromFastAPI(t *testing.T) {
+	body := `{"detail": "slug_not_found"}`
+	if got := decodeDetailString(body); got != "slug_not_found" {
+		t.Errorf("decodeDetailString: got %q", got)
+	}
+}
+
+// TestDecodeDetailStringFallback — non-FastAPI body returns the raw
+// trimmed body rather than swallowing it.
+func TestDecodeDetailStringFallback(t *testing.T) {
+	body := "  plain text error\n"
+	if got := decodeDetailString(body); got != "plain text error" {
+		t.Errorf("decodeDetailString fallback: got %q", got)
+	}
+}
+
+// TestPathEscapePreservesSlugChars — kb slugs are
+// `[a-z][a-z0-9.\-]*[a-z0-9]?`; PathEscape must not mangle the
+// operator-typical characters.
+func TestPathEscapePreservesSlugChars(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"vcenter-9.0-overview", "vcenter-9.0-overview"},
+		{"a", "a"},
+		{"slug-with-dot.0.1", "slug-with-dot.0.1"},
+		{"weird slug with space", "weird%20slug%20with%20space"},
+	}
+	for _, c := range cases {
+		if got := pathEscape(c.in); got != c.want {
+			t.Errorf("pathEscape(%q): got %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestTruncateRuneAware — multi-byte UTF-8 stays valid when the
+// table renderer truncates a long slug / preview.
+func TestTruncateRuneAware(t *testing.T) {
+	if got := truncate("café", 3); got != "ca…" {
+		t.Fatalf("truncate multi-byte: got %q; want %q", got, "ca…")
+	}
+	if got := truncate("hello", 10); got != "hello" {
+		t.Fatalf("truncate within budget: got %q; want %q", got, "hello")
+	}
+	if got := truncate("anything", 0); got != "" {
+		t.Fatalf("truncate maxLen=0 should be empty; got %q", got)
+	}
+}
+
+// TestParseMetadataFlagEmpty — empty input returns nil so the
+// caller can omit the field.
+func TestParseMetadataFlagEmpty(t *testing.T) {
+	got, err := parseMetadataFlag("")
+	if err != nil {
+		t.Fatalf("parseMetadataFlag(\"\"): %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for empty input; got %+v", got)
+	}
+}
+
+// TestParseMetadataFlagSinglePair — single k=v pair.
+func TestParseMetadataFlagSinglePair(t *testing.T) {
+	got, err := parseMetadataFlag("owner=ops")
+	if err != nil {
+		t.Fatalf("parseMetadataFlag: %v", err)
+	}
+	if v, ok := got["owner"].(string); !ok || v != "ops" {
+		t.Errorf("expected owner=ops; got %+v", got)
+	}
+}
+
+// TestParseMetadataFlagMultiplePairs — commas separate pairs and
+// whitespace is trimmed around keys / values.
+func TestParseMetadataFlagMultiplePairs(t *testing.T) {
+	got, err := parseMetadataFlag("owner = ops, source =runbook ")
+	if err != nil {
+		t.Fatalf("parseMetadataFlag: %v", err)
+	}
+	if v, ok := got["owner"].(string); !ok || v != "ops" {
+		t.Errorf("expected owner=ops; got %+v", got["owner"])
+	}
+	if v, ok := got["source"].(string); !ok || v != "runbook" {
+		t.Errorf("expected source=runbook; got %+v", got["source"])
+	}
+}
+
+// TestParseMetadataFlagEmptyValue — value may be empty; key cannot.
+func TestParseMetadataFlagEmptyValue(t *testing.T) {
+	got, err := parseMetadataFlag("flag=")
+	if err != nil {
+		t.Fatalf("empty value should not error: %v", err)
+	}
+	if v, ok := got["flag"].(string); !ok || v != "" {
+		t.Errorf("expected flag with empty value; got %+v", got["flag"])
+	}
+}
+
+// TestParseMetadataFlagRejectsEmptyKey — empty key surfaces as a
+// clear CLI-side error rather than a 422 round-trip.
+func TestParseMetadataFlagRejectsEmptyKey(t *testing.T) {
+	if _, err := parseMetadataFlag("=value"); err == nil {
+		t.Errorf("expected error for empty key")
+	}
+}
+
+// TestParseMetadataFlagRejectsMissingEquals — a pair without `=`
+// surfaces as an error rather than being silently dropped.
+func TestParseMetadataFlagRejectsMissingEquals(t *testing.T) {
+	if _, err := parseMetadataFlag("nokv"); err == nil {
+		t.Errorf("expected error for pair without '='")
+	}
+}
+
+// TestLoadBodyFlagInlineText — inline text passes through verbatim.
+func TestLoadBodyFlagInlineText(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	got, err := loadBodyFlag(cmd, "inline content")
+	if err != nil {
+		t.Fatalf("loadBodyFlag: %v", err)
+	}
+	if got != "inline content" {
+		t.Errorf("expected verbatim inline; got %q", got)
+	}
+}
+
+// TestLoadBodyFlagRejectsEmpty — the substrate's min_length=1
+// constraint surfaces as a CLI-side error before the round-trip.
+func TestLoadBodyFlagRejectsEmpty(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	if _, err := loadBodyFlag(cmd, ""); err == nil {
+		t.Errorf("expected error for empty --body")
+	}
+}
+
+// TestLoadBodyFlagReadsFile — @<path> reads the file and strips
+// trailing newlines.
+func TestLoadBodyFlagReadsFile(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	tmp := filepath.Join(t.TempDir(), "entry.md")
+	if err := writeFile(tmp, "first line\nsecond line\n"); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	got, err := loadBodyFlag(cmd, "@"+tmp)
+	if err != nil {
+		t.Fatalf("loadBodyFlag: %v", err)
+	}
+	want := "first line\nsecond line"
+	if got != want {
+		t.Errorf("loadBodyFlag @file: got %q; want %q", got, want)
+	}
+}
+
+// TestLoadBodyFlagReadsStdin — `@-` reads from cmd.InOrStdin().
+func TestLoadBodyFlagReadsStdin(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString("from stdin\n"))
+	got, err := loadBodyFlag(cmd, "@-")
+	if err != nil {
+		t.Fatalf("loadBodyFlag @-: %v", err)
+	}
+	if got != "from stdin" {
+		t.Errorf("loadBodyFlag @-: got %q; want %q", got, "from stdin")
+	}
+}
+
+// TestLoadBodyFlagRejectsEmptyStdin — stdin that closes empty must
+// surface a clear error rather than silently sending an empty body
+// (the substrate would reject with 422 but the CLI error is
+// faster + more grep-able).
+func TestLoadBodyFlagRejectsEmptyStdin(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	if _, err := loadBodyFlag(cmd, "@-"); err == nil {
+		t.Errorf("expected error for empty @- input")
+	}
+}
+
+// TestLoadBodyFlagRejectsMissingFile — a missing @<path> surfaces
+// the underlying filesystem error.
+func TestLoadBodyFlagRejectsMissingFile(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	if _, err := loadBodyFlag(cmd, "@/no/such/path/entry.md"); err == nil {
+		t.Errorf("expected error for missing file")
+	}
+}
+
+// TestConfirmPromptYesNo — y/yes return true; everything else false.
+func TestConfirmPromptYesNo(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"yes\n", true},
+		{"Y\n", true},
+		{"YES\n", true},
+		{"n\n", false},
+		{"no\n", false},
+		{"\n", false},
+		{"", false}, // EOF on closed stdin
+		{"sure\n", false},
+	}
+	for _, c := range cases {
+		cmd := &cobra.Command{}
+		var stdout bytes.Buffer
+		cmd.SetIn(bytes.NewBufferString(c.input))
+		cmd.SetOut(&stdout)
+		if got := confirmPrompt(cmd, "test"); got != c.want {
+			t.Errorf("confirmPrompt(%q): got %v; want %v", c.input, got, c.want)
+		}
+		if !strings.Contains(stdout.String(), "test") {
+			t.Errorf("prompt text not echoed: %q", stdout.String())
+		}
+	}
+}
+
+// TestDoAuthedRequestRejectsOversizedResponse — the response-body
+// cap is paired with a +1-byte read so a response that fills the
+// cap surfaces as a clear error rather than feeding a truncated
+// body into the JSON decoder.
+func TestDoAuthedRequestRejectsOversizedResponse(t *testing.T) {
+	oversized := strings.Repeat("a", int(responseBodyCap)+1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/test", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(oversized))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := doAuthedRequest(ctx, srv.URL, "GET", "/api/v1/kb/test", nil)
+	if err == nil {
+		t.Fatalf("expected error on oversized response")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error message does not mention size cap: %v", err)
+	}
+}
+
+// TestDoAuthedRequestHandles204NoContent — the kb.delete route
+// returns 204 with an empty body whether or not the row existed;
+// doAuthedRequest must treat that as success (returning nil bytes)
+// rather than as a non-2xx httpError.
+func TestDoAuthedRequestHandles204NoContent(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/some-slug", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE; got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	raw, err := doAuthedRequest(ctx, srv.URL, "DELETE", "/api/v1/kb/some-slug", nil)
+	if err != nil {
+		t.Fatalf("204 should not produce an error: %v", err)
+	}
+	if raw != nil {
+		t.Errorf("expected nil body on 204; got %q", string(raw))
+	}
+}
+
+// writeFile is a tiny helper that mirrors os.WriteFile but is
+// independent of the test's import set — keeps the test file slim
+// (one helper rather than threading os.WriteFile import through
+// every test that touches the filesystem).
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}

--- a/cli/internal/cmd/kb/kb_test.go
+++ b/cli/internal/cmd/kb/kb_test.go
@@ -405,6 +405,30 @@ func TestDoAuthedRequestRejectsOversizedResponse(t *testing.T) {
 	}
 }
 
+// TestRenderRequestErrorEmptyBearerMapsToAuthExpired — an empty
+// stored bearer is a credential-state failure (the token row
+// exists but its `access_token` is empty); renderRequestError must
+// map it to auth_expired (exit 2) with a `meho login` hint rather
+// than letting it fall through to unreachable (exit 3) the generic
+// error string would land on.
+func TestRenderRequestErrorEmptyBearerMapsToAuthExpired(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := renderRequestError(cmd, "https://meho.test", errMissingAccessToken, false)
+	if err == nil {
+		t.Fatalf("expected non-nil error from renderRequestError")
+	}
+	if !strings.Contains(stderr.String(), "auth_expired") {
+		t.Errorf("expected auth_expired classification; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected `meho login` hint; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 2 {
+		t.Errorf("expected ExitCode 2 (auth_expired); got %v", err)
+	}
+}
+
 // TestDoAuthedRequestHandles204NoContent — the kb.delete route
 // returns 204 with an empty body whether or not the row existed;
 // doAuthedRequest must treat that as success (returning nil bytes)

--- a/cli/internal/cmd/kb/list.go
+++ b/cli/internal/cmd/kb/list.go
@@ -24,7 +24,7 @@ import (
 //	  [--filter PATTERN]   # SQL LIKE pattern forwarded to the substrate
 //	  [--limit N]          # 1..500, default 100 (server-side)
 //	  [--offset N]         # offset-based pagination, default 0
-//	  [--json]             # raw KbListResponse JSON instead of the table
+//	  [--json]             # raw ListResponse JSON instead of the table
 //	  [--backplane <url>]  # override the configured backplane URL
 //
 // Exit codes:
@@ -50,7 +50,7 @@ func newListCmd() *cobra.Command {
 			"operator is the trust boundary for pattern shape). " +
 			"--limit caps the page size (1..500, server default 100). " +
 			"--offset advances the page window (default 0). --json " +
-			"emits the raw KbListResponse envelope for jq pipelines.",
+			"emits the raw ListResponse envelope for jq pipelines.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -71,7 +71,7 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&offset, "offset", 0,
 		"offset into the slug-sorted result set (default 0)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw KbListResponse JSON instead of the human table")
+		"emit raw ListResponse JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -140,12 +140,12 @@ func buildListPath(opts listOptions) string {
 	return path
 }
 
-func getList(ctx context.Context, backplaneURL string, opts listOptions) (*KbListResponse, error) {
+func getList(ctx context.Context, backplaneURL string, opts listOptions) (*ListResponse, error) {
 	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
 	if err != nil {
 		return nil, err
 	}
-	var out KbListResponse
+	var out ListResponse
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, fmt.Errorf("decode kb list response: %w", err)
 	}
@@ -154,20 +154,22 @@ func getList(ctx context.Context, backplaneURL string, opts listOptions) (*KbLis
 
 // printListTable renders the list as a compact, scannable table.
 // Columns: SLUG, UPDATED, PREVIEW. The full ISO-8601 timestamp is
-// kept (not truncated) because operators correlating with audit-log
-// rows want the precise updated_at; the preview column carries a
-// 80-char excerpt of the 200-char backend preview so a default
-// terminal width doesn't wrap.
-func printListTable(w io.Writer, r *KbListResponse) {
+// kept verbatim (not truncated) because operators correlating with
+// audit-log rows want the precise updated_at; the column width is
+// 32 chars, sized for the worst-case Python `datetime.isoformat()`
+// shape `YYYY-MM-DDTHH:MM:SS.ffffff+HH:MM`. The preview column
+// carries an 80-char excerpt of the 200-char backend preview so a
+// default terminal width doesn't wrap.
+func printListTable(w io.Writer, r *ListResponse) {
 	if r == nil || len(r.Entries) == 0 {
 		fmt.Fprintln(w, "no kb entries registered in this tenant")
 		return
 	}
-	fmt.Fprintf(w, "%-40s %-26s %s\n", "SLUG", "UPDATED", "PREVIEW")
+	fmt.Fprintf(w, "%-40s %-32s %s\n", "SLUG", "UPDATED", "PREVIEW")
 	for _, e := range r.Entries {
-		fmt.Fprintf(w, "%-40s %-26s %s\n",
+		fmt.Fprintf(w, "%-40s %-32s %s\n",
 			truncate(e.Slug, 40),
-			truncate(e.UpdatedAt, 26),
+			e.UpdatedAt,
 			truncate(e.Preview, 80),
 		)
 	}

--- a/cli/internal/cmd/kb/list.go
+++ b/cli/internal/cmd/kb/list.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newListCmd returns the `meho kb list` command.
+//
+// CLI shape (per issue #418):
+//
+//	meho kb list \
+//	  [--filter PATTERN]   # SQL LIKE pattern forwarded to the substrate
+//	  [--limit N]          # 1..500, default 100 (server-side)
+//	  [--offset N]         # offset-based pagination, default 0
+//	  [--json]             # raw KbListResponse JSON instead of the table
+//	  [--backplane <url>]  # override the configured backplane URL
+//
+// Exit codes:
+//   - 0   list returned cleanly (including zero rows)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape
+//   - 5   insufficient_role
+func newListCmd() *cobra.Command {
+	var (
+		filter            string
+		limit             int
+		offset            int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List kb entries in your tenant",
+		Long: "list calls GET /api/v1/kb and renders the kb entries " +
+			"registered in the operator's tenant, slug-sorted. " +
+			"Optional --filter narrows by a SQL LIKE pattern (the " +
+			"operator is the trust boundary for pattern shape). " +
+			"--limit caps the page size (1..500, server default 100). " +
+			"--offset advances the page window (default 0). --json " +
+			"emits the raw KbListResponse envelope for jq pipelines.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runList(cmd, listOptions{
+				Filter:            filter,
+				Limit:             limit,
+				Offset:            offset,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&filter, "filter", "",
+		"narrow entries by a SQL LIKE pattern (e.g. `vcenter%`)")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max entries per page (1..500, server default 100 when omitted)")
+	cmd.Flags().IntVar(&offset, "offset", 0,
+		"offset into the slug-sorted result set (default 0)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw KbListResponse JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type listOptions struct {
+	Filter            string
+	Limit             int
+	Offset            int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runList(cmd *cobra.Command, opts listOptions) error {
+	// Fail fast on out-of-range --limit / --offset. The backend
+	// clamps internally (Query(ge=1, le=500) on limit, Query(ge=0)
+	// on offset) but explicit zero / negative would fall through
+	// with a 422 surprise.
+	if opts.Limit < 0 || opts.Limit > 500 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 500; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	if opts.Offset < 0 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--offset must be non-negative; got %d", opts.Offset)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	resp, err := getList(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	}
+	printListTable(cmd.OutOrStdout(), resp)
+	return nil
+}
+
+// buildListPath assembles the GET /api/v1/kb query string from the
+// per-call options. Exposed for unit tests so the URL construction
+// stays unit-checkable without standing up an httptest.Server.
+func buildListPath(opts listOptions) string {
+	q := url.Values{}
+	if opts.Filter != "" {
+		q.Set("filter", opts.Filter)
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Offset > 0 {
+		q.Set("offset", strconv.Itoa(opts.Offset))
+	}
+	path := "/api/v1/kb"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path
+}
+
+func getList(ctx context.Context, backplaneURL string, opts listOptions) (*KbListResponse, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out KbListResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode kb list response: %w", err)
+	}
+	return &out, nil
+}
+
+// printListTable renders the list as a compact, scannable table.
+// Columns: SLUG, UPDATED, PREVIEW. The full ISO-8601 timestamp is
+// kept (not truncated) because operators correlating with audit-log
+// rows want the precise updated_at; the preview column carries a
+// 80-char excerpt of the 200-char backend preview so a default
+// terminal width doesn't wrap.
+func printListTable(w io.Writer, r *KbListResponse) {
+	if r == nil || len(r.Entries) == 0 {
+		fmt.Fprintln(w, "no kb entries registered in this tenant")
+		return
+	}
+	fmt.Fprintf(w, "%-40s %-26s %s\n", "SLUG", "UPDATED", "PREVIEW")
+	for _, e := range r.Entries {
+		fmt.Fprintf(w, "%-40s %-26s %s\n",
+			truncate(e.Slug, 40),
+			truncate(e.UpdatedAt, 26),
+			truncate(e.Preview, 80),
+		)
+	}
+}

--- a/cli/internal/cmd/kb/list_test.go
+++ b/cli/internal/cmd/kb/list_test.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildListPathEmpty — empty options yield a clean path with
+// no query string.
+func TestBuildListPathEmpty(t *testing.T) {
+	if got := buildListPath(listOptions{}); got != "/api/v1/kb" {
+		t.Fatalf("empty opts path: got %q; want %q", got, "/api/v1/kb")
+	}
+}
+
+// TestBuildListPathSetsAllFilters — every option lands on the wire.
+func TestBuildListPathSetsAllFilters(t *testing.T) {
+	got := buildListPath(listOptions{Filter: "vcenter%", Limit: 25, Offset: 10})
+	for _, want := range []string{"filter=vcenter%25", "limit=25", "offset=10"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildListPath missing %q in %q", want, got)
+		}
+	}
+}
+
+// TestBuildListPathOmitsZeroOffsetAndLimit — zero values stay off
+// the wire so the backend's defaults apply.
+func TestBuildListPathOmitsZeroOffsetAndLimit(t *testing.T) {
+	got := buildListPath(listOptions{Filter: "x"})
+	if strings.Contains(got, "limit=") {
+		t.Errorf("expected limit omitted; got %q", got)
+	}
+	if strings.Contains(got, "offset=") {
+		t.Errorf("expected offset omitted; got %q", got)
+	}
+}
+
+// TestPrintListTableEmpty — zero-entry tenant renders the no-entries
+// line without the header row.
+func TestPrintListTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	printListTable(&buf, &KbListResponse{Entries: nil})
+	out := buf.String()
+	if !strings.Contains(out, "no kb entries") {
+		t.Errorf("empty render missing hint; got %q", out)
+	}
+	if strings.Contains(out, "SLUG") {
+		t.Errorf("empty render should skip header; got %q", out)
+	}
+}
+
+// TestPrintListTableRendersColumns — header + every column appears.
+func TestPrintListTableRendersColumns(t *testing.T) {
+	resp := &KbListResponse{
+		Entries: []KbEntryPreview{
+			{
+				Slug:      "vcenter-9.0-overview",
+				Preview:   "vCenter 9.0 has new APIs for…",
+				CreatedAt: "2026-05-01T00:00:00Z",
+				UpdatedAt: "2026-05-12T10:11:12Z",
+				Metadata:  map[string]any{"owner": "ops"},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	printListTable(&buf, resp)
+	out := buf.String()
+	for _, want := range []string{"SLUG", "UPDATED", "PREVIEW", "vcenter-9.0-overview", "2026-05-12T10:11:12Z", "vCenter 9.0 has new APIs"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printListTable missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestRunListRejectsOutOfRangeLimit — --limit > 500 is caught at
+// the CLI before the round-trip.
+func TestRunListRejectsOutOfRangeLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{Limit: 501})
+	if err == nil {
+		t.Fatalf("expected error for over-budget --limit")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 500") {
+		t.Errorf("stderr missing range hint; got %q", stderr.String())
+	}
+}
+
+// TestRunListRejectsNegativeLimit — symmetrical case for --limit=-1.
+func TestRunListRejectsNegativeLimit(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	err := runList(cmd, listOptions{Limit: -1})
+	if err == nil {
+		t.Fatalf("expected error for negative --limit")
+	}
+}
+
+// TestRunListRejectsNegativeOffset — same gate on --offset.
+func TestRunListRejectsNegativeOffset(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	err := runList(cmd, listOptions{Offset: -1})
+	if err == nil {
+		t.Fatalf("expected error for negative --offset")
+	}
+}
+
+// TestRunListHappyPath drives runList end-to-end through the auth
+// + transport stack against an httptest server.
+func TestRunListHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("filter"); got != "vcenter%" {
+			t.Errorf("query filter: got %q; want %q", got, "vcenter%")
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(KbListResponse{
+			Entries: []KbEntryPreview{
+				{
+					Slug:      "vcenter-9.0-overview",
+					Preview:   "vCenter 9.0 has…",
+					CreatedAt: "2026-05-01T00:00:00Z",
+					UpdatedAt: "2026-05-12T10:11:12Z",
+					Metadata:  map[string]any{},
+				},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{Filter: "vcenter%", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runList: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"SLUG", "vcenter-9.0-overview"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestRunListJSONHappyPath — --json round-trips the raw response
+// shape; operators piping through jq get a stable contract.
+func TestRunListJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(KbListResponse{
+			Entries: []KbEntryPreview{
+				{Slug: "a", Preview: "p", CreatedAt: "t", UpdatedAt: "u", Metadata: map[string]any{}},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runList --json: %v; stderr=%s", err, stderr.String())
+	}
+	var decoded KbListResponse
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(decoded.Entries) != 1 || decoded.Entries[0].Slug != "a" {
+		t.Errorf("--json decode produced %+v", decoded)
+	}
+}
+
+// TestRunList401SurfacesAuthExpired — exhausting the refresh budget
+// (no refresh_token present) must render as auth_expired with the
+// `meho login` hint.
+func TestRunList401SurfacesAuthExpired(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"detail":"token expired"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error; stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "auth_expired") {
+		t.Errorf("expected auth_expired in stderr; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected `meho login` hint; got %q", stderr.String())
+	}
+}
+
+// TestRunList403SurfacesInsufficientRole — RBAC denial renders with
+// the required-role string the backend supplied and exits 5.
+func TestRunList403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: operator required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(stderr.String(), "insufficient_role") {
+		t.Errorf("expected insufficient_role in stderr; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}

--- a/cli/internal/cmd/kb/list_test.go
+++ b/cli/internal/cmd/kb/list_test.go
@@ -47,7 +47,7 @@ func TestBuildListPathOmitsZeroOffsetAndLimit(t *testing.T) {
 // line without the header row.
 func TestPrintListTableEmpty(t *testing.T) {
 	var buf bytes.Buffer
-	printListTable(&buf, &KbListResponse{Entries: nil})
+	printListTable(&buf, &ListResponse{Entries: nil})
 	out := buf.String()
 	if !strings.Contains(out, "no kb entries") {
 		t.Errorf("empty render missing hint; got %q", out)
@@ -59,8 +59,8 @@ func TestPrintListTableEmpty(t *testing.T) {
 
 // TestPrintListTableRendersColumns — header + every column appears.
 func TestPrintListTableRendersColumns(t *testing.T) {
-	resp := &KbListResponse{
-		Entries: []KbEntryPreview{
+	resp := &ListResponse{
+		Entries: []EntryPreview{
 			{
 				Slug:      "vcenter-9.0-overview",
 				Preview:   "vCenter 9.0 has new APIs for…",
@@ -77,6 +77,34 @@ func TestPrintListTableRendersColumns(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("printListTable missing %q in %q", want, out)
 		}
+	}
+}
+
+// TestPrintListTablePreservesFullTimestamp — the docstring on
+// printListTable promises operators correlating with audit-log
+// rows that the full ISO-8601 `updated_at` is rendered intact.
+// Python's `datetime.isoformat()` with microseconds + offset
+// produces a 32-char string (`YYYY-MM-DDTHH:MM:SS.ffffff+HH:MM`),
+// and the UPDATED column must accommodate it without truncation.
+func TestPrintListTablePreservesFullTimestamp(t *testing.T) {
+	const fullTimestamp = "2026-05-12T10:11:12.123456+00:00" // 32 chars
+	if got := len(fullTimestamp); got != 32 {
+		t.Fatalf("fixture length: got %d; want 32 (test setup error)", got)
+	}
+	resp := &ListResponse{
+		Entries: []EntryPreview{
+			{
+				Slug:      "vcenter-9.0-overview",
+				Preview:   "preview",
+				UpdatedAt: fullTimestamp,
+				Metadata:  map[string]any{},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	printListTable(&buf, resp)
+	if !strings.Contains(buf.String(), fullTimestamp) {
+		t.Errorf("expected full 32-char timestamp intact in render; got %q", buf.String())
 	}
 }
 
@@ -123,8 +151,8 @@ func TestRunListHappyPath(t *testing.T) {
 			t.Errorf("missing Authorization header")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(KbListResponse{
-			Entries: []KbEntryPreview{
+		_ = json.NewEncoder(w).Encode(ListResponse{
+			Entries: []EntryPreview{
 				{
 					Slug:      "vcenter-9.0-overview",
 					Preview:   "vCenter 9.0 has…",
@@ -158,8 +186,8 @@ func TestRunListJSONHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/kb", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(KbListResponse{
-			Entries: []KbEntryPreview{
+		_ = json.NewEncoder(w).Encode(ListResponse{
+			Entries: []EntryPreview{
 				{Slug: "a", Preview: "p", CreatedAt: "t", UpdatedAt: "u", Metadata: map[string]any{}},
 			},
 		})
@@ -173,7 +201,7 @@ func TestRunListJSONHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runList --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded KbListResponse
+	var decoded ListResponse
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
 	}

--- a/cli/internal/cmd/kb/search.go
+++ b/cli/internal/cmd/kb/search.go
@@ -101,10 +101,15 @@ func runSearch(cmd *cobra.Command, opts searchOptions) error {
 	// Fail fast on out-of-range --limit. The backend clamps with
 	// Field(ge=1, le=50); the CLI mirrors the bound so operators
 	// see the constraint string locally instead of a 422 round-trip.
-	if opts.Limit < 0 || opts.Limit > 50 {
+	// Zero is cobra's default for an unset IntVar — preserve that as
+	// the "no flag" sentinel (`postSearch` omits the field on zero),
+	// but reject an *explicit* `--limit=0` (loud failure for a value
+	// outside the documented 1..50 range).
+	limitProvided := cmd.Flags().Changed("limit")
+	if opts.Limit < 0 || opts.Limit > 50 || (limitProvided && opts.Limit == 0) {
 		return output.RenderError(
 			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 50; got %d", opts.Limit)),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 50 when provided; got %d", opts.Limit)),
 			opts.JSONOut,
 		)
 	}

--- a/cli/internal/cmd/kb/search.go
+++ b/cli/internal/cmd/kb/search.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// retrieveRequest mirrors the backend RetrieveRequest pydantic
+// model. The kb `search` verb pins `source="kb"` so a search call
+// from this surface is always kb-scoped; the underlying
+// /api/v1/retrieve route supports cross-source retrieval but the
+// kb CLI deliberately constrains it (operators searching the
+// memory layer use `meho recall`, agents use the meta-tools).
+type retrieveRequest struct {
+	Query  string `json:"query"`
+	Source string `json:"source,omitempty"`
+	Kind   string `json:"kind,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+// newSearchCmd returns the `meho kb search` command.
+//
+// CLI shape (per issue #418):
+//
+//	meho kb search <query> [--limit N] [--json] [--backplane <url>]
+//
+// Role: operator. Pins `source="kb"` server-side so the retrieve
+// substrate scopes hits to kb-entry rows.
+//
+// Exit codes:
+//   - 0   search returned cleanly (incl. zero-hit result)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 422 query-too-long /
+//     query-empty; the backend caps query length at 2000 chars and
+//     limit at 50)
+//   - 5   insufficient_role
+func newSearchCmd() *cobra.Command {
+	var (
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search kb entries via hybrid BM25 + cosine retrieval",
+		Long: "search calls POST /api/v1/retrieve with source=\"kb\" " +
+			"and renders the ranked hits as a text table. Hybrid " +
+			"BM25 + cosine retrieval with RRF fusion is applied by " +
+			"the substrate; per-signal scores and ranks are visible " +
+			"in --json output for retrieval tuning. The query is " +
+			"capped at 2000 chars and the result limit at 50 by the " +
+			"backend (G0.4-T5 contract). The route audits the query " +
+			"hash but not the raw query (decision #3 in " +
+			"docs/planning/v0.2-decisions.md).",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSearch(cmd, searchOptions{
+				Query:             args[0],
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max hits to return (1..50, server default 10 when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw RetrieveResponse JSON (full RetrievalHit shape)")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type searchOptions struct {
+	Query             string
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runSearch(cmd *cobra.Command, opts searchOptions) error {
+	if opts.Query == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("search requires a non-empty <query> argument"),
+			opts.JSONOut,
+		)
+	}
+	// Fail fast on out-of-range --limit. The backend clamps with
+	// Field(ge=1, le=50); the CLI mirrors the bound so operators
+	// see the constraint string locally instead of a 422 round-trip.
+	if opts.Limit < 0 || opts.Limit > 50 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 50; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	resp, err := postSearch(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	}
+	printSearchTable(cmd.OutOrStdout(), resp)
+	return nil
+}
+
+func postSearch(ctx context.Context, backplaneURL string, opts searchOptions) (*RetrieveResponse, error) {
+	body := retrieveRequest{
+		Query:  opts.Query,
+		Source: "kb",
+	}
+	if opts.Limit > 0 {
+		body.Limit = opts.Limit
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal kb search request: %w", err)
+	}
+	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/retrieve", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out RetrieveResponse
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, fmt.Errorf("decode kb search response: %w", err)
+	}
+	return &out, nil
+}
+
+// printSearchTable renders the ranked hits as a compact table.
+// Columns: RANK (1-based), SCORE (fused), SLUG (the kb identifier
+// — the substrate's `source_id`), SNIPPET (200-char excerpt of the
+// body). The hit's `kind` is always `kb-entry` (the substrate
+// scopes via source filter); rendering it would be noise.
+func printSearchTable(w io.Writer, r *RetrieveResponse) {
+	if r == nil || len(r.Hits) == 0 {
+		fmt.Fprintln(w, "no kb hits for this query")
+		return
+	}
+	fmt.Fprintf(w, "%-5s %-8s %-40s %s\n", "RANK", "SCORE", "SLUG", "SNIPPET")
+	for i, hit := range r.Hits {
+		fmt.Fprintf(w, "%-5d %-8.4f %-40s %s\n",
+			i+1,
+			hit.FusedScore,
+			truncate(hit.SourceID, 40),
+			truncate(snippetOf(hit.Body), 80),
+		)
+	}
+	if r.QueryDurationMS > 0 {
+		fmt.Fprintf(w, "queried in %.2f ms\n", r.QueryDurationMS)
+	}
+}
+
+// snippetOf returns the first ~200 chars of body so the table render
+// fits a default terminal width. Pulled into a helper because the
+// truncate helper already trims to a final length — using a separate
+// snippet step keeps the search-table column widths independent of
+// the truncate(maxLen) contract used elsewhere.
+func snippetOf(body string) string {
+	const snippetChars = 200
+	runes := []rune(body)
+	if len(runes) <= snippetChars {
+		return body
+	}
+	return string(runes[:snippetChars]) + "…"
+}

--- a/cli/internal/cmd/kb/search_test.go
+++ b/cli/internal/cmd/kb/search_test.go
@@ -37,6 +37,52 @@ func TestRunSearchRejectsOutOfRangeLimit(t *testing.T) {
 	}
 }
 
+// TestRunSearchRejectsExplicitZeroLimit — `--limit 0` is outside
+// the documented 1..50 range and must be rejected. The cobra-default
+// zero (no flag passed) is still permitted; the distinction is made
+// via `cmd.Flags().Changed("limit")`.
+func TestRunSearchRejectsExplicitZeroLimit(t *testing.T) {
+	// Build a real cobra command so Changed("limit") returns true
+	// after the flag is set by name — the runSearch-only helper used
+	// by other tests doesn't go through flag parsing.
+	cmd := newSearchCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"x", "--limit", "0"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for explicit --limit=0")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 50") {
+		t.Errorf("expected range hint; got %q", stderr.String())
+	}
+}
+
+// TestRunSearchAllowsDefaultZeroLimit — without `--limit`, opts.Limit
+// is cobra's default zero and must be treated as "unset" (server-side
+// default applies). Range gate must not fire.
+func TestRunSearchAllowsDefaultZeroLimit(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/retrieve", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RetrieveResponse{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	// Drive through the cobra command so Changed("limit") is false.
+	cmd := newSearchCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"x", "--backplane", srv.URL})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("default zero limit should pass; got err=%v stderr=%q", err, stderr.String())
+	}
+}
+
 // TestRunSearchHappyPath — POSTs the right body (source pinned to
 // "kb") and renders the ranked-hits table.
 func TestRunSearchHappyPath(t *testing.T) {

--- a/cli/internal/cmd/kb/search_test.go
+++ b/cli/internal/cmd/kb/search_test.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRunSearchRejectsEmptyQuery — empty <query> arg is caught.
+func TestRunSearchRejectsEmptyQuery(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{Query: ""}); err == nil {
+		t.Fatalf("expected error for empty query")
+	} else if !strings.Contains(stderr.String(), "non-empty <query>") {
+		t.Errorf("expected query hint; got %q", stderr.String())
+	}
+}
+
+// TestRunSearchRejectsOutOfRangeLimit — --limit > 50 is rejected
+// before the round-trip.
+func TestRunSearchRejectsOutOfRangeLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{Query: "x", Limit: 51})
+	if err == nil {
+		t.Fatalf("expected error for over-budget limit")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 50") {
+		t.Errorf("expected range hint; got %q", stderr.String())
+	}
+}
+
+// TestRunSearchHappyPath — POSTs the right body (source pinned to
+// "kb") and renders the ranked-hits table.
+func TestRunSearchHappyPath(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/retrieve", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &bodyJSON)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RetrieveResponse{
+			Hits: []RetrievalHit{
+				{
+					DocumentID: "00000000-0000-0000-0000-000000000001",
+					Source:     "kb",
+					SourceID:   "vcenter-9.0-snapshot-revert",
+					Kind:       "kb-entry",
+					Body:       "Revert a snapshot in vCenter 9.0 via …",
+					FusedScore: 0.95,
+				},
+			},
+			QueryDurationMS: 12.5,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{Query: "vsphere snapshot", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runSearch: %v; stderr=%s", err, stderr.String())
+	}
+	if bodyJSON["source"] != "kb" {
+		t.Errorf("expected source=kb pinned; got %+v", bodyJSON)
+	}
+	if bodyJSON["query"] != "vsphere snapshot" {
+		t.Errorf("expected query in body; got %+v", bodyJSON)
+	}
+	// limit=0 → omitempty drops it from the wire; the backend's
+	// default of 10 applies.
+	if _, present := bodyJSON["limit"]; present {
+		t.Errorf("expected limit omitted at zero; got %+v", bodyJSON)
+	}
+	for _, want := range []string{"RANK", "SCORE", "SLUG", "vcenter-9.0-snapshot-revert", "0.9500"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+// TestRunSearchSendsLimitWhenSet — operator-supplied --limit lands
+// on the wire.
+func TestRunSearchSendsLimitWhenSet(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/retrieve", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &bodyJSON)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RetrieveResponse{Hits: nil})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{Query: "x", Limit: 25, BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	got, ok := bodyJSON["limit"].(float64)
+	if !ok || int(got) != 25 {
+		t.Errorf("expected limit=25; got %+v", bodyJSON)
+	}
+}
+
+// TestRunSearchZeroHits — empty hits renders the no-hits hint.
+func TestRunSearchZeroHits(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/retrieve", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RetrieveResponse{Hits: []RetrievalHit{}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{Query: "obscure", BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no kb hits") {
+		t.Errorf("expected no-hits line; got %q", stdout.String())
+	}
+}
+
+// TestRunSearchJSONHappyPath — --json emits the raw RetrieveResponse.
+func TestRunSearchJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/retrieve", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(RetrieveResponse{
+			Hits:            []RetrievalHit{{SourceID: "x", FusedScore: 0.5}},
+			QueryDurationMS: 1.0,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{Query: "x", JSONOut: true, BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runSearch --json: %v", err)
+	}
+	var decoded RetrieveResponse
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if len(decoded.Hits) != 1 || decoded.Hits[0].SourceID != "x" {
+		t.Errorf("decode produced %+v", decoded)
+	}
+}
+
+// TestRunSearch403SurfacesInsufficientRole — read_only role on the
+// retrieve route lands as 403.
+func TestRunSearch403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/retrieve", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: operator required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{Query: "x", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(stderr.String(), "operator required") {
+		t.Errorf("expected role hint; got %q", stderr.String())
+	}
+}
+
+// TestSnippetOfShortBody — body within the budget passes through.
+func TestSnippetOfShortBody(t *testing.T) {
+	if got := snippetOf("hello"); got != "hello" {
+		t.Errorf("snippetOf short: got %q", got)
+	}
+}
+
+// TestSnippetOfLongBody — body over the budget gets ellipsis-clipped.
+func TestSnippetOfLongBody(t *testing.T) {
+	long := strings.Repeat("a", 250)
+	got := snippetOf(long)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis suffix on long body; got %q", got)
+	}
+	// 200 chars + the ellipsis rune; the test must not rely on
+	// byte count due to multi-byte ellipsis.
+	if len([]rune(got)) != 201 {
+		t.Errorf("expected 201 runes; got %d", len([]rune(got)))
+	}
+}
+
+// TestPrintSearchTableRendersBM25CosineScores — *float64 fields
+// must render without panic when nil (one signal missed the hit).
+func TestPrintSearchTableHandlesNilScores(t *testing.T) {
+	cosine := 0.8
+	r := &RetrieveResponse{
+		Hits: []RetrievalHit{
+			{SourceID: "only-cosine", FusedScore: 0.5, CosineScore: &cosine, BM25Score: nil},
+		},
+		QueryDurationMS: 2.0,
+	}
+	var buf bytes.Buffer
+	printSearchTable(&buf, r)
+	if !strings.Contains(buf.String(), "only-cosine") {
+		t.Errorf("expected hit rendered; got %q", buf.String())
+	}
+}

--- a/cli/internal/cmd/kb/show.go
+++ b/cli/internal/cmd/kb/show.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -23,7 +24,7 @@ import (
 // Default output: writes the entry's body to stdout verbatim — the
 // body is already Markdown by the substrate's contract, so an
 // operator can pipe through `glow`, `bat -l md`, etc. for rendering.
-// `--json` wraps the full KbEntry shape (id, tenant_id, slug, body,
+// `--json` wraps the full Entry shape (id, tenant_id, slug, body,
 // metadata, created_at, updated_at).
 //
 // A 404 from the backend surfaces as "slug_not_found". The
@@ -51,7 +52,7 @@ func newShowCmd() *cobra.Command {
 			"entry body to stdout. The body is Markdown by the " +
 			"substrate's contract; pipe through a Markdown renderer " +
 			"(glow, bat -l md, mdcat, etc.) for prettified output. " +
-			"--json wraps the entry in the full KbEntry envelope " +
+			"--json wraps the entry in the full Entry envelope " +
 			"(id, slug, body, metadata, timestamps). A 404 means the " +
 			"slug doesn't exist in your tenant (the route deliberately " +
 			"conflates cross-tenant probes with genuine absence so " +
@@ -68,7 +69,7 @@ func newShowCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw KbEntry JSON instead of the Markdown body")
+		"emit raw Entry JSON instead of the Markdown body")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -110,12 +111,12 @@ func buildShowPath(slug string) string {
 	return "/api/v1/kb/" + pathEscape(slug)
 }
 
-func getEntry(ctx context.Context, backplaneURL, slug string) (*KbEntry, error) {
+func getEntry(ctx context.Context, backplaneURL, slug string) (*Entry, error) {
 	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildShowPath(slug), nil)
 	if err != nil {
 		return nil, err
 	}
-	var out KbEntry
+	var out Entry
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, fmt.Errorf("decode kb show response: %w", err)
 	}
@@ -123,13 +124,16 @@ func getEntry(ctx context.Context, backplaneURL, slug string) (*KbEntry, error) 
 }
 
 // printEntryBody writes the entry's Markdown body to stdout
-// verbatim, with a single trailing newline (always — the body may
-// or may not already end in one; the substrate stores whatever the
-// operator passed in). A trailing newline keeps shell prompts on
-// their own line after `meho kb show` invocations.
-func printEntryBody(w io.Writer, e *KbEntry) {
+// verbatim with exactly one trailing newline. The substrate stores
+// the body unmodified, so a Markdown file that already ends in `\n`
+// (the conventional shape — most editors enforce a trailing LF on
+// save) would otherwise produce two newlines when `Fprintln` adds
+// its own. Trimming `\r` + `\n` from the right keeps the single-
+// trailing-newline contract regardless of whether the operator
+// stored their body with or without a trailing LF/CRLF.
+func printEntryBody(w io.Writer, e *Entry) {
 	if e == nil {
 		return
 	}
-	fmt.Fprintln(w, e.Body)
+	fmt.Fprintln(w, strings.TrimRight(e.Body, "\r\n"))
 }

--- a/cli/internal/cmd/kb/show.go
+++ b/cli/internal/cmd/kb/show.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newShowCmd returns the `meho kb show` command.
+//
+// CLI shape (per issue #418):
+//
+//	meho kb show <slug> [--json] [--backplane <url>]
+//
+// Default output: writes the entry's body to stdout verbatim — the
+// body is already Markdown by the substrate's contract, so an
+// operator can pipe through `glow`, `bat -l md`, etc. for rendering.
+// `--json` wraps the full KbEntry shape (id, tenant_id, slug, body,
+// metadata, created_at, updated_at).
+//
+// A 404 from the backend surfaces as "slug_not_found". The
+// cross-tenant probe always reads as 404 — the substrate's tenant
+// WHERE clause yields zero rows for a slug outside the operator's
+// tenant, and the route returns 404 (not 403) so the existence of
+// a slug in another tenant never leaks through status-code
+// discrimination.
+//
+// Exit codes:
+//   - 0   entry rendered cleanly
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (includes 404 slug-not-found)
+//   - 5   insufficient_role
+func newShowCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "show <slug>",
+		Short: "Fetch a kb entry by slug",
+		Long: "show calls GET /api/v1/kb/{slug} and writes the full " +
+			"entry body to stdout. The body is Markdown by the " +
+			"substrate's contract; pipe through a Markdown renderer " +
+			"(glow, bat -l md, mdcat, etc.) for prettified output. " +
+			"--json wraps the entry in the full KbEntry envelope " +
+			"(id, slug, body, metadata, timestamps). A 404 means the " +
+			"slug doesn't exist in your tenant (the route deliberately " +
+			"conflates cross-tenant probes with genuine absence so " +
+			"existence is never leaked across tenant boundaries).",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShow(cmd, showOptions{
+				Slug:              args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw KbEntry JSON instead of the Markdown body")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type showOptions struct {
+	Slug              string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runShow(cmd *cobra.Command, opts showOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("show requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	entry, err := getEntry(cmd.Context(), backplaneURL, opts.Slug)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), entry)
+	}
+	printEntryBody(cmd.OutOrStdout(), entry)
+	return nil
+}
+
+// buildShowPath assembles the GET path. Exposed for unit tests so
+// URL encoding of slugs with dots / hyphens stays covered (the
+// substrate accepts `vcenter-9.0-snapshot-revert` shaped slugs).
+func buildShowPath(slug string) string {
+	return "/api/v1/kb/" + pathEscape(slug)
+}
+
+func getEntry(ctx context.Context, backplaneURL, slug string) (*KbEntry, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildShowPath(slug), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out KbEntry
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode kb show response: %w", err)
+	}
+	return &out, nil
+}
+
+// printEntryBody writes the entry's Markdown body to stdout
+// verbatim, with a single trailing newline (always — the body may
+// or may not already end in one; the substrate stores whatever the
+// operator passed in). A trailing newline keeps shell prompts on
+// their own line after `meho kb show` invocations.
+func printEntryBody(w io.Writer, e *KbEntry) {
+	if e == nil {
+		return
+	}
+	fmt.Fprintln(w, e.Body)
+}

--- a/cli/internal/cmd/kb/show_test.go
+++ b/cli/internal/cmd/kb/show_test.go
@@ -47,7 +47,7 @@ func TestRunShowRejectsEmptySlug(t *testing.T) {
 // TestRunShowHappyPath — body goes to stdout verbatim; --json
 // wraps the full entry.
 func TestRunShowHappyPath(t *testing.T) {
-	entry := KbEntry{
+	entry := Entry{
 		ID:        "00000000-0000-0000-0000-000000000001",
 		TenantID:  "00000000-0000-0000-0000-000000000002",
 		Slug:      "vcenter-9.0",
@@ -82,9 +82,9 @@ func TestRunShowHappyPath(t *testing.T) {
 	}
 }
 
-// TestRunShowJSONHappyPath — --json wraps the full KbEntry shape.
+// TestRunShowJSONHappyPath — --json wraps the full Entry shape.
 func TestRunShowJSONHappyPath(t *testing.T) {
-	entry := KbEntry{
+	entry := Entry{
 		ID:   "00000000-0000-0000-0000-000000000001",
 		Slug: "x", Body: "b",
 		Metadata: map[string]any{"k": "v"},
@@ -103,7 +103,7 @@ func TestRunShowJSONHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runShow --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded KbEntry
+	var decoded Entry
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
 	}
@@ -137,11 +137,27 @@ func TestRunShow404SurfacesSlugNotFound(t *testing.T) {
 }
 
 // TestPrintEntryBodyEmitsBodyAndNewline — non-JSON render writes
-// the body then a single trailing newline.
+// the body then a single trailing newline. Bodies with no trailing
+// newline get exactly one appended; bodies that already end in
+// `\n` or `\r\n` get normalised down to exactly one trailing `\n`
+// rather than doubling up.
 func TestPrintEntryBodyEmitsBodyAndNewline(t *testing.T) {
-	var buf bytes.Buffer
-	printEntryBody(&buf, &KbEntry{Body: "hello"})
-	if buf.String() != "hello\n" {
-		t.Errorf("unexpected render: %q", buf.String())
+	cases := []struct {
+		name, body, want string
+	}{
+		{"no trailing newline", "hello", "hello\n"},
+		{"already ends in LF", "hello\n", "hello\n"},
+		{"already ends in CRLF", "hello\r\n", "hello\n"},
+		{"multiple trailing newlines", "hello\n\n\n", "hello\n"},
+		{"empty body", "", "\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printEntryBody(&buf, &Entry{Body: c.body})
+			if buf.String() != c.want {
+				t.Errorf("unexpected render: got %q; want %q", buf.String(), c.want)
+			}
+		})
 	}
 }

--- a/cli/internal/cmd/kb/show_test.go
+++ b/cli/internal/cmd/kb/show_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package kb
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBuildShowPathEscapesSlug — dots / hyphens pass through;
+// space-like operator typos surface as %20 so the route's
+// `{slug:str}` matcher sees a single segment.
+func TestBuildShowPathEscapesSlug(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"vcenter-9.0", "/api/v1/kb/vcenter-9.0"},
+		{"a", "/api/v1/kb/a"},
+		{"slug with space", "/api/v1/kb/slug%20with%20space"},
+	}
+	for _, c := range cases {
+		if got := buildShowPath(c.in); got != c.want {
+			t.Errorf("buildShowPath(%q): got %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestRunShowRejectsEmptySlug — args[0] of empty string must fail
+// at the runner before hitting the backplane.
+func TestRunShowRejectsEmptySlug(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{Slug: ""})
+	if err == nil {
+		t.Fatalf("expected error for empty slug")
+	}
+	if !strings.Contains(stderr.String(), "non-empty <slug>") {
+		t.Errorf("expected slug hint in stderr; got %q", stderr.String())
+	}
+}
+
+// TestRunShowHappyPath — body goes to stdout verbatim; --json
+// wraps the full entry.
+func TestRunShowHappyPath(t *testing.T) {
+	entry := KbEntry{
+		ID:        "00000000-0000-0000-0000-000000000001",
+		TenantID:  "00000000-0000-0000-0000-000000000002",
+		Slug:      "vcenter-9.0",
+		Body:      "# vcenter 9.0\n\nOverview body.",
+		Metadata:  map[string]any{},
+		CreatedAt: "2026-05-01T00:00:00Z",
+		UpdatedAt: "2026-05-12T10:11:12Z",
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/vcenter-9.0") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entry)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{Slug: "vcenter-9.0", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runShow: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "# vcenter 9.0") {
+		t.Errorf("expected Markdown body in stdout; got %q", stdout.String())
+	}
+	// The non-JSON mode must NOT emit JSON.
+	if strings.Contains(stdout.String(), "tenant_id") {
+		t.Errorf("non-JSON mode leaked envelope: %q", stdout.String())
+	}
+}
+
+// TestRunShowJSONHappyPath — --json wraps the full KbEntry shape.
+func TestRunShowJSONHappyPath(t *testing.T) {
+	entry := KbEntry{
+		ID:   "00000000-0000-0000-0000-000000000001",
+		Slug: "x", Body: "b",
+		Metadata: map[string]any{"k": "v"},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entry)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{Slug: "x", JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runShow --json: %v; stderr=%s", err, stderr.String())
+	}
+	var decoded KbEntry
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if decoded.Slug != "x" || decoded.Body != "b" {
+		t.Errorf("decode produced %+v", decoded)
+	}
+}
+
+// TestRunShow404SurfacesSlugNotFound — the substrate returns
+// `slug_not_found` for both cross-tenant probes and genuine
+// absences; the CLI must render it as an unexpected_response with
+// the backend's detail intact.
+func TestRunShow404SurfacesSlugNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/kb/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"slug_not_found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{Slug: "missing", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 404")
+	}
+	if !strings.Contains(stderr.String(), "slug_not_found") {
+		t.Errorf("expected slug_not_found detail; got %q", stderr.String())
+	}
+}
+
+// TestPrintEntryBodyEmitsBodyAndNewline — non-JSON render writes
+// the body then a single trailing newline.
+func TestPrintEntryBodyEmitsBodyAndNewline(t *testing.T) {
+	var buf bytes.Buffer
+	printEntryBody(&buf, &KbEntry{Body: "hello"})
+	if buf.String() != "hello\n" {
+		t.Errorf("unexpected render: %q", buf.String())
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/cmd/audit"
 	"github.com/evoila/meho/cli/internal/cmd/connector"
+	"github.com/evoila/meho/cli/internal/cmd/kb"
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
 	"github.com/evoila/meho/cli/internal/cmd/targets"
@@ -114,6 +115,14 @@ func newRootCmd() *cobra.Command {
 	// before registerDynamicSubcommands so the backplane manifest
 	// cannot shadow the built-in `audit` parent.
 	root.AddCommand(audit.NewRootCmd())
+
+	// G4.1-T4 (#418) -- kb verbs (ingest / search / list / show /
+	// add / delete) for Initiative #331. Wraps the five /api/v1/kb*
+	// routes shipped by G4.1-T2 (#416) plus the /api/v1/retrieve
+	// route for the search verb. Registered before
+	// registerDynamicSubcommands so the backplane manifest cannot
+	// shadow the built-in `kb` parent.
+	root.AddCommand(kb.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -21,10 +21,10 @@ ADR 0006 identity-claim format. Server-driven subcommand discovery
 runs at every startup (empty manifest in v0.1; populated by
 post-Goal-2 backplanes without a CLI binary release).
 
-The v0.2 substrate adds three statically-registered subcommand
-trees alongside the discovery surface. All three follow the same
-pattern: a per-package `NewRootCmd()` returns a cobra parent that
-holds per-verb subcommands; the parents register before the dynamic
+The v0.2 substrate adds several statically-registered subcommand
+trees alongside the discovery surface. All follow the same pattern:
+a per-package `NewRootCmd()` returns a cobra parent that holds
+per-verb subcommands; the parents register before the dynamic
 discovery hook so backplane manifests cannot shadow built-in verb
 names.
 
@@ -38,6 +38,11 @@ names.
 - `meho audit ...` (G8.1-T3 #467) — audit-log query surface
   (`query`, `recent`, `show`, `who-touched`, `my-recent`) wrapping
   the four `/api/v1/audit/*` routes shipped by G8.1-T2 (#466).
+- `meho kb ...` (G4.1-T4 #418) — knowledge-base operator surface
+  (`ingest`, `search`, `list`, `show`, `add`, `delete`) wrapping
+  the five `/api/v1/kb*` routes shipped by G4.1-T2 (#416) plus the
+  `/api/v1/retrieve` route (G0.4-T5 #262, `source="kb"` scoped)
+  for the search verb.
 
 ## Module layout
 
@@ -90,6 +95,21 @@ cli/
     │   │   ├── who_touched_test.go # query-param emit + table render tests.
     │   │   ├── my_recent_test.go # JWT-only-principal contract tests.
     │   │   └── recent_test.go    # since=24h binding + --json passthrough tests.
+    │   ├── kb/               # G4.1-T4 #418 — `meho kb …` verb tree.
+    │   │   ├── kb.go             # NewRootCmd + shared HTTP/auth helpers + body/metadata/confirm helpers.
+    │   │   ├── ingest.go         # `meho kb ingest <directory> [--dry-run]` (POST /api/v1/kb/ingest).
+    │   │   ├── search.go         # `meho kb search <query>` (POST /api/v1/retrieve, source="kb").
+    │   │   ├── list.go           # `meho kb list [--filter --limit --offset]` (GET /api/v1/kb).
+    │   │   ├── show.go           # `meho kb show <slug>` (GET /api/v1/kb/{slug}); body to stdout.
+    │   │   ├── add.go            # `meho kb add <slug> --body @file|@-|text` (POST /api/v1/kb).
+    │   │   ├── delete.go         # `meho kb delete <slug> [--confirm]` (DELETE /api/v1/kb/{slug}).
+    │   │   ├── kb_test.go        # helpers + register-all-verbs + body/metadata/confirm contract tests.
+    │   │   ├── ingest_test.go    # POST body + four-bucket render + 400 directory_not_found tests.
+    │   │   ├── search_test.go    # POST body (source pinned) + table render + nil-score safety tests.
+    │   │   ├── list_test.go      # query-param emit + table render + limit-range gate tests.
+    │   │   ├── show_test.go      # path-escape + Markdown body to stdout + 404 slug_not_found tests.
+    │   │   ├── add_test.go       # body-from-file / @- / inline + metadata parse + 422 surface tests.
+    │   │   └── delete_test.go    # confirm-prompt + idempotent-204 + --json envelope tests.
     │   ├── connector/         # G0.7-T5 #405 — `meho connector …` verb tree.
     │   │   ├── connector.go      # NewRootCmd + shared HTTP/auth helpers.
     │   │   ├── ingest.go         # `meho connector ingest` (POST /api/v1/connectors/ingest).


### PR DESCRIPTION
## Summary

- Ships the operator-facing `meho kb` verb tree (G4.1-T4) wrapping the five `/api/v1/kb*` routes from T2 (#416) plus `/api/v1/retrieve` with `source="kb"` for the search verb — the CLI counterpart to T3's MCP meta-tools (#417), targeting muscle-memory operator workflows rather than agent flows.
- All six verbs (`ingest`, `search`, `list`, `show`, `add`, `delete`) follow the established sibling pattern (`audit/`, `targets/`, `connector/`, `operation/`, `retrieval/`): in-package HTTP helpers to avoid the cmd → cmd/<tree> → cmd import cycle a shared `api_client` would close. Error classification mirrors the audit/targets ladder with kb-specific 4xx handling (slug_not_found 404, directory_not_found 400, tarball-not-implemented 501).
- `meho kb add --body` accepts inline text, `@<path>` file references, and `@-` stdin; `meho kb delete` confirms on stdin unless `--confirm`; every verb supports `--json` for jq pipelines.

## Test plan

- [x] `go test -race -cover ./internal/cmd/kb/...` — pass, 86.9% coverage, race-clean
- [x] `go test ./...` — pass across the entire CLI module (audit/targets/connector/operation/retrieval/discovery/output unchanged)
- [x] `go vet ./...` — clean
- [x] `gofmt -l internal/cmd/kb/` — clean
- [x] `go build ./...` — clean
- [x] `meho kb --help` renders all six verbs from a built binary
- [x] AC1 `meho kb ingest` end-to-end — substrate-level contract covered by `TestRunIngestHappyPath` + `TestRunIngestDryRunBindsBody` (live-backend integration belongs in the docker-compose smoke harness, recorded as adjacent finding)
- [x] AC2 `meho kb search` returns ranked hits as table — `TestRunSearchHappyPath`
- [x] AC3 `meho kb list` + `--filter` — `TestRunListHappyPath`
- [x] AC4 `meho kb show <slug>` prints Markdown body — `TestRunShowHappyPath`
- [x] AC5 `meho kb add` w/ `@file` and `@-` — `TestRunAddHappyPath`, `TestRunAddReadsBodyFromStdin`
- [x] AC6 `meho kb delete --confirm` idempotent — `TestRunDeleteWithConfirmSkipsPrompt`, `TestRunDeleteIdempotent204`
- [x] AC7 `--json` on every verb — covered per-verb (six `*JSONHappyPath` tests)
- [x] AC8 `--dry-run` on ingest binds `dry_run=true` and doesn't write — `TestRunIngestDryRunBindsBody`
- [x] AC9 tenant_admin enforcement on delete/ingest/add — three `*403SurfacesInsufficientRole` tests confirm the CLI surfaces the backend's 403 with exit code 5
- [x] AC10 confirmation prompt fires by default — `TestRunDeletePromptDeclined` (declined path) + `TestRunDeleteWithConfirmSkipsPrompt` (skip path)
- [x] AC11 all 5 routes wrapped + retrieve — every route has a runner and a contract test
- [x] AC13 CI green; `go test ./cli/...` passes — confirmed locally

## Out of scope

- `meho kb edit <slug>` opening `$EDITOR` — per issue body, v0.2.next polish
- `meho kb export <slug>` — redundant with `meho kb show > file.md`
- Multipart tarball upload — substrate exposes only `ingest_directory` in v0.2; route returns 501 on `tarball_url` (forward-compat in the schema)
- Live-backplane integration test in the unit suite — belongs in the docker-compose smoke harness (operator-driven)
- Convention deviation from issue body: the issue text mentions `cli/internal/api_client/kb.go`, but every sibling verb tree uses in-package HTTP helpers (no `api_client/` directory exists). Following the established convention; recorded as an adjacent finding rather than introducing a fresh shared package mid-initiative.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #418


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full meho kb command suite: add, delete, ingest, list, show, search with flags for --body (inline/file/stdin), --metadata, --confirm/--dry-run, --limit/--offset/--filter, --json, and --backplane override; human-readable tables and stable JSON outputs.
  * Ingest shows per-file results and counts; delete supports interactive confirmation and JSON status.

* **Tests**
  * Extensive test coverage for all kb commands, flags, error paths, and output modes.

* **Documentation**
  * CLI docs updated to include the new kb command group.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/512)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-15)

Addressed all 7 findings from the iter-1 [`/auto-review-pr` REQUEST_CHANGES verdict](https://github.com/evoila/meho/pull/512#issuecomment-4460260931). 1 blocker + 2 majors + 4 minors — every finding addressed, none deferred. New head SHA: `8ab79b4`.

- **B1** (blocker) `8ab79b4` — drop the `Kb` prefix on 4 exported types (`KbEntry` → `Entry`, `KbEntryPreview` → `EntryPreview`, `KbListResponse` → `ListResponse`, `KbIngestionResult` → `IngestionResult`). Resolves the 4 `revive` stutter errors that broke `golangci-lint v1.64.8` on the head SHA.
- **M1** (major) `8ab79b4` — move `resolveBackplane(...)` below the confirmPrompt branch in `delete.go` so a decline-without-login exits 0 with `status=declined` instead of `auth_expired`.
- **M2** (major) `8ab79b4` — drop `truncate(e.UpdatedAt, 26)` in `printListTable`; widen the column to `%-32s` to accommodate Python `datetime.isoformat()` (32 chars).
- **m1** (minor) `8ab79b4` — reject explicit `--limit=0` on `meho kb search` via `cmd.Flags().Changed("limit")`; preserve the cobra-default-zero sentinel for "no flag passed".
- **m2** (minor) `8ab79b4` — `printEntryBody` now normalises trailing newlines via `strings.TrimRight(..., "\r\n")` so a body already ending in `\n` doesn't render with two trailing newlines.
- **m3** (minor) `8ab79b4` — package-level `errMissingAccessToken` sentinel returned by `doAuthedRequest` and recognised in `renderRequestError` as auth_expired (exit 2) instead of unreachable (exit 3).
- **m4** (minor) `8ab79b4` — `TestRunAdd422SurfacesValidationDetail` now asserts the backend's `SLUG_PATTERN` detail survives the round-trip into stderr.

No findings disputed; no findings deferred. Pre-existing sibling-package version of m3 (audit/targets/connector/operation/retrieval also fall through to unreachable on empty bearer) recorded as an adjacent finding — worth a follow-up Initiative-scoped Task to fix the classification uniformly across all six packages.

Verification: `gofmt -l` clean, `go vet ./...` clean, `golangci-lint v1.64.8 run ./...` clean (4 stutter errors gone), `go test -race -cover ./internal/cmd/kb/...` 87.2% coverage (up from 86.9%) race-clean, `go test -race ./...` full CLI module passes.

<!-- auto-implement-issue: continue, iteration 2 -->
