### PR TITLE
docs(knowledge): G4.1-T6 kb migration runbook + kb architecture doc

### DIFF
--- a/docs/architecture/kb.md
+++ b/docs/architecture/kb.md
@@ -1,0 +1,123 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Knowledge base (G4.1)
+
+> Reads [CLAUDE.md](../../CLAUDE.md) postulate 5 (the agent surface is a narrow waist of meta-tools — `search_knowledge` / `add_to_knowledge` are 2 of the ~17) and postulate 7 (audit is synchronous, append-only). Sister to [operations-substrate.md](operations-substrate.md): that doc owns the dispatcher and the `endpoint_descriptor` table; this doc owns the kb layer that rides on the G0.4 `documents` retrieval substrate.
+>
+> Covers the implementation that landed under [Initiative #331 G4.1](https://github.com/evoila/meho/issues/331) (Tasks #415-#420). The operator runbook that uses this surface is [`docs/cross-repo/kb-migration.md`](../cross-repo/kb-migration.md).
+
+## What this surface does
+
+One sentence: tenant-scoped retrieval of the team's distilled vendor knowledge (Markdown kb entries — vCenter / NSX / Vault / Keycloak / k8s / Argo / Harbor / general), so a new entry reaches every operator in the tenant on ingest instead of via clone + `grep`.
+
+The kb layer does not own a storage table of its own. It is a thin, kb-shaped vocabulary (slug, snippet, `KbEntry`) over the G0.4 retrieval substrate's `documents` table, pinned to `source="kb"`. Every kb row is a `documents` row with `source="kb"` and `kind="kb-entry"`; the natural key is `(tenant_id, source, source_id)` where `source_id` is the slug. Hybrid BM25 + cosine retrieval, tenant scoping, and the body-hash re-embed short-circuit are all inherited from G0.4 (#225) — G4.1 adds the vocabulary, the four consumer surfaces, and the ingestion file-walker.
+
+This realises [decision #2](../planning/v0.2-decisions.md) (one-shot import + ≥1-month overlap; operator-driven retire).
+
+## Module shape
+
+The substrate lives in [`backend/src/meho_backplane/kb/`](../../backend/src/meho_backplane/kb/):
+
+| File | What it owns |
+|---|---|
+| [`schemas.py`](../../backend/src/meho_backplane/kb/schemas.py) | The string contract against the `documents` table — `KB_SOURCE = "kb"`, `KB_KIND_ENTRY = "kb-entry"` (changing either is a data migration). `SLUG_PATTERN` (`^[a-z](?:[a-z0-9.\-]*[a-z0-9])?$` — lowercase, starts with a letter, ends with letter/digit, **dots allowed** for version numbers like `vcenter-9.0-snapshot-revert`). `validate_slug()`, `InvalidKbSlugError`. Frozen Pydantic v2 models: `KbEntry`, `KbEntrySearchHit`, `KbIngestionResult` (four-bucket counter: inserted / updated / skipped / error). |
+| [`file_walker.py`](../../backend/src/meho_backplane/kb/file_walker.py) | `walk_kb_directory(root, errors=None) -> Iterator[KbFileRecord]`. Recursively yields one record per ingestible `*.md` file: skips hidden paths and any path matched by an optional root-level `.kb-ignore` file (one glob pattern per line, `#` comments). Slug = front-matter `slug:` override when present, else `Path.stem`; validated. Front-matter parsed via `python-frontmatter` 1.x; malformed YAML → `KbFileParseError`. `errors=None` is strict mode (first bad file aborts); a supplied list is best-effort mode (per-file failures are collected, the walk continues). |
+| [`service.py`](../../backend/src/meho_backplane/kb/service.py) | `KbService` — the single class every front-end calls. Stateless, method-scoped: each public method opens its own `AsyncSession` and commits before returning. Per-file commits during ingest are deliberate (one bad file in a 44-entry corpus must not roll back the good files). |
+| [`__init__.py`](../../backend/src/meho_backplane/kb/__init__.py) | Re-exports `KbService`, `KbEntry`, `KbEntrySearchHit`, `KbIngestionResult`. |
+
+There is no separate per-operation handler module — the issue's draft outline said "per-op handlers"; the shipped shape collapses all operations onto `KbService`'s methods, which is what every surface below calls.
+
+## The `KbService`
+
+`KbService` takes no constructor arguments. Every public method takes `tenant_id` as its first parameter — no contextvar resolution; the route / CLI / MCP layer binds the value from the operator's JWT and the tenant boundary is auditable at the call site. RBAC is **not** in the service: it assumes the caller already gated the role. Splitting RBAC out keeps the service callable from contexts with different role discipline (a future unattended reindex job).
+
+| Method | Wraps | Used by |
+|---|---|---|
+| `ingest_directory(directory, tenant_id, *, dry_run=False) -> KbIngestionResult` | `walk_kb_directory` + `index_document` (G0.4-T3) per file, with an extra `SELECT` per file to classify inserted / updated / skipped. `dry_run` classifies without writing. | `POST /api/v1/kb/ingest`, `meho kb ingest` |
+| `list_entries(tenant_id, *, filter_pattern=None, limit=100, offset=0) -> list[KbEntry]` | Direct `select(Document)` scoped to `source="kb"`, slug-sorted. `filter_pattern` is a forwarded SQL `LIKE`. Pure list, no retrieval. | `GET /api/v1/kb`, `meho kb list` |
+| `get_entry(tenant_id, slug) -> KbEntry \| None` | Natural-key `select`. Slug is **not** re-validated here (the route/CLI does it); a malformed slug just yields `None`. | `GET /api/v1/kb/{slug}`, `meho kb show`, `meho://kb/{slug}` |
+| `create_entry(tenant_id, slug, body, metadata=None) -> KbEntry` | `validate_slug` then `index_document`. Body-hash short-circuit means a same-body re-add costs only an `updated_at` bump. `metadata=None` preserves an existing row's metadata; `{}` clears it. | `POST /api/v1/kb`, `add_to_knowledge` |
+| `delete_entry(tenant_id, slug) -> bool` | Natural-key `delete`. Returns whether a row existed. | `DELETE /api/v1/kb/{slug}`, `meho kb delete` |
+| `search_entries(tenant_id, query, *, filters=None, limit=10) -> list[KbEntrySearchHit]` | `retrieve()` (G0.4-T4) with `source="kb"` pinned. Adapts `RetrievalHit` → `KbEntrySearchHit` (slug instead of source_id, a ~200-char snippet instead of full body). `filters` consumes only the `"kind"` key in v0.2; other keys are reserved. | `POST /api/v1/retrieve` (CLI search verb), `search_knowledge` |
+
+The snippet/full-body split is the load-bearing agent recipe: `search → decide on a slug → fetch the full body` without round-tripping every full body on every search.
+
+## The four surfaces
+
+All four converge on `KbService`. None is a wrapper for another — each is a transport front on the same backplane.
+
+### REST (T2 #416) — five routes under `/api/v1/kb*`
+
+[`backend/src/meho_backplane/api/v1/kb.py`](../../backend/src/meho_backplane/api/v1/kb.py):
+
+| Route | Role | Notes |
+|---|---|---|
+| `GET /api/v1/kb` | `operator` | Paginated list. Query params `filter` (SQL `LIKE`), `limit` (1-500, default 100), `offset`. Returns `{"entries": [KbEntryPreview]}` — body truncated to a 200-char preview. |
+| `GET /api/v1/kb/{slug}` | `operator` | Full entry. Absent **or cross-tenant** slug → 404 `slug_not_found` (the conflation prevents enumerating other tenants via status differential). |
+| `POST /api/v1/kb` | `tenant_admin` | Create / re-index. 201. Invalid slug → 422. |
+| `DELETE /api/v1/kb/{slug}` | `tenant_admin` | Idempotent: 204 whether the row existed or not (a 404-on-missing would let an operator probe for a slug they can't read). |
+| `POST /api/v1/kb/ingest` | `tenant_admin` | Server-side bulk ingest from a directory on the backplane host. `tarball_url` is accepted by the request schema for forward-compat but returns **501** — only `directory` is implemented in v0.2. |
+
+There is **no kb search route**. kb-scoped search rides the G0.4-T5 `POST /api/v1/retrieve` route with `source="kb"`. Every route binds `audit_op_id` (`kb.list` / `kb.show` / `kb.create` / `kb.delete` / `kb.ingest`) + `audit_op_class` (`read` / `write`) before the service call so the chassis audit middleware and the decision-#3 broadcast classifier shape the row correctly; the ingest route additionally binds the four `KbIngestionResult` counters into the audit payload — never the file contents.
+
+### MCP meta-tools (T3 #417)
+
+[`backend/src/meho_backplane/mcp/tools/knowledge.py`](../../backend/src/meho_backplane/mcp/tools/knowledge.py) — two of the ~17 agent-facing meta-tools:
+
+- **`search_knowledge(query, filters?, limit?)`** — `op_class="read"`, `operator` role. Hybrid retrieval over the tenant's kb corpus. Default limit 10, cap 50. Returns `{"hits": [...]}` with a 200-char snippet per hit.
+- **`add_to_knowledge(slug, body, metadata?)`** — `op_class="write"`, `operator` role (deliberately **not** `tenant_admin` like the REST `POST` route: the agent surface is intentionally narrow; the audit row + broadcast event provide traceability, and the stricter REST gate is for fleet-wide bulk imports the agent surface does not perform). `InvalidKbSlugError` → JSON-RPC `-32602`.
+
+The tool descriptions are load-bearing agent UX (`search_knowledge` is one of the most-called tools across every G3-G9 flow) and teach the recipe "search → pick a slug → fetch the full body via the resource".
+
+### MCP resource (T3 #417)
+
+[`backend/src/meho_backplane/mcp/resources/kb.py`](../../backend/src/meho_backplane/mcp/resources/kb.py) — `meho://kb/{slug}` (`operator` role, `mimeType: text/markdown`). The fetch-by-slug companion to `search_knowledge`: the agent calls `resources/read` with a hit's slug to get the full body. A malformed slug or a slug absent in the operator's tenant collapses to `-32602` "not found" (cross-tenant reads do not reveal the foreign tenant's existence). `resources/subscribe` is advertised `false` in v0.2.
+
+### CLI (T4 #418)
+
+[`cli/internal/cmd/kb/`](../../cli/internal/cmd/kb/) — six operator verbs. Each wraps one REST route (or, for search, the retrieve route) and renders human-readable output or `--json`. Auth piggybacks on the token `meho login` wrote.
+
+| Verb | Backend call | Role |
+|---|---|---|
+| `meho kb ingest <dir> [--dry-run] [--json]` | `POST /api/v1/kb/ingest` | `tenant_admin` |
+| `meho kb search <query> [--limit N] [--json]` | `POST /api/v1/retrieve` (`source="kb"` pinned) | `operator` |
+| `meho kb list [--filter P] [--limit N] [--offset N] [--json]` | `GET /api/v1/kb` | `operator` |
+| `meho kb show <slug> [--json]` | `GET /api/v1/kb/{slug}` | `operator` |
+| `meho kb add <slug> --body @file\|@-\|<text> [--metadata k=v,...] [--json]` | `POST /api/v1/kb` | `tenant_admin` |
+| `meho kb delete <slug> [--confirm] [--json]` | `DELETE /api/v1/kb/{slug}` | `tenant_admin` |
+
+`meho kb search` exists as an operator convenience; the agent reaches the same data via the `search_knowledge` meta-tool (CLI `list` / `show` are not MCP tools — the agent reaches `list` via a broad `search_knowledge`, and `show` is implicit once it picks a hit).
+
+## How agents use it
+
+Per CLAUDE.md postulate 5, the agent never sees vendor-specific tools. The kb flow is:
+
+1. When the agent needs an answer it doesn't already have, `search_knowledge` is one of its first calls (before asking the operator a factual question — the answer may already be captured).
+2. It picks a hit by slug, then `resources/read` on `meho://kb/{slug}` for the full body if the 200-char snippet is not enough.
+3. When the agent (or the operator working with it) learns something generalisable, it `search_knowledge` first to avoid duplicates, then `add_to_knowledge` — same-slug re-add merges in place via the body-hash short-circuit. Ephemeral session notes belong in `add_to_memory` (G5), not the kb.
+
+## Decision #2 migration shape
+
+- One-shot import: the operator points `meho kb ingest` at their cloned consumer `kb/` directory; re-running after a consumer-side `git pull` is cheap (body-hash skip re-embeds only changed entries).
+- ≥1-month overlap: the consumer repo's `kb/` stays live as the fallback; operators use `meho kb search` for daily lookups, `grep` is the override.
+- Operator-driven retire — there is **no auto-retirement**. The retire decision is operationalised by G4.3's `meho retrieval retire-checklist` (a surface-scoped 5-criterion checklist; kb is one of three surfaces it scores), backed by the G4.3 eval corpus (#440, closed) and eval runner (#441, closed — `meho retrieval eval` / `POST /api/v1/retrieve/eval`, precision@5 / MRR / coverage@5 vs the `grep` baseline). The G4.3 Initiative [#373](https://github.com/evoila/meho/issues/373) tracks the remaining operationalisation. The operator runbook [`docs/cross-repo/kb-migration.md`](../cross-repo/kb-migration.md) is the end-to-end recipe.
+
+## What's intentionally out of scope
+
+- **Per-entry version history** — v0.2.next.
+- **Tarball ingest** — the request schema accepts `tarball_url` but the route returns 501; v0.2.next.
+- **kb editing UI (web admin)** — Goal G10.2 [#339](https://github.com/evoila/meho/issues/339).
+- **Vendor docs ingestion** (the larger `docs/<product>-<version>/` shelf) — covered by the G0.6 + G0.7 operation-search surface, not the kb layer.
+- **Multilingual retrieval** — English-only per the G0.4 substrate.
+
+## References
+
+- [Initiative #331 G4.1](https://github.com/evoila/meho/issues/331) — scope + DoD. Tasks: T1 [#415](https://github.com/evoila/meho/issues/415), T2 [#416](https://github.com/evoila/meho/issues/416), T3 [#417](https://github.com/evoila/meho/issues/417), T4 [#418](https://github.com/evoila/meho/issues/418), T5 [#419](https://github.com/evoila/meho/issues/419), T6 [#420](https://github.com/evoila/meho/issues/420).
+- Substrate: [#225 G0.4 retrieval substrate](https://github.com/evoila/meho/issues/225) — `index_document` ([`retrieval/indexer.py`](../../backend/src/meho_backplane/retrieval/indexer.py)), `retrieve` ([`retrieval/retriever.py`](../../backend/src/meho_backplane/retrieval/retriever.py)).
+- [decision #2](../planning/v0.2-decisions.md) — one-shot import + 1-month overlap.
+- Downstream: [#373 G4.3](https://github.com/evoila/meho/issues/373) — retrieval migration tooling (eval + `meho retrieval retire-checklist`).
+- Canary acceptance: [`backend/tests/acceptance/test_g41_kb_canary.py`](../../backend/tests/acceptance/test_g41_kb_canary.py) (T5 #419).
+- [docs/architecture/connectors.md](connectors.md), [docs/architecture/mcp.md](mcp.md), [docs/architecture/audit.md](audit.md).

--- a/docs/cross-repo/README.md
+++ b/docs/cross-repo/README.md
@@ -65,6 +65,7 @@ implementation to track separately:
 | [`broadcast-onboarding.md`](./broadcast-onboarding.md) | How to subscribe to the per-tenant Valkey broadcast stream from `meho status --watch`, an MCP client, or a custom downstream subscriber. |
 | [`connector-ingestion.md`](./connector-ingestion.md) | How to add a new vendor surface to MEHO via the G0.7 spec-ingestion pipeline — `meho connector ingest/review/edit/enable/disable`. Companion architecture: [`docs/architecture/spec-ingestion.md`](../architecture/spec-ingestion.md). |
 | [`g07-vsphere-canary.md`](./g07-vsphere-canary.md) | The worked-example canary procedure: ingest the vCenter REST spec, drive the operator workflow, run the 10-query govc-parity benchmark. |
+| [`kb-migration.md`](./kb-migration.md) | How to migrate the consumer's `kb/` knowledge corpus into MEHO via the G4.1 surface — `meho kb ingest/search/list/show/add/delete`, the ≥1-month overlap, the G4.3 eval, and the operator-driven retire decision. Companion architecture: [`docs/architecture/kb.md`](../architecture/kb.md). |
 | [`mcp-client-setup.md`](./mcp-client-setup.md) | How to wire an MCP client (Claude.ai Custom Connector, MCP Inspector, Cline, Continue) to a running MEHO backplane, plus the Keycloak realm-side audience configuration. |
 
 ## Related

--- a/docs/cross-repo/kb-migration.md
+++ b/docs/cross-repo/kb-migration.md
@@ -1,0 +1,141 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Migrating the consumer's `kb/` to MEHO — operator runbook
+
+> Operator-facing runbook for the G4.1 knowledge-base surface. Architecture sits in [`docs/architecture/kb.md`](../architecture/kb.md); this doc is the cookbook the operator follows to point MEHO at the consumer's `kb/`, verify ingestion, run the ≥1-month overlap, and retire the in-repo copy. Implements [decision #2](../planning/v0.2-decisions.md): "one-shot import + 1-month overlap; retire when daily use shifts."
+
+## Why this matters
+
+- The consumer's [`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc) repo carries a `kb/` directory — the team's distilled vendor knowledge (vCenter / NSX / Vault / Keycloak / k8s / Argo / Harbor / general; ~44 entries at the time of writing, and growing).
+- Today every operator's Claude session relies on the repo being cloned and `grep kb/`. New knowledge reaches the team only via PR review + clone. **Two operators landing the same kb entry independently is a real failure mode.**
+- Per [decision #2](../planning/v0.2-decisions.md): MEHO ingests the corpus once; the repo `kb/` stays live as the fallback for ≥1 month; the in-repo copy retires only when `meho kb search` is in daily use and the team agrees. There is no auto-retirement — the retire decision is an explicit operator call backed by the G4.3 eval.
+
+The entry count is a moving target — the canary acceptance test asserts the body-hash idempotency property, not a fixed cardinality. Treat "44" below as "however many `*.md` files the consumer's `kb/` currently holds".
+
+## Prerequisites
+
+- **Roles.** `meho kb ingest` / `add` / `delete` require `tenant_admin`. `meho kb search` / `list` / `show` are `operator`-level. `read_only` callers get HTTP 403 (CLI exit code 5). Tenant scoping is enforced server-side from the JWT — no surface accepts a tenant id.
+- **A running backplane.** `meho login <backplane-url>` writes a session token the CLI reuses across every verb. Override per-call with `--backplane <url>`.
+- **A local checkout of the consumer repo.** `meho kb ingest <dir>` is a server-side bulk import: the path is interpreted on the **backplane host's** filesystem. Run it where the backplane can see the directory (the operator's deploy host with the consumer repo checked out, or a CI runner). The architecture doc's [REST section](../architecture/kb.md#rest-t2-416--five-routes-under-apiv1kb) explains the `tenant_admin` gate.
+
+## Step-by-step ingestion
+
+### 1. Clone the consumer repo
+
+```bash
+git clone git@github.com:evoila-bosnia/claude-rdc-hetzner-dc.git
+cd claude-rdc-hetzner-dc
+```
+
+### 2. Dry-run first
+
+`--dry-run` walks the directory and classifies every file (insert / update / skip) **without writing**. Use it to confirm the path resolves and the corpus shape looks right before a real run:
+
+```bash
+meho kb ingest ./kb --dry-run --json
+```
+
+Expected on a never-ingested corpus: `inserted_count == <file count>`, `updated_count == 0`, `skipped_count == 0`, `error_count == 0`. The four counters always partition every discovered `*.md` file: `inserted + updated + skipped + error == total`.
+
+### 3. Ingest for real
+
+```bash
+meho kb ingest ./kb --json
+```
+
+Expected: a `KbIngestionResult` with `inserted_count == <file count>` on the first real run. Any per-file failure (binary file masquerading as `.md`, malformed front-matter, invalid slug) is counted in `error_count` and described in `errors[]` — the run continues; one bad file does not abort the corpus.
+
+Slug derivation: the slug is the filename stem (`vcenter-9.0-snapshot-revert.md` → slug `vcenter-9.0-snapshot-revert`) unless the file's YAML front-matter carries a `slug:` override. The consumer's kb has no front-matter today; the override is future-compat. Slugs must match `^[a-z](?:[a-z0-9.\-]*[a-z0-9])?$` — lowercase, start with a letter, end with a letter or digit, with hyphens and **dots** allowed (dots carry the version numbers, e.g. `vcenter-9.0-...`). A filename that does not produce a valid slug surfaces as a per-file error rather than aborting the run.
+
+To skip drafts or scratch files, drop a `.kb-ignore` file at the kb root — one glob pattern per line, `#` for comments. A bare directory name (`drafts`) skips everything beneath it.
+
+### 4. Verify ingestion
+
+```bash
+meho kb list                       # all entries, slug-sorted, 200-char preview each
+meho kb search "vsphere snapshot"  # ranked hits via hybrid BM25 + cosine
+meho kb show vcenter-9.0-snapshot-revert   # full Markdown body of one entry
+```
+
+`meho kb list` should return the ingested count. `meho kb search` returns ranked hits (slug + ~200-char snippet + fused score); `--json` exposes the per-signal BM25 / cosine scores and ranks for retrieval tuning. `meho kb show <slug>` returns the full body. Note the recipe: **search → identify slug → `show` (or, for agents, the `meho://kb/{slug}` resource) for the full body** — the snippet is deliberately truncated so a search response stays small.
+
+### 5. Re-ingest after consumer-side updates
+
+```bash
+git -C claude-rdc-hetzner-dc pull
+meho kb ingest ./claude-rdc-hetzner-dc/kb --json
+```
+
+Idempotent. The body-hash short-circuit from the G0.4 substrate means an unchanged corpus produces `skipped_count == <total>` and zero embedding compute; a single edited entry produces `updated_count == 1, skipped_count == <total - 1>`. Re-run as often as the consumer's `kb/` changes — it is cheap.
+
+## During the ≥1-month overlap
+
+- The consumer repo's `kb/` **stays live as the fallback.** Do not delete it yet.
+- Operators use `meho kb search` for daily lookups; `grep kb/` is the override when search misses.
+- Re-ingest on a cadence that tracks the consumer's `kb/` churn (a cron or a post-`git pull` hook on the deploy host). The cost is bounded by the number of *changed* entries, not corpus size.
+- Measure whether the migration is succeeding with the G4.3 eval (already shipped — see "Measuring the overlap" below). The retire decision is data-driven, not a calendar event.
+
+## Measuring the overlap
+
+The eval tooling is already on `main` (G4.3-T1 [#440](https://github.com/evoila/meho/issues/440) corpus + G4.3-T2 [#441](https://github.com/evoila/meho/issues/441) runner). The remaining operationalisation is tracked by G4.3 Initiative [#373](https://github.com/evoila/meho/issues/373).
+
+```bash
+meho retrieval eval --json    # precision@5 / MRR / coverage@5 vs the grep baseline
+```
+
+This runs the seeded 10-query kb eval corpus through MEHO's hybrid retrieval and against a `grep` baseline, and reports precision@5, MRR, and coverage@5. The Initiative #373 green defaults are MRR ≥ 0.50 and coverage@5 ≥ 0.90 (the canary test [`backend/tests/acceptance/test_g41_kb_canary.py`](../../backend/tests/acceptance/test_g41_kb_canary.py) gates on these). Decision #2's acceptance — 10 sampled queries return answers equivalent to `grep kb/` — is exactly what this eval measures; treat a sustained green eval over the overlap window as the quantitative half of the retire decision.
+
+## Retiring the in-repo copy
+
+The retire decision is **operator-driven** and surface-scoped. Run the checklist verb (note: it is `meho retrieval retire-checklist`, not a `kb`-specific verb — one checklist scores all three retrieval surfaces; kb is one of them):
+
+```bash
+meho retrieval retire-checklist --json
+```
+
+It combines the eval results with the open-blocker count (GitHub issues labelled `retrieval-migration-blocker`) into a per-surface GREEN / YELLOW / RED verdict over five criteria. When the **kb** surface is GREEN on all five and the team agrees daily use has shifted:
+
+1. Open a PR in `evoila-bosnia/claude-rdc-hetzner-dc` removing `kb/`.
+2. Update the consumer's `CLAUDE.md` to drop "grep `kb/`" patterns in favour of "use `meho kb search`".
+3. Keep the deleted directory recoverable from git history (a tag or the merge commit SHA is enough — see Rollback).
+
+Do not retire on a calendar alone. A GREEN checklist over a sustained window is the contract; the 1-month overlap is the *minimum*, not the trigger.
+
+## Rollback
+
+If a retrieval-quality regression surfaces after retiring the in-repo copy:
+
+1. Restore the deleted directory from git history in the consumer repo:
+   ```bash
+   git -C claude-rdc-hetzner-dc checkout <pre-retire-sha> -- kb/
+   ```
+   (`<pre-retire-sha>` is the commit immediately before the retire PR merged — the parent of the deletion commit.)
+2. Open an issue in the consumer repo labelled `retrieval-migration-blocker` so the next `meho retrieval retire-checklist` run flips the kb surface off GREEN until the regression is resolved.
+3. Re-investigate via `meho retrieval eval --json`: did precision@5 / MRR / coverage@5 drop? Is a specific query class failing? Re-ingest with `meho kb ingest ./kb --json` after the consumer-side `kb/` is restored, then re-measure.
+
+Retiring is reversible by design — the corpus is in git on the consumer side and re-ingest is idempotent and cheap.
+
+## Writing new kb entries through MEHO
+
+Once daily use is established, new knowledge is written through MEHO directly (no PR review cycle — the entry reaches every operator in the tenant on write):
+
+- **Agent path.** `add_to_knowledge {"slug": "...", "body": "...", "metadata": {...}}`. The agent must `search_knowledge` for the topic **first** — re-adding under a different slug fragments the corpus and dilutes retrieval. A same-slug re-add merges in place via the body-hash short-circuit. `add_to_knowledge` is `operator`-role on the agent surface (deliberately narrower than the REST `tenant_admin` gate — the audit row + broadcast event provide traceability).
+- **Operator CLI.** `tenant_admin` only:
+  ```bash
+  meho kb add my-product-9.0-topic --body @./entry.md --metadata source=runbook,owner=ops
+  ```
+  `--body` accepts inline text, `@<path>` for a file, or `@-` for stdin. Slugs are validated against the same pattern as ingestion.
+- **Delete.** `meho kb delete <slug>` (`tenant_admin`). Idempotent — deleting an already-absent slug still returns success (204), so scripts are safe to re-run. `--confirm` skips the interactive prompt for scripted use.
+
+Ephemeral session notes do **not** belong in the kb — those go in `add_to_memory` (G5). The kb is durable, team-wide knowledge.
+
+## Related
+
+- [`docs/architecture/kb.md`](../architecture/kb.md) — the architecture companion: module shape, `KbService` method map, the four surfaces, RBAC matrix.
+- [Initiative #331 G4.1](https://github.com/evoila/meho/issues/331) — scope + definition of done.
+- [decision #2](../planning/v0.2-decisions.md) — one-shot import + 1-month overlap.
+- [Initiative #373 G4.3](https://github.com/evoila/meho/issues/373) — retrieval migration tooling (eval + retire-checklist) that operationalises the retire decision.
+- [`docs/cross-repo/README.md`](./README.md) — the index of cross-repo coordination specs and operator runbooks this doc is listed in.

--- a/docs/cross-repo/kb-migration.md
+++ b/docs/cross-repo/kb-migration.md
@@ -65,8 +65,8 @@ meho kb show vcenter-9.0-snapshot-revert   # full Markdown body of one entry
 ### 5. Re-ingest after consumer-side updates
 
 ```bash
-git -C claude-rdc-hetzner-dc pull
-meho kb ingest ./claude-rdc-hetzner-dc/kb --json
+git pull
+meho kb ingest ./kb --json
 ```
 
 Idempotent. The body-hash short-circuit from the G0.4 substrate means an unchanged corpus produces `skipped_count == <total>` and zero embedding compute; a single edited entry produces `updated_count == 1, skipped_count == <total - 1>`. Re-run as often as the consumer's `kb/` changes — it is cheap.
@@ -108,9 +108,9 @@ Do not retire on a calendar alone. A GREEN checklist over a sustained window is 
 
 If a retrieval-quality regression surfaces after retiring the in-repo copy:
 
-1. Restore the deleted directory from git history in the consumer repo:
+1. From the consumer repo checkout (the same `claude-rdc-hetzner-dc` working directory established in step 1), restore the deleted directory from git history:
    ```bash
-   git -C claude-rdc-hetzner-dc checkout <pre-retire-sha> -- kb/
+   git checkout <pre-retire-sha> -- kb/
    ```
    (`<pre-retire-sha>` is the commit immediately before the retire PR merged — the parent of the deletion commit.)
 2. Open an issue in the consumer repo labelled `retrieval-migration-blocker` so the next `meho retrieval retire-checklist` run flips the kb surface off GREEN until the regression is resolved.


### PR DESCRIPTION
## Summary

- Ship `docs/cross-repo/kb-migration.md` — the canonical operator runbook for migrating the consumer's `kb/` corpus into MEHO (dry-run-first ingestion, verification, the ≥1-month overlap, the data-driven retire decision, rollback).
- Ship `docs/architecture/kb.md` — the architecture explainer following the established architecture+runbook convention (sister to `audit.md`): module shape, the single `KbService` method map, the four surfaces with the real RBAC matrix, the decision-#2 migration shape.
- List `kb-migration.md` in the `docs/cross-repo/README.md` operator-runbooks table.

Both docs were written against the **actually shipped** G4.1-T1..T5 code, not the issue-body outline. Corrected drift:

- The shipped retire verb is `meho retrieval retire-checklist` (surface-scoped — kb is one of three retrieval surfaces), **not** a `meho kb retire-checklist`.
- The G4.3 eval corpus (#440) and eval runner (#441) already landed, so the runbook points at `meho retrieval eval --json` as the live overlap-measurement path rather than describing it as future work.
- `meho kb search` rides `POST /api/v1/retrieve` with `source="kb"` — there is no kb search route; documented as such.
- Module path is `backend/src/meho_backplane/kb/` (not `meho_app/`); a single `KbService` class, not "per-op handlers". Every named symbol/route/verb/role in the architecture doc was verified against source.

## Test plan

- [x] Pre-commit hygiene gates (trailing-whitespace, end-of-file, merge-conflict, gitleaks, mixed-line-ending, conventional-commit) — all Passed on the three changed files.
- [x] No markdownlint configured in repo — confirmed; no CI markdown gate to satisfy.
- [x] Every relative link target in both new docs verified to exist (the `../../CLAUDE.md` reference matches the existing convention in sibling `docs/architecture/audit.md` — gitignored symlink materialised by `scripts/meho-init`).
- [x] `docs/architecture/kb.md`: every named function (`ingest_directory`, `list_entries`, `get_entry`, `create_entry`, `delete_entry`, `search_entries`, `walk_kb_directory`, `validate_slug`), route, MCP tool/resource, and CLI verb maps to a real symbol in the shipped T1-T5 code.
- [x] `docs/cross-repo/kb-migration.md`: ingestion / verify / overlap / retire / rollback procedure cross-checked against the real CLI flags (`--dry-run`, `--json`, `--filter`, `--body @file`, `--confirm`) and the real `meho retrieval retire-checklist` / `meho retrieval eval` verbs.

## Out of scope

- The eval tooling itself — G4.3 #373 (already shipped via #440/#441; this doc references it).
- The "cross-link from CLAUDE.md" acceptance line — intentionally deferred: CLAUDE.md is managed out-of-band and must not be edited from a code PR (the issue body itself scopes it as "or follow-up").
- A backlink from `docs/architecture/connectors.md` — skipped deliberately: connectors.md is the vendor-connector surface, not the knowledge layer; a kb backlink there would be a non-sequitur. The kb doc cross-links *to* connectors.md/mcp.md/audit.md as siblings.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #420


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture guidance for the Knowledge Base layer, describing its role, consumer surfaces, authentication expectations, ingest/search flows, and acceptance/testing notes.
  * Added an operator runbook for migrating existing knowledge corpora into the system, including prerequisites, dry-run/ingest steps, verification, overlap measurement, and retirement/rollback procedures.
  * Updated cross-repo runbook index to include the migration entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-16)

Addressed review finding from [pr-532-iter-1 REQUEST_CHANGES](https://github.com/evoila/meho/pull/532):

- **B1** `2c85337` — step 5 re-ingest now uses `git pull` / `meho kb ingest ./kb --json` (was `git -C claude-rdc-hetzner-dc pull` / `./claude-rdc-hetzner-dc/kb`), consistent with the `cd claude-rdc-hetzner-dc` cwd model established in step 1 and used by steps 2-4. Same defect class also fixed in the adjacent Rollback step 1 (`git -C claude-rdc-hetzner-dc checkout` → `git checkout` from the consumer checkout), which was internally inconsistent with the same section's later `./kb` re-ingest.

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 1 -->
