### PR TITLE
chore(backend): route Dockerfile FROM through harbor.evba.lab proxy cache

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,7 +38,7 @@ ARG PYTHON_BASE_DIGEST=sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa
 # `docs/codebase/backend.md`). `BUILDPLATFORM` and `TARGETPLATFORM` are
 # auto-populated by BuildKit and surfaced in the build log so CI runs
 # show which arch each layer compiled on.
-FROM python@${PYTHON_BASE_DIGEST} AS builder
+FROM harbor.evba.lab/dockerhub-proxy/library/python@${PYTHON_BASE_DIGEST} AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -83,7 +83,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --no-editable
 
 # ---------- Runtime ----------------------------------------------------------
-FROM python@${PYTHON_BASE_DIGEST} AS runtime
+FROM harbor.evba.lab/dockerhub-proxy/library/python@${PYTHON_BASE_DIGEST} AS runtime
 
 # Non-root user (uid 1001 — fixed for k8s SecurityContext alignment).
 RUN useradd --system --uid 1001 --gid 0 --no-create-home --shell /usr/sbin/nologin meho


### PR DESCRIPTION
## Summary

Rewrites both `FROM python@${PYTHON_BASE_DIGEST}` stages (builder + runtime) in `backend/Dockerfile` to `FROM harbor.evba.lab/dockerhub-proxy/library/python@${PYTHON_BASE_DIGEST}`. The digest pin is unchanged; Harbor's proxy-cache serves byte-identical content (cache miss falls through to docker.io, cache hit returns from local storage).

This is Half A, **3 of 3**, of [meho-internal#78](https://github.com/evoila-bosnia/meho-internal/issues/78).

## Why this is safe

- `FROM image` is a build-time pull, not runtime. The resulting image's layer manifests reference content-addressable layers, not the registry of origin. Users pulling `ghcr.io/evoila/meho:<tag>` don't care that the base was pulled via Harbor.
- `image.yml`'s `build` job runs on `meho-runners`, whose DinD daemon has the `harbor.evba.lab` CA trusted via [meho-internal#75](https://github.com/evoila-bosnia/meho-internal/issues/75). Buildx delegates to the daemon for base-image pulls.
- The base-image refresh policy in the surrounding comment block is unchanged: future digest bumps still run `docker manifest inspect python:3.12-slim` against the canonical docker.io source, then update `PYTHON_BASE_DIGEST`. Harbor serves the new digest on first cache miss.

## What this PR exercises

- DinD/BuildKit daemon's trust of `harbor.evba.lab`
- Harbor's `dockerhub-proxy` project serving `library/python@<digest>` (multi-arch manifest list)
- Multi-arch QEMU build still works through the cache prefix (per-arch image variant within the manifest list resolves correctly)

## Test plan

- [x] `git diff` shows only the two `FROM` lines changed
- [ ] image.yml's build job completes on this branch for both amd64 + arm64
- [ ] Post-merge: Harbor side shows `dockerhub-proxy/library/python` repo populating; resulting `ghcr.io/evoila/meho:<sha>` image still pullable and runnable from a user cluster (no Harbor reference in the runtime manifest)

Closes evoila-bosnia/meho-internal#78 (partial — 3 of 3 Half-A PRs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image registry configuration for build infrastructure to use internal proxy service for improved dependency management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/528)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->