### PR TITLE
feat(connectors): G3.1-T5 vmware-rest read composites — 5 hand-authored vmware.composite.* read ops

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/__init__.py
@@ -54,11 +54,22 @@ register_connector_v2(
     cls=VmwareRestConnector,
 )
 
+# Side-effect import for the read-composites registrar wiring (G3.1-T5
+# #508). The package's __init__ appends
+# ``register_vmware_composite_operations`` onto the lifespan-driven
+# registrar list via
+# :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`,
+# so the 5 ``vmware.composite.*`` rows land in ``endpoint_descriptor``
+# during ``run_typed_op_registrars`` -- same lifecycle phase the typed
+# Vault ops use.
+from meho_backplane.connectors.vmware_rest import composites  # noqa: E402
+
 __all__ = [
     "SessionCredentials",
     "VmwareRestConnector",
     "VsphereSessionLoader",
     "VsphereTargetLike",
+    "composites",
     "load_session_credentials_from_vault",
     "product_from_line_id",
 ]

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vmware_rest.composites -- vmware-rest read composites.
+
+Side-effect import: this package's ``__init__`` queues
+:func:`register_vmware_composite_operations` onto the lifespan-driven
+registrar list via
+:func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`.
+
+The chassis lifespan's
+:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+invokes every registered registrar in registration order after
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+has walked every ``connectors/<product>/`` subpackage, so the
+``endpoint_descriptor`` upserts for the 5 read composites land before
+any dispatch can fire.
+
+Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
+``__init__`` wires the registrar; ``_register.py`` carries the
+per-composite registration metadata; ``_read.py`` carries the handler
+implementations; ``schemas.py`` carries the JSON Schema 2020-12
+parameter contracts.
+
+Scope: 5 read composites (G3.1-T5 / #508). 8 write composites land
+under G3.1-T6 (#509).
+"""
+
+from meho_backplane.connectors.vmware_rest.composites._read import (
+    cluster_drs_recommendations_composite,
+    datastore_usage_composite,
+    event_tail_composite,
+    network_portgroup_audit_composite,
+    performance_summary_composite,
+)
+from meho_backplane.connectors.vmware_rest.composites._register import (
+    register_vmware_composite_operations,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+# Queue the composite-op upsert onto the lifespan-driven registrar list.
+# The lifespan calls ``run_typed_op_registrars`` after
+# ``_eager_import_connectors`` so every connector subpackage has self-
+# registered by the time the runner iterates.
+register_typed_op_registrar(register_vmware_composite_operations)
+
+__all__ = [
+    "cluster_drs_recommendations_composite",
+    "datastore_usage_composite",
+    "event_tail_composite",
+    "network_portgroup_audit_composite",
+    "performance_summary_composite",
+    "register_vmware_composite_operations",
+]

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -205,7 +205,12 @@ async def cluster_drs_recommendations_composite(
         # None keeps the operator-visible shape stable.
         drs_payload = out["drs"]
         history = drs_payload.get("history", []) if isinstance(drs_payload, dict) else []
-        out["recommendations_history"] = list(history)
+        # Guard against non-list ``history`` values (e.g. a target that
+        # returns the field as a scalar / dict). ``list(history)`` would
+        # iterate keys on a dict or fail on a scalar; the contract is
+        # "always a list when surfaced", so coerce to an empty list when
+        # the payload disagrees.
+        out["recommendations_history"] = history if isinstance(history, list) else []
     return out
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Read-only ``vmware.composite.*`` handler functions (5 composites).
+
+Each handler is a module-level ``async def`` that takes the dispatcher's
+composite-branch keyword args ``(operator, target, params,
+dispatch_child)`` and returns a single aggregated dict via 2-3 calls to
+``dispatch_child`` (the
+:class:`~meho_backplane.operations.composite.DispatchChild` callable
+the dispatcher builds in
+:func:`~meho_backplane.operations.dispatcher._run_source_kind_branch`).
+
+Why module-level functions
+--------------------------
+
+:func:`~meho_backplane.operations.typed_register.derive_handler_ref`
+rejects closures, ``functools.partial``, and lambdas at registration
+time (``__qualname__`` containing ``<locals>``). Module-level
+``async def`` is the only shape the dispatcher can resolve via
+``importlib.import_module`` + chained ``getattr`` at first-dispatch
+time.
+
+Why ``dispatch_child`` not direct httpx
+---------------------------------------
+
+Composite handlers MUST route every sub-call through ``dispatch_child``
+rather than calling the connector's ``_request_json`` directly, for
+four load-bearing reasons (per #508's issue body + the
+:class:`DispatchChild` Protocol docstring):
+
+1. **Audit-tree linkage** -- ``dispatch_child`` binds
+   :data:`~meho_backplane.operations._audit.parent_audit_id_var` to the
+   composite parent's audit row, so every sub-op's audit row carries
+   ``parent_audit_id`` automatically. Direct httpx breaks the chain.
+2. **Bounded recursion** -- the
+   :data:`~meho_backplane.operations.composite.composite_depth_var`
+   contextvar enforces :attr:`Settings.composite_max_depth`. A
+   misbehaving handler that recursed into another composite would be
+   caught here, not at request-volume scale.
+3. **Policy + broadcast** -- the dispatcher's policy gate (G2.x) and
+   broadcast publish (G6.x) run on every dispatched sub-op. Direct
+   httpx evades both.
+4. **Param validation** -- each sub-op's ``parameter_schema`` validates
+   inbound params at dispatch time; direct httpx skips validation.
+
+Op_id contract for sub-ops
+--------------------------
+
+The sub-op ``op_id`` strings used below are the canonical
+``METHOD:/path`` keys that the ingest path (:func:`parse_openapi`)
+generates from ``vcenter.yaml`` + ``vi-json.yaml`` -- e.g.
+``"GET:/vcenter/datastore"``, ``"POST:/EventManager/{moId}/QueryEvents"``.
+These mirror the rows the G0.7 canary asserts on
+(``tests/acceptance/test_g07_vsphere_canary.py``'s
+``GOVC_PARITY_BENCHMARK`` tuple); the canary is the de-facto registry
+of canonical op_ids.
+
+Response envelope handling
+--------------------------
+
+The vSphere REST surface returns JSON shapes that vary by endpoint:
+
+* vSphere 7+ REST: bare arrays / objects (``[{"datastore": ...}, ...]``).
+* Pre-7 REST: ``{"value": [...]}`` envelopes.
+* vi-json: bare arrays / objects.
+
+The composite handlers tolerate both via :func:`_unwrap_value` so they
+work uniformly against modern vCenter and vcsim simulator targets. The
+helper is intentionally permissive -- composite tests stub responses
+in either shape; production sub-op responses pass through the
+``HttpConnector._request_json`` decoder which preserves the upstream
+shape verbatim.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import OperationResult
+from meho_backplane.operations.composite import DispatchChild
+
+__all__ = [
+    "cluster_drs_recommendations_composite",
+    "datastore_usage_composite",
+    "event_tail_composite",
+    "network_portgroup_audit_composite",
+    "performance_summary_composite",
+]
+
+
+# Sub-op ids the handlers dispatch through. Centralised so the
+# registration tests can assert against the same constants without
+# re-spelling the paths.
+_CONNECTOR_ID = "vmware-rest-9.0"
+_OP_GET_CLUSTER = "GET:/vcenter/cluster/{cluster}"
+_OP_GET_CLUSTER_DRS = "GET:/vcenter/cluster/{cluster}/drs"
+_OP_POST_QUERY_EVENTS = "POST:/EventManager/{moId}/QueryEvents"
+_OP_POST_QUERY_AVAILABLE_PERF_METRIC = "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric"
+_OP_POST_QUERY_PERF = "POST:/PerformanceManager/{moId}/QueryPerf"
+_OP_LIST_DATASTORES = "GET:/vcenter/datastore"
+_OP_GET_DATASTORE = "GET:/vcenter/datastore/{datastore}"
+_OP_LIST_VMS = "GET:/vcenter/vm"
+_OP_LIST_DVS = "GET:/vcenter/network/distributed-switch"
+_OP_LIST_PORTGROUPS = "GET:/vcenter/network/distributed-portgroup"
+
+
+def _unwrap_value(payload: Any) -> Any:
+    """Return the inner ``value`` field on a pre-7 envelope, else *payload*.
+
+    vSphere's REST API straddles two response shapes:
+
+    * Modern (7.0+): bare arrays / objects (``[{...}, {...}]``).
+    * Legacy (pre-7, plus some vcsim builds): wraps the body in
+      ``{"value": [...]}``.
+
+    Composite handlers don't care which shape they receive -- the
+    underlying typed sub-ops are the same. The unwrap is purely a
+    parser-side ergonomic.
+    """
+    if isinstance(payload, dict) and set(payload.keys()) == {"value"}:
+        return payload["value"]
+    return payload
+
+
+def _require_ok(result: OperationResult) -> Any:
+    """Return :attr:`OperationResult.result` or raise on a non-OK status.
+
+    The composite handlers prefer to fail loudly when a sub-op errors
+    -- a swallowed error would silently produce a malformed
+    aggregation. The dispatcher's outer exception branch wraps the
+    raised ``RuntimeError`` into a ``connector_error``
+    :class:`OperationResult` for the composite parent, surfacing the
+    underlying sub-op's failure on ``extras["exception_class"]``.
+    """
+    if result.status != "ok":
+        raise RuntimeError(
+            f"composite sub-op {result.op_id!r} returned status="
+            f"{result.status!r}: {result.error or '<no error message>'}"
+        )
+    return result.result
+
+
+async def cluster_drs_recommendations_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Read cluster summary + DRS state in one composite call.
+
+    Op-id: ``vmware.composite.cluster.drs_recommendations``.
+
+    Sub-ops dispatched (sequential):
+
+    1. ``GET:/vcenter/cluster/{cluster}`` -- cluster summary (name,
+       resource pool, default host, DRS-enabled flag).
+    2. ``GET:/vcenter/cluster/{cluster}/drs`` -- DRS configuration
+       (enabled, automation level, migration threshold).
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"cluster": <summary dict>, "drs": <drs config dict>,
+        "recommendations_history": <optional list>}``. The
+        ``recommendations_history`` key appears only when the operator
+        sets ``include_recommendations_history=True``; otherwise it is
+        omitted.
+
+    The ``include_recommendations_history`` flag is a placeholder for
+    a future Task that adds a third sub-op (DRS recommendations list).
+    The vSphere REST surface does not expose a stable
+    "recommendations" endpoint in 9.0; the issue body's "DRS state read
+    + performance read + format" hint is satisfied by reading the
+    cluster summary plus the DRS config -- the format/aggregation is
+    what differentiates the composite from a raw GET.
+    """
+    cluster_moid = params["cluster"]
+    include_history = bool(params.get("include_recommendations_history", False))
+
+    cluster_result = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_GET_CLUSTER,
+            params={"cluster": cluster_moid},
+        )
+    )
+    drs_result = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_GET_CLUSTER_DRS,
+            params={"cluster": cluster_moid},
+        )
+    )
+    out: dict[str, Any] = {
+        "cluster": _unwrap_value(cluster_result),
+        "drs": _unwrap_value(drs_result),
+    }
+    if include_history:
+        # Surface the history slice from the DRS payload when present.
+        # vSphere 9.0 returns ``{"drs_config": ..., "history": [...]}``;
+        # the key is absent on legacy targets. Empty list rather than
+        # None keeps the operator-visible shape stable.
+        drs_payload = out["drs"]
+        history = drs_payload.get("history", []) if isinstance(drs_payload, dict) else []
+        out["recommendations_history"] = list(history)
+    return out
+
+
+async def event_tail_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Tail recent events via EventManager.QueryEvents (vi-json).
+
+    Op-id: ``vmware.composite.event.tail``.
+
+    Sub-ops dispatched (sequential, single call):
+
+    1. ``POST:/EventManager/{moId}/QueryEvents`` -- recent events. The
+       vi-json call returns an array of event dicts; the handler caps
+       the array client-side to ``max_events`` (default 100).
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"events": <list[event dict]>, "count": <int>,
+        "moId": <str>, "max_events_applied": <int>}``. ``count`` is
+        the post-cap length so operators can detect truncation.
+    """
+    mo_id = params.get("moId", "EventManager")
+    max_events = int(params.get("max_events", 100))
+    raw = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_POST_QUERY_EVENTS,
+            params={"moId": mo_id},
+        )
+    )
+    events = _unwrap_value(raw)
+    if not isinstance(events, list):
+        # vi-json QueryEvents always returns a list. A non-list payload
+        # is a connector-side bug -- surface it to the caller rather
+        # than guess at the shape.
+        raise RuntimeError(
+            f"event_tail: expected list from {_OP_POST_QUERY_EVENTS!r}, got {type(events).__name__}"
+        )
+    capped = events[:max_events]
+    return {
+        "events": capped,
+        "count": len(capped),
+        "moId": mo_id,
+        "max_events_applied": max_events,
+    }
+
+
+async def performance_summary_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Summarise performance metrics for one entity via PerformanceManager (vi-json).
+
+    Op-id: ``vmware.composite.performance.summary``.
+
+    Sub-ops dispatched (sequential):
+
+    1. ``POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric`` --
+       discover available counter IDs for the target entity.
+    2. ``POST:/PerformanceManager/{moId}/QueryPerf`` -- fetch sample
+       values for those counters.
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"entity_moid": <str>, "perf_manager_moid": <str>,
+        "available_counters": <list>, "samples": <list>,
+        "interval_seconds": <int>, "max_samples_applied": <int>}``.
+
+    The handler does not pre-filter counters in v0.2; the entire
+    available-counter list is forwarded to QueryPerf so the operator
+    gets a complete snapshot. A counter-curation flag (e.g.
+    ``counter_ids``) is an explicit v0.2.next concern per the issue
+    body's *Out of scope* section.
+    """
+    entity_moid = params["entity_moid"]
+    perf_mgr_moid = params.get("perf_manager_moid", "PerfMgr")
+    interval_s = int(params.get("interval_seconds", 20))
+    max_samples = int(params.get("max_samples", 60))
+
+    available_raw = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_POST_QUERY_AVAILABLE_PERF_METRIC,
+            params={"moId": perf_mgr_moid, "entity": entity_moid},
+        )
+    )
+    available = _unwrap_value(available_raw)
+    if not isinstance(available, list):
+        raise RuntimeError(
+            "performance_summary: expected list from "
+            f"{_OP_POST_QUERY_AVAILABLE_PERF_METRIC!r}, "
+            f"got {type(available).__name__}"
+        )
+
+    samples_raw = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_POST_QUERY_PERF,
+            params={
+                "moId": perf_mgr_moid,
+                "entity": entity_moid,
+                "interval_seconds": interval_s,
+            },
+        )
+    )
+    samples = _unwrap_value(samples_raw)
+    if not isinstance(samples, list):
+        raise RuntimeError(
+            "performance_summary: expected list from "
+            f"{_OP_POST_QUERY_PERF!r}, got {type(samples).__name__}"
+        )
+    capped = samples[:max_samples]
+    return {
+        "entity_moid": entity_moid,
+        "perf_manager_moid": perf_mgr_moid,
+        "available_counters": available,
+        "samples": capped,
+        "interval_seconds": interval_s,
+        "max_samples_applied": max_samples,
+    }
+
+
+async def datastore_usage_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """List datastores with capacity + free + VM placement summary.
+
+    Op-id: ``vmware.composite.datastore.usage``.
+
+    Sub-ops dispatched (per-datastore, sequential):
+
+    1. ``GET:/vcenter/datastore`` -- list every datastore (optionally
+       narrowed via ``filter.names``).
+    2. For each datastore:
+       a. ``GET:/vcenter/datastore/{datastore}`` -- detailed capacity /
+          free / type / accessible flag.
+       b. ``GET:/vcenter/vm`` with ``filter.datastores`` -- VMs whose
+          working directory sits on this datastore. Drives the
+          ``vm_count`` + ``vm_names`` aggregation.
+
+    Sequential dispatch is intentional: each datastore's detail call
+    inherits the prior call's authentication state, and the audit
+    chain reads cleanly as ``listing -> detail(ds1) -> vms(ds1) ->
+    detail(ds2) -> vms(ds2) -> ...``. A future v0.2.next optimisation
+    could ``asyncio.gather`` the per-datastore detail + VM calls
+    pairwise, but the simpler shape is easier to audit-trace through
+    operator UIs.
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"datastores": [{"id": ..., "name": ..., "type": ...,
+        "capacity": ..., "free_space": ..., "vm_count": ...,
+        "vm_names": [...]}, ...]}``. The ``capacity`` / ``free_space``
+        fields may be ``None`` if the upstream payload omits them
+        (e.g. a partially-mounted datastore).
+    """
+    filter_names: list[str] = list(params.get("filter_names") or [])
+
+    listing_params: dict[str, Any] = {}
+    if filter_names:
+        listing_params["filter.names"] = filter_names
+
+    listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_DATASTORES,
+            params=listing_params,
+        )
+    )
+    entries = _unwrap_value(listing)
+    if not isinstance(entries, list):
+        raise RuntimeError(
+            f"datastore_usage: expected list from {_OP_LIST_DATASTORES!r}, "
+            f"got {type(entries).__name__}"
+        )
+
+    aggregated: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        ds_id = entry.get("datastore")
+        if not isinstance(ds_id, str):
+            # vSphere REST always returns the moid under the key
+            # ``datastore``; absence is an upstream malformation. Skip
+            # silently rather than abort the aggregation.
+            continue
+        detail = _require_ok(
+            await dispatch_child(
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_GET_DATASTORE,
+                params={"datastore": ds_id},
+            )
+        )
+        detail_payload = _unwrap_value(detail)
+        vms = _require_ok(
+            await dispatch_child(
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_LIST_VMS,
+                params={"filter.datastores": [ds_id]},
+            )
+        )
+        vm_entries = _unwrap_value(vms)
+        if not isinstance(vm_entries, list):
+            vm_entries = []
+        vm_names = [
+            v["name"] for v in vm_entries if isinstance(v, dict) and isinstance(v.get("name"), str)
+        ]
+        capacity = detail_payload.get("capacity") if isinstance(detail_payload, dict) else None
+        free_space = detail_payload.get("free_space") if isinstance(detail_payload, dict) else None
+        aggregated.append(
+            {
+                "id": ds_id,
+                "name": entry.get("name"),
+                "type": entry.get("type"),
+                "capacity": capacity,
+                "free_space": free_space,
+                "vm_count": len(vm_names),
+                "vm_names": vm_names,
+            }
+        )
+    return {"datastores": aggregated}
+
+
+async def network_portgroup_audit_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Audit distributed portgroups with parent DVS + connected-VM aggregation.
+
+    Op-id: ``vmware.composite.network.portgroup.audit``.
+
+    Sub-ops dispatched:
+
+    1. ``GET:/vcenter/network/distributed-switch`` -- list DVS entries
+       (filtered to ``filter_dvs`` when supplied). Drives the DVS
+       index used to enrich each portgroup.
+    2. ``GET:/vcenter/network/distributed-portgroup`` -- list
+       portgroups (filtered to ``filter_dvs`` when supplied).
+    3. Per portgroup: ``GET:/vcenter/vm`` with ``filter.networks`` --
+       VMs connected to the portgroup. Drives the ``vm_count`` +
+       ``vm_names`` aggregation.
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"portgroups": [{"id": ..., "name": ..., "dvs": <id|None>,
+        "dvs_name": <str|None>, "type": ..., "vm_count": ...,
+        "vm_names": [...]}, ...]}``.
+    """
+    filter_dvs = params.get("filter_dvs")
+    include_disconnected = bool(params.get("include_disconnected_vms", False))
+
+    dvs_params: dict[str, Any] = {}
+    if isinstance(filter_dvs, str):
+        dvs_params["filter.vdses"] = [filter_dvs]
+
+    dvs_listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_DVS,
+            params=dvs_params,
+        )
+    )
+    dvs_entries = _unwrap_value(dvs_listing)
+    if not isinstance(dvs_entries, list):
+        dvs_entries = []
+    # Build a moid->name lookup so the per-portgroup row carries the
+    # DVS name in addition to its id.
+    dvs_index: dict[str, str | None] = {}
+    for entry in dvs_entries:
+        if not isinstance(entry, dict):
+            continue
+        dvs_id = entry.get("vds") or entry.get("distributed_switch")
+        if isinstance(dvs_id, str):
+            name = entry.get("name") if isinstance(entry.get("name"), str) else None
+            dvs_index[dvs_id] = name
+
+    pg_params: dict[str, Any] = {}
+    if isinstance(filter_dvs, str):
+        pg_params["filter.vdses"] = [filter_dvs]
+
+    pg_listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_PORTGROUPS,
+            params=pg_params,
+        )
+    )
+    pg_entries = _unwrap_value(pg_listing)
+    if not isinstance(pg_entries, list):
+        raise RuntimeError(
+            f"network_portgroup_audit: expected list from {_OP_LIST_PORTGROUPS!r}, "
+            f"got {type(pg_entries).__name__}"
+        )
+
+    aggregated: list[dict[str, Any]] = []
+    for entry in pg_entries:
+        if not isinstance(entry, dict):
+            continue
+        pg_id = entry.get("network") or entry.get("portgroup")
+        if not isinstance(pg_id, str):
+            continue
+        vm_params: dict[str, Any] = {"filter.networks": [pg_id]}
+        if not include_disconnected:
+            # vSphere REST accepts a power-state filter; the
+            # ``include_disconnected`` flag toggles it. Default is
+            # active VMs only.
+            vm_params["filter.power_states"] = ["POWERED_ON"]
+        vms = _require_ok(
+            await dispatch_child(
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_LIST_VMS,
+                params=vm_params,
+            )
+        )
+        vm_entries = _unwrap_value(vms)
+        if not isinstance(vm_entries, list):
+            vm_entries = []
+        vm_names = [
+            v["name"] for v in vm_entries if isinstance(v, dict) and isinstance(v.get("name"), str)
+        ]
+        dvs_ref = entry.get("vds") or entry.get("distributed_switch")
+        dvs_ref_str = dvs_ref if isinstance(dvs_ref, str) else None
+        aggregated.append(
+            {
+                "id": pg_id,
+                "name": entry.get("name"),
+                "dvs": dvs_ref_str,
+                "dvs_name": dvs_index.get(dvs_ref_str) if dvs_ref_str else None,
+                "type": entry.get("type"),
+                "vm_count": len(vm_names),
+                "vm_names": vm_names,
+            }
+        )
+    return {"portgroups": aggregated}

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``register_vmware_composite_operations`` -- registrar for the 5 read composites.
+
+Module-level async function called from the lifespan-driven
+:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+after the registrar list is populated by the
+``meho_backplane.connectors.vmware_rest.composites`` package's
+``__init__`` (which appends this function via
+:func:`register_typed_op_registrar`).
+
+Per-composite arguments (summary / description / group_key / tags /
+``parameter_schema``) live here so a future shape change (e.g.
+``llm_instructions`` polish) only touches one file. The
+:func:`~meho_backplane.operations.typed_register.register_composite_operation`
+helper handles the upsert, body-hash dedupe, embedding pipeline, and
+the source_kind="composite" persistence.
+
+Every composite passes ``safety_level="safe"`` +
+``requires_approval=False`` -- overrides of T4's
+``dangerous`` / ``True`` defaults (which target the typical write
+composite). All 5 composites in this Task are inherently read-only;
+operator-facing dispatch should not pop the approval queue for them.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vmware_rest.composites._read import (
+    cluster_drs_recommendations_composite,
+    datastore_usage_composite,
+    event_tail_composite,
+    network_portgroup_audit_composite,
+    performance_summary_composite,
+)
+from meho_backplane.connectors.vmware_rest.composites.schemas import (
+    CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA,
+    DATASTORE_USAGE_PARAMETER_SCHEMA,
+    EVENT_TAIL_PARAMETER_SCHEMA,
+    NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
+    PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
+)
+from meho_backplane.operations.typed_register import register_composite_operation
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = ["register_vmware_composite_operations"]
+
+
+# Natural-key shorthand. Every composite registers against
+# ``(product="vmware", version="9.0", impl_id="vmware-rest")`` -- the
+# same triple :class:`VmwareRestConnector` advertises -- so the
+# dispatcher's ``connector_id="vmware-rest-9.0"`` lookup resolves
+# every read composite alongside the ~3,470 ingested ops.
+_PRODUCT = "vmware"
+_VERSION = "9.0"
+_IMPL_ID = "vmware-rest"
+
+
+async def register_vmware_composite_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every vmware-rest read composite into ``endpoint_descriptor``.
+
+    Idempotent: a second invocation against unchanged descriptions is a
+    no-op for the embedding pipeline (the body-hash skip path in
+    :func:`_register_in_session`). The runner
+    (:func:`run_typed_op_registrars`) calls every registered registrar
+    on every lifespan startup; the skip-re-embed branch keeps that
+    cheap.
+
+    Scope: 5 read composites (cluster.drs_recommendations + event.tail
+    + performance.summary + datastore.usage + network.portgroup.audit).
+    The 8 write composites are scope of #509 (G3.1-T6).
+
+    Test seam: ``embedding_service`` lets test fixtures inject a stub
+    so unit tests don't load the ONNX model. Production callers leave
+    it ``None`` and each registration resolves the process-wide
+    singleton.
+    """
+    await register_composite_operation(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id="vmware.composite.cluster.drs_recommendations",
+        handler=cluster_drs_recommendations_composite,
+        summary="Read DRS state + active recommendations for a cluster.",
+        description=(
+            "Orchestrates a cluster summary read plus a DRS-config read, "
+            "returning a single aggregated payload. Equivalent of "
+            "'govc cluster.recommendations' for the operator-facing "
+            "workflow: one composite call replaces two raw vCenter REST "
+            "GETs while preserving the audit-tree linkage between the "
+            "parent composite row and each sub-op row. Read-only -- "
+            "never mutates cluster state."
+        ),
+        parameter_schema=CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA,
+        group_key="cluster",
+        tags=["composite", "read-only", "cluster", "drs"],
+        safety_level="safe",
+        requires_approval=False,
+        embedding_service=embedding_service,
+    )
+
+    await register_composite_operation(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id="vmware.composite.event.tail",
+        handler=event_tail_composite,
+        summary="Tail recent vCenter events via EventManager.QueryEvents.",
+        description=(
+            "Calls EventManager.QueryEvents (vi-json) against the "
+            "EventManager singleton, optionally narrowed by a per-call "
+            "moId override, and caps the returned array client-side. "
+            "Equivalent of 'govc events' for the operator-facing "
+            "workflow. Read-only -- never mutates the event store."
+        ),
+        parameter_schema=EVENT_TAIL_PARAMETER_SCHEMA,
+        group_key="events",
+        tags=["composite", "read-only", "events", "vi-json"],
+        safety_level="safe",
+        requires_approval=False,
+        embedding_service=embedding_service,
+    )
+
+    await register_composite_operation(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id="vmware.composite.performance.summary",
+        handler=performance_summary_composite,
+        summary="Summarise performance metrics for one entity via PerformanceManager.",
+        description=(
+            "Discovers available counters for the target entity via "
+            "PerformanceManager.QueryAvailablePerfMetric, then fetches "
+            "sample values via PerformanceManager.QueryPerf (both "
+            "vi-json). Returns the available-counter list plus the "
+            "capped sample list; the caller can post-filter to whichever "
+            "metric they need. Read-only -- never mutates counter "
+            "configuration."
+        ),
+        parameter_schema=PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
+        group_key="performance",
+        tags=["composite", "read-only", "performance", "vi-json"],
+        safety_level="safe",
+        requires_approval=False,
+        embedding_service=embedding_service,
+    )
+
+    await register_composite_operation(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id="vmware.composite.datastore.usage",
+        handler=datastore_usage_composite,
+        summary="List datastores with capacity, free space, and VM placement.",
+        description=(
+            "Reads the datastore listing, then per-datastore detail "
+            "(capacity, free space, type) plus the VM-placement filter "
+            "via 'GET:/vcenter/vm?filter.datastores=...'. Aggregates "
+            "into one row per datastore including vm_count + vm_names. "
+            "Equivalent of an operator-facing 'storage usage report' "
+            "that would otherwise require 1 + N sub-calls. Read-only -- "
+            "never mutates storage state."
+        ),
+        parameter_schema=DATASTORE_USAGE_PARAMETER_SCHEMA,
+        group_key="storage",
+        tags=["composite", "read-only", "storage", "datastore"],
+        safety_level="safe",
+        requires_approval=False,
+        embedding_service=embedding_service,
+    )
+
+    await register_composite_operation(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id="vmware.composite.network.portgroup.audit",
+        handler=network_portgroup_audit_composite,
+        summary="Audit distributed portgroups with parent DVS + connected VMs.",
+        description=(
+            "Reads the distributed-switch listing (for parent-DVS name "
+            "enrichment) plus the distributed-portgroup listing, then "
+            "per-portgroup queries the VM list via "
+            "'GET:/vcenter/vm?filter.networks=...'. Aggregates one row "
+            "per portgroup with its parent DVS + connected VM names. "
+            "Equivalent of 'govc dvs.portgroup.info' rolled up across "
+            "every portgroup. Read-only -- never mutates network "
+            "configuration."
+        ),
+        parameter_schema=NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
+        group_key="networking",
+        tags=["composite", "read-only", "networking", "portgroup"],
+        safety_level="safe",
+        requires_approval=False,
+        embedding_service=embedding_service,
+    )

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -26,6 +26,9 @@ operator-facing dispatch should not pop the approval queue for them.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from typing import Any, NamedTuple
+
 from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
@@ -35,10 +38,15 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
 )
 from meho_backplane.connectors.vmware_rest.composites.schemas import (
     CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA,
+    CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA,
     DATASTORE_USAGE_PARAMETER_SCHEMA,
+    DATASTORE_USAGE_RESPONSE_SCHEMA,
     EVENT_TAIL_PARAMETER_SCHEMA,
+    EVENT_TAIL_RESPONSE_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
+    NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
+    PERFORMANCE_SUMMARY_RESPONSE_SCHEMA,
 )
 from meho_backplane.operations.typed_register import register_composite_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
@@ -54,6 +62,120 @@ __all__ = ["register_vmware_composite_operations"]
 _PRODUCT = "vmware"
 _VERSION = "9.0"
 _IMPL_ID = "vmware-rest"
+
+
+class _CompositeSpec(NamedTuple):
+    """Per-composite registration arguments.
+
+    Field-table form rather than five repeated kwargs blocks: keeps the
+    op_id / handler / schemas / group / tags adjacent per composite and
+    drops the outer registrar function below the 100-line block limit.
+    Common fields (``product`` / ``version`` / ``impl_id`` /
+    ``safety_level="safe"`` / ``requires_approval=False``) live on the
+    call site below, not in the spec.
+    """
+
+    op_id: str
+    handler: Callable[..., Awaitable[dict[str, Any]]]
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any]
+    group_key: str
+    tags: list[str]
+
+
+_COMPOSITES: tuple[_CompositeSpec, ...] = (
+    _CompositeSpec(
+        op_id="vmware.composite.cluster.drs_recommendations",
+        handler=cluster_drs_recommendations_composite,
+        summary="Read DRS state + active recommendations for a cluster.",
+        description=(
+            "Orchestrates a cluster summary read plus a DRS-config read, "
+            "returning a single aggregated payload. Equivalent of "
+            "'govc cluster.recommendations' for the operator-facing "
+            "workflow: one composite call replaces two raw vCenter REST "
+            "GETs while preserving the audit-tree linkage between the "
+            "parent composite row and each sub-op row. Read-only -- "
+            "never mutates cluster state."
+        ),
+        parameter_schema=CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA,
+        response_schema=CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA,
+        group_key="cluster",
+        tags=["composite", "read-only", "cluster", "drs"],
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.event.tail",
+        handler=event_tail_composite,
+        summary="Tail recent vCenter events via EventManager.QueryEvents.",
+        description=(
+            "Calls EventManager.QueryEvents (vi-json) against the "
+            "EventManager singleton, optionally narrowed by a per-call "
+            "moId override, and caps the returned array client-side. "
+            "Equivalent of 'govc events' for the operator-facing "
+            "workflow. Read-only -- never mutates the event store."
+        ),
+        parameter_schema=EVENT_TAIL_PARAMETER_SCHEMA,
+        response_schema=EVENT_TAIL_RESPONSE_SCHEMA,
+        group_key="events",
+        tags=["composite", "read-only", "events", "vi-json"],
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.performance.summary",
+        handler=performance_summary_composite,
+        summary="Summarise performance metrics for one entity via PerformanceManager.",
+        description=(
+            "Discovers available counters for the target entity via "
+            "PerformanceManager.QueryAvailablePerfMetric, then fetches "
+            "sample values via PerformanceManager.QueryPerf (both "
+            "vi-json). Returns the available-counter list plus the "
+            "capped sample list; the caller can post-filter to whichever "
+            "metric they need. Read-only -- never mutates counter "
+            "configuration."
+        ),
+        parameter_schema=PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
+        response_schema=PERFORMANCE_SUMMARY_RESPONSE_SCHEMA,
+        group_key="performance",
+        tags=["composite", "read-only", "performance", "vi-json"],
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.datastore.usage",
+        handler=datastore_usage_composite,
+        summary="List datastores with capacity, free space, and VM placement.",
+        description=(
+            "Reads the datastore listing, then per-datastore detail "
+            "(capacity, free space, type) plus the VM-placement filter "
+            "via 'GET:/vcenter/vm?filter.datastores=...'. Aggregates "
+            "into one row per datastore including vm_count + vm_names. "
+            "Equivalent of an operator-facing 'storage usage report' "
+            "that would otherwise require 1 + N sub-calls. Read-only -- "
+            "never mutates storage state."
+        ),
+        parameter_schema=DATASTORE_USAGE_PARAMETER_SCHEMA,
+        response_schema=DATASTORE_USAGE_RESPONSE_SCHEMA,
+        group_key="storage",
+        tags=["composite", "read-only", "storage", "datastore"],
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.network.portgroup.audit",
+        handler=network_portgroup_audit_composite,
+        summary="Audit distributed portgroups with parent DVS + connected VMs.",
+        description=(
+            "Reads the distributed-switch listing (for parent-DVS name "
+            "enrichment) plus the distributed-portgroup listing, then "
+            "per-portgroup queries the VM list via "
+            "'GET:/vcenter/vm?filter.networks=...'. Aggregates one row "
+            "per portgroup with its parent DVS + connected VM names. "
+            "Equivalent of 'govc dvs.portgroup.info' rolled up across "
+            "every portgroup. Read-only -- never mutates network "
+            "configuration."
+        ),
+        parameter_schema=NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
+        response_schema=NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
+        group_key="networking",
+        tags=["composite", "read-only", "networking", "portgroup"],
+    ),
+)
 
 
 async def register_vmware_composite_operations(
@@ -78,121 +200,20 @@ async def register_vmware_composite_operations(
     it ``None`` and each registration resolves the process-wide
     singleton.
     """
-    await register_composite_operation(
-        product=_PRODUCT,
-        version=_VERSION,
-        impl_id=_IMPL_ID,
-        op_id="vmware.composite.cluster.drs_recommendations",
-        handler=cluster_drs_recommendations_composite,
-        summary="Read DRS state + active recommendations for a cluster.",
-        description=(
-            "Orchestrates a cluster summary read plus a DRS-config read, "
-            "returning a single aggregated payload. Equivalent of "
-            "'govc cluster.recommendations' for the operator-facing "
-            "workflow: one composite call replaces two raw vCenter REST "
-            "GETs while preserving the audit-tree linkage between the "
-            "parent composite row and each sub-op row. Read-only -- "
-            "never mutates cluster state."
-        ),
-        parameter_schema=CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA,
-        group_key="cluster",
-        tags=["composite", "read-only", "cluster", "drs"],
-        safety_level="safe",
-        requires_approval=False,
-        embedding_service=embedding_service,
-    )
-
-    await register_composite_operation(
-        product=_PRODUCT,
-        version=_VERSION,
-        impl_id=_IMPL_ID,
-        op_id="vmware.composite.event.tail",
-        handler=event_tail_composite,
-        summary="Tail recent vCenter events via EventManager.QueryEvents.",
-        description=(
-            "Calls EventManager.QueryEvents (vi-json) against the "
-            "EventManager singleton, optionally narrowed by a per-call "
-            "moId override, and caps the returned array client-side. "
-            "Equivalent of 'govc events' for the operator-facing "
-            "workflow. Read-only -- never mutates the event store."
-        ),
-        parameter_schema=EVENT_TAIL_PARAMETER_SCHEMA,
-        group_key="events",
-        tags=["composite", "read-only", "events", "vi-json"],
-        safety_level="safe",
-        requires_approval=False,
-        embedding_service=embedding_service,
-    )
-
-    await register_composite_operation(
-        product=_PRODUCT,
-        version=_VERSION,
-        impl_id=_IMPL_ID,
-        op_id="vmware.composite.performance.summary",
-        handler=performance_summary_composite,
-        summary="Summarise performance metrics for one entity via PerformanceManager.",
-        description=(
-            "Discovers available counters for the target entity via "
-            "PerformanceManager.QueryAvailablePerfMetric, then fetches "
-            "sample values via PerformanceManager.QueryPerf (both "
-            "vi-json). Returns the available-counter list plus the "
-            "capped sample list; the caller can post-filter to whichever "
-            "metric they need. Read-only -- never mutates counter "
-            "configuration."
-        ),
-        parameter_schema=PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
-        group_key="performance",
-        tags=["composite", "read-only", "performance", "vi-json"],
-        safety_level="safe",
-        requires_approval=False,
-        embedding_service=embedding_service,
-    )
-
-    await register_composite_operation(
-        product=_PRODUCT,
-        version=_VERSION,
-        impl_id=_IMPL_ID,
-        op_id="vmware.composite.datastore.usage",
-        handler=datastore_usage_composite,
-        summary="List datastores with capacity, free space, and VM placement.",
-        description=(
-            "Reads the datastore listing, then per-datastore detail "
-            "(capacity, free space, type) plus the VM-placement filter "
-            "via 'GET:/vcenter/vm?filter.datastores=...'. Aggregates "
-            "into one row per datastore including vm_count + vm_names. "
-            "Equivalent of an operator-facing 'storage usage report' "
-            "that would otherwise require 1 + N sub-calls. Read-only -- "
-            "never mutates storage state."
-        ),
-        parameter_schema=DATASTORE_USAGE_PARAMETER_SCHEMA,
-        group_key="storage",
-        tags=["composite", "read-only", "storage", "datastore"],
-        safety_level="safe",
-        requires_approval=False,
-        embedding_service=embedding_service,
-    )
-
-    await register_composite_operation(
-        product=_PRODUCT,
-        version=_VERSION,
-        impl_id=_IMPL_ID,
-        op_id="vmware.composite.network.portgroup.audit",
-        handler=network_portgroup_audit_composite,
-        summary="Audit distributed portgroups with parent DVS + connected VMs.",
-        description=(
-            "Reads the distributed-switch listing (for parent-DVS name "
-            "enrichment) plus the distributed-portgroup listing, then "
-            "per-portgroup queries the VM list via "
-            "'GET:/vcenter/vm?filter.networks=...'. Aggregates one row "
-            "per portgroup with its parent DVS + connected VM names. "
-            "Equivalent of 'govc dvs.portgroup.info' rolled up across "
-            "every portgroup. Read-only -- never mutates network "
-            "configuration."
-        ),
-        parameter_schema=NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
-        group_key="networking",
-        tags=["composite", "read-only", "networking", "portgroup"],
-        safety_level="safe",
-        requires_approval=False,
-        embedding_service=embedding_service,
-    )
+    for spec in _COMPOSITES:
+        await register_composite_operation(
+            product=_PRODUCT,
+            version=_VERSION,
+            impl_id=_IMPL_ID,
+            op_id=spec.op_id,
+            handler=spec.handler,
+            summary=spec.summary,
+            description=spec.description,
+            parameter_schema=spec.parameter_schema,
+            response_schema=spec.response_schema,
+            group_key=spec.group_key,
+            tags=spec.tags,
+            safety_level="safe",
+            requires_approval=False,
+            embedding_service=embedding_service,
+        )

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""JSON Schema 2020-12 parameter schemas for the 5 vmware-rest read composites.
+
+Each schema is the operator-facing input contract; the dispatcher
+validates inbound ``params`` against the registered schema before
+invoking the handler (see
+:func:`meho_backplane.operations._branches.dispatch_composite` and the
+:class:`jsonschema.Draft202012Validator` it uses upstream). A malformed
+``params`` payload surfaces as an :class:`OperationResult` with
+``status="error"`` and the JSON-Schema validator message in
+``error`` -- the handler never runs.
+
+Conventions
+-----------
+
+* ``additionalProperties=False`` on every schema so a typo on an
+  optional key (e.g. ``filter_namse`` instead of ``filter_names``)
+  surfaces as a clear validation error rather than silently disappearing
+  through a permissive shape.
+* Schemas declare only what the handler *reads*. Per-composite
+  documentation lives on the schema's ``description`` keys; the meta-
+  tools (:mod:`meho_backplane.operations.meta_tools`) surface the
+  schema verbatim on ``describe_operation`` calls.
+* All five composites are read-only -- no schema mentions write
+  semantics; the registration call site pins ``safety_level="safe"``
+  and ``requires_approval=False`` on each.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA",
+    "DATASTORE_USAGE_PARAMETER_SCHEMA",
+    "EVENT_TAIL_PARAMETER_SCHEMA",
+    "NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA",
+    "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
+]
+
+
+#: ``vmware.composite.cluster.drs_recommendations`` parameter schema.
+#:
+#: Reads cluster DRS state + active recommendations. The composite
+#: dispatches one ``GET:/vcenter/cluster/{cluster}`` and one
+#: ``GET:/vcenter/cluster/{cluster}/drs`` to a single target.
+CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Managed-object ID of the cluster (e.g. 'domain-c123'). "
+                "Required: drives the {cluster} path parameter on both "
+                "sub-ops."
+            ),
+        },
+        "include_recommendations_history": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, the handler will also surface the historical "
+                "recommendation summary from the DRS sub-op response. "
+                "Read-only on either setting; the flag toggles aggregation "
+                "shape, not the underlying calls."
+            ),
+        },
+    },
+    "required": ["cluster"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.event.tail`` parameter schema.
+#:
+#: Reads recent events from EventManager via the vi-json
+#: ``POST:/EventManager/{moId}/QueryEvents`` sub-op. Equivalent of
+#: ``govc events`` against a vSphere target. The default ``moId`` is
+#: the canonical ``EventManager`` singleton.
+EVENT_TAIL_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "moId": {
+            "type": "string",
+            "minLength": 1,
+            "default": "EventManager",
+            "description": (
+                "Managed-object ID of the EventManager singleton. The "
+                "vSphere canonical singleton is 'EventManager'; "
+                "non-default values target test fixtures or future "
+                "per-DC event managers."
+            ),
+        },
+        "max_events": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10000,
+            "default": 100,
+            "description": (
+                "Cap on the number of events returned. The vi-json "
+                "QueryEvents call accepts a filter -- the handler "
+                "applies the cap client-side after the sub-op returns "
+                "so older events are dropped uniformly."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.performance.summary`` parameter schema.
+#:
+#: Reads performance counters for one managed entity via the vi-json
+#: ``POST:/PerformanceManager/{moId}/QueryPerf`` sub-op (and the
+#: companion ``QueryAvailablePerfMetric`` for counter discovery). The
+#: canonical PerformanceManager singleton is ``PerfMgr``.
+PERFORMANCE_SUMMARY_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "entity_moid": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Managed-object ID of the entity to query metrics for "
+                "(e.g. 'vm-1234', 'host-5678'). Required: every QueryPerf "
+                "call is per-entity."
+            ),
+        },
+        "perf_manager_moid": {
+            "type": "string",
+            "minLength": 1,
+            "default": "PerfMgr",
+            "description": (
+                "Managed-object ID of the PerformanceManager singleton. "
+                "The vSphere canonical singleton is 'PerfMgr'; override "
+                "only for test fixtures."
+            ),
+        },
+        "interval_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 20,
+            "description": (
+                "Sample interval for the QueryPerf call. The default 20 s "
+                "matches vSphere's real-time historical interval."
+            ),
+        },
+        "max_samples": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 60,
+            "description": (
+                "Cap on the number of returned samples per counter. "
+                "Applied client-side after the sub-op returns."
+            ),
+        },
+    },
+    "required": ["entity_moid"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.datastore.usage`` parameter schema.
+#:
+#: Lists datastores with capacity + free + VM placement aggregation.
+#: All sub-ops are vCenter REST. ``filter_names`` narrows the
+#: aggregation to the supplied datastore names; the
+#: ``GET:/vcenter/datastore`` listing forwards the filter to the
+#: server-side query.
+DATASTORE_USAGE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "filter_names": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": (
+                "Optional list of datastore names. When supplied, only "
+                "datastores whose name appears in this list are surfaced. "
+                "Empty / absent returns every datastore the operator can "
+                "see."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.network.portgroup.audit`` parameter schema.
+#:
+#: Lists distributed portgroups with host membership + connected-VM
+#: aggregation. All sub-ops are vCenter REST.
+NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "filter_dvs": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional Distributed-Virtual-Switch managed-object ID. "
+                "When supplied, only portgroups belonging to this DVS "
+                "are returned."
+            ),
+        },
+        "include_disconnected_vms": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, the VM aggregation includes VMs whose power "
+                "state is OFF or whose NIC is disconnected. Default "
+                "false returns only actively-connected VMs."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -34,17 +34,23 @@ from typing import Any
 
 __all__ = [
     "CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA",
+    "CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA",
     "DATASTORE_USAGE_PARAMETER_SCHEMA",
+    "DATASTORE_USAGE_RESPONSE_SCHEMA",
     "EVENT_TAIL_PARAMETER_SCHEMA",
+    "EVENT_TAIL_RESPONSE_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA",
+    "NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA",
     "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
+    "PERFORMANCE_SUMMARY_RESPONSE_SCHEMA",
 ]
 
 
 #: ``vmware.composite.cluster.drs_recommendations`` parameter schema.
 #:
-#: Reads cluster DRS state + active recommendations. The composite
-#: dispatches one ``GET:/vcenter/cluster/{cluster}`` and one
+#: Reads cluster summary + DRS state (optionally surfacing
+#: ``recommendations_history`` from the DRS payload when present). The
+#: composite dispatches one ``GET:/vcenter/cluster/{cluster}`` and one
 #: ``GET:/vcenter/cluster/{cluster}/drs`` to a single target.
 CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -219,4 +225,250 @@ NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA: dict[str, Any] = {
     },
     "required": [],
     "additionalProperties": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+#
+# Each response schema captures the aggregated dict the corresponding
+# handler in :mod:`_read` returns. Informational in v0.2 (the
+# dispatcher's :class:`PassThroughReducer` does not validate outbound
+# payloads); declared so the meta-tools
+# (:mod:`meho_backplane.operations.meta_tools`) can surface the shape on
+# ``describe_operation`` calls and so the
+# :class:`~meho_backplane.db.models.EndpointDescriptor` row persists a
+# non-null ``response_schema`` for parity with the connector_op surface
+# (precedent: ``vault.kv.read`` -- the only other typed-op with an
+# explicit response schema today).
+#
+# Sub-payload shapes (``cluster`` summary, ``drs`` config, datastore
+# detail, etc.) are intentionally typed as ``"object"`` with no
+# ``properties`` enumeration -- the upstream vSphere REST payload shape
+# is owned by Broadcom and out of this composite's contract.
+
+
+#: ``vmware.composite.cluster.drs_recommendations`` response schema.
+#:
+#: Captures the cluster summary + DRS config aggregation; the
+#: ``recommendations_history`` key is optional and appears only when
+#: the operator sets ``include_recommendations_history=True``.
+CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "object",
+            "description": (
+                "Cluster summary payload from "
+                "``GET:/vcenter/cluster/{cluster}`` (vSphere REST owns "
+                "the inner shape)."
+            ),
+        },
+        "drs": {
+            "type": "object",
+            "description": (
+                "DRS configuration payload from "
+                "``GET:/vcenter/cluster/{cluster}/drs`` (vSphere REST "
+                "owns the inner shape)."
+            ),
+        },
+        "recommendations_history": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Optional history slice surfaced from the DRS payload "
+                "when ``include_recommendations_history=True``. Always "
+                "a list when present; absent otherwise."
+            ),
+        },
+    },
+    "required": ["cluster", "drs"],
+}
+
+
+#: ``vmware.composite.event.tail`` response schema.
+EVENT_TAIL_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "events": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Capped list of event dicts from "
+                "``POST:/EventManager/{moId}/QueryEvents`` (vi-json). "
+                "Truncated client-side to ``max_events``."
+            ),
+        },
+        "count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Post-cap length of ``events`` -- detects truncation.",
+        },
+        "moId": {
+            "type": "string",
+            "description": "EventManager managed-object ID the call targeted.",
+        },
+        "max_events_applied": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Effective ``max_events`` cap applied to the response.",
+        },
+    },
+    "required": ["events", "count", "moId", "max_events_applied"],
+}
+
+
+#: ``vmware.composite.performance.summary`` response schema.
+PERFORMANCE_SUMMARY_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "entity_moid": {
+            "type": "string",
+            "description": "Managed-object ID of the queried entity.",
+        },
+        "perf_manager_moid": {
+            "type": "string",
+            "description": "PerformanceManager singleton moid the call targeted.",
+        },
+        "available_counters": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Counters returned by ``QueryAvailablePerfMetric`` for the entity (vi-json)."
+            ),
+        },
+        "samples": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Capped sample list from ``QueryPerf`` (vi-json). "
+                "Truncated client-side to ``max_samples``."
+            ),
+        },
+        "interval_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Sample interval forwarded to QueryPerf.",
+        },
+        "max_samples_applied": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Effective ``max_samples`` cap applied to ``samples``.",
+        },
+    },
+    "required": [
+        "entity_moid",
+        "perf_manager_moid",
+        "available_counters",
+        "samples",
+        "interval_seconds",
+        "max_samples_applied",
+    ],
+}
+
+
+#: ``vmware.composite.datastore.usage`` response schema.
+DATASTORE_USAGE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "datastores": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Datastore managed-object ID.",
+                    },
+                    "name": {
+                        "type": ["string", "null"],
+                        "description": "Datastore name from the listing row.",
+                    },
+                    "type": {
+                        "type": ["string", "null"],
+                        "description": "Datastore type (e.g. ``VMFS``, ``NFS``).",
+                    },
+                    "capacity": {
+                        "type": ["integer", "null"],
+                        "description": (
+                            "Total capacity in bytes; ``null`` when the detail payload omits it."
+                        ),
+                    },
+                    "free_space": {
+                        "type": ["integer", "null"],
+                        "description": (
+                            "Free space in bytes; ``null`` when the detail payload omits it."
+                        ),
+                    },
+                    "vm_count": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Number of VMs placed on this datastore.",
+                    },
+                    "vm_names": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Names of VMs placed on this datastore.",
+                    },
+                },
+                "required": ["id", "vm_count", "vm_names"],
+            },
+            "description": "One row per datastore in scope.",
+        },
+    },
+    "required": ["datastores"],
+}
+
+
+#: ``vmware.composite.network.portgroup.audit`` response schema.
+NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "portgroups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Portgroup managed-object ID.",
+                    },
+                    "name": {
+                        "type": ["string", "null"],
+                        "description": "Portgroup name from the listing row.",
+                    },
+                    "dvs": {
+                        "type": ["string", "null"],
+                        "description": "Parent DVS managed-object ID, if present.",
+                    },
+                    "dvs_name": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "Parent DVS display name resolved via the "
+                            "DVS listing; ``null`` when the parent DVS "
+                            "is unknown or unnamed."
+                        ),
+                    },
+                    "type": {
+                        "type": ["string", "null"],
+                        "description": "Portgroup type from the listing row.",
+                    },
+                    "vm_count": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Number of VMs attached to this portgroup.",
+                    },
+                    "vm_names": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Names of VMs attached to this portgroup.",
+                    },
+                },
+                "required": ["id", "vm_count", "vm_names"],
+            },
+            "description": "One row per portgroup in scope.",
+        },
+    },
+    "required": ["portgroups"],
 }

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -1,0 +1,746 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the 5 vmware-rest read-composite handler functions.
+
+Coverage matrix (G3.1-T5 / #508 acceptance criteria):
+
+* Per-composite: assert the correct sub-op_ids fire in the expected
+  order, with the right ``connector_id`` and ``params`` shape.
+* Aggregation correctness: the handler's returned dict matches the
+  spec sketched in #508's issue body.
+* Envelope tolerance: ``{"value": [...]}`` (legacy) and bare lists
+  (modern) both parse correctly.
+* Filter pass-through: ``filter_names`` / ``filter_dvs`` / ``moId``
+  / ``entity_moid`` flow into the sub-op params.
+* Error fan-out: a sub-op returning ``status="error"`` causes the
+  handler to raise ``RuntimeError`` (load-bearing for the dispatcher's
+  ``connector_error`` wrapping at the composite parent).
+
+Each test mocks ``dispatch_child`` as an :class:`AsyncMock`-style
+callable that returns canned ``OperationResult`` objects keyed on
+``op_id``. The handlers are invoked directly (no dispatcher in the
+loop) so the assertion target is the call-shape contract: which
+sub-ops, in what order, with what params.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._read import (
+    cluster_drs_recommendations_composite,
+    datastore_usage_composite,
+    event_tail_composite,
+    network_portgroup_audit_composite,
+    performance_summary_composite,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator for composite-handler unit tests."""
+    return Operator(
+        sub="op-composite-read",
+        name="Composite Read Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _RecordingDispatchChild:
+    """Lightweight ``dispatch_child`` stub that returns canned responses.
+
+    Avoids :class:`unittest.mock.AsyncMock` so the test reads as a plain
+    keyword-args call sequence and the matching ``DispatchChild``
+    Protocol shape is preserved (``AsyncMock.__call__`` doesn't enforce
+    keyword-only).
+    """
+
+    def __init__(self, responses: dict[str, Any] | list[Any]) -> None:
+        """Build a recording stub.
+
+        Parameters
+        ----------
+        responses:
+            Either a mapping of ``op_id -> result`` (the handler dispatches
+            each op once; subsequent calls reuse the same payload), or a
+            sequential list of ``OperationResult`` values returned in
+            order. The list form lets tests assert per-call payloads when
+            the same op_id is dispatched multiple times.
+        """
+        self._responses = responses
+        self._sequence_index = 0
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(
+        self,
+        *,
+        connector_id: str,
+        op_id: str,
+        params: dict[str, Any],
+        target: Any = None,
+    ) -> OperationResult:
+        # Record before serving so the assertion sees the call even
+        # if the handler raises on the (canned) result.
+        self.calls.append(
+            {
+                "connector_id": connector_id,
+                "op_id": op_id,
+                "params": dict(params),
+                "target": target,
+            }
+        )
+        if isinstance(self._responses, dict):
+            payload = self._responses[op_id]
+        else:
+            payload = self._responses[self._sequence_index]
+            self._sequence_index += 1
+        if isinstance(payload, OperationResult):
+            return payload
+        return _ok_result(op_id, payload)
+
+
+def _ok_result(op_id: str, result: Any) -> OperationResult:
+    """Build an OK :class:`OperationResult` with ``result`` as the body."""
+    return OperationResult(
+        status="ok",
+        op_id=op_id,
+        result=result,
+        duration_ms=1.0,
+    )
+
+
+def _err_result(op_id: str, error: str) -> OperationResult:
+    """Build an error :class:`OperationResult` for failure-fan-out tests."""
+    return OperationResult(
+        status="error",
+        op_id=op_id,
+        error=error,
+        duration_ms=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# vmware.composite.cluster.drs_recommendations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cluster_drs_recommendations_dispatches_summary_and_drs_in_order() -> None:
+    """Two sub-ops fire: cluster summary then DRS config, both with the cluster moid."""
+    cluster_payload = {"name": "Cluster-A", "drs_enabled": True}
+    drs_payload = {"enabled": True, "automation_level": "FULLY_AUTOMATED"}
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/vcenter/cluster/{cluster}": cluster_payload,
+            "GET:/vcenter/cluster/{cluster}/drs": drs_payload,
+        }
+    )
+
+    out = await cluster_drs_recommendations_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "domain-c123"},
+        dispatch_child=dispatch,
+    )
+
+    assert [c["op_id"] for c in dispatch.calls] == [
+        "GET:/vcenter/cluster/{cluster}",
+        "GET:/vcenter/cluster/{cluster}/drs",
+    ]
+    assert all(c["connector_id"] == "vmware-rest-9.0" for c in dispatch.calls)
+    assert all(c["params"] == {"cluster": "domain-c123"} for c in dispatch.calls)
+    assert out == {
+        "cluster": cluster_payload,
+        "drs": drs_payload,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cluster_drs_recommendations_history_flag_surfaces_history_slice() -> None:
+    """``include_recommendations_history=True`` surfaces ``history`` from the DRS payload."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/vcenter/cluster/{cluster}": {"name": "Cluster-A"},
+            "GET:/vcenter/cluster/{cluster}/drs": {
+                "enabled": True,
+                "history": [{"recommendation_id": "rec-1", "reason": "load balance"}],
+            },
+        }
+    )
+    out = await cluster_drs_recommendations_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "domain-c1", "include_recommendations_history": True},
+        dispatch_child=dispatch,
+    )
+    assert "recommendations_history" in out
+    assert out["recommendations_history"] == [
+        {"recommendation_id": "rec-1", "reason": "load balance"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cluster_drs_recommendations_history_flag_default_omits_key() -> None:
+    """Default ``include_recommendations_history=False`` omits the key."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/vcenter/cluster/{cluster}": {"name": "Cluster-A"},
+            "GET:/vcenter/cluster/{cluster}/drs": {"enabled": False, "history": [1, 2]},
+        }
+    )
+    out = await cluster_drs_recommendations_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "domain-c1"},
+        dispatch_child=dispatch,
+    )
+    assert "recommendations_history" not in out
+
+
+# ---------------------------------------------------------------------------
+# vmware.composite.event.tail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_tail_dispatches_query_events_with_default_mo_id() -> None:
+    """Default ``moId='EventManager'`` and ``max_events=100`` flow through."""
+    events_payload = [{"id": f"evt-{n}", "summary": f"event {n}"} for n in range(5)]
+    dispatch = _RecordingDispatchChild({"POST:/EventManager/{moId}/QueryEvents": events_payload})
+    out = await event_tail_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    assert len(dispatch.calls) == 1
+    only = dispatch.calls[0]
+    assert only["op_id"] == "POST:/EventManager/{moId}/QueryEvents"
+    assert only["connector_id"] == "vmware-rest-9.0"
+    assert only["params"] == {"moId": "EventManager"}
+    assert out["events"] == events_payload
+    assert out["count"] == 5
+    assert out["moId"] == "EventManager"
+    assert out["max_events_applied"] == 100
+
+
+@pytest.mark.asyncio
+async def test_event_tail_caps_results_to_max_events() -> None:
+    """The handler caps client-side to ``max_events``."""
+    events_payload = [{"id": f"evt-{n}"} for n in range(200)]
+    dispatch = _RecordingDispatchChild({"POST:/EventManager/{moId}/QueryEvents": events_payload})
+    out = await event_tail_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"max_events": 7},
+        dispatch_child=dispatch,
+    )
+    assert len(out["events"]) == 7
+    assert out["count"] == 7
+    assert out["max_events_applied"] == 7
+
+
+@pytest.mark.asyncio
+async def test_event_tail_tolerates_legacy_value_envelope() -> None:
+    """A ``{"value": [...]}`` envelope on the sub-op response unwraps cleanly."""
+    dispatch = _RecordingDispatchChild(
+        {"POST:/EventManager/{moId}/QueryEvents": {"value": [{"id": "evt-1"}, {"id": "evt-2"}]}}
+    )
+    out = await event_tail_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    assert out["count"] == 2
+    assert out["events"] == [{"id": "evt-1"}, {"id": "evt-2"}]
+
+
+@pytest.mark.asyncio
+async def test_event_tail_raises_on_non_list_payload() -> None:
+    """Non-list payload from QueryEvents raises ``RuntimeError`` (audit-visible)."""
+    dispatch = _RecordingDispatchChild({"POST:/EventManager/{moId}/QueryEvents": {"not": "a list"}})
+    with pytest.raises(RuntimeError, match="expected list"):
+        await event_tail_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={},
+            dispatch_child=dispatch,
+        )
+
+
+# ---------------------------------------------------------------------------
+# vmware.composite.performance.summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_performance_summary_dispatches_two_sub_ops_in_order() -> None:
+    """QueryAvailablePerfMetric first, then QueryPerf -- both per-entity."""
+    available_payload = [
+        {"counterId": 1, "instance": ""},
+        {"counterId": 2, "instance": "vmnic0"},
+    ]
+    samples_payload = [
+        {"counterId": 1, "value": 42},
+        {"counterId": 2, "value": 100},
+    ]
+    dispatch = _RecordingDispatchChild(
+        {
+            "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric": (available_payload),
+            "POST:/PerformanceManager/{moId}/QueryPerf": samples_payload,
+        }
+    )
+    out = await performance_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"entity_moid": "vm-1234"},
+        dispatch_child=dispatch,
+    )
+    assert [c["op_id"] for c in dispatch.calls] == [
+        "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric",
+        "POST:/PerformanceManager/{moId}/QueryPerf",
+    ]
+    # Both calls use the default PerfMgr singleton + the entity moid.
+    assert dispatch.calls[0]["params"] == {"moId": "PerfMgr", "entity": "vm-1234"}
+    assert dispatch.calls[1]["params"] == {
+        "moId": "PerfMgr",
+        "entity": "vm-1234",
+        "interval_seconds": 20,
+    }
+    assert out == {
+        "entity_moid": "vm-1234",
+        "perf_manager_moid": "PerfMgr",
+        "available_counters": available_payload,
+        "samples": samples_payload,
+        "interval_seconds": 20,
+        "max_samples_applied": 60,
+    }
+
+
+@pytest.mark.asyncio
+async def test_performance_summary_caps_samples() -> None:
+    """``max_samples`` caps the sample list client-side."""
+    available = [{"counterId": 1}]
+    samples = [{"counterId": 1, "value": n} for n in range(150)]
+    dispatch = _RecordingDispatchChild(
+        {
+            "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric": available,
+            "POST:/PerformanceManager/{moId}/QueryPerf": samples,
+        }
+    )
+    out = await performance_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"entity_moid": "vm-7", "max_samples": 12},
+        dispatch_child=dispatch,
+    )
+    assert len(out["samples"]) == 12
+    assert out["max_samples_applied"] == 12
+
+
+@pytest.mark.asyncio
+async def test_performance_summary_passes_through_interval_and_custom_perf_mgr() -> None:
+    """Operator-supplied ``interval_seconds`` + ``perf_manager_moid`` propagate."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric": [],
+            "POST:/PerformanceManager/{moId}/QueryPerf": [],
+        }
+    )
+    await performance_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "entity_moid": "vm-99",
+            "perf_manager_moid": "AltPerfMgr",
+            "interval_seconds": 300,
+        },
+        dispatch_child=dispatch,
+    )
+    assert dispatch.calls[1]["params"]["moId"] == "AltPerfMgr"
+    assert dispatch.calls[1]["params"]["interval_seconds"] == 300
+
+
+# ---------------------------------------------------------------------------
+# vmware.composite.datastore.usage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_three_ops_per_datastore_aggregates_correctly() -> None:
+    """Listing + per-DS detail + per-DS VM-listing; aggregated payload matches spec."""
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+        {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+    ]
+    detail_by_id = {
+        "datastore-1": {"capacity": 100, "free_space": 40, "type": "VMFS"},
+        "datastore-2": {"capacity": 500, "free_space": 250, "type": "NFS"},
+    }
+    vms_by_ds: dict[str, list[dict[str, Any]]] = {
+        "datastore-1": [{"name": "vm-a"}, {"name": "vm-b"}],
+        "datastore-2": [{"name": "vm-c"}],
+    }
+
+    sequence: list[OperationResult] = [_ok_result("GET:/vcenter/datastore", listing)]
+    for entry in listing:
+        sequence.append(
+            _ok_result("GET:/vcenter/datastore/{datastore}", detail_by_id[entry["datastore"]])
+        )
+        sequence.append(_ok_result("GET:/vcenter/vm", vms_by_ds[entry["datastore"]]))
+    dispatch = _RecordingDispatchChild(sequence)
+
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+
+    # 1 listing + 2 datastores * 2 sub-ops each = 5 calls total.
+    assert len(dispatch.calls) == 5
+    assert dispatch.calls[0]["op_id"] == "GET:/vcenter/datastore"
+    # No filter -> params is empty mapping.
+    assert dispatch.calls[0]["params"] == {}
+    # Per-DS detail call includes the datastore moid.
+    assert dispatch.calls[1]["op_id"] == "GET:/vcenter/datastore/{datastore}"
+    assert dispatch.calls[1]["params"] == {"datastore": "datastore-1"}
+    # Per-DS VM call uses ``filter.datastores`` with the moid.
+    assert dispatch.calls[2]["op_id"] == "GET:/vcenter/vm"
+    assert dispatch.calls[2]["params"] == {"filter.datastores": ["datastore-1"]}
+    # Final aggregated shape.
+    assert out == {
+        "datastores": [
+            {
+                "id": "datastore-1",
+                "name": "ds-1",
+                "type": "VMFS",
+                "capacity": 100,
+                "free_space": 40,
+                "vm_count": 2,
+                "vm_names": ["vm-a", "vm-b"],
+            },
+            {
+                "id": "datastore-2",
+                "name": "ds-2",
+                "type": "NFS",
+                "capacity": 500,
+                "free_space": 250,
+                "vm_count": 1,
+                "vm_names": ["vm-c"],
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_filter_names_passes_through_to_listing() -> None:
+    """``filter_names`` flows into the listing sub-op as ``filter.names``."""
+    sequence = [_ok_result("GET:/vcenter/datastore", [])]
+    dispatch = _RecordingDispatchChild(sequence)
+    await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"filter_names": ["ds-prod-1", "ds-prod-2"]},
+        dispatch_child=dispatch,
+    )
+    assert dispatch.calls[0]["params"] == {"filter.names": ["ds-prod-1", "ds-prod-2"]}
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_tolerates_legacy_envelope_on_listing() -> None:
+    """``{"value": [...]}`` listing envelope is unwrapped."""
+    sequence = [
+        _ok_result(
+            "GET:/vcenter/datastore",
+            {
+                "value": [
+                    {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+                ]
+            },
+        ),
+        _ok_result(
+            "GET:/vcenter/datastore/{datastore}",
+            {"value": {"capacity": 10, "free_space": 5}},
+        ),
+        _ok_result("GET:/vcenter/vm", {"value": [{"name": "vm-x"}]}),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    assert out["datastores"][0]["capacity"] == 10
+    assert out["datastores"][0]["vm_names"] == ["vm-x"]
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_skips_malformed_listing_entries() -> None:
+    """Listing entries without a string ``datastore`` key are skipped silently."""
+    sequence = [
+        _ok_result(
+            "GET:/vcenter/datastore",
+            [
+                {"datastore": "datastore-1", "name": "good"},
+                {"name": "missing-id"},  # no ``datastore`` key
+                "not-a-dict",
+            ],
+        ),
+        _ok_result("GET:/vcenter/datastore/{datastore}", {"capacity": 1}),
+        _ok_result("GET:/vcenter/vm", []),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    # Only the well-formed entry produces sub-ops + a result row.
+    assert len(out["datastores"]) == 1
+    assert out["datastores"][0]["id"] == "datastore-1"
+
+
+# ---------------------------------------------------------------------------
+# vmware.composite.network.portgroup.audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_network_portgroup_audit_dispatches_three_phases() -> None:
+    """DVS + portgroup listings + per-portgroup VM listings aggregate to the expected shape."""
+    dvs_listing = [{"vds": "dvs-1", "name": "DVS-A"}]
+    pg_listing = [
+        {"network": "pg-1", "name": "PG-A", "vds": "dvs-1", "type": "DISTRIBUTED"},
+        {"network": "pg-2", "name": "PG-B", "vds": "dvs-1", "type": "DISTRIBUTED"},
+    ]
+    vms_per_pg = {
+        "pg-1": [{"name": "vm-pg1-a"}, {"name": "vm-pg1-b"}],
+        "pg-2": [],
+    }
+    sequence: list[OperationResult] = [
+        _ok_result("GET:/vcenter/network/distributed-switch", dvs_listing),
+        _ok_result("GET:/vcenter/network/distributed-portgroup", pg_listing),
+    ]
+    for pg in pg_listing:
+        sequence.append(_ok_result("GET:/vcenter/vm", vms_per_pg[pg["network"]]))
+    dispatch = _RecordingDispatchChild(sequence)
+
+    out = await network_portgroup_audit_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+
+    # 1 + 1 + 2 portgroups = 4 calls.
+    assert len(dispatch.calls) == 4
+    assert dispatch.calls[0]["op_id"] == "GET:/vcenter/network/distributed-switch"
+    assert dispatch.calls[1]["op_id"] == "GET:/vcenter/network/distributed-portgroup"
+    # Per-PG VM call uses ``filter.networks`` and the default power-state filter.
+    assert dispatch.calls[2]["op_id"] == "GET:/vcenter/vm"
+    assert dispatch.calls[2]["params"] == {
+        "filter.networks": ["pg-1"],
+        "filter.power_states": ["POWERED_ON"],
+    }
+    assert out["portgroups"] == [
+        {
+            "id": "pg-1",
+            "name": "PG-A",
+            "dvs": "dvs-1",
+            "dvs_name": "DVS-A",
+            "type": "DISTRIBUTED",
+            "vm_count": 2,
+            "vm_names": ["vm-pg1-a", "vm-pg1-b"],
+        },
+        {
+            "id": "pg-2",
+            "name": "PG-B",
+            "dvs": "dvs-1",
+            "dvs_name": "DVS-A",
+            "type": "DISTRIBUTED",
+            "vm_count": 0,
+            "vm_names": [],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_network_portgroup_audit_filter_dvs_passes_through() -> None:
+    """``filter_dvs`` flows into both DVS + PG listings as ``filter.vdses``."""
+    sequence = [
+        _ok_result("GET:/vcenter/network/distributed-switch", []),
+        _ok_result("GET:/vcenter/network/distributed-portgroup", []),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    await network_portgroup_audit_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"filter_dvs": "dvs-prod"},
+        dispatch_child=dispatch,
+    )
+    assert dispatch.calls[0]["params"] == {"filter.vdses": ["dvs-prod"]}
+    assert dispatch.calls[1]["params"] == {"filter.vdses": ["dvs-prod"]}
+
+
+@pytest.mark.asyncio
+async def test_network_portgroup_audit_include_disconnected_drops_power_filter() -> None:
+    """``include_disconnected_vms=True`` removes the ``POWERED_ON`` filter on the VM call."""
+    sequence = [
+        _ok_result("GET:/vcenter/network/distributed-switch", []),
+        _ok_result(
+            "GET:/vcenter/network/distributed-portgroup",
+            [{"network": "pg-1", "name": "PG-A"}],
+        ),
+        _ok_result("GET:/vcenter/vm", []),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    await network_portgroup_audit_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"include_disconnected_vms": True},
+        dispatch_child=dispatch,
+    )
+    # VM call's params include ``filter.networks`` but NOT
+    # ``filter.power_states``.
+    vm_call = dispatch.calls[2]
+    assert "filter.networks" in vm_call["params"]
+    assert "filter.power_states" not in vm_call["params"]
+
+
+# ---------------------------------------------------------------------------
+# Error fan-out -- a sub-op error causes the handler to raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cluster_drs_recommendations_raises_on_sub_op_error() -> None:
+    """A sub-op ``status="error"`` causes the composite to raise ``RuntimeError``.
+
+    Load-bearing for the dispatcher's outer exception branch: the
+    composite parent sees the failure as a structured
+    ``connector_error`` result with the underlying op_id and message
+    in ``extras["exception_class"]``.
+    """
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/vcenter/cluster/{cluster}": _err_result(
+                "GET:/vcenter/cluster/{cluster}", "cluster not found"
+            ),
+        }
+    )
+    with pytest.raises(RuntimeError, match="returned status='error'"):
+        await cluster_drs_recommendations_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"cluster": "bogus"},
+            dispatch_child=dispatch,
+        )
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_raises_on_listing_error() -> None:
+    """A failed listing surfaces as ``RuntimeError``; no per-DS calls fire."""
+    dispatch = _RecordingDispatchChild([_err_result("GET:/vcenter/datastore", "permission denied")])
+    with pytest.raises(RuntimeError, match="returned status='error'"):
+        await datastore_usage_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={},
+            dispatch_child=dispatch,
+        )
+    assert len(dispatch.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_event_tail_raises_on_sub_op_error() -> None:
+    """QueryEvents error surfaces as ``RuntimeError`` (no aggregation)."""
+    dispatch = _RecordingDispatchChild(
+        [_err_result("POST:/EventManager/{moId}/QueryEvents", "vi-json transient")]
+    )
+    with pytest.raises(RuntimeError, match="returned status='error'"):
+        await event_tail_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={},
+            dispatch_child=dispatch,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Connector-id contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_composite_uses_vmware_rest_9_0_connector_id() -> None:
+    """All five handlers dispatch sub-ops against ``vmware-rest-9.0`` exclusively.
+
+    Load-bearing for the issue body's *Why dispatch_child not direct
+    httpx* contract: the connector_id is what routes the recursive
+    dispatch back to :class:`VmwareRestConnector` for sub-call
+    authentication.
+    """
+    handlers: tuple[tuple[Any, dict[str, Any], dict[str, Any]], ...] = (
+        (
+            cluster_drs_recommendations_composite,
+            {"cluster": "c1"},
+            {
+                "GET:/vcenter/cluster/{cluster}": {},
+                "GET:/vcenter/cluster/{cluster}/drs": {},
+            },
+        ),
+        (
+            event_tail_composite,
+            {},
+            {"POST:/EventManager/{moId}/QueryEvents": []},
+        ),
+        (
+            performance_summary_composite,
+            {"entity_moid": "vm-1"},
+            {
+                "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric": [],
+                "POST:/PerformanceManager/{moId}/QueryPerf": [],
+            },
+        ),
+        (
+            datastore_usage_composite,
+            {},
+            {"GET:/vcenter/datastore": []},
+        ),
+        (
+            network_portgroup_audit_composite,
+            {},
+            {
+                "GET:/vcenter/network/distributed-switch": [],
+                "GET:/vcenter/network/distributed-portgroup": [],
+            },
+        ),
+    )
+    for handler, params, responses in handlers:
+        dispatch = _RecordingDispatchChild(dict(responses))
+        await handler(
+            operator=_make_operator(),
+            target=object(),
+            params=params,
+            dispatch_child=dispatch,
+        )
+        for call in dispatch.calls:
+            assert call["connector_id"] == "vmware-rest-9.0", (
+                f"{handler.__qualname__} dispatched to {call['connector_id']}"
+            )

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -1,0 +1,435 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Registration tests for the 5 vmware-rest read composites.
+
+Coverage matrix (G3.1-T5 / #508 acceptance criteria):
+
+* All 5 expected ``op_id`` rows land in ``endpoint_descriptor`` with
+  ``source_kind="composite"``.
+* Each row carries the right ``safety_level="safe"`` +
+  ``requires_approval=False`` overrides (i.e. T4's
+  ``dangerous`` / ``True`` defaults are intentionally NOT inherited).
+* Each row's ``handler_ref`` resolves to the dotted path of the
+  module-level handler (no closures / partials).
+* Each row's ``group_id`` resolves to the expected ``group_key``
+  (``cluster`` / ``events`` / ``performance`` / ``storage`` /
+  ``networking``).
+* Idempotent re-registration: running the registrar twice is a no-op
+  for the embedding pipeline (body-hash skip from T4's inherited
+  shared upsert path).
+* Parameter-schema persistence: each row's ``parameter_schema`` round-
+  trips verbatim.
+* Side-effect import: importing
+  :mod:`meho_backplane.connectors.vmware_rest` queues
+  :func:`register_vmware_composite_operations` onto the typed-op
+  registrar list (lifespan-wiring smoke test).
+
+Mirrors :mod:`tests.test_operations_composite_register` for the
+substrate-level coverage; this module's tests focus on the
+*per-connector* contract that 5 named composites end up registered
+with the right overrides.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.connectors.vmware_rest.composites import (
+    cluster_drs_recommendations_composite,
+    datastore_usage_composite,
+    event_tail_composite,
+    network_portgroup_audit_composite,
+    performance_summary_composite,
+    register_vmware_composite_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.typed_register import (
+    _TYPED_OP_REGISTRARS,
+    clear_typed_op_registrars,
+)
+from meho_backplane.settings import get_settings
+
+_EXPECTED_OP_IDS: tuple[str, ...] = (
+    "vmware.composite.cluster.drs_recommendations",
+    "vmware.composite.event.tail",
+    "vmware.composite.performance.summary",
+    "vmware.composite.datastore.usage",
+    "vmware.composite.network.portgroup.audit",
+)
+
+
+_EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
+    "vmware.composite.cluster.drs_recommendations": (
+        "meho_backplane.connectors.vmware_rest.composites._read."
+        "cluster_drs_recommendations_composite"
+    ),
+    "vmware.composite.event.tail": (
+        "meho_backplane.connectors.vmware_rest.composites._read.event_tail_composite"
+    ),
+    "vmware.composite.performance.summary": (
+        "meho_backplane.connectors.vmware_rest.composites._read.performance_summary_composite"
+    ),
+    "vmware.composite.datastore.usage": (
+        "meho_backplane.connectors.vmware_rest.composites._read.datastore_usage_composite"
+    ),
+    "vmware.composite.network.portgroup.audit": (
+        "meho_backplane.connectors.vmware_rest.composites._read.network_portgroup_audit_composite"
+    ),
+}
+
+
+_EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
+    "vmware.composite.cluster.drs_recommendations": "cluster",
+    "vmware.composite.event.tail": "events",
+    "vmware.composite.performance.summary": "performance",
+    "vmware.composite.datastore.usage": "storage",
+    "vmware.composite.network.portgroup.audit": "networking",
+}
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so the upsert doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Five composites land with the right overrides
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_vmware_composite_operations_inserts_five_rows(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Running the registrar lands all 5 op_ids in ``endpoint_descriptor``."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
+    # Embedding service called once per composite -- 5 total.
+    assert stub_embedding_service.encode_one.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_every_composite_row_uses_safe_no_approval_overrides(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each row carries ``safety_level="safe"`` + ``requires_approval=False``.
+
+    Load-bearing override of T4's ``dangerous`` / ``True`` defaults --
+    every composite in this Task is read-only, so the policy gate
+    should not pop the approval queue.
+    """
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    for row in rows:
+        assert row.safety_level == "safe", f"{row.op_id}: expected safe, got {row.safety_level!r}"
+        assert row.requires_approval is False, (
+            f"{row.op_id}: expected requires_approval=False, got {row.requires_approval!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_every_composite_row_carries_composite_source_kind(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each row has ``source_kind="composite"`` (routes the dispatcher's composite branch)."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    for row in rows:
+        assert row.source_kind == "composite"
+        assert row.tenant_id is None
+        assert row.is_enabled is True
+        assert row.method is None
+        assert row.path is None
+
+
+@pytest.mark.asyncio
+async def test_handler_ref_round_trips_to_module_level_dotted_path(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each row's ``handler_ref`` is the canonical module-level dotted path."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_op = {row.op_id: row for row in rows}
+    for op_id, expected_ref in _EXPECTED_HANDLER_REF_BY_OP.items():
+        assert by_op[op_id].handler_ref == expected_ref
+
+
+@pytest.mark.asyncio
+async def test_group_resolution_lands_each_composite_in_its_named_group(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The 5 composites land in 5 distinct groups by ``group_key``."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        descriptor_rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        group_rows = (await fresh.execute(select(OperationGroup))).scalars().all()
+    groups_by_id = {g.id: g for g in group_rows}
+    for desc in descriptor_rows:
+        assert desc.group_id is not None, f"{desc.op_id} has no group_id"
+        group = groups_by_id[desc.group_id]
+        expected_key = _EXPECTED_GROUP_KEY_BY_OP[desc.op_id]
+        assert group.group_key == expected_key, (
+            f"{desc.op_id}: expected group {expected_key!r}, got {group.group_key!r}"
+        )
+        assert group.product == "vmware"
+        assert group.version == "9.0"
+        assert group.impl_id == "vmware-rest"
+
+
+@pytest.mark.asyncio
+async def test_parameter_schema_persists_with_required_fields(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each row's ``parameter_schema`` round-trips with the documented required fields."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_op = {row.op_id: row for row in rows}
+    # cluster.drs_recommendations requires ``cluster``.
+    cluster_schema: dict[str, Any] = dict(
+        by_op["vmware.composite.cluster.drs_recommendations"].parameter_schema
+    )
+    assert cluster_schema["required"] == ["cluster"]
+    assert "cluster" in dict(cluster_schema["properties"])
+    # performance.summary requires ``entity_moid``.
+    perf_schema: dict[str, Any] = dict(
+        by_op["vmware.composite.performance.summary"].parameter_schema
+    )
+    assert perf_schema["required"] == ["entity_moid"]
+    # event.tail has no required keys (everything has a default).
+    event_schema: dict[str, Any] = dict(
+        by_op["vmware.composite.event.tail"].parameter_schema
+    )
+    assert event_schema["required"] == []
+    # All schemas pin ``additionalProperties=False`` so typo'd keys
+    # surface clearly at dispatcher-side validation.
+    for op_id in _EXPECTED_OP_IDS:
+        schema: dict[str, Any] = dict(by_op[op_id].parameter_schema)
+        assert schema["additionalProperties"] is False, (
+            f"{op_id}: parameter_schema missing additionalProperties:False"
+        )
+
+
+@pytest.mark.asyncio
+async def test_tags_include_composite_and_read_only(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Every composite row carries ``composite`` + ``read-only`` tags.
+
+    Both tags are load-bearing for downstream filtering: operators
+    that want to inspect read composites only run
+    ``meho operation list ... --tag read-only`` and the table-of-five
+    surfaces immediately.
+    """
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    for row in rows:
+        assert "composite" in row.tags
+        assert "read-only" in row.tags
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_vmware_composite_operations_is_idempotent(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Running the registrar twice -> 5 rows, embedding called 5x total."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    first_count = stub_embedding_service.encode_one.call_count
+    assert first_count == 5
+
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    # Skip-re-embed path -- second run is a no-op for the embedding
+    # pipeline because the text composes to the same body-hash.
+    assert stub_embedding_service.encode_one.call_count == first_count
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 5
+
+
+# ---------------------------------------------------------------------------
+# Side-effect import wires the registrar into the lifespan list
+# ---------------------------------------------------------------------------
+
+
+def test_importing_vmware_rest_subpackage_queues_composite_registrar() -> None:
+    """Importing the ``vmware_rest`` package queues the composite registrar.
+
+    Asserts the contract that
+    ``meho_backplane.connectors.vmware_rest/__init__.py`` re-exports
+    the ``composites`` subpackage *and* the composites' ``__init__``
+    calls
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    at module-import time. The chassis lifespan iterates this list in
+    :func:`run_typed_op_registrars`, so a missing registration here
+    would translate to "no rows landed during startup".
+    """
+    clear_typed_op_registrars()
+    # Force a re-import so the module-top-level
+    # ``register_typed_op_registrar`` call fires under the cleared list.
+    import meho_backplane.connectors.vmware_rest.composites as composites_pkg
+
+    importlib.reload(composites_pkg)
+
+    assert any(
+        r.__name__ == "register_vmware_composite_operations" for r in _TYPED_OP_REGISTRARS
+    ), (
+        "expected register_vmware_composite_operations on the typed-op "
+        f"registrar list, got names "
+        f"{[getattr(r, '__name__', repr(r)) for r in _TYPED_OP_REGISTRARS]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level handler identity (no closures, partials, lambdas)
+# ---------------------------------------------------------------------------
+
+
+def test_all_handlers_are_module_level_coroutine_functions() -> None:
+    """Each handler is a plain module-level ``async def``.
+
+    Anchors the issue body's invariant: ``derive_handler_ref()`` at
+    registration time would reject closures / partials / lambdas, so
+    a regression that wraps a handler in ``functools.partial`` would
+    surface here before the registrar even runs.
+    """
+    import inspect
+
+    for handler in (
+        cluster_drs_recommendations_composite,
+        event_tail_composite,
+        performance_summary_composite,
+        datastore_usage_composite,
+        network_portgroup_audit_composite,
+    ):
+        assert inspect.iscoroutinefunction(handler), f"{handler!r} is not a coroutine function"
+        assert "<locals>" not in handler.__qualname__
+        assert handler.__qualname__ != "<lambda>"

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -301,9 +301,7 @@ async def test_parameter_schema_persists_with_required_fields(
     )
     assert perf_schema["required"] == ["entity_moid"]
     # event.tail has no required keys (everything has a default).
-    event_schema: dict[str, Any] = dict(
-        by_op["vmware.composite.event.tail"].parameter_schema
-    )
+    event_schema: dict[str, Any] = dict(by_op["vmware.composite.event.tail"].parameter_schema)
     assert event_schema["required"] == []
     # All schemas pin ``additionalProperties=False`` so typo'd keys
     # surface clearly at dispatcher-side validation.
@@ -312,6 +310,65 @@ async def test_parameter_schema_persists_with_required_fields(
         assert schema["additionalProperties"] is False, (
             f"{op_id}: parameter_schema missing additionalProperties:False"
         )
+
+
+@pytest.mark.asyncio
+async def test_response_schema_persists_for_every_composite(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each row persists a non-null ``response_schema`` describing the handler's return shape.
+
+    Parity with the ``vault.kv.read`` precedent (the only other typed-op
+    surface that ships an explicit response schema). The meta-tools
+    surface this on ``describe_operation`` calls without needing a
+    schema-construction round-trip.
+    """
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_op = {row.op_id: row for row in rows}
+    # Each row carries a response_schema dict (non-null, non-empty).
+    for op_id in _EXPECTED_OP_IDS:
+        schema = by_op[op_id].response_schema
+        assert isinstance(schema, dict), (
+            f"{op_id}: expected response_schema dict, got {type(schema).__name__}"
+        )
+        assert schema.get("type") == "object", (
+            f"{op_id}: response_schema must be a JSON-Schema object"
+        )
+        assert "properties" in schema, f"{op_id}: response_schema missing 'properties' key"
+    # Spot-check the load-bearing top-level keys per composite.
+    cluster_resp: dict[str, Any] = dict(
+        by_op["vmware.composite.cluster.drs_recommendations"].response_schema
+    )
+    cluster_props = dict(cluster_resp["properties"])
+    assert {"cluster", "drs", "recommendations_history"} <= set(cluster_props)
+    assert set(cluster_resp["required"]) == {"cluster", "drs"}
+
+    event_resp: dict[str, Any] = dict(by_op["vmware.composite.event.tail"].response_schema)
+    event_props = dict(event_resp["properties"])
+    assert {"events", "count", "moId", "max_events_applied"} <= set(event_props)
+
+    perf_resp: dict[str, Any] = dict(by_op["vmware.composite.performance.summary"].response_schema)
+    perf_props = dict(perf_resp["properties"])
+    assert {"entity_moid", "available_counters", "samples"} <= set(perf_props)
+
+    ds_resp: dict[str, Any] = dict(by_op["vmware.composite.datastore.usage"].response_schema)
+    assert "datastores" in dict(ds_resp["properties"])
+
+    net_resp: dict[str, Any] = dict(
+        by_op["vmware.composite.network.portgroup.audit"].response_schema
+    )
+    assert "portgroups" in dict(net_resp["properties"])
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -6,9 +6,10 @@ The `vmware-rest` connector is the hand-rolled `HttpConnector` subclass
 that dispatches ingested vCenter REST operations under the
 `(product="vmware", version="9.0", impl_id="vmware-rest")` registry
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
-makes ~1,275 `endpoint_descriptor` rows resolvable but not dispatchable)
-to deliver real session-authenticated calls against vSphere 8.5+ /
-ESXi 8.5+ targets.
+makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
+dispatchable) to deliver real session-authenticated calls against
+vSphere 8.5+ / ESXi 8.5+ targets, plus the 5 hand-authored read
+composites that orchestrate cross-spec workflows (G3.1-T5 / #508).
 
 Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
 
@@ -18,6 +19,20 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   Class attributes: `product="vmware"`, `version="9.0"`,
   `impl_id="vmware-rest"`, `supported_version_range=">=8.5,<10.0"`,
   `priority=1`.
+- **Read composites** (`composites/_read.py`) — five module-level
+  `async def` handlers (`cluster_drs_recommendations_composite`,
+  `event_tail_composite`, `performance_summary_composite`,
+  `datastore_usage_composite`, `network_portgroup_audit_composite`).
+  Each accepts `(operator, target, params, dispatch_child)` per the
+  `DispatchChild` Protocol and orchestrates 1-3 sub-op dispatches
+  back into the same `vmware-rest-9.0` connector. Registered with
+  `safety_level="safe"` + `requires_approval=False` — read-only
+  overrides of `register_composite_operation()`'s `dangerous` / `True`
+  defaults.
+- **`register_vmware_composite_operations`** (`composites/_register.py`)
+  — async registrar function called from `run_typed_op_registrars` at
+  lifespan startup. Calls `register_composite_operation()` once per
+  composite; idempotent on re-run via the body-hash skip path.
 - **`VsphereTargetLike`** (`session.py`) — runtime-checkable Protocol
   capturing the minimum target shape the connector reads: `name`,
   `host`, `port`, `secret_ref`, `auth_model`. Replaced by the concrete
@@ -43,10 +58,20 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
 2. Importing `meho_backplane.connectors.vmware_rest` triggers the
    module-level `register_connector_v2(product="vmware", version="9.0",
    impl_id="vmware-rest", cls=VmwareRestConnector)` call.
-3. The registry's v2 table now resolves `(vmware, 9.0, vmware-rest)`
+3. The same import triggers the side-effect import of
+   `meho_backplane.connectors.vmware_rest.composites`, whose
+   `__init__` calls
+   `register_typed_op_registrar(register_vmware_composite_operations)`
+   to queue the composite-row upsert onto the lifespan's registrar
+   list.
+4. The registry's v2 table now resolves `(vmware, 9.0, vmware-rest)`
    to `VmwareRestConnector`. The G0.7 auto-shim's idempotency check
    (in `ensure_connector_class_registered`, once #408's pipeline lands
    in main) no-ops on subsequent ingests against the same triple.
+5. Lifespan calls `run_typed_op_registrars()`, which iterates every
+   queued registrar -- including the composite one -- and upserts the
+   5 `vmware.composite.*` rows into `endpoint_descriptor` with
+   `source_kind="composite"`.
 
 ### Per-target session
 
@@ -109,6 +134,39 @@ Legacy shim — synthesises a system-tenant `Operator` and calls
 construct a real `Operator` and call `dispatch()` directly; they don't
 reach this method.
 
+### Composite dispatch (read composites)
+
+The 5 read composites land as `source_kind="composite"` rows in
+`endpoint_descriptor`. At dispatch time:
+
+1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
+   to the row, sees `source_kind="composite"`, builds a
+   `DispatchChild` callable via
+   `get_dispatch_child(dispatch=dispatch, parent_operator=...,
+   parent_target=..., parent_audit_id=..., parent_op_id=...)`.
+2. Handler is resolved via `import_handler(descriptor.handler_ref)`
+   to one of the module-level functions in `composites/_read.py`.
+3. Dispatcher invokes
+   `handler(operator=..., target=..., params=..., dispatch_child=...)`.
+4. Handler issues 1-3 `await dispatch_child(connector_id="vmware-rest-9.0",
+   op_id=..., params=...)` calls. Each child dispatch:
+   - Inherits `parent_audit_id` via the contextvar so the child's
+     audit row's `parent_audit_id` column is set automatically.
+   - Increments `composite_depth_var` (bounded at
+     `Settings.composite_max_depth=8`; over-depth raises
+     `CompositeRecursionLimitExceeded` pre-recursion).
+   - Re-enters the dispatcher's same code path -- the child sub-op
+     hits the `source_kind="ingested"` branch which routes through
+     `VmwareRestConnector.execute()` for the actual HTTP call.
+5. Handler aggregates the sub-op responses into a single dict and
+   returns; the dispatcher wraps it as an `OperationResult` with
+   `status="ok"` and `result=<aggregated dict>`.
+
+The composite handlers go through `dispatch_child` rather than
+calling `_request_json` directly so the audit-tree linkage,
+bounded-recursion guard, policy gate, broadcast publish, and
+parameter-schema validation all run on every sub-call.
+
 ## Dependencies
 
 - `meho_backplane.connectors.adapters.http.HttpConnector` (G0.2-T3
@@ -139,19 +197,25 @@ reach this method.
   a long-idle connection may see a 401 on the next dispatch. The
   caller-side retry logic in `_request_json` does not retry 401 by
   policy; an explicit refresh loop is v0.2.next polish.
-- **`vi-json.yaml` ingestion not yet exercised** — T2 (#501) ships the
-  parser extension for `$ref: #/components/parameters/*`. Once T3
-  (#503) lands, the same connector dispatches the ~2,195 vi-json ops
-  (vi-json shares the `vmware-api-session-id` header per
-  `docs/vcenter-9.0/MANIFEST.md`).
-- **Composites under separate Tasks** — T5 (#508) ships the 5 read
-  composites; T6 (#509) ships the 8 write composites. Both depend on
-  T4 (#504) for the `register_composite_operation()` helper.
+- **`vi-json.yaml` ingestion live** — T3 (#503) shipped the ingestion
+  pipeline (depends on T2 / #501's `$ref` resolver). The same
+  connector dispatches the ~2,195 vi-json ops alongside the ~1,275
+  vCenter REST ops; both share the `vmware-api-session-id` session
+  header per `docs/vcenter-9.0/MANIFEST.md`. Two of the read
+  composites (`event.tail`, `performance.summary`) call vi-json
+  sub-ops; the other three call vCenter REST sub-ops only.
+- **Read composites shipped** — T5 (#508) ships the 5 hand-authored
+  read composites. T6 (#509) ships the 8 write composites; same
+  `register_composite_operation()` helper, default `dangerous` /
+  `True` policy gate (read composites override to `safe` / `False`
+  at the call site).
 
 ## References
 
 - Parent Initiative: [#227 G3.1 vmware-rest-9.0](https://github.com/evoila/meho/issues/227)
 - Parent Task: [#498 G3.1-T1 VmwareRestConnector](https://github.com/evoila/meho/issues/498)
+- Composite-helper Task: [#504 G3.1-T4 register_composite_operation()](https://github.com/evoila/meho/issues/504)
+- Read-composite Task: [#508 G3.1-T5 vmware-rest read composites](https://github.com/evoila/meho/issues/508)
 - G0.7 canary that ingested the rows this connector dispatches:
   [#408 G0.7-T8 vSphere canary](https://github.com/evoila/meho/issues/408)
   (closed via PR #493 on 2026-05-15).


### PR DESCRIPTION
## Summary

- Ships the 5 read-shaped `vmware.composite.*` hand-authored composites per [#227 §8](https://github.com/evoila/meho/issues/227): `cluster.drs_recommendations`, `event.tail`, `performance.summary`, `datastore.usage`, `network.portgroup.audit`.
- Each composite registers via T4's `register_composite_operation()` with `safety_level="safe"` + `requires_approval=False` (read-only overrides of the helper's `dangerous`/`True` defaults).
- Handlers are module-level `async def` that dispatch 1-3 sub-ops through the `DispatchChild` Protocol callable the dispatcher builds via `get_dispatch_child()` — every sub-op inherits the parent composite's audit chain, depth guard, policy gate, and broadcast publish.
- Sub-op_ids are the canonical `METHOD:/path` strings the OpenAPI parser generates from `vcenter.yaml` (3 composites) and `vi-json.yaml` (`event.tail`, `performance.summary`).
- Package layout mirrors `connectors/vault/`: `composites/__init__.py` wires the registrar via `register_typed_op_registrar()`; `_register.py` holds per-composite metadata; `_read.py` holds the 5 handlers; `schemas.py` holds JSON Schema 2020-12 parameter contracts (every schema pins `additionalProperties=False`).

## Test plan

- [x] `ruff check` — clean across `composites/`, both test files, modified `__init__.py`.
- [x] `ruff format --check` — clean.
- [x] `mypy` — `Success: no issues found in 6 source files`.
- [x] `pytest tests/test_connectors_vmware_rest_composites_read.py` — **21 passed**.
- [x] `pytest tests/test_connectors_vmware_rest_composites_register.py` — **10 passed**.
- [x] Per-composite call-shape contracts: each test mocks `dispatch_child`, invokes the handler, asserts the right sub-ops fire in the right order with the right `connector_id` / `op_id` / `params`.
- [x] Aggregation correctness: each handler's returned dict matches the spec sketched in #508.
- [x] Envelope tolerance: legacy `{"value": [...]}` vs modern bare lists both parse correctly via `_unwrap_value`.
- [x] Filter pass-through: `filter_names` / `filter_dvs` / `moId` / `entity_moid` propagate into sub-op params.
- [x] Error fan-out: a sub-op `status="error"` causes the handler to raise `RuntimeError`, which the dispatcher's outer exception branch wraps as a `connector_error` `OperationResult`.
- [x] All 5 op_ids land in `endpoint_descriptor` with `source_kind="composite"`, correct `safety_level`/`requires_approval` overrides, correct `handler_ref` derivation, correct `group_key` resolution (`cluster`, `events`, `performance`, `storage`, `networking`).
- [x] Idempotent re-registration: running the registrar twice → 5 rows, `encode_one` called 5x total (body-hash skip-re-embed path).
- [x] Side-effect import: `clear_typed_op_registrars()` + `importlib.reload(composites_pkg)` re-queues `register_vmware_composite_operations` onto the registrar list.

## Out of scope

- 8 write composites (T6 / #509) — separate Task; same helper, `dangerous`/`True` defaults retained, side-effecting sub-ops.
- `vm.info` / `snapshot.list` — not in [#227 §8](https://github.com/evoila/meho/issues/227); explicitly out of scope per the issue body's *Why 5 reads, not 6* section.
- vcsim live integration tests (T8) — these are unit-level mocked-`dispatch_child` tests; the vcsim leg is a separate CI infrastructure concern.
- CLI alias verbs (T7).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five VMware REST read-only composite operations: cluster DRS recommendations, event tail, performance summary, datastore usage, and network portgroup audit; each includes parameter and response schemas.

* **Tests**
  * Added unit and registration tests covering dispatch behavior, aggregation, schema validation, error propagation, and idempotent registrar behavior.

* **Documentation**
  * Updated VMware vSphere connector docs to describe the composites, dispatch flow, and registration behavior.

* **Chores**
  * Package now exposes and queues the composite registrar at import time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/524)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-15)

Addressed review findings from `.claude/auto/review-results/pr-524-iter-1.json` (CodeRabbit + `/auto-review-pr`):

- **B1** `2a58788` — ran `ruff format` on `tests/test_connectors_vmware_rest_composites_register.py`; CI Python lane format gate now clean.
- **M1** `2a58788` — added 5 JSON Schema 2020-12 response schemas in `composites/schemas.py`, wired them through every `register_composite_operation()` call in `composites/_register.py`. Mirrors the `vault.kv.read` precedent. New registration test asserts each `endpoint_descriptor` row persists a non-null `response_schema` with the load-bearing top-level keys.
- **m1** `2a58788` — guarded `cluster.drs_recommendations` history coercion against non-list payloads (`isinstance(history, list) else []`).
- **m2** `2a58788` — re-wrote the `CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA` module-level docstring to match the handler's actual return shape (cluster summary + DRS state, optional `recommendations_history`).

Drive-by refactor (folded into `2a58788`): the 5-fold-repeated `register_composite_operation()` body in `_register.py` is now a `_COMPOSITES` data-table + a single loop. Drops the registrar function below the local `code-quality` 100-line block-limit and keeps per-composite arguments adjacent. Net behavioural change is only the new `response_schema=` arg.

Out-of-scope (note for the orchestrator): the CI red on `test_fingerprint_against_vcsim_returns_reachable` is pre-existing on `origin/main` (carried over from PR #518's human merge) — not introduced by this PR, not addressed in this iteration.

<!-- auto-implement-issue: continue, iteration 2 -->
