### PR TITLE
feat(ingest): G0.7-T11 OpenAPI parameter-ref resolver — $ref to #/components/parameters/*

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -194,11 +194,17 @@ def parse_openapi(
         raise InvalidSpecError(
             f"'components.schemas' must be a mapping, got {type(component_schemas).__name__}"
         )
+    component_parameters = components.get("parameters") or {}
+    if not isinstance(component_parameters, dict):
+        raise InvalidSpecError(
+            f"'components.parameters' must be a mapping, got {type(component_parameters).__name__}"
+        )
 
     return list(
         _iter_operations(
             paths=paths,
             component_schemas=cast(dict[str, Any], component_schemas),
+            component_parameters=cast(dict[str, Any], component_parameters),
             spec_source=spec_source,
         )
     )
@@ -288,6 +294,7 @@ def _iter_operations(
     *,
     paths: dict[str, Any],
     component_schemas: dict[str, Any],
+    component_parameters: dict[str, Any],
     spec_source: str | None,
 ) -> Iterable[EndpointDescriptorProto]:
     """Yield one :class:`EndpointDescriptorProto` per (method, path)."""
@@ -314,6 +321,7 @@ def _iter_operations(
                 operation=operation,
                 path_level_params=path_level_params,
                 component_schemas=component_schemas,
+                component_parameters=component_parameters,
                 spec_source=spec_source,
             )
 
@@ -325,6 +333,7 @@ def _build_proto(
     operation: dict[str, Any],
     path_level_params: list[Any],
     component_schemas: dict[str, Any],
+    component_parameters: dict[str, Any],
     spec_source: str | None,
 ) -> EndpointDescriptorProto:
     """Assemble a single :class:`EndpointDescriptorProto`."""
@@ -342,6 +351,7 @@ def _build_proto(
         op_level_params=op_params,
         request_body=operation.get("requestBody"),
         component_schemas=component_schemas,
+        component_parameters=component_parameters,
     )
     response_schema = _extract_response_schema(
         responses=operation.get("responses") or {},
@@ -404,6 +414,7 @@ def _build_parameter_schema(
     op_level_params: list[Any],
     request_body: Any,
     component_schemas: dict[str, Any],
+    component_parameters: dict[str, Any],
 ) -> dict[str, object]:
     """Flatten path + operation parameters + request body into one JSON Schema object.
 
@@ -412,6 +423,15 @@ def _build_parameter_schema(
     both ``name`` and ``in`` match. Each surviving parameter becomes
     a top-level property on the returned object with the
     ``x-meho-param-loc`` extension carrying its OpenAPI ``in`` value.
+
+    Parameters may be inlined (``{"name": ..., "in": ..., "schema": ...}``)
+    or referenced via ``{"$ref": "#/components/parameters/<name>"}`` —
+    the second form is what ``vi-json.yaml`` uses on every operation
+    (the shared ``moId`` path parameter). Refs are resolved against
+    ``component_parameters`` here, before the resolved-param ``schema``
+    field is itself ref-resolved against ``component_schemas`` (the
+    parameter object's ``schema`` field can independently carry its
+    own ``$ref`` into ``#/components/schemas/*``).
 
     The request body (when present) is inlined as a single ``body``
     property whose schema is the resolved ``application/json`` (or
@@ -426,7 +446,7 @@ def _build_parameter_schema(
 
     merged: dict[tuple[str, str], dict[str, Any]] = {}
     for raw_param in [*path_level_params, *op_level_params]:
-        resolved = _resolve_shallow_ref(raw_param, component_schemas)
+        resolved = _resolve_shallow_ref(raw_param, component_schemas, component_parameters)
         if not isinstance(resolved, dict):
             raise InvalidSchemaError(
                 f"paths.{path}.{method.lower()}: parameter must be a mapping, "

--- a/backend/src/meho_backplane/operations/ingest/refs.py
+++ b/backend/src/meho_backplane/operations/ingest/refs.py
@@ -68,15 +68,32 @@ PREFERRED_MEDIA_TYPES = ("application/json", "*/*")
 def resolve_shallow_ref(
     obj: Any,
     component_schemas: dict[str, Any],
+    component_parameters: dict[str, Any] | None = None,
 ) -> Any:
     """Inline one level of ``$ref``; preserve any nested refs unchanged.
 
-    ``$ref: "#/components/schemas/X"`` returns the resolved schema X
-    verbatim (a copy is NOT taken — callers that mutate must copy
-    first). Component-path drill-down refs
-    (``"#/components/schemas/X/properties/Y"``) raise
-    :exc:`InvalidSchemaError`. Cross-document refs raise
-    :exc:`UnsupportedSpecError`.
+    Supports refs to two OpenAPI 3.x component buckets:
+
+    * ``$ref: "#/components/schemas/X"`` — JSON Schema components.
+      The resolved schema is returned verbatim (a copy is NOT taken —
+      callers that mutate must copy first).
+    * ``$ref: "#/components/parameters/X"`` — Parameter Object
+      components (OpenAPI 3.0 §4.7.12 / 3.1 §4.8.7). Same return
+      semantics. ``vi-json.yaml`` uses this on every operation via the
+      shared ``moId`` path parameter.
+
+    ``component_parameters`` defaults to ``None`` so existing callers
+    that only need schema-ref resolution don't have to thread the
+    extra arg. Passing ``None`` keeps the legacy behaviour
+    (parameter refs raise :exc:`UnsupportedSpecError`); passing a
+    dict — even an empty one — opts in to the parameter-bucket branch.
+
+    Component-path drill-down refs into either bucket
+    (``"#/components/schemas/X/properties/Y"`` or
+    ``"#/components/parameters/X/schema"``) raise
+    :exc:`InvalidSchemaError` — the OpenAPI spec only declares fragment
+    refs to *named* components, not to subpaths within them.
+    Cross-document refs raise :exc:`UnsupportedSpecError`.
 
     Non-dict input or dicts without ``$ref`` pass through unchanged.
     """
@@ -85,24 +102,59 @@ def resolve_shallow_ref(
     ref = obj["$ref"]
     if not isinstance(ref, str):
         raise InvalidSchemaError(f"$ref value must be a string, got {type(ref).__name__}")
-    if not ref.startswith("#/components/schemas/"):
-        # Anything else — external file refs, parameter refs, response refs,
-        # or fragment-walk refs into other component buckets — is out of
-        # scope for v0.2. The dispatcher will not validate against them.
-        if not ref.startswith("#/"):
-            raise UnsupportedSpecError(f"cross-document $ref is not supported (got {ref!r})")
-        raise UnsupportedSpecError(
-            f"$ref to non-schema component is not supported (got {ref!r}); "
-            f"v0.2 only inlines #/components/schemas/* refs"
+    if ref.startswith("#/components/schemas/"):
+        return _resolve_named_component(
+            ref=ref,
+            bucket=component_schemas,
+            prefix="#/components/schemas/",
         )
-    name = ref[len("#/components/schemas/") :]
+    if ref.startswith("#/components/parameters/"):
+        if component_parameters is None:
+            # Caller did not opt in to parameter-ref resolution.
+            # Legacy behaviour: reject. Threading
+            # ``component_parameters`` from ``parse_openapi`` flips
+            # this branch off for the full pipeline.
+            raise UnsupportedSpecError(
+                f"$ref to #/components/parameters/* requires the caller to pass "
+                f"component_parameters (got {ref!r})"
+            )
+        return _resolve_named_component(
+            ref=ref,
+            bucket=component_parameters,
+            prefix="#/components/parameters/",
+        )
+    # Anything else — external file refs, response refs, requestBody
+    # refs, or fragment-walk refs into other component buckets — is
+    # out of scope for v0.2. The dispatcher will not validate against
+    # them.
+    if not ref.startswith("#/"):
+        raise UnsupportedSpecError(f"cross-document $ref is not supported (got {ref!r})")
+    raise UnsupportedSpecError(
+        f"$ref to non-schema/non-parameter component is not supported (got {ref!r}); "
+        f"v0.2 only inlines #/components/schemas/* and #/components/parameters/* refs"
+    )
+
+
+def _resolve_named_component(
+    *,
+    ref: str,
+    bucket: dict[str, Any],
+    prefix: str,
+) -> Any:
+    """Resolve a ``#/components/<kind>/<name>`` ref against ``bucket``.
+
+    Shared between the schema-ref branch and the parameter-ref branch
+    of :func:`resolve_shallow_ref` so drill-down and missing-component
+    handling stay symmetric across both buckets.
+    """
+    name = ref[len(prefix) :]
     if "/" in name:
         raise InvalidSchemaError(
             f"$ref drill-down into component subpaths is not supported (got {ref!r})"
         )
-    if name not in component_schemas:
+    if name not in bucket:
         raise InvalidSchemaError(f"$ref points at missing component (got {ref!r})")
-    return component_schemas[name]
+    return bucket[name]
 
 
 def select_media_type_schema(

--- a/backend/tests/acceptance/_vcenter_spec.py
+++ b/backend/tests/acceptance/_vcenter_spec.py
@@ -35,7 +35,6 @@ from pathlib import Path
 
 __all__ = [
     "VCENTER_SPEC_REASON",
-    "VI_JSON_PARAMETER_REF_LIMITATION",
     "resolve_vcenter_yaml",
     "resolve_vi_json_yaml",
 ]
@@ -48,21 +47,6 @@ VCENTER_SPEC_REASON = (
     "MEHO_VCENTER_OPENAPI_VI_JSON to absolute paths, or set MEHO_CONSUMER_DOCS_ROOT "
     "to a directory containing vcenter-9.0/{vcenter.yaml,vi-json.yaml}. "
     "See tests/acceptance/_vcenter_spec.py for the resolver contract."
-)
-
-#: Reason ``vi-json.yaml`` is currently not ingested by the canary.
-#: Surfaced in the test docstring + canary doc so operators following
-#: the procedure understand why the second spec is gated on a
-#: follow-up parser extension. Filed as a follow-up ticket from the
-#: PR body for issue #408 — `vi-json.yaml` uses
-#: `$ref: '#/components/parameters/moId'` on every operation, which
-#: the T1 parser explicitly rejects (`refs.py` line ~93). The fix is
-#: small but lives in T1's scope, not T8's acceptance work.
-VI_JSON_PARAMETER_REF_LIMITATION = (
-    "vi-json.yaml ingest is blocked on T1 parameter-ref resolver support "
-    "(uses $ref to #/components/parameters/moId on every operation). "
-    "Tracked as a follow-up ticket; the canary still proves end-to-end "
-    "for the vcenter.yaml spec corpus (~1275 operations)."
 )
 
 
@@ -103,10 +87,10 @@ def resolve_vi_json_yaml() -> Path | None:
     """Return the local path to ``vi-json.yaml``, or ``None`` if unconfigured.
 
     Same resolver chain as :func:`resolve_vcenter_yaml` but for the
-    Managed-Object JSON spec shelf. Currently unused by the canary
-    (see :data:`VI_JSON_PARAMETER_REF_LIMITATION`); kept here so the
-    follow-up parser-extension ticket can flip the test on with one
-    code change.
+    Managed-Object JSON spec shelf. The vi-json.yaml parser smoke test
+    in ``tests/integration/test_operations_ingest_vi_json.py``
+    consumes this resolver; full ingestion (storage + grouping +
+    operator review + retrieval) is tracked under #227 G3.1 T3.
     """
     explicit = _expand_optional_path(os.getenv("MEHO_VCENTER_OPENAPI_VI_JSON"))
     if explicit is not None:

--- a/backend/tests/acceptance/test_g07_vsphere_canary.py
+++ b/backend/tests/acceptance/test_g07_vsphere_canary.py
@@ -31,10 +31,9 @@ asserts:
   cardinal operations whose spec descriptions are
   vendor-schema-heavy and lose to short sub-path descriptions in
   BM25 ranking. The xfail markers + follow-up tickets (T3 per-op
-  ``llm_instructions``, T1 parameter-ref support, spec
-  description-quality polish) make the gap visible and tracked
-  rather than silently absorbed. See *Known gaps* in
-  ``docs/cross-repo/g07-vsphere-canary.md``.
+  ``llm_instructions``, spec description-quality polish) make the
+  gap visible and tracked rather than silently absorbed. See *Known
+  gaps* in ``docs/cross-repo/g07-vsphere-canary.md``.
 
 The benchmark is parametrised so every (query, expected_op_id) pair
 runs as its own test case in CI's report.
@@ -62,19 +61,22 @@ index 661. The govc-parity benchmark therefore requires the PG path,
 which means the test fixture is the testcontainers-backed
 ``pg_engine`` (re-exported here from ``tests/integration/conftest.py``).
 
-Why ``vi-json.yaml`` is currently not ingested
-==============================================
+Why this canary stays ``vcenter.yaml``-only after T11
+=====================================================
 
-The second vSphere spec corpus, ``vi-json.yaml`` (~2195 operations),
-uses ``$ref: '#/components/parameters/moId'`` on every operation. The
-T1 OpenAPI parser (#429) explicitly rejects non-schema component refs
-(:func:`refs.resolve_shallow_ref` raises
-:class:`UnsupportedSpecError`); extending it to resolve
-``#/components/parameters/*`` is small but lives in T1's scope, not
-T8's acceptance work. Filed as a follow-up ticket from the PR body;
-the canary still proves end-to-end for the vcenter.yaml corpus
-(~1275 operations). See
-:data:`~tests.acceptance._vcenter_spec.VI_JSON_PARAMETER_REF_LIMITATION`.
+T11 (#501) extended the T1 parser to resolve
+``$ref: '#/components/parameters/*'`` so the second vSphere spec
+corpus, ``vi-json.yaml`` (~2,195 Managed Object operations), now
+parses end-to-end. The parser smoke test lives at
+``tests/integration/test_operations_ingest_vi_json.py``. Full
+ingestion (~2,195 rows persisted under
+``connector_id="vmware-rest-9.0"``, LLM-grouping pass on
+PerformanceManager / EventManager / managed-object families, operator
+review + enable cascade, benchmark expansion with vi-json queries) is
+the consumer work tracked under #227 G3.1 T3, not this canary. The
+canary deliberately stays focused on the REST-automation surface
+(``vcenter.yaml``, ~1,275 operations) so the acceptance gate's
+~5 s ingest budget and 10-query benchmark stay fast.
 
 Why the LLM client is stubbed by default
 ========================================

--- a/backend/tests/fixtures/openapi/parameter_refs_30.yaml
+++ b/backend/tests/fixtures/openapi/parameter_refs_30.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.3
+info:
+  title: Parameter-ref fixture
+  version: 1.0.0
+# Models the vi-json.yaml shape: a shared path parameter (``moId``)
+# defined once under ``components.parameters`` and referenced by every
+# operation. T11 (#501) flips this shape from rejected to accepted.
+paths:
+  /vm/{moId}/PowerOn_Task:
+    post:
+      summary: Power on the virtual machine
+      tags:
+        - vm
+      parameters:
+        - $ref: "#/components/parameters/moId"
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: string
+  /vm/{moId}/PowerOff_Task:
+    post:
+      summary: Power off the virtual machine
+      tags:
+        - vm
+      parameters:
+        - $ref: "#/components/parameters/moId"
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: string
+  /host/{moId}/EnterMaintenanceMode_Task:
+    post:
+      summary: Move the host into maintenance mode
+      tags:
+        - host
+      parameters:
+        - $ref: "#/components/parameters/moId"
+        - name: timeout
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: string
+components:
+  parameters:
+    moId:
+      name: moId
+      in: path
+      required: true
+      description: Managed object identifier
+      schema:
+        type: string

--- a/backend/tests/integration/test_operations_ingest_vi_json.py
+++ b/backend/tests/integration/test_operations_ingest_vi_json.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration test for :func:`parse_openapi` against vSphere's ``vi-json.yaml``.
+
+vi-json.yaml (~2,195 Managed Object operations) uses
+``$ref: "#/components/parameters/moId"`` on every operation. Until T11
+(#501) extended the parser to resolve ``#/components/parameters/*``
+refs, the first operation in the spec raised :class:`UnsupportedSpecError`
+and the entire spec failed to ingest. This integration test is the
+load-bearing smoke check that the parser-extension landed —
+asserts the spec parses end-to-end without raising and returns
+>= 2,000 :class:`EndpointDescriptorProto` rows (the ~2,195 figure
+varies slightly with spec revs; 2,000 is the load-bearing threshold
+the Task ACs name).
+
+Skipped when no spec source is configured, mirroring the
+``vcenter.yaml`` integration test next door. Storage + grouping +
+retrieval are downstream Tasks (T3 under #227 G3.1); this test only
+asserts the parser does not raise.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.operations.ingest import parse_openapi
+from tests.acceptance._vcenter_spec import VCENTER_SPEC_REASON, resolve_vi_json_yaml
+
+
+@pytest.mark.skipif(
+    resolve_vi_json_yaml() is None,
+    reason=VCENTER_SPEC_REASON,
+)
+def test_parse_vi_json_does_not_raise() -> None:
+    """vi-json.yaml parses end-to-end after T11's parameter-ref resolver landed."""
+    spec_path = resolve_vi_json_yaml()
+    assert spec_path is not None  # guarded by skipif above
+    rows = parse_openapi(str(spec_path), spec_source="spec:vi-json.yaml")
+    assert len(rows) >= 2000, f"got {len(rows)} rows; acceptance threshold is 2000"
+    # Spot-check the parameter-ref resolution path: every row that
+    # carries an ``moId`` property must have ``x-meho-param-loc="path"``
+    # (the shared parameter is declared ``in: path``).
+    rows_with_moid = [
+        row
+        for row in rows
+        if isinstance(row.parameter_schema.get("properties"), dict)
+        and "moId" in row.parameter_schema["properties"]
+    ]
+    assert rows_with_moid, "expected at least one operation to reference the shared moId param"
+    for row in rows_with_moid[:25]:
+        properties = row.parameter_schema["properties"]
+        assert isinstance(properties, dict)
+        mo_id = properties["moId"]
+        assert isinstance(mo_id, dict), f"{row.op_id}: moId property is not a mapping"
+        assert mo_id.get("x-meho-param-loc") == "path", (
+            f"{row.op_id}: moId x-meho-param-loc is {mo_id.get('x-meho-param-loc')!r}"
+        )
+    # spec_source threading.
+    assert all("spec:vi-json.yaml" in row.tags for row in rows)

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -32,6 +32,7 @@ FIXTURES = Path(__file__).parent / "fixtures" / "openapi"
 PETSTORE_30 = FIXTURES / "petstore_30.yaml"
 PETSTORE_31_YAML = FIXTURES / "petstore_31.yaml"
 PETSTORE_31_JSON = FIXTURES / "petstore_31.json"
+PARAMETER_REFS_30 = FIXTURES / "parameter_refs_30.yaml"
 
 
 def _by_op_id(rows: list[EndpointDescriptorProto]) -> dict[str, EndpointDescriptorProto]:
@@ -270,7 +271,14 @@ paths:
         parse_openapi(str(spec))
 
 
-def test_non_schema_local_ref_raises(tmp_path: Path) -> None:
+def test_component_parameter_ref_resolves(tmp_path: Path) -> None:
+    """``$ref: '#/components/parameters/<name>'`` resolves to the shared parameter.
+
+    The pre-T11 contract rejected this with ``UnsupportedSpecError`` —
+    every vi-json.yaml operation uses this shape so the rejection
+    blocked the entire ~2,195-op spec. The new contract inlines the
+    referenced parameter the same way it inlines schema refs.
+    """
     spec = tmp_path / "param_ref.yaml"
     spec.write_text(
         """
@@ -289,12 +297,165 @@ components:
     Shared:
       name: shared
       in: query
+      required: true
       schema:
         type: string
         """.lstrip()
     )
-    with pytest.raises(UnsupportedSpecError, match="non-schema component"):
+    rows = parse_openapi(str(spec))
+    assert len(rows) == 1
+    properties = rows[0].parameter_schema["properties"]
+    assert isinstance(properties, dict)
+    assert "shared" in properties
+    assert properties["shared"]["x-meho-param-loc"] == "query"
+    assert properties["shared"]["type"] == "string"
+    assert rows[0].parameter_schema["required"] == ["shared"]
+
+
+def test_component_parameter_ref_missing_name_raises(tmp_path: Path) -> None:
+    """A ref to an unknown parameter component raises ``InvalidSchemaError``.
+
+    Mirrors the existing schema-bucket missing-component behaviour;
+    the symmetry keeps the parser failure mode predictable across
+    both component kinds.
+    """
+    spec = tmp_path / "param_ref_dangling.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/Missing'
+      responses:
+        "200":
+          description: ok
+components:
+  parameters:
+    Other:
+      name: other
+      in: query
+      schema:
+        type: string
+        """.lstrip()
+    )
+    with pytest.raises(InvalidSchemaError, match="missing component"):
         parse_openapi(str(spec))
+
+
+def test_component_parameter_ref_drilldown_raises(tmp_path: Path) -> None:
+    """A ref into a parameter component's subpath raises ``InvalidSchemaError``.
+
+    Symmetric with the schema-bucket drill-down rejection. The
+    OpenAPI spec only declares fragment refs to *named* components.
+    """
+    spec = tmp_path / "param_ref_drilldown.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/Shared/schema'
+      responses:
+        "200":
+          description: ok
+components:
+  parameters:
+    Shared:
+      name: shared
+      in: query
+      schema:
+        type: string
+        """.lstrip()
+    )
+    with pytest.raises(InvalidSchemaError, match="drill-down"):
+        parse_openapi(str(spec))
+
+
+def test_non_parameter_local_ref_raises(tmp_path: Path) -> None:
+    """Refs to component buckets we don't support (e.g. ``requestBodies``) stay rejected."""
+    spec = tmp_path / "request_body_ref.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/SharedBody'
+      responses:
+        "200":
+          description: ok
+components:
+  requestBodies:
+    SharedBody:
+      content:
+        application/json:
+          schema:
+            type: object
+        """.lstrip()
+    )
+    with pytest.raises(UnsupportedSpecError, match="non-schema/non-parameter component"):
+        parse_openapi(str(spec))
+
+
+def test_resolve_shallow_ref_parameter_ref_opt_in() -> None:
+    """Direct-call contract: parameter refs require ``component_parameters`` to opt in.
+
+    ``parse_openapi`` always passes the dict (even when empty), so the
+    full pipeline never trips this branch. The function is exported
+    so T2 / future multi-spec merge can call it directly; this test
+    locks the opt-in semantics for those callers.
+    """
+    from meho_backplane.operations.ingest.refs import resolve_shallow_ref
+
+    ref = {"$ref": "#/components/parameters/X"}
+    parameters = {"X": {"name": "x", "in": "query", "schema": {"type": "string"}}}
+
+    # Opt-in: resolves cleanly.
+    resolved = resolve_shallow_ref(ref, {}, parameters)
+    assert resolved == parameters["X"]
+
+    # Opt-out (None): legacy behaviour, rejected.
+    with pytest.raises(UnsupportedSpecError, match="component_parameters"):
+        resolve_shallow_ref(ref, {}, None)
+
+
+def test_parse_parameter_refs_30_fixture() -> None:
+    """End-to-end: a vi-json-shaped fixture parses cleanly.
+
+    Locks the cross-op resolution path: one shared ``moId`` parameter
+    is referenced by three operations and reassembled identically each
+    time, including ``x-meho-param-loc="path"`` and required-by-default
+    path-parameter semantics.
+    """
+    rows = parse_openapi(str(PARAMETER_REFS_30))
+    op_ids = {row.op_id for row in rows}
+    assert op_ids == {
+        "POST:/vm/{moId}/PowerOn_Task",
+        "POST:/vm/{moId}/PowerOff_Task",
+        "POST:/host/{moId}/EnterMaintenanceMode_Task",
+    }
+    for row in rows:
+        properties = row.parameter_schema["properties"]
+        assert isinstance(properties, dict)
+        assert "moId" in properties, f"{row.op_id}: missing moId after ref resolution"
+        assert properties["moId"]["x-meho-param-loc"] == "path"
+        assert properties["moId"]["type"] == "string"
+        assert "moId" in row.parameter_schema["required"]
+    # The host op carries an inlined ``timeout`` query param alongside
+    # the resolved ``moId`` — the ref doesn't clobber the inlined param.
+    host_op = next(r for r in rows if r.op_id == "POST:/host/{moId}/EnterMaintenanceMode_Task")
+    properties = host_op.parameter_schema["properties"]
+    assert isinstance(properties, dict)
+    assert "timeout" in properties
+    assert properties["timeout"]["x-meho-param-loc"] == "query"
 
 
 def test_missing_schema_ref_raises(tmp_path: Path) -> None:

--- a/docs/architecture/spec-ingestion.md
+++ b/docs/architecture/spec-ingestion.md
@@ -72,13 +72,18 @@ One `EndpointDescriptorProto` per `(method, path)` entry under `paths`:
 
 ### `$ref` resolution — intentionally shallow
 
-[`refs.py::_resolve_shallow_ref`](../../backend/src/meho_backplane/operations/ingest/refs.py) inlines exactly one level of `$ref` into each parameter / response / body schema and leaves nested `$ref` strings verbatim. The parameter_schema is self-contained enough for the dispatcher's `jsonschema.Draft202012Validator` to validate the immediate parameter shape; deeper schema dereferencing (chasing nested `$ref`s through `components.schemas`) is the dispatcher's concern.
+[`refs.py::resolve_shallow_ref`](../../backend/src/meho_backplane/operations/ingest/refs.py) inlines exactly one level of `$ref` into each parameter / response / body schema and leaves nested `$ref` strings verbatim. The parameter_schema is self-contained enough for the dispatcher's `jsonschema.Draft202012Validator` to validate the immediate parameter shape; deeper schema dereferencing (chasing nested `$ref`s through `components.schemas`) is the dispatcher's concern.
+
+Two component buckets resolve:
+
+- **`#/components/schemas/<name>`** — JSON Schema components. The dominant shape, used by every vendor spec the canary covers.
+- **`#/components/parameters/<name>`** — Parameter Object components (OpenAPI 3.0 §4.7.12 / 3.1 §4.8.7). Used by every operation in vSphere's `vi-json.yaml` via the shared `moId` path parameter. T11 (#501) landed the resolver extension; T1's earlier rejection of this shape is gone.
 
 Three classes of `$ref` are explicitly rejected with `UnsupportedSpecError` so the operator sees the problem at ingest time rather than at dispatch time:
 
-- **Non-schema component refs.** `$ref: "#/components/parameters/..."`, `$ref: "#/components/requestBodies/..."`, etc. vCenter's `vcenter.yaml` doesn't use these; **`vi-json.yaml` does** (every op references `#/components/parameters/moId`). See [Future work](#future-work) below — this is the load-bearing extension that unblocks vi-json ingestion.
+- **Other-bucket component refs.** `$ref: "#/components/requestBodies/..."`, `$ref: "#/components/responses/..."`, `$ref: "#/components/headers/..."`. Not used by any currently-targeted vendor spec (vcenter.yaml, vi-json.yaml, NSX, SDDC Manager); defer until a real spec needs them.
 - **Cross-document refs.** `$ref: "other.yaml#/..."`. External files require either a pre-process pass or a v0.2.next resolver extension.
-- **`$ref` drill-down.** Refs that walk into a component's sub-tree (`#/components/schemas/X/properties/y`) raise `InvalidSchemaError`.
+- **`$ref` drill-down.** Refs that walk into a component's sub-tree (`#/components/schemas/X/properties/y`, `#/components/parameters/X/schema`) raise `InvalidSchemaError`.
 
 ## T2 — register_ingested_operations
 
@@ -297,13 +302,9 @@ The G0.7 pipeline is unblocked the moment G0.6 lands its T1 (tables) + T2 (regis
 
 ## Future work
 
-The vSphere canary surfaced three gaps that are real but out of G0.7's v0.2 scope. Document inline; file as separate Tasks when they become blockers for a specific consumer.
+The vSphere canary surfaced two remaining gaps that are real but out of G0.7's v0.2 scope. Document inline; file as separate Tasks when they become blockers for a specific consumer. (A third gap — the parser's rejection of `$ref: "#/components/parameters/*"` — was closed by T11 #501; `vi-json.yaml` now parses end-to-end.)
 
-### Gap 1 — T1 `$ref` extension for `vi-json.yaml`
-
-Every operation in `vi-json.yaml` references `$ref: "#/components/parameters/moId"`. The current T1 parser explicitly rejects non-schema component refs (`refs.py::resolve_shallow_ref` raises `UnsupportedSpecError`). Extending the resolver to inline `#/components/parameters/*` is ~40 LoC plus tests but lives in T1's scope, not T9's docs work. **Block on G0.7 quality if vi-json coverage is required for an early operator**; the canary covers `vcenter.yaml` alone today.
-
-### Gap 2 — T3 `llm_instructions` per-op enhancement
+### Gap 1 — T3 `llm_instructions` per-op enhancement
 
 Three of the 10 canary queries (`list virtual machines`, `power on virtual machine`, `power off virtual machine`) `xfail`. The drivers:
 
@@ -312,7 +313,7 @@ Three of the 10 canary queries (`list virtual machines`, `power on virtual machi
 
 Resolution path: add a T3 enhancement pass that generates per-op `llm_instructions` from the spec body (one LLM call per op, batched), then re-bench. The `endpoint_descriptor.llm_instructions` column already exists ([G0.6-T1 #392](https://github.com/evoila/meho/issues/392)) so the storage shape is settled.
 
-### Gap 3 — live-LLM canary validation
+### Gap 2 — live-LLM canary validation
 
 The G0.7 canary is currently stub-LLM-only — the acceptance test ships a deterministic path-prefix classifier so the suite stays reproducible and fast (~5 s ingest + ~1–2 s per benchmark query). A live-LLM variant gated on `MEHO_G07_CANARY_LIVE_LLM=1` is reserved for the day [Task #467](https://github.com/evoila/meho/issues/467) (Anthropic chassis adapter) lands. Once #467 ships, re-run the canary against harder queries (snapshot revert, performance-metrics query, host-network atomic mutation) that the path-prefix stub cannot trivially classify.
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -66,10 +66,16 @@ The pipeline is broken into work items per Initiative #389:
   Acceptance test that drives the full pipeline against the consumer's
   vCenter REST spec (~1,275 ops): parse → register → group → review →
   enable → 10-query govc-parity benchmark over `search_operations`.
-  Ships with `vcenter.yaml` only; `vi-json.yaml` ingestion is blocked
-  on a T1 parser extension for `#/components/parameters/*` (~40 LoC).
-  Three of 10 queries currently `xfail` pending a T3 per-op
-  `llm_instructions` enhancement. See the [vSphere canary
+  Ships with `vcenter.yaml` only; `vi-json.yaml` parses end-to-end
+  after T11 (#501) extended the parser to resolve
+  `$ref: "#/components/parameters/*"` (the load-bearing rejection
+  in `refs.py` is gone), and the parser smoke test at
+  `tests/integration/test_operations_ingest_vi_json.py` proves it.
+  Full vi-json ingestion (~2,195 rows persisted + LLM grouping +
+  operator review + benchmark expansion) is tracked under #227 G3.1
+  T3 — out of scope for the canary itself. Three of 10 queries
+  currently `xfail` pending a T3 per-op `llm_instructions`
+  enhancement. See the [vSphere canary
   runbook](../cross-repo/g07-vsphere-canary.md) for the operator
   procedure.
 * **T9 — Docs** (#409). Two new docs:

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -471,17 +471,20 @@ operations go live.
   Real vendor specs in v0.2 scope (vCenter / NSX / SDDC Manager)
   never use this combination. T2 will log a warning if it spots a
   collision after upsert.
-* **Non-schema `$ref` rejected.** `$ref: "#/components/parameters/X"`,
-  `$ref: "#/components/requestBodies/X"`, etc. raise
-  `UnsupportedSpecError`. vCenter doesn't use these; future specs
-  that do will need either a pre-process pass or a v0.2.next
-  extension of the resolver.
+* **Other-bucket `$ref` rejected.** `$ref:
+  "#/components/requestBodies/X"`, `$ref:
+  "#/components/responses/X"`, `$ref: "#/components/headers/X"`
+  raise `UnsupportedSpecError`. Not used by any currently-targeted
+  vendor spec (vcenter.yaml, vi-json.yaml, NSX, SDDC Manager);
+  defer until a real spec needs them. (T11 / #501 landed the
+  `#/components/parameters/*` resolver — see the T8 paragraph
+  above and `docs/architecture/spec-ingestion.md` §T1.)
 * **Cross-document `$ref` rejected.** External files
   (`other.yaml#/...`) raise `UnsupportedSpecError`. Same v0.2.next
   note.
 * **`$ref` drill-down rejected.** Refs that walk into a component's
-  sub-tree (`#/components/schemas/X/properties/y`) raise
-  `InvalidSchemaError`.
+  sub-tree (`#/components/schemas/X/properties/y`,
+  `#/components/parameters/X/schema`) raise `InvalidSchemaError`.
 
 ## References
 

--- a/docs/cross-repo/g07-vsphere-canary.md
+++ b/docs/cross-repo/g07-vsphere-canary.md
@@ -232,20 +232,29 @@ The 10 (query, expected_op_id) govc-parity pairs are:
 
 ## Known gaps (filed as PR-body follow-ups)
 
-### 1. `vi-json.yaml` is not yet ingested
+### 1. `vi-json.yaml` parses but the canary stays vcenter-only
 
-The second vSphere spec corpus (~2195 Managed Object operations)
-uses ``$ref: '#/components/parameters/moId'`` on every operation. The
-T1 parser explicitly rejects non-schema component refs
-(``refs.py::resolve_shallow_ref`` raises
-``UnsupportedSpecError``). Extending the parser to resolve
-``#/components/parameters/*`` is small (~40 LoC + tests) but
-lives in T1's scope, not T8's acceptance work.
+T11 (#501) extended the parser to resolve
+``$ref: '#/components/parameters/*'`` — every vi-json.yaml operation
+references the shared ``moId`` path parameter via that shape, and the
+T1 parser's earlier rejection has been replaced with the
+:func:`refs.resolve_shallow_ref` parameter-bucket branch. The parser
+smoke test at
+``tests/integration/test_operations_ingest_vi_json.py`` asserts the
+spec parses end-to-end and yields >= 2,000 EndpointDescriptorProto
+rows.
 
-Until that lands, govc workflows that fundamentally need vi-json
-ops (``govc snapshot.revert``,
-``govc events``, ``govc host.evac``) are not part of the canary's
-benchmark.
+Full ingestion (~2,195 rows persisted under
+``connector_id="vmware-rest-9.0"``, LLM-grouping pass on
+PerformanceManager / EventManager / managed-object families, operator
+review + enable cascade, benchmark expansion with vi-json queries)
+is the consumer work tracked under [#227 G3.1
+T3](https://github.com/evoila/meho/issues/227); the canary itself
+deliberately stays focused on the REST-automation surface so the
+acceptance gate's ~5 s ingest budget and 10-query benchmark stay
+fast. Until #227 T3 lands, govc workflows that fundamentally need
+vi-json ops (``govc snapshot.revert``, ``govc events``,
+``govc host.evac``) are not part of the canary's benchmark.
 
 ### 2. Cardinal-op descriptions under-rank against sub-paths
 


### PR DESCRIPTION
## Summary

- Extend the OpenAPI parser to resolve `$ref: "#/components/parameters/<name>"` so vi-json.yaml (~2,195 Managed Object ops, every op references the shared `moId` path parameter via this shape) parses end-to-end. The pre-T11 parser explicitly rejected non-schema component refs at `refs.py:88-97`, which blocked the entire spec at the first operation.
- `resolve_shallow_ref` gains an optional `component_parameters` kwarg that opts in to the parameter-bucket branch — additive, backwards-compatible with existing callers that only need schema-ref resolution. `parse_openapi` always threads the dict through the call chain so the pipeline's parameter-ref site at `_build_parameter_schema` resolves cleanly.
- Drill-down refs into either bucket (`#/components/schemas/X/properties/Y`, `#/components/parameters/X/schema`) stay rejected with `InvalidSchemaError`; cross-document refs and other-bucket refs (`#/components/requestBodies/*`, `#/components/responses/*`) stay rejected with `UnsupportedSpecError` — out of scope for v0.2.
- The `VI_JSON_PARAMETER_REF_LIMITATION` gap marker in `tests/acceptance/_vcenter_spec.py` is removed (its existence was the merge-time signal this Task was outstanding). Canary docstring + architecture / codebase / cross-repo runbooks updated to reflect the new state.

## Test plan

- [x] `ruff check src/ tests/` — clean.
- [x] `ruff format --check src/ tests/` — clean.
- [x] `mypy src/ --ignore-missing-imports` — clean (135 source files).
- [x] `pytest tests/test_operations_ingest_openapi.py tests/test_operations_register_ingested.py tests/test_operations_ingest_llm_groups.py tests/test_operations_ingest_review.py tests/test_api_v1_connectors_ingest.py tests/test_mcp_tools_connector_admin.py` — 166 passed, 1 skipped (the new vi-json integration smoke test skips without env; runs in CI when the spec is provisioned).
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 4 pre-existing warnings (file-size + function-size on `openapi.py` and `refs.py`; recorded as adjacent findings).
- [x] **AC: `resolve_shallow_ref(...parameters={...})` returns the resolved parameter object** — `test_component_parameter_ref_resolves` covers the positive path; `test_resolve_shallow_ref_parameter_ref_opt_in` covers the direct-call contract.
- [x] **AC: passing `parameters=None` stays rejected with operator-readable message** — `test_resolve_shallow_ref_parameter_ref_opt_in`'s second branch.
- [x] **AC: missing component name raises `InvalidSchemaError`** — `test_component_parameter_ref_missing_name_raises`.
- [x] **AC: drill-down ref raises `InvalidSchemaError`** — `test_component_parameter_ref_drilldown_raises`.
- [x] **AC: vi-json-shaped fixture parses with correct `x-meho-param-loc="path"` + required-by-default semantics** — `test_parse_parameter_refs_30_fixture` against the new `parameter_refs_30.yaml` fixture (three ops sharing one `moId` parameter plus an inlined query parameter).
- [x] **AC: existing rejection test rewritten (not deleted) into positive assertion** — `test_non_schema_local_ref_raises` was renamed to `test_component_parameter_ref_resolves` and flipped; a separate `test_non_parameter_local_ref_raises` covers the still-rejected other-bucket case.
- [x] **AC: `vi-json.yaml` parses end-to-end** — `tests/integration/test_operations_ingest_vi_json.py` smoke test, skipped without env, runs in CI.
- [x] **AC: `VI_JSON_PARAMETER_REF_LIMITATION` removed + docstring framing updated** — `_vcenter_spec.py`, `test_g07_vsphere_canary.py`, `docs/architecture/spec-ingestion.md`, `docs/codebase/spec-ingestion.md`, `docs/cross-repo/g07-vsphere-canary.md` all updated.
- [x] **AC: `vcenter.yaml` canary still passes unchanged** — vcenter.yaml uses no parameter refs; the new code path is dormant for the existing acceptance suite. Canary test collection clean (20 tests collected).

## Out of scope

- Full vi-json.yaml ingestion (~2,195 rows persisted under `connector_id="vmware-rest-9.0"`, LLM-grouping pass on PerformanceManager / EventManager / managed-object families, operator review + enable cascade, benchmark expansion with vi-json queries) — tracked under #227 G3.1 T3.
- Cross-document `$ref` support, `#/components/requestBodies/*` / `responses/*` / `headers/*` ref support — stay rejected; defer until a real spec needs them.
- Drill-down ref resolution — stays rejected with `InvalidSchemaError` (symmetric with the schema-bucket drill-down behaviour).
- Per-op `llm_instructions` / summary rewrite for the 3 xfail benchmark queries — separate G0.7 follow-up (Gap 1 in the architecture doc).

### Adjacent findings (recorded, not edited)

- `openapi.py` is now 596 lines (warn-threshold 400, block-threshold 600). The file's at a natural split point (extraction helpers under `_iter_operations` / `_build_*` are the load-bearing surface). Pre-existing issue magnified slightly by this Task's threading of the new kwarg.
- `_build_parameter_schema` is now 77 lines (warn-threshold 60). Consider extraction in a follow-up refactor.
- `resolve_shallow_ref` is 68 lines (warn-threshold 60). Mostly docstring after the bucket-aware extraction helper landed; the actual control-flow code is well under threshold.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parser now shallow-resolves component parameter references so reusable parameters are inlined into operations.

* **Tests**
  * Added unit and integration tests plus a new fixture to verify parameter-ref resolution and a canary smoke test for vSphere ingestion.

* **Documentation**
  * Updated architecture, codebase, and canary docs to reflect parameter-ref support and current ingestion scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/516)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->