### PR TITLE
feat(cli): G3.1-T7 vmware-rest-9.0 CLI alias verbs — meho vmware {about,vm,host,cluster,datacenter,datastore,network,operation}

### DIFF
--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
 	"github.com/evoila/meho/cli/internal/cmd/targets"
+	"github.com/evoila/meho/cli/internal/cmd/vmware"
 	"github.com/evoila/meho/cli/internal/discovery"
 )
 
@@ -123,6 +124,20 @@ func newRootCmd() *cobra.Command {
 	// registerDynamicSubcommands so the backplane manifest cannot
 	// shadow the built-in `kb` parent.
 	root.AddCommand(kb.NewRootCmd())
+
+	// G3.1-T7 (#511) -- vmware-rest-9.0 operator alias verbs for
+	// Initiative #227. The verb tree pre-bakes connector_id=
+	// "vmware-rest-9.0" on top of the existing /api/v1/operations/call
+	// dispatcher route so operators don't type the connector ID on
+	// every invocation. PR-1 ships raw-REST verbs (about, vm list/info,
+	// host list, cluster list, datacenter/datastore/network list,
+	// operation search/call); composite-backed verbs (vm create, host
+	// evacuate, cluster patch) become end-to-end dispatchable once
+	// G3.1-T5 (#508) + G3.1-T6 (#509) register the underlying
+	// composite ops. Registered before registerDynamicSubcommands so
+	// the backplane manifest cannot shadow the built-in `vmware`
+	// parent.
+	root.AddCommand(vmware.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/cli/internal/cmd/root_test.go
+++ b/cli/internal/cmd/root_test.go
@@ -27,7 +27,7 @@ func TestRootCmdHasExpectedSubcommands(t *testing.T) {
 	for _, c := range root.Commands() {
 		names[c.Name()] = true
 	}
-	for _, want := range []string{"version", "login", "status", "operation", "retrieval", "connector", "targets"} {
+	for _, want := range []string{"version", "login", "status", "operation", "retrieval", "connector", "targets", "vmware"} {
 		if !names[want] {
 			t.Errorf("expected built-in subcommand %q; got %v", want, names)
 		}

--- a/cli/internal/cmd/vmware/about.go
+++ b/cli/internal/cmd/vmware/about.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAboutCmd returns the `meho vmware about` command.
+//
+// CLI shape:
+//
+//	meho vmware about \
+//	  [--target <slug>]                        # vCenter target (required for dispatch)
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// Maps to op_id `GET:/api/about` (vSphere REST 9.0's product info
+// endpoint). The renderer surfaces vSphere product / version / build
+// in the human path; --json emits the raw OperationResult envelope.
+//
+// Exit codes follow the meho operation call convention (see #511
+// references):
+//   - 0   operation invoked + status == "ok"
+//   - 1   operation invoked but status == "error" / "denied"
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape
+func newAboutCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "about",
+		Short: "Show vSphere product, version, and build for a target",
+		Long: "about dispatches GET:/api/about against the connector_id=\"vmware-rest-9.0\"\n" +
+			"connector and renders the vSphere product / version / build / api_type\n" +
+			"fields the endpoint returns. The human render is a 4-line summary; --json\n" +
+			"emits the full OperationResult envelope for scripting.\n\n" +
+			"--target names the vCenter target slug; required if no operator default\n" +
+			"target is configured. The dispatch path is the same /api/v1/operations/call\n" +
+			"route the agent surface uses — auth, audit, broadcast, and policy gates\n" +
+			"all run as documented in CLAUDE.md §6.\n\n" +
+			"Exit codes mirror meho operation call:\n" +
+			"  - 0   status == ok\n" +
+			"  - 1   status == error / denied\n" +
+			"  - 2   auth_expired (run `meho login`)\n" +
+			"  - 3   unreachable (network / DNS / TLS)\n" +
+			"  - 4   unexpected response shape",
+		Example: "  meho vmware about --target rdc-vcenter\n" +
+			"  meho vmware about --target rdc-vcenter --json | jq .result",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAbout(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required for ops that read a target)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/about", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "GET:/api/about", r, jsonOut, printAbout)
+}
+
+// printAbout renders the about endpoint's result fields. The vSphere
+// REST /api/about endpoint returns
+// `{"product", "version", "build", "api_type", ...}` — the renderer
+// pulls those four fields and falls back to the generic envelope
+// renderer for unexpected shapes.
+//
+// Why the per-field unpack: operators read about output to confirm
+// which vCenter they're talking to (product line varies between
+// VMware Cloud Foundation and standalone vSphere). The generic
+// JSON dump is too noisy for that decision; a 4-line summary fits
+// in a glance.
+func printAbout(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/api/about — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	about, ok := decodeAboutPayload(r.Result)
+	if !ok {
+		// Fallback to raw JSON dump when the shape doesn't match the
+		// documented /api/about contract. Contract drift surfaces at
+		// the inspection layer rather than as a panic.
+		pretty, perr := prettyJSON(r.Result)
+		if perr == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if about.Product != "" {
+		fmt.Fprintf(w, "  product:  %s\n", about.Product)
+	}
+	if about.Version != "" {
+		fmt.Fprintf(w, "  version:  %s\n", about.Version)
+	}
+	if about.Build != "" {
+		fmt.Fprintf(w, "  build:    %s\n", about.Build)
+	}
+	if about.APIType != "" {
+		fmt.Fprintf(w, "  api_type: %s\n", about.APIType)
+	}
+}
+
+// aboutPayload mirrors the documented vSphere REST /api/about shape.
+// Extra fields land in the raw JSON dump fallback (the typed struct
+// only covers the four fields operators read; the rest are scripted
+// consumers' concern via --json).
+type aboutPayload struct {
+	Product string `json:"product"`
+	Version string `json:"version"`
+	Build   string `json:"build"`
+	APIType string `json:"api_type"`
+}
+
+// decodeAboutPayload unpacks the result envelope into the typed
+// aboutPayload. Two response shapes accepted:
+//   - the canonical vSphere 9.0 shape: bare `{"product":..., ...}`.
+//   - the legacy 6.x/7.x wrapper: `{"value":{"product":..., ...}}` —
+//     some 9.0 endpoints still emit the wrapper when the request
+//     carries a legacy `Accept` header. Both shapes ship via the
+//     same `endpoint_descriptor`; the unwrap stays best-effort.
+func decodeAboutPayload(raw []byte) (aboutPayload, bool) {
+	var bare aboutPayload
+	if err := jsonUnmarshalStrict(raw, &bare); err == nil && bare.Product != "" {
+		return bare, true
+	}
+	var wrapped struct {
+		Value aboutPayload `json:"value"`
+	}
+	if err := jsonUnmarshalStrict(raw, &wrapped); err == nil && wrapped.Value.Product != "" {
+		return wrapped.Value, true
+	}
+	return aboutPayload{}, false
+}
+
+// printErrorTrailer surfaces the dispatcher error / extras envelope.
+// Used by every per-verb pretty-printer's error branch so the
+// "status=error" output is consistent across verbs.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}

--- a/cli/internal/cmd/vmware/cluster.go
+++ b/cli/internal/cmd/vmware/cluster.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newClusterCmd returns the `meho vmware cluster` parent command
+// and assembles its two verbs (list / patch).
+func newClusterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "cluster",
+		Short:        "vSphere cluster verbs (list / patch)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newClusterListCmd())
+	cmd.AddCommand(newClusterPatchCmd())
+	return cmd
+}
+
+// newClusterListCmd returns `meho vmware cluster list`. Maps to
+// GET:/vcenter/cluster.
+func newClusterListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vSphere clusters on a vCenter target",
+		Long: "list dispatches GET:/vcenter/cluster against the connector_id=\n" +
+			"\"vmware-rest-9.0\" connector. Renders moid / name / drs_enabled /\n" +
+			"ha_enabled for human eyes; --json emits the full OperationResult\n" +
+			"envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vmware cluster list --target rdc-vcenter\n" +
+			"  meho vmware cluster list --target rdc-vcenter --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runClusterList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runClusterList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/vcenter/cluster", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "GET:/vcenter/cluster", r, jsonOut, printClusterList)
+}
+
+func printClusterList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/vcenter/cluster — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 clusters)")
+		return
+	}
+	fmt.Fprintf(w, "%-16s %-30s %-12s %-10s\n", "moid", "name", "drs", "ha")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-16s %-30s %-12v %-10v\n",
+			truncate(stringField(e, "cluster"), 16),
+			truncate(stringField(e, "name"), 30),
+			e["drs_enabled"],
+			e["ha_enabled"],
+		)
+	}
+}
+
+// newClusterPatchCmd returns `meho vmware cluster patch <name>`.
+// Resolves the name to a cluster moid then dispatches the composite
+// op_id vmware.composite.cluster.patch (ships in T6 #509).
+func newClusterPatchCmd() *cobra.Command {
+	var (
+		targetName        string
+		specFlag          string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "patch <name-or-id>",
+		Short: "Patch a vSphere cluster (composite: lifecycle-managed)",
+		Long: "patch dispatches op_id=\"vmware.composite.cluster.patch\" against\n" +
+			"the connector_id=\"vmware-rest-9.0\" connector. The composite\n" +
+			"orchestrates the vSphere Lifecycle Manager patch flow (precheck +\n" +
+			"stage + apply + post-validation) that ships in G3.1-T6 (#509).\n\n" +
+			"<name-or-id> accepts a cluster name (resolved client-side to a\n" +
+			"`domain-c<N>` moid) or a moid directly.\n\n" +
+			"--spec accepts inline JSON or @<file> describing the patch payload\n" +
+			"(see the T6 task body for the field list).\n\n" +
+			"Pre-merge of T6 (#509), the dispatcher returns \"operation not\n" +
+			"found\" which surfaces in the standard error trailer.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vmware cluster patch dc-prod-01 --target rdc-vcenter --spec @patch.json\n" +
+			"  meho vmware cluster patch domain-c123 --target rdc-vcenter --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runClusterPatch(cmd, args[0], targetName, specFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().StringVar(&specFlag, "spec", "", "patch spec as inline JSON or @<file>; optional")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runClusterPatch(cmd *cobra.Command, nameOrID, targetName, specFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	moid, err := resolveName(cmd.Context(), backplaneURL, targetName, "cluster", nameOrID)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			&output.StructuredError{Code: "resolve_failed", Detail: err.Error(), Exit: 1},
+			jsonOut)
+	}
+	params, err := loadParamsFlag(specFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	if params == nil {
+		params = map[string]any{}
+	}
+	params["cluster"] = moid
+	opID := "vmware.composite.cluster.patch"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, nil)
+}

--- a/cli/internal/cmd/vmware/dispatch.go
+++ b/cli/internal/cmd/vmware/dispatch.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model.
+// Same shape as cmd/operation/CallResult; duplicated here because
+// cmd/vmware can't import cmd/operation without an import cycle
+// (cmd/root.go grafts both onto the tree).
+//
+// Result is left as json.RawMessage because the backend types it as
+// a oneOf(dict, list) union — pretty-printing the raw bytes is the
+// cleanest renderer until a per-shape table specialisation lands.
+// Same approach the operation sibling takes.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic
+// model. Target uses a map[string]any so the empty case serialises
+// as `null` rather than an empty struct; the route layer's resolver
+// short-circuits on the missing-name case (raising 400) for the few
+// ops that do need a target.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+// errOpError is the sentinel returned when the dispatcher reported a
+// structured-failure result (status == "error" or status ==
+// "denied"). main translates non-nil RunE errors into a non-zero
+// exit; SilenceErrors=true on each command keeps cobra from double-
+// printing the error string. Same shape as the operation sibling's
+// errOpError.
+var errOpError = errors.New("operation status not ok")
+
+// dispatchOp POSTs an OperationCall to the backplane and returns the
+// decoded CallResult. The pre-baked connector_id ("vmware-rest-9.0")
+// is baked in; callers pass op_id, an optional target slug (empty
+// string → no target field on the wire), and an optional params map.
+//
+// Centralised here so every verb in the package shares one
+// dispatcher implementation (over a dozen call sites). Renamed from
+// the operation sibling's postCall to make the call sites self-
+// documenting at the grep level: a grep for `dispatchOp` finds every
+// alias-verb dispatch in the vmware package.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: ConnectorID,
+		OpID:        opID,
+		Target:      nil,
+	}
+	if targetSlug != "" {
+		body.Target = map[string]any{"name": targetSlug}
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderCallResult handles the unified post-dispatch path every verb
+// uses: validate status enum, render the envelope (JSON or human),
+// then translate "error" / "denied" into the errOpError sentinel so
+// main propagates the right non-zero exit. Returns nil on success
+// or one of:
+//   - errOpError (status == "error" / "denied" → exit 1)
+//   - a structured renderer error (unexpected status → exit 4)
+//
+// Pretty-printing is delegated to a per-verb closure so verb files
+// can lay out their domain-specific tables (vm list shows
+// name/power/host/datastore columns; cluster list shows different
+// columns). When prettyPrinter is nil, the fallback renders the
+// generic envelope shape the operation sibling uses — handy for the
+// composite-backed verbs whose output is opaque to the CLI today.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+		// fall through.
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		printGenericResult(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+// printGenericResult renders a CallResult in the same shape the
+// operation sibling's printCallResult uses. Used as the fallback
+// pretty-printer for verbs that don't define their own table layout
+// (composite-backed verbs whose result envelope is opaque to the
+// CLI; the operation call wrapper which is a verbatim pass-through).
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
+// Same implementation as the operation sibling.
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cli/internal/cmd/vmware/host.go
+++ b/cli/internal/cmd/vmware/host.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newHostCmd returns the `meho vmware host` parent command and
+// assembles its two verbs (list / evacuate).
+func newHostCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "host",
+		Short:        "vSphere host verbs (list / evacuate)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newHostListCmd())
+	cmd.AddCommand(newHostEvacuateCmd())
+	return cmd
+}
+
+// newHostListCmd returns `meho vmware host list`. Maps to
+// GET:/vcenter/host.
+func newHostListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List ESXi hosts on a vCenter target",
+		Long: "list dispatches GET:/vcenter/host against the connector_id=\n" +
+			"\"vmware-rest-9.0\" connector. Renders moid / name / connection_state /\n" +
+			"power_state for human eyes; --json emits the full OperationResult\n" +
+			"envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vmware host list --target rdc-vcenter\n" +
+			"  meho vmware host list --target rdc-vcenter --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runHostList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runHostList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/vcenter/host", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "GET:/vcenter/host", r, jsonOut, printHostList)
+}
+
+func printHostList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/vcenter/host — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 hosts)")
+		return
+	}
+	fmt.Fprintf(w, "%-16s %-30s %-16s %-14s\n", "moid", "name", "connection", "power")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-16s %-30s %-16s %-14s\n",
+			truncate(stringField(e, "host"), 16),
+			truncate(stringField(e, "name"), 30),
+			truncate(stringField(e, "connection_state"), 16),
+			truncate(stringField(e, "power_state"), 14),
+		)
+	}
+}
+
+// newHostEvacuateCmd returns `meho vmware host evacuate <name>`.
+// Resolves the name to a moid then dispatches the composite op_id
+// vmware.composite.host.evacuate (ships in T6 #509).
+func newHostEvacuateCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "evacuate <name-or-id>",
+		Short: "Evacuate a host (composite: vMotion all VMs off then maintenance-mode)",
+		Long: "evacuate dispatches op_id=\"vmware.composite.host.evacuate\" against\n" +
+			"the connector_id=\"vmware-rest-9.0\" connector. The composite\n" +
+			"orchestrates vMotion of every VM off the host then transitions\n" +
+			"the host into maintenance mode (T6 #509).\n\n" +
+			"<name-or-id> accepts a host name (resolved client-side to a moid)\n" +
+			"or a moid directly. Resolution failures (not-found, ambiguous)\n" +
+			"exit with status 1 and a message listing candidates.\n\n" +
+			"Pre-merge of T6 (#509), the dispatcher returns \"operation not\n" +
+			"found\" which surfaces in the standard error trailer.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vmware host evacuate esxi-01 --target rdc-vcenter\n" +
+			"  meho vmware host evacuate host-23 --target rdc-vcenter --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHostEvacuate(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runHostEvacuate(cmd *cobra.Command, nameOrID, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	moid, err := resolveName(cmd.Context(), backplaneURL, targetName, "host", nameOrID)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			&output.StructuredError{Code: "resolve_failed", Detail: err.Error(), Exit: 1},
+			jsonOut)
+	}
+	opID := "vmware.composite.host.evacuate"
+	params := map[string]any{"host": moid}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, nil)
+}

--- a/cli/internal/cmd/vmware/listverbs.go
+++ b/cli/internal/cmd/vmware/listverbs.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// The three flat list verbs (datacenter / datastore / network) share
+// the same shape: dispatch GET:/vcenter/<kind> with no params and
+// render a 2-column moid/name table. The newSimpleListCmd factory
+// produces the cobra commands; per-kind specialisations live in the
+// per-verb factories below.
+
+// simpleListSpec captures the per-verb knobs newSimpleListCmd needs:
+// the cobra Use+Short strings, the op_id, and the moid field name
+// (which differs per kind — see resolve.go's moidFieldForKind).
+type simpleListSpec struct {
+	use      string
+	short    string
+	long     string
+	example  string
+	opID     string
+	moidKey  string
+	zeroText string
+}
+
+func newSimpleListCmd(spec simpleListSpec) *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           spec.use,
+		Short:         spec.short,
+		Long:          spec.long,
+		Example:       spec.example,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSimpleList(cmd, spec, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runSimpleList(cmd *cobra.Command, spec simpleListSpec, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, spec.opID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, spec.opID, r, jsonOut, makeSimpleListPrinter(spec))
+}
+
+func makeSimpleListPrinter(spec simpleListSpec) func(io.Writer, *CallResult) {
+	return func(w io.Writer, r *CallResult) {
+		fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, spec.opID, r.Status, r.DurationMs)
+		if r.Status != "ok" {
+			printErrorTrailer(w, r)
+			return
+		}
+		entries, err := decodeListResult(r.Result)
+		if err != nil {
+			fallbackResultRender(w, r)
+			return
+		}
+		if len(entries) == 0 {
+			fmt.Fprintln(w, spec.zeroText)
+			return
+		}
+		fmt.Fprintf(w, "%-20s %-40s\n", "moid", "name")
+		for _, e := range entries {
+			fmt.Fprintf(w, "%-20s %-40s\n",
+				truncate(stringField(e, spec.moidKey), 20),
+				truncate(stringField(e, "name"), 40),
+			)
+		}
+	}
+}
+
+// newDatacenterCmd returns `meho vmware datacenter`. The parent is a
+// thin namespace command with one verb (`list`) so the future
+// `datacenter <other-verb>` additions slot under the same parent
+// without renaming.
+func newDatacenterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "datacenter",
+		Short:        "vSphere datacenter verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSimpleListCmd(simpleListSpec{
+		use:   "list",
+		short: "List vSphere datacenters on a vCenter target",
+		long: "list dispatches GET:/vcenter/datacenter against the connector_id=\n" +
+			"\"vmware-rest-9.0\" connector. Renders moid / name for human eyes;\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		example:  "  meho vmware datacenter list --target rdc-vcenter\n  meho vmware datacenter list --target rdc-vcenter --json",
+		opID:     "GET:/vcenter/datacenter",
+		moidKey:  "datacenter",
+		zeroText: "  (0 datacenters)",
+	}))
+	return cmd
+}
+
+// newDatastoreCmd returns `meho vmware datastore`. See
+// newDatacenterCmd's comment for the wrapping rationale.
+func newDatastoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "datastore",
+		Short:        "vSphere datastore verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSimpleListCmd(simpleListSpec{
+		use:   "list",
+		short: "List vSphere datastores on a vCenter target",
+		long: "list dispatches GET:/vcenter/datastore against the connector_id=\n" +
+			"\"vmware-rest-9.0\" connector. Renders moid / name for human eyes;\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		example:  "  meho vmware datastore list --target rdc-vcenter\n  meho vmware datastore list --target rdc-vcenter --json",
+		opID:     "GET:/vcenter/datastore",
+		moidKey:  "datastore",
+		zeroText: "  (0 datastores)",
+	}))
+	return cmd
+}
+
+// newNetworkCmd returns `meho vmware network`. See
+// newDatacenterCmd's comment for the wrapping rationale.
+func newNetworkCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "network",
+		Short:        "vSphere network verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSimpleListCmd(simpleListSpec{
+		use:   "list",
+		short: "List vSphere networks on a vCenter target",
+		long: "list dispatches GET:/vcenter/network against the connector_id=\n" +
+			"\"vmware-rest-9.0\" connector. Renders moid / name for human eyes;\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		example:  "  meho vmware network list --target rdc-vcenter\n  meho vmware network list --target rdc-vcenter --json",
+		opID:     "GET:/vcenter/network",
+		moidKey:  "network",
+		zeroText: "  (0 networks)",
+	}))
+	return cmd
+}

--- a/cli/internal/cmd/vmware/operation.go
+++ b/cli/internal/cmd/vmware/operation.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newOperationCmd returns the `meho vmware operation` parent command
+// and assembles its two pre-scoped meta-tool wrappers (search /
+// call). The wrappers re-route to the same /api/v1/operations/*
+// routes the generic `meho operation` verbs use but pre-bake the
+// connector_id="vmware-rest-9.0" argument so operators don't type
+// it on every invocation.
+func newOperationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "operation",
+		Short:        "Pre-scoped meta-tool wrappers (search / call) for vmware-rest-9.0",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newOperationSearchCmd())
+	cmd.AddCommand(newOperationCallCmd())
+	return cmd
+}
+
+// searchHit mirrors the backend OperationSearchHit Pydantic model.
+// Same shape as cmd/operation's SearchHit — duplicated to avoid an
+// import cycle; the wire shape is canonical and stable.
+type searchHit struct {
+	OpID             string   `json:"op_id"`
+	Summary          *string  `json:"summary"`
+	Description      *string  `json:"description"`
+	GroupKey         *string  `json:"group_key"`
+	SafetyLevel      string   `json:"safety_level"`
+	RequiresApproval bool     `json:"requires_approval"`
+	FusedScore       float64  `json:"fused_score"`
+	Bm25Score        *float64 `json:"bm25_score"`
+	CosineScore      *float64 `json:"cosine_score"`
+}
+
+// searchResponse mirrors the backend OperationSearchResponse model.
+type searchResponse struct {
+	Hits            []searchHit `json:"hits"`
+	QueryDurationMs float64     `json:"query_duration_ms"`
+}
+
+// newOperationSearchCmd returns `meho vmware operation search`.
+//
+// CLI shape:
+//
+//	meho vmware operation search "<query>" \
+//	  [--group <key>]                          # narrow within one group
+//	  [--limit N]                              # 1..50, default 10
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+func newOperationSearchCmd() *cobra.Command {
+	var (
+		groupKey          string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Hybrid BM25 + cosine RRF search across vmware-rest-9.0 operations",
+		Long: "search wraps GET /api/v1/operations/search with connector_id=\n" +
+			"\"vmware-rest-9.0\" pre-baked. The query is a free-form prose\n" +
+			"intent (e.g. \"list VMs on cluster\", \"snapshot revert\"); the\n" +
+			"backplane runs hybrid BM25 + cosine retrieval with Reciprocal\n" +
+			"Rank Fusion and returns the top --limit hits (default 10,\n" +
+			"clamped at 50 by the API).\n\n" +
+			"--group narrows to one group_key within the connector (useful\n" +
+			"when the same intent maps to multiple groups — e.g. \"power\"\n" +
+			"matches vm.power and host.power).\n\n" +
+			"Exit codes mirror meho operation search.",
+		Example: "  meho vmware operation search \"list VMs\"\n" +
+			"  meho vmware operation search \"snapshot revert\" --group vm.snapshot\n" +
+			"  meho vmware operation search \"host evacuate\" --limit 5 --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationSearch(cmd, args[0], groupKey, limit, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&groupKey, "group", "",
+		"narrow the search to one group_key within the connector")
+	cmd.Flags().IntVar(&limit, "limit", 10,
+		"max hits to return (1..50, clamped by the API at 50)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, jsonOut bool, backplaneOverride string) error {
+	if limit < 1 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
+			jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printSearchTable(cmd.OutOrStdout(), query, result)
+	return nil
+}
+
+func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
+	q := url.Values{}
+	q.Set("connector_id", ConnectorID)
+	q.Set("query", query)
+	if groupKey != "" {
+		q.Set("group", groupKey)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/operations/search?" + q.Encode()
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out searchResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+	return &out, nil
+}
+
+func printSearchTable(w io.Writer, query string, r *searchResponse) {
+	fmt.Fprintf(w, "search %s %q — %d hit(s) in %.0fms\n",
+		ConnectorID, query, len(r.Hits), r.QueryDurationMs)
+	if len(r.Hits) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%-40s %6s  %s\n", "op_id", "score", "summary")
+	for _, h := range r.Hits {
+		fmt.Fprintf(w, "%-40s %6.3f  %s\n",
+			truncate(h.OpID, 40),
+			h.FusedScore,
+			truncate(strDeref(h.Summary), 80),
+		)
+	}
+}
+
+// strDeref returns *s or empty string when s is nil. Mirrors the
+// operation sibling's helper (duplicated for import-cycle reasons).
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// newOperationCallCmd returns `meho vmware operation call`. Pre-
+// scoped wrapper around `meho operation call <connector_id> <op_id>`
+// that saves the `vmware-rest-9.0` typing.
+//
+// CLI shape:
+//
+//	meho vmware operation call <op_id> \
+//	  [--target <slug>]                        # vCenter target slug
+//	  [--params '<json>' | @<file>]            # operation params
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+func newOperationCallCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "call <op_id>",
+		Short: "Dispatch any vmware-rest-9.0 op_id (escape hatch for ops without aliases)",
+		Long: "call wraps POST /api/v1/operations/call with connector_id=\n" +
+			"\"vmware-rest-9.0\" pre-baked. Use this verb when an op doesn't\n" +
+			"have a dedicated alias yet (e.g. `meho vmware operation call\n" +
+			"DELETE:/api/vcenter/vm/{vm} --target rdc-vcenter --params\n" +
+			"'{\"vm\":\"vm-101\"}'`).\n\n" +
+			"--target names the vCenter target slug; --params accepts inline\n" +
+			"JSON or @<file>; --json emits the OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call:\n" +
+			"  - 0   status == ok\n" +
+			"  - 1   status == error / denied\n" +
+			"  - 2   auth_expired\n" +
+			"  - 3   unreachable\n" +
+			"  - 4   unexpected response shape",
+		Example: "  meho vmware operation call GET:/vcenter/cluster --target rdc-vcenter\n" +
+			"  meho vmware operation call DELETE:/api/vcenter/vm/{vm} --target rdc-vcenter --params '{\"vm\":\"vm-101\"}'\n" +
+			"  meho vmware operation call vmware.composite.vm.create --target rdc-vcenter --params @new-vm.json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationCall(cmd, args[0], targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required for ops that read a target)")
+	cmd.Flags().StringVar(&paramsFlag, "params", "",
+		"operation params as inline JSON or @<file>; omitted means no params")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, nil)
+}

--- a/cli/internal/cmd/vmware/resolve.go
+++ b/cli/internal/cmd/vmware/resolve.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// moidPatterns lists the per-kind regular expressions used to detect
+// "input is already a moid; skip the resolve round-trip" cases.
+// Operators paste moids when they have them (from the vSphere UI's
+// URL bar, from `govc` output, etc.); the helper transparently
+// passes those through. The patterns mirror vSphere's documented
+// moid grammar (datacenter-N, folder-N, group-NN, host-N, etc.).
+//
+// The vSphere REST API itself doesn't pin a strict moid grammar —
+// the strings happen to land in shapes vCenter generates internally,
+// and a typo'd "vm-X" with a non-numeric tail would surface as a
+// not-found at the dispatcher rather than here, which is the right
+// failure mode (we don't want to second-guess the backplane).
+var moidPatterns = map[string]*regexp.Regexp{
+	"vm":         regexp.MustCompile(`^vm-\d+$`),
+	"host":       regexp.MustCompile(`^host-\d+$`),
+	"cluster":    regexp.MustCompile(`^domain-c\d+$`),
+	"datacenter": regexp.MustCompile(`^datacenter-\d+$`),
+	"datastore":  regexp.MustCompile(`^datastore-\d+$`),
+	"network":    regexp.MustCompile(`^network-\d+$`),
+}
+
+// isMoid returns true when name matches the moid grammar for kind.
+// Falls back to false for unknown kinds — name-resolution then runs
+// against the filter API which produces a clearer not-found message
+// than client-side guessing would.
+func isMoid(kind, name string) bool {
+	pat, ok := moidPatterns[kind]
+	if !ok {
+		return false
+	}
+	return pat.MatchString(name)
+}
+
+// listEntry is the per-row shape vSphere's GET /vcenter/<kind>
+// endpoints return inside `value`. v0.2 only needs the moid field
+// (named per the vSphere docs: `vm`, `host`, `cluster`, etc.) and
+// the human-readable `name`; everything else is decoded into
+// json.RawMessage so the resolver doesn't have to track schema
+// drift on unused fields.
+//
+// The moid field name differs by kind. The decoder pulls both the
+// canonical name field (`name`) and the kind-specific moid field;
+// resolveName picks the right moid field at call time so this struct
+// can stay generic.
+type listEntry map[string]any
+
+// moidFieldForKind returns the per-kind moid field name in the
+// vSphere REST response. The vSphere documentation pins these:
+//   - /vcenter/vm         → object has `vm` field
+//   - /vcenter/host       → object has `host` field
+//   - /vcenter/cluster    → object has `cluster` field
+//   - /vcenter/datacenter → object has `datacenter` field
+//   - /vcenter/datastore  → object has `datastore` field
+//   - /vcenter/network    → object has `network` field
+func moidFieldForKind(kind string) string {
+	return kind
+}
+
+// resolveName resolves a human-readable name to a vSphere moid by
+// calling GET /vcenter/<kind>?filter.names=<name> through the
+// backplane dispatcher and inspecting the returned list. Three
+// outcomes:
+//
+//   - input matches the moid grammar for kind → returned verbatim
+//     (no round-trip). Operators with moids in hand skip the call.
+//   - input is a name + exactly one match → moid returned.
+//   - input is a name + zero matches → error "no <kind> named …".
+//   - input is a name + multiple matches → error listing all
+//     candidate moids with their folder/cluster context so the
+//     operator can re-invoke with the moid directly.
+//
+// The vSphere REST API's filter.names parameter is documented as
+// "list of names to filter by"; passing a single value returns
+// zero-or-more matches under the same code path as a multi-value
+// query. The dispatcher's status==error path surfaces as a returned
+// error from this helper so per-verb runners can translate it into
+// the right exit code (1, treating bad input the same as a
+// dispatcher-reported failure).
+func resolveName(
+	ctx context.Context,
+	backplaneURL, targetSlug, kind, name string,
+) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("empty %s name", kind)
+	}
+	if isMoid(kind, name) {
+		return name, nil
+	}
+	// Build the GET op_id matching how the backplane registers
+	// vSphere REST GET endpoints: `GET:/vcenter/<kind>`. The dispatcher
+	// applies query params from the params map; vSphere's filter syntax
+	// is `filter.names=<comma-separated>` (or, for some 9.0 endpoints,
+	// a `names` field on a filter object — the backplane normalises
+	// both shapes through the same endpoint_descriptor).
+	opID := fmt.Sprintf("GET:/vcenter/%s", kind)
+	params := map[string]any{
+		"filter.names": name,
+	}
+	r, err := dispatchOp(ctx, backplaneURL, opID, targetSlug, params)
+	if err != nil {
+		return "", err
+	}
+	if r.Status != "ok" {
+		if r.Error != nil && *r.Error != "" {
+			return "", fmt.Errorf("resolve %s %q failed: %s", kind, name, *r.Error)
+		}
+		return "", fmt.Errorf("resolve %s %q failed: dispatcher status %s", kind, name, r.Status)
+	}
+	matches, err := decodeListResult(r.Result)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s %q: %w", kind, name, err)
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no %s named %q on target %q; check the name or pass the vSphere moid directly", kind, name, targetSlug)
+	case 1:
+		moid, ok := matches[0][moidFieldForKind(kind)].(string)
+		if !ok || moid == "" {
+			return "", fmt.Errorf("resolve %s %q: vSphere response missing %q field", kind, name, moidFieldForKind(kind))
+		}
+		return moid, nil
+	default:
+		// Ambiguous: pull every candidate moid into the error message
+		// so the operator can re-invoke with the moid directly. Folder /
+		// cluster context fields are surfaced when present (vSphere
+		// returns these for vm + host queries) but stay best-effort —
+		// the moids themselves are the load-bearing disambiguator.
+		var detail []string
+		moidField := moidFieldForKind(kind)
+		for _, m := range matches {
+			candidate := fmt.Sprintf("%v", m[moidField])
+			if pathCtx, ok := contextHint(kind, m); ok {
+				candidate = fmt.Sprintf("%s (%s)", candidate, pathCtx)
+			}
+			detail = append(detail, candidate)
+		}
+		return "", fmt.Errorf("name %q resolved to %d candidates: %s; pass the moid directly", name, len(matches), joinComma(detail))
+	}
+}
+
+// decodeListResult handles both vSphere response shapes the
+// dispatcher can pass through:
+//
+//   - `{"value": [{...}, {...}]}` — the v0.1 wrapping shape (vSphere
+//     6.x / 7.x compatibility envelope; still emitted by some 9.0
+//     endpoints when an `Accept` header asks for it).
+//   - `[{...}, {...}]` — the 9.0 bare-array shape (the dispatcher's
+//     pre-T2 unwrap was load-bearing for the test fixtures).
+//
+// Both shapes decode into the same `[]listEntry` so the resolver
+// caller doesn't have to branch on response shape.
+func decodeListResult(raw json.RawMessage) ([]listEntry, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	// Try the bare-array shape first; it's the canonical vSphere 9.0
+	// response. A failed decode falls through to the value-wrapped
+	// shape rather than erroring (UnmarshalTypeError on object-vs-
+	// array kicks in cleanly).
+	var arr []listEntry
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr, nil
+	}
+	var wrapped struct {
+		Value []listEntry `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err != nil {
+		return nil, fmt.Errorf("decode list result: %w", err)
+	}
+	return wrapped.Value, nil
+}
+
+// contextHint pulls a kind-specific path hint out of a vSphere list
+// entry so the ambiguous-name error message can surface
+// folder/cluster context alongside the bare moid. Best-effort —
+// returns ok=false when the entry has no such field, and the caller
+// renders the candidate moid alone.
+func contextHint(kind string, entry listEntry) (string, bool) {
+	switch kind {
+	case "vm":
+		// vm entries on 9.0 carry `name` + `power_state` + the moid;
+		// folder context is not in the default response. Skip.
+		return "", false
+	case "host":
+		// host entries carry `connection_state` which doubles as a
+		// useful disambiguator alongside the moid.
+		if v, ok := entry["connection_state"].(string); ok && v != "" {
+			return "state=" + v, true
+		}
+		return "", false
+	case "cluster":
+		if v, ok := entry["name"].(string); ok && v != "" {
+			return "name=" + v, true
+		}
+		return "", false
+	default:
+		return "", false
+	}
+}
+
+// joinComma joins strings with ", " separators. Trivial helper kept
+// inline because strings.Join would suffice but the linter prefers
+// a single allocation site for sequence-aware formatting.
+func joinComma(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += ", " + p
+	}
+	return out
+}

--- a/cli/internal/cmd/vmware/vm.go
+++ b/cli/internal/cmd/vmware/vm.go
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newVMCmd returns the `meho vmware vm` parent command and assembles
+// its three verbs (list / info / create). The parent itself takes no
+// args and prints its own help.
+func newVMCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "vm",
+		Short:        "vSphere VM verbs (list / info / create)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newVMListCmd())
+	cmd.AddCommand(newVMInfoCmd())
+	cmd.AddCommand(newVMCreateCmd())
+	return cmd
+}
+
+// newVMListCmd returns `meho vmware vm list`.
+//
+// Maps to op_id `GET:/vcenter/vm`. Optional --filter flags expose
+// the vSphere REST filter parameters (powered_states, names,
+// clusters, hosts, etc.); the v0.2 surface ships only --names and
+// --power-state because those are the two filters every operator
+// reaches for first. Additional filters land via --filter "k=v"
+// repeats which marshal into the params map verbatim.
+func newVMListCmd() *cobra.Command {
+	var (
+		targetName        string
+		filterNames       []string
+		filterPowerStates []string
+		filterRaw         []string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List VMs on a vCenter target",
+		Long: "list dispatches GET:/vcenter/vm against the connector_id=\n" +
+			"\"vmware-rest-9.0\" connector. Optional filters narrow the result;\n" +
+			"the human render shows name / power_state / cpu / memory_size,\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"--names accepts repeated values to filter by VM name; --power-state\n" +
+			"narrows by powered_states (POWERED_ON / POWERED_OFF / SUSPENDED).\n" +
+			"--filter \"k=v\" is the escape hatch for filters the dedicated flags\n" +
+			"don't cover (clusters, hosts, datacenters, folders, etc.).\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vmware vm list --target rdc-vcenter\n" +
+			"  meho vmware vm list --target rdc-vcenter --power-state POWERED_ON\n" +
+			"  meho vmware vm list --target rdc-vcenter --json | jq '.result[].name'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runVMList(cmd, vmListOpts{
+				TargetName:        targetName,
+				FilterNames:       filterNames,
+				FilterPowerStates: filterPowerStates,
+				FilterRaw:         filterRaw,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().StringArrayVar(&filterNames, "names", nil,
+		"filter by VM name; repeat for multiple matches")
+	cmd.Flags().StringArrayVar(&filterPowerStates, "power-state", nil,
+		"filter by powered_states (POWERED_ON / POWERED_OFF / SUSPENDED); repeat for OR")
+	cmd.Flags().StringArrayVar(&filterRaw, "filter", nil,
+		"raw vSphere filter as k=v; repeat for multiple filters (e.g. --filter clusters=domain-c1)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type vmListOpts struct {
+	TargetName        string
+	FilterNames       []string
+	FilterPowerStates []string
+	FilterRaw         []string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runVMList(cmd *cobra.Command, opts vmListOpts) error {
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	params, perr := buildListParams(opts.FilterNames, opts.FilterPowerStates, opts.FilterRaw)
+	if perr != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(perr.Error()), opts.JSONOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/vcenter/vm", opts.TargetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	return renderCallResult(cmd, "GET:/vcenter/vm", r, opts.JSONOut, printVMList)
+}
+
+// printVMList renders a VM list as a table. vSphere's GET /vcenter/vm
+// returns entries with `vm` (moid), `name`, `power_state`, `cpu_count`,
+// `memory_size_MiB`. The renderer falls back to the generic JSON
+// dump when the shape doesn't decode (per-endpoint drift surfaces
+// in the fallback rather than as a panic).
+func printVMList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/vcenter/vm — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeListResult(r.Result)
+	if err != nil || len(entries) == 0 {
+		if err == nil {
+			fmt.Fprintln(w, "  (0 VMs)")
+			return
+		}
+		// Fall back to raw render on decode failure.
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "%-16s %-30s %-12s %4s %10s\n", "moid", "name", "power", "cpu", "memMiB")
+	for _, e := range entries {
+		moid := stringField(e, "vm")
+		name := stringField(e, "name")
+		power := stringField(e, "power_state")
+		cpu := intField(e, "cpu_count")
+		mem := intField(e, "memory_size_MiB")
+		fmt.Fprintf(w, "%-16s %-30s %-12s %4d %10d\n",
+			truncate(moid, 16),
+			truncate(name, 30),
+			truncate(power, 12),
+			cpu,
+			mem,
+		)
+	}
+}
+
+// fallbackResultRender dumps the result envelope verbatim when the
+// typed per-verb decode fails. Used by every verb's pretty-printer
+// so contract drift surfaces with the same affordance.
+func fallbackResultRender(w io.Writer, r *CallResult) {
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	pretty, err := prettyJSON(r.Result)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+		return
+	}
+	fmt.Fprintln(w, string(r.Result))
+}
+
+// stringField pulls a string field from a vSphere list entry,
+// returning empty string when the field is missing or wrong type.
+// The vSphere REST API stays disciplined about field shapes but the
+// dispatcher pass-through preserves whatever the backend emitted,
+// including JSON null on optional fields — empty is the safe render.
+func stringField(e listEntry, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// intField pulls an integer field from a vSphere list entry. JSON
+// integers land as float64 after json.Unmarshal into map[string]any
+// — the conversion is documented behaviour, not a workaround.
+func intField(e listEntry, key string) int {
+	v, ok := e[key]
+	if !ok {
+		return 0
+	}
+	if f, ok := v.(float64); ok {
+		return int(f)
+	}
+	return 0
+}
+
+// buildListParams folds the typed filter flags + raw --filter k=v
+// repeats into the params map the dispatcher passes through. The
+// vSphere REST filter syntax uses dotted keys (`filter.names`,
+// `filter.power_states`) — the helper writes them verbatim so the
+// shape lines up with the endpoint_descriptor's documented inputs.
+//
+// --filter raw values follow `k=v` with a single `=` separator.
+// Multi-equals values (`k=a=b`) split on the first `=` so the value
+// can itself contain `=`. Missing `=` returns an error.
+func buildListParams(names, powerStates, raw []string) (map[string]any, error) {
+	out := map[string]any{}
+	if len(names) > 0 {
+		out["filter.names"] = names
+	}
+	if len(powerStates) > 0 {
+		out["filter.power_states"] = powerStates
+	}
+	for _, kv := range raw {
+		k, v, ok := splitOnce(kv, "=")
+		if !ok {
+			return nil, fmt.Errorf("--filter %q: expected k=v form", kv)
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// splitOnce splits s on the first occurrence of sep. Returns
+// (before, after, true) when sep is found, (s, "", false) otherwise.
+// strings.SplitN(s, sep, 2) handles the same case but with three
+// allocations; this single-allocation form is in line with the
+// project's allocation discipline on hot paths.
+func splitOnce(s, sep string) (before, after string, ok bool) {
+	for i := 0; i+len(sep) <= len(s); i++ {
+		if s[i:i+len(sep)] == sep {
+			return s[:i], s[i+len(sep):], true
+		}
+	}
+	return s, "", false
+}
+
+// newVMInfoCmd returns `meho vmware vm info <name-or-id>`.
+//
+// Resolves <name-or-id> via resolveName(kind="vm") then dispatches
+// GET:/vcenter/vm/{vm} with the resolved moid passed as the {vm}
+// path parameter. The dispatcher's endpoint_descriptor declares
+// {vm} as a path param; the params map carries it under that key.
+func newVMInfoCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "info <name-or-id>",
+		Short: "Show details for one VM by name or moid",
+		Long: "info accepts a VM name (resolved client-side to a moid via\n" +
+			"GET:/vcenter/vm?filter.names=<name>) or a moid directly. After\n" +
+			"resolution, dispatches GET:/vcenter/vm/{vm} with the resolved\n" +
+			"moid as the {vm} path parameter.\n\n" +
+			"A name that resolves to 0 or >1 candidates exits with status 1\n" +
+			"and a message naming the candidates so the operator can re-invoke\n" +
+			"with the moid directly.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vmware vm info web-prod-01 --target rdc-vcenter\n" +
+			"  meho vmware vm info vm-101 --target rdc-vcenter --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVMInfo(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runVMInfo(cmd *cobra.Command, nameOrID, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	moid, err := resolveName(cmd.Context(), backplaneURL, targetName, "vm", nameOrID)
+	if err != nil {
+		// Name-resolution failures (not-found, ambiguous, dispatcher
+		// error during the resolve round-trip) map to exit 1 — same
+		// shape as a dispatcher-reported status==error. The verb
+		// surfaces the resolver's prose without re-decorating it
+		// because resolveName already names the kind / target.
+		return output.RenderError(cmd.ErrOrStderr(),
+			&output.StructuredError{
+				Code:   "resolve_failed",
+				Detail: err.Error(),
+				Exit:   1,
+			}, jsonOut)
+	}
+	opID := "GET:/vcenter/vm/{vm}"
+	params := map[string]any{"vm": moid}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printVMInfo)
+}
+
+// printVMInfo renders a single-VM detail block. The result body's
+// shape on 9.0 includes name / power_state / cpu / memory / disks /
+// nics / boot — operators read a flat property summary. We pull the
+// top-level scalar fields and leave nested sequences to --json.
+func printVMInfo(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/vcenter/vm/{vm} — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	// vm info can come back bare or value-wrapped just like the about
+	// endpoint. Unwrap before reading scalar fields.
+	body := unwrapValue(r.Result)
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	for _, key := range []string{"name", "power_state", "cpu_count", "memory_size_MiB", "guest_OS"} {
+		v, ok := m[key]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(w, "  %-17s %v\n", key+":", v)
+	}
+}
+
+// unwrapValue strips the legacy `{"value": ...}` envelope when
+// present; otherwise returns raw verbatim. Used by every per-verb
+// renderer that wants to drop into a typed shape without branching
+// on response form.
+func unwrapValue(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var wrapped struct {
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && len(wrapped.Value) > 0 {
+		return wrapped.Value
+	}
+	return raw
+}
+
+// newVMCreateCmd returns `meho vmware vm create`. Dispatches the
+// composite op_id `vmware.composite.vm.create` (ships in T6 #509).
+// Pre-merge of T6, the dispatcher returns "operation not found"
+// which surfaces in the standard error trailer.
+func newVMCreateCmd() *cobra.Command {
+	var (
+		targetName        string
+		specFlag          string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a VM via the composite create flow",
+		Long: "create dispatches op_id=\"vmware.composite.vm.create\" against the\n" +
+			"connector_id=\"vmware-rest-9.0\" connector. The composite orchestrates\n" +
+			"the multi-step vSphere REST create flow (placement spec → create →\n" +
+			"power-on policy → tag application) that ships in G3.1-T6 (#509).\n\n" +
+			"--spec accepts inline JSON or @<file>; the JSON shape is the\n" +
+			"vSphere `Vm.CreateSpec` model the composite consumes (see the T6\n" +
+			"task body for the field list).\n\n" +
+			"Pre-merge of T6 (#509), the dispatcher returns \"operation not\n" +
+			"found\" which surfaces in the standard error trailer.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vmware vm create --target rdc-vcenter --spec @new-vm.json\n" +
+			"  meho vmware vm create --target rdc-vcenter --spec '{\"name\":\"x\",\"power_on\":true}'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runVMCreate(cmd, targetName, specFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().StringVar(&specFlag, "spec", "", "vSphere CreateSpec as inline JSON or @<file>; required")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	_ = cmd.MarkFlagRequired("spec")
+	return cmd
+}
+
+func runVMCreate(cmd *cobra.Command, targetName, specFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(specFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	opID := "vmware.composite.vm.create"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	// The composite's success shape is opaque to the CLI today
+	// (T6 ships the canonical envelope; CLI consumers read --json).
+	// Use the generic renderer until the shape stabilises.
+	return renderCallResult(cmd, opID, r, jsonOut, nil)
+}

--- a/cli/internal/cmd/vmware/vmware.go
+++ b/cli/internal/cmd/vmware/vmware.go
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package vmware hosts the cobra commands under `meho vmware ...` for
+// G3.1-T7 (#511) of Initiative #227. v0.2 ships the operator-facing
+// alias verbs the issue #227 §10 verb table names, each pre-baking
+// the `connector_id="vmware-rest-9.0"` argument so operators don't
+// type the connector ID on every dispatch:
+//
+//   - `meho vmware about [--target T]`              — GET:/api/about
+//   - `meho vmware vm list [--target T]`            — GET:/vcenter/vm
+//   - `meho vmware vm info <name-or-id>`            — name → moid then GET:/vcenter/vm/{vm}
+//   - `meho vmware vm create --spec @file`          — vmware.composite.vm.create (T6)
+//   - `meho vmware host list`                       — GET:/vcenter/host
+//   - `meho vmware host evacuate <name>`            — vmware.composite.host.evacuate (T6)
+//   - `meho vmware cluster list`                    — GET:/vcenter/cluster
+//   - `meho vmware cluster patch <name>`            — vmware.composite.cluster.patch (T6)
+//   - `meho vmware datacenter list`                 — GET:/vcenter/datacenter
+//   - `meho vmware datastore list`                  — GET:/vcenter/datastore
+//   - `meho vmware network list`                    — GET:/vcenter/network
+//   - `meho vmware operation search "<query>"`      — search_operations pre-scoped
+//   - `meho vmware operation call <op_id> ...`      — call_operation pre-scoped
+//
+// Every verb is a thin Cobra command that POSTs to
+// `/api/v1/operations/call` (or GET /api/v1/operations/search for
+// the meta-tool wrapper) with a pre-baked connector_id. No new
+// backend code; no new HTTP routes — CLI alias verbs are pure
+// operator ergonomics over the existing dispatcher surface (per
+// CLAUDE.md postulate 5: agent surface stays narrow-waist meta-tools;
+// vendor-specific tooling lives only in the CLI).
+//
+// The composite-backed verbs (`vm create`, `host evacuate`,
+// `cluster patch`) dispatch their composite op_ids verbatim. Pre-
+// merge of #508 (T5 read composites) and #509 (T6 write composites),
+// the dispatcher returns a "operation not found" status which the
+// verb surfaces with operator-readable text via the same renderer
+// the success path uses. PR-1 (this) ships the verb tree on top of
+// T1 (#498); the composite-backed verbs become end-to-end
+// dispatchable once #508 + #509 merge.
+package vmware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under
+// `meho vmware ...` dispatches against. Exported so the per-verb
+// files and tests reference the same constant; a future
+// re-versioning (vmware-rest-9.1) lands as a single line edit here.
+const ConnectorID = "vmware-rest-9.0"
+
+// NewRootCmd returns the `meho vmware` parent command. cmd/root.go
+// grafts this onto the top-level command tree alongside the other
+// built-in verb trees (operation / connector / targets / kb /
+// retrieval / audit). The parent itself takes no args and prints its
+// own help; every piece of behaviour lives in the per-subcommand
+// RunE closures.
+//
+// Sub-tree layout follows the issue #227 §10 verb table:
+//   - `vmware about`              — flat verb
+//   - `vmware vm <list|info|create>`     — sub-tree
+//   - `vmware host <list|evacuate>`      — sub-tree
+//   - `vmware cluster <list|patch>`      — sub-tree
+//   - `vmware datacenter list`           — flat verb
+//   - `vmware datastore list`            — flat verb
+//   - `vmware network list`              — flat verb
+//   - `vmware operation <search|call>`   — sub-tree (meta-tool wrappers)
+//
+// Sub-tree roots delegate to their own NewRootCmd-style factories in
+// nested subpackages (cmd/vmware/vm, cmd/vmware/host, etc.) so each
+// noun's verbs live next to their tests without bloating this file.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vmware",
+		Short: "Pre-scoped CLI verbs for the vmware-rest-9.0 connector",
+		Long: "vmware is the operator-facing verb tree for the vmware-rest-9.0\n" +
+			"connector. Each verb dispatches through POST /api/v1/operations/call\n" +
+			"with connector_id=\"vmware-rest-9.0\" pre-baked so operators don't\n" +
+			"type the connector ID on every command. Verbs that accept human-\n" +
+			"readable names (vm info, host evacuate, cluster patch) resolve\n" +
+			"name → moid client-side via the appropriate /vcenter/<kind>?filter\n" +
+			"call before dispatching the target operation.\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
+			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
+			"continue to use search_operations / call_operation against the\n" +
+			"narrow-waist meta-tool contract.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAboutCmd())
+	cmd.AddCommand(newVMCmd())
+	cmd.AddCommand(newHostCmd())
+	cmd.AddCommand(newClusterCmd())
+	cmd.AddCommand(newDatacenterCmd())
+	cmd.AddCommand(newDatastoreCmd())
+	cmd.AddCommand(newNetworkCmd())
+	cmd.AddCommand(newOperationCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" (→ auth_expired exit
+// code 2 — the right fix is `meho login`) from URL-parse failures
+// (→ unexpected exit code 4 — the right fix is correcting argv).
+// Same shape as the operation / connector / kb siblings; kept
+// independent because cmd/{operation,connector,kb,vmware} can't
+// import each other without an import cycle (cmd/root.go grafts each
+// onto the tree).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane mirrors the operation / connector sibling
+// helpers: --backplane override flag wins; otherwise read the URL
+// the most recent `meho login` wrote to config.json. Missing config
+// surfaces as errNoBackplaneConfigured so classifyBackplaneError
+// can route it to auth_expired.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical routing to the operation
+// sibling: missing-config → auth_expired; everything else (parse
+// errors, fs errors) → unexpected.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail fast
+// on garbage input. Mirrors the operation / connector siblings.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from doAuthedRequest into
+// the right output.RenderError category. Same classification ladder
+// as the operation sibling: token-not-found / no-refresh-token →
+// auth_expired with `meho login` hints; HTTP-error → unexpected;
+// everything else (transport) → unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// httpError carries a non-2xx response so renderRequestError can
+// pick the right StructuredError category. Same shape as the
+// operation / connector siblings.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection + one-shot 401-refresh-retry. Mirrors the
+// operation / connector siblings verbatim (duplicated to avoid an
+// import cycle — cmd/root.go grafts each onto the tree). Centralised
+// per-package so the per-verb runners stay small.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	// 1 MiB cap matches the operation sibling. Vendor responses (vm
+	// lists on busy targets) can be hundreds of KiB; the cap leaves
+	// headroom while still bounding pathological payloads.
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// sendRequest builds + fires the HTTP request. Mirrors the operation
+// sibling; split out so the 401-refresh-retry path can reuse the
+// same body bytes without re-marshalling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// loadParamsFlag parses the --params flag value. Prefixing with '@'
+// loads the named file as JSON; otherwise the value itself is parsed
+// as inline JSON. Returns nil for an empty value so the caller can
+// omit the "params" key from the JSON body. Same shape as the
+// operation sibling.
+func loadParamsFlag(val string) (map[string]any, error) {
+	if val == "" {
+		return nil, nil
+	}
+	var raw []byte
+	if strings.HasPrefix(val, "@") {
+		path := strings.TrimPrefix(val, "@")
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read params file %q: %w", path, err)
+		}
+	} else {
+		raw = []byte(val)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parse params JSON: %w", err)
+	}
+	return m, nil
+}
+
+// jsonUnmarshalStrict is a thin wrapper over json.Unmarshal that
+// keeps the call sites readable when the shape is unsigned (`if err
+// := jsonUnmarshalStrict(raw, &x); err == nil && x.Foo != ""`).
+// Same semantics as json.Unmarshal — kept as a wrapper so we can
+// swap in a stricter decoder (DisallowUnknownFields) on a future
+// audit pass without touching every call site.
+func jsonUnmarshalStrict(raw []byte, out any) error {
+	return json.Unmarshal(raw, out)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Operates on runes (not bytes) so multi-byte
+// UTF-8 in vmware-side names survives without producing an invalid
+// UTF-8 cut. Same implementation as the operation / connector
+// siblings — duplicated to avoid import cycle.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/vmware/vmware_test.go
+++ b/cli/internal/cmd/vmware/vmware_test.go
@@ -1,0 +1,943 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vmware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests (pure-function) ----------
+
+// TestTruncatePassthroughAndCut covers the rune-aware truncate
+// helper. Same shape as the operation / connector siblings —
+// duplicated because cmd/vmware can't import them without an import
+// cycle.
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+// TestNormaliseURLBasic mirrors the operation / connector siblings —
+// trailing-slash trimming + reject-empty are the load-bearing
+// properties.
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
+// any wrapping error) maps to AuthExpired; everything else maps
+// to Unexpected.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+// TestConnectorIDIsFrozen pins the pre-baked connector_id constant.
+// Every verb file dispatches against this value; a regression here
+// would silently rebind every alias verb to a different connector.
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "vmware-rest-9.0" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "vmware-rest-9.0")
+	}
+}
+
+// ---------- loadParamsFlag ----------
+
+// TestLoadParamsFlagEmpty — empty flag value returns (nil, nil) so
+// runners can omit the params key from the body.
+func TestLoadParamsFlagEmpty(t *testing.T) {
+	got, err := loadParamsFlag("")
+	if err != nil {
+		t.Fatalf("loadParamsFlag(\"\"): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("loadParamsFlag(\"\") should be nil; got %v", got)
+	}
+}
+
+// TestLoadParamsFlagInlineJSON — happy-path inline JSON object.
+func TestLoadParamsFlagInlineJSON(t *testing.T) {
+	got, err := loadParamsFlag(`{"name":"web-01","power_on":true}`)
+	if err != nil {
+		t.Fatalf("loadParamsFlag: %v", err)
+	}
+	if got["name"] != "web-01" || got["power_on"] != true {
+		t.Fatalf("inline JSON params not parsed; got %v", got)
+	}
+}
+
+// TestLoadParamsFlagFileReference — `@<file>` form reads + parses.
+func TestLoadParamsFlagFileReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.json")
+	if err := os.WriteFile(path, []byte(`{"vm":"vm-101"}`), 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	got, err := loadParamsFlag("@" + path)
+	if err != nil {
+		t.Fatalf("loadParamsFlag @file: %v", err)
+	}
+	if got["vm"] != "vm-101" {
+		t.Fatalf("file params not parsed; got %v", got)
+	}
+}
+
+// TestLoadParamsFlagInvalidJSONReportsError — malformed JSON
+// surfaces a `parse params JSON` error string.
+func TestLoadParamsFlagInvalidJSONReportsError(t *testing.T) {
+	_, err := loadParamsFlag(`{not json`)
+	if err == nil {
+		t.Fatalf("expected parse error; got nil")
+	}
+	if !strings.Contains(err.Error(), "parse params JSON") {
+		t.Fatalf("error should name parse failure; got %v", err)
+	}
+}
+
+// ---------- splitOnce ----------
+
+// TestSplitOnce covers the inline `k=v` parser used by --filter.
+func TestSplitOnce(t *testing.T) {
+	cases := []struct {
+		in, sep, wantBefore, wantAfter string
+		wantOK                         bool
+	}{
+		{"k=v", "=", "k", "v", true},
+		{"k=v=v2", "=", "k", "v=v2", true},
+		{"kv", "=", "kv", "", false},
+		{"", "=", "", "", false},
+	}
+	for _, tc := range cases {
+		b, a, ok := splitOnce(tc.in, tc.sep)
+		if b != tc.wantBefore || a != tc.wantAfter || ok != tc.wantOK {
+			t.Errorf("splitOnce(%q, %q) = (%q, %q, %v); want (%q, %q, %v)",
+				tc.in, tc.sep, b, a, ok, tc.wantBefore, tc.wantAfter, tc.wantOK)
+		}
+	}
+}
+
+// ---------- buildListParams ----------
+
+// TestBuildListParamsTypedFlags — --names + --power-state land
+// under the canonical filter.* keys.
+func TestBuildListParamsTypedFlags(t *testing.T) {
+	got, err := buildListParams([]string{"web-01", "web-02"}, []string{"POWERED_ON"}, nil)
+	if err != nil {
+		t.Fatalf("buildListParams: %v", err)
+	}
+	names, _ := got["filter.names"].([]string)
+	if len(names) != 2 || names[0] != "web-01" {
+		t.Errorf("filter.names: got %v", got["filter.names"])
+	}
+	ps, _ := got["filter.power_states"].([]string)
+	if len(ps) != 1 || ps[0] != "POWERED_ON" {
+		t.Errorf("filter.power_states: got %v", got["filter.power_states"])
+	}
+}
+
+// TestBuildListParamsRawKV — --filter k=v lands verbatim.
+func TestBuildListParamsRawKV(t *testing.T) {
+	got, err := buildListParams(nil, nil, []string{"clusters=domain-c1"})
+	if err != nil {
+		t.Fatalf("buildListParams: %v", err)
+	}
+	if got["clusters"] != "domain-c1" {
+		t.Errorf("clusters: got %v", got)
+	}
+}
+
+// TestBuildListParamsRawKVRejectsMalformed — bare value (no `=`)
+// errors so the operator sees the typo client-side.
+func TestBuildListParamsRawKVRejectsMalformed(t *testing.T) {
+	_, err := buildListParams(nil, nil, []string{"no-equals"})
+	if err == nil || !strings.Contains(err.Error(), "k=v") {
+		t.Fatalf("malformed filter should reject with k=v hint; got %v", err)
+	}
+}
+
+// TestBuildListParamsEmptyReturnsNil — no flags means no params on
+// the wire (omitting the key, not sending an empty object).
+func TestBuildListParamsEmptyReturnsNil(t *testing.T) {
+	got, err := buildListParams(nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildListParams: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("empty flags should produce nil map; got %v", got)
+	}
+}
+
+// ---------- isMoid / moidFieldForKind ----------
+
+// TestIsMoidPerKind — each kind's grammar matches its expected
+// moid shape and rejects everything else.
+func TestIsMoidPerKind(t *testing.T) {
+	cases := []struct {
+		kind, input string
+		want        bool
+	}{
+		{"vm", "vm-101", true},
+		{"vm", "web-01", false},
+		{"host", "host-23", true},
+		{"host", "esxi-01", false},
+		{"cluster", "domain-c123", true},
+		{"cluster", "dc-prod-01", false},
+		{"datacenter", "datacenter-1", true},
+		{"datastore", "datastore-7", true},
+		{"network", "network-5", true},
+		{"unknown", "anything", false},
+	}
+	for _, c := range cases {
+		if got := isMoid(c.kind, c.input); got != c.want {
+			t.Errorf("isMoid(%q, %q) = %v; want %v", c.kind, c.input, got, c.want)
+		}
+	}
+}
+
+// TestMoidFieldForKindAllKinds pins the per-kind moid field name.
+func TestMoidFieldForKindAllKinds(t *testing.T) {
+	for _, k := range []string{"vm", "host", "cluster", "datacenter", "datastore", "network"} {
+		if got := moidFieldForKind(k); got != k {
+			t.Errorf("moidFieldForKind(%q) = %q; want %q", k, got, k)
+		}
+	}
+}
+
+// ---------- decodeListResult ----------
+
+// TestDecodeListResultBareArray covers the canonical vSphere 9.0
+// response shape.
+func TestDecodeListResultBareArray(t *testing.T) {
+	raw := json.RawMessage(`[{"vm":"vm-101","name":"web-01"},{"vm":"vm-102","name":"web-02"}]`)
+	entries, err := decodeListResult(raw)
+	if err != nil {
+		t.Fatalf("decodeListResult bare: %v", err)
+	}
+	if len(entries) != 2 || entries[0]["vm"] != "vm-101" {
+		t.Fatalf("bare-array decode: got %+v", entries)
+	}
+}
+
+// TestDecodeListResultValueWrapped covers the legacy 6.x/7.x wrap
+// shape that some 9.0 endpoints still emit.
+func TestDecodeListResultValueWrapped(t *testing.T) {
+	raw := json.RawMessage(`{"value":[{"vm":"vm-101","name":"web-01"}]}`)
+	entries, err := decodeListResult(raw)
+	if err != nil {
+		t.Fatalf("decodeListResult wrapped: %v", err)
+	}
+	if len(entries) != 1 || entries[0]["name"] != "web-01" {
+		t.Fatalf("value-wrapped decode: got %+v", entries)
+	}
+}
+
+// TestDecodeListResultEmpty — null / empty raw returns nil with no
+// error so the renderer can show "(0 …)".
+func TestDecodeListResultEmpty(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		entries, err := decodeListResult(raw)
+		if err != nil {
+			t.Fatalf("decodeListResult empty: %v", err)
+		}
+		if entries != nil {
+			t.Fatalf("empty raw should decode to nil; got %+v", entries)
+		}
+	}
+}
+
+// ---------- decodeAboutPayload ----------
+
+// TestDecodeAboutPayloadBare covers the canonical 9.0 shape.
+func TestDecodeAboutPayloadBare(t *testing.T) {
+	raw := []byte(`{"product":"VMware vCenter Server","version":"9.0.0","build":"12345","api_type":"VirtualCenter"}`)
+	got, ok := decodeAboutPayload(raw)
+	if !ok {
+		t.Fatalf("decodeAboutPayload bare: ok=false")
+	}
+	if got.Product != "VMware vCenter Server" || got.Version != "9.0.0" {
+		t.Fatalf("decoded payload: %+v", got)
+	}
+}
+
+// TestDecodeAboutPayloadWrapped covers the legacy wrap.
+func TestDecodeAboutPayloadWrapped(t *testing.T) {
+	raw := []byte(`{"value":{"product":"VCSA","version":"7.0.3","build":"22222","api_type":"VirtualCenter"}}`)
+	got, ok := decodeAboutPayload(raw)
+	if !ok || got.Product != "VCSA" {
+		t.Fatalf("decoded wrapped: ok=%v payload=%+v", ok, got)
+	}
+}
+
+// TestDecodeAboutPayloadShapeDrift — unknown shape returns ok=false
+// so the renderer falls back to raw JSON dump.
+func TestDecodeAboutPayloadShapeDrift(t *testing.T) {
+	raw := []byte(`{"unexpected":true}`)
+	_, ok := decodeAboutPayload(raw)
+	if ok {
+		t.Fatalf("decodeAboutPayload should reject unknown shape")
+	}
+}
+
+// ---------- renderers ----------
+
+// TestPrintAboutHumanFormat — happy-path render with all four
+// product fields present.
+func TestPrintAboutHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "GET:/api/about",
+		Result:     json.RawMessage(`{"product":"VMware vCenter Server","version":"9.0.0","build":"12345","api_type":"VirtualCenter"}`),
+		DurationMs: 42.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=ok", "vmware-rest-9.0", "VMware vCenter Server", "9.0.0", "12345", "VirtualCenter"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintAboutErrorRendersErrorString — status=error with a
+// non-nil Error pointer surfaces the error string + extras.
+func TestPrintAboutErrorRendersErrorString(t *testing.T) {
+	errMsg := "unknown_op: GET:/api/about"
+	r := &CallResult{
+		Status:     "error",
+		OpID:       "GET:/api/about",
+		Error:      &errMsg,
+		Extras:     json.RawMessage(`{"known_op_count":7}`),
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=error", "unknown_op", "extras:", "known_op_count"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout error missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintVMListTable — happy-path render with 2 VMs.
+func TestPrintVMListTable(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "GET:/vcenter/vm",
+		Result:     json.RawMessage(`[{"vm":"vm-101","name":"web-01","power_state":"POWERED_ON","cpu_count":4,"memory_size_MiB":8192},{"vm":"vm-102","name":"web-02","power_state":"POWERED_OFF","cpu_count":2,"memory_size_MiB":4096}]`),
+		DurationMs: 12.0,
+	}
+	var buf bytes.Buffer
+	printVMList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"vm-101", "web-01", "POWERED_ON", "vm-102", "POWERED_OFF", "moid", "name", "power"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printVMList missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintVMListEmpty — zero VMs renders the count line.
+func TestPrintVMListEmpty(t *testing.T) {
+	r := &CallResult{Status: "ok", Result: json.RawMessage(`[]`)}
+	var buf bytes.Buffer
+	printVMList(&buf, r)
+	if !strings.Contains(buf.String(), "(0 VMs)") {
+		t.Errorf("empty list should announce 0 VMs; got:\n%s", buf.String())
+	}
+}
+
+// TestPrintHostList — happy-path render.
+func TestPrintHostList(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`[{"host":"host-23","name":"esxi-01","connection_state":"CONNECTED","power_state":"POWERED_ON"}]`),
+	}
+	var buf bytes.Buffer
+	printHostList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"host-23", "esxi-01", "CONNECTED"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printHostList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintClusterList — happy-path render.
+func TestPrintClusterList(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`[{"cluster":"domain-c123","name":"dc-prod","drs_enabled":true,"ha_enabled":false}]`),
+	}
+	var buf bytes.Buffer
+	printClusterList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"domain-c123", "dc-prod"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printClusterList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintSearchTable — happy-path render with 2 hits.
+func TestPrintSearchTable(t *testing.T) {
+	summary := "List VMs"
+	r := &searchResponse{
+		Hits: []searchHit{
+			{OpID: "GET:/vcenter/vm", Summary: &summary, FusedScore: 0.987},
+			{OpID: "POST:/vcenter/vm", Summary: nil, FusedScore: 0.413},
+		},
+		QueryDurationMs: 42.0,
+	}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "list vms", r)
+	out := buf.String()
+	for _, want := range []string{"vmware-rest-9.0", "list vms", "2 hit(s)", "GET:/vcenter/vm", "List VMs", "0.987"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSearchTable missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintSearchTableEmpty — zero hits skips the table header.
+func TestPrintSearchTableEmpty(t *testing.T) {
+	r := &searchResponse{Hits: nil, QueryDurationMs: 1.0}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "no-match", r)
+	out := buf.String()
+	if !strings.Contains(out, "0 hit(s)") {
+		t.Errorf("empty search should announce 0 hits; got:\n%s", out)
+	}
+	if strings.Contains(out, "op_id") {
+		t.Errorf("empty search should skip header; got:\n%s", out)
+	}
+}
+
+// TestStrDerefNilEmptyOtherwiseValue — Optional[str] handling.
+func TestStrDerefNilEmptyOtherwiseValue(t *testing.T) {
+	if got := strDeref(nil); got != "" {
+		t.Fatalf("strDeref(nil): got %q", got)
+	}
+	v := "hello"
+	if got := strDeref(&v); got != "hello" {
+		t.Fatalf("strDeref(&v): got %q", got)
+	}
+}
+
+// ---------- errOpError sentinel ----------
+
+func TestErrOpErrorIsSentinel(t *testing.T) {
+	if errOpError == nil {
+		t.Fatalf("errOpError should be non-nil")
+	}
+	if errors.Is(errOpError, errors.New("other")) {
+		t.Fatalf("errOpError should not match arbitrary errors")
+	}
+}
+
+// ---------- HTTP wire shape (mocked) ----------
+
+type mockHandler = http.HandlerFunc
+
+// mockBackplane stands up an httptest.Server that routes by
+// `<METHOD> <path>` keys. The empty key acts as a catch-all. Same
+// shape as the connector sibling's helper.
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+// primeToken installs an in-memory token store with a usable bearer
+// for the mocked backplane URL. Mirrors the connector sibling's
+// primeToken helper.
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID — every verb dispatches with
+// connector_id="vmware-rest-9.0" pre-baked. This test pins that the
+// dispatcher helper writes the canonical connector_id into the
+// CallOperationBody — a regression here would silently rebind every
+// alias verb to a different connector.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "vmware-rest-9.0" {
+				t.Errorf("connector_id: got %q want vmware-rest-9.0", body.ConnectorID)
+			}
+			if body.OpID != "GET:/api/about" {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "GET:/api/about",
+				Result: json.RawMessage(`{"product":"vCenter"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, "GET:/api/about", "rdc-vcenter", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestDispatchOpEmptyTargetSendsNullTarget — the empty target slug
+// must surface as `null` on the wire so the dispatcher's resolver
+// can fall through to the no-target path for typed handlers that
+// don't need a target.
+func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if raw["target"] != nil {
+				t.Errorf("target should be null when targetSlug empty; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "x"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "x", "", nil); err != nil {
+		t.Fatalf("dispatchOp empty-target: %v", err)
+	}
+}
+
+// TestDispatchOpTargetSlugWrappedAsName — a non-empty target slug
+// must surface as `{"name": "<slug>"}` so the dispatcher's resolver
+// pulls it under the canonical TargetRef shape.
+func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			tgt, _ := raw["target"].(map[string]any)
+			if tgt == nil || tgt["name"] != "rdc-vcenter" {
+				t.Errorf("target should wrap slug as {name: ...}; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "x"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "x", "rdc-vcenter", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestSearchSendsConnectorIDPreBaked — the search wrapper pre-bakes
+// connector_id="vmware-rest-9.0" into the query string so operators
+// don't type it.
+func TestSearchSendsConnectorIDPreBaked(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/operations/search": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("connector_id"); got != "vmware-rest-9.0" {
+				t.Errorf("connector_id: got %q", got)
+			}
+			if got := r.URL.Query().Get("query"); got != "list VMs" {
+				t.Errorf("query: got %q", got)
+			}
+			writeJSON(t, w, 200, searchResponse{
+				Hits: []searchHit{{OpID: "GET:/vcenter/vm", FusedScore: 1.0}},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := getSearch(context.Background(), srv.URL, "list VMs", "", 10)
+	if err != nil {
+		t.Fatalf("getSearch: %v", err)
+	}
+	if len(r.Hits) != 1 || r.Hits[0].OpID != "GET:/vcenter/vm" {
+		t.Fatalf("unexpected search response: %+v", r)
+	}
+}
+
+// TestResolveNameAlreadyMoid — moid input passes through without
+// the resolve round-trip.
+func TestResolveNameAlreadyMoid(t *testing.T) {
+	// Use a server that errors if hit so the test fails noisily on
+	// any accidental round-trip.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("resolveName should not round-trip for a moid input")
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	moid, err := resolveName(context.Background(), srv.URL, "rdc-vcenter", "vm", "vm-101")
+	if err != nil {
+		t.Fatalf("resolveName moid passthrough: %v", err)
+	}
+	if moid != "vm-101" {
+		t.Fatalf("moid passthrough: got %q want vm-101", moid)
+	}
+}
+
+// TestResolveNameSingleMatch — happy-path name → moid resolution.
+func TestResolveNameSingleMatch(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != "GET:/vcenter/vm" {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			if body.Params["filter.names"] != "web-prod-01" {
+				t.Errorf("filter.names: got %v", body.Params["filter.names"])
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "GET:/vcenter/vm",
+				Result: json.RawMessage(`[{"vm":"vm-101","name":"web-prod-01"}]`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	moid, err := resolveName(context.Background(), srv.URL, "rdc-vcenter", "vm", "web-prod-01")
+	if err != nil {
+		t.Fatalf("resolveName: %v", err)
+	}
+	if moid != "vm-101" {
+		t.Fatalf("resolved moid: got %q want vm-101", moid)
+	}
+}
+
+// TestResolveNameNotFound — zero matches produces a clear error.
+func TestResolveNameNotFound(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "GET:/vcenter/vm",
+				Result: json.RawMessage(`[]`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	_, err := resolveName(context.Background(), srv.URL, "rdc-vcenter", "vm", "ghost-vm")
+	if err == nil {
+		t.Fatalf("expected not-found error")
+	}
+	if !strings.Contains(err.Error(), "no vm named") {
+		t.Errorf("error should name kind + value; got %v", err)
+	}
+}
+
+// TestResolveNameAmbiguous — multiple matches lists candidates.
+func TestResolveNameAmbiguous(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "GET:/vcenter/vm",
+				Result: json.RawMessage(`[{"vm":"vm-101","name":"web-01"},{"vm":"vm-204","name":"web-01"}]`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	_, err := resolveName(context.Background(), srv.URL, "rdc-vcenter", "vm", "web-01")
+	if err == nil {
+		t.Fatalf("expected ambiguous error")
+	}
+	if !strings.Contains(err.Error(), "candidates") || !strings.Contains(err.Error(), "vm-101") || !strings.Contains(err.Error(), "vm-204") {
+		t.Errorf("ambiguous error should list candidates; got %v", err)
+	}
+}
+
+// TestResolveNameDispatcherError — dispatcher status==error during
+// resolve round-trip surfaces with the dispatcher's error string.
+func TestResolveNameDispatcherError(t *testing.T) {
+	errMsg := "vcenter timeout"
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, CallResult{
+				Status: "error",
+				OpID:   "GET:/vcenter/vm",
+				Error:  &errMsg,
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	_, err := resolveName(context.Background(), srv.URL, "rdc-vcenter", "vm", "web-01")
+	if err == nil {
+		t.Fatalf("expected dispatcher-error wrap")
+	}
+	if !strings.Contains(err.Error(), "vcenter timeout") {
+		t.Errorf("error should propagate dispatcher message; got %v", err)
+	}
+}
+
+// TestRenderCallResultUnknownStatus — anything outside the
+// ok/error/denied enum surfaces as an unexpected-response
+// StructuredError so main exits with code 4 instead of pretending
+// nothing happened.
+func TestRenderCallResultUnknownStatus(t *testing.T) {
+	r := &CallResult{Status: "what", OpID: "x"}
+	var buf bytes.Buffer
+	cmd := newOperationCallCmd()
+	cmd.SetErr(&buf)
+	cmd.SetOut(&buf)
+	err := renderCallResult(cmd, "x", r, false, nil)
+	if err == nil {
+		t.Fatalf("unknown status should surface as error")
+	}
+	if !strings.Contains(buf.String(), "unexpected_response") && !strings.Contains(buf.String(), "invalid OperationResult") {
+		t.Errorf("unknown-status render should mention unexpected_response or invalid; got:\n%s", buf.String())
+	}
+}
+
+// TestNewRootCmdAssemblesAllVerbs pins the verb tree shape — the
+// acceptance criteria require `meho vmware --help` to list every
+// top-level verb. A regression here (missing AddCommand, typo'd
+// Use) would silently drop a verb from the tree.
+func TestNewRootCmdAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"about":      true,
+		"vm":         true,
+		"host":       true,
+		"cluster":    true,
+		"datacenter": true,
+		"datastore":  true,
+		"network":    true,
+		"operation":  true,
+	}
+	for _, c := range root.Commands() {
+		delete(want, c.Name())
+	}
+	if len(want) > 0 {
+		t.Errorf("vmware tree missing top-level verbs: %v", want)
+	}
+}
+
+// TestVMSubtreeAssemblesAllVerbs pins the `vmware vm` sub-tree.
+func TestVMSubtreeAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	var vmCmd *struct{ commands func() }
+	_ = vmCmd
+	for _, c := range root.Commands() {
+		if c.Name() == "vm" {
+			subnames := map[string]bool{}
+			for _, sub := range c.Commands() {
+				subnames[sub.Name()] = true
+			}
+			for _, want := range []string{"list", "info", "create"} {
+				if !subnames[want] {
+					t.Errorf("vmware vm sub-tree missing %q; got %v", want, subnames)
+				}
+			}
+			return
+		}
+	}
+	t.Fatalf("vm sub-tree not found")
+}
+
+// TestHostSubtreeAssemblesAllVerbs pins the `vmware host` sub-tree.
+func TestHostSubtreeAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() == "host" {
+			subnames := map[string]bool{}
+			for _, sub := range c.Commands() {
+				subnames[sub.Name()] = true
+			}
+			for _, want := range []string{"list", "evacuate"} {
+				if !subnames[want] {
+					t.Errorf("vmware host sub-tree missing %q; got %v", want, subnames)
+				}
+			}
+			return
+		}
+	}
+	t.Fatalf("host sub-tree not found")
+}
+
+// TestClusterSubtreeAssemblesAllVerbs pins the `vmware cluster` sub-tree.
+func TestClusterSubtreeAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() == "cluster" {
+			subnames := map[string]bool{}
+			for _, sub := range c.Commands() {
+				subnames[sub.Name()] = true
+			}
+			for _, want := range []string{"list", "patch"} {
+				if !subnames[want] {
+					t.Errorf("vmware cluster sub-tree missing %q; got %v", want, subnames)
+				}
+			}
+			return
+		}
+	}
+	t.Fatalf("cluster sub-tree not found")
+}
+
+// TestOperationSubtreeAssemblesAllVerbs pins the `vmware operation`
+// sub-tree. Both verbs are pre-scoped meta-tool wrappers.
+func TestOperationSubtreeAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() == "operation" {
+			subnames := map[string]bool{}
+			for _, sub := range c.Commands() {
+				subnames[sub.Name()] = true
+			}
+			for _, want := range []string{"search", "call"} {
+				if !subnames[want] {
+					t.Errorf("vmware operation sub-tree missing %q; got %v", want, subnames)
+				}
+			}
+			return
+		}
+	}
+	t.Fatalf("operation sub-tree not found")
+}
+
+// TestFlatListVerbsHaveListSubcommand pins the
+// datacenter/datastore/network "list" sub-verbs.
+func TestFlatListVerbsHaveListSubcommand(t *testing.T) {
+	root := NewRootCmd()
+	for _, parent := range []string{"datacenter", "datastore", "network"} {
+		found := false
+		for _, c := range root.Commands() {
+			if c.Name() != parent {
+				continue
+			}
+			for _, sub := range c.Commands() {
+				if sub.Name() == "list" {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Errorf("vmware %s missing 'list' sub-verb", parent)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the `meho vmware ...` operator alias verb tree on top of the G0.6 dispatcher — each verb is a thin Cobra command that POSTs to `/api/v1/operations/call` with `connector_id="vmware-rest-9.0"` pre-baked so operators don't type the connector ID on every dispatch.
- Sets the verb-tree convention every future G3.x vendor tree (Vault, K8s, bind9, NSX, SDDC, Harbor, gcloud, Hetzner Robot) will mirror. Pattern follows `cmd/operation/call.go` for per-verb shape and `cmd/connector/connector.go` for tree assembly + shared HTTP helpers.
- Per CLAUDE.md postulate 5 these alias verbs are operator-only ergonomics — they are not mirrored on the MCP surface. Agents continue to use `search_operations` / `call_operation` against the narrow-waist meta-tool contract.

## Implementation choice: PR-1 split path (all 14 verbs ship together)

The Task body's Implementation Notes explicitly allows a 2-PR split:

> **PR-1: Verb-tree scaffolding + raw-REST verbs** — only depends on T1 (#498); can ship as soon as T1 merges.
> **PR-2: Composite-backed verbs** — depends on T5 (#508) + T6 (#509).

This PR ships **all 14 verbs** in a single commit but documents the dependency reality:

- **Raw-REST verbs** (depend only on T1 #498, merged): `about`, `vm list`, `vm info`, `host list`, `cluster list`, `datacenter list`, `datastore list`, `network list`, `operation search`, `operation call`. These work end-to-end today.
- **Composite-backed verbs** (depend on T5 #508 + T6 #509, both open): `vm create`, `host evacuate`, `cluster patch`. The verb code is shipped in this PR; the dispatcher returns `operation not found` (status="error", surfaced in the standard error trailer with operator-readable text) until #508 + #509 register the underlying composite ops. **No follow-up PR needed** — once #508 + #509 merge, the verbs become dispatchable without any CLI changes.

This was chosen over the strict PR-1 / PR-2 split because the verb code for composite dispatch is identical in shape to raw-REST dispatch (`dispatchOp(ctx, backplane, opID, target, params)` regardless of whether opID is a raw REST verb or a composite). Splitting would have shipped two PRs that touch the same files and forced a needless rebase.

## Files

New:
- `cli/internal/cmd/vmware/vmware.go` — package root + NewRootCmd + shared HTTP helpers (resolveBackplane, doAuthedRequest, etc.) duplicating the operation/connector siblings (import-cycle constraint).
- `cli/internal/cmd/vmware/dispatch.go` — shared `dispatchOp(ctx, backplane, opID, targetSlug, params)` helper + CallResult + renderCallResult.
- `cli/internal/cmd/vmware/resolve.go` — name → moid resolution helper used by `vm info`, `host evacuate`, `cluster patch`. Handles already-a-moid passthrough, not-found / ambiguous-name errors.
- `cli/internal/cmd/vmware/about.go` — `meho vmware about`.
- `cli/internal/cmd/vmware/vm.go` — `vm list`, `vm info`, `vm create`.
- `cli/internal/cmd/vmware/host.go` — `host list`, `host evacuate`.
- `cli/internal/cmd/vmware/cluster.go` — `cluster list`, `cluster patch`.
- `cli/internal/cmd/vmware/listverbs.go` — `datacenter list`, `datastore list`, `network list` (share a factory).
- `cli/internal/cmd/vmware/operation.go` — pre-scoped `operation search` + `operation call` meta-tool wrappers.
- `cli/internal/cmd/vmware/vmware_test.go` — unit tests covering: helpers (truncate, normaliseURL, classifyBackplaneError), loadParamsFlag (3 paths), splitOnce, buildListParams (typed + raw + reject malformed), isMoid (per-kind), moidFieldForKind, decodeListResult (bare-array + value-wrapped + empty), decodeAboutPayload (bare + wrapped + drift), per-verb renderers, errOpError sentinel, dispatchOp wire shape (connector_id pre-bake + null-target + name-wrap), getSearch wire shape (connector_id pre-bake), resolveName (moid passthrough + single-match + not-found + ambiguous + dispatcher-error), renderCallResult unknown-status, NewRootCmd / sub-tree assembly pins.

Modified:
- `cli/internal/cmd/root.go` — register `vmware.NewRootCmd()`.
- `cli/internal/cmd/root_test.go` — add `vmware` to the expected built-in subcommand list.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `golangci-lint run ./...` — clean.
- [x] `go test ./cli/...` — all 13 packages green (vmware suite is 40+ tests covering helpers, decoders, renderers, dispatch wire shape, resolveName, sub-tree assembly).
- [x] `meho vmware --help` lists `about / vm / host / cluster / datacenter / datastore / network / operation`. Sub-trees expand correctly (`meho vmware vm --help` shows `list / info / create`; same shape for host, cluster, operation; flat `datacenter list / datastore list / network list`).
- [x] Each verb has Use, Short, Long (≥2 paragraphs), Example, and an exit-code section.
- [x] Exit codes follow `meho operation call` convention (0 ok, 1 error/denied/resolve_failed, 2 auth_expired, 3 unreachable, 4 unexpected_response).
- [x] `--target` honoured; empty target serialises as `null` on the wire (per `TestDispatchOpEmptyTargetSendsNullTarget`).
- [x] `--json` emits the OperationResult envelope; default emits the per-verb pretty render.
- [x] `connector_id="vmware-rest-9.0"` is pre-baked on every dispatch (pinned by `TestDispatchOpBakesConnectorID` + `TestConnectorIDIsFrozen`).
- [x] `resolveName` correctly handles already-a-moid input (no round-trip), single match (returns moid), not-found (`no vm named...`), ambiguous (lists candidates). All four paths covered by tests.

## Out of scope

- `meho vmware ls [path]` — govc-style path walking is deferred to v0.2.next per the Task body.
- MCP mirroring — `vmware.*` MCP tools would violate CLAUDE.md postulate 5; agents use the meta-tools.
- Generic table renderer — per-verb pretty-printing lives in each verb's closure; a shared `cli/internal/output/table.go` is a v0.2.next refactor.
- `meho vmware vm clone/migrate/snapshot.revert/power.bulk` and `host detach_from_vds` — composites exist in T6 #509 but aren't in #227 §10's CLI verb list. Escape hatch: `meho vmware operation call vmware.composite.vm.clone ...` works without a dedicated alias.
- Vendor-tree convention doc (`docs/architecture/connector-cli-aliases.md`) — deferred to v0.2.next when G3.2 (k8s) follows the same pattern.
- Cross-vendor name-resolution helper migration to `cli/internal/api/` — premature abstraction until G3.2 needs name-resolution for namespace/pod/node.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #511


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive VMware management commands for listing and managing virtual machines, hosts, clusters, datacenters, datastores, and networks
  * Added operation search and execution capabilities for VMware operations
  * All VMware commands support JSON output option and customizable target/backplane settings

* **Tests**
  * Comprehensive test coverage for all VMware functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/523)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->