### PR TITLE
docs(audit): G8.1-T6 audit-query operator runbook + canonical architecture doc

### DIFF
--- a/docs/architecture/audit.md
+++ b/docs/architecture/audit.md
@@ -1,0 +1,115 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Audit query (G8)
+
+> Reads [CLAUDE.md](../../CLAUDE.md) postulates 5 (narrow-waist agent surface) and 7 (audit is synchronous, append-only, WORM-grade). Sister to [operations-substrate.md](operations-substrate.md) — that doc owns the dispatcher and the `endpoint_descriptor` table the audit log records dispatches against; this doc owns the read-side substrate operators and agents use to query those records.
+>
+> Covers the implementation that landed under [Initiative #334 G8.1](https://github.com/evoila/meho/issues/334).
+
+## What this surface does
+
+One sentence: queryable interface to the WORM-grade `audit_log` table that the chassis middleware writes synchronously on every authenticated dispatch, replacing the `git log` + ticket-thread + Slack-search archaeology operators previously stitched together when answering "who did X to Y and when?".
+
+The substrate operationalises three contracts:
+
+- **CLAUDE.md postulate 7** — every authenticated dispatch writes one audit row, append-only, before the response yields back. G8.1 ships the read surface that turns those rows into investigation answers.
+- **CLAUDE.md postulate 5** — the agent surface is a narrow waist. Operators get five CLI verbs (per-shape conveniences); agents get one MCP tool (`query_audit`). The conveniences collapse into filter combinations on the same substrate handler.
+- **Decision #3** ([v0.2-decisions.md](../planning/v0.2-decisions.md)) — `query_audit` is privacy-sensitive: a free-text broadcast of "operator X queried for principal Y on target Z" would leak the investigation intent. The G6.1 sensitivity classifier renders every `op_class="audit_query"` event as aggregate-only `{op_id, result_status, row_count}`; filter contents stay local to the operator.
+
+## Module shape
+
+The substrate lives in [`backend/src/meho_backplane/audit_query/`](../../backend/src/meho_backplane/audit_query/):
+
+| File | What it owns |
+|---|---|
+| [`schemas.py`](../../backend/src/meho_backplane/audit_query/schemas.py) | `AuditQueryFilters` (input filter — frozen Pydantic v2), `AuditEntry` (one row), `AuditQueryResult` (page + forward-only `next_cursor`). `tenant_id` is deliberately **not** on `AuditQueryFilters` — the handler takes it as a mandatory keyword-only argument so an operator-controllable filter object cannot smuggle the tenant boundary. |
+| [`cursor.py`](../../backend/src/meho_backplane/audit_query/cursor.py) | Opaque base64-encoded JSON `{"ts": "<ISO-8601>", "id": "<uuid>"}` cursor. Forward-only. `decode_cursor` raises `InvalidCursorError` on tamper or corruption; tests round-trip + reject malformed input. |
+| [`query.py`](../../backend/src/meho_backplane/audit_query/query.py) | `query_audit(filters, *, tenant_id, session) -> AuditQueryResult` — the substrate handler T2 (REST), T3 (CLI), T4 (MCP) all dispatch through. Tenant-scoping baked in (first WHERE clause); LEFT JOIN to `targets` for `target_name` denormalization is *also* scoped on `Target.tenant_id` so a cross-tenant `target_id` resolves to `target_name=None` rather than leaking the other tenant's name. |
+| [`duration.py`](../../backend/src/meho_backplane/audit_query/duration.py) | `parse_duration("24h" \| "7d" \| ISO-8601, *, now) -> datetime` for the router layer. Grammar wider than `retrieval/usage.py::parse_since` (which accepts `d` / `h` only) because audit forensics often wants sub-minute resolution and multi-week windows; unifying the two parsers is a v0.2.next surface. |
+
+The engineering-facing companion doc — [`docs/codebase/audit_query.md`](../codebase/audit_query.md) — owns the field-by-field schema reconciliation (which `AuditEntry` fields are real columns, which are computed at query time, which are v0.2 placeholders), the control-flow diagram, and the catalogue of known v0.2 gaps.
+
+## Surfaces
+
+The substrate has three consumer-facing surfaces, all dispatching through `query_audit` with `tenant_id` injected from the operator JWT:
+
+### REST — four routes under `/api/v1/audit/*` ([T2 #466](https://github.com/evoila/meho/issues/466))
+
+| Route | Filter shape | Notes |
+|---|---|---|
+| `POST /api/v1/audit/query` | Body is `AuditQueryRequest`; `since` / `until` are strings parsed at the router via `parse_duration`. Client-supplied `tenant_id` is silently dropped by Pydantic's default `extra="ignore"`. | Full-filter surface. |
+| `GET /api/v1/audit/who-touched/{target}` | Path param → `filters.target`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
+| `GET /api/v1/audit/my-recent` | `filters.principal = operator.sub`; `since` defaults to `"24h"`. | Pre-canned shortcut — operator can never see another operator's `my-recent` through this route. |
+| `GET /api/v1/audit/show/{audit_id}` | `filters.audit_id = <path>`, `limit=1`. Cross-tenant lookups → 404 (never 403, so existence never leaks). | Single-row fetch. |
+
+Every route binds two audit-override contextvars **before** the substrate call — `audit_op_id="meho.audit.query"` and `audit_op_class="audit_query"` — so the audit row the chassis middleware writes for this request carries the canonical op_id and the broadcast event ships as aggregate-only per decision #3. `audit_row_count` is bound after the substrate returns so the broadcast event's `row_count` reflects the returned cardinality. The pattern mirrors [`api/v1/retrieve_usage.py`](../../backend/src/meho_backplane/api/v1/retrieve_usage.py).
+
+### CLI — five verbs under `meho audit ...` ([T3 #467](https://github.com/evoila/meho/issues/467))
+
+The CLI ([`cli/internal/cmd/audit/`](../../cli/internal/cmd/audit/)) ships `query`, `recent`, `show`, `who-touched`, and `my-recent`. Each verb wraps exactly one REST route and renders the response as either a tabular summary (default) or raw JSON (`--json`). Authentication piggybacks on the token `meho login` wrote — same pattern as `meho targets` and `meho retrieval`. The operator-facing recipe with worked examples is in the [cross-repo runbook](../cross-repo/audit-query.md).
+
+### MCP — one meta-tool `query_audit` ([T4 #468](https://github.com/evoila/meho/issues/468))
+
+The agent surface is a single tool registered against the [G0.5 MCP server](../../backend/src/meho_backplane/mcp/server.py) in [`mcp/tools/audit.py`](../../backend/src/meho_backplane/mcp/tools/audit.py). The per-shape CLI conveniences collapse into filter combinations on this tool per [CLAUDE.md](../../CLAUDE.md) postulate 5; no `audit.show` / `audit.who_touched` / `audit.my_recent` MCP tools exist.
+
+Hand-built `inputSchema` (not `AuditQueryFilters.model_json_schema()`) because the substrate filter uses `datetime` for `since` / `until` and the agent passes duration shorthand — a `format: date-time` constraint on the substrate-derived schema would reject `"24h"` at the jsonschema layer. `additionalProperties: false` rejects smuggled `tenant_id` before the handler runs. Substrate / parser errors (`DurationParseError`, `InvalidCursorError`, `UnsupportedFilterError`, residual `pydantic.ValidationError`) are caught in the handler and re-raised as `McpInvalidParamsError` → JSON-RPC `-32602`.
+
+## Tenant boundary
+
+The tenant-scoping invariant is enforced redundantly at two layers:
+
+1. **Substrate** — `query_audit(filters, *, tenant_id, session)` takes `tenant_id` as a mandatory keyword-only argument. `AuditQueryFilters` has no `tenant_id` field at all. The first SQL WHERE clause is always `audit_log.tenant_id = :tenant_id`; the LEFT JOIN to `targets` for `target_name` denormalization is *also* scoped on `Target.tenant_id`, so a cross-tenant `target_id` (allowed today because `audit_log.target_id` keeps no FK in v0.2 per the soft-FK discipline) resolves to `target_name=None` rather than leaking the other tenant's target name.
+2. **Surface** — every route, every CLI verb, every MCP handler pulls `tenant_id` from `operator.tenant_id` (the JWT claim resolved by `verify_jwt_and_bind` / `verify_mcp_jwt_and_bind`) and passes it into the substrate. The REST POST body's Pydantic model has no `tenant_id` field, so a client-supplied value is silently dropped. The MCP tool's `inputSchema` has `additionalProperties: false`, so an agent that tries to smuggle `tenant_id` is rejected by the dispatcher's jsonschema layer with `-32602` before reaching the handler.
+
+There is no admin escape hatch. Cross-tenant queries are structurally impossible, by design and by code. The `show` route surfaces 404 (not 403) for cross-tenant audit-ids so a probing operator cannot even distinguish "row doesn't exist" from "row exists in another tenant".
+
+## Cursor pagination
+
+Forward-only, opaque base64 of `{ts, id}`. The substrate orders rows `(occurred_at DESC, id DESC)` and uses an `N+1` fetch to detect whether more pages exist; if `N+1` rows come back, the (N+1)th row is dropped from the returned page and its `(occurred_at, id)` is encoded as `next_cursor`. The next-page query applies the lex-compare `(occurred_at, id) < (cursor.ts, cursor.id)` so the next row is strictly older than the cursor's row.
+
+The cursor is **correct under concurrent insert load**: rows inserted between page N and page N+1 do not appear inside a cursor-paginated continuation (they're newer than the cursor's `(ts, id)`); they are visible only on a fresh page-1 call. This is the snapshot semantics operators expect from a forensic-reconstruction surface — what was true at the time the cursor was issued stays the page the cursor reads back.
+
+`decode_cursor` raises `InvalidCursorError` on tamper or corruption; the surfaces map it to 400 (REST) or `-32602` (MCP).
+
+## Decision #3 alignment — aggregate-only audit broadcasts
+
+The `audit_log` row this surface produces feeds into the [G6.1 sensitivity classifier](https://github.com/evoila/meho/issues/228), which renders every `op_class="audit_query"` event as aggregate-only on the per-tenant Valkey broadcast stream:
+
+```json
+{"op_id": "meho.audit.query", "op_class": "audit_query", "result_status": "ok", "row_count": 47}
+```
+
+The filter contents — which principal you queried, which target, which op_id glob — are **never** broadcast. The full audit row remains queryable (via this same surface, with the appropriate role on the appropriate tenant), but the live SSE / Slack feed sees only the aggregate.
+
+### Two known chain gaps for the MCP path
+
+T5 (acceptance integration, [#469](https://github.com/evoila/meho/issues/469)) is the gate that verifies the chain end-to-end. The MCP dispatch path ships with two known gaps that T5 will surface and either fix in place or escalate to standalone Tasks:
+
+1. **MCP broadcast publisher does not honor `defn.op_class`.** [`mcp/handlers.py::_publish_mcp_event`](../../backend/src/meho_backplane/mcp/handlers.py) re-runs `classify_op(op_id)` instead of using the `op_class` the audit-write step already set from `defn.op_class`. For `query_audit` (`op_id="query_audit"` per the MCP tool-name-as-op-id dispatcher convention), `classify_op` returns `"other"` — so the broadcast event ships with the full audit payload instead of the aggregate-only shape decision #3 requires. The chassis HTTP publisher already honors the override ([`audit.py::_publish_broadcast_event:346-357`](../../backend/src/meho_backplane/audit.py)); the MCP publisher needs the same ~3-line change.
+2. **MCP dispatcher's `audit_payload` is built statically.** No mechanism for the handler to surface `audit_row_count` to the audit row / broadcast event, so the MCP broadcast event carries `row_count: None` even when the handler returns N rows. The HTTP chassis path uses contextvar enrichment via `_resolve_audit_payload`; the MCP dispatcher would need an equivalent shim.
+
+Both gaps are downstream of T4 and disclosed in #468's PR body (#505). T5's acceptance scope covers the integration verification that surfaces them.
+
+### op_id asymmetry between REST and MCP
+
+The REST surface emits `op_id="meho.audit.query"` (the canonical, bound via the `audit_op_id` contextvar override the chassis honors). The MCP surface emits `op_id="query_audit"` (the tool name verbatim, per the MCP dispatcher convention at [`mcp/handlers.py:199`](../../backend/src/meho_backplane/mcp/handlers.py)). Same logical operation; different identifiers per dispatch path. Operators forensically searching `audit_log` for "all audit-query calls regardless of surface" today need to OR both op_ids. Unifying via a `ToolDefinition.audit_op_id` override field or a tool rename is a v0.2.next surface.
+
+## Sibling Initiative
+
+[G8.2 (#377)](https://github.com/evoila/meho/issues/377) — audit replay (`meho audit replay <session-id>`) — builds a recursive-CTE traversal on top of the `parent_audit_id` filter shipped in [T1 (#465)](https://github.com/evoila/meho/issues/465). G8.1 ships the filter (which raises `UnsupportedFilterError` in v0.2 because the column hasn't landed yet); G8.2 ships the schema column, the recursive traversal, and the operator-facing `replay` verb. The split keeps each Initiative shippable on its own clock.
+
+## References
+
+- Implementation Initiative: [G8.1 #334](https://github.com/evoila/meho/issues/334).
+- Substrate tasks: [T1 #465](https://github.com/evoila/meho/issues/465) (substrate), [T2 #466](https://github.com/evoila/meho/issues/466) (REST), [T3 #467](https://github.com/evoila/meho/issues/467) (CLI), [T4 #468](https://github.com/evoila/meho/issues/468) (MCP), [T5 #469](https://github.com/evoila/meho/issues/469) (acceptance), [T6 #470](https://github.com/evoila/meho/issues/470) (this doc + the operator runbook).
+- Companion docs: [`docs/cross-repo/audit-query.md`](../cross-repo/audit-query.md) (operator runbook), [`docs/codebase/audit_query.md`](../codebase/audit_query.md) (engineering-facing internal).
+- Substrate primitives: [`broadcast.events.classify_op`](../../backend/src/meho_backplane/broadcast/events.py) (op_id → op_class lookup, shared with the broadcast publish path), [`broadcast.events.redact_payload`](../../backend/src/meho_backplane/broadcast/events.py) (aggregate-only redaction for `op_class="audit_query"`).
+- Write paths: [`audit.py`](../../backend/src/meho_backplane/audit.py) (chassis HTTP `AuditMiddleware`), [`mcp/audit.py`](../../backend/src/meho_backplane/mcp/audit.py) (MCP `write_mcp_audit_row`).
+- Schema: [`db/models.py`](../../backend/src/meho_backplane/db/models.py) (`AuditLog`, `Target`).
+- Migrations: [`alembic/versions/0001_create_audit_log.py`](../../backend/alembic/versions/0001_create_audit_log.py), [`0002_create_tenant_and_audit_tenant_id.py`](../../backend/alembic/versions/0002_create_tenant_and_audit_tenant_id.py), [`0004_create_targets_and_audit_target_id.py`](../../backend/alembic/versions/0004_create_targets_and_audit_target_id.py), [`0006_add_audit_log_parent_audit_id.py`](../../backend/alembic/versions/0006_add_audit_log_parent_audit_id.py).
+- Sibling Initiative: [G8.2 #377](https://github.com/evoila/meho/issues/377) (audit replay).
+- Decision: [`v0.2-decisions.md` decision #3](../planning/v0.2-decisions.md) (PII defaults / aggregate-only audit broadcasts).
+- Consumer needs: §G8 of [`consumer-needs.md`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/docs/meho-coordination/consumer-needs.md) L214-234.

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -259,8 +259,17 @@ Reverse dependencies:
 * Tasks: [G8.1-T1 #465](https://github.com/evoila/meho/issues/465) (substrate),
   [G8.1-T2 #466](https://github.com/evoila/meho/issues/466) (REST routes +
   duration parser),
+  [G8.1-T3 #467](https://github.com/evoila/meho/issues/467) (CLI verbs),
   [G8.1-T4 #468](https://github.com/evoila/meho/issues/468) (MCP
-  meta-tool).
+  meta-tool),
+  [G8.1-T6 #470](https://github.com/evoila/meho/issues/470)
+  (architecture + operator runbook docs).
+* Companion docs:
+  [`docs/architecture/audit.md`](../architecture/audit.md) (canonical
+  architecture reference for the substrate + decision-#3 alignment),
+  [`docs/cross-repo/audit-query.md`](../cross-repo/audit-query.md)
+  (operator-facing runbook with the five CLI verbs and forensic
+  example queries).
 * Write paths: `backend/src/meho_backplane/audit.py`,
   `backend/src/meho_backplane/mcp/audit.py`.
 * Op-class classifier: `backend/src/meho_backplane/broadcast/events.py:172`

--- a/docs/cross-repo/README.md
+++ b/docs/cross-repo/README.md
@@ -61,6 +61,7 @@ implementation to track separately:
 
 | Doc | Purpose |
 | --- | --- |
+| [`audit-query.md`](./audit-query.md) | How to investigate "who did X to Y and when?" via the G8.1 audit query surface — the five `meho audit ...` CLI verbs, common forensic questions, filter semantics, cross-tenant boundary, and aggregate-only audit-on-audit broadcast posture. Companion architecture: [`docs/architecture/audit.md`](../architecture/audit.md). |
 | [`broadcast-onboarding.md`](./broadcast-onboarding.md) | How to subscribe to the per-tenant Valkey broadcast stream from `meho status --watch`, an MCP client, or a custom downstream subscriber. |
 | [`connector-ingestion.md`](./connector-ingestion.md) | How to add a new vendor surface to MEHO via the G0.7 spec-ingestion pipeline — `meho connector ingest/review/edit/enable/disable`. Companion architecture: [`docs/architecture/spec-ingestion.md`](../architecture/spec-ingestion.md). |
 | [`g07-vsphere-canary.md`](./g07-vsphere-canary.md) | The worked-example canary procedure: ingest the vCenter REST spec, drive the operator workflow, run the 10-query govc-parity benchmark. |

--- a/docs/cross-repo/audit-query.md
+++ b/docs/cross-repo/audit-query.md
@@ -87,7 +87,9 @@ The cross-tenant probe semantic: if the audit id exists but belongs to another t
 
 ### "Trace one agent session"
 
-The `agent_session_id` column does not exist on `audit_log` in v0.2. The CLI flag is reserved on the substrate but the substrate returns `-32602 / UnsupportedFilterError` if you supply it; the column lands with a future schema migration. For now the closest approximation is `--json` plus `jq` over a wider time window:
+The `agent_session_id` column does not exist on `audit_log` in v0.2 and there is no `--agent-session-id` CLI flag. The substrate's filter type carries the field as a forward-compatibility hook — the REST `POST /api/v1/audit/query` body and the MCP `query_audit` tool both accept it on the wire, but the substrate raises `UnsupportedFilterError` (rendered as HTTP 400 by the REST router; `-32602` by the MCP dispatcher) until the column lands with a future schema migration.
+
+For now the closest approximation from the CLI is `--json` plus `jq` over a wider window keyed on `request_id` (the chassis-bound `X-Request-Id` propagates into the audit row):
 
 ```bash
 meho audit query --since 24h --json | jq '.rows[] | select(.request_id=="<request-uuid>")'

--- a/docs/cross-repo/audit-query.md
+++ b/docs/cross-repo/audit-query.md
@@ -1,0 +1,179 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Querying the MEHO audit log — operator runbook
+
+> Operator-facing runbook for the G8.1 audit query surface. Architecture sits in [`docs/architecture/audit.md`](../architecture/audit.md); this doc is the cookbook every operator reads when answering "who did X to Y and when?".
+
+## What this surface answers
+
+Today, answering "who patched the NSX firewall on Tuesday and why?" requires stitching a Slack thread, a ticket, a PR, and maybe a knowledge-base entry. That's archaeology, not investigation.
+
+After G8.1, `meho audit query --target rdc-nsx --since 7d --op-class write` returns the rows in under 30 seconds. Same data, structured rows, tenant-scoped automatically.
+
+The audit log is **WORM-grade** (write-once, read-many) — written synchronously on every authenticated request by the backplane's chassis middleware. There is no operator-facing edit path; queries here read what was logged, never mutate it.
+
+## Prerequisites
+
+- **Role.** Every audit verb requires `operator` role minimum. `read_only` callers get HTTP 403 (CLI exit code 5); `tenant_admin` is also accepted (same tenant scope as `operator` — there is no admin escape hatch).
+- **A running backplane.** `meho login <backplane-url>` writes a session token the CLI reuses across every verb. Override per-call with `--backplane <url>` when needed.
+- **Filter intent stays local.** Per [decision #3](../planning/v0.2-decisions.md), the broadcast event emitted for every `query_audit` call is **aggregate-only** — `{op_id, result_status, row_count}`. Slack subscribers and the SSE feed never see which principal you queried, which target, or which op_id pattern. Your investigation intent is yours.
+
+## The five CLI verbs
+
+The G8.1-T3 CLI ships five verbs under `meho audit ...`. All five wrap the [G8.1-T2 REST routes](../../backend/src/meho_backplane/api/v1/audit.py) under `/api/v1/audit/*` and produce identical results to the equivalent HTTP request — the CLI is a render surface, not a separate data path.
+
+| Verb | REST route | Filter shape |
+|---|---|---|
+| `meho audit query` | `POST /api/v1/audit/query` | Full filter — every field below. |
+| `meho audit recent` | `POST /api/v1/audit/query` with `since="24h"` bound at the CLI | Convenience: most recent N rows of operator's tenant. |
+| `meho audit show <audit-id>` | `GET /api/v1/audit/show/{audit_id}` | Single-row detail. Cross-tenant id returns "audit row not found" (the backend returns 404, never 403, so existence never leaks). |
+| `meho audit who-touched <target>` | `GET /api/v1/audit/who-touched/{target}` | Pre-canned: target name + since window. |
+| `meho audit my-recent` | `GET /api/v1/audit/my-recent` | Pre-canned: `principal_sub` = your operator JWT sub. |
+
+Every verb accepts `--json` to print the raw `AuditQueryResult` envelope (rows + cursor) for piping into `jq`. Without `--json` the verbs print a tabular summary plus a `NEXT: --cursor=...` line when more pages remain.
+
+## Common forensic questions
+
+### "Who patched rdc-nsx on Tuesday?"
+
+```bash
+meho audit query --target rdc-nsx --since 7d --op-class write
+```
+
+`--op-class write` narrows to the destructive verbs (POST / PUT / PATCH / DELETE and the typed-connector write ops). Drop it to see reads too.
+
+### "What did Damir do across all targets in the last 24 hours?"
+
+If you are Damir:
+
+```bash
+meho audit my-recent --since 24h
+```
+
+If you are auditing someone else's activity:
+
+```bash
+meho audit query --principal damir --since 24h
+```
+
+`--principal` is a partial-match on `audit_log.operator_sub` (case-insensitive `ILIKE %damir%`). The pre-canned `my-recent` infers the principal from your own JWT subject and never accepts a `--principal` override — it always reports on you.
+
+### "All denied operations across the tenant in the last week"
+
+```bash
+meho audit query --result-status denied --since 7d
+```
+
+`--result-status` accepts one of `ok` (200–399), `denied` (401, 403), or `error` (every other 4xx / 5xx). The classifier mirrors the broadcast publisher's status-code trichotomy.
+
+### "Every vSphere VM operation in the last hour"
+
+```bash
+meho audit query --op-id "vsphere.vm.*" --since 1h
+```
+
+`--op-id` accepts a glob; `*` translates to SQL `LIKE %` while literal `%` and `_` in your input are escaped so they match verbatim. The pattern matches against `payload->>'op_id'` for MCP / typed-op rows and against the derived `http.{method.lower()}:{path}` for chassis HTTP rows in the same query.
+
+### "Show one audit row in full detail"
+
+```bash
+meho audit show 11111111-1111-1111-1111-111111111111
+```
+
+The cross-tenant probe semantic: if the audit id exists but belongs to another tenant, the backplane returns 404 ("audit row not found") — not 403. The substrate's first WHERE clause is always `audit_log.tenant_id = <operator JWT tenant>`, so a cross-tenant id resolves to zero rows; the router surfaces 404 deliberately so a probing operator cannot distinguish "row never existed" from "row exists in another tenant".
+
+### "Trace one agent session"
+
+The `agent_session_id` column does not exist on `audit_log` in v0.2. The CLI flag is reserved on the substrate but the substrate returns `-32602 / UnsupportedFilterError` if you supply it; the column lands with a future schema migration. For now the closest approximation is `--json` plus `jq` over a wider time window:
+
+```bash
+meho audit query --since 24h --json | jq '.rows[] | select(.request_id=="<request-uuid>")'
+```
+
+Full session-graph traversal is the [G8.2 audit replay](https://github.com/evoila/meho/issues/377) Initiative's job (`meho audit replay <session-id>`); G8.1 ships the substrate `parent_audit_id` filter that G8.2's recursive-CTE traversal builds on.
+
+## Filter semantics
+
+| Flag | Type | Notes |
+|---|---|---|
+| `--target` | string (target name or alias) | Matches against `targets.name` scoped to your tenant. Unknown name returns zero rows, not an error. |
+| `--principal` | string | Substring `ILIKE` match on `operator_sub`. Empty string is treated as no filter. |
+| `--op-id` | glob | `*` → SQL `%`. Literal `%` / `_` escaped. Matches both `payload->>'op_id'` (MCP / typed) and `http.{method}:{path}` (chassis). |
+| `--op-class` | enum | One of `read` / `write` / `credential_read` / `audit_query` / `other`. Exact match against `payload->>'op_class'`. |
+| `--result-status` | enum | One of `ok` / `error` / `denied`. Maps to status-code ranges. |
+| `--since` / `--until` | duration shorthand or ISO-8601 | Shorthand grammar: `<N><unit>` where unit ∈ `{s, m, h, d, w}` and N ≤ 9999. ISO-8601 accepted via `datetime.fromisoformat` (Python 3.11+, including the `Z` suffix). |
+| `--audit-id` | UUID | Exact-id lookup. Combined with the tenant boundary, produces 0 or 1 row. |
+| `--parent-audit-id` | UUID | Composite-op subtree filter. **Returns `-32602` in v0.2** — the column lands with G0.6-T7. |
+| `--limit` | int 1..1000 | Default 100, max 1000. |
+| `--cursor` | string (opaque) | Forward-only base64 cursor from a prior page's `next_cursor`. Tampered cursors return 400. |
+
+All filters are AND'd. Empty-string string filters are still applied at the substrate (so passing `--principal ""` explicitly matches every row, by virtue of `ILIKE %%`).
+
+## Pagination
+
+Default `--limit 100`, maximum 1000. The substrate orders rows `(occurred_at DESC, id DESC)` and uses an `N+1` fetch to detect whether more pages exist. When more rows are available, the response includes `next_cursor` (opaque base64 of `{ts, id}`); the tabular CLI output prints `NEXT: --cursor=<value>`.
+
+Page forward by passing that cursor back in:
+
+```bash
+meho audit query --since 7d --cursor "<value-from-previous-page>"
+```
+
+The cursor is **forward-only** — there is no `--prev-cursor`. To go back to "page 1" of a query, re-run without `--cursor`. Rows inserted between two cursor-paginated pages are visible only on a fresh page-1 call; they do not appear inside a cursor-paginated continuation. This is correctness-by-design: a snapshot of the rows older than the cursor's `(ts, id)` is what the operator asked for.
+
+## Cross-tenant boundary
+
+Every verb is tenant-scoped via your operator JWT. There is **no admin escape hatch**; cross-tenant queries are structurally impossible:
+
+- The backplane's substrate enforces `tenant_id = <JWT tenant>` as the first SQL WHERE clause. The `tenant_id` argument is keyword-only on the handler and the model has no `tenant_id` field at all.
+- The REST `POST /api/v1/audit/query` body's Pydantic model has no `tenant_id` field, so any client-supplied `tenant_id` is silently dropped by Pydantic's default `extra="ignore"`.
+- The MCP tool's `inputSchema` has `additionalProperties: false`, so an agent that tries to smuggle `tenant_id` in `arguments` is rejected by the dispatcher's jsonschema layer with `-32602` before reaching the handler.
+- The `show` route returns 404 (not 403) for any audit-id that exists in another tenant.
+
+If you need to query another tenant's audit log, you need an operator JWT for that tenant — there is no cross-tenant capability.
+
+## Audit-on-audit-query (decision #3)
+
+Every `query_audit` call is itself an authenticated request and writes its own audit row. That row's broadcast event ships under `op_class="audit_query"` per the [G6.1 sensitivity classifier](https://github.com/evoila/meho/issues/228), which means subscribers to the per-tenant Valkey stream and Slack relay see:
+
+```json
+{"op_id": "meho.audit.query", "result_status": "ok", "row_count": 47}
+```
+
+**Filter contents are never broadcast.** Which principal you investigated, which target, which op_id glob — all of that stays in the audit row itself and is invisible to anyone watching the live feed. The full audit row is still queryable (via this same surface) by anyone with the appropriate role on the appropriate tenant.
+
+The REST surface emits the canonical op_id `meho.audit.query` for these audit rows. The MCP surface emits `op_id = "query_audit"` (the tool name verbatim, per the MCP dispatcher convention) — the same logical operation, different identifier per dispatch path. A v0.2.next unification is on the roadmap; operators querying for "all audit-query calls regardless of surface" today need to OR both op_ids.
+
+## MCP agent surface
+
+Agents see exactly one tool for audit data: `query_audit(filters)`. The narrow-waist contract ([CLAUDE.md](../../CLAUDE.md) postulate 5) collapses the per-shape CLI conveniences (`show` / `who-touched` / `my-recent`) into filter combinations on the same tool:
+
+| CLI verb | Equivalent MCP call |
+|---|---|
+| `meho audit query --target X --since 24h` | `tools/call query_audit {"target": "X", "since": "24h"}` |
+| `meho audit show <uuid>` | `tools/call query_audit {"audit_id": "<uuid>", "limit": 1}` |
+| `meho audit who-touched X` | `tools/call query_audit {"target": "X", "since": "24h"}` |
+| `meho audit my-recent` | `tools/call query_audit {"principal": "<your sub>", "since": "24h"}` |
+
+The MCP tool's input schema, full description, and RBAC posture are documented in [`docs/codebase/audit_query.md`](../codebase/audit_query.md#mcp-tool-surface-g81-t4-468) (the engineering-facing companion to this runbook).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `audit row not found` on a row you know exists | Row belongs to another tenant — the 404 is a deliberate cross-tenant probe defence. | Use the operator JWT for the tenant that owns the row. |
+| `unrecognised duration '<value>': expected '<N>{s\|m\|h\|d\|w}' or an ISO-8601 datetime` | `--since` / `--until` shorthand failed to parse. | Use one of the grammars above (`24h`, `7d`, `2026-04-01T00:00:00Z`). |
+| `parent_audit_id filter not supported in v0.2` | The column lands with G0.6-T7. | Drop the flag; if you need composite-op-tree traversal today, wait for [G8.2](https://github.com/evoila/meho/issues/377). |
+| `cursor` returns 400 | The cursor was tampered with, truncated, or copy-pasted across queries with incompatible filter shapes. | Re-run the query without `--cursor` to get a fresh page-1 cursor. |
+| Empty result on a filter you know should match | Filter ANDs with the tenant boundary first. A row in another tenant won't appear under any filter. Also check `--since` — the default is **no** time bound for `meho audit query`, but each pre-canned shortcut defaults `since=24h`. | Widen `--since` (`--since 7d`); confirm the tenant matches; if `--op-id` is involved, double-check the glob (literal segment boundaries matter — `vsphere.vm.*` does not match `vsphere.vmware.foo`). |
+
+## Related
+
+- [`docs/architecture/audit.md`](../architecture/audit.md) — canonical architecture reference for the audit-query module (substrate, surfaces, decision #3 alignment).
+- [`docs/codebase/audit_query.md`](../codebase/audit_query.md) — engineering-facing internal doc covering the schemas, the cursor format, control flow, and known v0.2 gaps.
+- [Initiative #334 (G8.1)](https://github.com/evoila/meho/issues/334) — the issues that delivered the surface (substrate, REST, CLI, MCP, acceptance, docs).
+- [Initiative #377 (G8.2)](https://github.com/evoila/meho/issues/377) — the audit replay sibling Initiative (`meho audit replay <session-id>`) that builds on the `parent_audit_id` filter shipped here.
+- [CLAUDE.md](../../CLAUDE.md) postulate 5 (narrow-waist agent surface) — the rule that collapses the per-shape MCP tools into a single `query_audit`.

--- a/docs/cross-repo/audit-query.md
+++ b/docs/cross-repo/audit-query.md
@@ -43,7 +43,7 @@ Every verb accepts `--json` to print the raw `AuditQueryResult` envelope (rows +
 meho audit query --target rdc-nsx --since 7d --op-class write
 ```
 
-`--op-class write` narrows to the destructive verbs (POST / PUT / PATCH / DELETE and the typed-connector write ops). Drop it to see reads too.
+`--op-class write` narrows to typed-connector write operations (those registered with `op_class="write"` on the `ToolDefinition` / `EndpointDescriptor`) plus any HTTP route that explicitly binds `audit_op_class="write"` via the contextvar override. Chassis HTTP POST / PUT / PATCH / DELETE rows whose op_id is the synthetic `http.{method}:{path}` get `op_class="other"` (the synthetic op_id has no write-verb suffix that `classify_op` recognises), so they don't match this filter. Drop `--op-class write` to see them.
 
 ### "What did Damir do across all targets in the last 24 hours?"
 


### PR DESCRIPTION
## Summary

- Ships `docs/cross-repo/audit-query.md` — the operator-facing cookbook for the G8.1 audit query surface. Five CLI verbs with one-line role + REST-mapping, six worked-example forensic questions ("who patched X on Tuesday?", "all denied operations last week", "trace one agent session"), full filter-semantics table, cursor-pagination contract, tenant-boundary invariant, decision-#3 audit-on-audit-query posture, MCP-vs-CLI shape-mapping table.
- Ships `docs/architecture/audit.md` — the canonical architecture sister-page to `docs/architecture/{mcp,operations-substrate,spec-ingestion}.md`. Module-shape catalogue (`audit_query/{schemas,cursor,query,duration}`), three-surface inventory (REST T2, CLI T3, MCP T4), two-layer tenant-boundary proof, cursor correctness under concurrent insert load, decision-#3 alignment including the two known MCP chain gaps T5 (#469) will verify end-to-end, REST-vs-MCP op_id asymmetry queued for v0.2.next.
- Cross-links `docs/cross-repo/README.md`'s operator-runbook table to point at the new runbook, and `docs/codebase/audit_query.md`'s References to point outward at the new architecture + runbook docs.
- No production code touched — pure docs PR. `ruff` + `mypy` on the unchanged source re-verified clean.

## Test plan

- [x] **AC1** (operator runbook): `docs/cross-repo/audit-query.md` carries every section the issue body specified — `When to use` / `Prerequisites` / `The 5 CLI verbs` / `Common forensic questions` (6 worked examples) / `Filter semantics` / `Pagination` / `Cross-tenant boundary` / `Audit-on-audit-query (decision #3)` / `MCP agent surface` / `Troubleshooting` / `Related`. Verified by reading the file end-to-end.
- [x] **AC2** (architecture doc): `docs/architecture/audit.md` is shipped; every named function maps to a real symbol — Phase 7 link check (`for path in ...; do [ -e ... ] ...`) confirmed all 22 backend / CLI relative paths resolve, including `schemas.py`, `cursor.py`, `query.py`, `duration.py`, `audit.py`, `mcp/tools/audit.py`, `mcp/handlers.py`, `mcp/audit.py`, `mcp/server.py`, `broadcast/events.py`, `db/models.py`, all four migrations, `api/v1/retrieve_usage.py`, the CLI directory. The `../../CLAUDE.md` cross-link follows the same gitignored-per-user-local convention as `docs/architecture/mcp.md` and `spec-ingestion.md`.
- [x] **AC3** (G8.2 cross-link): present in both new docs — runbook §"Related" links #377, architecture doc §"Sibling Initiative" + References both link #377.
- [x] **AC4** (CI green): `ruff check src/` — clean; `mypy src/` — no issues in 132 source files. No markdown linter configured in the repo's `.pre-commit-config.yaml`; pre-commit's universal hygiene hooks (trailing-whitespace + EOF newline) both verified clean by hand.
- [x] **Anti-pattern check**: `grep -E "\.NET\|XAML\|Blazor\|C#"` against both new docs returns no matches (per the slim-skill's no-analogies rule for `docs/`).

## Out of scope

- T5 (#469) — acceptance integration. The architecture doc surfaces the two known MCP chain gaps for T5 to verify and either fix in place or escalate to standalone Tasks.
- Audit replay (`meho audit replay <session-id>`) — G8.2 (#377) Initiative; cross-linked but not documented here.
- Compliance-shaped exports (SOC2 / ISO27001 / HIPAA): v0.2.next.
- Web UI for audit: not in v0.2 scope.

Closes #470


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive audit-query architecture docs covering module design, API surfaces (REST, CLI, MCP), pagination, tenant-boundary rules, and error semantics.
  * Published an operator runbook with the five CLI verbs, usage examples, flags/JSON output, cursor pagination, forensic queries, and troubleshooting guidance.
  * Updated cross-repo references and README entries to link the new docs and task references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/513)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->