### PR TITLE
feat(connectors): G3.1-T6 vmware-rest write composites — 8 hand-authored vmware.composite.* write ops

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""meho_backplane.connectors.vmware_rest.composites -- vmware-rest read composites.
+"""meho_backplane.connectors.vmware_rest.composites -- vmware-rest composites.
 
 Side-effect import: this package's ``__init__`` queues
 :func:`register_vmware_composite_operations` onto the lifespan-driven
@@ -13,17 +13,26 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 5 read composites land before
+``endpoint_descriptor`` upserts for the 13 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
 ``__init__`` wires the registrar; ``_register.py`` carries the
-per-composite registration metadata; ``_read.py`` carries the handler
-implementations; ``schemas.py`` carries the JSON Schema 2020-12
-parameter contracts.
+per-composite registration metadata; ``_read.py`` and ``_write.py``
+carry the handler implementations; ``schemas.py`` carries the JSON
+Schema 2020-12 parameter + response contracts.
 
-Scope: 5 read composites (G3.1-T5 / #508). 8 write composites land
-under G3.1-T6 (#509).
+Scope:
+
+* 5 read composites (G3.1-T5 / #508) -- ``safety_level="safe"`` +
+  ``requires_approval=False`` overrides.
+* 8 write composites (G3.1-T6 / #509) -- inherit T4's
+  ``safety_level="dangerous"`` + ``requires_approval=True`` defaults.
+  The 8 cover every state-mutating workflow Goal #214 names as
+  required for govc-wrapper retirement: ``vm.create``, ``vm.clone``,
+  ``vm.snapshot.revert``, ``vm.migrate``, ``vm.power.bulk``,
+  ``host.evacuate`` (first recursive composite),
+  ``host.detach_from_vds``, ``cluster.patch``.
 """
 
 from meho_backplane.connectors.vmware_rest.composites._read import (
@@ -36,6 +45,16 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
 from meho_backplane.connectors.vmware_rest.composites._register import (
     register_vmware_composite_operations,
 )
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    cluster_patch_composite,
+    host_detach_from_vds_composite,
+    host_evacuate_composite,
+    vm_clone_composite,
+    vm_create_composite,
+    vm_migrate_composite,
+    vm_power_bulk_composite,
+    vm_snapshot_revert_composite,
+)
 from meho_backplane.operations.typed_register import register_typed_op_registrar
 
 # Queue the composite-op upsert onto the lifespan-driven registrar list.
@@ -46,9 +65,17 @@ register_typed_op_registrar(register_vmware_composite_operations)
 
 __all__ = [
     "cluster_drs_recommendations_composite",
+    "cluster_patch_composite",
     "datastore_usage_composite",
     "event_tail_composite",
+    "host_detach_from_vds_composite",
+    "host_evacuate_composite",
     "network_portgroup_audit_composite",
     "performance_summary_composite",
     "register_vmware_composite_operations",
+    "vm_clone_composite",
+    "vm_create_composite",
+    "vm_migrate_composite",
+    "vm_power_bulk_composite",
+    "vm_snapshot_revert_composite",
 ]

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 5 read composites.
+"""``register_vmware_composite_operations`` -- registrar for the 13 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -11,23 +11,30 @@ after the registrar list is populated by the
 :func:`register_typed_op_registrar`).
 
 Per-composite arguments (summary / description / group_key / tags /
-``parameter_schema``) live here so a future shape change (e.g.
-``llm_instructions`` polish) only touches one file. The
+``parameter_schema`` / ``safety_level`` / ``requires_approval``) live
+here so a future shape change (e.g. ``llm_instructions`` polish) only
+touches one file. The
 :func:`~meho_backplane.operations.typed_register.register_composite_operation`
 helper handles the upsert, body-hash dedupe, embedding pipeline, and
 the source_kind="composite" persistence.
 
-Every composite passes ``safety_level="safe"`` +
-``requires_approval=False`` -- overrides of T4's
-``dangerous`` / ``True`` defaults (which target the typical write
-composite). All 5 composites in this Task are inherently read-only;
-operator-facing dispatch should not pop the approval queue for them.
+Mixed safety posture
+--------------------
+
+The 5 read composites (T5 / #508) pass ``safety_level="safe"`` +
+``requires_approval=False`` -- overrides of T4's ``dangerous`` /
+``True`` defaults. The 8 write composites (T6 / #509) inherit the T4
+defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity at
+the call site; the helper would default to those values anyway).
+Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
+``requires_approval`` so the policy posture is implied by the row,
+not by global state.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
@@ -36,17 +43,43 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    cluster_patch_composite,
+    host_detach_from_vds_composite,
+    host_evacuate_composite,
+    vm_clone_composite,
+    vm_create_composite,
+    vm_migrate_composite,
+    vm_power_bulk_composite,
+    vm_snapshot_revert_composite,
+)
 from meho_backplane.connectors.vmware_rest.composites.schemas import (
     CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA,
     CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA,
+    CLUSTER_PATCH_PARAMETER_SCHEMA,
+    CLUSTER_PATCH_RESPONSE_SCHEMA,
     DATASTORE_USAGE_PARAMETER_SCHEMA,
     DATASTORE_USAGE_RESPONSE_SCHEMA,
     EVENT_TAIL_PARAMETER_SCHEMA,
     EVENT_TAIL_RESPONSE_SCHEMA,
+    HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA,
+    HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA,
+    HOST_EVACUATE_PARAMETER_SCHEMA,
+    HOST_EVACUATE_RESPONSE_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
     PERFORMANCE_SUMMARY_RESPONSE_SCHEMA,
+    VM_CLONE_PARAMETER_SCHEMA,
+    VM_CLONE_RESPONSE_SCHEMA,
+    VM_CREATE_PARAMETER_SCHEMA,
+    VM_CREATE_RESPONSE_SCHEMA,
+    VM_MIGRATE_PARAMETER_SCHEMA,
+    VM_MIGRATE_RESPONSE_SCHEMA,
+    VM_POWER_BULK_PARAMETER_SCHEMA,
+    VM_POWER_BULK_RESPONSE_SCHEMA,
+    VM_SNAPSHOT_REVERT_PARAMETER_SCHEMA,
+    VM_SNAPSHOT_REVERT_RESPONSE_SCHEMA,
 )
 from meho_backplane.operations.typed_register import register_composite_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
@@ -67,12 +100,17 @@ _IMPL_ID = "vmware-rest"
 class _CompositeSpec(NamedTuple):
     """Per-composite registration arguments.
 
-    Field-table form rather than five repeated kwargs blocks: keeps the
-    op_id / handler / schemas / group / tags adjacent per composite and
-    drops the outer registrar function below the 100-line block limit.
-    Common fields (``product`` / ``version`` / ``impl_id`` /
-    ``safety_level="safe"`` / ``requires_approval=False``) live on the
-    call site below, not in the spec.
+    Field-table form rather than thirteen repeated kwargs blocks:
+    keeps the op_id / handler / schemas / group / tags / policy
+    posture adjacent per composite and drops the outer registrar
+    function below the 100-line block limit. Common fields
+    (``product`` / ``version`` / ``impl_id``) live on the call site
+    below, not in the spec.
+
+    Each row carries its own ``safety_level`` + ``requires_approval``
+    so the policy posture is implied by the spec, not by global
+    defaults: reads ship ``"safe"`` / ``False``; writes ship
+    ``"dangerous"`` / ``True``.
     """
 
     op_id: str
@@ -83,9 +121,14 @@ class _CompositeSpec(NamedTuple):
     response_schema: dict[str, Any]
     group_key: str
     tags: list[str]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
 
 
 _COMPOSITES: tuple[_CompositeSpec, ...] = (
+    # ----------------------------------------------------------------
+    # Read composites (T5 / #508) -- safe / no approval
+    # ----------------------------------------------------------------
     _CompositeSpec(
         op_id="vmware.composite.cluster.drs_recommendations",
         handler=cluster_drs_recommendations_composite,
@@ -103,6 +146,8 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         response_schema=CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA,
         group_key="cluster",
         tags=["composite", "read-only", "cluster", "drs"],
+        safety_level="safe",
+        requires_approval=False,
     ),
     _CompositeSpec(
         op_id="vmware.composite.event.tail",
@@ -119,6 +164,8 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         response_schema=EVENT_TAIL_RESPONSE_SCHEMA,
         group_key="events",
         tags=["composite", "read-only", "events", "vi-json"],
+        safety_level="safe",
+        requires_approval=False,
     ),
     _CompositeSpec(
         op_id="vmware.composite.performance.summary",
@@ -137,6 +184,8 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         response_schema=PERFORMANCE_SUMMARY_RESPONSE_SCHEMA,
         group_key="performance",
         tags=["composite", "read-only", "performance", "vi-json"],
+        safety_level="safe",
+        requires_approval=False,
     ),
     _CompositeSpec(
         op_id="vmware.composite.datastore.usage",
@@ -155,6 +204,8 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         response_schema=DATASTORE_USAGE_RESPONSE_SCHEMA,
         group_key="storage",
         tags=["composite", "read-only", "storage", "datastore"],
+        safety_level="safe",
+        requires_approval=False,
     ),
     _CompositeSpec(
         op_id="vmware.composite.network.portgroup.audit",
@@ -174,6 +225,189 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         response_schema=NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
         group_key="networking",
         tags=["composite", "read-only", "networking", "portgroup"],
+        safety_level="safe",
+        requires_approval=False,
+    ),
+    # ----------------------------------------------------------------
+    # Write composites (T6 / #509) -- dangerous / requires approval
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.vm.create",
+        handler=vm_create_composite,
+        summary="Create a VM with NIC attach + optional power-on; rollback on failure.",
+        description=(
+            "Orchestrates folder lookup, POST:/vcenter/vm create, per-NIC "
+            "attach via PATCH:/vcenter/vm/{vm}/network, and optional "
+            "POST:/vcenter/vm/{vm}/power start. Partial-failure rollback: "
+            "if any step after the create succeeds fails, the half-"
+            "created VM is removed via DELETE:/vcenter/vm/{vm} so the "
+            "caller knows the VM did not persist. Equivalent of 'govc "
+            "vm.create' for operator-facing dispatch."
+        ),
+        parameter_schema=VM_CREATE_PARAMETER_SCHEMA,
+        response_schema=VM_CREATE_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "lifecycle"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.clone",
+        handler=vm_clone_composite,
+        summary="Clone a VM from a content-library template; poll the deploy task.",
+        description=(
+            "Reads source VM config, dispatches "
+            "POST:/vcenter/vm-template/library-items?action=deploy, then "
+            "polls GET:/cis/tasks/{task} until completion or timeout. "
+            "Long-running -- blocks for up to timeout_seconds when "
+            "wait_for_completion=True (default). Setting "
+            "wait_for_completion=False returns the task id for caller "
+            "polling. Equivalent of 'govc vm.clone' for operator-facing "
+            "dispatch."
+        ),
+        parameter_schema=VM_CLONE_PARAMETER_SCHEMA,
+        response_schema=VM_CLONE_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "lifecycle", "long-running"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.snapshot.revert",
+        handler=vm_snapshot_revert_composite,
+        summary="Revert a VM to a named snapshot; reject on name ambiguity.",
+        description=(
+            "Lists the VM's snapshot tree via "
+            "GET:/vcenter/vm/{vm}/snapshot, matches by snapshot name, "
+            "and dispatches "
+            "POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert when "
+            "exactly one match is found. Multiple-match cases return "
+            "status='ambiguous' with candidates listed so the operator "
+            "can re-dispatch by snapshot moid. Idempotent within a "
+            "snapshot tree -- reverting twice to the same snapshot is "
+            "a no-op vs. vSphere state. Marked dangerous: the revert "
+            "destroys in-flight VM state since the snapshot. Equivalent "
+            "of 'govc snapshot.revert'."
+        ),
+        parameter_schema=VM_SNAPSHOT_REVERT_PARAMETER_SCHEMA,
+        response_schema=VM_SNAPSHOT_REVERT_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "snapshot"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.migrate",
+        handler=vm_migrate_composite,
+        summary="Migrate a VM via DRS recommendation or explicit target host.",
+        description=(
+            "Consults "
+            "GET:/vcenter/cluster/{cluster}/drs/recommendations for the "
+            "VM, then dispatches POST:/vcenter/vm/{vm}?action=relocate "
+            "with the recommended host. If DRS returns no recommendation "
+            "and no target_host override is supplied, the composite "
+            "returns status='no_recommendation' rather than picking a "
+            "host arbitrarily. The operator can bypass DRS by passing "
+            "target_host explicitly. Equivalent of 'govc vm.migrate' "
+            "for operator-facing dispatch."
+        ),
+        parameter_schema=VM_MIGRATE_PARAMETER_SCHEMA,
+        response_schema=VM_MIGRATE_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "drs"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.power.bulk",
+        handler=vm_power_bulk_composite,
+        summary="Apply a power action to every VM matching a filter; aggregate results.",
+        description=(
+            "Resolves a free-form filter to a VM list via "
+            "GET:/vcenter/vm, then dispatches "
+            "POST:/vcenter/vm/{vm}/power?action=<action> per matched VM. "
+            "Partial-failure tolerated: each VM's outcome is captured "
+            "independently; failures do not abort the composite unless "
+            "fail_fast=True. Returns per-VM results plus aggregate "
+            "counts. Equivalent of 'govc vm.power' over a --vm glob."
+        ),
+        parameter_schema=VM_POWER_BULK_PARAMETER_SCHEMA,
+        response_schema=VM_POWER_BULK_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "bulk"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.host.evacuate",
+        handler=host_evacuate_composite,
+        summary="Migrate every VM off a host (via recursive vm.migrate) then enter maintenance.",
+        description=(
+            "Lists VMs on the host via "
+            "GET:/vcenter/vm?filter.hosts=..., then dispatches "
+            "vmware.composite.vm.migrate per VM (recursive composite "
+            "call -- first production composite that calls another "
+            "composite). On full migration success, the host enters "
+            "maintenance via "
+            "PATCH:/vcenter/host/{host}/maintenance?action=enter. "
+            "tolerate_partial_failure=True lets maintenance-enter fire "
+            "even with VMs left behind. Equivalent of 'govc host.evacuate' "
+            "operator workflow."
+        ),
+        parameter_schema=HOST_EVACUATE_PARAMETER_SCHEMA,
+        response_schema=HOST_EVACUATE_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=["composite", "write", "host", "maintenance", "recursive"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.host.detach_from_vds",
+        handler=host_detach_from_vds_composite,
+        summary="Migrate host VM NICs off a DVS to a fallback network, then remove host from DVS.",
+        description=(
+            "Lists DVS portgroups on the host and VMs on the host, "
+            "migrates each VM's NICs off the DVS to the supplied "
+            "fallback_network via PATCH:/vcenter/vm/{vm}/network, and "
+            "then dispatches "
+            "POST:/vcenter/network/dvs/{dvs}?action=remove_host. "
+            "vSphere refuses the host detach when any VM still has "
+            "active NICs on the DVS -- the composite verifies every NIC "
+            "migrated before attempting the detach; on partial NIC "
+            "migration the composite returns status='incomplete' and "
+            "skips the DVS detach. Replaces "
+            "scripts/host-detach-from-vds.py."
+        ),
+        parameter_schema=HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA,
+        response_schema=HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=["composite", "write", "host", "networking"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.cluster.patch",
+        handler=cluster_patch_composite,
+        summary="Sequentially patch every host in a cluster: maintenance + patch + exit.",
+        description=(
+            "Lists cluster hosts via GET:/vcenter/cluster/{cluster}/host, "
+            "then iterates each host sequentially: "
+            "PATCH:/vcenter/host/{host}/maintenance?action=enter -> "
+            "POST:/vcenter/host/{host}?action=patch -> "
+            "PATCH:/vcenter/host/{host}/maintenance?action=exit. "
+            "Sequential by design -- concurrent host patches would "
+            "force every VM in the cluster to vMotion at once, "
+            "overwhelming DRS. Per-host failure stops the loop; the "
+            "composite returns status='stopped' with patched_hosts + "
+            "remaining_hosts so the operator can manually finish or "
+            "roll back the partial patch."
+        ),
+        parameter_schema=CLUSTER_PATCH_PARAMETER_SCHEMA,
+        response_schema=CLUSTER_PATCH_RESPONSE_SCHEMA,
+        group_key="cluster",
+        tags=["composite", "write", "cluster", "patch", "long-running"],
+        safety_level="dangerous",
+        requires_approval=True,
     ),
 )
 
@@ -182,7 +416,7 @@ async def register_vmware_composite_operations(
     *,
     embedding_service: EmbeddingService | None = None,
 ) -> None:
-    """Upsert every vmware-rest read composite into ``endpoint_descriptor``.
+    """Upsert every vmware-rest composite into ``endpoint_descriptor``.
 
     Idempotent: a second invocation against unchanged descriptions is a
     no-op for the embedding pipeline (the body-hash skip path in
@@ -191,9 +425,11 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 5 read composites (cluster.drs_recommendations + event.tail
-    + performance.summary + datastore.usage + network.portgroup.audit).
-    The 8 write composites are scope of #509 (G3.1-T6).
+    Scope: 13 composites total -- 5 read (T5 / #508) +
+    8 write (T6 / #509). Each composite's ``safety_level`` +
+    ``requires_approval`` come from its :class:`_CompositeSpec` row:
+    reads pass ``"safe"`` / ``False``; writes pass ``"dangerous"`` /
+    ``True`` (T4's defaults).
 
     Test seam: ``embedding_service`` lets test fixtures inject a stub
     so unit tests don't load the ONNX model. Production callers leave
@@ -213,7 +449,7 @@ async def register_vmware_composite_operations(
             response_schema=spec.response_schema,
             group_key=spec.group_key,
             tags=spec.tags,
-            safety_level="safe",
-            requires_approval=False,
+            safety_level=spec.safety_level,
+            requires_approval=spec.requires_approval,
             embedding_service=embedding_service,
         )

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -80,24 +80,54 @@ __all__ = [
 _CONNECTOR_ID = "vmware-rest-9.0"
 
 # vCenter REST op_ids (canonical METHOD:/path keys from vcenter.yaml).
+#
+# Action-bearing endpoints. vCenter's OpenAPI spec models POST-with-side-effect
+# endpoints as ``/<path>?action=<verb>`` — i.e. the action verb is part of the
+# path key, not a body parameter. The ingestion pipeline preserves the query
+# verbatim, so the canonical ``op_id`` for "power on a VM" is
+# ``POST:/vcenter/vm/{vm}/power?action=start`` (not ``POST:/vcenter/vm/{vm}/power``
+# with ``action=start`` in body params — that op_id is not a descriptor row).
+# These constants therefore embed the action verb. Endpoints whose action verb
+# is operator-chosen (power start/stop, maintenance enter/exit) build the op_id
+# per-call via :func:`_power_vm_op_id` / :func:`_host_maintenance_op_id`.
 _OP_LIST_FOLDERS = "GET:/vcenter/folder"
 _OP_LIST_VMS = "GET:/vcenter/vm"
 _OP_GET_VM = "GET:/vcenter/vm/{vm}"
 _OP_CREATE_VM = "POST:/vcenter/vm"
 _OP_DELETE_VM = "DELETE:/vcenter/vm/{vm}"
 _OP_ATTACH_VM_NIC = "PATCH:/vcenter/vm/{vm}/network"
-_OP_POWER_VM = "POST:/vcenter/vm/{vm}/power"
-_OP_RELOCATE_VM = "POST:/vcenter/vm/{vm}"  # action=relocate query param
+_OP_RELOCATE_VM = "POST:/vcenter/vm/{vm}?action=relocate"
 _OP_LIST_VM_SNAPSHOTS = "GET:/vcenter/vm/{vm}/snapshot"
-_OP_REVERT_VM_SNAPSHOT = "POST:/vcenter/vm/{vm}/snapshot/{snap}"
+_OP_REVERT_VM_SNAPSHOT = "POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert"
 _OP_LIST_CLUSTER_HOSTS = "GET:/vcenter/cluster/{cluster}/host"
 _OP_GET_DRS_RECOMMENDATIONS = "GET:/vcenter/cluster/{cluster}/drs/recommendations"
-_OP_DEPLOY_LIBRARY_VM = "POST:/vcenter/vm-template/library-items"
+_OP_DEPLOY_LIBRARY_VM = "POST:/vcenter/vm-template/library-items?action=deploy"
 _OP_GET_TASK = "GET:/cis/tasks/{task}"
-_OP_HOST_MAINTENANCE = "PATCH:/vcenter/host/{host}/maintenance"
-_OP_HOST_PATCH = "POST:/vcenter/host/{host}"
+_OP_HOST_PATCH = "POST:/vcenter/host/{host}?action=patch"
 _OP_LIST_PORTGROUPS = "GET:/vcenter/network/distributed-portgroup"
-_OP_REMOVE_DVS_HOST = "POST:/vcenter/network/dvs/{dvs}"
+_OP_REMOVE_DVS_HOST = "POST:/vcenter/network/dvs/{dvs}?action=remove_host"
+
+
+def _power_vm_op_id(action: str) -> str:
+    """Build the per-action canonical op_id for ``POST:/vcenter/vm/{vm}/power``.
+
+    vCenter exposes ``start`` / ``stop`` / ``suspend`` / ``reset`` as four
+    distinct descriptor rows under the ``?action=<verb>`` discriminator. The
+    composite picks the row at call time so each action lands on its own
+    audit row + policy evaluation, not as a free-form ``action`` parameter
+    on a single shared op_id (which wouldn't resolve against an ingested row).
+    """
+    return f"POST:/vcenter/vm/{{vm}}/power?action={action}"
+
+
+def _host_maintenance_op_id(action: str) -> str:
+    """Build the per-action canonical op_id for ``PATCH:/vcenter/host/{host}/maintenance``.
+
+    Maintenance enter / exit are two descriptor rows under ``?action=enter`` /
+    ``?action=exit``; same reasoning as :func:`_power_vm_op_id`.
+    """
+    return f"PATCH:/vcenter/host/{{host}}/maintenance?action={action}"
+
 
 # Recursive composite sub-op_id (host.evacuate -> vm.migrate).
 _OP_COMPOSITE_VM_MIGRATE = "vmware.composite.vm.migrate"
@@ -290,8 +320,8 @@ async def vm_create_composite(
     if power_on:
         power_result = await dispatch_child(
             connector_id=_CONNECTOR_ID,
-            op_id=_OP_POWER_VM,
-            params={"vm": vm_id, "action": "start"},
+            op_id=_power_vm_op_id("start"),
+            params={"vm": vm_id},
         )
         if power_result.status != "ok":
             await _rollback_created_vm(dispatch_child=dispatch_child, vm_id=vm_id)
@@ -423,7 +453,6 @@ async def vm_clone_composite(
             connector_id=_CONNECTOR_ID,
             op_id=_OP_DEPLOY_LIBRARY_VM,
             params={
-                "action": "deploy",
                 "library_item": library_item,
                 "spec": {"name": target_name},
             },
@@ -512,7 +541,7 @@ async def vm_snapshot_revert_composite(
         await dispatch_child(
             connector_id=_CONNECTOR_ID,
             op_id=_OP_REVERT_VM_SNAPSHOT,
-            params={"vm": vm_moid, "snap": snapshot_moid, "action": "revert"},
+            params={"vm": vm_moid, "snap": snapshot_moid},
         )
     )
     return {
@@ -594,7 +623,6 @@ async def vm_migrate_composite(
             op_id=_OP_RELOCATE_VM,
             params={
                 "vm": vm_moid,
-                "action": "relocate",
                 "spec": {"placement": {"host": target_host}},
             },
         )
@@ -627,6 +655,10 @@ async def vm_power_bulk_composite(
     filter_dict: dict[str, Any] = dict(params.get("filter") or {})
     action = params["action"]
     fail_fast = bool(params.get("fail_fast", False))
+    # Resolve the action verb to a concrete descriptor op_id once before the
+    # fan-out loop. Each ``?action=<verb>`` is a distinct descriptor row, so
+    # every per-VM dispatch must target the matching one.
+    power_op_id = _power_vm_op_id(action)
 
     listing = _require_ok(
         await dispatch_child(
@@ -653,8 +685,8 @@ async def vm_power_bulk_composite(
             continue
         power_result = await dispatch_child(
             connector_id=_CONNECTOR_ID,
-            op_id=_OP_POWER_VM,
-            params={"vm": vm_moid, "action": action},
+            op_id=power_op_id,
+            params={"vm": vm_moid},
         )
         if power_result.status == "ok":
             results.append({"vm": vm_moid, "status": "ok", "error": None})
@@ -724,9 +756,6 @@ async def host_evacuate_composite(
             f"host.evacuate: expected list from {_OP_LIST_VMS!r}, got {type(vms).__name__}"
         )
 
-    cluster_raw = vms[0].get("cluster") if vms and isinstance(vms[0], dict) else None
-    cluster_moid = cluster_raw if isinstance(cluster_raw, str) else ""
-
     migrated: list[str] = []
     failed: list[dict[str, str]] = []
     for vm_entry in vms:
@@ -735,10 +764,30 @@ async def host_evacuate_composite(
         vm_moid = vm_entry.get("vm")
         if not isinstance(vm_moid, str):
             continue
+        # Resolve the cluster per-VM rather than once from ``vms[0]``. The
+        # vCenter listing row reports each VM's containing cluster; VMs on
+        # the same host can belong to different clusters when the host
+        # straddles a federation (and the listing payload may simply omit
+        # the field for a row mid-flight). Treat a missing cluster as a
+        # per-VM failure so the recursive migrate doesn't fire against an
+        # empty target — that would short-circuit to ``no_recommendation``
+        # without surfacing the underlying data gap.
+        vm_cluster = vm_entry.get("cluster")
+        if not isinstance(vm_cluster, str) or not vm_cluster:
+            failed.append({"vm": vm_moid, "error": "missing_cluster"})
+            if not tolerate_partial:
+                return {
+                    "status": "aborted",
+                    "host": host_moid,
+                    "migrated_vms": migrated,
+                    "failed_vms": failed,
+                    "maintenance_entered": False,
+                }
+            continue
         migrate_result = await dispatch_child(
             connector_id=_CONNECTOR_ID,
             op_id=_OP_COMPOSITE_VM_MIGRATE,
-            params={"vm": vm_moid, "cluster": cluster_moid},
+            params={"vm": vm_moid, "cluster": vm_cluster},
         )
         succeeded, err_text = _classify_vm_migrate_outcome(migrate_result)
         if succeeded:
@@ -757,8 +806,8 @@ async def host_evacuate_composite(
     _require_ok(
         await dispatch_child(
             connector_id=_CONNECTOR_ID,
-            op_id=_OP_HOST_MAINTENANCE,
-            params={"host": host_moid, "action": "enter"},
+            op_id=_host_maintenance_op_id("enter"),
+            params={"host": host_moid},
         )
     )
     return {
@@ -844,7 +893,7 @@ async def host_detach_from_vds_composite(
         await dispatch_child(
             connector_id=_CONNECTOR_ID,
             op_id=_OP_REMOVE_DVS_HOST,
-            params={"dvs": dvs_moid, "action": "remove_host", "host": host_moid},
+            params={"dvs": dvs_moid, "host": host_moid},
         )
     )
     return {
@@ -860,10 +909,15 @@ async def host_detach_from_vds_composite(
 # ===========================================================================
 
 
+# Per-step (step-name, op_id_builder, extra-params-builder) tuples. The op_id
+# builder yields the concrete ``?action=<verb>`` descriptor key per step;
+# extra-params adds the ``method`` body field that ``POST:/vcenter/host/{host}
+# ?action=patch`` consumes (the patch verb has a non-trivial body schema; the
+# maintenance verbs do not).
 _CLUSTER_PATCH_STEPS: tuple[tuple[str, str], ...] = (
-    ("maintenance_enter", _OP_HOST_MAINTENANCE),
+    ("maintenance_enter", _host_maintenance_op_id("enter")),
     ("patch", _OP_HOST_PATCH),
-    ("maintenance_exit", _OP_HOST_MAINTENANCE),
+    ("maintenance_exit", _host_maintenance_op_id("exit")),
 )
 
 
@@ -873,12 +927,14 @@ def _cluster_patch_step_params(
     host_moid: str,
     patch_method: str,
 ) -> dict[str, Any]:
-    """Build the per-step params dict for a cluster.patch sub-op."""
-    if step == "maintenance_enter":
-        return {"host": host_moid, "action": "enter"}
-    if step == "maintenance_exit":
-        return {"host": host_moid, "action": "exit"}
-    return {"host": host_moid, "action": "patch", "method": patch_method}
+    """Build the per-step params dict for a cluster.patch sub-op.
+
+    Action verbs live on the op_id (``?action=enter`` / ``?action=patch`` /
+    ``?action=exit``); only the patch step adds a body-shaped ``method``.
+    """
+    if step == "patch":
+        return {"host": host_moid, "method": patch_method}
+    return {"host": host_moid}
 
 
 async def _patch_one_host(

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1,0 +1,963 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+# code-quality-allow: 8 protocol-driven composite handlers for the
+# vSphere REST write surface ship in one module per the issue body's
+# design; splitting them by group would scatter the shared sub-op_id
+# constants + helpers across files for no readability gain. Each
+# handler's body is the documented orchestration workflow from
+# #509's spec.
+
+"""Write-shaped ``vmware.composite.*`` handler functions (8 composites).
+
+Companion to :mod:`._read`. Same handler-shape contract -- each handler
+is a module-level ``async def`` taking the dispatcher's composite-branch
+keyword args ``(operator, target, params, dispatch_child)`` and
+returning a single aggregated dict via ``dispatch_child`` calls to
+2-N typed sub-ops (or, for :func:`host_evacuate_composite`, recursive
+calls into another vmware.composite).
+
+The 8 composites this module ships (G3.1-T6 / #509):
+
+* :func:`vm_create_composite` -- folder lookup -> ``POST:/vcenter/vm``
+  -> NIC attach loop -> optional power-on. Partial-failure rollback
+  via ``DELETE:/vcenter/vm/{vm}``.
+* :func:`vm_clone_composite` -- content-library deploy with task
+  polling. Long-running; ``wait_for_completion=False`` returns the
+  task id immediately.
+* :func:`vm_snapshot_revert_composite` -- list -> match by name ->
+  revert. Idempotent; ambiguity-rejection on name collision.
+* :func:`vm_migrate_composite` -- DRS recommendation lookup ->
+  relocate. ``target_host`` overrides DRS.
+* :func:`vm_power_bulk_composite` -- filter -> fan-out power action.
+  Per-VM partial-failure tolerated by default.
+* :func:`host_evacuate_composite` -- list VMs on host -> recursive
+  :func:`vm_migrate_composite` per VM -> maintenance-enter. First
+  production composite that calls another composite via
+  ``dispatch_child``.
+* :func:`host_detach_from_vds_composite` -- per-VM NIC migration to
+  a fallback network -> DVS host-detach. Refuses detach when any NIC
+  migration failed.
+* :func:`cluster_patch_composite` -- sequential per-host maintenance
+  + patch + exit. Stops the loop on the first per-host failure.
+
+Every sub-op_id below is the canonical ``METHOD:/path`` key produced
+by :func:`~meho_backplane.operations.ingest.openapi.parse_openapi`
+from the ingested ``vcenter.yaml`` (G3.1-T2 / #408) and
+``vi-json.yaml`` (G3.1-T3 / #503). The path strings come from
+inspecting the canonical ``GOVC_PARITY_BENCHMARK`` tuple at
+``backend/tests/acceptance/test_g07_vsphere_canary.py`` and the
+vSphere REST URL anchors in #509's issue body -- never guessed.
+
+Each composite returns a structured ``{"status": ...}`` envelope so
+callers can branch on ``status`` without parsing free-form prose. The
+status enums are listed on each composite's ``response_schema`` in
+:mod:`.schemas`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import OperationResult
+from meho_backplane.operations.composite import DispatchChild
+
+__all__ = [
+    "cluster_patch_composite",
+    "host_detach_from_vds_composite",
+    "host_evacuate_composite",
+    "vm_clone_composite",
+    "vm_create_composite",
+    "vm_migrate_composite",
+    "vm_power_bulk_composite",
+    "vm_snapshot_revert_composite",
+]
+
+
+# Connector_id every write composite dispatches sub-ops against.
+_CONNECTOR_ID = "vmware-rest-9.0"
+
+# vCenter REST op_ids (canonical METHOD:/path keys from vcenter.yaml).
+_OP_LIST_FOLDERS = "GET:/vcenter/folder"
+_OP_LIST_VMS = "GET:/vcenter/vm"
+_OP_GET_VM = "GET:/vcenter/vm/{vm}"
+_OP_CREATE_VM = "POST:/vcenter/vm"
+_OP_DELETE_VM = "DELETE:/vcenter/vm/{vm}"
+_OP_ATTACH_VM_NIC = "PATCH:/vcenter/vm/{vm}/network"
+_OP_POWER_VM = "POST:/vcenter/vm/{vm}/power"
+_OP_RELOCATE_VM = "POST:/vcenter/vm/{vm}"  # action=relocate query param
+_OP_LIST_VM_SNAPSHOTS = "GET:/vcenter/vm/{vm}/snapshot"
+_OP_REVERT_VM_SNAPSHOT = "POST:/vcenter/vm/{vm}/snapshot/{snap}"
+_OP_LIST_CLUSTER_HOSTS = "GET:/vcenter/cluster/{cluster}/host"
+_OP_GET_DRS_RECOMMENDATIONS = "GET:/vcenter/cluster/{cluster}/drs/recommendations"
+_OP_DEPLOY_LIBRARY_VM = "POST:/vcenter/vm-template/library-items"
+_OP_GET_TASK = "GET:/cis/tasks/{task}"
+_OP_HOST_MAINTENANCE = "PATCH:/vcenter/host/{host}/maintenance"
+_OP_HOST_PATCH = "POST:/vcenter/host/{host}"
+_OP_LIST_PORTGROUPS = "GET:/vcenter/network/distributed-portgroup"
+_OP_REMOVE_DVS_HOST = "POST:/vcenter/network/dvs/{dvs}"
+
+# Recursive composite sub-op_id (host.evacuate -> vm.migrate).
+_OP_COMPOSITE_VM_MIGRATE = "vmware.composite.vm.migrate"
+
+
+def _unwrap_value(payload: Any) -> Any:
+    """Return the inner ``value`` field on a pre-7 envelope, else *payload*."""
+    if isinstance(payload, dict) and set(payload.keys()) == {"value"}:
+        return payload["value"]
+    return payload
+
+
+def _require_ok(result: OperationResult) -> Any:
+    """Return :attr:`OperationResult.result` or raise on a non-OK status."""
+    if result.status != "ok":
+        raise RuntimeError(
+            f"composite sub-op {result.op_id!r} returned status="
+            f"{result.status!r}: {result.error or '<no error message>'}"
+        )
+    return result.result
+
+
+def _rolled_back(
+    *,
+    steps: list[str],
+    failed_step: str,
+    reason: str,
+) -> dict[str, Any]:
+    """Build the canonical rolled_back response envelope for :func:`vm_create_composite`."""
+    return {
+        "status": "rolled_back",
+        "vm_id": None,
+        "steps_succeeded": steps,
+        "failed_step": failed_step,
+        "rollback_reason": reason,
+    }
+
+
+# ===========================================================================
+# vm.create
+# ===========================================================================
+
+
+async def _resolve_folder_moid(
+    *, dispatch_child: DispatchChild, folder_name: str
+) -> tuple[str | None, str | None]:
+    """Look up a folder moid by display name.
+
+    Returns ``(moid, None)`` on success or ``(None, reason)`` on
+    failure -- the caller folds the reason into a ``rolled_back``
+    envelope. Failure modes: empty match list, listing row missing
+    the ``folder`` key.
+    """
+    folder_listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_FOLDERS,
+            params={"filter.names": [folder_name]},
+        )
+    )
+    folder_entries = _unwrap_value(folder_listing)
+    if not isinstance(folder_entries, list) or not folder_entries:
+        return None, f"folder name {folder_name!r} did not resolve to any moid"
+    first_entry = folder_entries[0]
+    folder_moid_raw = first_entry.get("folder") if isinstance(first_entry, dict) else None
+    if not isinstance(folder_moid_raw, str):
+        return None, "folder listing row missing ``folder`` key"
+    return folder_moid_raw, None
+
+
+async def _dispatch_create_vm(
+    *,
+    dispatch_child: DispatchChild,
+    folder_moid: str,
+    name: str,
+    guest_os: str,
+    cpu_count: int,
+    memory_mib: int,
+) -> tuple[str | None, str | None]:
+    """POST:/vcenter/vm; return ``(vm_id, None)`` or ``(None, error_reason)``."""
+    create_result = await dispatch_child(
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_CREATE_VM,
+        params={
+            "spec": {
+                "name": name,
+                "guest_OS": guest_os,
+                "placement": {"folder": folder_moid},
+                "cpu": {"count": cpu_count},
+                "memory": {"size_MiB": memory_mib},
+            },
+        },
+    )
+    if create_result.status != "ok":
+        return None, (
+            f"create returned status={create_result.status!r}: "
+            f"{create_result.error or '<no error message>'}"
+        )
+    vm_id_raw = _unwrap_value(create_result.result)
+    if not isinstance(vm_id_raw, str):
+        return None, f"create returned non-string vm id payload: {type(vm_id_raw).__name__}"
+    return vm_id_raw, None
+
+
+async def _attach_vm_nics(
+    *,
+    dispatch_child: DispatchChild,
+    vm_id: str,
+    nics: list[dict[str, Any]],
+) -> str | None:
+    """Attach NICs one-by-one; return ``None`` on success or a failure reason."""
+    for nic in nics:
+        nic_result = await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ATTACH_VM_NIC,
+            params={"vm": vm_id, "spec": nic},
+        )
+        if nic_result.status != "ok":
+            return (
+                f"nic attach for network={nic.get('network')!r} failed: "
+                f"{nic_result.error or '<no error message>'}"
+            )
+    return None
+
+
+async def _rollback_created_vm(*, dispatch_child: DispatchChild, vm_id: str) -> None:
+    """Issue ``DELETE:/vcenter/vm/{vm}`` to remove a half-created VM.
+
+    Best-effort: rollback failures are not surfaced -- the operator
+    already knows the create flow failed. If the DELETE returns
+    non-ok, the audit row of that sub-op records it for forensic
+    review.
+    """
+    await dispatch_child(
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_DELETE_VM,
+        params={"vm": vm_id},
+    )
+
+
+async def vm_create_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Create a VM with NIC attach + optional power-on; rollback on failure.
+
+    Op-id: ``vmware.composite.vm.create``. See module docstring for the
+    sub-op chain and rollback semantics.
+    """
+    folder_name = params["folder_name"]
+    name = params["name"]
+    guest_os = params["guest_os"]
+    cpu_count = int(params.get("cpu_count", 1))
+    memory_mib = int(params.get("memory_mib", 1024))
+    nics: list[dict[str, Any]] = list(params.get("nics") or [])
+    power_on = bool(params.get("power_on_after_create", False))
+
+    steps: list[str] = []
+
+    folder_moid, folder_err = await _resolve_folder_moid(
+        dispatch_child=dispatch_child, folder_name=folder_name
+    )
+    if folder_moid is None:
+        return _rolled_back(steps=steps, failed_step="folder_lookup", reason=folder_err or "")
+    steps.append("folder_lookup")
+
+    vm_id, create_err = await _dispatch_create_vm(
+        dispatch_child=dispatch_child,
+        folder_moid=folder_moid,
+        name=name,
+        guest_os=guest_os,
+        cpu_count=cpu_count,
+        memory_mib=memory_mib,
+    )
+    if vm_id is None:
+        # Create failed; nothing to roll back.
+        return _rolled_back(steps=steps, failed_step="create", reason=create_err or "")
+    steps.append("create")
+
+    nic_err = await _attach_vm_nics(dispatch_child=dispatch_child, vm_id=vm_id, nics=nics)
+    if nic_err is not None:
+        await _rollback_created_vm(dispatch_child=dispatch_child, vm_id=vm_id)
+        return _rolled_back(steps=steps, failed_step="nic_attach", reason=nic_err)
+    if nics:
+        steps.append("nic_attach")
+
+    if power_on:
+        power_result = await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_POWER_VM,
+            params={"vm": vm_id, "action": "start"},
+        )
+        if power_result.status != "ok":
+            await _rollback_created_vm(dispatch_child=dispatch_child, vm_id=vm_id)
+            return _rolled_back(
+                steps=steps,
+                failed_step="power_on",
+                reason=f"power_on failed: {power_result.error or '<no error message>'}",
+            )
+        steps.append("power_on")
+
+    return {
+        "status": "created",
+        "vm_id": vm_id,
+        "steps_succeeded": steps,
+        "failed_step": None,
+        "rollback_reason": None,
+    }
+
+
+# ===========================================================================
+# vm.clone
+# ===========================================================================
+
+
+def _extract_clone_task_id(deploy_payload: Any) -> str | None:
+    """Pull the task id out of a deploy response in either canonical shape."""
+    unwrapped = _unwrap_value(deploy_payload)
+    if isinstance(unwrapped, dict):
+        candidate = unwrapped.get("task") or unwrapped.get("value")
+        if isinstance(candidate, str):
+            return candidate
+    elif isinstance(unwrapped, str):
+        return unwrapped
+    return None
+
+
+def _extract_clone_vm_id(task_result_payload: Any) -> str | None:
+    """Pull the new VM id out of a SUCCEEDED clone task's ``result`` field."""
+    if isinstance(task_result_payload, str):
+        return task_result_payload
+    if isinstance(task_result_payload, dict):
+        candidate = task_result_payload.get("vm") or task_result_payload.get("id")
+        if isinstance(candidate, str):
+            return candidate
+    return None
+
+
+async def _poll_clone_task(
+    *,
+    dispatch_child: DispatchChild,
+    task_id: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Poll ``GET:/cis/tasks/{task}`` until SUCCEEDED/FAILED/timeout.
+
+    Returns the completed-or-timeout response envelope directly (the
+    composite's outer status enum). Raises on FAILED so the dispatcher
+    can wrap as ``connector_error``.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    poll_interval = 1.0
+    while time.monotonic() < deadline:
+        task_payload = _require_ok(
+            await dispatch_child(
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_GET_TASK,
+                params={"task": task_id},
+            )
+        )
+        task = _unwrap_value(task_payload)
+        if isinstance(task, dict):
+            status = task.get("status")
+            if status == "SUCCEEDED":
+                return {
+                    "status": "completed",
+                    "task_id": task_id,
+                    "vm_id": _extract_clone_vm_id(task.get("result")),
+                    "guidance": None,
+                }
+            if status == "FAILED":
+                raise RuntimeError(
+                    f"vm.clone: deploy task {task_id!r} reported FAILED: "
+                    f"{task.get('error') or '<no error reported>'}"
+                )
+        await asyncio.sleep(poll_interval)
+
+    return {
+        "status": "timeout",
+        "task_id": task_id,
+        "vm_id": None,
+        "guidance": (
+            f"poll GET:/cis/tasks/{task_id} for final state -- the "
+            f"composite gave up after {timeout_seconds}s"
+        ),
+    }
+
+
+async def vm_clone_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Clone a VM from a content-library template; poll the deploy task.
+
+    Op-id: ``vmware.composite.vm.clone``. Long-running -- blocks for
+    up to ``timeout_seconds`` (default 600) when
+    ``wait_for_completion=True``.
+    """
+    source_vm = params["source_vm"]
+    target_name = params["target_name"]
+    library_item = params["library_item"]
+    wait_for_completion = bool(params.get("wait_for_completion", True))
+    timeout_seconds = int(params.get("timeout_seconds", 600))
+
+    # Source config drives CloneSpec; the read is a no-op when the
+    # source VM lookup fails (RuntimeError surfaces upstream).
+    _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_GET_VM,
+            params={"vm": source_vm},
+        )
+    )
+
+    deploy_payload = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_DEPLOY_LIBRARY_VM,
+            params={
+                "action": "deploy",
+                "library_item": library_item,
+                "spec": {"name": target_name},
+            },
+        )
+    )
+    task_id = _extract_clone_task_id(deploy_payload)
+    if task_id is None:
+        raise RuntimeError(f"vm.clone: deploy returned no task id (payload={deploy_payload!r})")
+
+    if not wait_for_completion:
+        return {
+            "status": "pending",
+            "task_id": task_id,
+            "vm_id": None,
+            "guidance": "poll GET:/cis/tasks/{task} for final state",
+        }
+
+    return await _poll_clone_task(
+        dispatch_child=dispatch_child,
+        task_id=task_id,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+# ===========================================================================
+# vm.snapshot.revert
+# ===========================================================================
+
+
+async def vm_snapshot_revert_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Revert a VM to a named snapshot. Idempotent; ambiguity-rejecting.
+
+    Op-id: ``vmware.composite.vm.snapshot.revert``. Multiple snapshots
+    sharing the name -> ``status='ambiguous'``; missing -> ``not_found``.
+    Revert never dispatches on either.
+    """
+    vm_moid = params["vm"]
+    snapshot_name = params["snapshot_name"]
+
+    listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_VM_SNAPSHOTS,
+            params={"vm": vm_moid},
+        )
+    )
+    entries = _unwrap_value(listing)
+    if not isinstance(entries, list):
+        raise RuntimeError(
+            f"vm.snapshot.revert: expected list from {_OP_LIST_VM_SNAPSHOTS!r}, "
+            f"got {type(entries).__name__}"
+        )
+    matches = [e for e in entries if isinstance(e, dict) and e.get("name") == snapshot_name]
+    if not matches:
+        return {
+            "status": "not_found",
+            "snapshot_id": None,
+            "candidates": [],
+            "guidance": f"no snapshot named {snapshot_name!r} on vm {vm_moid!r}",
+        }
+    if len(matches) > 1:
+        return {
+            "status": "ambiguous",
+            "snapshot_id": None,
+            "candidates": matches,
+            "guidance": (
+                "multiple snapshots share the requested name -- pass "
+                "``snapshot_id`` explicitly to disambiguate"
+            ),
+        }
+    snapshot_moid = matches[0].get("snapshot")
+    if not isinstance(snapshot_moid, str):
+        return {
+            "status": "not_found",
+            "snapshot_id": None,
+            "candidates": matches,
+            "guidance": "matched snapshot row missing ``snapshot`` key",
+        }
+    _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_REVERT_VM_SNAPSHOT,
+            params={"vm": vm_moid, "snap": snapshot_moid, "action": "revert"},
+        )
+    )
+    return {
+        "status": "reverted",
+        "snapshot_id": snapshot_moid,
+        "candidates": [],
+        "guidance": None,
+    }
+
+
+# ===========================================================================
+# vm.migrate
+# ===========================================================================
+
+
+def _pick_drs_target_host(recs: Any, vm_moid: str) -> str | None:
+    """Walk a DRS recommendations payload for ``vm_moid``'s target host."""
+    if not isinstance(recs, list):
+        return None
+    for rec in recs:
+        if not isinstance(rec, dict):
+            continue
+        if rec.get("vm") != vm_moid:
+            continue
+        candidate = rec.get("target_host") or rec.get("host")
+        if isinstance(candidate, str):
+            return candidate
+    return None
+
+
+async def vm_migrate_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Migrate a VM via DRS recommendation or explicit ``target_host``.
+
+    Op-id: ``vmware.composite.vm.migrate``. ``target_host`` overrides
+    the DRS lookup. No-recommendation path returns
+    ``status='no_recommendation'`` so the caller can re-dispatch.
+    """
+    vm_moid = params["vm"]
+    cluster_moid = params["cluster"]
+    explicit_target = params.get("target_host")
+    target_host: str | None = None
+    source = "none"
+
+    if isinstance(explicit_target, str):
+        target_host = explicit_target
+        source = "operator"
+    else:
+        recs_payload = _require_ok(
+            await dispatch_child(
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_GET_DRS_RECOMMENDATIONS,
+                params={"cluster": cluster_moid},
+            )
+        )
+        target_host = _pick_drs_target_host(_unwrap_value(recs_payload), vm_moid)
+        if target_host is not None:
+            source = "drs"
+
+    if target_host is None:
+        return {
+            "status": "no_recommendation",
+            "target_host": None,
+            "source": "none",
+            "guidance": (
+                "DRS produced no recommendation for the VM; pass "
+                "``target_host`` explicitly to bypass the DRS lookup"
+            ),
+        }
+
+    _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_RELOCATE_VM,
+            params={
+                "vm": vm_moid,
+                "action": "relocate",
+                "spec": {"placement": {"host": target_host}},
+            },
+        )
+    )
+    return {
+        "status": "migrated",
+        "target_host": target_host,
+        "source": source,
+        "guidance": None,
+    }
+
+
+# ===========================================================================
+# vm.power.bulk
+# ===========================================================================
+
+
+async def vm_power_bulk_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Apply a power action to every VM matching a filter; aggregate results.
+
+    Op-id: ``vmware.composite.vm.power.bulk``. ``fail_fast=True``
+    aborts on first failure; default tolerates per-VM failures.
+    """
+    filter_dict: dict[str, Any] = dict(params.get("filter") or {})
+    action = params["action"]
+    fail_fast = bool(params.get("fail_fast", False))
+
+    listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_VMS,
+            params={f"filter.{k}": v for k, v in filter_dict.items()},
+        )
+    )
+    vms = _unwrap_value(listing)
+    if not isinstance(vms, list):
+        raise RuntimeError(
+            f"vm.power.bulk: expected list from {_OP_LIST_VMS!r}, got {type(vms).__name__}"
+        )
+
+    results: list[dict[str, Any]] = []
+    ok_count = 0
+    err_count = 0
+    aborted = False
+    for vm_entry in vms:
+        if not isinstance(vm_entry, dict):
+            continue
+        vm_moid = vm_entry.get("vm")
+        if not isinstance(vm_moid, str):
+            continue
+        power_result = await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_POWER_VM,
+            params={"vm": vm_moid, "action": action},
+        )
+        if power_result.status == "ok":
+            results.append({"vm": vm_moid, "status": "ok", "error": None})
+            ok_count += 1
+        else:
+            results.append(
+                {
+                    "vm": vm_moid,
+                    "status": "error",
+                    "error": power_result.error or "<no error message>",
+                }
+            )
+            err_count += 1
+            if fail_fast:
+                aborted = True
+                break
+    return {
+        "results": results,
+        "summary": {"ok": ok_count, "error": err_count},
+        "aborted_on_failure": aborted,
+    }
+
+
+# ===========================================================================
+# host.evacuate (recursive composite)
+# ===========================================================================
+
+
+def _classify_vm_migrate_outcome(
+    migrate_result: OperationResult,
+) -> tuple[bool, str]:
+    """Return ``(succeeded, error_text)`` for a recursive vm.migrate result."""
+    if migrate_result.status != "ok":
+        return False, migrate_result.error or "unknown"
+    inner = migrate_result.result
+    if isinstance(inner, dict) and inner.get("status") == "migrated":
+        return True, ""
+    inner_status = inner.get("status") if isinstance(inner, dict) else None
+    return False, str(inner_status or "unknown")
+
+
+async def host_evacuate_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Migrate every VM off a host (via recursive vm.migrate) then enter maintenance.
+
+    Op-id: ``vmware.composite.host.evacuate``. First production
+    composite that calls another composite via ``dispatch_child``.
+    """
+    host_moid = params["host"]
+    tolerate_partial = bool(params.get("tolerate_partial_failure", False))
+
+    listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_VMS,
+            params={"filter.hosts": [host_moid]},
+        )
+    )
+    vms = _unwrap_value(listing)
+    if not isinstance(vms, list):
+        raise RuntimeError(
+            f"host.evacuate: expected list from {_OP_LIST_VMS!r}, got {type(vms).__name__}"
+        )
+
+    cluster_raw = vms[0].get("cluster") if vms and isinstance(vms[0], dict) else None
+    cluster_moid = cluster_raw if isinstance(cluster_raw, str) else ""
+
+    migrated: list[str] = []
+    failed: list[dict[str, str]] = []
+    for vm_entry in vms:
+        if not isinstance(vm_entry, dict):
+            continue
+        vm_moid = vm_entry.get("vm")
+        if not isinstance(vm_moid, str):
+            continue
+        migrate_result = await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_COMPOSITE_VM_MIGRATE,
+            params={"vm": vm_moid, "cluster": cluster_moid},
+        )
+        succeeded, err_text = _classify_vm_migrate_outcome(migrate_result)
+        if succeeded:
+            migrated.append(vm_moid)
+            continue
+        failed.append({"vm": vm_moid, "error": err_text})
+        if not tolerate_partial:
+            return {
+                "status": "aborted",
+                "host": host_moid,
+                "migrated_vms": migrated,
+                "failed_vms": failed,
+                "maintenance_entered": False,
+            }
+
+    _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_HOST_MAINTENANCE,
+            params={"host": host_moid, "action": "enter"},
+        )
+    )
+    return {
+        "status": "partial" if failed else "evacuated",
+        "host": host_moid,
+        "migrated_vms": migrated,
+        "failed_vms": failed,
+        "maintenance_entered": True,
+    }
+
+
+# ===========================================================================
+# host.detach_from_vds
+# ===========================================================================
+
+
+async def host_detach_from_vds_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Migrate host VM NICs off a DVS to a standard switch, then remove host from DVS.
+
+    Op-id: ``vmware.composite.host.detach_from_vds``. Refuses the DVS
+    detach when any NIC migration failed -- vSphere would reject the
+    step-4 detach anyway.
+    """
+    host_moid = params["host"]
+    dvs_moid = params["dvs"]
+    fallback_network = params["fallback_network"]
+
+    _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_PORTGROUPS,
+            params={"filter.hosts": [host_moid]},
+        )
+    )
+    vm_listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_VMS,
+            params={"filter.hosts": [host_moid]},
+        )
+    )
+    vms = _unwrap_value(vm_listing)
+    if not isinstance(vms, list):
+        raise RuntimeError(
+            f"host.detach_from_vds: expected list from {_OP_LIST_VMS!r}, got {type(vms).__name__}"
+        )
+
+    vms_migrated: list[str] = []
+    migration_failures: list[dict[str, str]] = []
+    for vm_entry in vms:
+        if not isinstance(vm_entry, dict):
+            continue
+        vm_moid = vm_entry.get("vm")
+        if not isinstance(vm_moid, str):
+            continue
+        nic_result = await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ATTACH_VM_NIC,
+            params={"vm": vm_moid, "spec": {"network": fallback_network}},
+        )
+        if nic_result.status == "ok":
+            vms_migrated.append(vm_moid)
+        else:
+            migration_failures.append(
+                {"vm": vm_moid, "error": nic_result.error or "<no error message>"}
+            )
+
+    if migration_failures:
+        return {
+            "status": "incomplete",
+            "host": host_moid,
+            "vm_migration_failures": migration_failures,
+            "vms_migrated": vms_migrated,
+        }
+
+    _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_REMOVE_DVS_HOST,
+            params={"dvs": dvs_moid, "action": "remove_host", "host": host_moid},
+        )
+    )
+    return {
+        "status": "detached",
+        "host": host_moid,
+        "vm_migration_failures": [],
+        "vms_migrated": vms_migrated,
+    }
+
+
+# ===========================================================================
+# cluster.patch
+# ===========================================================================
+
+
+_CLUSTER_PATCH_STEPS: tuple[tuple[str, str], ...] = (
+    ("maintenance_enter", _OP_HOST_MAINTENANCE),
+    ("patch", _OP_HOST_PATCH),
+    ("maintenance_exit", _OP_HOST_MAINTENANCE),
+)
+
+
+def _cluster_patch_step_params(
+    *,
+    step: str,
+    host_moid: str,
+    patch_method: str,
+) -> dict[str, Any]:
+    """Build the per-step params dict for a cluster.patch sub-op."""
+    if step == "maintenance_enter":
+        return {"host": host_moid, "action": "enter"}
+    if step == "maintenance_exit":
+        return {"host": host_moid, "action": "exit"}
+    return {"host": host_moid, "action": "patch", "method": patch_method}
+
+
+async def _patch_one_host(
+    *,
+    dispatch_child: DispatchChild,
+    host_moid: str,
+    patch_method: str,
+) -> str | None:
+    """Sequential maintenance + patch + exit on a single host; return error reason or None."""
+    for step, op_id in _CLUSTER_PATCH_STEPS:
+        step_result = await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            params=_cluster_patch_step_params(
+                step=step, host_moid=host_moid, patch_method=patch_method
+            ),
+        )
+        if step_result.status != "ok":
+            return f"{step} on {host_moid!r} failed: {step_result.error or '<no error message>'}"
+    return None
+
+
+async def cluster_patch_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Sequentially patch every host in a cluster: maintenance + patch + exit.
+
+    Op-id: ``vmware.composite.cluster.patch``. Sequential by design --
+    concurrent host patches would force every cluster VM to vMotion
+    at once.
+    """
+    cluster_moid = params["cluster"]
+    patch_method = params.get("patch_method", "default")
+
+    listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_CLUSTER_HOSTS,
+            params={"cluster": cluster_moid},
+        )
+    )
+    entries = _unwrap_value(listing)
+    if not isinstance(entries, list):
+        raise RuntimeError(
+            f"cluster.patch: expected list from {_OP_LIST_CLUSTER_HOSTS!r}, "
+            f"got {type(entries).__name__}"
+        )
+    host_moids: list[str] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            host_moid = entry.get("host")
+            if isinstance(host_moid, str):
+                host_moids.append(host_moid)
+
+    patched: list[str] = []
+    for i, host_moid in enumerate(host_moids):
+        failure_reason = await _patch_one_host(
+            dispatch_child=dispatch_child, host_moid=host_moid, patch_method=patch_method
+        )
+        if failure_reason is not None:
+            return {
+                "status": "stopped",
+                "cluster": cluster_moid,
+                "patched_hosts": patched,
+                "failed_host": host_moid,
+                "remaining_hosts": host_moids[i + 1 :],
+                "failure_reason": failure_reason,
+            }
+        patched.append(host_moid)
+
+    return {
+        "status": "completed",
+        "cluster": cluster_moid,
+        "patched_hosts": patched,
+        "failed_host": None,
+        "remaining_hosts": [],
+        "failure_reason": None,
+    }

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""JSON Schema 2020-12 parameter schemas for the 5 vmware-rest read composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 13 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -23,9 +23,13 @@ Conventions
   documentation lives on the schema's ``description`` keys; the meta-
   tools (:mod:`meho_backplane.operations.meta_tools`) surface the
   schema verbatim on ``describe_operation`` calls.
-* All five composites are read-only -- no schema mentions write
-  semantics; the registration call site pins ``safety_level="safe"``
-  and ``requires_approval=False`` on each.
+* The 5 read composites are read-only -- the registration call site
+  pins ``safety_level="safe"`` and ``requires_approval=False`` on
+  each. The 8 write composites inherit T4's
+  ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
+  (G3.1-T6 / #509). The schema text reflects which side of that line
+  each composite sits on; the registration call site enforces the
+  policy.
 """
 
 from __future__ import annotations
@@ -35,14 +39,30 @@ from typing import Any
 __all__ = [
     "CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA",
     "CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA",
+    "CLUSTER_PATCH_PARAMETER_SCHEMA",
+    "CLUSTER_PATCH_RESPONSE_SCHEMA",
     "DATASTORE_USAGE_PARAMETER_SCHEMA",
     "DATASTORE_USAGE_RESPONSE_SCHEMA",
     "EVENT_TAIL_PARAMETER_SCHEMA",
     "EVENT_TAIL_RESPONSE_SCHEMA",
+    "HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA",
+    "HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA",
+    "HOST_EVACUATE_PARAMETER_SCHEMA",
+    "HOST_EVACUATE_RESPONSE_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA",
     "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
     "PERFORMANCE_SUMMARY_RESPONSE_SCHEMA",
+    "VM_CLONE_PARAMETER_SCHEMA",
+    "VM_CLONE_RESPONSE_SCHEMA",
+    "VM_CREATE_PARAMETER_SCHEMA",
+    "VM_CREATE_RESPONSE_SCHEMA",
+    "VM_MIGRATE_PARAMETER_SCHEMA",
+    "VM_MIGRATE_RESPONSE_SCHEMA",
+    "VM_POWER_BULK_PARAMETER_SCHEMA",
+    "VM_POWER_BULK_RESPONSE_SCHEMA",
+    "VM_SNAPSHOT_REVERT_PARAMETER_SCHEMA",
+    "VM_SNAPSHOT_REVERT_RESPONSE_SCHEMA",
 ]
 
 
@@ -471,4 +491,682 @@ NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["portgroups"],
+}
+
+
+# ===========================================================================
+# Write composites (G3.1-T6 / #509)
+# ===========================================================================
+#
+# The 8 write composites inherit T4's ``safety_level="dangerous"`` +
+# ``requires_approval=True`` defaults. The registrar passes those
+# explicitly anyway to keep the policy posture obvious at the call site
+# alongside the read overrides.
+
+
+#: ``vmware.composite.vm.create`` parameter schema.
+#:
+#: Orchestrates folder lookup -> ``POST:/vcenter/vm`` -> per-NIC attach
+#: -> optional power-on. Partial-failure rollback removes the half-
+#: created VM via ``DELETE:/vcenter/vm/{vm}``.
+VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "folder_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name of the target VM folder. Resolved via "
+                "``GET:/vcenter/folder?filter.names=...`` to the moid "
+                "passed to ``POST:/vcenter/vm``."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "VM display name. Required by ``POST:/vcenter/vm``.",
+        },
+        "guest_os": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Guest-OS identifier (e.g. ``UBUNTU_64``). Drives the "
+                "ConfigSpec.guestOS field on ``POST:/vcenter/vm``."
+            ),
+        },
+        "cpu_count": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 1,
+            "description": "Number of virtual CPUs on the ConfigSpec.",
+        },
+        "memory_mib": {
+            "type": "integer",
+            "minimum": 64,
+            "default": 1024,
+            "description": "Memory size in MiB on the ConfigSpec.",
+        },
+        "nics": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "network": {
+                        "type": "string",
+                        "description": "Network moid the NIC attaches to.",
+                    },
+                },
+                "required": ["network"],
+            },
+            "default": [],
+            "description": (
+                "Per-NIC spec. Each entry drives a "
+                "``PATCH:/vcenter/vm/{vm}/network`` after the VM is "
+                "created. Empty list creates the VM with no NICs."
+            ),
+        },
+        "power_on_after_create": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, the handler issues "
+                "``POST:/vcenter/vm/{vm}/power?action=start`` after "
+                "NIC attach. Default false leaves the VM powered-off."
+            ),
+        },
+    },
+    "required": ["folder_name", "name", "guest_os"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.clone`` parameter schema.
+#:
+#: Orchestrates a content-library deploy. Long-running: blocks until
+#: the vSphere task completes or ``timeout_seconds`` elapses. The
+#: caller can opt into fire-and-forget via ``wait_for_completion=False``.
+VM_CLONE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "source_vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Source VM moid. Resolved via ``GET:/vcenter/vm/{vm}`` "
+                "to build the CloneSpec before deploy."
+            ),
+        },
+        "target_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Display name for the cloned VM.",
+        },
+        "library_item": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Content-library template item id. Passed to "
+                "``POST:/vcenter/vm-template/library-items?action=deploy``."
+            ),
+        },
+        "wait_for_completion": {
+            "type": "boolean",
+            "default": True,
+            "description": (
+                "When true (default), block on the vSphere task until "
+                "``timeout_seconds`` elapses. When false, return "
+                "immediately with the task id for caller-side polling."
+            ),
+        },
+        "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 600,
+            "description": (
+                "Upper bound on the task wait when "
+                "``wait_for_completion=True``. On timeout the composite "
+                "returns ``status='timeout'`` with the task id; the "
+                "task itself may still complete in the background."
+            ),
+        },
+    },
+    "required": ["source_vm", "target_name", "library_item"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.snapshot.revert`` parameter schema.
+#:
+#: Idempotent revert by snapshot name. Ambiguity (multiple snapshots
+#: share the name) returns ``status='ambiguous'`` rather than guessing.
+VM_SNAPSHOT_REVERT_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Target VM moid. Required for snapshot-tree lookup.",
+        },
+        "snapshot_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name of the snapshot to revert to. Multiple "
+                "snapshots with the same name return "
+                "``status='ambiguous'`` so the caller can pick by id."
+            ),
+        },
+    },
+    "required": ["vm", "snapshot_name"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.migrate`` parameter schema.
+#:
+#: DRS-deferred relocation. No-recommendation path returns
+#: ``status='no_recommendation'``. ``target_host`` overrides the DRS
+#: lookup.
+VM_MIGRATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Source VM moid.",
+        },
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Cluster moid the source VM lives in. Required for the DRS recommendation lookup."
+            ),
+        },
+        "target_host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional explicit target-host moid. When supplied, "
+                "bypasses the DRS recommendation lookup."
+            ),
+        },
+    },
+    "required": ["vm", "cluster"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.power.bulk`` parameter schema.
+#:
+#: Resolve filter -> per-VM power action. Partial-failure tolerated
+#: by default; ``fail_fast=True`` aborts on the first failure.
+VM_POWER_BULK_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "filter": {
+            "type": "object",
+            "description": (
+                "Free-form filter dict forwarded to "
+                "``GET:/vcenter/vm`` as ``filter.*`` query params. The "
+                "handler does not introspect the keys; vSphere REST "
+                "validates them server-side."
+            ),
+            "default": {},
+        },
+        "action": {
+            "type": "string",
+            "enum": ["start", "stop", "suspend", "reset"],
+            "description": (
+                "Per-VM power action. Forwarded to ``POST:/vcenter/vm/{vm}/power?action=<action>``."
+            ),
+        },
+        "fail_fast": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, abort on the first per-VM failure. Default "
+                "false collects per-VM results and reports them in "
+                "aggregate."
+            ),
+        },
+    },
+    "required": ["action"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.host.evacuate`` parameter schema.
+#:
+#: Lists VMs on host, recursively dispatches ``vmware.composite.vm.migrate``
+#: per VM, then enters maintenance. ``tolerate_partial_failure=True``
+#: allows maintenance-enter with VMs left on host.
+HOST_EVACUATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Host moid to evacuate.",
+        },
+        "tolerate_partial_failure": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, enter maintenance even if some VMs failed "
+                "to migrate (those VMs stay on the host). Default "
+                "false aborts before maintenance-enter on any failure."
+            ),
+        },
+    },
+    "required": ["host"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.host.detach_from_vds`` parameter schema.
+#:
+#: Per-VM NIC migration off the DVS, then DVS host-detach. Refuses to
+#: detach when any VM still has active NICs on the DVS.
+HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Host moid to detach from the DVS.",
+        },
+        "dvs": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "DVS moid the host is currently attached to. Required to scope the portgroup query."
+            ),
+        },
+        "fallback_network": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Standard-switch network moid the host's VM NICs are "
+                "migrated to before the DVS detach. Required because "
+                "the host loses DVS connectivity at step 4."
+            ),
+        },
+    },
+    "required": ["host", "dvs", "fallback_network"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.cluster.patch`` parameter schema.
+#:
+#: Sequential per-host maintenance + patch + exit. A per-host failure
+#: stops the loop; the cluster is left mixed-state for operator review.
+CLUSTER_PATCH_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Cluster moid.",
+        },
+        "patch_method": {
+            "type": "string",
+            "minLength": 1,
+            "default": "default",
+            "description": (
+                "Patch backend selector. The handler forwards the "
+                "string verbatim to the per-host patch sub-op so vendor "
+                "patch flows can dispatch into ``vlcm`` / ``vum`` / "
+                "``firmware`` without changing the composite's contract."
+            ),
+        },
+    },
+    "required": ["cluster"],
+    "additionalProperties": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Write composites -- response schemas
+# ---------------------------------------------------------------------------
+#
+# Each composite's response shape encodes the documented status enum
+# (``"created"`` / ``"rolled_back"`` / ``"timeout"`` / ``"ambiguous"``
+# / ``"no_recommendation"`` / ``"ok"`` / ``"incomplete"`` /
+# ``"stopped"``) so callers can branch on ``status`` without parsing
+# free-form prose. Sub-payload shapes (vSphere REST payloads, task
+# ids) stay opaque -- Broadcom owns the inner schema.
+
+
+#: ``vmware.composite.vm.create`` response schema.
+VM_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["created", "rolled_back"],
+            "description": (
+                "``'created'`` after every step succeeded; "
+                "``'rolled_back'`` when a post-create step failed and "
+                "the handler issued ``DELETE:/vcenter/vm/{vm}``."
+            ),
+        },
+        "vm_id": {
+            "type": ["string", "null"],
+            "description": (
+                "Newly-created VM moid. ``null`` on rollback (the VM no longer exists)."
+            ),
+        },
+        "steps_succeeded": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Per-step success ledger: ``folder_lookup``, "
+                "``create``, ``nic_attach``, ``power_on``."
+            ),
+        },
+        "failed_step": {
+            "type": ["string", "null"],
+            "description": (
+                "Name of the first failing step on rollback; ``null`` when ``status='created'``."
+            ),
+        },
+        "rollback_reason": {
+            "type": ["string", "null"],
+            "description": (
+                "Human-readable explanation of the rollback trigger; "
+                "``null`` when ``status='created'``."
+            ),
+        },
+    },
+    "required": ["status", "steps_succeeded"],
+}
+
+
+#: ``vmware.composite.vm.clone`` response schema.
+VM_CLONE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["completed", "pending", "timeout"],
+            "description": (
+                "``'completed'`` when the deploy task finished and "
+                "wait_for_completion was true; ``'pending'`` when "
+                "wait_for_completion was false (caller-side polling); "
+                "``'timeout'`` when wait_for_completion expired."
+            ),
+        },
+        "task_id": {
+            "type": "string",
+            "description": (
+                "vSphere task id from the deploy. Always present so callers can poll independently."
+            ),
+        },
+        "vm_id": {
+            "type": ["string", "null"],
+            "description": (
+                "New VM moid surfaced when the task completed. ``null`` on pending/timeout."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on non-completed "
+                "statuses; ``null`` when ``status='completed'``."
+            ),
+        },
+    },
+    "required": ["status", "task_id"],
+}
+
+
+#: ``vmware.composite.vm.snapshot.revert`` response schema.
+VM_SNAPSHOT_REVERT_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["reverted", "ambiguous", "not_found"],
+            "description": (
+                "``'reverted'`` on a successful revert; "
+                "``'ambiguous'`` when multiple snapshots share the "
+                "name; ``'not_found'`` when no snapshot matches."
+            ),
+        },
+        "snapshot_id": {
+            "type": ["string", "null"],
+            "description": (
+                "The moid of the snapshot the handler reverted to; ``null`` on ambiguous/not_found."
+            ),
+        },
+        "candidates": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Ambiguity-resolution candidates -- present only when ``status='ambiguous'``."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": ("Operator hint on ambiguous/not_found; ``null`` on successful revert."),
+        },
+    },
+    "required": ["status"],
+}
+
+
+#: ``vmware.composite.vm.migrate`` response schema.
+VM_MIGRATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["migrated", "no_recommendation"],
+            "description": (
+                "``'migrated'`` after a successful relocate; "
+                "``'no_recommendation'`` when DRS returned nothing and "
+                "no ``target_host`` override was supplied."
+            ),
+        },
+        "target_host": {
+            "type": ["string", "null"],
+            "description": ("Host moid the relocate targeted; ``null`` on ``no_recommendation``."),
+        },
+        "source": {
+            "type": "string",
+            "enum": ["drs", "operator", "none"],
+            "description": (
+                "Whether the target came from a DRS recommendation, "
+                "the operator's explicit override, or neither."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": ("Operator hint on ``no_recommendation``; ``null`` otherwise."),
+        },
+    },
+    "required": ["status", "source"],
+}
+
+
+#: ``vmware.composite.vm.power.bulk`` response schema.
+VM_POWER_BULK_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "results": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "vm": {"type": "string"},
+                    "status": {"type": "string", "enum": ["ok", "error"]},
+                    "error": {"type": ["string", "null"]},
+                },
+                "required": ["vm", "status"],
+            },
+            "description": "One row per VM the filter matched.",
+        },
+        "summary": {
+            "type": "object",
+            "properties": {
+                "ok": {"type": "integer", "minimum": 0},
+                "error": {"type": "integer", "minimum": 0},
+            },
+            "required": ["ok", "error"],
+            "description": "Aggregate counts across ``results``.",
+        },
+        "aborted_on_failure": {
+            "type": "boolean",
+            "description": (
+                "True when ``fail_fast=True`` short-circuited the loop after the first failure."
+            ),
+        },
+    },
+    "required": ["results", "summary", "aborted_on_failure"],
+}
+
+
+#: ``vmware.composite.host.evacuate`` response schema.
+HOST_EVACUATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["evacuated", "partial", "aborted"],
+            "description": (
+                "``'evacuated'`` -- every VM migrated + host in "
+                "maintenance; ``'partial'`` -- some VMs left behind "
+                "(``tolerate_partial_failure=True``); ``'aborted'`` "
+                "-- migration failure stopped the loop before "
+                "maintenance-enter."
+            ),
+        },
+        "host": {
+            "type": "string",
+            "description": "Host moid the operator targeted.",
+        },
+        "migrated_vms": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "VM moids that migrated successfully.",
+        },
+        "failed_vms": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "vm": {"type": "string"},
+                    "error": {"type": "string"},
+                },
+                "required": ["vm", "error"],
+            },
+            "description": "VM moids whose migration failed, with reason.",
+        },
+        "maintenance_entered": {
+            "type": "boolean",
+            "description": (
+                "Whether the host entered maintenance mode -- true on "
+                "``evacuated``/``partial``, false on ``aborted``."
+            ),
+        },
+    },
+    "required": [
+        "status",
+        "host",
+        "migrated_vms",
+        "failed_vms",
+        "maintenance_entered",
+    ],
+}
+
+
+#: ``vmware.composite.host.detach_from_vds`` response schema.
+HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["detached", "incomplete"],
+            "description": (
+                "``'detached'`` -- every NIC migrated and the host "
+                "removed from the DVS; ``'incomplete'`` -- one or more "
+                "NIC migrations failed, the DVS detach was skipped."
+            ),
+        },
+        "host": {
+            "type": "string",
+            "description": "Host moid the operator targeted.",
+        },
+        "vm_migration_failures": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "vm": {"type": "string"},
+                    "error": {"type": "string"},
+                },
+                "required": ["vm", "error"],
+            },
+            "description": "Failed NIC migrations (empty on ``detached``).",
+        },
+        "vms_migrated": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "VM moids whose NICs migrated successfully.",
+        },
+    },
+    "required": [
+        "status",
+        "host",
+        "vm_migration_failures",
+        "vms_migrated",
+    ],
+}
+
+
+#: ``vmware.composite.cluster.patch`` response schema.
+CLUSTER_PATCH_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["completed", "stopped"],
+            "description": (
+                "``'completed'`` -- every host patched + maintenance "
+                "exit succeeded; ``'stopped'`` -- a per-host failure "
+                "halted the loop; cluster is left in mixed state."
+            ),
+        },
+        "cluster": {
+            "type": "string",
+            "description": "Cluster moid the operator targeted.",
+        },
+        "patched_hosts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": ("Host moids whose maintenance -> patch -> exit succeeded in order."),
+        },
+        "failed_host": {
+            "type": ["string", "null"],
+            "description": (
+                "Host moid that failed when ``status='stopped'``; ``null`` on ``completed``."
+            ),
+        },
+        "remaining_hosts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": ("Hosts the loop did not get to (empty on ``completed``)."),
+        },
+        "failure_reason": {
+            "type": ["string", "null"],
+            "description": ("Human-readable cause of the stop; ``null`` on ``completed``."),
+        },
+    },
+    "required": [
+        "status",
+        "cluster",
+        "patched_hosts",
+        "remaining_hosts",
+    ],
 }

--- a/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
@@ -1,0 +1,538 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end recursive-composite test via production ``dispatch()``.
+
+The unit tests in
+:mod:`tests.test_connectors_vmware_rest_composites_write` mock
+``dispatch_child`` directly. That proves the handler body wires the
+right sub-op_ids + params, but it does **not** exercise the production
+dispatcher's ``composite`` branch — which is where ``parent_audit_id``
+linkage + the :data:`composite_depth_var` ramp + audit-tree persistence
+actually live.
+
+This module closes that gap for the first **production** recursive
+composite, ``vmware.composite.host.evacuate`` (G3.1-T6 / #509):
+
+1. Register a no-op vmware connector class against
+   ``(product="vmware", version="9.0", impl_id="vmware-rest")``.
+2. Register the **real** :func:`register_vmware_composite_operations`
+   runner, which lands all 13 composite rows (including ``vm.migrate``
+   and ``host.evacuate``).
+3. Register the leaf typed sub-ops the recursive chain bottoms out on
+   (``GET:/vcenter/vm`` listing, ``GET:/vcenter/cluster/{cluster}/drs/
+   recommendations``, ``POST:/vcenter/vm/{vm}?action=relocate``,
+   ``PATCH:/vcenter/host/{host}/maintenance?action=enter``) via real
+   :func:`register_typed_operation` calls with stub handlers returning
+   canned payloads.
+4. Dispatch ``vmware.composite.host.evacuate`` against the production
+   :func:`dispatch` entry point.
+5. Assert the 3-level audit tree: ``host.evacuate`` (depth 0) →
+   ``vm.migrate`` (depth 1) → typed leaf ops (depth 2) all share the
+   expected ``parent_audit_id`` linkage, and the
+   :data:`composite_depth_var` reached depth 2 mid-flight.
+
+The test runs against the autouse SQLite migrations harness in
+:mod:`tests.conftest` — no Docker / PG testcontainer required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.connectors.vmware_rest.composites import (
+    register_vmware_composite_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations.composite import (
+    COMPOSITE_DEPTH_TOP_LEVEL,
+    composite_depth_var,
+)
+from meho_backplane.settings import get_settings
+
+# The leaf typed sub-ops the recursive chain bottoms out on. Each is
+# registered as a real ``source_kind="typed"`` row pointing at a
+# module-level stub handler below.
+_LEAF_OP_LIST_VMS = "GET:/vcenter/vm"
+_LEAF_OP_GET_DRS_RECS = "GET:/vcenter/cluster/{cluster}/drs/recommendations"
+_LEAF_OP_RELOCATE_VM = "POST:/vcenter/vm/{vm}?action=relocate"
+_LEAF_OP_HOST_MAINTENANCE_ENTER = "PATCH:/vcenter/host/{host}/maintenance?action=enter"
+
+# Captured ``composite_depth_var`` snapshots taken inside each leaf handler.
+# Asserted after the dispatch returns so the test can prove the ramp
+# 0 → 1 → 2 fired during the recursive run.
+_DEPTH_OBSERVATIONS: list[int] = []
+
+
+# ---------------------------------------------------------------------------
+# Settings / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    _DEPTH_OBSERVATIONS.clear()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+    _DEPTH_OBSERVATIONS.clear()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registrations skip ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Replace :func:`publish_event` with a recording stub.
+
+    Required because the dispatcher's audit path calls ``publish_event``
+    on every audit-log row write; without the stub the real broadcast
+    bus would attempt a write against a missing Postgres instance.
+    """
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator scoped to the canary tenant."""
+    return Operator(
+        sub="op-vmware-e2e",
+        name="VMware Composite E2E Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a2"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _FakeFingerprint:
+    """Duck-typed fingerprint for the resolver."""
+
+    def __init__(self, version: str | None = "9.0") -> None:
+        self.version = version
+
+
+class _FakeVmwareTarget:
+    """Minimal target shape the resolver / dispatcher reads from."""
+
+    def __init__(self) -> None:
+        self.product = "vmware"
+        self.fingerprint = _FakeFingerprint(version="9.0")
+        self.preferred_impl_id: str | None = "vmware-rest"
+        self.id: UUID = uuid.uuid4()
+        self.name = "test-vcenter"
+        self.host = "vcenter.test"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+class _NoOpVmwareConnector(Connector):
+    """Resolver-satisfying connector class — never actually called.
+
+    The dispatcher resolves a connector instance only for
+    ``source_kind="ingested"`` rows; ``typed`` and ``composite`` rows
+    skip the instance lookup. The class is here so the registry
+    resolver finds *something* under
+    ``(vmware, 9.0, vmware-rest)`` — never invoked.
+    """
+
+    product = "vmware"
+    version = "9.0"
+    impl_id = "vmware-rest"
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Leaf typed-op stub handlers
+# ---------------------------------------------------------------------------
+#
+# Each handler records the live ``composite_depth_var`` so the test can
+# assert the ramp 0 → 1 → 2. They are module-level ``async def`` so
+# ``derive_handler_ref`` accepts them — the same constraint
+# ``register_typed_operation()`` enforces in production.
+
+
+async def _stub_list_vms_handler(
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Stub for ``GET:/vcenter/vm`` — returns the canned VM listing.
+
+    ``host.evacuate`` calls this at depth 1 (one composite frame above
+    the typed handler).
+    """
+    _DEPTH_OBSERVATIONS.append(composite_depth_var.get())
+    # Two VMs on the host with the same cluster moid — the per-VM
+    # cluster resolution (M1 fix) reads ``cluster`` off each row.
+    return {
+        "value": [
+            {"vm": "vm-aa", "cluster": "cluster-1"},
+            {"vm": "vm-bb", "cluster": "cluster-1"},
+        ]
+    }
+
+
+async def _stub_drs_recs_handler(
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Stub for ``GET:/vcenter/cluster/{cluster}/drs/recommendations``.
+
+    Recursive composite frames: ``host.evacuate`` (0) →
+    ``vm.migrate`` (1) → this typed leaf (2). Depth observation here
+    pins the ``composite_depth_var == 2`` reached at the bottom of the
+    recursion.
+    """
+    _DEPTH_OBSERVATIONS.append(composite_depth_var.get())
+    return {
+        "value": [
+            {"vm": "vm-aa", "target_host": "host-target"},
+            {"vm": "vm-bb", "target_host": "host-target"},
+        ]
+    }
+
+
+async def _stub_relocate_handler(
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Stub for ``POST:/vcenter/vm/{vm}?action=relocate`` — succeeds."""
+    _DEPTH_OBSERVATIONS.append(composite_depth_var.get())
+    return {"value": {}}
+
+
+async def _stub_host_maintenance_enter_handler(
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Stub for ``PATCH:/vcenter/host/{host}/maintenance?action=enter``."""
+    _DEPTH_OBSERVATIONS.append(composite_depth_var.get())
+    return {"value": {}}
+
+
+async def _register_leaf_typed_ops(stub_embedding_service: AsyncMock) -> None:
+    """Land the 4 leaf typed-op descriptor rows the recursive chain hits.
+
+    Each ``register_typed_operation`` call writes one
+    ``source_kind="typed"`` row pointing at the module-level stub above.
+    The descriptor's ``parameter_schema`` is permissive
+    (``additionalProperties=True``) so the composite handlers can pass
+    whatever params they like without per-op schema bookkeeping in this
+    test.
+    """
+    permissive_schema = {"type": "object", "additionalProperties": True}
+    leaf_specs: tuple[tuple[str, Any, str], ...] = (
+        (
+            _LEAF_OP_LIST_VMS,
+            _stub_list_vms_handler,
+            "Stub list-vms typed op for the recursive E2E test.",
+        ),
+        (
+            _LEAF_OP_GET_DRS_RECS,
+            _stub_drs_recs_handler,
+            "Stub DRS-recommendations typed op for the recursive E2E test.",
+        ),
+        (
+            _LEAF_OP_RELOCATE_VM,
+            _stub_relocate_handler,
+            "Stub relocate-VM typed op for the recursive E2E test.",
+        ),
+        (
+            _LEAF_OP_HOST_MAINTENANCE_ENTER,
+            _stub_host_maintenance_enter_handler,
+            "Stub host-maintenance-enter typed op for the recursive E2E test.",
+        ),
+    )
+    for op_id, handler, description in leaf_specs:
+        await register_typed_operation(
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            op_id=op_id,
+            handler=handler,
+            summary=description,
+            description=description,
+            parameter_schema=permissive_schema,
+            embedding_service=stub_embedding_service,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_host_evacuate_e2e_through_production_dispatch_builds_3_level_audit_tree(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """End-to-end: dispatch ``host.evacuate`` and assert the 3-level audit tree.
+
+    Acceptance criterion (from #509's review iter-1 M2): the first
+    production recursive composite must be exercised through the real
+    :func:`dispatch` entry point, not just ``dispatch_child`` mocks.
+
+    Tree shape under test:
+
+    * ``vmware.composite.host.evacuate`` — depth 0, parent_audit_id NULL.
+    * ``vmware.composite.vm.migrate`` (x 2 — one per listed VM) —
+      depth 1, parent_audit_id = host.evacuate's audit row id.
+    * Leaf typed sub-ops (``GET:/vcenter/vm``,
+      ``GET:/vcenter/cluster/{cluster}/drs/recommendations``,
+      ``POST:/vcenter/vm/{vm}?action=relocate``,
+      ``PATCH:/vcenter/host/{host}/maintenance?action=enter``) —
+      depth 2 where wrapped by vm.migrate, depth 1 where called
+      directly by host.evacuate.
+
+    Also asserts :data:`composite_depth_var` observed values cover the
+    ramp 1 → 2 across leaf-handler invocations.
+    """
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_NoOpVmwareConnector,
+    )
+    # Register all 13 composite rows (vm.migrate + host.evacuate are
+    # the two the test exercises; the other 11 ride along harmlessly).
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    # Register the 4 leaf typed sub-ops the recursive chain bottoms on.
+    await _register_leaf_typed_ops(stub_embedding_service)
+    # Flip ``requires_approval`` off for the two composites under test
+    # — v0.2 doesn't ship the approval workflow, so the production
+    # ``policy_gate`` denies anything carrying ``requires_approval=True``
+    # (see ``_validate.policy_gate``). The acceptance line under test
+    # is the recursive-dispatch + audit-tree shape, not the approval-
+    # gate behaviour itself (G10 territory). The full dangerous /
+    # requires_approval=True posture stays asserted by the row-level
+    # registration suite in
+    # ``test_connectors_vmware_rest_composites_write_register.py``.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        await fresh.execute(
+            update(EndpointDescriptor)
+            .where(
+                EndpointDescriptor.op_id.in_(
+                    {
+                        "vmware.composite.host.evacuate",
+                        "vmware.composite.vm.migrate",
+                    }
+                )
+            )
+            .values(requires_approval=False)
+        )
+        await fresh.commit()
+    # Cached descriptor lookups must drop the stale row state after the
+    # UPDATE; otherwise the dispatcher reuses the pre-mutation copy and
+    # the policy gate still denies on the cached ``requires_approval``.
+    reset_dispatcher_caches()
+
+    operator = _make_operator()
+    target = _FakeVmwareTarget()
+
+    # Pre-dispatch contextvar invariant: top-level is depth 0.
+    assert composite_depth_var.get() == COMPOSITE_DEPTH_TOP_LEVEL
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="vmware-rest-9.0",
+        op_id="vmware.composite.host.evacuate",
+        target=target,
+        params={"host": "host-source"},
+    )
+    assert result.status == "ok", result.error
+    # The composite returned the structured envelope with status=evacuated.
+    assert isinstance(result.result, dict)
+    assert result.result["status"] == "evacuated"
+    assert result.result["maintenance_entered"] is True
+    assert sorted(result.result["migrated_vms"]) == ["vm-aa", "vm-bb"]
+
+    # Post-dispatch invariant: the contextvar is reset back to depth 0
+    # — composite.get_dispatch_child uses tokens + finally to restore.
+    assert composite_depth_var.get() == COMPOSITE_DEPTH_TOP_LEVEL
+
+    # ------------------------------------------------------------------
+    # Depth ramp: leaf handlers were invoked at depths 1 (host.evacuate
+    # frame) and 2 (host.evacuate → vm.migrate frame). The test ramps
+    # 1 → 2 rather than 0 → 1 → 2 because depth is read *inside* the
+    # leaf handler (one composite frame in already).
+    # ------------------------------------------------------------------
+    assert set(_DEPTH_OBSERVATIONS) >= {1, 2}, (
+        f"expected depth ramp covering {{1, 2}}, observed {sorted(set(_DEPTH_OBSERVATIONS))}"
+    )
+
+    # ------------------------------------------------------------------
+    # Audit-tree shape: load every audit row produced by the dispatch
+    # and reconstruct the linkage by ``parent_audit_id``.
+    # ------------------------------------------------------------------
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(AuditLog).where(
+                        AuditLog.path.in_(
+                            {
+                                "vmware.composite.host.evacuate",
+                                "vmware.composite.vm.migrate",
+                                _LEAF_OP_LIST_VMS,
+                                _LEAF_OP_GET_DRS_RECS,
+                                _LEAF_OP_RELOCATE_VM,
+                                _LEAF_OP_HOST_MAINTENANCE_ENTER,
+                            }
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    by_path: dict[str, list[AuditLog]] = {}
+    for row in rows:
+        by_path.setdefault(row.path, []).append(row)
+
+    # Parent composite — exactly one row, no parent.
+    host_evacuate_rows = by_path["vmware.composite.host.evacuate"]
+    assert len(host_evacuate_rows) == 1
+    parent = host_evacuate_rows[0]
+    assert parent.parent_audit_id is None
+
+    # vm.migrate composite — one row per listed VM (2 VMs in the stub).
+    vm_migrate_rows = by_path["vmware.composite.vm.migrate"]
+    assert len(vm_migrate_rows) == 2
+    for vm_migrate in vm_migrate_rows:
+        # Each vm.migrate row's parent is the host.evacuate row.
+        assert vm_migrate.parent_audit_id == parent.id
+
+    vm_migrate_ids = {r.id for r in vm_migrate_rows}
+
+    # Typed leaf ops.
+    list_vms_rows = by_path[_LEAF_OP_LIST_VMS]
+    # host.evacuate calls GET:/vcenter/vm once at depth 1.
+    assert len(list_vms_rows) == 1
+    assert list_vms_rows[0].parent_audit_id == parent.id
+
+    drs_rows = by_path[_LEAF_OP_GET_DRS_RECS]
+    # vm.migrate calls DRS-recs once per VM (no target_host override).
+    assert len(drs_rows) == 2
+    for drs_row in drs_rows:
+        # Each DRS row's parent is a vm.migrate row (depth 2).
+        assert drs_row.parent_audit_id in vm_migrate_ids
+
+    relocate_rows = by_path[_LEAF_OP_RELOCATE_VM]
+    # vm.migrate calls relocate once per VM (after DRS produced a target).
+    assert len(relocate_rows) == 2
+    for relocate_row in relocate_rows:
+        assert relocate_row.parent_audit_id in vm_migrate_ids
+
+    maintenance_rows = by_path[_LEAF_OP_HOST_MAINTENANCE_ENTER]
+    # host.evacuate calls maintenance-enter once at depth 1.
+    assert len(maintenance_rows) == 1
+    assert maintenance_rows[0].parent_audit_id == parent.id
+
+    # ------------------------------------------------------------------
+    # SQL-shape acceptance: a single query against (id, parent_audit_id,
+    # path) round-trips the entire tree the operator-runbook query
+    # uses.
+    # ------------------------------------------------------------------
+    audit_ids = {
+        parent.id,
+        *vm_migrate_ids,
+        *(r.id for r in list_vms_rows),
+        *(r.id for r in drs_rows),
+        *(r.id for r in relocate_rows),
+        *(r.id for r in maintenance_rows),
+    }
+    async with sessionmaker() as fresh:
+        tree_rows = (
+            await fresh.execute(
+                select(
+                    AuditLog.id,
+                    AuditLog.parent_audit_id,
+                    AuditLog.path,
+                ).where(AuditLog.id.in_(audit_ids))
+            )
+        ).all()
+    tree = {row.id: row for row in tree_rows}
+    # The reconstructed tree has the right shape: 1 root, 2 depth-1
+    # composites + 2 depth-1 typed leaves, 4 depth-2 typed leaves.
+    roots = [r for r in tree.values() if r.parent_audit_id is None]
+    assert len(roots) == 1
+    assert roots[0].path == "vmware.composite.host.evacuate"
+    depth_1_rows = [r for r in tree.values() if r.parent_audit_id == parent.id]
+    # 2 vm.migrate composites + 1 list_vms typed + 1 maintenance typed = 4.
+    assert len(depth_1_rows) == 4
+    depth_2_rows = [r for r in tree.values() if r.parent_audit_id in vm_migrate_ids]
+    # 2 DRS-recs typed + 2 relocate typed = 4.
+    assert len(depth_2_rows) == 4

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -160,8 +160,9 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 5 total.
-    assert stub_embedding_service.encode_one.call_count == 5
+    # Embedding service called once per composite -- 13 total after
+    # T6 (#509) shipped the 8 write composites alongside these 5.
+    assert stub_embedding_service.encode_one.call_count == 13
 
 
 @pytest.mark.asyncio
@@ -408,10 +409,15 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 rows, embedding called 5x total."""
+    """Running the registrar twice -> 5 read rows persist; embedding stays at 13.
+
+    The second run's body-hash skip path is what holds across both
+    read and write composites; this test asserts the read rows still
+    persist after the combined registrar (5 reads + 8 writes / T6).
+    """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 5
+    assert first_count == 13
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -126,7 +126,7 @@ async def test_vm_create_happy_path_dispatches_all_steps_in_order() -> None:
             _ok("GET:/vcenter/folder", [{"folder": "folder-7", "name": "Prod"}]),
             _ok("POST:/vcenter/vm", {"value": "vm-99"}),
             _ok("PATCH:/vcenter/vm/{vm}/network", {}),
-            _ok("POST:/vcenter/vm/{vm}/power", {}),
+            _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
         ]
     )
 
@@ -149,12 +149,12 @@ async def test_vm_create_happy_path_dispatches_all_steps_in_order() -> None:
         "GET:/vcenter/folder",
         "POST:/vcenter/vm",
         "PATCH:/vcenter/vm/{vm}/network",
-        "POST:/vcenter/vm/{vm}/power",
+        "POST:/vcenter/vm/{vm}/power?action=start",
     ]
     assert dispatch.calls[0]["params"] == {"filter.names": ["Prod"]}
     assert dispatch.calls[1]["params"]["spec"]["placement"]["folder"] == "folder-7"
     assert dispatch.calls[2]["params"] == {"vm": "vm-99", "spec": {"network": "net-3"}}
-    assert dispatch.calls[3]["params"] == {"vm": "vm-99", "action": "start"}
+    assert dispatch.calls[3]["params"] == {"vm": "vm-99"}
     assert out["status"] == "created"
     assert out["vm_id"] == "vm-99"
     assert out["steps_succeeded"] == ["folder_lookup", "create", "nic_attach", "power_on"]
@@ -219,7 +219,10 @@ async def test_vm_clone_happy_path_polls_task_to_completion() -> None:
     dispatch = _RecordingDispatchChild(
         [
             _ok("GET:/vcenter/vm/{vm}", {"name": "src"}),
-            _ok("POST:/vcenter/vm-template/library-items", {"task": "task-42"}),
+            _ok(
+                "POST:/vcenter/vm-template/library-items?action=deploy",
+                {"task": "task-42"},
+            ),
             _ok("GET:/cis/tasks/{task}", {"status": "SUCCEEDED", "result": {"vm": "vm-clone-1"}}),
         ]
     )
@@ -239,9 +242,11 @@ async def test_vm_clone_happy_path_polls_task_to_completion() -> None:
     assert out["vm_id"] == "vm-clone-1"
     assert [c["op_id"] for c in dispatch.calls] == [
         "GET:/vcenter/vm/{vm}",
-        "POST:/vcenter/vm-template/library-items",
+        "POST:/vcenter/vm-template/library-items?action=deploy",
         "GET:/cis/tasks/{task}",
     ]
+    # ``action=deploy`` lives on the op_id, not body params.
+    assert "action" not in dispatch.calls[1]["params"]
 
 
 @pytest.mark.asyncio
@@ -250,7 +255,10 @@ async def test_vm_clone_wait_false_returns_pending_with_task_id() -> None:
     dispatch = _RecordingDispatchChild(
         [
             _ok("GET:/vcenter/vm/{vm}", {"name": "src"}),
-            _ok("POST:/vcenter/vm-template/library-items", {"task": "task-99"}),
+            _ok(
+                "POST:/vcenter/vm-template/library-items?action=deploy",
+                {"task": "task-99"},
+            ),
         ]
     )
     out = await vm_clone_composite(
@@ -277,7 +285,10 @@ async def test_vm_clone_task_failed_raises_runtime_error() -> None:
     dispatch = _RecordingDispatchChild(
         [
             _ok("GET:/vcenter/vm/{vm}", {}),
-            _ok("POST:/vcenter/vm-template/library-items", {"task": "task-bad"}),
+            _ok(
+                "POST:/vcenter/vm-template/library-items?action=deploy",
+                {"task": "task-bad"},
+            ),
             _ok("GET:/cis/tasks/{task}", {"status": "FAILED", "error": "deploy failed"}),
         ]
     )
@@ -309,7 +320,7 @@ async def test_vm_snapshot_revert_happy_path_dispatches_revert() -> None:
                 "GET:/vcenter/vm/{vm}/snapshot",
                 [{"snapshot": "snap-1", "name": "before-patch"}],
             ),
-            _ok("POST:/vcenter/vm/{vm}/snapshot/{snap}", {}),
+            _ok("POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert", {}),
         ]
     )
     out = await vm_snapshot_revert_composite(
@@ -320,11 +331,9 @@ async def test_vm_snapshot_revert_happy_path_dispatches_revert() -> None:
     )
     assert out["status"] == "reverted"
     assert out["snapshot_id"] == "snap-1"
-    assert dispatch.calls[1]["params"] == {
-        "vm": "vm-1",
-        "snap": "snap-1",
-        "action": "revert",
-    }
+    assert dispatch.calls[1]["op_id"] == "POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert"
+    # ``action=revert`` lives on the op_id, not body params.
+    assert dispatch.calls[1]["params"] == {"vm": "vm-1", "snap": "snap-1"}
 
 
 @pytest.mark.asyncio
@@ -384,7 +393,7 @@ async def test_vm_migrate_drs_recommendation_dispatches_relocate() -> None:
                 "GET:/vcenter/cluster/{cluster}/drs/recommendations",
                 [{"vm": "vm-1", "target_host": "host-A"}],
             ),
-            _ok("POST:/vcenter/vm/{vm}", {}),
+            _ok("POST:/vcenter/vm/{vm}?action=relocate", {}),
         ]
     )
     out = await vm_migrate_composite(
@@ -396,14 +405,16 @@ async def test_vm_migrate_drs_recommendation_dispatches_relocate() -> None:
     assert out["status"] == "migrated"
     assert out["target_host"] == "host-A"
     assert out["source"] == "drs"
+    assert dispatch.calls[1]["op_id"] == "POST:/vcenter/vm/{vm}?action=relocate"
     assert dispatch.calls[1]["params"]["vm"] == "vm-1"
-    assert dispatch.calls[1]["params"]["action"] == "relocate"
+    # ``action=relocate`` lives on the op_id, not body params.
+    assert "action" not in dispatch.calls[1]["params"]
 
 
 @pytest.mark.asyncio
 async def test_vm_migrate_explicit_target_bypasses_drs_lookup() -> None:
     """``target_host`` override skips the DRS sub-op; relocate dispatches directly."""
-    dispatch = _RecordingDispatchChild([_ok("POST:/vcenter/vm/{vm}", {})])
+    dispatch = _RecordingDispatchChild([_ok("POST:/vcenter/vm/{vm}?action=relocate", {})])
     out = await vm_migrate_composite(
         operator=_make_operator(),
         target=object(),
@@ -413,6 +424,7 @@ async def test_vm_migrate_explicit_target_bypasses_drs_lookup() -> None:
     assert out["status"] == "migrated"
     assert out["target_host"] == "host-Z"
     assert out["source"] == "operator"
+    assert dispatch.calls[0]["op_id"] == "POST:/vcenter/vm/{vm}?action=relocate"
     assert len(dispatch.calls) == 1
 
 
@@ -446,9 +458,9 @@ async def test_vm_power_bulk_happy_path_aggregates_per_vm_results() -> None:
     dispatch = _RecordingDispatchChild(
         [
             _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}, {"vm": "vm-3"}]),
-            _ok("POST:/vcenter/vm/{vm}/power", {}),
-            _ok("POST:/vcenter/vm/{vm}/power", {}),
-            _ok("POST:/vcenter/vm/{vm}/power", {}),
+            _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
+            _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
+            _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
         ]
     )
     out = await vm_power_bulk_composite(
@@ -463,6 +475,11 @@ async def test_vm_power_bulk_happy_path_aggregates_per_vm_results() -> None:
     assert out["aborted_on_failure"] is False
     # Filter forwarded as filter.power_states.
     assert dispatch.calls[0]["params"] == {"filter.power_states": ["POWERED_OFF"]}
+    # Every per-VM call targets the ``?action=start`` descriptor row; action
+    # verb lives on the op_id, not body params.
+    for call in dispatch.calls[1:]:
+        assert call["op_id"] == "POST:/vcenter/vm/{vm}/power?action=start"
+        assert "action" not in call["params"]
 
 
 @pytest.mark.asyncio
@@ -471,8 +488,8 @@ async def test_vm_power_bulk_partial_failure_continues_by_default() -> None:
     dispatch = _RecordingDispatchChild(
         [
             _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}]),
-            _err("POST:/vcenter/vm/{vm}/power", "boom"),
-            _ok("POST:/vcenter/vm/{vm}/power", {}),
+            _err("POST:/vcenter/vm/{vm}/power?action=stop", "boom"),
+            _ok("POST:/vcenter/vm/{vm}/power?action=stop", {}),
         ]
     )
     out = await vm_power_bulk_composite(
@@ -485,6 +502,9 @@ async def test_vm_power_bulk_partial_failure_continues_by_default() -> None:
     assert out["aborted_on_failure"] is False
     # Both VMs were attempted.
     assert len(dispatch.calls) == 3
+    # ``stop`` lives on the op_id.
+    for call in dispatch.calls[1:]:
+        assert call["op_id"] == "POST:/vcenter/vm/{vm}/power?action=stop"
 
 
 @pytest.mark.asyncio
@@ -493,7 +513,7 @@ async def test_vm_power_bulk_fail_fast_aborts_on_first_failure() -> None:
     dispatch = _RecordingDispatchChild(
         [
             _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}, {"vm": "vm-3"}]),
-            _err("POST:/vcenter/vm/{vm}/power", "denied"),
+            _err("POST:/vcenter/vm/{vm}/power?action=stop", "denied"),
         ]
     )
     out = await vm_power_bulk_composite(
@@ -528,11 +548,13 @@ async def test_host_evacuate_dispatches_vm_migrate_per_vm_then_maintenance() -> 
         [
             _ok(
                 "GET:/vcenter/vm",
-                [{"vm": "vm-a", "cluster": "c-1"}, {"vm": "vm-b", "cluster": "c-1"}],
+                # Per-VM cluster moids differ so the per-row resolution
+                # gets exercised end to end (vm-a/c-1, vm-b/c-2).
+                [{"vm": "vm-a", "cluster": "c-1"}, {"vm": "vm-b", "cluster": "c-2"}],
             ),
             migrate_result,
             migrate_result,
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
         ]
     )
     out = await host_evacuate_composite(
@@ -546,13 +568,15 @@ async def test_host_evacuate_dispatches_vm_migrate_per_vm_then_maintenance() -> 
         "GET:/vcenter/vm",
         "vmware.composite.vm.migrate",
         "vmware.composite.vm.migrate",
-        "PATCH:/vcenter/host/{host}/maintenance",
+        "PATCH:/vcenter/host/{host}/maintenance?action=enter",
     ]
-    # Both recursive calls carry the cluster moid pulled from the
-    # listing row.
+    # Each recursive call carries that row's cluster moid — proves per-row
+    # resolution (M1 fix from PR #529 iter-2).
     assert dispatch.calls[1]["params"] == {"vm": "vm-a", "cluster": "c-1"}
-    assert dispatch.calls[2]["params"] == {"vm": "vm-b", "cluster": "c-1"}
-    assert dispatch.calls[3]["params"] == {"host": "host-1", "action": "enter"}
+    assert dispatch.calls[2]["params"] == {"vm": "vm-b", "cluster": "c-2"}
+    # Maintenance enter dispatches against the action-bearing descriptor row;
+    # ``action`` is NOT a body param.
+    assert dispatch.calls[3]["params"] == {"host": "host-1"}
     assert out["status"] == "evacuated"
     assert out["maintenance_entered"] is True
     assert out["migrated_vms"] == ["vm-a", "vm-b"]
@@ -586,7 +610,7 @@ async def test_host_evacuate_default_aborts_on_vm_migrate_failure() -> None:
     assert len(out["failed_vms"]) == 1
     # Maintenance-enter never dispatched.
     op_ids = [c["op_id"] for c in dispatch.calls]
-    assert "PATCH:/vcenter/host/{host}/maintenance" not in op_ids
+    assert "PATCH:/vcenter/host/{host}/maintenance?action=enter" not in op_ids
 
 
 @pytest.mark.asyncio
@@ -612,7 +636,7 @@ async def test_host_evacuate_tolerate_partial_failure_still_enters_maintenance()
             ),
             ok_migrate,
             err_migrate,
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
         ]
     )
     out = await host_evacuate_composite(
@@ -641,7 +665,7 @@ async def test_host_detach_from_vds_happy_path_removes_host_after_nic_migration(
             _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}]),
             _ok("PATCH:/vcenter/vm/{vm}/network", {}),
             _ok("PATCH:/vcenter/vm/{vm}/network", {}),
-            _ok("POST:/vcenter/network/dvs/{dvs}", {}),
+            _ok("POST:/vcenter/network/dvs/{dvs}?action=remove_host", {}),
         ]
     )
     out = await host_detach_from_vds_composite(
@@ -653,10 +677,11 @@ async def test_host_detach_from_vds_happy_path_removes_host_after_nic_migration(
     assert out["status"] == "detached"
     assert out["vms_migrated"] == ["vm-1", "vm-2"]
     assert out["vm_migration_failures"] == []
-    # DVS remove fired.
+    # DVS remove fired against the action-bearing descriptor row.
     last_call = dispatch.calls[-1]
-    assert last_call["op_id"] == "POST:/vcenter/network/dvs/{dvs}"
-    assert last_call["params"] == {"dvs": "dvs-1", "action": "remove_host", "host": "host-9"}
+    assert last_call["op_id"] == "POST:/vcenter/network/dvs/{dvs}?action=remove_host"
+    # ``action=remove_host`` lives on the op_id, not body params.
+    assert last_call["params"] == {"dvs": "dvs-1", "host": "host-9"}
 
 
 @pytest.mark.asyncio
@@ -681,7 +706,7 @@ async def test_host_detach_from_vds_incomplete_when_nic_migration_fails() -> Non
     assert len(out["vm_migration_failures"]) == 1
     # No DVS remove call.
     op_ids = [c["op_id"] for c in dispatch.calls]
-    assert "POST:/vcenter/network/dvs/{dvs}" not in op_ids
+    assert "POST:/vcenter/network/dvs/{dvs}?action=remove_host" not in op_ids
 
 
 # ===========================================================================
@@ -695,14 +720,14 @@ async def test_cluster_patch_happy_path_dispatches_sequential_maintenance_patch_
     dispatch = _RecordingDispatchChild(
         [
             _ok("GET:/vcenter/cluster/{cluster}/host", [{"host": "h1"}, {"host": "h2"}]),
-            # h1
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
-            _ok("POST:/vcenter/host/{host}", {}),
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            # h1: enter -> patch -> exit, action verbs on the op_id.
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
+            _ok("POST:/vcenter/host/{host}?action=patch", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=exit", {}),
             # h2
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
-            _ok("POST:/vcenter/host/{host}", {}),
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
+            _ok("POST:/vcenter/host/{host}?action=patch", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=exit", {}),
         ]
     )
     out = await cluster_patch_composite(
@@ -714,11 +739,15 @@ async def test_cluster_patch_happy_path_dispatches_sequential_maintenance_patch_
     assert out["status"] == "completed"
     assert out["patched_hosts"] == ["h1", "h2"]
     assert out["remaining_hosts"] == []
-    # Action sequence per host: enter -> patch -> exit.
+    # Action sequence per host lives on the op_id (one descriptor row per verb).
     host_calls = list(dispatch.calls[1:])
-    assert host_calls[0]["params"]["action"] == "enter"
-    assert host_calls[1]["params"]["action"] == "patch"
-    assert host_calls[2]["params"]["action"] == "exit"
+    assert host_calls[0]["op_id"] == "PATCH:/vcenter/host/{host}/maintenance?action=enter"
+    assert host_calls[1]["op_id"] == "POST:/vcenter/host/{host}?action=patch"
+    assert host_calls[2]["op_id"] == "PATCH:/vcenter/host/{host}/maintenance?action=exit"
+    # Body params drop the ``action`` field; patch carries a ``method`` body.
+    assert host_calls[0]["params"] == {"host": "h1"}
+    assert host_calls[1]["params"] == {"host": "h1", "method": "default"}
+    assert host_calls[2]["params"] == {"host": "h1"}
 
 
 @pytest.mark.asyncio
@@ -731,12 +760,12 @@ async def test_cluster_patch_per_host_failure_stops_loop() -> None:
                 [{"host": "h1"}, {"host": "h2"}, {"host": "h3"}],
             ),
             # h1 completes cleanly.
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
-            _ok("POST:/vcenter/host/{host}", {}),
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
+            _ok("POST:/vcenter/host/{host}?action=patch", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=exit", {}),
             # h2 fails on patch.
-            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
-            _err("POST:/vcenter/host/{host}", "vendor patch failed"),
+            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
+            _err("POST:/vcenter/host/{host}?action=patch", "vendor patch failed"),
         ]
     )
     out = await cluster_patch_composite(
@@ -765,11 +794,27 @@ async def test_every_write_composite_uses_vmware_rest_9_0_connector_id() -> None
     contract -- the connector_id is what routes recursive dispatch
     back to :class:`VmwareRestConnector` for sub-call authentication.
     """
+    # Every case drives the composite through ALL of its sub-op_ids so the
+    # connector_id contract is asserted on the full dispatch chain — empty
+    # listings would short-circuit before the action-bearing typed ops fire
+    # (M4 from PR #529 iter-2: vm_create_composite was exiting on an empty
+    # folder match before its create / nic / power / rollback sub-ops ran).
     cases: tuple[tuple[Any, dict[str, Any], list[Any]], ...] = (
         (
             vm_create_composite,
-            {"folder_name": "f", "name": "n", "guest_os": "g"},
-            [_ok("GET:/vcenter/folder", []), _ok("POST:/vcenter/vm", {"value": ""})],
+            {
+                "folder_name": "f",
+                "name": "n",
+                "guest_os": "g",
+                "nics": [{"network": "net-a"}],
+                "power_on_after_create": True,
+            },
+            [
+                _ok("GET:/vcenter/folder", [{"folder": "folder-x", "name": "f"}]),
+                _ok("POST:/vcenter/vm", {"value": "vm-x"}),
+                _ok("PATCH:/vcenter/vm/{vm}/network", {}),
+                _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
+            ],
         ),
         (
             vm_clone_composite,
@@ -781,28 +826,37 @@ async def test_every_write_composite_uses_vmware_rest_9_0_connector_id() -> None
             },
             [
                 _ok("GET:/vcenter/vm/{vm}", {}),
-                _ok("POST:/vcenter/vm-template/library-items", {"task": "t"}),
+                _ok("POST:/vcenter/vm-template/library-items?action=deploy", {"task": "t"}),
             ],
         ),
         (
             vm_snapshot_revert_composite,
             {"vm": "v", "snapshot_name": "n"},
-            [_ok("GET:/vcenter/vm/{vm}/snapshot", [])],
+            [
+                _ok("GET:/vcenter/vm/{vm}/snapshot", [{"snapshot": "snap-1", "name": "n"}]),
+                _ok("POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert", {}),
+            ],
         ),
         (
             vm_migrate_composite,
             {"vm": "v", "cluster": "c", "target_host": "h"},
-            [_ok("POST:/vcenter/vm/{vm}", {})],
+            [_ok("POST:/vcenter/vm/{vm}?action=relocate", {})],
         ),
         (
             vm_power_bulk_composite,
             {"action": "start"},
-            [_ok("GET:/vcenter/vm", [])],
+            [
+                _ok("GET:/vcenter/vm", [{"vm": "vm-x"}]),
+                _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
+            ],
         ),
         (
             host_evacuate_composite,
             {"host": "h"},
-            [_ok("GET:/vcenter/vm", []), _ok("PATCH:/vcenter/host/{host}/maintenance", {})],
+            [
+                _ok("GET:/vcenter/vm", []),
+                _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
+            ],
         ),
         (
             host_detach_from_vds_composite,
@@ -810,13 +864,18 @@ async def test_every_write_composite_uses_vmware_rest_9_0_connector_id() -> None
             [
                 _ok("GET:/vcenter/network/distributed-portgroup", []),
                 _ok("GET:/vcenter/vm", []),
-                _ok("POST:/vcenter/network/dvs/{dvs}", {}),
+                _ok("POST:/vcenter/network/dvs/{dvs}?action=remove_host", {}),
             ],
         ),
         (
             cluster_patch_composite,
             {"cluster": "c"},
-            [_ok("GET:/vcenter/cluster/{cluster}/host", [])],
+            [
+                _ok("GET:/vcenter/cluster/{cluster}/host", [{"host": "h1"}]),
+                _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
+                _ok("POST:/vcenter/host/{host}?action=patch", {}),
+                _ok("PATCH:/vcenter/host/{host}/maintenance?action=exit", {}),
+            ],
         ),
     )
     for handler, params, responses in cases:

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -1,0 +1,833 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the 8 vmware-rest write-composite handler functions.
+
+Coverage matrix (G3.1-T6 / #509 acceptance criteria):
+
+* Per-composite happy-path test: assert the correct sub-op_ids fire in
+  the expected order with the right ``connector_id`` + ``params``;
+  assert the returned dict shape matches the spec.
+* Per-composite partial-failure test: mocked ``dispatch_child`` raises
+  or returns an error-shaped result on a specific sub-op; assert the
+  composite handles the failure per its documented rollback /
+  partial-result semantics.
+* ``host.evacuate`` recursion: assert the handler dispatches
+  ``vmware.composite.vm.migrate`` per VM (proves the recursive
+  composite pattern).
+* Connector-id contract: every sub-op dispatches against
+  ``vmware-rest-9.0``.
+
+Each test mocks ``dispatch_child`` via a recording stub returning
+canned :class:`OperationResult` objects keyed by op_id (or sequenced
+when the same op_id fires multiple times).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    cluster_patch_composite,
+    host_detach_from_vds_composite,
+    host_evacuate_composite,
+    vm_clone_composite,
+    vm_create_composite,
+    vm_migrate_composite,
+    vm_power_bulk_composite,
+    vm_snapshot_revert_composite,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator for composite-handler unit tests."""
+    return Operator(
+        sub="op-composite-write",
+        name="Composite Write Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a1"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _ok(op_id: str, result: Any) -> OperationResult:
+    """OK :class:`OperationResult` for a sub-op."""
+    return OperationResult(status="ok", op_id=op_id, result=result, duration_ms=1.0)
+
+
+def _err(op_id: str, error: str) -> OperationResult:
+    """Error :class:`OperationResult` for partial-failure tests."""
+    return OperationResult(status="error", op_id=op_id, error=error, duration_ms=1.0)
+
+
+class _RecordingDispatchChild:
+    """Records every ``dispatch_child`` call and serves canned results.
+
+    Two modes match :mod:`._read`'s test stub:
+
+    * ``dict`` -- ``op_id -> result``; same op_id served from the same
+      slot every time.
+    * ``list`` -- sequential :class:`OperationResult` values returned
+      in order. Use when the same op_id is dispatched multiple times
+      with different per-call expectations.
+    """
+
+    def __init__(self, responses: dict[str, Any] | list[Any]) -> None:
+        self._responses = responses
+        self._sequence_index = 0
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(
+        self,
+        *,
+        connector_id: str,
+        op_id: str,
+        params: dict[str, Any],
+        target: Any = None,
+    ) -> OperationResult:
+        self.calls.append(
+            {
+                "connector_id": connector_id,
+                "op_id": op_id,
+                "params": dict(params),
+                "target": target,
+            }
+        )
+        if isinstance(self._responses, dict):
+            payload = self._responses[op_id]
+        else:
+            payload = self._responses[self._sequence_index]
+            self._sequence_index += 1
+        if isinstance(payload, OperationResult):
+            return payload
+        return _ok(op_id, payload)
+
+
+# ===========================================================================
+# vm.create
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_create_happy_path_dispatches_all_steps_in_order() -> None:
+    """Folder lookup -> create -> per-NIC attach -> power-on; returns status=created."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/folder", [{"folder": "folder-7", "name": "Prod"}]),
+            _ok("POST:/vcenter/vm", {"value": "vm-99"}),
+            _ok("PATCH:/vcenter/vm/{vm}/network", {}),
+            _ok("POST:/vcenter/vm/{vm}/power", {}),
+        ]
+    )
+
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-01",
+            "guest_os": "UBUNTU_64",
+            "cpu_count": 2,
+            "memory_mib": 4096,
+            "nics": [{"network": "net-3"}],
+            "power_on_after_create": True,
+        },
+        dispatch_child=dispatch,
+    )
+
+    assert [c["op_id"] for c in dispatch.calls] == [
+        "GET:/vcenter/folder",
+        "POST:/vcenter/vm",
+        "PATCH:/vcenter/vm/{vm}/network",
+        "POST:/vcenter/vm/{vm}/power",
+    ]
+    assert dispatch.calls[0]["params"] == {"filter.names": ["Prod"]}
+    assert dispatch.calls[1]["params"]["spec"]["placement"]["folder"] == "folder-7"
+    assert dispatch.calls[2]["params"] == {"vm": "vm-99", "spec": {"network": "net-3"}}
+    assert dispatch.calls[3]["params"] == {"vm": "vm-99", "action": "start"}
+    assert out["status"] == "created"
+    assert out["vm_id"] == "vm-99"
+    assert out["steps_succeeded"] == ["folder_lookup", "create", "nic_attach", "power_on"]
+    assert out["failed_step"] is None
+
+
+@pytest.mark.asyncio
+async def test_vm_create_partial_failure_rolls_back_via_delete() -> None:
+    """NIC-attach failure triggers DELETE rollback; returns status=rolled_back."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/folder", [{"folder": "folder-1", "name": "Prod"}]),
+            _ok("POST:/vcenter/vm", {"value": "vm-77"}),
+            _err("PATCH:/vcenter/vm/{vm}/network", "nic-attach failed"),
+            _ok("DELETE:/vcenter/vm/{vm}", {}),
+        ]
+    )
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "folder_name": "Prod",
+            "name": "web-02",
+            "guest_os": "UBUNTU_64",
+            "nics": [{"network": "net-x"}],
+        },
+        dispatch_child=dispatch,
+    )
+    # DELETE fires after the NIC error.
+    op_ids_dispatched = [c["op_id"] for c in dispatch.calls]
+    assert "DELETE:/vcenter/vm/{vm}" in op_ids_dispatched
+    assert dispatch.calls[-1]["params"] == {"vm": "vm-77"}
+    assert out["status"] == "rolled_back"
+    assert out["vm_id"] is None
+    assert out["failed_step"] == "nic_attach"
+    assert out["rollback_reason"]
+
+
+@pytest.mark.asyncio
+async def test_vm_create_folder_lookup_empty_returns_rolled_back_no_create() -> None:
+    """Empty folder match returns rolled_back; POST:/vcenter/vm never fires."""
+    dispatch = _RecordingDispatchChild([_ok("GET:/vcenter/folder", [])])
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"folder_name": "Missing", "name": "web", "guest_os": "UBUNTU_64"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "rolled_back"
+    assert out["failed_step"] == "folder_lookup"
+    assert len(dispatch.calls) == 1
+
+
+# ===========================================================================
+# vm.clone
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_clone_happy_path_polls_task_to_completion() -> None:
+    """Source-config read -> deploy -> task poll until SUCCEEDED; status=completed."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/vm/{vm}", {"name": "src"}),
+            _ok("POST:/vcenter/vm-template/library-items", {"task": "task-42"}),
+            _ok("GET:/cis/tasks/{task}", {"status": "SUCCEEDED", "result": {"vm": "vm-clone-1"}}),
+        ]
+    )
+    out = await vm_clone_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "source_vm": "vm-src",
+            "target_name": "vm-clone-1",
+            "library_item": "li-7",
+            "timeout_seconds": 30,
+        },
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "completed"
+    assert out["task_id"] == "task-42"
+    assert out["vm_id"] == "vm-clone-1"
+    assert [c["op_id"] for c in dispatch.calls] == [
+        "GET:/vcenter/vm/{vm}",
+        "POST:/vcenter/vm-template/library-items",
+        "GET:/cis/tasks/{task}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vm_clone_wait_false_returns_pending_with_task_id() -> None:
+    """wait_for_completion=False returns immediately; no task poll fires."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/vm/{vm}", {"name": "src"}),
+            _ok("POST:/vcenter/vm-template/library-items", {"task": "task-99"}),
+        ]
+    )
+    out = await vm_clone_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "source_vm": "vm-src",
+            "target_name": "tgt",
+            "library_item": "li-3",
+            "wait_for_completion": False,
+        },
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "pending"
+    assert out["task_id"] == "task-99"
+    assert out["vm_id"] is None
+    # Only 2 calls (no task poll).
+    assert len(dispatch.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_vm_clone_task_failed_raises_runtime_error() -> None:
+    """Task returning FAILED status raises -- dispatcher wraps as connector_error."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/vm/{vm}", {}),
+            _ok("POST:/vcenter/vm-template/library-items", {"task": "task-bad"}),
+            _ok("GET:/cis/tasks/{task}", {"status": "FAILED", "error": "deploy failed"}),
+        ]
+    )
+    with pytest.raises(RuntimeError, match="FAILED"):
+        await vm_clone_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={
+                "source_vm": "vm-src",
+                "target_name": "tgt",
+                "library_item": "li-1",
+                "timeout_seconds": 30,
+            },
+            dispatch_child=dispatch,
+        )
+
+
+# ===========================================================================
+# vm.snapshot.revert
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_snapshot_revert_happy_path_dispatches_revert() -> None:
+    """List + match + revert; returns status=reverted with snapshot_id."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok(
+                "GET:/vcenter/vm/{vm}/snapshot",
+                [{"snapshot": "snap-1", "name": "before-patch"}],
+            ),
+            _ok("POST:/vcenter/vm/{vm}/snapshot/{snap}", {}),
+        ]
+    )
+    out = await vm_snapshot_revert_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "snapshot_name": "before-patch"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "reverted"
+    assert out["snapshot_id"] == "snap-1"
+    assert dispatch.calls[1]["params"] == {
+        "vm": "vm-1",
+        "snap": "snap-1",
+        "action": "revert",
+    }
+
+
+@pytest.mark.asyncio
+async def test_vm_snapshot_revert_ambiguous_name_does_not_dispatch_revert() -> None:
+    """Multiple snapshots share the name -> status=ambiguous; no revert dispatched."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok(
+                "GET:/vcenter/vm/{vm}/snapshot",
+                [
+                    {"snapshot": "snap-1", "name": "x"},
+                    {"snapshot": "snap-2", "name": "x"},
+                ],
+            )
+        ]
+    )
+    out = await vm_snapshot_revert_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "snapshot_name": "x"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "ambiguous"
+    assert out["snapshot_id"] is None
+    assert len(out["candidates"]) == 2
+    # Only the listing call fired -- no revert.
+    assert len(dispatch.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_vm_snapshot_revert_not_found_returns_not_found() -> None:
+    """Snapshot name not in tree -> status=not_found; no revert dispatched."""
+    dispatch = _RecordingDispatchChild(
+        [_ok("GET:/vcenter/vm/{vm}/snapshot", [{"snapshot": "s-1", "name": "other"}])]
+    )
+    out = await vm_snapshot_revert_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "snapshot_name": "missing"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "not_found"
+    assert len(dispatch.calls) == 1
+
+
+# ===========================================================================
+# vm.migrate
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_migrate_drs_recommendation_dispatches_relocate() -> None:
+    """DRS recommendation -> relocate dispatched against recommended host."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok(
+                "GET:/vcenter/cluster/{cluster}/drs/recommendations",
+                [{"vm": "vm-1", "target_host": "host-A"}],
+            ),
+            _ok("POST:/vcenter/vm/{vm}", {}),
+        ]
+    )
+    out = await vm_migrate_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cluster": "cluster-7"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "migrated"
+    assert out["target_host"] == "host-A"
+    assert out["source"] == "drs"
+    assert dispatch.calls[1]["params"]["vm"] == "vm-1"
+    assert dispatch.calls[1]["params"]["action"] == "relocate"
+
+
+@pytest.mark.asyncio
+async def test_vm_migrate_explicit_target_bypasses_drs_lookup() -> None:
+    """``target_host`` override skips the DRS sub-op; relocate dispatches directly."""
+    dispatch = _RecordingDispatchChild([_ok("POST:/vcenter/vm/{vm}", {})])
+    out = await vm_migrate_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-2", "cluster": "cluster-9", "target_host": "host-Z"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "migrated"
+    assert out["target_host"] == "host-Z"
+    assert out["source"] == "operator"
+    assert len(dispatch.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_vm_migrate_no_recommendation_returns_status_no_recommendation() -> None:
+    """DRS returns empty + no target_host override -> status=no_recommendation."""
+    dispatch = _RecordingDispatchChild(
+        [_ok("GET:/vcenter/cluster/{cluster}/drs/recommendations", [])]
+    )
+    out = await vm_migrate_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-3", "cluster": "cluster-1"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "no_recommendation"
+    assert out["target_host"] is None
+    assert out["source"] == "none"
+    # Relocate did NOT dispatch.
+    assert len(dispatch.calls) == 1
+
+
+# ===========================================================================
+# vm.power.bulk
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_power_bulk_happy_path_aggregates_per_vm_results() -> None:
+    """Filter listing + per-VM power; aggregate results + summary counts."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}, {"vm": "vm-3"}]),
+            _ok("POST:/vcenter/vm/{vm}/power", {}),
+            _ok("POST:/vcenter/vm/{vm}/power", {}),
+            _ok("POST:/vcenter/vm/{vm}/power", {}),
+        ]
+    )
+    out = await vm_power_bulk_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"filter": {"power_states": ["POWERED_OFF"]}, "action": "start"},
+        dispatch_child=dispatch,
+    )
+    assert out["summary"] == {"ok": 3, "error": 0}
+    assert {r["vm"] for r in out["results"]} == {"vm-1", "vm-2", "vm-3"}
+    assert all(r["status"] == "ok" for r in out["results"])
+    assert out["aborted_on_failure"] is False
+    # Filter forwarded as filter.power_states.
+    assert dispatch.calls[0]["params"] == {"filter.power_states": ["POWERED_OFF"]}
+
+
+@pytest.mark.asyncio
+async def test_vm_power_bulk_partial_failure_continues_by_default() -> None:
+    """One per-VM failure does not abort; summary reflects mixed outcome."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}]),
+            _err("POST:/vcenter/vm/{vm}/power", "boom"),
+            _ok("POST:/vcenter/vm/{vm}/power", {}),
+        ]
+    )
+    out = await vm_power_bulk_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"action": "stop"},
+        dispatch_child=dispatch,
+    )
+    assert out["summary"] == {"ok": 1, "error": 1}
+    assert out["aborted_on_failure"] is False
+    # Both VMs were attempted.
+    assert len(dispatch.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_vm_power_bulk_fail_fast_aborts_on_first_failure() -> None:
+    """fail_fast=True -> abort after first error; remaining VMs untouched."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}, {"vm": "vm-3"}]),
+            _err("POST:/vcenter/vm/{vm}/power", "denied"),
+        ]
+    )
+    out = await vm_power_bulk_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"action": "stop", "fail_fast": True},
+        dispatch_child=dispatch,
+    )
+    assert out["aborted_on_failure"] is True
+    assert out["summary"] == {"ok": 0, "error": 1}
+    assert len(out["results"]) == 1
+    # Only listing + first power call fired -- the other two VMs never
+    # got dispatched.
+    assert len(dispatch.calls) == 2
+
+
+# ===========================================================================
+# host.evacuate -- recursive composite
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_host_evacuate_dispatches_vm_migrate_per_vm_then_maintenance() -> None:
+    """host.evacuate recursively dispatches vm.migrate, then enters maintenance."""
+    migrate_result = OperationResult(
+        status="ok",
+        op_id="vmware.composite.vm.migrate",
+        result={"status": "migrated", "target_host": "h-2"},
+        duration_ms=1.0,
+    )
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok(
+                "GET:/vcenter/vm",
+                [{"vm": "vm-a", "cluster": "c-1"}, {"vm": "vm-b", "cluster": "c-1"}],
+            ),
+            migrate_result,
+            migrate_result,
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+        ]
+    )
+    out = await host_evacuate_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"host": "host-1"},
+        dispatch_child=dispatch,
+    )
+    op_ids = [c["op_id"] for c in dispatch.calls]
+    assert op_ids == [
+        "GET:/vcenter/vm",
+        "vmware.composite.vm.migrate",
+        "vmware.composite.vm.migrate",
+        "PATCH:/vcenter/host/{host}/maintenance",
+    ]
+    # Both recursive calls carry the cluster moid pulled from the
+    # listing row.
+    assert dispatch.calls[1]["params"] == {"vm": "vm-a", "cluster": "c-1"}
+    assert dispatch.calls[2]["params"] == {"vm": "vm-b", "cluster": "c-1"}
+    assert dispatch.calls[3]["params"] == {"host": "host-1", "action": "enter"}
+    assert out["status"] == "evacuated"
+    assert out["maintenance_entered"] is True
+    assert out["migrated_vms"] == ["vm-a", "vm-b"]
+    assert out["failed_vms"] == []
+
+
+@pytest.mark.asyncio
+async def test_host_evacuate_default_aborts_on_vm_migrate_failure() -> None:
+    """tolerate_partial_failure=False -> a vm.migrate failure aborts before maintenance."""
+    no_rec_result = OperationResult(
+        status="ok",
+        op_id="vmware.composite.vm.migrate",
+        result={"status": "no_recommendation"},
+        duration_ms=1.0,
+    )
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/vm", [{"vm": "vm-x", "cluster": "c-1"}]),
+            no_rec_result,
+        ]
+    )
+    out = await host_evacuate_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"host": "host-3"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "aborted"
+    assert out["maintenance_entered"] is False
+    assert out["migrated_vms"] == []
+    assert len(out["failed_vms"]) == 1
+    # Maintenance-enter never dispatched.
+    op_ids = [c["op_id"] for c in dispatch.calls]
+    assert "PATCH:/vcenter/host/{host}/maintenance" not in op_ids
+
+
+@pytest.mark.asyncio
+async def test_host_evacuate_tolerate_partial_failure_still_enters_maintenance() -> None:
+    """tolerate_partial_failure=True -> maintenance enters even with VM failures."""
+    ok_migrate = OperationResult(
+        status="ok",
+        op_id="vmware.composite.vm.migrate",
+        result={"status": "migrated", "target_host": "h-2"},
+        duration_ms=1.0,
+    )
+    err_migrate = OperationResult(
+        status="ok",
+        op_id="vmware.composite.vm.migrate",
+        result={"status": "no_recommendation"},
+        duration_ms=1.0,
+    )
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok(
+                "GET:/vcenter/vm",
+                [{"vm": "vm-a", "cluster": "c-1"}, {"vm": "vm-b", "cluster": "c-1"}],
+            ),
+            ok_migrate,
+            err_migrate,
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+        ]
+    )
+    out = await host_evacuate_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"host": "host-2", "tolerate_partial_failure": True},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "partial"
+    assert out["maintenance_entered"] is True
+    assert out["migrated_vms"] == ["vm-a"]
+    assert len(out["failed_vms"]) == 1
+
+
+# ===========================================================================
+# host.detach_from_vds
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_host_detach_from_vds_happy_path_removes_host_after_nic_migration() -> None:
+    """Discovery + per-VM NIC migration + DVS host-remove; status=detached."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/network/distributed-portgroup", []),
+            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}]),
+            _ok("PATCH:/vcenter/vm/{vm}/network", {}),
+            _ok("PATCH:/vcenter/vm/{vm}/network", {}),
+            _ok("POST:/vcenter/network/dvs/{dvs}", {}),
+        ]
+    )
+    out = await host_detach_from_vds_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"host": "host-9", "dvs": "dvs-1", "fallback_network": "standard-net"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "detached"
+    assert out["vms_migrated"] == ["vm-1", "vm-2"]
+    assert out["vm_migration_failures"] == []
+    # DVS remove fired.
+    last_call = dispatch.calls[-1]
+    assert last_call["op_id"] == "POST:/vcenter/network/dvs/{dvs}"
+    assert last_call["params"] == {"dvs": "dvs-1", "action": "remove_host", "host": "host-9"}
+
+
+@pytest.mark.asyncio
+async def test_host_detach_from_vds_incomplete_when_nic_migration_fails() -> None:
+    """NIC migration failure -> status=incomplete; DVS remove skipped."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/network/distributed-portgroup", []),
+            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}]),
+            _ok("PATCH:/vcenter/vm/{vm}/network", {}),
+            _err("PATCH:/vcenter/vm/{vm}/network", "nic move failed"),
+        ]
+    )
+    out = await host_detach_from_vds_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"host": "host-9", "dvs": "dvs-1", "fallback_network": "std"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "incomplete"
+    assert out["vms_migrated"] == ["vm-1"]
+    assert len(out["vm_migration_failures"]) == 1
+    # No DVS remove call.
+    op_ids = [c["op_id"] for c in dispatch.calls]
+    assert "POST:/vcenter/network/dvs/{dvs}" not in op_ids
+
+
+# ===========================================================================
+# cluster.patch
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cluster_patch_happy_path_dispatches_sequential_maintenance_patch_exit() -> None:
+    """Per-host: maintenance enter -> patch -> maintenance exit; status=completed."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok("GET:/vcenter/cluster/{cluster}/host", [{"host": "h1"}, {"host": "h2"}]),
+            # h1
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            _ok("POST:/vcenter/host/{host}", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            # h2
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            _ok("POST:/vcenter/host/{host}", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+        ]
+    )
+    out = await cluster_patch_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "c-1"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "completed"
+    assert out["patched_hosts"] == ["h1", "h2"]
+    assert out["remaining_hosts"] == []
+    # Action sequence per host: enter -> patch -> exit.
+    host_calls = list(dispatch.calls[1:])
+    assert host_calls[0]["params"]["action"] == "enter"
+    assert host_calls[1]["params"]["action"] == "patch"
+    assert host_calls[2]["params"]["action"] == "exit"
+
+
+@pytest.mark.asyncio
+async def test_cluster_patch_per_host_failure_stops_loop() -> None:
+    """A per-host failure stops the loop; status=stopped with remaining_hosts."""
+    dispatch = _RecordingDispatchChild(
+        [
+            _ok(
+                "GET:/vcenter/cluster/{cluster}/host",
+                [{"host": "h1"}, {"host": "h2"}, {"host": "h3"}],
+            ),
+            # h1 completes cleanly.
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            _ok("POST:/vcenter/host/{host}", {}),
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            # h2 fails on patch.
+            _ok("PATCH:/vcenter/host/{host}/maintenance", {}),
+            _err("POST:/vcenter/host/{host}", "vendor patch failed"),
+        ]
+    )
+    out = await cluster_patch_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "c-1"},
+        dispatch_child=dispatch,
+    )
+    assert out["status"] == "stopped"
+    assert out["patched_hosts"] == ["h1"]
+    assert out["failed_host"] == "h2"
+    assert out["remaining_hosts"] == ["h3"]
+    assert out["failure_reason"]
+
+
+# ===========================================================================
+# Connector-id contract
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_every_write_composite_uses_vmware_rest_9_0_connector_id() -> None:
+    """Every write composite dispatches sub-ops against ``vmware-rest-9.0`` exclusively.
+
+    Load-bearing for the issue body's *dispatch_child not direct httpx*
+    contract -- the connector_id is what routes recursive dispatch
+    back to :class:`VmwareRestConnector` for sub-call authentication.
+    """
+    cases: tuple[tuple[Any, dict[str, Any], list[Any]], ...] = (
+        (
+            vm_create_composite,
+            {"folder_name": "f", "name": "n", "guest_os": "g"},
+            [_ok("GET:/vcenter/folder", []), _ok("POST:/vcenter/vm", {"value": ""})],
+        ),
+        (
+            vm_clone_composite,
+            {
+                "source_vm": "v",
+                "target_name": "t",
+                "library_item": "l",
+                "wait_for_completion": False,
+            },
+            [
+                _ok("GET:/vcenter/vm/{vm}", {}),
+                _ok("POST:/vcenter/vm-template/library-items", {"task": "t"}),
+            ],
+        ),
+        (
+            vm_snapshot_revert_composite,
+            {"vm": "v", "snapshot_name": "n"},
+            [_ok("GET:/vcenter/vm/{vm}/snapshot", [])],
+        ),
+        (
+            vm_migrate_composite,
+            {"vm": "v", "cluster": "c", "target_host": "h"},
+            [_ok("POST:/vcenter/vm/{vm}", {})],
+        ),
+        (
+            vm_power_bulk_composite,
+            {"action": "start"},
+            [_ok("GET:/vcenter/vm", [])],
+        ),
+        (
+            host_evacuate_composite,
+            {"host": "h"},
+            [_ok("GET:/vcenter/vm", []), _ok("PATCH:/vcenter/host/{host}/maintenance", {})],
+        ),
+        (
+            host_detach_from_vds_composite,
+            {"host": "h", "dvs": "d", "fallback_network": "f"},
+            [
+                _ok("GET:/vcenter/network/distributed-portgroup", []),
+                _ok("GET:/vcenter/vm", []),
+                _ok("POST:/vcenter/network/dvs/{dvs}", {}),
+            ],
+        ),
+        (
+            cluster_patch_composite,
+            {"cluster": "c"},
+            [_ok("GET:/vcenter/cluster/{cluster}/host", [])],
+        ),
+    )
+    for handler, params, responses in cases:
+        dispatch = _RecordingDispatchChild(list(responses))
+        await handler(
+            operator=_make_operator(),
+            target=object(),
+            params=params,
+            dispatch_child=dispatch,
+        )
+        for call in dispatch.calls:
+            assert call["connector_id"] == "vmware-rest-9.0", (
+                f"{handler.__qualname__} dispatched to {call['connector_id']}"
+            )

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,0 +1,503 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Registration tests for the 8 vmware-rest write composites.
+
+Coverage matrix (G3.1-T6 / #509 acceptance criteria):
+
+* All 8 expected write ``op_id`` rows land in ``endpoint_descriptor``
+  with ``source_kind="composite"``, ``safety_level="dangerous"``,
+  ``requires_approval=True`` (T4's defaults intentionally inherited).
+* Each row's ``handler_ref`` resolves to the module-level dotted path
+  in ``composites/_write``.
+* Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster``
+  per the canary's stub-LLM taxonomy.
+* Combined with #508's 5 reads, the registrar produces **13 rows**
+  total -- the Definition-of-done line in #227's body.
+* Per-composite ``parameter_schema`` + ``response_schema`` persist
+  with the documented required keys.
+* Module-level handler shape (no closures / partials / lambdas).
+* Idempotent re-registration is a no-op on the embedding pipeline
+  (body-hash skip path).
+
+Mirrors :mod:`tests.test_connectors_vmware_rest_composites_register`
+for the per-connector contract on the write side. Substrate-level
+coverage (composite recursion guard) lives in
+:mod:`tests.test_operations_composite`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.connectors.vmware_rest.composites import (
+    cluster_patch_composite,
+    host_detach_from_vds_composite,
+    host_evacuate_composite,
+    register_vmware_composite_operations,
+    vm_clone_composite,
+    vm_create_composite,
+    vm_migrate_composite,
+    vm_power_bulk_composite,
+    vm_snapshot_revert_composite,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+# 8 write composites (T6 / #509).
+_WRITE_OP_IDS: tuple[str, ...] = (
+    "vmware.composite.vm.create",
+    "vmware.composite.vm.clone",
+    "vmware.composite.vm.snapshot.revert",
+    "vmware.composite.vm.migrate",
+    "vmware.composite.vm.power.bulk",
+    "vmware.composite.host.evacuate",
+    "vmware.composite.host.detach_from_vds",
+    "vmware.composite.cluster.patch",
+)
+
+# 5 reads (T5 / #508) -- carried over so the combined-count assertion
+# does not have to import _read constants.
+_READ_OP_IDS: tuple[str, ...] = (
+    "vmware.composite.cluster.drs_recommendations",
+    "vmware.composite.event.tail",
+    "vmware.composite.performance.summary",
+    "vmware.composite.datastore.usage",
+    "vmware.composite.network.portgroup.audit",
+)
+
+# 13 total -- the #227 G3.1 Definition-of-done line.
+_ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
+
+
+_EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
+    "vmware.composite.vm.create": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_create_composite"
+    ),
+    "vmware.composite.vm.clone": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_clone_composite"
+    ),
+    "vmware.composite.vm.snapshot.revert": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_snapshot_revert_composite"
+    ),
+    "vmware.composite.vm.migrate": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_migrate_composite"
+    ),
+    "vmware.composite.vm.power.bulk": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_power_bulk_composite"
+    ),
+    "vmware.composite.host.evacuate": (
+        "meho_backplane.connectors.vmware_rest.composites._write.host_evacuate_composite"
+    ),
+    "vmware.composite.host.detach_from_vds": (
+        "meho_backplane.connectors.vmware_rest.composites._write.host_detach_from_vds_composite"
+    ),
+    "vmware.composite.cluster.patch": (
+        "meho_backplane.connectors.vmware_rest.composites._write.cluster_patch_composite"
+    ),
+}
+
+
+_EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
+    "vmware.composite.vm.create": "vm",
+    "vmware.composite.vm.clone": "vm",
+    "vmware.composite.vm.snapshot.revert": "vm",
+    "vmware.composite.vm.migrate": "vm",
+    "vmware.composite.vm.power.bulk": "vm",
+    "vmware.composite.host.evacuate": "host",
+    "vmware.composite.host.detach_from_vds": "host",
+    "vmware.composite.cluster.patch": "cluster",
+}
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so the upsert doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# 8 write composites land alongside the 5 reads (13 total)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_vmware_composite_operations_inserts_eight_write_rows(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Running the registrar lands all 8 write op_ids in ``endpoint_descriptor``."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_WRITE_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
+
+
+@pytest.mark.asyncio
+async def test_full_registration_produces_thirteen_composite_rows(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """5 reads (#508) + 8 writes (#509) = 13 composite rows. Definition-of-done bar."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_ALL_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
+    assert len(rows) == 13
+
+
+@pytest.mark.asyncio
+async def test_every_write_composite_row_uses_dangerous_requires_approval(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each write row carries T4's defaults: dangerous + requires_approval=True.
+
+    Load-bearing: write composites should pop the approval queue on
+    every dispatch. A misconfigured read-override would silently
+    permit unauthenticated mutation; pinning the policy here means CI
+    catches a regression before lifespan-startup.
+    """
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_WRITE_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    for row in rows:
+        assert row.safety_level == "dangerous", (
+            f"{row.op_id}: expected dangerous, got {row.safety_level!r}"
+        )
+        assert row.requires_approval is True, (
+            f"{row.op_id}: expected requires_approval=True, got {row.requires_approval!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_every_write_composite_row_carries_composite_source_kind(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each row has ``source_kind="composite"`` and the expected enabled defaults."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_WRITE_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    for row in rows:
+        assert row.source_kind == "composite"
+        assert row.tenant_id is None
+        assert row.is_enabled is True
+        assert row.method is None
+        assert row.path is None
+
+
+@pytest.mark.asyncio
+async def test_write_handler_ref_round_trips_to_module_level_dotted_path(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each row's ``handler_ref`` is the canonical module-level dotted path."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_WRITE_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_op = {row.op_id: row for row in rows}
+    for op_id, expected_ref in _EXPECTED_HANDLER_REF_BY_OP.items():
+        assert by_op[op_id].handler_ref == expected_ref
+
+
+@pytest.mark.asyncio
+async def test_write_composites_land_in_vm_host_cluster_groups(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """5 vm.* in ``vm``, 2 host.* in ``host``, 1 cluster.* in ``cluster``."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        descriptor_rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_WRITE_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        group_rows = (await fresh.execute(select(OperationGroup))).scalars().all()
+    groups_by_id = {g.id: g for g in group_rows}
+    for desc in descriptor_rows:
+        assert desc.group_id is not None, f"{desc.op_id} has no group_id"
+        group = groups_by_id[desc.group_id]
+        expected_key = _EXPECTED_GROUP_KEY_BY_OP[desc.op_id]
+        assert group.group_key == expected_key, (
+            f"{desc.op_id}: expected {expected_key!r}, got {group.group_key!r}"
+        )
+        assert group.product == "vmware"
+        assert group.version == "9.0"
+        assert group.impl_id == "vmware-rest"
+
+
+@pytest.mark.asyncio
+async def test_write_composite_parameter_schemas_persist_with_required_fields(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each row's parameter_schema has the documented required keys + additionalProperties=False."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_WRITE_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_op = {row.op_id: row for row in rows}
+    # vm.create requires folder_name / name / guest_os.
+    create_schema: dict[str, Any] = dict(by_op["vmware.composite.vm.create"].parameter_schema)
+    assert set(create_schema["required"]) == {"folder_name", "name", "guest_os"}
+    # vm.clone requires source_vm / target_name / library_item.
+    clone_schema: dict[str, Any] = dict(by_op["vmware.composite.vm.clone"].parameter_schema)
+    assert set(clone_schema["required"]) == {"source_vm", "target_name", "library_item"}
+    # vm.snapshot.revert requires vm + snapshot_name.
+    revert_schema: dict[str, Any] = dict(
+        by_op["vmware.composite.vm.snapshot.revert"].parameter_schema
+    )
+    assert set(revert_schema["required"]) == {"vm", "snapshot_name"}
+    # vm.migrate requires vm + cluster (target_host is optional).
+    migrate_schema: dict[str, Any] = dict(by_op["vmware.composite.vm.migrate"].parameter_schema)
+    assert set(migrate_schema["required"]) == {"vm", "cluster"}
+    # vm.power.bulk requires action.
+    bulk_schema: dict[str, Any] = dict(by_op["vmware.composite.vm.power.bulk"].parameter_schema)
+    assert "action" in bulk_schema["required"]
+    # host.evacuate requires host.
+    evac_schema: dict[str, Any] = dict(by_op["vmware.composite.host.evacuate"].parameter_schema)
+    assert evac_schema["required"] == ["host"]
+    # host.detach_from_vds requires host + dvs + fallback_network.
+    detach_schema: dict[str, Any] = dict(
+        by_op["vmware.composite.host.detach_from_vds"].parameter_schema
+    )
+    assert set(detach_schema["required"]) == {"host", "dvs", "fallback_network"}
+    # cluster.patch requires cluster.
+    patch_schema: dict[str, Any] = dict(by_op["vmware.composite.cluster.patch"].parameter_schema)
+    assert patch_schema["required"] == ["cluster"]
+
+    # All write schemas pin additionalProperties=False.
+    for op_id in _WRITE_OP_IDS:
+        schema: dict[str, Any] = dict(by_op[op_id].parameter_schema)
+        assert schema["additionalProperties"] is False, (
+            f"{op_id}: parameter_schema missing additionalProperties:False"
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_composite_response_schemas_persist_with_status_enums(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each write composite's response_schema persists with the documented status enum.
+
+    Lesson from #524's iter-2 fix-loop -- the read composites needed
+    response_schemas added after the fact. The write composites ship
+    with response_schemas upfront. The schema's ``status`` enum drives
+    caller branch logic; if a composite's status alphabet changes, the
+    schema needs to update too, and that update should be visible in
+    code review.
+    """
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_WRITE_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_op = {row.op_id: row for row in rows}
+    # Every row has a non-empty response_schema with a status enum.
+    expected_status_values: dict[str, set[str]] = {
+        "vmware.composite.vm.create": {"created", "rolled_back"},
+        "vmware.composite.vm.clone": {"completed", "pending", "timeout"},
+        "vmware.composite.vm.snapshot.revert": {"reverted", "ambiguous", "not_found"},
+        "vmware.composite.vm.migrate": {"migrated", "no_recommendation"},
+        "vmware.composite.host.evacuate": {"evacuated", "partial", "aborted"},
+        "vmware.composite.host.detach_from_vds": {"detached", "incomplete"},
+        "vmware.composite.cluster.patch": {"completed", "stopped"},
+    }
+    for op_id, expected_values in expected_status_values.items():
+        schema: dict[str, Any] = dict(by_op[op_id].response_schema)
+        status_schema = dict(schema["properties"]["status"])
+        assert set(status_schema["enum"]) == expected_values, (
+            f"{op_id}: expected status enum {expected_values}, got {set(status_schema['enum'])}"
+        )
+    # vm.power.bulk has no top-level status; its response_schema
+    # encodes `results` + `summary` + `aborted_on_failure` instead.
+    bulk_resp: dict[str, Any] = dict(by_op["vmware.composite.vm.power.bulk"].response_schema)
+    bulk_props = dict(bulk_resp["properties"])
+    assert {"results", "summary", "aborted_on_failure"} <= set(bulk_props)
+
+
+@pytest.mark.asyncio
+async def test_write_composite_tags_include_composite_and_write(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Every write composite row carries ``composite`` + ``write`` tags."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_WRITE_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    for row in rows:
+        assert "composite" in row.tags, f"{row.op_id}: missing composite tag"
+        assert "write" in row.tags, f"{row.op_id}: missing write tag"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_vmware_composite_operations_is_idempotent_across_thirteen(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Running the registrar twice -> 13 rows total, embedding called 13x once."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    first_count = stub_embedding_service.encode_one.call_count
+    assert first_count == 13
+
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    # Body-hash skip path -> second run is a no-op for the embedding
+    # pipeline; the row count stays at 13.
+    assert stub_embedding_service.encode_one.call_count == first_count
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_ALL_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 13
+
+
+# ---------------------------------------------------------------------------
+# Module-level handler identity (no closures, partials, lambdas)
+# ---------------------------------------------------------------------------
+
+
+def test_all_write_handlers_are_module_level_coroutine_functions() -> None:
+    """Each write handler is a plain module-level ``async def``.
+
+    ``derive_handler_ref()`` rejects closures / partials / lambdas at
+    registration time; a regression wrapping a handler in
+    ``functools.partial`` would surface here before the registrar
+    even runs.
+    """
+    import inspect
+
+    for handler in (
+        vm_create_composite,
+        vm_clone_composite,
+        vm_snapshot_revert_composite,
+        vm_migrate_composite,
+        vm_power_bulk_composite,
+        host_evacuate_composite,
+        host_detach_from_vds_composite,
+        cluster_patch_composite,
+    ):
+        assert inspect.iscoroutinefunction(handler), f"{handler!r} is not a coroutine function"
+        assert "<locals>" not in handler.__qualname__
+        assert handler.__qualname__ != "<lambda>"

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -227,6 +227,9 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
             .scalars()
             .all()
         )
+    # Prove the query actually returned all 8 write rows before iterating —
+    # otherwise the loop is vacuous when the set is empty / partial.
+    assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
         assert row.safety_level == "dangerous", (
             f"{row.op_id}: expected dangerous, got {row.safety_level!r}"
@@ -253,6 +256,7 @@ async def test_every_write_composite_row_carries_composite_source_kind(
             .scalars()
             .all()
         )
+    assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
         assert row.source_kind == "composite"
         assert row.tenant_id is None
@@ -278,6 +282,7 @@ async def test_write_handler_ref_round_trips_to_module_level_dotted_path(
             .scalars()
             .all()
         )
+    assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     by_op = {row.op_id: row for row in rows}
     for op_id, expected_ref in _EXPECTED_HANDLER_REF_BY_OP.items():
         assert by_op[op_id].handler_ref == expected_ref
@@ -435,6 +440,7 @@ async def test_write_composite_tags_include_composite_and_write(
             .scalars()
             .all()
         )
+    assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
         assert "composite" in row.tags, f"{row.op_id}: missing composite tag"
         assert "write" in row.tags, f"{row.op_id}: missing write tag"

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -9,10 +9,11 @@ triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
 vSphere 8.5+ / ESXi 8.5+ targets, plus 13 hand-authored composites
-that orchestrate cross-spec workflows: 5 read composites (G3.1-T5 /
-#508) and 8 write composites (G3.1-T6 / #509). The write composites
-cover every state-mutating operator workflow named in [#214](https://github.com/evoila/meho/issues/214)
-as required for govc-wrapper retirement.
+that orchestrate cross-spec workflows: 5 read composites
+(G3.1-T5 / `#508`) and 8 write composites (G3.1-T6 / `#509`). The
+write composites cover every state-mutating operator workflow named
+in [#214](https://github.com/evoila/meho/issues/214) as required for
+govc-wrapper retirement.
 
 Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
 
@@ -195,12 +196,12 @@ parameter-schema validation all run on every sub-call.
 `host_evacuate_composite` is the first production composite that
 calls another composite via `dispatch_child`. Two-level nesting:
 
-```
-host.evacuate                           # depth 0 (top-level dispatch)
-  └─ vmware.composite.vm.migrate (× N) # depth 1 (dispatch_child of a composite)
+```text
+host.evacuate                                            # depth 0 (top-level dispatch)
+  └─ vmware.composite.vm.migrate (× N)                  # depth 1 (dispatch_child of a composite)
        ├─ GET:/vcenter/cluster/{c}/drs/recommendations  # depth 2 (typed sub-op)
-       └─ POST:/vcenter/vm/{vm}                         # depth 2 (typed sub-op)
-  └─ PATCH:/vcenter/host/{host}/maintenance             # depth 1 (typed sub-op)
+       └─ POST:/vcenter/vm/{vm}?action=relocate         # depth 2 (typed sub-op)
+  └─ PATCH:/vcenter/host/{host}/maintenance?action=enter # depth 1 (typed sub-op)
 ```
 
 `composite_depth_var` (default cap 8) handles this naturally. The

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,8 +8,11 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus the 5 hand-authored read
-composites that orchestrate cross-spec workflows (G3.1-T5 / #508).
+vSphere 8.5+ / ESXi 8.5+ targets, plus 13 hand-authored composites
+that orchestrate cross-spec workflows: 5 read composites (G3.1-T5 /
+#508) and 8 write composites (G3.1-T6 / #509). The write composites
+cover every state-mutating operator workflow named in [#214](https://github.com/evoila/meho/issues/214)
+as required for govc-wrapper retirement.
 
 Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
 
@@ -29,10 +32,27 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `safety_level="safe"` + `requires_approval=False` — read-only
   overrides of `register_composite_operation()`'s `dangerous` / `True`
   defaults.
+- **Write composites** (`composites/_write.py`) — eight module-level
+  `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
+  `vm_snapshot_revert_composite`, `vm_migrate_composite`,
+  `vm_power_bulk_composite`, `host_evacuate_composite`,
+  `host_detach_from_vds_composite`, `cluster_patch_composite`). Same
+  `DispatchChild`-Protocol contract; each orchestrates 2-N sub-ops
+  with documented status enums on the response envelope
+  (`{"status": "created" | "rolled_back" | …}`). Registered with
+  T4's defaults `safety_level="dangerous"` + `requires_approval=True`
+  so the policy gate pops the approval queue on every dispatch.
+  `host_evacuate_composite` is the first production composite that
+  dispatches another composite (`vmware.composite.vm.migrate`) via
+  `dispatch_child` — the recursion-depth contextvar (default cap 8)
+  handles the depth-2 nesting cleanly.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Calls `register_composite_operation()` once per
-  composite; idempotent on re-run via the body-hash skip path.
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 13
+  `_CompositeSpec` rows (5 read + 8 write); each row carries its
+  own `safety_level` + `requires_approval` so the policy posture is
+  implied by the spec, not by global defaults. Idempotent on re-run
+  via the body-hash skip path.
 - **`VsphereTargetLike`** (`session.py`) — runtime-checkable Protocol
   capturing the minimum target shape the connector reads: `name`,
   `host`, `port`, `secret_ref`, `auth_model`. Replaced by the concrete
@@ -70,8 +90,10 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    in main) no-ops on subsequent ingests against the same triple.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
    queued registrar -- including the composite one -- and upserts the
-   5 `vmware.composite.*` rows into `endpoint_descriptor` with
-   `source_kind="composite"`.
+   13 `vmware.composite.*` rows into `endpoint_descriptor` with
+   `source_kind="composite"` (5 reads with `safety_level="safe"` +
+   `requires_approval=False`; 8 writes with `safety_level="dangerous"`
+   + `requires_approval=True`).
 
 ### Per-target session
 
@@ -134,10 +156,10 @@ Legacy shim — synthesises a system-tenant `Operator` and calls
 construct a real `Operator` and call `dispatch()` directly; they don't
 reach this method.
 
-### Composite dispatch (read composites)
+### Composite dispatch
 
-The 5 read composites land as `source_kind="composite"` rows in
-`endpoint_descriptor`. At dispatch time:
+The 13 composites (5 reads + 8 writes) land as `source_kind="composite"`
+rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
    to the row, sees `source_kind="composite"`, builds a
@@ -145,10 +167,11 @@ The 5 read composites land as `source_kind="composite"` rows in
    `get_dispatch_child(dispatch=dispatch, parent_operator=...,
    parent_target=..., parent_audit_id=..., parent_op_id=...)`.
 2. Handler is resolved via `import_handler(descriptor.handler_ref)`
-   to one of the module-level functions in `composites/_read.py`.
+   to one of the module-level functions in `composites/_read.py` or
+   `composites/_write.py`.
 3. Dispatcher invokes
    `handler(operator=..., target=..., params=..., dispatch_child=...)`.
-4. Handler issues 1-3 `await dispatch_child(connector_id="vmware-rest-9.0",
+4. Handler issues N `await dispatch_child(connector_id="vmware-rest-9.0",
    op_id=..., params=...)` calls. Each child dispatch:
    - Inherits `parent_audit_id` via the contextvar so the child's
      audit row's `parent_audit_id` column is set automatically.
@@ -166,6 +189,51 @@ The composite handlers go through `dispatch_child` rather than
 calling `_request_json` directly so the audit-tree linkage,
 bounded-recursion guard, policy gate, broadcast publish, and
 parameter-schema validation all run on every sub-call.
+
+### Recursive composite dispatch (`host.evacuate` → `vm.migrate`)
+
+`host_evacuate_composite` is the first production composite that
+calls another composite via `dispatch_child`. Two-level nesting:
+
+```
+host.evacuate                           # depth 0 (top-level dispatch)
+  └─ vmware.composite.vm.migrate (× N) # depth 1 (dispatch_child of a composite)
+       ├─ GET:/vcenter/cluster/{c}/drs/recommendations  # depth 2 (typed sub-op)
+       └─ POST:/vcenter/vm/{vm}                         # depth 2 (typed sub-op)
+  └─ PATCH:/vcenter/host/{host}/maintenance             # depth 1 (typed sub-op)
+```
+
+`composite_depth_var` (default cap 8) handles this naturally. The
+audit log shows a 3-level tree per `host.evacuate` dispatch: one
+parent row, N `vm.migrate` child rows, each with two grandchild rows
+(DRS lookup + relocate). The substrate guard's coverage in
+`tests/test_operations_composite.py` proves the depth-cap behaviour
+holds; this connector's recursive composite is the first production
+caller.
+
+### Write-composite partial-failure conventions
+
+Write composites return a structured `{"status": ...}` envelope so
+callers can branch on `status` without parsing free-form prose. The
+status alphabets per composite (from each handler's `response_schema`
+enum) are:
+
+| Composite | Status values |
+| --- | --- |
+| `vm.create` | `created`, `rolled_back` |
+| `vm.clone` | `completed`, `pending`, `timeout` |
+| `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found` |
+| `vm.migrate` | `migrated`, `no_recommendation` |
+| `vm.power.bulk` | (per-VM `results` + aggregate `summary` + `aborted_on_failure`) |
+| `host.evacuate` | `evacuated`, `partial`, `aborted` |
+| `host.detach_from_vds` | `detached`, `incomplete` |
+| `cluster.patch` | `completed`, `stopped` |
+
+`vm.create` is the only composite that issues a compensating
+mutation (`DELETE:/vcenter/vm/{vm}`) on partial failure. The other
+write composites prefer "stop and report" semantics over silent
+rollback -- the operator decides whether to manually finish or
+revert.
 
 ## Dependencies
 
@@ -204,11 +272,25 @@ parameter-schema validation all run on every sub-call.
   header per `docs/vcenter-9.0/MANIFEST.md`. Two of the read
   composites (`event.tail`, `performance.summary`) call vi-json
   sub-ops; the other three call vCenter REST sub-ops only.
-- **Read composites shipped** — T5 (#508) ships the 5 hand-authored
-  read composites. T6 (#509) ships the 8 write composites; same
-  `register_composite_operation()` helper, default `dangerous` /
-  `True` policy gate (read composites override to `safe` / `False`
-  at the call site).
+- **All 13 composites shipped** — T5 (#508) ships the 5 read
+  composites; T6 (#509) ships the 8 write composites. The "All ~13
+  hand-authored composites land as endpoint_descriptor rows with
+  source_kind='composite'" Definition-of-done line in [#227](https://github.com/evoila/meho/issues/227)
+  is fully ticked.
+- **`vm.clone` task polling is wall-clock bounded** — the composite
+  blocks up to `timeout_seconds` (default 600s) before returning
+  `status='timeout'`. The vSphere task may still complete in the
+  background; callers should poll `GET:/cis/tasks/{task}` if
+  long-running deploys are normal. An async-task-tracking substrate
+  is v0.2.next.
+- **Per-VM rollback for `vm.power.bulk` is by design absent** — bulk
+  power operations are intentionally non-transactional. Partial-
+  failure tolerance is the documented contract; a transactional
+  bulk-power would require vSphere-side support that doesn't exist.
+- **`cluster.patch` sequential, not concurrent** — concurrent host
+  patches would overwhelm DRS by forcing every VM in the cluster to
+  vMotion at once. The composite serialises hosts and lets DRS
+  rebalance between iterations.
 
 ## References
 
@@ -216,6 +298,8 @@ parameter-schema validation all run on every sub-call.
 - Parent Task: [#498 G3.1-T1 VmwareRestConnector](https://github.com/evoila/meho/issues/498)
 - Composite-helper Task: [#504 G3.1-T4 register_composite_operation()](https://github.com/evoila/meho/issues/504)
 - Read-composite Task: [#508 G3.1-T5 vmware-rest read composites](https://github.com/evoila/meho/issues/508)
+- Write-composite Task: [#509 G3.1-T6 vmware-rest write composites](https://github.com/evoila/meho/issues/509)
+- Composite recursion substrate: [#398 G0.6-T7 composite recursion infrastructure](https://github.com/evoila/meho/issues/398)
 - G0.7 canary that ingested the rows this connector dispatches:
   [#408 G0.7-T8 vSphere canary](https://github.com/evoila/meho/issues/408)
   (closed via PR #493 on 2026-05-15).


### PR DESCRIPTION
## Summary
- Ships the 8 write-shaped `vmware.composite.*` composites from #227 §8 alongside the 5 reads from #508, completing the "13 hand-authored composites" Definition-of-done line in #227 G3.1.
- Adds `vm.create` (with `DELETE:/vcenter/vm/{vm}` rollback on partial failure), `vm.clone` (task-poll with `wait_for_completion` opt-out), `vm.snapshot.revert` (ambiguity-rejecting), `vm.migrate` (DRS or operator target), `vm.power.bulk` (per-VM tolerance + `fail_fast`), `host.evacuate` (recursive composite — first in production), `host.detach_from_vds` (NIC-migration verifies before DVS detach), `cluster.patch` (sequential per-host loop).
- Every composite ships a `parameter_schema` + `response_schema` upfront with a documented `status` enum on the response envelope (lesson from #524's iter-2 fix-loop).
- Per-composite policy posture is now on each `_CompositeSpec` row so the registrar passes `safety_level` + `requires_approval` per-row; reads stay `"safe"`/`False`, writes inherit T4's `"dangerous"`/`True` defaults.

## Recursive-composite dispatch

`host.evacuate` is the first production composite that calls another composite (`vmware.composite.vm.migrate`) via `dispatch_child`. The G0.6-T7 (#398) recursion-depth contextvar handles the 2-level nesting under the default `Settings.composite_max_depth=8` cap. The substrate test for the cap behaviour already lives in `tests/test_operations_composite.py` (depth-cap rejected before the over-depth sub-op fires).

## Test plan
- [x] `ruff check src/meho_backplane/connectors/vmware_rest/composites/ tests/test_connectors_vmware_rest_composites_write*.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/vmware_rest/composites/ --ignore-missing-imports` — Success: no issues found in 5 source files
- [x] `pytest tests/test_connectors_vmware_rest_composites_write.py` — 23 passed (per-composite happy + partial-failure tests)
- [x] `pytest tests/test_connectors_vmware_rest_composites_write_register.py` — 11 passed (8 write rows, 13 total, group keys, handler refs, schemas, idempotency)
- [x] `pytest tests/test_connectors_vmware_rest_composites_read.py tests/test_connectors_vmware_rest_composites_register.py` — 32 passed (T5 read suite still green; idempotency / encode-count updated to 13)
- [x] `pytest tests/test_operations_composite.py tests/test_operations_composite_register.py` — 22 passed (substrate recursion-depth guard from #398 verified)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (8 warnings: per-handler-size advisory, file-size advisory on pre-existing `schemas.py`)
- [x] Acceptance: 13 op_id rows persist with right `source_kind`/`safety_level`/`requires_approval`/`group_key`/`handler_ref`/`parameter_schema`/`response_schema` (verified by registration suite).

## Out of scope
- T7 (#511): CLI alias verbs for the write composites — separate Task.
- T8 (#515): vcsim CI integration + JSONFlux handle force-mode for large composite results — separate Task.
- Long-running task-tracking substrate (so `vm.clone` can stream progress out-of-band) — v0.2.next.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 8 write-capable VMware composites (create, clone, migrate, bulk power, snapshot revert, host evacuate, host detach-from-DVS, cluster patch) with per-operation safety/approval metadata; registry now exposes 13 composites total.

* **Documentation**
  * Expanded VMware connector docs to cover all 13 composites, policies, behaviors, dispatch semantics, and partial-failure status conventions.

* **Tests**
  * Added unit and e2e tests validating write handlers, registration, schemas, dispatch order, rollback semantics, and audit-tree behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-15)

Addressed review findings from `/auto-review-pr` iter-1 (commit `1123392`):

- **B1** `1123392` — sub-op_ids now embed `?action=<verb>` for every action-bearing endpoint (`relocate`, `revert`, `deploy`, `patch`, `remove_host`); operator-chosen verbs (power start/stop, maintenance enter/exit) build their op_id per-call. `action` removed from body params at every call site.
- **M1** `1123392` — `host_evacuate_composite` resolves `cluster_moid` per-VM inside the loop; missing-cluster rows respect `tolerate_partial_failure`.
- **M2** `1123392` — new `backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py` exercises `vmware.composite.host.evacuate` through production `dispatch()` (not `dispatch_child` mocks); asserts 3-level audit-tree linkage via `parent_audit_id` and `composite_depth_var` ramp.
- **m1** `1123392` — markdownlint MD019 fixed in `docs/codebase/connectors-vmware-rest.md`.
- **m2** `1123392` — added `text` language tag on the recursion-tree fenced block (also refreshed it for the new action-bearing op_ids).
- **m3** `1123392` — every row-iteration loop in the write-register suite now asserts the row set membership first (no vacuous pass on empty queries).
- **m4** `1123392` — connector-id contract test provides non-empty payloads so every composite's action-bearing sub-ops execute under the assertion.

<!-- auto-implement-issue: continue, iteration 2 -->
