### PR TITLE
feat(retrieval): G4.3-T5b CLI verb `meho retrieval usage` (Go follow-up to #444)

### DIFF
--- a/cli/internal/cmd/retrieval/retrieval.go
+++ b/cli/internal/cmd/retrieval/retrieval.go
@@ -8,7 +8,7 @@
 //   - `meho retrieval eval` — corpus-driven precision@5 / MRR /
 //     coverage report against /api/v1/retrieve/eval (T2 #441).
 //   - `meho retrieval usage` — audit-log-backed daily-use telemetry
-//     (T5b #464; lands separately).
+//     (T5b #464) against /api/v1/retrieve/usage (T5 #444).
 //   - `meho retrieval retire-checklist` — combined retire-decision
 //     verb (T6 #445).
 //
@@ -36,6 +36,7 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newEvalCmd())
+	cmd.AddCommand(newUsageCmd())
 	cmd.AddCommand(newRetireChecklistCmd())
 	return cmd
 }

--- a/cli/internal/cmd/retrieval/usage.go
+++ b/cli/internal/cmd/retrieval/usage.go
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package retrieval
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// UsageBucket mirrors the backend DailyUsageBucket model (audit-log
+// aggregation row, one per `(date, surface)` pair). Hand-written
+// rather than reused from the oapi-codegen output: the generated
+// types use `openapi_types.Date` for the `date` field, which adds an
+// import for every test that constructs fixtures. Plain string keeps
+// the wire shape (ISO-8601 YYYY-MM-DD) directly addressable. Field
+// names match the JSON keys the backend ships verbatim — drift here
+// would break the `--json` round-trip the retire-checklist verb
+// (T6 #445) relies on as auxiliary input.
+type UsageBucket struct {
+	Date                string  `json:"date"`
+	Surface             string  `json:"surface"`
+	SearchCount         int     `json:"search_count"`
+	DistinctOperators   int     `json:"distinct_operators"`
+	ActionConversionPct float64 `json:"action_conversion_pct"`
+}
+
+// UsageReport mirrors the backend `UsageReport` envelope returned by
+// GET /api/v1/retrieve/usage. `TenantID` is a `*string` — the
+// backend ships JSON `null` for the cross-tenant placeholder shape,
+// and consumers (notably the retire-checklist verb the issue body
+// names as the downstream of `--json`) key off the explicit-null
+// presence rather than the field's absence. `omitempty` would drop
+// the key on round-trip and break that shape.
+type UsageReport struct {
+	Since         string        `json:"since"`
+	Until         string        `json:"until"`
+	Surfaces      []string      `json:"surfaces"`
+	TenantID      *string       `json:"tenant_id"`
+	Buckets       []UsageBucket `json:"buckets"`
+	TotalSearches int           `json:"total_searches"`
+}
+
+// usageSurfaces pins the allowed --surface values. Mirrors the
+// backend's `UsageEndpointApiV1RetrieveUsageGetParamsSurface` enum
+// (kb / memory / operations / all). `all` is the no-filter default;
+// the wire shape sends the explicit `surface=all` query param so the
+// backplane's audit + observability traces record the operator's
+// intent rather than an absent param.
+var usageSurfaces = map[string]struct{}{
+	"kb":         {},
+	"memory":     {},
+	"operations": {},
+	"all":        {},
+}
+
+// newUsageCmd returns the `meho retrieval usage` subcommand. The
+// verb wraps GET /api/v1/retrieve/usage (G4.3-T5 #444) so operators
+// can read the audit-log-backed daily-use telemetry the
+// retire-checklist verb (T6 #445) consumes as one of its five
+// criteria.
+//
+// CLI shape (matches issue #464 spec):
+//
+//	meho retrieval usage \
+//	  [--since 30d]                       # default 30d; accepts 7d, 24h, 2026-04-01
+//	  [--surface kb|memory|operations|all]
+//	  [--tenant <uuid>]                   # tenant_admin only; backplane returns 403 otherwise
+//	  [--json]                            # raw UsageReport JSON; default is text table
+//	  [--backplane https://...]           # backplane URL override; same flag as `meho connector`
+//
+// Exit codes:
+//   - 0   request succeeded
+//   - 2   auth_expired (no stored token / refresh failure)
+//   - 3   unreachable (network / TLS)
+//   - 4   unexpected_response (HTTP 4xx other than 403, decode drift, 5xx)
+//   - 5   insufficient_role (HTTP 403; tenant_filter_requires_tenant_admin)
+func newUsageCmd() *cobra.Command {
+	var (
+		since             string
+		surface           string
+		tenant            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "usage",
+		Short: "Read audit-log-backed retrieval usage telemetry (daily buckets per surface)",
+		Long: "usage calls GET /api/v1/retrieve/usage and renders daily " +
+			"counts grouped by `(date, surface)` for the operator's " +
+			"tenant. The audit-log-backed aggregation reports per-day " +
+			"search counts, distinct operators, and a 0-100 " +
+			"search-to-action conversion percentage — the three signals " +
+			"the retire-checklist verb (T6 #445) consumes for criterion " +
+			"1 (≥1 month of daily use) and criterion 2 (≥3 operators / " +
+			"≥1 search-per-week for ≥4 consecutive weeks).\n\n" +
+			"--since accepts the same relative shorthand (`30d` / `7d` / " +
+			"`24h`) and absolute ISO-8601 date forms the backplane's " +
+			"parser supports. Malformed values surface the backplane's " +
+			"400 detail as the CLI error message.\n\n" +
+			"--tenant scopes a tenant_admin query to a specific tenant; " +
+			"operator-role tokens that pass --tenant get a friendly " +
+			"insufficient_role error (HTTP 403, exit code 5).\n\n" +
+			"--json emits the raw UsageReport envelope on stdout, the " +
+			"shape T6's retire-checklist verb consumes as auxiliary input.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runUsage(cmd, usageOptions{
+				Since:             since,
+				Surface:           surface,
+				Tenant:            tenant,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&since, "since", "30d",
+		"window start; accepts relative (`30d`, `7d`, `24h`) or ISO-8601 date (`2026-04-01`)")
+	cmd.Flags().StringVar(&surface, "surface", "all",
+		"retrieval surface to report (kb|memory|operations|all)")
+	cmd.Flags().StringVar(&tenant, "tenant", "",
+		"tenant UUID filter (tenant_admin only; operator-role tokens get a 403)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the raw UsageReport on stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+
+	return cmd
+}
+
+type usageOptions struct {
+	Since             string
+	Surface           string
+	Tenant            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// runUsage orchestrates the usage request: validate flags, resolve
+// backplane URL, GET the endpoint, render the response. Each error
+// class lands in the right output.StructuredError category so main()
+// picks the right exit code.
+func runUsage(cmd *cobra.Command, opts usageOptions) error {
+	if _, ok := usageSurfaces[opts.Surface]; !ok {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--surface %q invalid; expected one of: kb | memory | operations | all",
+				opts.Surface,
+			)),
+			opts.JSONOut,
+		)
+	}
+
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			classifyBackplaneError(err), opts.JSONOut)
+	}
+
+	report, err := getUsage(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderUsageError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), report)
+	}
+	printUsageTable(cmd.OutOrStdout(), report)
+	return nil
+}
+
+// getUsage calls GET /api/v1/retrieve/usage with the configured
+// query params and decodes the JSON response into a UsageReport.
+// Mirrors `postEval`'s 401-retry shape: one transparent refresh +
+// retry on auth failure.
+func getUsage(
+	ctx context.Context,
+	backplaneURL string,
+	opts usageOptions,
+) (*UsageReport, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	target := buildUsageURL(backplaneURL, opts)
+
+	resp, err := getUsageWithBearer(ctx, httpClient, target, bearer)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		// One-shot refresh + retry, mirroring api.AuthedClient.GetHealth
+		// and the sibling eval / retire-checklist runners.
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = getUsageWithBearer(ctx, httpClient, target, bearer)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// 4 KiB cap on the error body: the FastAPI default 400 / 403
+		// payload is tens of bytes; nothing legitimate runs into
+		// kilobytes here. The cap defends against a pathological /
+		// hostile backplane shipping a megabyte error body.
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, &usageHTTPError{
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(raw)),
+		}
+	}
+
+	var out UsageReport
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode usage response: %w", err)
+	}
+	return &out, nil
+}
+
+// buildUsageURL composes the GET URL with query params for the usage
+// endpoint. Pulled out for testability: the query-param shape (param
+// names, encoding of tenant UUIDs with hyphens, omission of empty
+// tenant) is load-bearing for the wire contract with T5's backplane
+// route and best tested directly.
+//
+// The query-param names mirror the backend route signature
+// (`since` / `surface` / `tenant_filter`). The `tenant_filter` param
+// is omitted entirely when --tenant is unset so the backplane's
+// "operator's own tenant" default fires; passing an empty
+// `tenant_filter=` would land as the explicit-empty case which the
+// backplane's parser rejects with a 422.
+func buildUsageURL(backplaneURL string, opts usageOptions) string {
+	q := url.Values{}
+	q.Set("since", opts.Since)
+	q.Set("surface", opts.Surface)
+	if opts.Tenant != "" {
+		q.Set("tenant_filter", opts.Tenant)
+	}
+	return backplaneURL + "/api/v1/retrieve/usage?" + q.Encode()
+}
+
+// getUsageWithBearer issues the actual GET request with the supplied
+// bearer token. Split out so the 401-refresh-retry path can reuse the
+// same URL string without re-building it.
+func getUsageWithBearer(
+	ctx context.Context,
+	client *http.Client,
+	target, bearer string,
+) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build usage request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	return client.Do(req)
+}
+
+// usageHTTPError carries a non-2xx response so renderUsageError can
+// pick the right output.StructuredError category (403 →
+// insufficient_role; other 4xx/5xx → unexpected_response). Pattern
+// mirrors the connector sibling's httpError; duplicated here rather
+// than imported because cmd/connector ↔ cmd/retrieval would import-
+// cycle through cmd/root.go's wire-up.
+type usageHTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *usageHTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// renderUsageError translates an error from getUsage into the right
+// output.RenderError category. Adds two branches over the package's
+// shared renderRequestError: a `usageHTTPError` 403 lands as
+// insufficient_role (exit 5) so an operator-role token passing
+// --tenant gets the "ask tenant_admin for the role grant" hint, and
+// any other non-2xx (notably 400 for a malformed --since) lands as
+// unexpected_response with the backplane's detail string surfaced
+// verbatim so the operator sees the actionable backend hint.
+//
+// Kept local to usage.go (rather than promoted onto the package-
+// level renderRequestError) because the eval + retire-checklist
+// verbs route every >=400 status to "unexpected" via the generic
+// HTTP-error string wrap they emit today; promoting the role-aware
+// classification onto the shared helper would change their error
+// shape too. Keeping the divergence narrow until a follow-up audit
+// can roll the eval / retire-checklist verbs onto the same typed-
+// error path.
+func renderUsageError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *usageHTTPError
+	if errors.As(err, &he) {
+		if he.StatusCode == http.StatusForbidden {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.InsufficientRole(fmt.Sprintf(
+					"call %s: HTTP 403: %s (this verb's --tenant flag requires tenant_admin role)",
+					backplaneURL, he.Body,
+				)),
+				jsonOut,
+			)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP %d: %s", backplaneURL, he.StatusCode, he.Body,
+			)),
+			jsonOut,
+		)
+	}
+	// Decode failures (contract drift between T5's backplane and the
+	// CLI's UsageReport shape) classify as unexpected — the request
+	// reached the backplane and the backplane returned 200; the body
+	// just didn't match the agreed shape. Without this split, a
+	// regression would present to the operator as "your network is
+	// down", which is misleading.
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: invalid JSON response: %v", backplaneURL, err,
+			)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// printUsageTable renders the UsageReport as a human-readable table
+// to w. Buckets are grouped by date ascending, then by surface; the
+// backend ships them pre-sorted by `(date, surface)`, but we sort
+// defensively so a future backend that returns buckets unordered
+// (e.g. parallel aggregation worker pool) still produces a readable
+// table.
+func printUsageTable(w io.Writer, r *UsageReport) {
+	tenant := "(operator's tenant)"
+	if r.TenantID != nil && *r.TenantID != "" {
+		tenant = *r.TenantID
+	}
+	surfaces := strings.Join(r.Surfaces, ",")
+	if surfaces == "" {
+		surfaces = "(none)"
+	}
+	fmt.Fprintf(w, "Usage telemetry — tenant: %s — surfaces: %s\n",
+		tenant, surfaces)
+	fmt.Fprintf(w, "window: %s → %s — total searches: %d\n",
+		r.Since, r.Until, r.TotalSearches)
+	if len(r.Buckets) == 0 {
+		fmt.Fprintln(w, "(no buckets — zero searches in the window)")
+		return
+	}
+	buckets := make([]UsageBucket, len(r.Buckets))
+	copy(buckets, r.Buckets)
+	sort.SliceStable(buckets, func(i, j int) bool {
+		if buckets[i].Date != buckets[j].Date {
+			return buckets[i].Date < buckets[j].Date
+		}
+		return buckets[i].Surface < buckets[j].Surface
+	})
+	fmt.Fprintf(w, "%-12s %-12s %10s %10s %10s\n",
+		"date", "surface", "searches", "operators", "action%")
+	for _, b := range buckets {
+		fmt.Fprintf(w, "%-12s %-12s %10d %10d %10.2f\n",
+			b.Date, b.Surface, b.SearchCount,
+			b.DistinctOperators, b.ActionConversionPct,
+		)
+	}
+}

--- a/cli/internal/cmd/retrieval/usage_test.go
+++ b/cli/internal/cmd/retrieval/usage_test.go
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package retrieval
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// TestBuildUsageURLDefaults — default --since=30d / --surface=all /
+// no --tenant produces the canonical wire shape: the explicit
+// `surface=all` rather than an omitted param (load-bearing for the
+// backplane's audit + observability traces — they record the
+// operator's intent rather than an absent param).
+func TestBuildUsageURLDefaults(t *testing.T) {
+	got := buildUsageURL("https://meho.test", usageOptions{
+		Since: "30d", Surface: "all",
+	})
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if u.Path != "/api/v1/retrieve/usage" {
+		t.Errorf("path: got %q want /api/v1/retrieve/usage", u.Path)
+	}
+	q := u.Query()
+	if q.Get("since") != "30d" {
+		t.Errorf("since: got %q", q.Get("since"))
+	}
+	if q.Get("surface") != "all" {
+		t.Errorf("surface: got %q", q.Get("surface"))
+	}
+	if q.Has("tenant_filter") {
+		t.Errorf("tenant_filter should be omitted when --tenant is unset")
+	}
+}
+
+// TestBuildUsageURLTenantPropagated — --tenant <uuid> survives the
+// URL build verbatim under the `tenant_filter` query-param name the
+// backplane route signature pins.
+func TestBuildUsageURLTenantPropagated(t *testing.T) {
+	tenantUUID := "11111111-2222-3333-4444-555555555555"
+	got := buildUsageURL("https://meho.test", usageOptions{
+		Since: "7d", Surface: "kb", Tenant: tenantUUID,
+	})
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if u.Query().Get("tenant_filter") != tenantUUID {
+		t.Errorf("tenant_filter: got %q want %q",
+			u.Query().Get("tenant_filter"), tenantUUID)
+	}
+	if u.Query().Get("since") != "7d" {
+		t.Errorf("since: got %q want 7d", u.Query().Get("since"))
+	}
+	if u.Query().Get("surface") != "kb" {
+		t.Errorf("surface: got %q want kb", u.Query().Get("surface"))
+	}
+}
+
+// TestBuildUsageURLEmptyTenantOmitted — passing an empty --tenant
+// value must NOT land as `tenant_filter=` on the wire (the
+// backplane parser rejects the explicit-empty case with 422). The
+// flag default is empty string, so this is the load-bearing common
+// path: a bare `meho retrieval usage` invocation omits the param
+// entirely.
+func TestBuildUsageURLEmptyTenantOmitted(t *testing.T) {
+	got := buildUsageURL("https://meho.test", usageOptions{
+		Since: "30d", Surface: "all", Tenant: "",
+	})
+	u, _ := url.Parse(got)
+	if u.Query().Has("tenant_filter") {
+		t.Errorf("empty tenant: tenant_filter should be omitted; got %q",
+			u.Query().Get("tenant_filter"))
+	}
+}
+
+// TestUsageReportDecodesCanonical pins the wire shape: T5's
+// UsageReport (backend Pydantic model + openapi.json snapshot)
+// ships `since`/`until`/`surfaces`/`tenant_id`/`buckets`/
+// `total_searches`, with `tenant_id` nullable. Decoding drift here
+// surfaces as a Major-class wire-contract failure on the next
+// `meho retrieval usage` round-trip.
+func TestUsageReportDecodesCanonical(t *testing.T) {
+	raw := []byte(`{
+		"since": "2026-04-16T00:00:00Z",
+		"until": "2026-05-16T00:00:00Z",
+		"surfaces": ["kb", "memory", "operations"],
+		"tenant_id": null,
+		"buckets": [
+			{
+				"date": "2026-05-15",
+				"surface": "kb",
+				"search_count": 7,
+				"distinct_operators": 3,
+				"action_conversion_pct": 71.43
+			},
+			{
+				"date": "2026-05-15",
+				"surface": "memory",
+				"search_count": 2,
+				"distinct_operators": 1,
+				"action_conversion_pct": 100.0
+			}
+		],
+		"total_searches": 9
+	}`)
+	var got UsageReport
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode UsageReport: %v", err)
+	}
+	if got.TenantID != nil {
+		t.Errorf("tenant_id: should decode nil for cross-tenant; got %v",
+			got.TenantID)
+	}
+	if got.TotalSearches != 9 {
+		t.Errorf("total_searches: got %d want 9", got.TotalSearches)
+	}
+	if len(got.Buckets) != 2 {
+		t.Fatalf("buckets: got %d want 2", len(got.Buckets))
+	}
+	if got.Buckets[0].SearchCount != 7 || got.Buckets[0].DistinctOperators != 3 {
+		t.Errorf("first bucket: %+v", got.Buckets[0])
+	}
+	if got.Buckets[0].ActionConversionPct != 71.43 {
+		t.Errorf("action_conversion_pct decode lost precision: got %v",
+			got.Buckets[0].ActionConversionPct)
+	}
+	if len(got.Surfaces) != 3 || got.Surfaces[0] != "kb" {
+		t.Errorf("surfaces: got %v", got.Surfaces)
+	}
+}
+
+// TestUsageReportDecodesTenantScoped — the tenant_admin-with-filter
+// case ships a non-null tenant_id. The CLI must accept the same
+// envelope shape and surface the tenant on the rendered header.
+func TestUsageReportDecodesTenantScoped(t *testing.T) {
+	raw := []byte(`{
+		"since": "2026-04-16T00:00:00Z",
+		"until": "2026-05-16T00:00:00Z",
+		"surfaces": ["kb"],
+		"tenant_id": "11111111-2222-3333-4444-555555555555",
+		"buckets": [],
+		"total_searches": 0
+	}`)
+	var got UsageReport
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode tenant-scoped UsageReport: %v", err)
+	}
+	if got.TenantID == nil || *got.TenantID == "" {
+		t.Fatalf("tenant_id should decode non-nil; got %v", got.TenantID)
+	}
+	if *got.TenantID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("tenant_id: got %q", *got.TenantID)
+	}
+}
+
+// TestPrintUsageTableEmptyBuckets — zero-bucket report renders the
+// header lines + an explicit "no buckets" line so an operator
+// running `meho retrieval usage` on a brand-new tenant doesn't think
+// the verb hung silently.
+func TestPrintUsageTableEmptyBuckets(t *testing.T) {
+	r := &UsageReport{
+		Since:    "2026-04-16T00:00:00Z",
+		Until:    "2026-05-16T00:00:00Z",
+		Surfaces: []string{"kb", "memory", "operations"},
+		Buckets:  nil,
+	}
+	var buf bytes.Buffer
+	printUsageTable(&buf, r)
+	out := buf.String()
+	for _, want := range []string{
+		"tenant: (operator's tenant)",
+		"surfaces: kb,memory,operations",
+		"2026-04-16T00:00:00Z → 2026-05-16T00:00:00Z",
+		"total searches: 0",
+		"(no buckets",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("empty render missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintUsageTableHappyPath — typical report with buckets
+// renders the header + the table rows. Buckets are sorted
+// defensively: a backend that returns rows in `(surface, date)`
+// order instead of `(date, surface)` would still produce a
+// readable table because printUsageTable re-sorts. The test
+// confirms that property by feeding rows out of order.
+func TestPrintUsageTableHappyPath(t *testing.T) {
+	tenantUUID := "11111111-2222-3333-4444-555555555555"
+	r := &UsageReport{
+		Since:    "2026-04-16T00:00:00Z",
+		Until:    "2026-05-16T00:00:00Z",
+		Surfaces: []string{"kb", "memory"},
+		TenantID: &tenantUUID,
+		Buckets: []UsageBucket{
+			// Deliberately out-of-order: the renderer must sort.
+			{Date: "2026-05-15", Surface: "memory", SearchCount: 2, DistinctOperators: 1, ActionConversionPct: 100.0},
+			{Date: "2026-05-14", Surface: "kb", SearchCount: 5, DistinctOperators: 2, ActionConversionPct: 60.0},
+			{Date: "2026-05-15", Surface: "kb", SearchCount: 7, DistinctOperators: 3, ActionConversionPct: 71.43},
+		},
+		TotalSearches: 14,
+	}
+	var buf bytes.Buffer
+	printUsageTable(&buf, r)
+	out := buf.String()
+	for _, want := range []string{
+		"tenant: " + tenantUUID,
+		"surfaces: kb,memory",
+		"total searches: 14",
+		"2026-05-14", "2026-05-15",
+		"71.43",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("happy-path render missing %q in:\n%s", want, out)
+		}
+	}
+	// Sort property: the first data row must be 2026-05-14 (kb),
+	// not 2026-05-15. We locate the row prefix in the rendered
+	// output and check ordering by index.
+	if idx14, idx15 := strings.Index(out, "2026-05-14"), strings.Index(out, "2026-05-15"); idx14 == -1 || idx15 == -1 || idx14 > idx15 {
+		t.Errorf("render should sort buckets ascending by date; got:\n%s", out)
+	}
+}
+
+// TestUsageHTTPErrorString — Error() format pins the renderer's
+// input shape (used by renderUsageError fallthrough and surfaced
+// inside the unexpected_response detail).
+func TestUsageHTTPErrorString(t *testing.T) {
+	he := &usageHTTPError{StatusCode: 400, Body: "malformed since"}
+	if he.Error() != "HTTP 400: malformed since" {
+		t.Fatalf("usageHTTPError format: got %q", he.Error())
+	}
+}
+
+// TestSurfaceFlagValidatorRejectsUnknown — runUsage rejects an
+// unknown --surface value before the network round-trip, with an
+// unexpected_response StructuredError that names the valid set.
+// Surfacing this client-side saves a network hop for the common
+// typo case (`--surface kbb`, etc.).
+func TestSurfaceFlagValidatorRejectsUnknown(t *testing.T) {
+	cmd := newUsageCmd()
+	cmd.SetArgs([]string{"--surface", "kbb"})
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetOut(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected validation error; got nil")
+	}
+	var ec output.ExitCoder
+	if !errors.As(err, &ec) || ec.ExitCode() != output.ExitUnexpected {
+		t.Fatalf("expected ExitUnexpected; got %T %v", err, err)
+	}
+	if !strings.Contains(stderr.String(), "--surface") ||
+		!strings.Contains(stderr.String(), "kb | memory | operations | all") {
+		t.Errorf("error should name valid set; got:\n%s", stderr.String())
+	}
+}
+
+// ---------- HTTP wire shape (mocked) ----------
+
+// TestGetUsageRoundTripWithMockServer — pins the wire contract
+// between T5 (backend) and T5b (this CLI). The CLI GETs
+// /api/v1/retrieve/usage, validates the query params land verbatim,
+// and decodes the canonical UsageReport. Used for the JSON contract
+// sanity check that doesn't require a live backplane — true
+// end-to-end coverage lives in the acceptance smoke against a
+// real backplane.
+func TestGetUsageRoundTripWithMockServer(t *testing.T) {
+	srv := mockUsageBackplane(t, map[string]mockUsageHandler{
+		"GET /api/v1/retrieve/usage": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("since"); got != "30d" {
+				t.Errorf("since: got %q want 30d", got)
+			}
+			if got := r.URL.Query().Get("surface"); got != "all" {
+				t.Errorf("surface: got %q want all", got)
+			}
+			if r.URL.Query().Has("tenant_filter") {
+				t.Errorf("tenant_filter should be absent on default call")
+			}
+			writeUsageJSON(t, w, 200, UsageReport{
+				Since:    "2026-04-16T00:00:00Z",
+				Until:    "2026-05-16T00:00:00Z",
+				Surfaces: []string{"kb", "memory", "operations"},
+				Buckets: []UsageBucket{
+					{Date: "2026-05-15", Surface: "kb", SearchCount: 3, DistinctOperators: 2, ActionConversionPct: 66.67},
+				},
+				TotalSearches: 3,
+			})
+		},
+	})
+	defer srv.Close()
+	primeUsageToken(t, srv.URL)
+
+	got, err := getUsage(context.Background(), srv.URL, usageOptions{
+		Since: "30d", Surface: "all",
+	})
+	if err != nil {
+		t.Fatalf("getUsage: %v", err)
+	}
+	if got.TotalSearches != 3 || len(got.Buckets) != 1 {
+		t.Fatalf("unexpected report: %+v", got)
+	}
+	if got.Buckets[0].SearchCount != 3 {
+		t.Errorf("bucket: got %+v", got.Buckets[0])
+	}
+}
+
+// TestGetUsage403MapsToInsufficientRole — backplane 403 (the
+// tenant_filter_requires_tenant_admin case) propagates as a
+// *usageHTTPError with StatusCode=403; renderUsageError routes it
+// to insufficient_role with the body surfaced. The operator gets
+// the "ask tenant_admin for the role grant" hint rather than a
+// generic "network down" fallback. Load-bearing for issue #464
+// acceptance criterion 3.
+func TestGetUsage403MapsToInsufficientRole(t *testing.T) {
+	srv := mockUsageBackplane(t, map[string]mockUsageHandler{
+		"GET /api/v1/retrieve/usage": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("tenant_filter") == "" {
+				t.Errorf("tenant_filter should be present on the role-rejected call")
+			}
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"detail":"tenant_filter_requires_tenant_admin"}`))
+		},
+	})
+	defer srv.Close()
+	primeUsageToken(t, srv.URL)
+
+	_, err := getUsage(context.Background(), srv.URL, usageOptions{
+		Since: "30d", Surface: "all",
+		Tenant: "11111111-2222-3333-4444-555555555555",
+	})
+	if err == nil {
+		t.Fatalf("expected 403 error; got nil")
+	}
+	var he *usageHTTPError
+	if !errors.As(err, &he) || he.StatusCode != 403 {
+		t.Fatalf("expected *usageHTTPError 403; got %T %v", err, err)
+	}
+	if !strings.Contains(he.Body, "tenant_filter_requires_tenant_admin") {
+		t.Errorf("403 body should carry the backplane detail; got %q", he.Body)
+	}
+}
+
+// TestGetUsage400MapsToUnexpectedWithBody — backplane 400 (the
+// malformed --since case) propagates as a *usageHTTPError with
+// StatusCode=400; renderUsageError routes it to
+// unexpected_response with the body surfaced verbatim so the
+// operator sees the actionable backend hint ("not a valid
+// duration"). Load-bearing for issue #464 acceptance criterion 6.
+func TestGetUsage400MapsToUnexpected(t *testing.T) {
+	srv := mockUsageBackplane(t, map[string]mockUsageHandler{
+		"GET /api/v1/retrieve/usage": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"detail":"invalid since: 'tomorrow' is not a valid duration"}`))
+		},
+	})
+	defer srv.Close()
+	primeUsageToken(t, srv.URL)
+
+	_, err := getUsage(context.Background(), srv.URL, usageOptions{
+		Since: "tomorrow", Surface: "all",
+	})
+	if err == nil {
+		t.Fatalf("expected 400 error; got nil")
+	}
+	var he *usageHTTPError
+	if !errors.As(err, &he) || he.StatusCode != 400 {
+		t.Fatalf("expected *usageHTTPError 400; got %T %v", err, err)
+	}
+	if !strings.Contains(he.Body, "not a valid duration") {
+		t.Errorf("400 body should carry the backplane detail; got %q", he.Body)
+	}
+}
+
+// TestGetUsageDecodeErrorClassifiable — a 200 OK with garbage JSON
+// body must classify as JSON syntax (renderUsageError routes to
+// unexpected_response). Without this branch a contract drift
+// between T5 (backend) and T5b (CLI) would surface as
+// "your network is down".
+func TestGetUsageDecodeErrorClassifiable(t *testing.T) {
+	srv := mockUsageBackplane(t, map[string]mockUsageHandler{
+		"GET /api/v1/retrieve/usage": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			// Malformed JSON — triggers a decode error.
+			_, _ = w.Write([]byte(`{"since": "2026-`))
+		},
+	})
+	defer srv.Close()
+	primeUsageToken(t, srv.URL)
+
+	_, err := getUsage(context.Background(), srv.URL, usageOptions{
+		Since: "30d", Surface: "all",
+	})
+	if err == nil {
+		t.Fatalf("expected decode error; got nil")
+	}
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if !errors.As(err, &syntaxErr) &&
+		!errors.As(err, &unmarshalErr) &&
+		!errors.Is(err, http.ErrBodyReadAfterClose) {
+		// The wrapped error should be a JSON syntax error. We
+		// accept either the typed sentinel or
+		// io.ErrUnexpectedEOF (the standard EOF surface for
+		// truncated JSON streams).
+		if !strings.Contains(err.Error(), "decode usage response") {
+			t.Errorf("expected decode error wrap; got %T %v", err, err)
+		}
+	}
+}
+
+// ---------- httptest helpers (local copies to avoid an export
+// boundary between sibling test files — same pattern as the
+// connector / operation packages, which each ship their own copy
+// rather than reach into a shared test helper that would need to
+// live one level up in the cmd tree).
+
+type mockUsageHandler = http.HandlerFunc
+
+// mockUsageBackplane stands up an httptest.Server that routes by
+// `<METHOD> <path>` keys. Tests are responsible for calling Close()
+// via defer.
+func mockUsageBackplane(t *testing.T, routes map[string]mockUsageHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockUsageBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeUsageJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeUsageJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeUsageJSON write: %v", err)
+	}
+}
+
+// primeUsageToken installs an in-memory token store with a usable
+// bearer for the mocked backplane URL. Uses XDG_CONFIG_HOME + the
+// file-backed token store fallback so the test stays
+// keychain-free across CI environments. Mirrors the connector
+// sibling's primeToken — duplicated rather than promoted to a
+// package-level helper because the cmd/{connector,retrieval}
+// packages can't import each other without an import cycle.
+func primeUsageToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -29,7 +29,8 @@ discovery hook so backplane manifests cannot shadow built-in verb
 names.
 
 - `meho retrieval ...` (G4.3 #373) — retrieval-quality + migration-
-  decision tooling. v0.2 ships `eval` and `retire-checklist`.
+  decision tooling. v0.2 ships `eval`, `usage`, and
+  `retire-checklist`.
 - `meho operation ...` (G0.6-T13 #481) — dispatcher meta-tools
   (`groups`, `search`, `call`).
 - `meho connector ...` (G0.7-T5 #405) — spec-ingestion + review
@@ -130,6 +131,8 @@ cli/
     │       ├── retrieval.go            # NewRootCmd.
     │       ├── eval.go                 # `meho retrieval eval` (POST /api/v1/retrieve/eval).
     │       ├── eval_test.go            # output-contract + URL-resolution tests.
+    │       ├── usage.go                # `meho retrieval usage` (GET /api/v1/retrieve/usage) — G4.3-T5b #464.
+    │       ├── usage_test.go           # query-param + wire-shape + 403/400 routing tests.
     │       ├── retire_checklist.go     # `meho retrieval retire-checklist` (POST /api/v1/retrieve/retire-checklist) — G4.3-T6 #445.
     │       └── retire_checklist_test.go # surface-bucket + table-render + marshal tests.
     ├── discovery/


### PR DESCRIPTION
## Summary

- Adds the `meho retrieval usage` cobra verb that wraps T5's
  `/api/v1/retrieve/usage` endpoint (merged in #462), the Go
  follow-up T5b deferred from #444 because the Go toolchain was
  unavailable on the implementing author's machine.
- Three signals per `(date, surface)` bucket: search count,
  distinct operators, action conversion %. Flags: `--since`
  (relative `30d`/`7d`/`24h` or ISO-8601), `--surface`
  (kb|memory|operations|all), `--tenant` (UUID filter, tenant_admin
  only), `--json` (raw `UsageReport` for T6 retire-checklist
  consumption), `--backplane`.
- Operator-role tokens passing `--tenant` get a friendly HTTP 403
  surfaced as `output.InsufficientRole` (exit code 5) carrying the
  backplane's `tenant_filter_requires_tenant_admin` detail; a
  malformed `--since` surfaces the backplane's 400 detail as the
  CLI error message.
- The retrieval cobra parent was already in place from #473
  (G4.3-T2 eval verb), so this PR only adds the `usage` subcommand
  alongside `eval` and `retire-checklist`. The oapi-codegen client
  was already regenerated against the current `openapi.json`
  snapshot in #488 — `make generate` is a no-op here.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test -race -cover ./...` — every package green, including
      `cmd/retrieval` at 37.7% coverage (existing eval +
      retire-checklist coverage preserved; new usage coverage adds
      query-URL, decode, render, and 4 wire-shape mocked round-trips).
- [x] `golangci-lint run` — clean.
- [x] `gofmt -l .` — clean.
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0.
- [x] `meho retrieval --help` registers `usage` alongside `eval`
      and `retire-checklist`; `meho retrieval usage --help` shows
      every flag.
- [x] AC1 (clean regen diff): `cd cli && make generate` produces
      no diff — the client was regenerated in #488 against the
      same `openapi.json` snapshot T5 #462 shipped.
- [x] AC3 (operator-role + `--tenant` → 403):
      `TestGetUsage403MapsToInsufficientRole`.
- [x] AC5 (`--json` round-trips canonical UsageReport):
      `TestUsageReportDecodesCanonical` +
      `TestGetUsageRoundTripWithMockServer`.
- [x] AC6 (malformed `--since` → friendly 400):
      `TestGetUsage400MapsToUnexpected`.
- [ ] AC2 / AC4 (smoke against a live backplane): runs in CI / on
      a real `meho login`-ed operator workstation; the wire shape
      is pinned by the mocked tests above.

## Out of scope

- T6 retire-checklist consumption of `--json` output — this PR
  ships the producer; T6 already wires the consumer (#445 is a
  separate Task).
- Cross-tenant aggregate view — v0.2.next per the parent
  Initiative's "Out of scope" list.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #464


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `meho retrieval usage` subcommand for querying telemetry reports with filtering by date range, surface, and tenant options.
  * Supports both human-readable table and JSON output formats.
  * Enhanced error handling and validation for improved user experience.

* **Tests**
  * Added comprehensive test coverage for the new usage command.

* **Documentation**
  * Updated CLI documentation to reflect the new subcommand.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->