### PR TITLE
docs(ci): correct RDC_DISPATCH_TOKEN scope in image.yml notify step

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -356,11 +356,19 @@ jobs:
         #
         # Auth: cross-repo dispatches need a PAT (fine-grained, single-repo
         # on claude-rdc-hetzner-dc, scoped to `metadata: read` +
-        # `actions: write`). The default GITHUB_TOKEN is scoped to this
-        # repo only and the API returns 404 if used cross-repo.
+        # `contents: write`). `contents: write` is the permission the
+        # create-a-repository-dispatch-event endpoint requires for a
+        # fine-grained token — NOT `actions: write` (that covers
+        # workflow_dispatch / re-running runs, a different endpoint). A
+        # token minted with the wrong scope authenticates fine but the
+        # dispatch POST returns 403 "Resource not accessible by personal
+        # access token" (see the May 2026 incident on this step). The
+        # default GITHUB_TOKEN is scoped to this repo only and the API
+        # returns 404 if used cross-repo.
         #
         # Failure mode: fail-loud on PAT-present but dispatch fails. A 401
-        # (revoked/wrong token) or 422 (bad payload shape) means the
+        # (revoked/expired token), 403 (token present but under-scoped —
+        # missing `contents: write`), or 422 (bad payload shape) means the
         # consumer never learns about the new image; silent swallow would
         # leave the lab on a stale revision indefinitely. No
         # `continue-on-error`.


### PR DESCRIPTION
## What

Comment-only fix to the `Notify claude-rdc-hetzner-dc (repository_dispatch)` step in `.github/workflows/image.yml`.

The step documented the fine-grained PAT behind `RDC_DISPATCH_TOKEN` as scoped to `metadata: read` + `actions: write`. That is wrong: the *create-a-repository-dispatch-event* endpoint requires **`contents: write`** for fine-grained tokens. `actions: write` covers `workflow_dispatch` / re-running runs — a different endpoint.

## Why

A token minted from the old comment authenticates fine but the dispatch POST returns `403 "Resource not accessible by personal access token"`, silently breaking the cross-repo deploy handshake to `evoila-bosnia/claude-rdc-hetzner-dc`. This actually happened (May 2026 incident on this step). The PAT has since been re-scoped to `contents: write` and the step is green again; this PR stops the stale comment from causing a repeat on the next token rotation.

## Changes

- Correct the documented scope to `metadata: read` + `contents: write`, with a note on why `actions: write` is wrong.
- Add `403` (token present but under-scoped) to the documented fail-loud cases alongside `401`/`422`.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to clarify authentication requirements and troubleshooting guidance for dispatch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->