### PR TITLE
chore(ci): route testcontainers pulls through harbor.evba.lab proxy cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,21 @@ jobs:
     # at 49% through unit tests under the old 10-min cap; doubling
     # gives headroom for moderate suite growth.
     timeout-minutes: 20
+    env:
+      # Route testcontainers pulls through the in-cluster Harbor proxy
+      # cache (claude-rdc-hetzner-dc#463; project `dockerhub-proxy` public,
+      # anonymous consumer auth, wired into runner DinD via
+      # meho-internal#75). The test code reads these env vars with a
+      # docker.io short-name default — see backend/tests/test_db_engine.py
+      # `MEHO_TEST_PGVECTOR_IMAGE`, backend/tests/test_broadcast_client.py
+      # `MEHO_TEST_VALKEY_IMAGE`, backend/tests/integration/
+      # test_connectors_vmware_rest_vcsim.py `MEHO_TEST_VCSIM_IMAGE` —
+      # so the env-only swap requires no source-code changes.
+      # `docker/login-action` below stays load-bearing until #78's Half
+      # B sees a green cache-hit week and retires it.
+      MEHO_TEST_PGVECTOR_IMAGE: harbor.evba.lab/dockerhub-proxy/pgvector/pgvector:pg16
+      MEHO_TEST_VALKEY_IMAGE: harbor.evba.lab/dockerhub-proxy/valkey/valkey:8
+      MEHO_TEST_VCSIM_IMAGE: harbor.evba.lab/dockerhub-proxy/vmware/vcsim:latest
     defaults:
       run:
         # backend/ is the only Python project today; pyproject.toml


### PR DESCRIPTION
## Summary

Adds three job-level env vars to the `python-lint-test` job in `ci.yml`:

```
MEHO_TEST_PGVECTOR_IMAGE=harbor.evba.lab/dockerhub-proxy/pgvector/pgvector:pg16
MEHO_TEST_VALKEY_IMAGE=harbor.evba.lab/dockerhub-proxy/valkey/valkey:8
MEHO_TEST_VCSIM_IMAGE=harbor.evba.lab/dockerhub-proxy/vmware/vcsim:latest
```

Each name was already env-overridable in the test code with a docker.io short-name default — see [backend/tests/test_db_engine.py:420](backend/tests/test_db_engine.py#L420), [backend/tests/test_broadcast_client.py:403](backend/tests/test_broadcast_client.py#L403), [backend/tests/integration/test_connectors_vmware_rest_vcsim.py:111](backend/tests/integration/test_connectors_vmware_rest_vcsim.py#L111). Workflow-only change; no Python source touched.

This is Half A, **2 of 3**, of [meho-internal#78](https://github.com/evoila-bosnia/meho-internal/issues/78).

## Why job-level `env:` not step-level

Cleaner; affects only the steps that actually read these vars (the pytest step). Adding more pytest invocations in the future won't need a per-step env duplication. The non-test steps (ruff/mypy) ignore them.

## What this PR exercises

- DinD daemon's trust of `harbor.evba.lab` (wired by [meho-internal#75](https://github.com/evoila-bosnia/meho-internal/issues/75))
- Harbor's `dockerhub-proxy` project serving `pgvector/pgvector:pg16`, `valkey/valkey:8`, `vmware/vcsim:latest`

The `docker/login-action` step earlier in the same job stays load-bearing until Half B of #78 retires it in a follow-up.

## Test plan

- [x] `yaml.safe_load` parses
- [ ] Python (ruff + mypy + pytest) check passes on this branch (testcontainers pulls go through Harbor; pre-existing TRUNCATE/migration test debt — unrelated to this PR — may still surface)
- [ ] Post-merge: Harbor side shows `dockerhub-proxy/pgvector/pgvector`, `dockerhub-proxy/valkey/valkey`, `dockerhub-proxy/vmware/vcsim` repos populating

Closes evoila-bosnia/meho-internal#78 (partial — 2 of 3 Half-A PRs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI infrastructure configuration to route container dependencies through an in-cluster proxy service for improved build consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/527)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->