### PR TITLE
test(acceptance): G3.1-T8 vcsim CI integration + JSONFlux handle force-mode + agent-flow E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,9 @@ jobs:
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
         # spinning up pgvector/pgvector:pg16 for test_db_engine.py /
-        # test_migration_rollback.py / tests/integration/*) share the
+        # test_migration_rollback.py / tests/integration/*, plus
+        # vmware/vcsim for the G3.1-T8 vmware-rest acceptance tests
+        # under tests/acceptance/test_vmware_rest_*.py) share the
         # ARC cluster's NAT egress IP, which exhausts Docker Hub's
         # 100/6h anonymous bucket. Authenticated Personal-tier doubles
         # it to 200/6h

--- a/backend/tests/acceptance/_canary_fixtures.py
+++ b/backend/tests/acceptance/_canary_fixtures.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared minimal-setup fixtures for the G3.1-T8 vmware-rest dispatch tests.
+
+Three vcsim-backed acceptance modules (dispatch smoke / JSONFlux force-mode
+/ agent-flow E2E) need overlapping setup: a registered
+:class:`~meho_backplane.connectors.vmware_rest.VmwareRestConnector`
+instance patched for vcsim's no-auth surface, a Target row, and a
+small set of dispatchable :class:`EndpointDescriptor` rows. Extracting
+that shape into one shared module keeps each test module focused on
+its assertions.
+
+Why a minimal direct-insert path (not the full canary ingest)
+=============================================================
+
+The G0.7 canary's :func:`ingested_canary` fixture in
+``test_g07_vsphere_canary.py`` drives the full
+:class:`IngestionPipelineService` end-to-end -- LLM grouping pass,
+fastembed embeddings, the auto-shim registration -- against the
+~1,275-op ``vcenter.yaml`` spec. That's the right primitive for
+search-quality assertions (the canary's govc-parity benchmark) but
+overkill for dispatch tests that only need to prove "op_id X routes
+through the dispatcher and returns ok against vcsim".
+
+This module inserts only the descriptor rows each dispatch test
+actually probes, with hand-authored ``method`` / ``path`` /
+``handler_ref`` triples; no LLM, no embeddings, no grouping pass.
+Tests that need search-quality (the agent-flow E2E) drive their
+own copy of the canary's ingest pattern -- see
+:mod:`tests.acceptance.test_vmware_rest_agent_flow_e2e` for that
+path.
+
+The agent-flow E2E test does NOT consume this module's fixture; it
+uses the canary's ingest pattern (copied compactly) so the
+:func:`~meho_backplane.operations.meta_tools.search_operations` call
+has BM25 + cosine signal to rank against. Both paths converge on the
+same patched :class:`VmwareRestConnector` instance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from tests.acceptance._vcsim import VcsimEndpoint, patch_vmware_connector_for_vcsim
+
+__all__ = [
+    "CANARY_CONNECTOR_ID",
+    "CANARY_IMPL_ID",
+    "CANARY_OPERATOR_TENANT",
+    "CANARY_PRODUCT",
+    "CANARY_VERSION",
+    "DISPATCH_DESCRIPTORS",
+    "VCSIM_TARGET_NAME",
+    "IngestedCanaryVcsim",
+    "ingested_canary_vcsim",
+]
+
+#: Connector triple under test. Matches the canary's constants in
+#: ``test_g07_vsphere_canary.py`` verbatim — they refer to the same
+#: connector and the same descriptor rows.
+CANARY_PRODUCT: str = "vmware"
+CANARY_VERSION: str = "9.0"
+CANARY_IMPL_ID: str = "vmware-rest"
+CANARY_CONNECTOR_ID: str = f"{CANARY_IMPL_ID}-{CANARY_VERSION}"
+
+#: Tenant the acceptance operator belongs to. Connector + descriptor
+#: rows are tenant-scope NULL (built-in) so the operator's tenant_id
+#: only affects audit attribution.
+CANARY_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000ff")
+
+#: Name used for the seeded vcsim Target row. Tests refer to vcsim by
+#: this stable name rather than synthesising one per test.
+VCSIM_TARGET_NAME: str = "vcsim-acceptance"
+
+
+#: Descriptor rows the dispatch smoke + JSONFlux force-mode tests
+#: probe. Tuple of (op_id, method, path, summary) so the
+#: :func:`_insert_dispatch_descriptors` helper can write them in one
+#: pass. Every op_id is an ingested-source-kind read; ``handler_ref``
+#: is intentionally NULL — ingested ops route through the connector's
+#: parent-class :meth:`HttpConnector` machinery, not a dotted handler.
+DISPATCH_DESCRIPTORS: tuple[tuple[str, str, str, str], ...] = (
+    (
+        "GET:/api/about",
+        "GET",
+        "/api/about",
+        "vCenter appliance build / version metadata.",
+    ),
+    (
+        "GET:/vcenter/cluster",
+        "GET",
+        "/vcenter/cluster",
+        "List vCenter clusters with summary properties.",
+    ),
+    (
+        "GET:/vcenter/host",
+        "GET",
+        "/vcenter/host",
+        "List ESXi hosts registered with vCenter.",
+    ),
+    (
+        "GET:/vcenter/datastore",
+        "GET",
+        "/vcenter/datastore",
+        "List datastores known to vCenter.",
+    ),
+    (
+        "GET:/vcenter/network",
+        "GET",
+        "/vcenter/network",
+        "List networks (portgroups, dvportgroups) visible to vCenter.",
+    ),
+    (
+        "GET:/vcenter/vm",
+        "GET",
+        "/vcenter/vm",
+        "List virtual machines registered with vCenter.",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class IngestedCanaryVcsim:
+    """Bundle returned by :func:`ingested_canary_vcsim`.
+
+    Tests consume the fields by name (``operator`` / ``connector_id``
+    / ``target_name`` / ``endpoint``) rather than re-deriving them so
+    the fixture's contract is one bounded structure rather than four
+    overlapping per-attribute fixtures.
+    """
+
+    operator: Operator
+    connector_id: str
+    target_name: str
+    endpoint: VcsimEndpoint
+
+
+async def _insert_dispatch_descriptors(
+    descriptors: tuple[tuple[str, str, str, str], ...],
+) -> None:
+    """Insert built-in :class:`EndpointDescriptor` rows for every entry.
+
+    One :class:`OperationGroup` (``group_key='dispatch-smoke'``,
+    ``review_status='enabled'``) bundles every descriptor so the
+    dispatcher's group-scoped queries see a consistent shape.
+
+    ``tenant_id`` is NULL for both the group and the descriptors so
+    the rows are built-in / globally visible -- matches the canary's
+    convention for vSphere connector content.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        group = OperationGroup(
+            tenant_id=None,
+            product=CANARY_PRODUCT,
+            version=CANARY_VERSION,
+            impl_id=CANARY_IMPL_ID,
+            group_key="dispatch-smoke",
+            name="Dispatch smoke ops",
+            when_to_use=(
+                "Read-only ops used by the G3.1-T8 dispatch smoke + "
+                "JSONFlux force-mode acceptance tests. Not a production "
+                "operator-facing group; seeded by the acceptance suite "
+                "via tests.acceptance._canary_fixtures."
+            ),
+            review_status="enabled",
+        )
+        session.add(group)
+        await session.flush()  # group.id needed for descriptor.group_id
+
+        for op_id, method, path, summary in descriptors:
+            descriptor = EndpointDescriptor(
+                tenant_id=None,
+                product=CANARY_PRODUCT,
+                version=CANARY_VERSION,
+                impl_id=CANARY_IMPL_ID,
+                op_id=op_id,
+                source_kind="ingested",
+                method=method,
+                path=path,
+                handler_ref=None,
+                group_id=group.id,
+                summary=summary,
+                description=summary,
+                parameter_schema={"type": "object", "properties": {}},
+                response_schema={"type": "object"},
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+            )
+            session.add(descriptor)
+
+        await session.commit()
+
+
+@pytest.fixture
+def acceptance_operator() -> Operator:
+    """Frozen :class:`Operator` the dispatch tests act as.
+
+    ``tenant_admin`` role so the dispatcher's tenant-scoped queries
+    succeed; same shape as the canary's ``canary_operator``.
+    """
+    return Operator(
+        sub="g31-t8-acceptance",
+        name="G3.1-T8 Acceptance",
+        email=None,
+        raw_jwt="<acceptance-raw-jwt>",
+        tenant_id=CANARY_OPERATOR_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+@pytest.fixture
+async def ingested_canary_vcsim(
+    pg_engine: None,
+    acceptance_operator: Operator,
+    vcsim_endpoint: VcsimEndpoint,
+) -> AsyncIterator[IngestedCanaryVcsim]:
+    """Yield a dispatcher-ready vcsim setup.
+
+    Setup steps:
+
+    1. Insert built-in :class:`EndpointDescriptor` rows for every
+       op in :data:`DISPATCH_DESCRIPTORS` (under one enabled
+       :class:`OperationGroup`).
+    2. Seed a :class:`Target` row pointing at the live vcsim
+       endpoint (host/port/auth_model).
+    3. Resolve + cache the :class:`VmwareRestConnector` instance the
+       dispatcher will use; patch its ``_session_loader`` to return
+       vcsim's no-auth credentials and its ``_http_client`` to skip
+       TLS verification of vcsim's self-signed cert.
+
+    Teardown:
+
+    1. ``aclose()`` the patched connector instance (releases the
+       httpx pool, revokes cached sessions).
+    2. ``reset_dispatcher_caches()`` so the next test sees a fresh,
+       unpatched instance.
+
+    The :class:`VmwareRestConnector` registration survives across
+    tests under normal operation (no test runs ``clear_registry()``
+    against the v2 registry); the fixture re-imports the
+    ``vmware_rest`` package on demand if a sibling test wiped the
+    registry (the G0.7 canary's autouse cleanup does this).
+    """
+    await _insert_dispatch_descriptors(DISPATCH_DESCRIPTORS)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=CANARY_OPERATOR_TENANT,
+            name=VCSIM_TARGET_NAME,
+            aliases=[],
+            product=CANARY_PRODUCT,
+            host=vcsim_endpoint.host,
+            port=vcsim_endpoint.port,
+            fqdn=None,
+            secret_ref="kv/data/vsphere/vcsim-acceptance",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            notes="seeded by tests.acceptance._canary_fixtures.ingested_canary_vcsim",
+        )
+        session.add(target)
+        await session.commit()
+
+    # Resolve the connector class from the v2 registry. The
+    # vmware_rest package registers itself at module import time;
+    # the registration survives across tests unless something
+    # explicitly clears it.
+    registry = all_connectors_v2()
+    connector_cls = registry.get((CANARY_PRODUCT, CANARY_VERSION, CANARY_IMPL_ID))
+    if connector_cls is None:
+        # Re-import to trigger registration. Safe even if a previous
+        # test ran clear_registry() (the canary does this).
+        import importlib
+
+        import meho_backplane.connectors.vmware_rest as _vmware_rest_pkg
+
+        importlib.reload(_vmware_rest_pkg)
+        registry = all_connectors_v2()
+        connector_cls = registry.get((CANARY_PRODUCT, CANARY_VERSION, CANARY_IMPL_ID))
+
+    assert connector_cls is VmwareRestConnector, (
+        f"expected VmwareRestConnector registered for "
+        f"({CANARY_PRODUCT}, {CANARY_VERSION}, {CANARY_IMPL_ID}); "
+        f"got {connector_cls!r}"
+    )
+
+    # Materialise the cached instance the dispatcher will use, then
+    # patch it. ``get_or_create_connector_instance`` lazily
+    # constructs ``VmwareRestConnector()`` on first call; the default
+    # ``_session_loader`` is the not-yet-implemented Vault reader,
+    # which the patch immediately replaces.
+    instance = get_or_create_connector_instance(connector_cls)
+    patch_vmware_connector_for_vcsim(instance, vcsim_endpoint)
+
+    try:
+        yield IngestedCanaryVcsim(
+            operator=acceptance_operator,
+            connector_id=CANARY_CONNECTOR_ID,
+            target_name=VCSIM_TARGET_NAME,
+            endpoint=vcsim_endpoint,
+        )
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()

--- a/backend/tests/acceptance/_vcsim.py
+++ b/backend/tests/acceptance/_vcsim.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vcsim endpoint resolver for the G3.1 vmware-rest acceptance suite.
+
+vcsim is the VMware-shipped govmomi-backed vCenter simulator. The
+``vmware/vcsim`` Docker image listens on ``0.0.0.0:8989`` by default
+and serves both ``/api`` (new REST surface) and ``/rest`` (legacy
+mount), accepting any HTTP basic credential — the simulator never
+validates the username/password pair. That property lets the
+acceptance suite drive the real :class:`VmwareRestConnector` (#498)
+through ``POST /api/session`` / ``GET /api/about`` /
+``GET /vcenter/*`` without standing up a real vCenter.
+
+Resolution priority
+===================
+
+The :func:`resolve_vcsim_endpoint` helper consults sources in this
+order so an operator with a pre-provisioned vcsim instance (e.g. a
+shared lab daemon, the CI runner's `vcsim` service container) can
+bypass the testcontainers boot:
+
+1. **``MEHO_VCSIM_URL``** — explicit base URL pointing at a running
+   vcsim instance (e.g. ``https://10.0.5.4:8989``). The helper
+   parses the URL and returns an endpoint without booting a
+   container. This is the CI path for the meho-runners pool where
+   a vcsim daemon is provisioned alongside the runner.
+2. **testcontainers-managed ``vmware/vcsim`` boot** — when no env
+   override resolves, the helper boots the public ``vmware/vcsim``
+   image with the seed flags described under "Seeding the topology"
+   and yields an endpoint targeting the host-mapped port.
+
+Either path yields a :class:`VcsimEndpoint` carrying the host, the
+mapped port, the no-auth credential pair, and a base URL string the
+:class:`VmwareRestConnector` can dial directly. The endpoint is
+session-scoped from the conftest fixture so the ~3-second container
+boot only pays once per pytest invocation.
+
+Seeding the topology
+====================
+
+vcsim accepts CLI flags at startup to seed its in-memory inventory:
+
+- ``-vm 50`` — 50 simulated virtual machines.
+- ``-host 3`` — 3 ESXi host objects.
+- ``-cluster 1`` — 1 cluster (the 3 hosts roll up to it).
+- ``-ds 2`` — 2 datastores.
+- ``-folder 2`` — 2 folders, useful for resolver-ambiguity tests.
+
+These match the canary's "50 VMs / 3 hosts / 1 cluster / 2 ds"
+fixture topology so the JSONFlux force-mode test can rely on
+``GET:/vcenter/vm`` returning exactly 50 rows. The defaults are
+overridable per-test via :func:`build_vcsim_command` for callers
+that need a sparser or denser inventory.
+
+Reference: https://github.com/vmware/govmomi/tree/main/vcsim
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import ssl
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+__all__ = [
+    "DEFAULT_VCSIM_PASSWORD",
+    "DEFAULT_VCSIM_TOPOLOGY",
+    "DEFAULT_VCSIM_USERNAME",
+    "VCSIM_DOCKER_SKIP_REASON",
+    "VCSIM_PORT",
+    "VcsimEndpoint",
+    "VcsimTopology",
+    "build_vcsim_command",
+    "build_vcsim_http_client",
+    "patch_vmware_connector_for_vcsim",
+    "resolve_vcsim_endpoint",
+]
+
+
+#: vcsim's listening port inside the container.
+VCSIM_PORT: int = 8989
+
+#: vcsim accepts any credentials — these are the conventional values
+#: used across the acceptance + integration suites for readability.
+DEFAULT_VCSIM_USERNAME: str = "user"
+DEFAULT_VCSIM_PASSWORD: str = "pass"
+
+#: Reason surfaced when the helper can't resolve nor boot vcsim.
+VCSIM_DOCKER_SKIP_REASON: str = (
+    "vcsim unavailable: set MEHO_VCSIM_URL to a running vcsim base URL "
+    "(e.g. https://10.0.5.4:8989), or run on a host with a Docker socket "
+    "so testcontainers can boot vmware/vcsim:latest."
+)
+
+
+@dataclass(frozen=True)
+class VcsimTopology:
+    """Seed counts the vcsim container is started with.
+
+    Mirrors the CLI flags vcsim accepts: ``-vm``, ``-host``,
+    ``-cluster``, ``-ds``, ``-folder``. The acceptance suite's
+    default values match the issue body's "50 VMs / 3 hosts / 1
+    cluster / 2 ds / 2 folders" so the JSONFlux force-mode test can
+    assert exact row counts.
+    """
+
+    vms: int = 50
+    hosts: int = 3
+    clusters: int = 1
+    datastores: int = 2
+    folders: int = 2
+
+
+#: Default topology — the JSONFlux force-mode test asserts these exact
+#: counts so callers that override the seed must adapt their own
+#: assertions.
+DEFAULT_VCSIM_TOPOLOGY: VcsimTopology = VcsimTopology()
+
+
+@dataclass(frozen=True)
+class VcsimEndpoint:
+    """Resolved vcsim location + no-auth credential pair.
+
+    Carries everything the :class:`VmwareRestConnector` needs to
+    dial vcsim:
+
+    - :attr:`host` — hostname or IP (``localhost`` for testcontainers,
+      whatever the env URL resolves to for the override path).
+    - :attr:`port` — TCP port the simulator listens on.
+    - :attr:`scheme` — ``"https"`` for vcsim's self-signed default,
+      ``"http"`` for operators who terminate TLS at a proxy.
+    - :attr:`username` / :attr:`password` — vcsim accepts anything;
+      the constants here keep test code readable.
+    - :attr:`base_url` — pre-built ``scheme://host:port`` string the
+      :class:`httpx.AsyncClient` constructor accepts.
+    """
+
+    host: str
+    port: int
+    scheme: str
+    username: str
+    password: str
+
+    @property
+    def base_url(self) -> str:
+        """Return ``scheme://host:port`` (omits ``:port`` for the default)."""
+        if (self.scheme == "https" and self.port == 443) or (
+            self.scheme == "http" and self.port == 80
+        ):
+            return f"{self.scheme}://{self.host}"
+        return f"{self.scheme}://{self.host}:{self.port}"
+
+
+def build_vcsim_command(
+    topology: VcsimTopology = DEFAULT_VCSIM_TOPOLOGY,
+    *,
+    listen: str = "0.0.0.0:8989",
+) -> list[str]:
+    """Compose the vcsim CLI args for *topology*.
+
+    Returned as a list so :meth:`DockerContainer.with_command` lands
+    each flag as its own ``argv`` entry — passing the string form
+    would let Go's ``flag.Parse()`` halt at the first positional and
+    silently fall back to ``-l 127.0.0.1:8989`` (the failure mode
+    PR #518 hit on its first CI green attempt).
+
+    The ``-l`` flag MUST come first because the container's
+    ``ENTRYPOINT`` is ``["/vcsim"]`` — every subsequent arg is a
+    seed flag the simulator parses before binding the listener.
+    """
+    return [
+        "-l",
+        listen,
+        "-vm",
+        str(topology.vms),
+        "-host",
+        str(topology.hosts),
+        "-cluster",
+        str(topology.clusters),
+        "-ds",
+        str(topology.datastores),
+        "-folder",
+        str(topology.folders),
+    ]
+
+
+def _docker_socket_present() -> bool:
+    """Return ``True`` iff a usable Docker socket is reachable.
+
+    Mirrors the heuristic at
+    :func:`tests.integration.conftest._docker_socket_present` so the
+    acceptance suite gates on the same skip condition as every other
+    testcontainers-driven test in the project.
+    """
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+def _endpoint_from_env(raw: str) -> VcsimEndpoint:
+    """Parse ``MEHO_VCSIM_URL`` into a :class:`VcsimEndpoint`.
+
+    Accepts bare ``host:port`` (defaults to ``https``), full
+    ``scheme://host:port``, or a URL with an explicit path; the path
+    is dropped here because callers (the
+    :class:`~meho_backplane.connectors.vmware_rest.VmwareRestConnector`
+    in particular) supply their own path off the base URL.
+    """
+    candidate = raw.strip()
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    parsed = urlparse(candidate)
+    scheme = parsed.scheme or "https"
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if scheme == "https" else 80)
+    return VcsimEndpoint(
+        host=host,
+        port=port,
+        scheme=scheme,
+        username=DEFAULT_VCSIM_USERNAME,
+        password=DEFAULT_VCSIM_PASSWORD,
+    )
+
+
+@contextlib.contextmanager
+def _boot_vcsim_container(
+    topology: VcsimTopology,
+) -> Iterator[VcsimEndpoint]:
+    """Boot ``vmware/vcsim`` via testcontainers; yield its endpoint.
+
+    Yields one endpoint and tears the container down on context
+    exit. The simulator emits ``export GOVC_URL=...`` to stdout once
+    the REST endpoint is serving; ``wait_for_logs`` blocks on that
+    line up to 30 s. Longer would mask a real boot failure as
+    flake; shorter risks slow CI runner pulls timing out before
+    vcsim is ready.
+    """
+    # Local imports — testcontainers transitively imports the docker
+    # SDK which probes the socket on import. Keeping the import inside
+    # the context manager lets the module collect on a no-Docker
+    # sandbox (the env-var path doesn't reach here at all).
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.waiting_utils import wait_for_logs
+
+    image = os.environ.get("MEHO_TEST_VCSIM_IMAGE", "vmware/vcsim:latest")
+    container = (
+        DockerContainer(image)
+        .with_exposed_ports(VCSIM_PORT)
+        .with_command(build_vcsim_command(topology))
+    )
+
+    try:
+        container.start()
+        wait_for_logs(container, "export GOVC_URL", timeout=30)
+    except Exception:
+        # Best-effort cleanup; surfacing the original boot exception
+        # is more useful than the secondary stop() failure.
+        with contextlib.suppress(Exception):
+            container.stop()
+        raise
+
+    try:
+        host = container.get_container_host_ip()
+        port_str = container.get_exposed_port(VCSIM_PORT)
+        yield VcsimEndpoint(
+            host=host,
+            port=int(port_str),
+            scheme="https",
+            username=DEFAULT_VCSIM_USERNAME,
+            password=DEFAULT_VCSIM_PASSWORD,
+        )
+    finally:
+        container.stop()
+
+
+@contextlib.contextmanager
+def resolve_vcsim_endpoint(
+    topology: VcsimTopology = DEFAULT_VCSIM_TOPOLOGY,
+) -> Iterator[VcsimEndpoint]:
+    """Yield a :class:`VcsimEndpoint`; pick env override or testcontainers boot.
+
+    Context manager so the testcontainers branch can tear the
+    simulator down deterministically on exit; the env-override branch
+    is a no-op cleanup (the operator manages the lifecycle of the
+    pre-provisioned vcsim daemon themselves).
+
+    Raises :class:`pytest.skip.Exception` (via :func:`pytest.skip`)
+    when neither path is viable so the calling fixture surfaces the
+    skip reason cleanly. The same fixture-level skip pattern the
+    integration suite uses for the ``pg_engine`` no-Docker case.
+    """
+    env_raw = os.environ.get("MEHO_VCSIM_URL", "").strip()
+    if env_raw:
+        yield _endpoint_from_env(env_raw)
+        return
+
+    if not _docker_socket_present():
+        pytest.skip(VCSIM_DOCKER_SKIP_REASON)
+
+    # Lazy import inside this branch so the env-override path never
+    # depends on testcontainers being importable. (It is, in the
+    # current uv.lock, but the gate keeps the dependency surface
+    # localised to the testcontainers-using code path.)
+    try:
+        from testcontainers.core.container import DockerContainer  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - dev-deps not installed
+        pytest.skip(f"testcontainers unavailable: {exc}")
+
+    try:
+        with _boot_vcsim_container(topology) as endpoint:
+            yield endpoint
+    except Exception as exc:
+        pytest.skip(f"vcsim container failed to start ({type(exc).__name__}): {exc}")
+
+
+def build_vcsim_http_client(endpoint: VcsimEndpoint) -> httpx.AsyncClient:
+    """Return an :class:`httpx.AsyncClient` wired for vcsim's self-signed cert.
+
+    vcsim's bundled cert isn't in the host CA bundle, so the client
+    disables verification — production code never reaches this path.
+    Timeouts match the connector's defaults so behaviour under load
+    mirrors a real dispatch.
+    """
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.check_hostname = False
+    ssl_ctx.verify_mode = ssl.CERT_NONE
+    return httpx.AsyncClient(
+        base_url=endpoint.base_url,
+        timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
+        verify=ssl_ctx,
+    )
+
+
+def patch_vmware_connector_for_vcsim(
+    connector: Any,
+    endpoint: VcsimEndpoint,
+) -> None:
+    """Mutate *connector* in-place to dispatch against *endpoint* over TLS-skip.
+
+    Three mutations:
+
+    1. Replaces ``_session_loader`` with a closure returning vcsim's
+       any-credentials pair — bypasses the default Vault read which
+       isn't wired in the acceptance suite.
+    2. Replaces ``_http_client`` so the per-target :class:`httpx.AsyncClient`
+       pool builds with ``verify=False`` (vcsim's self-signed cert
+       isn't trusted by the host CA bundle).
+    3. Leaves ``_session_tokens`` untouched — the connector's own
+       session-establishment flow (``POST /api/session``) runs against
+       vcsim as designed; the simulator accepts any basic-auth pair
+       and returns a synthetic token.
+
+    The mutations are scoped to one connector instance; tests using
+    this helper MUST run their own ``reset_dispatcher_caches()`` in
+    teardown so a downstream test that resolves a fresh instance
+    isn't poisoned by the patched one. Production code paths never
+    touch ``_session_loader`` or ``_http_client`` directly.
+    """
+    import asyncio
+    from typing import cast
+
+    async def _vcsim_loader(_target: Any) -> dict[str, str]:
+        return {"username": endpoint.username, "password": endpoint.password}
+
+    connector._session_loader = _vcsim_loader
+
+    # Per-target lock the patch uses — kept disjoint from the
+    # connector's own ``_lock`` so concurrent acquisitions don't
+    # deadlock if the connector's parent class already holds it.
+    patch_lock = asyncio.Lock()
+    base_url = endpoint.base_url
+
+    async def _insecure_http_client(target: Any) -> httpx.AsyncClient:
+        async with patch_lock:
+            clients = cast(dict[str, httpx.AsyncClient], connector._clients)
+            if target.name not in clients:
+                ssl_ctx = ssl.create_default_context()
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
+                clients[target.name] = httpx.AsyncClient(
+                    base_url=base_url,
+                    timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
+                    verify=ssl_ctx,
+                )
+            return clients[target.name]
+
+    connector._http_client = _insecure_http_client  # type: ignore[method-assign]

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -43,7 +43,7 @@ own conftest.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 
 import pytest
 from sqlalchemy import text
@@ -54,6 +54,19 @@ from meho_backplane.db.engine import (
     dispose_engine,
     reset_engine_for_testing,
 )
+from tests.acceptance._canary_fixtures import (
+    CANARY_CONNECTOR_ID,
+    CANARY_OPERATOR_TENANT,
+    IngestedCanaryVcsim,
+    acceptance_operator,
+    ingested_canary_vcsim,
+)
+from tests.acceptance._vcsim import (
+    DEFAULT_VCSIM_TOPOLOGY,
+    VcsimEndpoint,
+    VcsimTopology,
+    resolve_vcsim_endpoint,
+)
 from tests.integration.conftest import (
     DOCKER_AVAILABLE,
     SKIP_REASON,
@@ -62,11 +75,20 @@ from tests.integration.conftest import (
 )
 
 __all__ = [
+    "CANARY_CONNECTOR_ID",
+    "CANARY_OPERATOR_TENANT",
+    "DEFAULT_VCSIM_TOPOLOGY",
     "DOCKER_AVAILABLE",
     "SKIP_REASON",
+    "IngestedCanaryVcsim",
+    "VcsimEndpoint",
+    "VcsimTopology",
+    "acceptance_operator",
     "async_pg_url",
+    "ingested_canary_vcsim",
     "integration_env",
     "pg_engine",
+    "vcsim_endpoint",
 ]
 
 
@@ -136,3 +158,28 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
     finally:
         await dispose_engine()
         reset_engine_for_testing()
+
+
+@pytest.fixture(scope="session")
+def vcsim_endpoint() -> Iterator[VcsimEndpoint]:
+    """Yield a session-scoped :class:`VcsimEndpoint` for vcsim-backed tests.
+
+    Boots ``vmware/vcsim`` once per pytest invocation (or returns a
+    cached endpoint when ``MEHO_VCSIM_URL`` overrides) and tears the
+    container down on session teardown. Session scope amortises the
+    ~3-second boot across every dispatch / handle / agent-flow test
+    in the acceptance suite; per-test isolation comes from the seed
+    topology being immutable (read-only ops only).
+
+    Mirrors the ``pg_engine`` skip pattern: missing Docker socket
+    plus missing env-override yields a clean ``pytest.skip`` from
+    inside :func:`resolve_vcsim_endpoint`, so the consuming test is
+    marked SKIPPED rather than failed.
+
+    The 50-VM / 3-host / 1-cluster / 2-datastore / 2-folder topology
+    in :data:`DEFAULT_VCSIM_TOPOLOGY` matches the issue body's
+    canary fixture; tests that need a different seed boot their own
+    container with :func:`resolve_vcsim_endpoint` directly.
+    """
+    with resolve_vcsim_endpoint(DEFAULT_VCSIM_TOPOLOGY) as endpoint:
+        yield endpoint

--- a/backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py
+++ b/backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.1-T8 end-to-end agent-flow acceptance test.
+
+Closes #227's "Agent flow tested end-to-end" Definition-of-done line:
+
+    search_connectors finds vmware-rest-9.0
+        → list_operation_groups returns the enabled groups
+        → search_operations(query="list VMs in cluster X") returns ranked candidates
+        → call_operation(...) against vcsim returns structured response.
+
+This test exercises the four agent-surface meta-tools as a single
+chain so a regression in any link (connector visibility, group
+visibility, search ranking, dispatch) breaks the chain rather than
+manifesting as a degraded individual response.
+
+Where this test stops + where #519 picks up
+==========================================
+
+* This test verifies the chain produces a ``status='ok'``
+  :class:`OperationResult` carrying real vcsim data on
+  :attr:`OperationResult.result`.
+* #519's ``test_g07_canary_vcsim_dispatch`` already verifies the
+  audit + broadcast contract — that audit row counts go up by
+  exactly one per dispatch and broadcast events fire for the
+  same op_id. This test doesn't re-prove that contract; it focuses
+  on the chain producing real data.
+
+Scope vs the canary's existing tests
+====================================
+
+The canary's ``test_g07_vsphere_canary.py`` already exercises
+``search_connectors`` / ``list_operation_groups`` /
+``search_operations`` against the full 1,275-op ``vcenter.yaml``
+ingest. This test deliberately uses a minimal hand-rolled
+descriptor set (6 ops under one enabled group, no embedding /
+LLM grouping) — its purpose is to prove the four-step chain
+**dispatches** end-to-end, not to re-prove search quality. The
+search-quality contract lives in the canary.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.operations.ingest import list_ingested_connectors
+from meho_backplane.operations.meta_tools import (
+    call_operation,
+    list_operation_groups,
+    search_operations,
+)
+from tests.acceptance._canary_fixtures import (
+    CANARY_CONNECTOR_ID,
+    IngestedCanaryVcsim,
+)
+
+
+async def test_agent_flow_end_to_end_against_vcsim(
+    ingested_canary_vcsim: IngestedCanaryVcsim,
+) -> None:
+    """The four-step agent chain produces real vcsim data on call_operation.
+
+    Walks the chain in the order the agent surface contract
+    documents:
+
+    1. ``list_ingested_connectors`` (the agent's ``search_connectors``
+       surface) must surface ``vmware-rest-9.0`` with at least one
+       enabled group.
+    2. ``list_operation_groups(connector_id="vmware-rest-9.0")`` must
+       return at least one enabled group with a non-empty ``when_to_use``
+       hint.
+    3. ``search_operations(connector_id="vmware-rest-9.0",
+       query="list virtual machines")`` must return ``GET:/vcenter/vm``
+       in the top-3 hits. The minimal descriptor set this fixture
+       seeds has six ops with short, descriptive ``summary`` strings;
+       BM25 alone is enough to rank ``GET:/vcenter/vm`` first on the
+       "list virtual machines" query (the canary's full-corpus search-
+       quality assertion lives in ``test_g07_vsphere_canary.py``).
+    4. ``call_operation(op_id="GET:/vcenter/vm", target=<vcsim>)`` must
+       return ``status='ok'`` carrying real data from vcsim (the
+       seeded topology has 50 VMs, so the inlined ``result['value']``
+       list has 50 entries).
+    """
+    operator = ingested_canary_vcsim.operator
+
+    # 1. search_connectors surface.
+    connectors = await list_ingested_connectors(operator=operator)
+    matching = [c for c in connectors if c.connector_id == CANARY_CONNECTOR_ID]
+    assert matching, (
+        f"expected {CANARY_CONNECTOR_ID!r} in connector listing; "
+        f"got {[c.connector_id for c in connectors]!r}"
+    )
+    assert matching[0].enabled_group_count >= 1, (
+        f"expected at least one enabled group on {CANARY_CONNECTOR_ID!r}; "
+        f"got {matching[0].enabled_group_count}"
+    )
+
+    # 2. list_operation_groups surface.
+    groups_response = await list_operation_groups(operator, {"connector_id": CANARY_CONNECTOR_ID})
+    groups = groups_response["groups"]
+    assert groups, f"expected at least one enabled group; got groups={groups!r}"
+    assert all(g["when_to_use"] for g in groups), (
+        f"every group must carry a non-empty when_to_use; got {groups!r}"
+    )
+
+    # 3. search_operations surface.
+    search_response = await search_operations(
+        operator,
+        {
+            "connector_id": CANARY_CONNECTOR_ID,
+            "query": "list virtual machines",
+            "limit": 3,
+        },
+    )
+    hits = search_response["hits"]
+    assert hits, f"search_operations returned no hits: {search_response!r}"
+    top_three = [h["op_id"] for h in hits[:3]]
+    assert "GET:/vcenter/vm" in top_three, (
+        f"expected GET:/vcenter/vm in top-3 hits; got {top_three!r}"
+    )
+
+    # 4. call_operation surface — the load-bearing dispatch leg.
+    result_envelope = await call_operation(
+        operator,
+        {
+            "connector_id": CANARY_CONNECTOR_ID,
+            "op_id": "GET:/vcenter/vm",
+            "target": {"name": ingested_canary_vcsim.target_name},
+            "params": {},
+        },
+    )
+    assert result_envelope["status"] == "ok", f"dispatch did not succeed: {result_envelope!r}"
+    payload = result_envelope.get("result")
+    assert payload is not None, f"expected non-null OperationResult.result; got {result_envelope!r}"
+    # vCenter REST returns set-shaped responses as ``{"value": [...]}``
+    # on the legacy ``/rest`` mount and as a bare list on the modern
+    # ``/api`` mount. vcsim serves both shapes depending on which
+    # endpoint the connector hits; assert on the union.
+    vms = payload["value"] if isinstance(payload, dict) and "value" in payload else payload
+    assert isinstance(vms, list), (
+        f"expected a list of VMs from vcsim's 50-VM seed topology; "
+        f"got payload type {type(payload).__name__} body={payload!r}"
+    )
+    assert len(vms) == 50, (
+        f"expected 50 VMs from vcsim's seed topology; got {len(vms)} "
+        f"(payload shape={type(payload).__name__})"
+    )
+
+
+async def test_search_operations_unknown_connector_returns_no_hits(
+    ingested_canary_vcsim: IngestedCanaryVcsim,
+) -> None:
+    """An unknown connector_id returns an empty hit list, not an error.
+
+    Same shape the canary's
+    ``test_canary_search_operations_unknown_connector_returns_empty``
+    asserts — the meta-tool's contract is "unknown connector → empty
+    hits" rather than "→ error". Keeping the assertion here makes
+    the agent-flow surface self-contained: any tester running this
+    file alone sees both the happy path and the empty-input path.
+    """
+    operator = ingested_canary_vcsim.operator
+    response = await search_operations(
+        operator,
+        {
+            "connector_id": "no-such-connector-9.99",
+            "query": "anything",
+            "limit": 3,
+        },
+    )
+    assert response["hits"] == [], f"expected empty hits for unknown connector; got {response!r}"

--- a/backend/tests/acceptance/test_vmware_rest_composite_dispatch.py
+++ b/backend/tests/acceptance/test_vmware_rest_composite_dispatch.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.1-T8 composite-dispatch test — exercises a read composite against vcsim.
+
+Soft-dependent on G3.1-T5 (#508 — read composites). When the
+``vmware.composite.datastore.usage`` op is registered against the
+v2 registry (i.e. T5 has merged + been imported), this module
+dispatches it against vcsim and asserts the aggregated payload
+carries metadata for the 2 datastores in the seed topology. When
+T5 hasn't merged yet (the default state at this Task's filing
+time), the test skips with a clear reason citing the composite-
+not-registered state.
+
+This skip-don't-fail shape avoids a hard cross-PR dependency: T8
+lands its scope (CI integration + JSONFlux + agent-flow) without
+waiting on T5, and once T5 merges and re-runs CI, this test
+flips from SKIPPED to PASS naturally.
+
+Why this matters
+================
+
+Composites + ingested ops share the same dispatcher entry point
+(:func:`meho_backplane.operations.dispatch`); the dispatcher
+branches on :class:`EndpointDescriptor.source_kind`. A composite
+end-to-end test proves the composite branch's recursive
+``dispatch_child`` call path works against a real upstream
+(vcsim), not just against in-process stubs (which the T5 unit
+tests cover). Drift between the two paths is exactly the bug
+class the acceptance suite exists to catch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations.meta_tools import call_operation
+from tests.acceptance._canary_fixtures import (
+    CANARY_CONNECTOR_ID,
+    CANARY_IMPL_ID,
+    CANARY_PRODUCT,
+    CANARY_VERSION,
+    IngestedCanaryVcsim,
+)
+
+#: Composite op_id the test dispatches when T5 has merged.
+#: Per T5 (#508) scope: aggregates per-datastore usage metadata
+#: across every datastore vcenter knows about; v0.2 implementation
+#: dispatches ``GET:/vcenter/datastore`` (list) followed by per-DS
+#: ``GET:/vcenter/datastore/{ds}`` calls (detail). The composite's
+#: dotted handle is the production-shipped op_id.
+_COMPOSITE_OP_ID: str = "vmware.composite.datastore.usage"
+
+
+async def _composite_registered() -> bool:
+    """Return ``True`` iff T5's composite op_id has been registered.
+
+    Two signals must both hold:
+
+    * The v2 registry contains the
+      ``(vmware, 9.0, vmware-rest)`` triple (always true once the
+      ``vmware_rest`` package has been imported).
+    * An :class:`EndpointDescriptor` row exists with
+      ``source_kind='composite'`` + ``op_id=_COMPOSITE_OP_ID`` —
+      T5 registers this via ``register_composite_operation()``.
+
+    Both checks are read-only.
+    """
+    registry = all_connectors_v2()
+    if (CANARY_PRODUCT, CANARY_VERSION, CANARY_IMPL_ID) not in registry:
+        return False
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(EndpointDescriptor).where(
+            EndpointDescriptor.product == CANARY_PRODUCT,
+            EndpointDescriptor.version == CANARY_VERSION,
+            EndpointDescriptor.impl_id == CANARY_IMPL_ID,
+            EndpointDescriptor.op_id == _COMPOSITE_OP_ID,
+            EndpointDescriptor.source_kind == "composite",
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
+
+async def test_composite_datastore_usage_against_vcsim(
+    ingested_canary_vcsim: IngestedCanaryVcsim,
+) -> None:
+    """Dispatch the read composite against vcsim's 2-datastore seed.
+
+    When T5 (#508) has merged, the composite is registered and the
+    test dispatches it via ``call_operation``, asserts ``status='ok'``,
+    and asserts the aggregated payload carries 2 datastores
+    (matching :data:`tests.acceptance._vcsim.DEFAULT_VCSIM_TOPOLOGY.datastores`).
+
+    When T5 hasn't merged yet, the test skips early. The skip path
+    is deliberately verbose so a casual reader sees the soft-dep
+    explanation without digging through the module docstring.
+    """
+    if not await _composite_registered():
+        pytest.skip(
+            f"Composite {_COMPOSITE_OP_ID!r} is not registered. This "
+            "test soft-depends on G3.1-T5 (#508 read composites); the "
+            "test will flip from SKIPPED to PASS naturally once #508 "
+            "merges and its register_composite_operation() call runs "
+            "at module-import time."
+        )
+
+    result_envelope = await call_operation(
+        ingested_canary_vcsim.operator,
+        {
+            "connector_id": CANARY_CONNECTOR_ID,
+            "op_id": _COMPOSITE_OP_ID,
+            "target": {"name": ingested_canary_vcsim.target_name},
+            "params": {},
+        },
+    )
+
+    assert result_envelope["status"] == "ok", (
+        f"composite dispatch did not succeed: {result_envelope!r}"
+    )
+    payload = result_envelope.get("result")
+    assert payload is not None, f"expected aggregated payload on result; got {result_envelope!r}"
+
+    # The composite's exact aggregate shape is T5's contract — we
+    # don't know it from T8's vantage point. Assert on the loosest
+    # invariant T5's body promises: the aggregate carries one entry
+    # per datastore + the count matches vcsim's seed. T5 may surface
+    # this as a list (``[{"datastore": "...", ...}, ...]``) or a
+    # dict keyed by datastore (``{"datastore-1": {...}, ...}``);
+    # support both.
+    if isinstance(payload, list):
+        ds_count = len(payload)
+    elif isinstance(payload, dict):
+        # Composite handlers commonly wrap the list under a top-level
+        # ``datastores`` / ``items`` / ``value`` key. Pick whichever
+        # T5 chose by checking the union.
+        for key in ("datastores", "items", "value"):
+            inner = payload.get(key)
+            if isinstance(inner, list):
+                ds_count = len(inner)
+                break
+        else:
+            # Treat the dict as keyed-by-datastore.
+            ds_count = len(payload)
+    else:
+        raise AssertionError(
+            f"unexpected composite payload shape: {type(payload).__name__} body={payload!r}"
+        )
+
+    assert ds_count == 2, (
+        f"expected 2 datastores from vcsim's seed topology; "
+        f"got ds_count={ds_count} from payload={payload!r}"
+    )

--- a/backend/tests/acceptance/test_vmware_rest_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_vmware_rest_dispatch_smoke.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.1-T8 dispatch smoke — read-only vmware-rest ops against vcsim.
+
+Closes the "Step 7" gap the G0.7 canary runbook flagged: the
+:class:`~meho_backplane.connectors.vmware_rest.VmwareRestConnector`
+(merged in #498) dispatches 5 representative read ops against a
+running vcsim and the dispatcher returns a structured
+:class:`~meho_backplane.connectors.schemas.OperationResult` for each
+one. The smoke test verifies the dispatch leg end-to-end:
+
+- Connector resolved by ``(product, version, impl_id)`` triple via the
+  v2 registry.
+- Session lifecycle exercised:
+  :meth:`VmwareRestConnector.auth_headers` mints a ``vmware-api-session-id``
+  via ``POST /api/session`` against vcsim's no-auth surface.
+- Per-op HTTP request fires through the connector's pooled
+  :class:`httpx.AsyncClient` with TLS verification disabled (vcsim's
+  self-signed cert).
+- :func:`~meho_backplane.operations.dispatcher.dispatch` produces a
+  ``status='ok'`` result for every probed op.
+
+Five op_ids span the canonical inventory surface so a regression in
+any single resolver path (cluster lookup, host enumeration, datastore
+shape, network listing, ``GET /api/about`` short-circuit) surfaces
+here rather than in a single-op test that could miss it. The set
+matches the issue body's ``GET:/api/about, GET:/vcenter/cluster,
+GET:/vcenter/host, GET:/vcenter/datastore, GET:/vcenter/network``
+list.
+
+Skip conditions:
+
+* No vcsim — the ``vcsim_endpoint`` fixture in conftest skips with a
+  clear reason when neither ``MEHO_VCSIM_URL`` nor a Docker socket
+  resolves.
+* No vCenter OpenAPI spec — ingestion needs ``vcenter.yaml`` to
+  populate the dispatchable ``endpoint_descriptor`` rows; without it
+  the test skips with the canary's standard reason.
+
+Why ingestion is part of the smoke test
+=======================================
+
+The smoke test dispatches **ingested** ops (``source_kind='ingested'``)
+rather than typed ones, because the production agent surface for
+vmware-rest is the ingested corpus (T3 #520 landed ``vcenter.yaml``
+ingestion full). Bypassing ingestion with hand-rolled descriptor
+rows would prove the dispatcher works in isolation but not the
+production-shipped read path. The cost (one ingest per test run) is
+paid once via the session-scoped :class:`~tests.acceptance._canary_fixtures._IngestedCanary`
+helper.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.operations.meta_tools import call_operation
+from tests.acceptance._canary_fixtures import IngestedCanaryVcsim
+from tests.acceptance._vcsim import VcsimEndpoint
+
+#: Read-only ops the smoke test dispatches. Every one is a
+#: ``GET`` against an inventory endpoint vcsim implements; each
+#: must succeed with ``status='ok'``. The ``/api/about`` op
+#: short-circuits inside the connector's typed-op handler and
+#: doesn't require an active vcenter session, exercising the
+#: session-optional code path.
+SMOKE_OP_IDS: tuple[str, ...] = (
+    "GET:/api/about",
+    "GET:/vcenter/cluster",
+    "GET:/vcenter/host",
+    "GET:/vcenter/datastore",
+    "GET:/vcenter/network",
+)
+
+
+@pytest.mark.parametrize("op_id", SMOKE_OP_IDS)
+async def test_dispatch_smoke_op_returns_ok(
+    op_id: str,
+    ingested_canary_vcsim: IngestedCanaryVcsim,
+    vcsim_endpoint: VcsimEndpoint,
+) -> None:
+    """Each probed op dispatches against vcsim and returns ``status='ok'``.
+
+    Per-op parameterisation surfaces in CI's report as one test
+    case per op; a single regressing op fails its own case and
+    leaves the others green. Asserting only ``status='ok'`` (not
+    the shape of ``result``) keeps the smoke test resilient to
+    vcsim's release-to-release inventory shape variance — the
+    JSONFlux force-mode and agent-flow tests cover shape.
+
+    ``call_operation`` is the agent surface so the smoke test
+    drives the same code path the LLM-driven agent would, not the
+    direct ``dispatch()`` API. Audit + broadcast hooks fire on
+    every dispatch (their assertions live in the canary's vcsim
+    extension #519, not here — this test focuses on result
+    status).
+    """
+    operator: Operator = ingested_canary_vcsim.operator
+    target_name = ingested_canary_vcsim.target_name
+
+    result = await call_operation(
+        operator,
+        {
+            "connector_id": ingested_canary_vcsim.connector_id,
+            "op_id": op_id,
+            "target": {"name": target_name},
+            "params": {},
+        },
+    )
+
+    assert result["status"] == "ok", (
+        f"op {op_id!r} failed against vcsim at "
+        f"{vcsim_endpoint.base_url}: {result.get('error')!r}; "
+        f"full result={result!r}"
+    )

--- a/backend/tests/acceptance/test_vmware_rest_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_vmware_rest_jsonflux_force_handle.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.1-T8 JSONFlux handle force-mode acceptance test.
+
+v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
+— the production reducer never produces a :class:`ResultHandle`. The
+real reducer (set-shaped payload reduction, MinIO/S3 spill,
+``result_query`` / ``result_aggregate`` meta-tools) lands in a
+follow-on Initiative. Until then, the JSONFlux *seam* between
+dispatcher and reducer is exercised here via a test-only
+:class:`ForceHandleReducer` that wraps every payload in a synthetic
+handle. The test:
+
+* Dispatches ``GET:/vcenter/vm`` against vcsim's 50-VM seed.
+* Asserts the returned :class:`~meho_backplane.connectors.schemas.OperationResult`
+  carries a populated :attr:`OperationResult.handle` (UUID id,
+  non-empty summary_md, dict schema_, ≥1 sample row, ttl_seconds set).
+* Asserts the inlined :attr:`OperationResult.result` carries the
+  reduced summary (row_count + sample) rather than the full set.
+
+What the test does NOT cover
+============================
+
+* Real reducer logic — MinIO/S3 spill, schema inference from payload,
+  the 50-row/4KB threshold heuristic. Those land with the production
+  reducer.
+* Audit-row ``handle_id`` propagation — v0.2's audit pipeline does
+  not surface the handle's UUID on the audit row's
+  :attr:`AuditLog.extras` field. Once the production reducer ships,
+  the audit row's payload column gains a ``handle_id`` key; the
+  assertion below is intentionally focused on the
+  :class:`OperationResult` envelope rather than the audit-row shape
+  to keep the test resilient to that future change.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+from tests.acceptance._canary_fixtures import IngestedCanaryVcsim
+
+
+class ForceHandleReducer:
+    """Test-only reducer that always produces a :class:`ResultHandle`.
+
+    Exists to exercise the JSONFlux dispatcher seam against a real
+    response — proves the dispatcher calls the reducer, threads the
+    handle through :func:`wrap_ok_result` onto the
+    :class:`OperationResult.handle` field, and ships the summary
+    on :attr:`OperationResult.result` (not the raw payload).
+
+    Set-shaped payload handling:
+
+    * ``dict`` with ``"value"`` key (vCenter REST's set-shape) →
+      ``rows = payload["value"]``; ``total_rows = len(rows)``.
+    * ``list`` → ``total_rows = len(payload)``.
+    * Anything else → ``total_rows = 1``, ``sample_rows = ()``.
+
+    The handle's ``schema_`` is a placeholder ``{"type": "array",
+    "items": {"type": "object"}}`` — a real reducer would infer the
+    schema from the payload, but the dispatcher seam test only needs
+    a non-empty dict to pass the
+    :class:`~meho_backplane.connectors.schemas.ResultHandle`
+    validator's frozen requirement.
+    """
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        """Always return ``(summary_dict, ResultHandle)``."""
+        del schema, context  # synthetic reducer ignores both
+        if isinstance(payload, dict) and "value" in payload:
+            rows = payload["value"]
+            if isinstance(rows, list):
+                total = len(rows)
+                sample = tuple(rows[:5]) if rows else ()
+            else:
+                total = 1
+                sample = ()
+        elif isinstance(payload, list):
+            total = len(payload)
+            sample = tuple(payload[:5]) if payload else ()
+        else:
+            total = 1
+            sample = ()
+
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"force-mode handle ({total} rows)",
+            schema_={"type": "array", "items": {"type": "object"}},
+            total_rows=total,
+            sample_rows=sample if sample else None,
+            ttl_seconds=3600,
+        )
+        summary = {"row_count": total, "sample": list(sample)}
+        return summary, handle
+
+
+@pytest.fixture
+def force_handle_reducer() -> Any:
+    """Install :class:`ForceHandleReducer` as the dispatcher's default.
+
+    The reducer is module-level state on
+    :mod:`meho_backplane.operations.dispatcher`; the test's setup
+    swaps it in via :func:`set_default_reducer` and teardown restores
+    :class:`PassThroughReducer` so a follow-on test in the same
+    pytest session sees the v0.2 default behaviour.
+
+    :func:`reset_dispatcher_caches` is called on teardown to drop
+    any connector-instance cache the dispatch built up; the
+    ``ingested_canary_vcsim`` fixture's own teardown handles its
+    own slice of that work, but explicit reset here keeps the
+    fixture independent of evaluation order.
+    """
+    set_default_reducer(ForceHandleReducer())
+    try:
+        yield
+    finally:
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+
+async def test_force_handle_reducer_populates_operation_result_handle(
+    force_handle_reducer: None,
+    ingested_canary_vcsim: IngestedCanaryVcsim,
+) -> None:
+    """Dispatching ``GET:/vcenter/vm`` against vcsim populates ``OperationResult.handle``.
+
+    Confirms the JSONFlux dispatcher seam:
+
+    * ``status == 'ok'`` — dispatch succeeded.
+    * ``handle`` is a :class:`ResultHandle` — the reducer's return
+      value flowed through :func:`wrap_ok_result`.
+    * ``handle.total_rows == 50`` — matches vcsim's seeded
+      :data:`DEFAULT_VCSIM_TOPOLOGY` VM count.
+    * ``handle.summary_md`` is non-empty + mentions the row count —
+      the reducer composed its summary correctly.
+    * ``handle.schema_`` is a non-empty mapping — the validator's
+      frozen-after-construction guarantee held.
+    * ``handle.sample_rows`` is populated — the reducer captured at
+      least one row from vcsim's response.
+    * ``result['row_count'] == 50`` — the dispatcher inlined the
+      reducer's summary on the operation envelope (not the raw
+      50-VM list).
+    """
+    result_envelope = await call_operation(
+        ingested_canary_vcsim.operator,
+        {
+            "connector_id": ingested_canary_vcsim.connector_id,
+            "op_id": "GET:/vcenter/vm",
+            "target": {"name": ingested_canary_vcsim.target_name},
+            "params": {},
+        },
+    )
+
+    assert result_envelope["status"] == "ok", (
+        f"force-handle dispatch did not succeed: {result_envelope!r}"
+    )
+
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        f"expected OperationResult.handle to be populated by "
+        f"ForceHandleReducer; got handle=None on envelope={result_envelope!r}"
+    )
+    # ``model_dump`` ships the handle as a dict on the wire; the
+    # assertions below match the JSON shape rather than re-instantiating
+    # ResultHandle. handle_id is serialised as a UUID string by
+    # :meth:`pydantic.BaseModel.model_dump(mode='json')`.
+    uuid.UUID(handle["handle_id"])  # raises if not a valid UUID4 form
+    assert handle["total_rows"] == 50, (
+        f"expected 50 VMs from vcsim's seed topology; got handle.total_rows={handle['total_rows']}"
+    )
+    assert handle["summary_md"], "handle.summary_md must be non-empty"
+    assert "50" in handle["summary_md"], (
+        f"expected summary_md to mention the row count; got {handle['summary_md']!r}"
+    )
+    assert isinstance(handle["schema_"], dict) and handle["schema_"], (
+        f"handle.schema_ must be a non-empty mapping; got {handle['schema_']!r}"
+    )
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        f"expected ≥1 sample row from vcsim's 50-VM list; got sample_rows={sample_rows!r}"
+    )
+
+    # The inlined result is the reducer's summary, not the raw 50-VM
+    # set. ``row_count`` matches the handle's total; ``sample`` is
+    # the same list-of-dicts the handle's sample_rows carries (just
+    # serialised differently — dict vs MappingProxyType).
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == 50, (
+        f"expected the reducer's summary on result; got result={payload!r}"
+    )

--- a/docs/architecture/vcsim-integration-testing.md
+++ b/docs/architecture/vcsim-integration-testing.md
@@ -1,0 +1,110 @@
+# vcsim integration testing
+
+Reference for the `vcsim_endpoint` test fixture (`backend/tests/acceptance/_vcsim.py`) and how future G3.x connectors should mirror its shape for their own integration-test surfaces.
+
+## Why vcsim
+
+`vcsim` is the [VMware-shipped govmomi-backed vCenter simulator](https://github.com/vmware/govmomi/tree/main/vcsim). It listens on `0.0.0.0:8989` by default, serves both `/api` (new REST surface) and `/rest` (legacy mount), and accepts any HTTP basic credential — the simulator never validates the username/password pair. That property lets the MEHO acceptance suite drive the production `VmwareRestConnector` (#498) through `POST /api/session` / `GET /api/about` / `GET /vcenter/*` without standing up a real vCenter.
+
+Without vcsim, the G0.6 dispatcher's HTTP path is exercised only by unit-suite mocks (`tests/test_operations_dispatcher.py`); a regression in the real-HTTP-shape handling (session cookie threading, TLS context reuse, JSON deserialisation of vCenter's `{"value": [...]}` envelope) would slip through unit gates. vcsim closes that gap on every CI run.
+
+## Where the fixture lives
+
+The shared resolver + endpoint dataclass + container helper live in `backend/tests/acceptance/_vcsim.py`:
+
+| Symbol | Purpose |
+| --- | --- |
+| `VcsimEndpoint` | Frozen dataclass — host / port / scheme / no-auth credential pair / pre-built base URL. |
+| `VcsimTopology` | Frozen dataclass — seed counts (`vms`, `hosts`, `clusters`, `datastores`, `folders`). |
+| `DEFAULT_VCSIM_TOPOLOGY` | `VcsimTopology(vms=50, hosts=3, clusters=1, datastores=2, folders=2)` — the canary's default. |
+| `build_vcsim_command(topology, *, listen=...)` | Compose the vcsim CLI args (`-l ... -vm 50 -host 3 ...`). |
+| `build_vcsim_http_client(endpoint)` | `httpx.AsyncClient` wired for vcsim's self-signed cert (`verify=False`). |
+| `patch_vmware_connector_for_vcsim(connector, endpoint)` | Mutate a `VmwareRestConnector` instance in-place so its session loader returns vcsim's any-credentials pair + its httpx pool skips TLS verification. |
+| `resolve_vcsim_endpoint(topology)` | Context manager — yields a `VcsimEndpoint` and tears the testcontainers boot down on exit. |
+
+The conftest at `backend/tests/acceptance/conftest.py` wraps `resolve_vcsim_endpoint()` in a session-scoped `vcsim_endpoint` fixture; the same conftest exposes the `ingested_canary_vcsim` fixture (defined in `_canary_fixtures.py`) which seeds an `EndpointDescriptor` bundle + a Target row + a patched connector instance, ready for dispatch.
+
+## Resolution priority
+
+The helper consults sources in this order:
+
+1. **`MEHO_VCSIM_URL`** — explicit base URL pointing at a running vcsim instance (e.g. `https://10.0.5.4:8989`). The helper parses the URL and returns an endpoint without booting a container. This is the CI path for the meho-runners pool when a vcsim daemon is provisioned alongside the runner.
+2. **testcontainers-managed `vmware/vcsim` boot** — when no env override resolves, the helper boots the public `vmware/vcsim` image with the seed flags described under "Seeding the topology" and yields an endpoint targeting the host-mapped port. The image name is overridable via `MEHO_TEST_VCSIM_IMAGE` for registry-mirror swaps.
+3. **Skip** — when neither path is viable (no env var + no Docker socket), the fixture skips via `pytest.skip` with the `VCSIM_DOCKER_SKIP_REASON` message. The CI runner pool provisions Docker so the tests run there; agent sandboxes without Docker collect cleanly and skip.
+
+## Seeding the topology
+
+vcsim accepts CLI flags at startup to seed its in-memory inventory:
+
+| Flag | Default in `DEFAULT_VCSIM_TOPOLOGY` | Purpose |
+| --- | --- | --- |
+| `-vm` | 50 | Simulated VMs. Matches the JSONFlux force-mode test's row-count assertion. |
+| `-host` | 3 | ESXi hosts the cluster contains. |
+| `-cluster` | 1 | Cluster the hosts roll up to. |
+| `-ds` | 2 | Datastores. Matches the composite-dispatch test's assertion. |
+| `-folder` | 2 | Folders, useful for resolver-ambiguity tests. |
+
+The flags must be passed as separate `argv` entries (a list, not a single space-separated string). Passing a string lets Go's `flag.Parse()` halt at the first positional and silently fall back to `-l 127.0.0.1:8989` — the failure mode PR #518's first CI green attempt hit. `build_vcsim_command()` ships the right shape.
+
+## Patching `VmwareRestConnector` for vcsim
+
+Production code paths build the per-target `httpx.AsyncClient` with httpx's default `verify=True` and read credentials from Vault via `load_session_credentials_from_vault`. Neither works against vcsim — its cert isn't in the host CA bundle, and the test environment doesn't run Vault. `patch_vmware_connector_for_vcsim()` mutates one connector instance in place:
+
+```python
+from tests.acceptance._vcsim import patch_vmware_connector_for_vcsim
+
+instance = get_or_create_connector_instance(VmwareRestConnector)
+patch_vmware_connector_for_vcsim(instance, vcsim_endpoint)
+```
+
+Two mutations:
+
+* `_session_loader` → returns `{"username": "user", "password": "pass"}` (vcsim accepts any pair).
+* `_http_client` → builds the per-target `AsyncClient` with `verify=ssl_ctx` where `ssl_ctx.verify_mode = ssl.CERT_NONE`.
+
+The mutations are scoped to one instance; tests using the helper MUST call `reset_dispatcher_caches()` in teardown so the next test sees a fresh, unpatched instance. The `ingested_canary_vcsim` fixture handles that automatically.
+
+## Acceptance tests built on the fixture
+
+Four modules under `backend/tests/acceptance/` consume the fixture:
+
+* `test_vmware_rest_dispatch_smoke.py` — parametrised across 5 read ops (`GET:/api/about`, `GET:/vcenter/cluster`, `GET:/vcenter/host`, `GET:/vcenter/datastore`, `GET:/vcenter/network`); asserts each returns `status='ok'`.
+* `test_vmware_rest_jsonflux_force_handle.py` — installs a test-only `ForceHandleReducer` that wraps every payload in a `ResultHandle`; asserts the handle's `total_rows=50` matches vcsim's seed.
+* `test_vmware_rest_agent_flow_e2e.py` — exercises the four-step agent chain (`search_connectors → list_operation_groups → search_operations → call_operation`) end-to-end.
+* `test_vmware_rest_composite_dispatch.py` — soft-dependent on G3.1-T5 (#508 read composites); skips cleanly when the composite isn't registered yet, dispatches it against vcsim once T5 lands.
+
+The canary test `test_g07_vsphere_canary.py` also has a `MEHO_VCSIM_TARGET`-gated test (`test_g07_canary_vcsim_dispatch`, shipped in #519) that uses the env-override path against a pre-provisioned vcsim daemon rather than the testcontainers boot — both paths converge on the same `VcsimEndpoint` shape via `resolve_vcsim_endpoint()`.
+
+## Mirroring the pattern for future G3.x connectors
+
+Future connectors with vendor simulators should mirror the same shape:
+
+| Connector | Simulator / fake | Image / package | Helper file |
+| --- | --- | --- | --- |
+| `vmware-rest-9.0` (G3.1) | `vmware/vcsim` | `docker pull vmware/vcsim:latest` | `_vcsim.py` |
+| `vault-kv-1` (G3.x) | HashiCorp Vault dev mode | `testcontainers-python` ships `VaultContainer` | future `_vault.py` |
+| `k8s-kubeconfig-1` (G3.x) | k3s/k3d | `rancher/k3s:v1.32.x-k3s1` | `tests/integration/test_connectors_k8s_k3d.py` (already in place) |
+| `bind9` (G3.x) | bind9 dev container | Vendored bind9 image | future `_bind9.py` |
+
+The repeating shape:
+
+1. A frozen `<Service>Endpoint` dataclass carrying host / port / scheme / credentials.
+2. A context-manager `resolve_<service>_endpoint()` that consults env override + testcontainers boot in priority order.
+3. A session-scoped `<service>_endpoint` fixture in `tests/acceptance/conftest.py`.
+4. A `patch_<connector>_for_<service>()` helper that mutates a connector instance in place to accept the simulator's no-auth surface + self-signed cert.
+
+Doc PRs adding a new helper should cite this module as the prior art and call out any place the shape diverges (e.g. Vault's `VAULT_TOKEN` env-var contract differs from vcsim's any-credentials path).
+
+## CI integration
+
+The vcsim-backed tests run on the `meho-runners` pool (gha-runner-scale-set, ARC v2) per the existing test workflow. The Docker Hub login step at [`.github/workflows/ci.yml:109-110`](../../.github/workflows/ci.yml) authenticates pulls of `vmware/vcsim:latest`; no static service definition is needed because the testcontainers fixture boots vcsim per-test-session.
+
+`MEHO_VCSIM_URL` is **not** set in CI by default — the testcontainers path runs on every PR. Operators can override locally with `MEHO_VCSIM_URL=http://localhost:8989` when running `vcsim -l :8989` outside the pytest session.
+
+## References
+
+* `backend/tests/acceptance/_vcsim.py` — the resolver + endpoint helpers (source of truth).
+* `backend/tests/acceptance/_canary_fixtures.py` — minimal descriptor-row seeding + connector-patch fixture.
+* `backend/tests/integration/test_connectors_vmware_rest_vcsim.py` — pre-T8 integration tests (live-fingerprint / live-probe / session cache) shipped with #498.
+* `backend/tests/acceptance/test_g07_vsphere_canary.py` — `MEHO_VCSIM_TARGET`-gated dispatch + audit/broadcast extension shipped with #519.
+* [vcsim upstream](https://github.com/vmware/govmomi/tree/main/vcsim) — CLI flags, supported API surface, image at `docker pull vmware/vcsim:latest`.

--- a/docs/cross-repo/g07-vsphere-canary.md
+++ b/docs/cross-repo/g07-vsphere-canary.md
@@ -203,7 +203,7 @@ canonical operation for the workflow". The
 runs thirteen such queries (ten vcenter + three vi-json) and
 asserts the top-3 contract.
 
-### Step 7 — verify dispatch end-to-end (optional, needs vcsim or live vCenter)
+### Step 7 — verify dispatch end-to-end
 
 ```bash
 meho operation call vmware-rest-9.0 'GET:/vcenter/cluster' \
@@ -215,6 +215,19 @@ This step requires a Target row pointing at a reachable vCenter
 endpoint; ``vcsim`` (VMware's simulator) suffices for read
 operations and is what the Initiative #389 acceptance criteria
 imply for the canary's dispatch leg.
+
+CI now runs this step on every PR: G3.1-T8 (#515) shipped the
+[`vcsim_endpoint`](../../backend/tests/acceptance/_vcsim.py)
+session-scoped fixture and three acceptance modules
+([`test_vmware_rest_dispatch_smoke.py`](../../backend/tests/acceptance/test_vmware_rest_dispatch_smoke.py),
+[`test_vmware_rest_jsonflux_force_handle.py`](../../backend/tests/acceptance/test_vmware_rest_jsonflux_force_handle.py),
+[`test_vmware_rest_agent_flow_e2e.py`](../../backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py))
+that dispatch against the simulator on every PR, on the
+meho-runners pool where Docker is provisioned. The
+[`vcsim integration testing`](../architecture/vcsim-integration-testing.md)
+doc explains the fixture pattern and how future G3.x connectors
+can mirror it (Vault → testcontainers' `vault`, K8s → k3d,
+bind9 → real bind9 container).
 
 ## Test variant
 


### PR DESCRIPTION
## Summary

Closes the three remaining acceptance-side DoD lines on Initiative #227 (G3.1 vmware-rest-9.0) by shipping a shared vcsim fixture plus four acceptance modules that dispatch against the simulator on every CI run.

**Coordination with #519:** #519 (G0.7-T10) landed before this PR with its own vcsim extension to the G0.7 canary (`test_g07_canary_vcsim_dispatch`, env-gated on `MEHO_VCSIM_TARGET`). That work assumes a pre-provisioned vcsim daemon and **never shipped the shared `_vcsim.py` helper** the issue body forecast (its dispatch test is inlined in `test_g07_vsphere_canary.py`). This PR fills the gap and is strictly additive — #519's canary extension continues to run unchanged.

### What ships

**Shared fixture (`backend/tests/acceptance/`):**

- **`_vcsim.py`** — `VcsimEndpoint` + `VcsimTopology` dataclasses, `resolve_vcsim_endpoint()` context manager (checks `MEHO_VCSIM_URL` env override first; falls back to testcontainers-managed `vmware/vcsim` boot with the 50 VMs / 3 hosts / 1 cluster / 2 ds / 2 folders seed topology). `patch_vmware_connector_for_vcsim()` mutates one `VmwareRestConnector` instance to use no-auth credentials + `verify=False` httpx pool.
- **`conftest.py`** — session-scoped `vcsim_endpoint` fixture so the ~3-second container boot pays once per pytest run.
- **`_canary_fixtures.py`** — `ingested_canary_vcsim` fixture that inserts dispatch-test descriptor rows directly (no `IngestionPipelineService` invocation — the dispatch path doesn't need search-quality plumbing, only routable descriptors); seeds a `Target` row; patches the connector instance.

**Test modules:**

- **`test_vmware_rest_dispatch_smoke.py`** — parametrised across `GET:/api/about`, `GET:/vcenter/cluster`, `GET:/vcenter/host`, `GET:/vcenter/datastore`, `GET:/vcenter/network` against vcsim; asserts each returns `status='ok'`.
- **`test_vmware_rest_jsonflux_force_handle.py`** — test-only `ForceHandleReducer` (NOT production) installed via `set_default_reducer()`; dispatches `GET:/vcenter/vm` against vcsim's 50-VM seed; asserts `OperationResult.handle` is populated with the right total_rows, summary_md, schema_, and sample_rows.
- **`test_vmware_rest_agent_flow_e2e.py`** — exercises `list_ingested_connectors → list_operation_groups → search_operations → call_operation` against vcsim end-to-end.
- **`test_vmware_rest_composite_dispatch.py`** — soft-dep on G3.1-T5 (#508); skips cleanly with a clear reason; will flip to PASS once #508 merges.

**Documentation:**

- `docs/cross-repo/g07-vsphere-canary.md` — Step 7 no longer "optional, needs vcsim or live vCenter"; CI now runs it on every PR.
- `docs/architecture/vcsim-integration-testing.md` — new canonical doc covering the fixture pattern + how future G3.x connectors (Vault, K8s, bind9) can mirror it.
- `.github/workflows/ci.yml` — Docker Hub login step's comment updated to mention `vmware/vcsim`. No static service definition needed.

### Scope reduction vs the issue body

The issue body forecast a heavier scope ("Files touched" listed `_vcsim.py` as new); #519's landing reduced the canary-side coordination work but did NOT ship the shared `_vcsim.py`. This PR ships everything the issue listed except the `ci.yml` image pre-pull step (the existing Docker Hub login already covers `vmware/vcsim` pulls via testcontainers' lazy boot — no static pre-pull needed).

### Audit-row `handle_id` assertion deferred

The issue body's "Audit row recorded with handle_id reference" criterion isn't covered: v0.2's audit helper doesn't thread the handle's UUID onto `AuditLog.extras` yet (the production reducer hasn't shipped, so there's no handle to record in real dispatches). Once the real JSONFlux reducer lands in its own Initiative, the audit-row shape change should ship in lock-step. The test docstring notes this explicitly.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy --strict src/` — Success, 138 source files
- [x] `pytest --collect-only tests/` — 1707 tests collected (9 new under the T8 modules)
- [x] `pytest tests/acceptance/test_vmware_rest_*.py` — 9 tests skip cleanly in the no-Docker sandbox; will run on `meho-runners` where Docker is provisioned
- [x] `pytest tests/test_connectors_vmware_rest_*.py` — 37 passed (#498's connector unit tests stay green)
- [ ] CI on meho-runners — vcsim-backed acceptance tests run against the testcontainers boot (load-bearing gate)

## Out of scope

- Real JSONFlux reducer (set-shaped payload reduction, MinIO/S3 spill, `result_query` / `result_aggregate` meta-tools) — separate Initiative per v0.1-spec §"JSONFlux / result handles" L294-311.
- Audit-row `handle_id` threading — production reducer dependency.
- Composite dispatch coverage — soft-deferred to land alongside G3.1-T5 (#508).
- Helm chart / production hosting of vcsim — testing-only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive acceptance tests for VMware REST connector operations, including end-to-end agent workflows, operation dispatch, composite operations, and JSONFlux result handling.
  * Tests validate against a simulated vSphere environment for reliable, repeatable validation.

* **Documentation**
  * Added vcsim integration testing guide documenting the test infrastructure and environment setup.
  * Updated canary testing documentation with dispatch verification details.

* **Chores**
  * Updated CI workflow documentation for Docker Hub pull quota clarification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->