### PR TITLE
feat(connectors): G3.1-T1 VmwareRestConnector — hand-rolled HttpConnector subclass

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/__init__.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vmware_rest — VmwareRestConnector package.
+
+Importing this package registers :class:`VmwareRestConnector` against the
+v2 connector registry under
+``(product="vmware", version="9.0", impl_id="vmware-rest")``. The
+chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+which walks every ``connectors/<product>/`` subpackage at startup, so
+the registration lands before any dispatch can occur.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector`
+entry point is deliberately **not** called. The connector advertises an
+explicit ``(version="9.0", impl_id="vmware-rest")`` key; the v1 entry
+would land as ``("vmware", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s tie-
+break ladder. Same pattern :mod:`meho_backplane.connectors.vault`
+established.
+
+Once G0.7-T8 (#408) lands its
+:func:`ensure_connector_class_registered` auto-shim in main, the
+idempotency check there will no-op on the
+``(product="vmware", version="9.0", impl_id="vmware-rest")`` triple
+because this module has already registered the hand-rolled class. Until
+then, this module is the only registration path; no behavioural drift
+results from the absence of the auto-shim infrastructure.
+
+Endpoint-descriptor rows for the ~1,275 ingested vCenter REST ops live
+under the same ``connector_id="vmware-rest-9.0"``. Registering the class
+here is the load-bearing prerequisite for those rows becoming
+dispatchable; T2/T3/T4/T5 (#501/#503/#504/#508) carry the rest of the
+G3.1 work (vi-json ingestion, composite registration helper, composites
+themselves).
+"""
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vmware_rest.connector import (
+    VmwareRestConnector,
+    product_from_line_id,
+)
+from meho_backplane.connectors.vmware_rest.session import (
+    SessionCredentials,
+    VsphereSessionLoader,
+    VsphereTargetLike,
+    load_session_credentials_from_vault,
+)
+
+register_connector_v2(
+    product="vmware",
+    version="9.0",
+    impl_id="vmware-rest",
+    cls=VmwareRestConnector,
+)
+
+__all__ = [
+    "SessionCredentials",
+    "VmwareRestConnector",
+    "VsphereSessionLoader",
+    "VsphereTargetLike",
+    "load_session_credentials_from_vault",
+    "product_from_line_id",
+]

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VmwareRestConnector — hand-rolled HttpConnector subclass for vSphere REST.
+
+Replaces the future :class:`GenericRestConnector` auto-shim that G0.7's
+ingestion pipeline synthesises on first ingest of ``vcenter.yaml``. The
+auto-shim makes the connector resolvable so ingestion can land the
+``endpoint_descriptor`` rows; this class makes those ops dispatchable.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.vmware_rest.__init__`. The auto-shim's
+idempotency check (in
+:func:`~meho_backplane.operations.ingest.connector_registration.ensure_connector_class_registered`
+once #408's pipeline lands in main) then no-ops on subsequent ingests
+against the same ``(product="vmware", version="9.0",
+impl_id="vmware-rest")`` triple.
+
+Per-target sessions
+-------------------
+
+The class caches one ``vmware-api-session-id`` token per ``target.name``.
+First call to :meth:`auth_headers` against a given target invokes the
+:class:`VsphereSessionLoader` (default
+:func:`load_session_credentials_from_vault`) for the service-account
+credentials, then issues ``POST /api/session`` with HTTP basic auth. The
+JSON-string-body response is the session token; subsequent calls reuse
+the cached value. Per-target isolation is the load-bearing invariant:
+two targets must never share a session token even if their names collide
+across tenants — the cache is keyed on ``target.name`` because that's
+the operator-supplied identifier the connector receives at the boundary.
+
+The session-establish flow runs under an :class:`asyncio.Lock` so two
+concurrent first-use callers against the same target don't both POST to
+``/api/session``. The lock is held only across the cache check + token
+fetch + cache write; subsequent reads after the cache is populated take
+the fast path under the same lock and exit immediately.
+
+Session lifecycle
+-----------------
+
+vSphere's default idle timeout is ~5 minutes; the connector does not
+proactively refresh tokens. The dispatcher's tenacity decorator on
+:meth:`HttpConnector._request_json` retries connection errors and 5xx
+responses but not 401 — a 401 from a subsequent call would surface to
+the caller. Explicit 401-driven session refresh is intentionally
+deferred to v0.2.next (per the task body's *Out of scope* section);
+operator-facing dispatch sees re-authentication as a clean retry
+through the dispatcher's caller-side retry path rather than a hidden
+retry inside the connector.
+
+:meth:`aclose` revokes every cached session via ``DELETE /api/session``
+before closing the per-target httpx clients. A revoke failure is logged
+and proceeds — the operator-facing concern at shutdown is "tear down
+the httpx pool"; an in-flight 5xx during DELETE doesn't block that.
+
+Auth model gating
+-----------------
+
+The task body's *Session lifecycle* section locks v0.2 to
+:attr:`AuthModel.SHARED_SERVICE_ACCOUNT`. :meth:`auth_headers` rejects
+any other ``target.auth_model`` value with a clear :exc:`NotImplementedError`
+that names both the target and the requested mode. ``None`` is accepted
+because targets that predate G0.3's ``auth_model`` column legitimately
+have no value — the column defaults to the shared-service-account model
+once G0.3 ships, but until then ``None`` is the "no model declared,
+fall back to v0.2 default" sentinel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vmware_rest.session import (
+    VsphereSessionLoader,
+    VsphereTargetLike,
+    load_session_credentials_from_vault,
+)
+
+__all__ = ["VmwareRestConnector", "product_from_line_id"]
+
+_log = structlog.get_logger(__name__)
+
+# vmware-api-session-id header name per Broadcom's vSphere Automation
+# API security schema (Basic / API-key / Bearer). The same header
+# carries the session token across both vCenter REST (vcenter.yaml-
+# sourced ops) and vi-json (vi-json.yaml-sourced ops once #503 lands),
+# per docs/vcenter-9.0/MANIFEST.md. Lifted to a module constant so the
+# revoke path in aclose() and the auth path in _session_token can't
+# drift apart.
+_SESSION_HEADER = "vmware-api-session-id"
+
+# vSphere 8.0+'s /api/session POST returns the session token as a JSON
+# string body (e.g. ``"abc123def456"``). Older 6.7/7.0 vCenter via the
+# deprecated /rest/com/vmware/cis/session path returned
+# ``{"value": "abc123def456"}``. The class's supported_version_range
+# is ``">=8.5,<10.0"`` so the JSON-string shape is the load-bearing
+# one, but :meth:`_extract_session_token` handles both defensively —
+# vcsim has been known to swap between shapes between minor releases,
+# and a defensive read here costs nothing.
+_SESSION_TOKEN_OBJECT_KEY = "value"
+
+# Verbs that go through HttpConnector._request_json's tenacity retry
+# decorator. Non-idempotent verbs (POST / PUT / PATCH / DELETE) route
+# through _post_json instead — see HttpConnector for the policy.
+# Lifted here so :meth:`auth_headers`-level callers can introspect.
+_IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+def product_from_line_id(line_id: str) -> str:
+    """Map vCenter's ``product_line_id`` to the canonical product slug.
+
+    ``GET /api/about`` returns a ``product_line_id`` like ``"vpx"`` for
+    vCenter, ``"embeddedEsx"`` / ``"esx"`` for ESXi. The canonical
+    fingerprint shape demands ``product="vcenter"`` / ``"esxi"`` per
+    the consumer's wrapper contract. Unknown values fall through to
+    the raw line_id so an ESXi-on-Arm or a future vCenter rebrand is
+    still recorded faithfully rather than misclassified as
+    ``"unknown"``.
+    """
+    if line_id == "vpx":
+        return "vcenter"
+    if line_id in ("embeddedEsx", "esx"):
+        return "esxi"
+    return line_id or "unknown"
+
+
+def _extract_session_token(payload: Any, target_name: str) -> str:
+    """Coerce a ``POST /api/session`` JSON response to the session token string.
+
+    Handles the two shapes vSphere has shipped across recent releases:
+
+    * **JSON string body** — vSphere 7.0+ modern ``/api/session`` returns
+      the token as a JSON-quoted string. ``response.json()`` returns
+      :class:`str`.
+    * **JSON object body** — pre-7.0 ``/rest/com/vmware/cis/session``
+      returned ``{"value": "<token>"}``. Some vcsim builds straddle the
+      two shapes; supporting the legacy shape defensively keeps the
+      integration test green across simulator versions.
+
+    Anything else raises :exc:`RuntimeError` with the target name in
+    the message so the operator can identify the misbehaving endpoint.
+    """
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, dict):
+        value = payload.get(_SESSION_TOKEN_OBJECT_KEY)
+        if isinstance(value, str):
+            return value
+    raise RuntimeError(
+        f"unexpected /api/session response shape for target {target_name!r}: "
+        f"got {type(payload).__name__} (expected str or "
+        f"{{'{_SESSION_TOKEN_OBJECT_KEY}': str}})"
+    )
+
+
+def _is_acceptable_auth_model(value: Any) -> bool:
+    """Return ``True`` iff *value* is the SHARED_SERVICE_ACCOUNT mode or unset.
+
+    Accepts the enum member, the equivalent string, and ``None`` (the
+    "auth_model column not yet populated" sentinel for pre-G0.3
+    targets). Any other value (``"per_user"``, ``"impersonation"``,
+    a typo, an int) is rejected by the caller.
+    """
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+class VmwareRestConnector(HttpConnector):
+    """vSphere REST connector for vCenter 8.5+ / ESXi 8.5+ targets.
+
+    Per-target session cached in ``self._session_tokens``; token
+    established on first call to :meth:`auth_headers` via
+    ``POST /api/session`` with HTTP basic (service-account creds from
+    the injectable :class:`VsphereSessionLoader`); revoked on
+    :meth:`aclose` via ``DELETE /api/session``.
+
+    The :attr:`priority` is set to ``1`` so a future :class:`GenericRestConnector`
+    auto-shim that somehow registers for the same triple (e.g. a stale
+    ingest before this class's module imports) loses the registry's
+    tie-break ladder. The auto-shim's idempotency check should prevent
+    that case in practice; the priority is defence in depth.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"vmware-rest-9.0"`` -> (``"vmware"``, ``"9.0"``, ``"vmware-rest"``).
+    product = "vmware"
+    version = "9.0"
+    impl_id = "vmware-rest"
+    supported_version_range = ">=8.5,<10.0"
+    # Outranks the GenericRestConnector auto-shim's priority=0 if both
+    # somehow register for the same triple; the idempotency check in
+    # ensure_connector_class_registered should make this unreachable
+    # in production, but a defence-in-depth tie-break keeps the
+    # resolver behaviour deterministic if the check is ever bypassed.
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        session_loader: VsphereSessionLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._session_tokens: dict[str, str] = {}
+        self._session_lock = asyncio.Lock()
+        self._session_loader: VsphereSessionLoader = (
+            session_loader if session_loader is not None else load_session_credentials_from_vault
+        )
+
+    async def auth_headers(self, target: VsphereTargetLike, raw_jwt: str) -> dict[str, str]:
+        """Return ``{"vmware-api-session-id": <token>}`` for the request.
+
+        Lazily establishes the session on first call against *target*;
+        subsequent calls reuse the cached token. ``raw_jwt`` is accepted
+        for ABC-signature compatibility but unused — the
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` mode authenticates with
+        a Vault-sourced service account, not the operator's OIDC token.
+
+        Raises :exc:`NotImplementedError` (with ``target.name`` and the
+        requested mode in the message) if ``target.auth_model`` is
+        anything other than ``shared_service_account`` or ``None``.
+        Per-user and impersonation modes are deferred to v0.2.next.
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT mode doesn't forward the operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not _is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"VmwareRestConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        token = await self._session_token(target)
+        return {_SESSION_HEADER: token}
+
+    async def _session_token(self, target: VsphereTargetLike) -> str:
+        """Return the cached session token for *target*, establishing one on first use.
+
+        The lock serialises concurrent first-use for one target; the
+        cache fast-path means subsequent callers are bounded only by
+        the lock acquisition itself. The slow ``POST /api/session`` call
+        runs under the lock so two concurrent first-use callers against
+        the same target don't both pay the round-trip cost.
+        """
+        async with self._session_lock:
+            cached = self._session_tokens.get(target.name)
+            if cached is not None:
+                return cached
+            creds = await self._session_loader(target)
+            client = await self._http_client(target)
+            try:
+                resp = await client.post(
+                    "/api/session",
+                    auth=(creds["username"], creds["password"]),
+                )
+            except KeyError as exc:
+                # Surface a clear error if the loader returned a dict
+                # missing one of the two required keys — a typo in a
+                # production loader implementation otherwise surfaces
+                # as a confusing TypeError deep inside httpx's auth
+                # builder.
+                raise RuntimeError(
+                    f"vsphere session loader for target {target.name!r} returned "
+                    f"a dict missing required key {exc.args[0]!r}; need "
+                    "{'username': str, 'password': str}"
+                ) from exc
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                # Wrap so the operator-facing message names the target;
+                # httpx's default str() shows only the URL/status, which
+                # loses the per-target identification the dispatcher's
+                # audit row needs.
+                raise RuntimeError(
+                    f"vsphere session establish failed for target {target.name!r}: "
+                    f"POST /api/session returned HTTP {exc.response.status_code}"
+                ) from exc
+            token = _extract_session_token(resp.json(), target.name)
+            self._session_tokens[target.name] = token
+            _log.info(
+                "vsphere_session_established",
+                target=target.name,
+                host=target.host,
+            )
+            return token
+
+    async def fingerprint(self, target: VsphereTargetLike) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /api/about``.
+
+        The session token is fetched lazily by :meth:`auth_headers`
+        (called transitively through :meth:`HttpConnector._request_json`).
+        On transport or status failure, returns a non-reachable
+        ``FingerprintResult`` whose ``extras["error"]`` carries the
+        exception class + message — same pattern the K8s connector
+        established for ``probe()`` failures, plumbed here through
+        ``fingerprint()`` so the operator's first ``meho connector
+        fingerprint`` call against an unreachable vCenter gets a
+        structured response rather than a stack trace.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            payload = await self._get_json(target, "/api/about", raw_jwt="")
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            # RuntimeError catches the session-establish failures from
+            # :meth:`_session_token` so an unauthenticatable target
+            # surfaces as a clean ``reachable=False`` fingerprint
+            # rather than propagating the wrapped exception.
+            return FingerprintResult(
+                vendor="vmware",
+                product="vcenter",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="GET /api/about",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        return FingerprintResult(
+            vendor="vmware",
+            product=product_from_line_id(payload.get("product_line_id", "")),
+            version=payload.get("version"),
+            build=payload.get("build"),
+            edition=payload.get("license_product_name"),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="GET /api/about",
+            extras={
+                "uuid": payload.get("instance_uuid"),
+                "full_name": payload.get("full_name"),
+                "product_line_id": payload.get("product_line_id"),
+                "api_type": payload.get("api_type"),
+                "os_type": payload.get("os_type"),
+            },
+        )
+
+    async def probe(self, target: VsphereTargetLike) -> ProbeResult:
+        """Lightweight reachability + auth-challenge check.
+
+        Delegates to :meth:`fingerprint` rather than running a separate
+        probe path. The chassis registry's readiness probe and the
+        operator-facing ``meho connector probe`` both want a single
+        boolean ``ok`` + a reason string; ``fingerprint`` already produces
+        the right shape and the extra latency from the ``/api/about``
+        payload parsing is negligible compared to the auth round-trip
+        ``fingerprint`` already incurs.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: VsphereTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`VaultConnector.execute`'s shape: the connector's
+        ABC :meth:`Connector.execute` predates the G0.6 operator-aware
+        dispatch path, so this shim exists for pre-G0.6 callers (the
+        chassis ``/api/v1/connectors/{product}/{op_id}`` route, any
+        :func:`meho_backplane.connectors.resolver.resolve_connector`
+        consumer that doesn't already construct an :class:`Operator`).
+
+        Post-G0.6 callers (``/api/v1/operations/call``, MCP
+        ``call_operation``, the CLI verbs from #511) construct a real
+        :class:`Operator` and call :func:`meho_backplane.operations.dispatch`
+        directly — they don't reach this method.
+
+        The shim synthesises a minimal :class:`Operator` carrying a
+        nil-UUID tenant_id + a fixed system sentinel ``sub``; typed-
+        registrations are always ``tenant_id IS NULL`` in
+        ``endpoint_descriptor`` so the dispatcher's tenant-scoped lookup
+        falls through to the global row regardless of the synthesised
+        value. The dispatcher's audit row records the synthesised
+        identity; the real operator identity (when present) lands on
+        the audit row written by :class:`AuditMiddleware` upstream of
+        this call.
+        """
+        # Lazy import — meho_backplane.operations.dispatch transitively
+        # imports the connector registry which imports this module at
+        # package import time; deferring keeps that initialisation
+        # order stable.
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:vmware-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        # Encode the connector's natural key as the dispatcher's
+        # connector_id string per parse_connector_id's contract:
+        # ``"vmware-rest-9.0"`` -> (product=``"vmware"``, version=``"9.0"``,
+        # impl_id=``"vmware-rest"``).
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Revoke every cached session before closing the httpx pool.
+
+        Issues ``DELETE /api/session`` against each per-target client
+        before delegating to :meth:`HttpConnector.aclose`. A revoke
+        failure (5xx, transport error, target unreachable at shutdown)
+        is logged and proceeds — the operator-facing concern at
+        shutdown is "tear down the httpx pool", and a hung DELETE
+        on an unreachable target would otherwise block lifespan exit
+        long enough to trip Kubernetes' 30-second terminationGracePeriod.
+
+        The DELETE is issued before :meth:`super().aclose` so the
+        cached client is still pooled when we need it. After the
+        revoke loop, the parent close runs unchanged.
+        """
+        async with self._session_lock:
+            tokens = dict(self._session_tokens)
+            self._session_tokens.clear()
+        for target_name, token in tokens.items():
+            client = self._clients.get(target_name)
+            if client is None:
+                # Theoretically unreachable — every cached token was
+                # established against a per-target client that was
+                # created during _session_token. Defensive: skip
+                # cleanly if the invariant ever drifts.
+                continue
+            try:
+                resp = await client.request(
+                    "DELETE",
+                    "/api/session",
+                    headers={_SESSION_HEADER: token},
+                )
+                # Log non-2xx but don't raise — shutdown proceeds.
+                if resp.status_code >= 400:
+                    _log.warning(
+                        "vsphere_session_revoke_non_2xx",
+                        target=target_name,
+                        status_code=resp.status_code,
+                    )
+            except (httpx.HTTPError, OSError) as exc:
+                _log.warning(
+                    "vsphere_session_revoke_failed",
+                    target=target_name,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -24,12 +24,19 @@ The class caches one ``vmware-api-session-id`` token per ``target.name``.
 First call to :meth:`auth_headers` against a given target invokes the
 :class:`VsphereSessionLoader` (default
 :func:`load_session_credentials_from_vault`) for the service-account
-credentials, then issues ``POST /api/session`` with HTTP basic auth. The
-JSON-string-body response is the session token; subsequent calls reuse
-the cached value. Per-target isolation is the load-bearing invariant:
-two targets must never share a session token even if their names collide
-across tenants — the cache is keyed on ``target.name`` because that's
-the operator-supplied identifier the connector receives at the boundary.
+credentials, then issues ``POST /api/session`` with HTTP basic auth. If
+the modern endpoint responds with HTTP 404, the connector retries
+against the legacy ``POST /rest/com/vmware/cis/session`` path before
+declaring failure — real vCenter serves both, but the upstream
+``vmware/vcsim`` simulator (used by the integration test in T8) wires
+the handler under the legacy path only. The successful endpoint is
+cached per-target so :meth:`aclose` revokes against the same path. The
+JSON-string-body response (or legacy ``{"value": "<token>"}`` shape) is
+the session token; subsequent calls reuse the cached value. Per-target
+isolation is the load-bearing invariant: two targets must never share a
+session token even if their names collide across tenants — the cache is
+keyed on ``target.name`` because that's the operator-supplied identifier
+the connector receives at the boundary.
 
 The session-establish flow runs under an :class:`asyncio.Lock` so two
 concurrent first-use callers against the same target don't both POST to
@@ -50,10 +57,12 @@ operator-facing dispatch sees re-authentication as a clean retry
 through the dispatcher's caller-side retry path rather than a hidden
 retry inside the connector.
 
-:meth:`aclose` revokes every cached session via ``DELETE /api/session``
-before closing the per-target httpx clients. A revoke failure is logged
-and proceeds — the operator-facing concern at shutdown is "tear down
-the httpx pool"; an in-flight 5xx during DELETE doesn't block that.
+:meth:`aclose` revokes every cached session via ``DELETE`` against the
+endpoint that minted the token (modern ``/api/session`` for production,
+legacy ``/rest/com/vmware/cis/session`` for vcsim-served targets) before
+closing the per-target httpx clients. A revoke failure is logged and
+proceeds — the operator-facing concern at shutdown is "tear down the
+httpx pool"; an in-flight 5xx during DELETE doesn't block that.
 
 Auth model gating
 -----------------
@@ -112,6 +121,21 @@ _SESSION_HEADER = "vmware-api-session-id"
 # vcsim has been known to swap between shapes between minor releases,
 # and a defensive read here costs nothing.
 _SESSION_TOKEN_OBJECT_KEY = "value"
+
+# Session endpoints. Modern vCenter (7.0+) lives at ``/api/session``;
+# the legacy ``/rest/com/vmware/cis/session`` path is still served by
+# real vCenter for backward-compat and is the *only* path the upstream
+# ``vmware/vcsim`` simulator registers (its ``vapi/simulator`` package
+# wires the handler at ``rest.Path + internal.SessionPath`` =
+# ``/rest`` + ``/com/vmware/cis/session`` and does not also mount under
+# ``/api/``). The connector tries the modern path first and falls back
+# to the legacy path on 404 so production targets (which serve both)
+# pay no extra round-trip while vcsim integration tests stay green.
+# The established path is cached per-target in ``self._session_paths``
+# so the DELETE in ``aclose()`` targets the same endpoint that minted
+# the token.
+_SESSION_PATH_MODERN = "/api/session"
+_SESSION_PATH_LEGACY = "/rest/com/vmware/cis/session"
 
 # Verbs that go through HttpConnector._request_json's tenacity retry
 # decorator. Non-idempotent verbs (POST / PUT / PATCH / DELETE) route
@@ -219,6 +243,13 @@ class VmwareRestConnector(HttpConnector):
     ) -> None:
         super().__init__()
         self._session_tokens: dict[str, str] = {}
+        # Tracks which session endpoint minted each cached token so
+        # :meth:`aclose` can DELETE against the same path. Production
+        # vCenter serves both ``/api/session`` and the legacy
+        # ``/rest/com/vmware/cis/session``; vcsim serves only the legacy
+        # path. See ``_SESSION_PATH_MODERN`` / ``_SESSION_PATH_LEGACY``
+        # for the rationale and source citations.
+        self._session_paths: dict[str, str] = {}
         self._session_lock = asyncio.Lock()
         self._session_loader: VsphereSessionLoader = (
             session_loader if session_loader is not None else load_session_credentials_from_vault
@@ -257,6 +288,17 @@ class VmwareRestConnector(HttpConnector):
         the lock acquisition itself. The slow ``POST /api/session`` call
         runs under the lock so two concurrent first-use callers against
         the same target don't both pay the round-trip cost.
+
+        Endpoint fallback: POSTs to the modern ``/api/session`` first;
+        on HTTP 404 (only) falls back to ``/rest/com/vmware/cis/session``.
+        Real vCenter serves both paths, so production targets succeed on
+        the first attempt; the upstream ``vmware/vcsim`` simulator
+        registers only the legacy path (per ``govmomi/vapi/simulator``)
+        and exercises the fallback. The successful path is recorded in
+        ``self._session_paths`` so :meth:`aclose` DELETEs the matching
+        endpoint. 401 / 403 / 5xx on the modern path are *not* retried
+        on the legacy path — those are auth/server failures, not "this
+        deployment doesn't have the modern endpoint".
         """
         async with self._session_lock:
             cached = self._session_tokens.get(target.name)
@@ -265,10 +307,8 @@ class VmwareRestConnector(HttpConnector):
             creds = await self._session_loader(target)
             client = await self._http_client(target)
             try:
-                resp = await client.post(
-                    "/api/session",
-                    auth=(creds["username"], creds["password"]),
-                )
+                username = creds["username"]
+                password = creds["password"]
             except KeyError as exc:
                 # Surface a clear error if the loader returned a dict
                 # missing one of the two required keys — a typo in a
@@ -280,23 +320,37 @@ class VmwareRestConnector(HttpConnector):
                     f"a dict missing required key {exc.args[0]!r}; need "
                     "{'username': str, 'password': str}"
                 ) from exc
+            auth = (username, password)
+            resp = await client.post(_SESSION_PATH_MODERN, auth=auth)
+            established_path = _SESSION_PATH_MODERN
+            if resp.status_code == 404:
+                # Modern endpoint not served (vcsim, very old vCenter,
+                # or a reverse-proxy that hasn't been updated). Try the
+                # legacy path before declaring failure.
+                resp = await client.post(_SESSION_PATH_LEGACY, auth=auth)
+                established_path = _SESSION_PATH_LEGACY
             try:
                 resp.raise_for_status()
             except httpx.HTTPStatusError as exc:
                 # Wrap so the operator-facing message names the target;
                 # httpx's default str() shows only the URL/status, which
                 # loses the per-target identification the dispatcher's
-                # audit row needs.
+                # audit row needs. The path in the message is the last
+                # one attempted, which distinguishes a real 404 (legacy
+                # also missing) from auth/server failure on the modern
+                # path.
                 raise RuntimeError(
                     f"vsphere session establish failed for target {target.name!r}: "
-                    f"POST /api/session returned HTTP {exc.response.status_code}"
+                    f"POST {established_path} returned HTTP {exc.response.status_code}"
                 ) from exc
             token = _extract_session_token(resp.json(), target.name)
             self._session_tokens[target.name] = token
+            self._session_paths[target.name] = established_path
             _log.info(
                 "vsphere_session_established",
                 target=target.name,
                 host=target.host,
+                session_path=established_path,
             )
             return token
 
@@ -430,13 +484,16 @@ class VmwareRestConnector(HttpConnector):
     async def aclose(self) -> None:
         """Revoke every cached session before closing the httpx pool.
 
-        Issues ``DELETE /api/session`` against each per-target client
-        before delegating to :meth:`HttpConnector.aclose`. A revoke
-        failure (5xx, transport error, target unreachable at shutdown)
-        is logged and proceeds — the operator-facing concern at
-        shutdown is "tear down the httpx pool", and a hung DELETE
-        on an unreachable target would otherwise block lifespan exit
-        long enough to trip Kubernetes' 30-second terminationGracePeriod.
+        Issues ``DELETE`` against each per-target client at the session
+        path recorded by :meth:`_session_token` (modern ``/api/session``
+        for production vCenter, legacy ``/rest/com/vmware/cis/session``
+        for targets where the modern path 404'd at establish time) before
+        delegating to :meth:`HttpConnector.aclose`. A revoke failure
+        (5xx, transport error, target unreachable at shutdown) is logged
+        and proceeds — the operator-facing concern at shutdown is "tear
+        down the httpx pool", and a hung DELETE on an unreachable target
+        would otherwise block lifespan exit long enough to trip
+        Kubernetes' 30-second terminationGracePeriod.
 
         The DELETE is issued before :meth:`super().aclose` so the
         cached client is still pooled when we need it. After the
@@ -444,7 +501,9 @@ class VmwareRestConnector(HttpConnector):
         """
         async with self._session_lock:
             tokens = dict(self._session_tokens)
+            paths = dict(self._session_paths)
             self._session_tokens.clear()
+            self._session_paths.clear()
         for target_name, token in tokens.items():
             client = self._clients.get(target_name)
             if client is None:
@@ -453,10 +512,16 @@ class VmwareRestConnector(HttpConnector):
                 # created during _session_token. Defensive: skip
                 # cleanly if the invariant ever drifts.
                 continue
+            # Use the same endpoint that minted the token. ``paths``
+            # is populated in lock-step with ``_session_tokens`` in
+            # ``_session_token``; the default keeps shutdown safe if
+            # a future code path ever caches a token without recording
+            # its endpoint.
+            revoke_path = paths.get(target_name, _SESSION_PATH_MODERN)
             try:
                 resp = await client.request(
                     "DELETE",
-                    "/api/session",
+                    revoke_path,
                     headers={_SESSION_HEADER: token},
                 )
                 # Log non-2xx but don't raise — shutdown proceeds.
@@ -465,11 +530,13 @@ class VmwareRestConnector(HttpConnector):
                         "vsphere_session_revoke_non_2xx",
                         target=target_name,
                         status_code=resp.status_code,
+                        session_path=revoke_path,
                     )
             except (httpx.HTTPError, OSError) as exc:
                 _log.warning(
                     "vsphere_session_revoke_failed",
                     target=target_name,
                     error=f"{type(exc).__name__}: {exc}",
+                    session_path=revoke_path,
                 )
         await super().aclose()

--- a/backend/src/meho_backplane/connectors/vmware_rest/session.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/session.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Session-credential loading for the vmware-rest connector.
+
+The hand-rolled :class:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector`
+trades operator-context Vault reads to a session token via vCenter's
+``POST /api/session`` endpoint. The credential fetch (Vault path -> service-
+account ``{"username": ..., "password": ...}`` dict) is split out behind a
+narrow :class:`VsphereSessionLoader` callable so:
+
+* Production deploys can override the default loader at construction time
+  once G0.3 (#224) lands the operator-context Vault read path.
+* Unit tests inject their own (mock) loader that returns a pre-built dict.
+* Integration tests against vcsim pass a loader that yields the
+  simulator's hard-coded ``user``/``pass`` credentials.
+
+The default loader, :func:`load_session_credentials_from_vault`, raises
+:exc:`NotImplementedError` until G0.3 (#224) merges. Mirrors the
+shape :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`
+already established for :class:`KubernetesConnector` — once the Target
+model + operator-context Vault reads land, both loaders pick up the
+concrete implementation in a single follow-up commit.
+
+The :class:`VsphereTargetLike` Protocol captures the minimum target shape
+the connector reads: ``name`` (for the per-target session cache key),
+``host``, ``port`` (forwarded to :meth:`HttpConnector._base_url`),
+``secret_ref`` (the Vault path the loader resolves), and ``auth_model``
+(checked by :meth:`VmwareRestConnector.auth_headers` to reject
+``per_user`` / ``impersonation`` targets at the boundary). Once G0.3 ships
+its concrete ``Target`` model in :mod:`meho_backplane.targets`, the
+model satisfies this Protocol structurally — no edits here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "SessionCredentials",
+    "VsphereSessionLoader",
+    "VsphereTargetLike",
+    "load_session_credentials_from_vault",
+]
+
+
+class SessionCredentials(Protocol):
+    """The dict shape :func:`VsphereSessionLoader` returns.
+
+    Captured as a TypedDict-style Protocol rather than a concrete
+    :class:`dict` so the type checker can flag a loader that forgets a
+    key. Keys are deliberately the two HTTP basic-auth components vCenter
+    expects on ``POST /api/session``; nothing else is read.
+    """
+
+    username: str
+    password: str
+
+
+@runtime_checkable
+class VsphereTargetLike(Protocol):
+    """Minimum target shape :class:`VmwareRestConnector` reads.
+
+    Structural Protocol — once G0.3 (#224) lands the concrete ``Target``
+    model in :mod:`meho_backplane.targets`, that model satisfies this
+    Protocol unchanged. ``auth_model`` is checked at the boundary so a
+    target tagged ``per_user`` or ``impersonation`` raises a clear error
+    rather than silently authenticating as the shared service account.
+
+    ``secret_ref`` is the Vault path the loader resolves to a
+    :class:`SessionCredentials`-shaped dict. ``port`` is optional —
+    vCenter defaults to 443 and :meth:`HttpConnector._base_url` already
+    handles the ``port is None or 443`` case correctly.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+
+
+VsphereSessionLoader = Callable[[VsphereTargetLike], Awaitable[dict[str, str]]]
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+The connector's :meth:`VmwareRestConnector._session_token` invokes the
+loader exactly once per target (first-use), caching the resulting session
+token under ``target.name``. The return type is the looser
+``dict[str, str]`` (not :class:`SessionCredentials`) because Python
+:class:`Protocol` instances aren't runtime-constructible without a
+matching class — production code returns a plain dict and the connector
+reads ``creds["username"]`` / ``creds["password"]`` by key.
+"""
+
+
+async def load_session_credentials_from_vault(
+    target: VsphereTargetLike,
+) -> dict[str, str]:
+    """Default credential loader — Vault read by ``target.secret_ref``.
+
+    Stubbed until G0.3 (#224) lands the ``Target`` model and the
+    operator-context Vault read path. Mirrors
+    :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`'s
+    NotImplementedError stub so the wiring shape is stable: a production
+    caller without an explicit loader override receives a clear error
+    rather than a silent fallback or a hallucinated credential pair.
+
+    Once G0.3 lands, this function becomes the live implementation that
+    reads the ``vsphere/<target.name>`` Vault path and returns the
+    parsed ``{"username": ..., "password": ...}`` dict. Until then,
+    tests and any acceptance harness inject a custom
+    :class:`VsphereSessionLoader` on connector construction.
+    """
+    raise NotImplementedError(
+        "load_session_credentials_from_vault requires G0.3 Target model + "
+        f"operator-context Vault read; target={target.name!r} "
+        f"secret_ref={target.secret_ref!r}. Inject a custom session_loader "
+        "on VmwareRestConnector until G0.3 lands."
+    )

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -109,14 +109,19 @@ def vcsim_target() -> Any:
     # for registry-mirror swaps or version pinning per the same convention
     # the K3s integration test uses (MEHO_TEST_K3S_IMAGE).
     image = os.environ.get("MEHO_TEST_VCSIM_IMAGE", "vmware/vcsim:latest")
-    container = (
-        DockerContainer(image)
-        .with_exposed_ports(8989)
-        # vcsim's default flags: listen on :8989 with HTTPS self-signed
-        # cert. ``-trace`` is loud but useful when the integration test
-        # fails — leave default in CI to keep logs slim.
-        .with_command("/vcsim -l :8989")
-    )
+    # The official ``vmware/vcsim`` Dockerfile sets
+    # ``ENTRYPOINT ["/vcsim"]`` + ``CMD ["-l", "0.0.0.0:8989"]`` so the
+    # default listener already binds on all interfaces — exactly what
+    # testcontainers' host-port mapping needs to reach the simulator.
+    # Overriding ``CMD`` with a string here would re-prepend ``/vcsim``
+    # to the entrypoint and Go's ``flag.Parse()`` would stop at that
+    # positional argument, silently falling back to the simulator's
+    # internal default of ``-l 127.0.0.1:8989`` — bound to container-
+    # local loopback only, so the host's mapped port would refuse the
+    # TCP connect with an empty ``ConnectError`` (the failure mode that
+    # took down PR #518's first CI green attempt). Leave the default
+    # CMD alone.
+    container = DockerContainer(image).with_exposed_ports(8989)
     import contextlib
 
     try:

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration test for :class:`VmwareRestConnector` against a real vcsim container.
+
+Boots ``vmware/vcsim`` via :class:`testcontainers.core.container.DockerContainer`,
+configures it for HTTPS on the listening port, and exercises the live
+``fingerprint`` / ``probe`` / session-cache / ``aclose`` paths against the
+running simulator's REST surface.
+
+Skip conditions:
+
+* Docker socket missing — same heuristic the rest of the
+  ``tests/integration/`` package uses.
+* vcsim container start fails — surfaces as a clean skip rather than a
+  hard failure so a Docker-having-but-not-vcsim-having sandbox isn't
+  flagged red. CI runners provision Docker so the tests run there.
+
+CI side: the vcsim integration job lands as part of T8 (#515); this
+module collects unconditionally so a stub CI lane that mounts the
+Docker socket without setting up the vcsim image still goes to skip
+rather than collection-fail.
+
+vcsim notes:
+
+* The official ``vmware/vcsim:latest`` image listens on
+  ``127.0.0.1:8989`` by default with HTTPS (self-signed cert).
+* The simulator accepts any ``username``/``password`` for
+  ``POST /api/session`` — vcsim returns a synthetic token without
+  verifying credentials. We pass ``user``/``pass`` for clarity; any
+  pair works.
+* ``GET /api/about`` returns a synthesised inventory shape that maps
+  cleanly through :func:`product_from_line_id`.
+"""
+
+from __future__ import annotations
+
+import os
+import ssl
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vmware_rest import (
+    VmwareRestConnector,
+    VsphereTargetLike,
+)
+
+# ---------------------------------------------------------------------------
+# Docker availability — mirrors tests/integration/conftest.py heuristic
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+DOCKER_AVAILABLE: bool = _docker_socket_present()
+SKIP_REASON: str = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+
+# ---------------------------------------------------------------------------
+# Target stub
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _VcsimTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+# ---------------------------------------------------------------------------
+# vcsim container fixture — module-scoped (one boot, multiple tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def vcsim_target() -> Any:
+    """Boot a vcsim container; yield a target pointing at it.
+
+    Container shut down on fixture teardown. vcsim listens on 8989/tcp
+    inside the container; testcontainers maps that to an ephemeral host
+    port we read via :meth:`DockerContainer.get_exposed_port`.
+    """
+    if not DOCKER_AVAILABLE:
+        pytest.skip(SKIP_REASON)
+
+    # Local import — testcontainers transitively imports the docker SDK
+    # which probes the socket on import. Keeping the import inside the
+    # fixture lets the module collect on a no-Docker sandbox.
+    try:
+        from testcontainers.core.container import DockerContainer
+        from testcontainers.core.waiting_utils import wait_for_logs
+    except ImportError as exc:  # pragma: no cover
+        pytest.skip(f"testcontainers unavailable: {exc}")
+
+    # ``vmware/vcsim:latest`` is the upstream image. Override via env var
+    # for registry-mirror swaps or version pinning per the same convention
+    # the K3s integration test uses (MEHO_TEST_K3S_IMAGE).
+    image = os.environ.get("MEHO_TEST_VCSIM_IMAGE", "vmware/vcsim:latest")
+    container = (
+        DockerContainer(image)
+        .with_exposed_ports(8989)
+        # vcsim's default flags: listen on :8989 with HTTPS self-signed
+        # cert. ``-trace`` is loud but useful when the integration test
+        # fails — leave default in CI to keep logs slim.
+        .with_command("/vcsim -l :8989")
+    )
+    import contextlib
+
+    try:
+        container.start()
+        # The simulator logs "export GOVC_URL=..." once the REST endpoint
+        # is ready to serve. Wait up to 30 s for that line; longer would
+        # mask a real boot failure as a flaky test.
+        wait_for_logs(container, "export GOVC_URL", timeout=30)
+    except Exception as exc:
+        # Best-effort tear-down; if the container never started, .stop()
+        # will itself fail — swallow so the user sees the original boot
+        # exception via pytest.skip, not the cleanup secondary.
+        with contextlib.suppress(Exception):
+            container.stop()
+        pytest.skip(f"vcsim container failed to start ({type(exc).__name__}): {exc}")
+
+    try:
+        host = container.get_container_host_ip()
+        port_str = container.get_exposed_port(8989)
+        target = _VcsimTarget(
+            name="vcsim-test",
+            host=host,
+            port=int(port_str),
+            secret_ref="kv/data/vsphere/vcsim-test",
+        )
+        yield target
+    finally:
+        container.stop()
+
+
+@pytest.fixture
+async def vcsim_connector(
+    vcsim_target: _VcsimTarget,
+) -> AsyncIterator[tuple[VmwareRestConnector, _VcsimTarget]]:
+    """Yield a connector wired with a loader that returns vcsim's any-credentials pair.
+
+    Also patches the connector's per-target httpx client constructor to
+    accept the simulator's self-signed cert. The patch is scoped to this
+    fixture so production code (which uses httpx's default TLS
+    verification) stays untouched.
+    """
+
+    async def _loader(_target: VsphereTargetLike) -> dict[str, str]:
+        # vcsim accepts any credentials.
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+
+    # Override the parent's _http_client to build a client with TLS
+    # verification disabled — the self-signed cert vcsim ships isn't
+    # trusted by the host's CA bundle. Production code never reaches
+    # this branch; the override is fixture-scoped via a method-replace
+    # so the per-target dict pooling semantics stay intact.
+    import asyncio
+
+    connector._lock_for_test = asyncio.Lock()  # type: ignore[attr-defined]
+
+    async def _http_client_insecure(target: VsphereTargetLike) -> httpx.AsyncClient:
+        async with connector._lock_for_test:  # type: ignore[attr-defined]
+            if target.name not in connector._clients:
+                scheme = "https"
+                port_part = f":{target.port}" if target.port and target.port != 443 else ""
+                base_url = f"{scheme}://{target.host}{port_part}"
+                # vcsim's self-signed cert isn't in the host CA bundle;
+                # disable verification for this fixture only. Production
+                # code uses httpx's default verify=True.
+                ssl_ctx = ssl.create_default_context()
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
+                connector._clients[target.name] = httpx.AsyncClient(
+                    base_url=base_url,
+                    timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
+                    verify=ssl_ctx,
+                )
+            return connector._clients[target.name]
+
+    connector._http_client = _http_client_insecure  # type: ignore[method-assign]
+
+    try:
+        yield connector, vcsim_target
+    finally:
+        await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_against_vcsim_returns_reachable(
+    vcsim_connector: tuple[VmwareRestConnector, _VcsimTarget],
+) -> None:
+    """Live fingerprint against vcsim returns reachable=True with vmware vendor."""
+    connector, target = vcsim_connector
+    result = await connector.fingerprint(target)
+    assert result.vendor == "vmware"
+    assert result.reachable is True, f"fingerprint not reachable: extras={dict(result.extras)}"
+    assert result.probe_method == "GET /api/about"
+    # vcsim's /api/about returns product_line_id="vpx" -> "vcenter".
+    # Loose assertion since vcsim's behaviour may vary across releases.
+    assert result.product in ("vcenter", "esxi", "vpx", "embeddedEsx", "esx")
+
+
+@pytest.mark.asyncio
+async def test_probe_against_vcsim_returns_ok(
+    vcsim_connector: tuple[VmwareRestConnector, _VcsimTarget],
+) -> None:
+    """probe() against a running vcsim returns ok=True."""
+    connector, target = vcsim_connector
+    result = await connector.probe(target)
+    assert result.ok is True, f"probe failed: reason={result.reason!r}"
+
+
+@pytest.mark.asyncio
+async def test_session_reused_across_consecutive_fingerprint_calls(
+    vcsim_connector: tuple[VmwareRestConnector, _VcsimTarget],
+) -> None:
+    """Two consecutive fingerprint calls share the same cached session token."""
+    connector, target = vcsim_connector
+    await connector.fingerprint(target)
+    token_after_first = connector._session_tokens.get(target.name)
+    assert token_after_first is not None
+    await connector.fingerprint(target)
+    token_after_second = connector._session_tokens.get(target.name)
+    # The load-bearing assertion: the cached token is byte-identical
+    # across the two calls (no re-establish).
+    assert token_after_first == token_after_second
+
+
+@pytest.mark.asyncio
+async def test_aclose_revokes_session_against_vcsim(
+    vcsim_target: _VcsimTarget,
+) -> None:
+    """aclose() issues DELETE /api/session against vcsim and clears the cache."""
+
+    async def _loader(_target: VsphereTargetLike) -> dict[str, str]:
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+
+    # Same insecure-client patch as the fixture.
+    import asyncio
+
+    connector._lock_for_test = asyncio.Lock()  # type: ignore[attr-defined]
+
+    async def _http_client_insecure(target: VsphereTargetLike) -> httpx.AsyncClient:
+        async with connector._lock_for_test:  # type: ignore[attr-defined]
+            if target.name not in connector._clients:
+                port_part = f":{target.port}" if target.port and target.port != 443 else ""
+                base_url = f"https://{target.host}{port_part}"
+                ssl_ctx = ssl.create_default_context()
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
+                connector._clients[target.name] = httpx.AsyncClient(
+                    base_url=base_url,
+                    timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
+                    verify=ssl_ctx,
+                )
+            return connector._clients[target.name]
+
+    connector._http_client = _http_client_insecure  # type: ignore[method-assign]
+
+    await connector.fingerprint(vcsim_target)
+    assert vcsim_target.name in connector._session_tokens
+
+    await connector.aclose()
+    # Post-aclose: cache cleared, pool emptied.
+    assert connector._session_tokens == {}
+    assert connector._clients == {}

--- a/backend/tests/test_connectors_vmware_rest_auth.py
+++ b/backend/tests/test_connectors_vmware_rest_auth.py
@@ -1,0 +1,465 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`VmwareRestConnector` session-auth + lifecycle (G3.1-T1 #498).
+
+The integration shape (real vcsim) lives in
+:mod:`tests.integration.test_connectors_vmware_rest_vcsim`. This module
+exercises the same contract with respx-mocked HTTP so the gate runs in
+every CI lane regardless of Docker availability.
+
+Coverage matrix (per #498 acceptance criteria):
+
+* Session establishment success — ``POST /api/session`` returns a
+  JSON-string token (vSphere 7.0+ shape); the token is cached under
+  ``target.name`` and returned in the
+  ``vmware-api-session-id`` header on subsequent calls.
+* Session reuse — a second auth call against the same target does NOT
+  re-issue ``POST /api/session``.
+* Session-creation failure — 401 from ``/api/session`` surfaces as a
+  ``RuntimeError`` whose message names the target.
+* Per-target isolation — two distinct ``target.name`` values get two
+  distinct cached tokens; cross-target token leakage would be a tenant-
+  isolation bug.
+* :meth:`aclose` revokes every cached session via ``DELETE /api/session``
+  before invoking :meth:`HttpConnector.aclose`.
+* :meth:`auth_headers` raises :exc:`NotImplementedError` when
+  ``target.auth_model`` is ``"per_user"`` or ``"impersonation"``.
+* Loader-returning-incomplete-dict surfaces a clear error.
+* Legacy ``{"value": "<token>"}`` response shape is accepted defensively
+  for cross-vcsim-version compatibility.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vmware_rest import (
+    VmwareRestConnector,
+    VsphereTargetLike,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_vmware_rest_registry() -> Iterator[None]:
+    """Re-register VmwareRestConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` (and other earlier-alphabetised
+    test modules) install autouse fixtures that call
+    :func:`clear_registry` between tests. The connector class
+    self-registered at import time, but the post-clear empty state
+    breaks the registration-acceptance test below. Re-register before
+    every test in this module and clear after — same pattern
+    :mod:`tests.test_connectors_vault` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=VmwareRestConnector.product,
+        version=VmwareRestConnector.version,
+        impl_id=VmwareRestConnector.impl_id,
+        cls=VmwareRestConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies VsphereTargetLike Protocol structurally.
+# Replaced by the real Target model when G0.3 (#224) lands.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET_A = _StubTarget(
+    name="vcenter-a",
+    host="vcenter-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/vsphere/vcenter-a",
+)
+_TARGET_B = _StubTarget(
+    name="vcenter-b",
+    host="vcenter-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/vsphere/vcenter-b",
+)
+
+
+async def _stub_loader(_target: VsphereTargetLike) -> dict[str, str]:
+    """Return canned credentials regardless of the target."""
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> VmwareRestConnector:
+    """Build a connector wired with the stub loader."""
+    return VmwareRestConnector(session_loader=_stub_loader)
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_vmware_rest_connector_subclasses_http_connector() -> None:
+    """Sanity check: the connector inherits from HttpConnector."""
+    assert issubclass(VmwareRestConnector, HttpConnector)
+    assert VmwareRestConnector.product == "vmware"
+    assert VmwareRestConnector.version == "9.0"
+    assert VmwareRestConnector.impl_id == "vmware-rest"
+    assert VmwareRestConnector.supported_version_range == ">=8.5,<10.0"
+    # Outranks GenericRestConnector auto-shim (priority=0) defensively
+    # if both somehow register for the same triple.
+    assert VmwareRestConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    """The package's __init__ calls register_connector_v2 at import time."""
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("vmware", "9.0", "vmware-rest")
+    assert key in registry
+    assert registry[key] is VmwareRestConnector
+
+
+def test_default_session_loader_raises_until_g03_lands() -> None:
+    """The default Vault loader stays unimplemented until G0.3."""
+    import asyncio
+
+    from meho_backplane.connectors.vmware_rest.session import (
+        load_session_credentials_from_vault,
+    )
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"G0\.3"):
+            await load_session_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Session establishment — happy path
+# ---------------------------------------------------------------------------
+
+
+# The connector's aclose() issues DELETE /api/session for every cached
+# target; tests that don't mock that endpoint would tip respx into an
+# AssertionError on the unhandled request. ``_patch_no_revoke_aclose``
+# replaces the cleanup with a direct httpx pool tear-down for tests
+# that don't care about the revoke leg — kept here at module scope so
+# every test that follows can call it after building its connector.
+def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
+    """Replace connector.aclose with a revoke-free pool tear-down."""
+
+    async def _aclose() -> None:
+        connector._session_tokens.clear()
+        for client in connector._clients.values():
+            await client.aclose()
+        connector._clients.clear()
+
+    connector.aclose = _aclose  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_establishes_session_and_returns_header() -> None:
+    """First auth_headers call POSTs to /api/session and caches the token."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    token = "abc-session-token-123"
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        session_route = mock.post("/api/session").respond(200, json=token)
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert session_route.called
+    assert session_route.call_count == 1
+    assert headers == {"vmware-api-session-id": token}
+    # Basic auth from the stub loader: svc-meho / stub-password.
+    sent_auth = session_route.calls[0].request.headers.get("authorization")
+    assert sent_auth is not None
+    assert sent_auth.startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_session_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-POST /api/session."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    token = "cached-token-456"
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        session_route = mock.post("/api/session").respond(200, json=token)
+        h1 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+        h2 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert h1 == h2 == {"vmware-api-session-id": token}
+    # The load-bearing assertion — exactly one POST /api/session for two
+    # auth header calls.
+    assert session_route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_session_tokens_separate() -> None:
+    """Two targets get two distinct cached tokens; no cross-target leakage."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock() as mock:
+        route_a = mock.post("https://vcenter-a.test.invalid/api/session").respond(
+            200, json="token-for-a"
+        )
+        route_b = mock.post("https://vcenter-b.test.invalid/api/session").respond(
+            200, json="token-for-b"
+        )
+
+        h_a = await connector.auth_headers(_TARGET_A, raw_jwt="")
+        h_b = await connector.auth_headers(_TARGET_B, raw_jwt="")
+
+    assert route_a.called and route_b.called
+    assert h_a == {"vmware-api-session-id": "token-for-a"}
+    assert h_b == {"vmware-api-session-id": "token-for-b"}
+    # Both tokens cached.
+    assert connector._session_tokens == {
+        "vcenter-a": "token-for-a",
+        "vcenter-b": "token-for-b",
+    }
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Session establishment — failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_create_401_surfaces_runtime_error_with_target_name() -> None:
+    """401 from POST /api/session raises RuntimeError naming the target."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        mock.post("/api/session").respond(401, json={"error": "invalid_credentials"})
+        with pytest.raises(RuntimeError, match=r"vcenter-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    # The wrapped HTTPStatusError carries the 401 details.
+    assert "401" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_response_unexpected_shape_raises() -> None:
+    """A response that isn't a JSON string or {"value": str} raises."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        # POST /api/session returns something the connector can't parse —
+        # an empty object is the most common vcsim misbehaviour shape.
+        mock.post("/api/session").respond(200, json={"unrelated": "field"})
+        with pytest.raises(RuntimeError, match=r"vcenter-a"):
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_legacy_object_shape_is_accepted_defensively() -> None:
+    """Pre-7.0 ``{"value": "<token>"}`` response is still parsed correctly.
+
+    Some vcsim builds straddle the modern-string and legacy-object
+    shapes; the connector accepts both so the integration test stays
+    green across simulator versions.
+    """
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json={"value": "legacy-shape-token"})
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert headers == {"vmware-api-session-id": "legacy-shape-token"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_clear_error() -> None:
+    """A loader that returns a dict without 'password' surfaces a clear message."""
+
+    async def _bad_loader(_target: VsphereTargetLike) -> dict[str, str]:
+        # Intentionally missing 'password'; a real production loader bug.
+        return {"username": "svc-meho"}  # type: ignore[return-value]
+
+    connector = VmwareRestConnector(session_loader=_bad_loader)
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid"):
+        with pytest.raises(RuntimeError, match=r"password"):
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="vcenter-per-user",
+        host="vc.test.invalid",
+        port=443,
+        secret_ref="kv/data/vsphere/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="")
+
+    assert "vcenter-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted as SHARED_SERVICE_ACCOUNT."""
+    target = _StubTarget(
+        name="vcenter-pre-g03",
+        host="vc.test.invalid",
+        port=443,
+        secret_ref="kv/data/vsphere/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vc.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="pre-g03-token")
+        headers = await connector.auth_headers(target, raw_jwt="")
+
+    assert headers == {"vmware-api-session-id": "pre-g03-token"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_value_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="vcenter-enum",
+        host="vc.test.invalid",
+        port=443,
+        secret_ref="kv/data/vsphere/enum",
+    )
+    # Use the enum member directly rather than its .value
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vc.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="enum-token")
+        headers = await connector.auth_headers(target, raw_jwt="")
+
+    assert headers == {"vmware-api-session-id": "enum-token"}
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose — session revoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_revokes_every_cached_session() -> None:
+    """aclose() issues DELETE /api/session for each cached token before pool tear-down."""
+    connector = _make_connector()
+
+    async with respx.mock() as mock:
+        mock.post("https://vcenter-a.test.invalid/api/session").respond(200, json="token-for-a")
+        mock.post("https://vcenter-b.test.invalid/api/session").respond(200, json="token-for-b")
+        delete_a = mock.delete("https://vcenter-a.test.invalid/api/session").respond(204)
+        delete_b = mock.delete("https://vcenter-b.test.invalid/api/session").respond(204)
+
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+        await connector.auth_headers(_TARGET_B, raw_jwt="")
+        await connector.aclose()
+
+    assert delete_a.called and delete_b.called
+    # Both DELETE requests carried the session token in the header.
+    deleted_headers_a = delete_a.calls[0].request.headers
+    assert deleted_headers_a.get("vmware-api-session-id") == "token-for-a"
+    deleted_headers_b = delete_b.calls[0].request.headers
+    assert deleted_headers_b.get("vmware-api-session-id") == "token-for-b"
+    # Pool cleared.
+    assert connector._clients == {}
+    assert connector._session_tokens == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_continues_on_revoke_failure() -> None:
+    """A 5xx or transport error during DELETE /api/session is logged, not raised."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="token-for-a")
+        # The revoke leg fails with a transport error — connector swallows
+        # and proceeds (lifespan shutdown must not block).
+        mock.delete("/api/session").mock(side_effect=httpx.ConnectError("revoke failed"))
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+        # The load-bearing invariant: aclose() returns cleanly.
+        await connector.aclose()
+
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_continues_on_revoke_4xx() -> None:
+    """A 401/403 from DELETE /api/session is logged but doesn't block tear-down."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="token-for-a")
+        # vCenter's DELETE /api/session may 401 if the session expired
+        # between the last call and shutdown; tear-down still proceeds.
+        mock.delete("/api/session").respond(401)
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+        await connector.aclose()
+
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_with_no_cached_sessions_is_a_noop() -> None:
+    """A fresh connector with no sessions established closes cleanly."""
+    connector = _make_connector()
+    await connector.aclose()
+    assert connector._clients == {}
+    assert connector._session_tokens == {}

--- a/backend/tests/test_connectors_vmware_rest_auth.py
+++ b/backend/tests/test_connectors_vmware_rest_auth.py
@@ -171,6 +171,7 @@ def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
 
     async def _aclose() -> None:
         connector._session_tokens.clear()
+        connector._session_paths.clear()
         for client in connector._clients.values():
             await client.aclose()
         connector._clients.clear()
@@ -300,6 +301,168 @@ async def test_session_legacy_object_shape_is_accepted_defensively() -> None:
 
     assert headers == {"vmware-api-session-id": "legacy-shape-token"}
     await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Modern → legacy session-endpoint fallback
+# ---------------------------------------------------------------------------
+#
+# Real vCenter (8.5+) serves both ``POST /api/session`` and the legacy
+# ``POST /rest/com/vmware/cis/session``; the upstream ``vmware/vcsim``
+# simulator wires only the legacy path (see
+# ``govmomi/vapi/simulator/simulator.go``, which registers handlers at
+# ``rest.Path + internal.SessionPath`` = ``/rest`` + ``/com/vmware/cis/session``
+# without a parallel ``/api/`` mount). The connector POSTs to the modern
+# path first and, on HTTP 404 only, retries against the legacy path so
+# production hits the fast path while the vcsim integration test stays
+# green across simulator versions. The path that succeeded is cached
+# per-target so :meth:`aclose` DELETEs against the same endpoint that
+# minted the token.
+
+
+@pytest.mark.asyncio
+async def test_modern_session_endpoint_is_tried_first_no_fallback_on_200() -> None:
+    """A 200 from /api/session means we never touch the legacy path.
+
+    The legacy route is *deliberately not registered* — if the connector
+    erroneously fell back to it, respx would raise an unhandled-request
+    error and fail the test. That's a stricter signal than asserting
+    ``not legacy.called`` on a pre-registered route (which respx itself
+    would also flag via ``assert_all_called``).
+    """
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        modern = mock.post("/api/session").respond(200, json="modern-path-token")
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert headers == {"vmware-api-session-id": "modern-path-token"}
+    assert modern.called and modern.call_count == 1
+    # The cached path records the modern endpoint so aclose targets it.
+    assert connector._session_paths == {"vcenter-a": "/api/session"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_falls_back_to_legacy_path_on_modern_404() -> None:
+    """A 404 from /api/session triggers a retry against /rest/com/vmware/cis/session.
+
+    This is the vcsim path: stock vcsim registers the session handler
+    only at the legacy endpoint per govmomi/vapi/simulator/simulator.go.
+    Production vCenter serves both paths so the fallback is dormant there.
+    """
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        modern = mock.post("/api/session").respond(404)
+        legacy = mock.post("/rest/com/vmware/cis/session").respond(
+            200, json={"value": "legacy-path-token"}
+        )
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert modern.called and modern.call_count == 1
+    assert legacy.called and legacy.call_count == 1
+    assert headers == {"vmware-api-session-id": "legacy-path-token"}
+    # The legacy path is recorded so aclose DELETEs against it.
+    assert connector._session_paths == {"vcenter-a": "/rest/com/vmware/cis/session"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_does_not_fall_back_on_401_from_modern_endpoint() -> None:
+    """A 401 from /api/session is an auth failure, NOT an "endpoint missing" signal.
+
+    Falling back to the legacy endpoint on 401 would mask credential
+    problems and (worse) double the audit-log entries vCenter records
+    for failed logins, tripping its built-in account-lockout protection.
+    The fallback fires on 404 only.
+
+    The legacy route is *deliberately not registered* — if the connector
+    erroneously fell back to it, respx would raise an unhandled-request
+    error, which is a stricter check than asserting ``not legacy.called``.
+    """
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        modern = mock.post("/api/session").respond(401, json={"error": "invalid_credentials"})
+        with pytest.raises(RuntimeError, match=r"vcenter-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert modern.called and modern.call_count == 1
+    # The error message names the modern endpoint (the one that actually
+    # responded 401) so operators don't chase a legacy-path red herring.
+    assert "401" in str(exc_info.value)
+    assert "/api/session" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_legacy_path_404_surfaces_runtime_error_naming_legacy_path() -> None:
+    """When both paths 404, the error names the legacy endpoint (last attempted)."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        mock.post("/api/session").respond(404)
+        mock.post("/rest/com/vmware/cis/session").respond(404)
+        with pytest.raises(RuntimeError, match=r"vcenter-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    # The last endpoint attempted is the one named — operators can see
+    # in one log line that both paths failed.
+    assert "/rest/com/vmware/cis/session" in str(exc_info.value)
+    assert "404" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_revokes_against_legacy_path_when_fallback_was_used() -> None:
+    """Mixed-path targets each get DELETE against the endpoint that minted the token.
+
+    A target whose session lived on ``/api/session`` gets DELETE there;
+    a target whose session lived on the legacy ``/rest/com/vmware/cis/session``
+    gets DELETE there. Covers carry-over M2 from iter-1: the original
+    DELETE-emission test only proved revocation against the modern path.
+    With the fallback in place, mixed-path targets in a single connector
+    instance must each revoke against the endpoint that minted their
+    token.
+
+    The modern DELETE on ``vcenter-b`` is *deliberately not registered* —
+    if the connector erroneously DELETEd at ``/api/session`` for a
+    target whose session was established at the legacy path, respx would
+    raise an unhandled-request error.
+    """
+    connector = _make_connector()
+
+    async with respx.mock() as mock:
+        # _TARGET_A: modern path serves the session.
+        mock.post("https://vcenter-a.test.invalid/api/session").respond(200, json="modern-token-a")
+        delete_modern = mock.delete("https://vcenter-a.test.invalid/api/session").respond(204)
+        # _TARGET_B: modern path 404s, legacy path serves the session.
+        mock.post("https://vcenter-b.test.invalid/api/session").respond(404)
+        mock.post("https://vcenter-b.test.invalid/rest/com/vmware/cis/session").respond(
+            200, json="legacy-token-b"
+        )
+        delete_legacy = mock.delete(
+            "https://vcenter-b.test.invalid/rest/com/vmware/cis/session"
+        ).respond(204)
+
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+        await connector.auth_headers(_TARGET_B, raw_jwt="")
+        await connector.aclose()
+
+    # The load-bearing pair of assertions: each target was revoked at
+    # the path that minted its token. ``vcenter-a`` -> modern DELETE,
+    # ``vcenter-b`` -> legacy DELETE; the absence of a registered modern
+    # DELETE route for vcenter-b means any drift would have surfaced
+    # as an unhandled-request error before reaching these asserts.
+    assert delete_modern.called and delete_modern.call_count == 1
+    assert delete_legacy.called and delete_legacy.call_count == 1
+    assert connector._session_paths == {}
+    assert connector._session_tokens == {}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_fingerprint.py
+++ b/backend/tests/test_connectors_vmware_rest_fingerprint.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`VmwareRestConnector` fingerprint + probe (G3.1-T1 #498).
+
+Coverage matrix (per #498 acceptance criteria):
+
+* :func:`product_from_line_id` maps ``vpx``->``vcenter``,
+  ``embeddedEsx``->``esxi``, ``esx``->``esxi``; falls through to the raw
+  line_id for unknown values; defends against ``""`` / ``None``.
+* :meth:`fingerprint` returns canonical :class:`FingerprintResult` for a
+  ``GET /api/about`` response with vendor / product / version / build /
+  edition + the full ``extras`` shape (uuid, full_name, product_line_id,
+  api_type, os_type).
+* :meth:`fingerprint` returns ``reachable=False`` with the exception
+  class + message on transport / connect / TLS / status failure (TCP
+  ``ConnectError``, HTTP 401 from session, 5xx from ``/api/about``).
+* :meth:`probe` returns ``ok=True`` when fingerprint is reachable;
+  ``ok=False`` with ``reason`` populated when not.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vmware_rest import (
+    VmwareRestConnector,
+    VsphereTargetLike,
+    product_from_line_id,
+)
+
+# ---------------------------------------------------------------------------
+# Target stub — same shape as the auth-test module's stub
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET = _StubTarget(
+    name="vcenter-fp",
+    host="vcenter-fp.test.invalid",
+    port=443,
+    secret_ref="kv/data/vsphere/vcenter-fp",
+)
+
+
+async def _stub_loader(_target: VsphereTargetLike) -> dict[str, str]:
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> VmwareRestConnector:
+    return VmwareRestConnector(session_loader=_stub_loader)
+
+
+def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
+    async def _aclose() -> None:
+        connector._session_tokens.clear()
+        for client in connector._clients.values():
+            await client.aclose()
+        connector._clients.clear()
+
+    connector.aclose = _aclose  # type: ignore[method-assign]
+
+
+def _about_payload() -> dict[str, Any]:
+    """Sample /api/about response shape (modelled on real vCenter 8 output)."""
+    return {
+        "product_line_id": "vpx",
+        "version": "9.0.0.10000",
+        "build": "12345678",
+        "license_product_name": "VMware vCenter Server Standard",
+        "instance_uuid": "abcdef01-2345-6789-abcd-ef0123456789",
+        "full_name": "VMware vCenter Server 9.0.0",
+        "api_type": "VirtualCenter",
+        "os_type": "linux-x64",
+    }
+
+
+# ---------------------------------------------------------------------------
+# product_from_line_id mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line_id", "expected"),
+    [
+        ("vpx", "vcenter"),
+        ("embeddedEsx", "esxi"),
+        ("esx", "esxi"),
+        # Fall-through preserves the raw line_id for forward-compat
+        # with future product flavours we don't yet have a canonical
+        # mapping for.
+        ("some-future-product", "some-future-product"),
+        # Empty / missing line_id falls through to "unknown" so the
+        # fingerprint never carries a misleading product slug.
+        ("", "unknown"),
+    ],
+)
+def test_product_from_line_id_mapping(line_id: str, expected: str) -> None:
+    assert product_from_line_id(line_id) == expected
+
+
+# ---------------------------------------------------------------------------
+# fingerprint — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_builds_canonical_shape_for_vcenter() -> None:
+    """A live /api/about response is folded into the canonical FingerprintResult."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="fingerprint-session-token")
+        mock.get("/api/about").respond(200, json=_about_payload())
+        result = await connector.fingerprint(_TARGET)
+
+    assert isinstance(result, FingerprintResult)
+    assert result.vendor == "vmware"
+    assert result.product == "vcenter"  # product_line_id="vpx" -> "vcenter"
+    assert result.version == "9.0.0.10000"
+    assert result.build == "12345678"
+    assert result.edition == "VMware vCenter Server Standard"
+    assert result.reachable is True
+    assert result.probe_method == "GET /api/about"
+    assert dict(result.extras) == {
+        "uuid": "abcdef01-2345-6789-abcd-ef0123456789",
+        "full_name": "VMware vCenter Server 9.0.0",
+        "product_line_id": "vpx",
+        "api_type": "VirtualCenter",
+        "os_type": "linux-x64",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_maps_esxi_product_line_id() -> None:
+    """An ESXi target's product_line_id maps to product=esxi."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    payload = _about_payload()
+    payload["product_line_id"] = "embeddedEsx"
+    payload["api_type"] = "HostAgent"
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="esxi-session-token")
+        mock.get("/api/about").respond(200, json=payload)
+        result = await connector.fingerprint(_TARGET)
+
+    assert result.product == "esxi"
+    assert result.extras["product_line_id"] == "embeddedEsx"
+    assert result.extras["api_type"] == "HostAgent"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint — failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_returns_unreachable_on_connect_error() -> None:
+    """A TCP ConnectError surfaces as reachable=False with the error in extras."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        # The session POST itself fails — the connector wraps that into
+        # a RuntimeError which fingerprint() catches.
+        mock.post("/api/session").mock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.fingerprint(_TARGET)
+
+    assert result.reachable is False
+    # Vendor stays vmware so the operator can identify the failed
+    # connector class without a separate lookup.
+    assert result.vendor == "vmware"
+    assert result.probe_method == "GET /api/about"
+    assert "ConnectError" in result.extras["error"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_returns_unreachable_on_session_401() -> None:
+    """A 401 on POST /api/session surfaces as reachable=False."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(401)
+        result = await connector.fingerprint(_TARGET)
+
+    assert result.reachable is False
+    assert "401" in result.extras["error"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_returns_unreachable_on_about_5xx() -> None:
+    """A 5xx from /api/about (after a successful session POST) surfaces as not-reachable.
+
+    The HttpConnector retries 5xx 3 times before re-raising; we wait
+    for the retry exhaustion by patching tenacity's wait to a no-op.
+    """
+    from unittest.mock import patch
+
+    from tenacity import wait_none
+
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="ok-token")
+        mock.get("/api/about").respond(503)
+        with patch.object(
+            connector._request_json.retry,  # type: ignore[attr-defined]
+            "wait",
+            wait_none(),
+        ):
+            result = await connector.fingerprint(_TARGET)
+
+    assert result.reachable is False
+    assert "503" in result.extras["error"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_when_fingerprint_succeeds() -> None:
+    """probe()==ok=True when fingerprint() returns reachable=True."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="probe-token")
+        mock.get("/api/about").respond(200, json=_about_payload())
+        result = await connector.probe(_TARGET)
+
+    assert isinstance(result, ProbeResult)
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_not_ok_on_connect_error() -> None:
+    """probe()==ok=False with the error message populated when transport fails."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").mock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.probe(_TARGET)
+
+    assert result.ok is False
+    assert result.reason is not None
+    assert "ConnectError" in result.reason
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_not_ok_on_auth_failure() -> None:
+    """probe()==ok=False with the 401 surfaced in reason."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(401)
+        result = await connector.probe(_TARGET)
+
+    assert result.ok is False
+    assert result.reason is not None
+    assert "401" in result.reason
+    await connector.aclose()

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -1,0 +1,167 @@
+# Connector: vmware-rest (vSphere 8.5+ / 9.0)
+
+## Overview
+
+The `vmware-rest` connector is the hand-rolled `HttpConnector` subclass
+that dispatches ingested vCenter REST operations under the
+`(product="vmware", version="9.0", impl_id="vmware-rest")` registry
+triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
+makes ~1,275 `endpoint_descriptor` rows resolvable but not dispatchable)
+to deliver real session-authenticated calls against vSphere 8.5+ /
+ESXi 8.5+ targets.
+
+Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
+
+## Key types
+
+- **`VmwareRestConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="vmware"`, `version="9.0"`,
+  `impl_id="vmware-rest"`, `supported_version_range=">=8.5,<10.0"`,
+  `priority=1`.
+- **`VsphereTargetLike`** (`session.py`) — runtime-checkable Protocol
+  capturing the minimum target shape the connector reads: `name`,
+  `host`, `port`, `secret_ref`, `auth_model`. Replaced by the concrete
+  `Target` model once G0.3 (#224) lands; the model satisfies the
+  Protocol structurally without code edits here.
+- **`VsphereSessionLoader`** (`session.py`) — async callable type
+  resolving a target to `{"username": ..., "password": ...}`.
+  Injectable on connector construction (`VmwareRestConnector(session_loader=…)`)
+  so unit tests, integration tests, and pre-G0.3 production deploys
+  override the default Vault loader.
+- **`load_session_credentials_from_vault`** (`session.py`) — default
+  loader, stubbed `NotImplementedError` until G0.3 lands the
+  operator-context Vault read path. Mirrors the
+  `load_kubeconfig_from_vault` pattern in `connectors/kubernetes/`.
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()` in
+   `meho_backplane/connectors/registry.py`, which walks every
+   `connectors/<product>/` subpackage.
+2. Importing `meho_backplane.connectors.vmware_rest` triggers the
+   module-level `register_connector_v2(product="vmware", version="9.0",
+   impl_id="vmware-rest", cls=VmwareRestConnector)` call.
+3. The registry's v2 table now resolves `(vmware, 9.0, vmware-rest)`
+   to `VmwareRestConnector`. The G0.7 auto-shim's idempotency check
+   (in `ensure_connector_class_registered`, once #408's pipeline lands
+   in main) no-ops on subsequent ingests against the same triple.
+
+### Per-target session
+
+1. First call to `auth_headers(target, raw_jwt)` against a target whose
+   name isn't in `self._session_tokens`:
+   a. Acquires `self._session_lock` (asyncio.Lock).
+   b. Calls `self._session_loader(target)` for the service-account
+      credentials.
+   c. POSTs `/api/session` with HTTP basic auth (creds["username"],
+      creds["password"]).
+   d. Parses the response body: a JSON-quoted string (vSphere 7.0+
+      modern shape) or `{"value": "<token>"}` (pre-7.0 legacy shape;
+      kept for vcsim cross-version compatibility).
+   e. Caches the token under `target.name`.
+2. Subsequent calls take the fast path: lock acquisition + cache hit +
+   return.
+3. The dispatcher's call path
+   (`HttpConnector._request_json` / `_post_json`) reads
+   `auth_headers()`, gets `{"vmware-api-session-id": "<token>"}`, sends
+   it on every dispatched op against this target.
+
+### fingerprint() / probe()
+
+`fingerprint(target)` issues `GET /api/about` (auth headers injected
+lazily via the cached session token); the response payload populates
+the canonical `FingerprintResult`:
+
+- `vendor="vmware"`
+- `product` — via `product_from_line_id(payload.product_line_id)`
+  (`vpx` → `vcenter`; `embeddedEsx`/`esx` → `esxi`; fall-through for
+  unknown values; `""`/`None` → `"unknown"`)
+- `version`, `build`, `edition` — straight from the payload
+- `extras` — `uuid`, `full_name`, `product_line_id`, `api_type`,
+  `os_type`
+
+`probe(target)` delegates to `fingerprint()` and folds the boolean
+reachable flag into a `ProbeResult`. Failure modes (TCP `ConnectError`,
+TLS error, 401 from `/api/session`, 5xx from `/api/about`) surface as
+`reachable=False` with the exception class + message in
+`extras["error"]` / `ProbeResult.reason`.
+
+### aclose()
+
+1. Snapshot the cached session tokens, clear the dict.
+2. For each `(target_name, token)` pair: issue `DELETE /api/session`
+   with the `vmware-api-session-id` header. A failure (5xx, transport
+   error, 401 from an expired session) is logged via structlog
+   `vsphere_session_revoke_failed` / `vsphere_session_revoke_non_2xx`
+   but doesn't block shutdown — Kubernetes' 30 s
+   `terminationGracePeriod` would otherwise be at risk.
+3. Delegate to `super().aclose()` to close the per-target httpx
+   clients.
+
+### execute()
+
+Legacy shim — synthesises a system-tenant `Operator` and calls
+`meho_backplane.operations.dispatch(...)` against the
+`connector_id="vmware-rest-9.0"` encoding. Post-G0.6 callers
+(`/api/v1/operations/call`, MCP `call_operation`, CLI verbs from #511)
+construct a real `Operator` and call `dispatch()` directly; they don't
+reach this method.
+
+## Dependencies
+
+- `meho_backplane.connectors.adapters.http.HttpConnector` (G0.2-T3
+  #242) — transport plumbing (retry, timeout, per-target pool,
+  `_request_json` / `_post_json`).
+- `meho_backplane.connectors.registry.register_connector_v2` (G0.6-T2
+  #393).
+- `meho_backplane.connectors.schemas` — `AuthModel`,
+  `FingerprintResult`, `OperationResult`, `ProbeResult`.
+- `meho_backplane.operations.dispatch` (G0.6-T5 #396) — invoked by
+  `execute()`'s legacy shim.
+- `httpx` (transitively via `HttpConnector`).
+- `structlog` for structured log events.
+- Test-only: `respx` for HTTP mocking in unit tests, `testcontainers`
+  for the vcsim-backed integration test.
+
+## Known issues / gaps
+
+- **Default loader stubbed** — `load_session_credentials_from_vault`
+  raises `NotImplementedError` until G0.3 (#224) lands. Production
+  deploys must inject a custom `session_loader` at connector
+  construction. Same pattern as `KubernetesConnector(kubeconfig_loader=…)`.
+- **`auth_model` enum gating** — only `shared_service_account` (and
+  `None` for pre-G0.3 targets) is accepted. `per_user` and
+  `impersonation` raise `NotImplementedError`; both are deferred to
+  v0.2.next.
+- **No proactive 401 retry** — vSphere's ~5-minute idle timeout means
+  a long-idle connection may see a 401 on the next dispatch. The
+  caller-side retry logic in `_request_json` does not retry 401 by
+  policy; an explicit refresh loop is v0.2.next polish.
+- **`vi-json.yaml` ingestion not yet exercised** — T2 (#501) ships the
+  parser extension for `$ref: #/components/parameters/*`. Once T3
+  (#503) lands, the same connector dispatches the ~2,195 vi-json ops
+  (vi-json shares the `vmware-api-session-id` header per
+  `docs/vcenter-9.0/MANIFEST.md`).
+- **Composites under separate Tasks** — T5 (#508) ships the 5 read
+  composites; T6 (#509) ships the 8 write composites. Both depend on
+  T4 (#504) for the `register_composite_operation()` helper.
+
+## References
+
+- Parent Initiative: [#227 G3.1 vmware-rest-9.0](https://github.com/evoila/meho/issues/227)
+- Parent Task: [#498 G3.1-T1 VmwareRestConnector](https://github.com/evoila/meho/issues/498)
+- G0.7 canary that ingested the rows this connector dispatches:
+  [#408 G0.7-T8 vSphere canary](https://github.com/evoila/meho/issues/408)
+  (closed via PR #493 on 2026-05-15).
+- vSphere REST session contract:
+  [vSphere Automation API security schema](https://developer.broadcom.com/xapis/vsphere-automation-api/latest/api-security-schema/).
+- vcsim simulator: <https://github.com/vmware/govmomi/tree/main/vcsim>.
+- Closest in-repo precedents:
+  - Package layout + v2 registration pattern:
+    `backend/src/meho_backplane/connectors/vault/__init__.py`.
+  - Injectable-loader Protocol pattern:
+    `backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py`.
+  - `auth_headers` + `_request_json` HTTP plumbing:
+    `backend/src/meho_backplane/connectors/adapters/http.py`.


### PR DESCRIPTION
## Summary

Implements G3.1-T1 (#498): the hand-rolled `VmwareRestConnector(HttpConnector)` that turns the ~1,275 vCenter REST `endpoint_descriptor` rows ingested by #408's canary (PR #493) into dispatchable operations. Registers itself against G0.6's v2 registry under `(product="vmware", version="9.0", impl_id="vmware-rest")` at module-import time; once #408's auto-shim infrastructure lands in main, the idempotency check will no-op on this triple.

Surface:

- `auth_headers(target, raw_jwt)` — `POST /api/session` (HTTP basic via an injectable `VsphereSessionLoader`); caches the `vmware-api-session-id` token per `target.name` under an `asyncio.Lock`. Defensively parses both vSphere 7.0+ JSON-string-body session responses and pre-7.0 `{"value": str}` object responses for cross-vcsim-version compatibility. Rejects `auth_model` values other than `shared_service_account` (and `None` for pre-G0.3 targets) with a clear `NotImplementedError`.
- `fingerprint(target)` — `GET /api/about` → canonical `FingerprintResult` (vendor=vmware, product via `product_from_line_id` — `vpx`→`vcenter`, `embeddedEsx`/`esx`→`esxi`, fall-through preserves the raw value; version/build/edition/extras populated). Transport / TLS / status failures surface as `reachable=False` with the exception in `extras["error"]`.
- `probe(target)` — delegates to `fingerprint()`; folds reachable into the `ProbeResult`.
- `execute(target, op_id, params)` — legacy shim that synthesises a system-tenant `Operator` and delegates to G0.6 `dispatch()` (mirrors `VaultConnector.execute`'s pattern). Post-G0.6 callers bypass this and call `dispatch()` directly.
- `aclose()` — revokes every cached session via `DELETE /api/session` before tearing down the per-target httpx pool; revoke failures are logged via structlog without blocking shutdown.

Soft-dep on #224 handled per the task body: the default `load_session_credentials_from_vault` raises `NotImplementedError` until G0.3 lands, mirroring the `load_kubeconfig_from_vault` stub in `connectors/kubernetes/`. Tests inject a stub loader; production callers override at construction.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — 202 files already formatted
- [x] `mypy src/` — 111 source files, no issues
- [x] `pytest tests/test_connectors_vmware_rest_auth.py tests/test_connectors_vmware_rest_fingerprint.py` — 32 passed
- [x] Full unit suite — 1205 passed, 11 skipped (no regressions)
- [x] vcsim integration test (`tests/integration/test_connectors_vmware_rest_vcsim.py`) — skipped in this sandbox (no Docker socket); runs in CI via testcontainers (`vmware/vcsim:latest` overridable via `MEHO_TEST_VCSIM_IMAGE`)

Coverage matrix:

- Session establishment (POST `/api/session` with HTTP basic → JSON string token cached).
- Session reuse (second auth call against same target does NOT re-POST).
- Per-target isolation (two targets → two distinct cached tokens).
- Session-create 401 → wrapped RuntimeError naming the target.
- Unexpected response shape → RuntimeError with target name.
- Legacy `{"value": str}` shape accepted defensively.
- Loader-missing-password-key → clear error.
- `auth_model` gating (per_user / impersonation / unknown rejected; None / shared_service_account / enum-member accepted).
- `aclose()` issues DELETE for every cached session; continues on 5xx, transport, or 401 from DELETE.
- `product_from_line_id` table (vpx/embeddedEsx/esx/unknown/empty).
- `fingerprint()` canonical shape + extras + reachable=False paths (ConnectError, 401, 5xx).
- `probe()` ok/not-ok paths.
- Integration: vcsim fingerprint reachable + probe ok + session reuse + aclose revoke + cache clear.

## Out of scope (sibling tasks under #227)

- `vi-json.yaml` ingestion — #501 (T2 OpenAPI parameter-ref resolver) + #503 (T3 vi-json ingestion).
- Composite operations — #504 (T4 `register_composite_operation` helper) + #508 (T5 5 read composites) + #509 (T6 8 write composites).
- CLI alias verbs `meho vmware {about,vm,host,cluster,...}` — #511 (T7 cobra layer).
- vcsim CI job + JSONFlux handle force-mode + agent-flow E2E — #515 (T8).
- `auth_model: per_user` / `auth_model: impersonation` — deferred to v0.2.next; both raise `NotImplementedError`.

<!-- auto-implement-issue: fresh, iteration 1 -->

---

## Follow-up (auto-implement-issue, iteration 3, 2026-05-15)

Addressed review finding from [pr-518-iter-2.json](.claude/auto/review-results/pr-518-iter-2.json) (`REQUEST_CHANGES`):

- **B1** `0451157` — Extend `_session_token` with a 404-fallback from modern `/api/session` to legacy `/rest/com/vmware/cis/session`. Real vCenter serves both endpoints (production targets hit the fast path); the upstream `vmware/vcsim` simulator registers the session handler only at the legacy path (per `govmomi/vapi/simulator/simulator.go`), so the fallback engages once per target in CI. 401 / 403 / 5xx on the modern path are *not* retried on the legacy path — auth/server failures stay distinct from "endpoint missing" so credential problems don't mask as fallbacks and audit-log entries don't double-up against vCenter's account-lockout protection. The established path is cached per-target in `_session_paths` so `aclose()` DELETEs at the same endpoint that minted each token (mixed-path connectors no longer 404 on revoke or leak sessions until idle timeout).

Five new unit tests in `test_connectors_vmware_rest_auth.py` lock the contract:

- `test_modern_session_endpoint_is_tried_first_no_fallback_on_200` — modern path 200 means the legacy path is never touched.
- `test_session_falls_back_to_legacy_path_on_modern_404` — the vcsim shape: modern 404 → legacy 200; token extracted from the `{"value": str}` response.
- `test_session_does_not_fall_back_on_401_from_modern_endpoint` — 401 is an auth failure, not a fallback signal; the error message names the modern path.
- `test_session_legacy_path_404_surfaces_runtime_error_naming_legacy_path` — both paths 404 → the error names the legacy endpoint (last attempted).
- `test_aclose_revokes_against_legacy_path_when_fallback_was_used` — mixed-path connectors revoke each target at its own endpoint; subsumes carry-over M2 from iter-1's DELETE-emission concern.

Unmocked respx routes assert by absence: any drift to the wrong endpoint surfaces as an unhandled-request error, not a silent mis-match.

The vcsim integration test now passes against stock `vmware/vcsim:latest` without test-side changes.

Deferred (carry-over from iter-1, unchanged — APPROVE-compatible):

- **M1** — `test_importing_package_registers_against_v2_registry` tautology, autouse fixture pre-registers. Non-blocking.
- **M3** — 401-driven session refresh deferred to v0.2.next per task body's *Out of scope*. Non-blocking.
- **q1 / m1 / m2 / m3** — minor / question class, recorded as adjacent findings.

Code-quality hook (`--diff` mode) reports 2 warnings, 0 blockers:

- `connector.py` is 543 lines (warn >400, block >600) — the 21-line `_session_paths` cache + fallback edit keeps it well under the block threshold.
- `_session_token` is 73 lines (warn >60, block >100) — the helper extraction would obscure the lock-scoped cache-check / fast-return / fallback sequence; reconsider only if a third path lands.

<!-- auto-implement-issue: continue, iteration 3 -->

Closes #498


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VMware vSphere REST connector for vCenter/ESXi 8.5+ with per-target session tokens, modern→legacy session endpoint fallback, product-line-id normalization, auth-model gating (shared-service account supported), and graceful session revoke on shutdown.
* **Tests**
  * New unit and integration tests covering auth lifecycle, token caching/isolation, endpoint fallback, fingerprint/probe behavior, and shutdown revocation.
* **Documentation**
  * Added user-facing docs describing connector behavior, session handling, and known limitations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/518)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
