### PR TITLE
feat(retrieval): G4.3-T4 memory eval corpus YAML — 10 queries across 5 scope shapes

### DIFF
--- a/backend/src/meho_backplane/retrieval/eval/corpus.py
+++ b/backend/src/meho_backplane/retrieval/eval/corpus.py
@@ -30,10 +30,10 @@ where a bare ``yes`` or unquoted slug becomes a ``bool``.
 from __future__ import annotations
 
 from importlib import resources
-from typing import Literal, overload
+from typing import Annotated, Any, Literal, overload
 
 import yaml
-from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
+from pydantic import BaseModel, BeforeValidator, ConfigDict, TypeAdapter, ValidationError
 
 __all__ = [
     "CorpusValidationError",
@@ -81,6 +81,36 @@ class KbCorpusQuery(BaseModel):
     notes: str | None = None
 
 
+def _coerce_scope_slug_pair(value: Any) -> Any:
+    """Convert a 2-element YAML sequence to a ``(scope, slug)`` tuple.
+
+    YAML has no native tuple type — ``yaml.safe_load`` always produces
+    ``list`` for sequence values — but the :class:`MemoryCorpusQuery`
+    schema is strict-mode and declares ``expected_hits`` as
+    ``list[tuple[str, str]]``. Strict Pydantic v2 rejects
+    ``list`` → ``tuple`` coercion, so a YAML row like
+    ``["user", "kubectl-preferences"]`` fails validation despite being
+    the wire shape the task body specifies.
+
+    This ``BeforeValidator`` runs ahead of the tuple-type check and
+    converts only the exact shape we accept (2-element sequence of
+    strings) to a tuple. Any other shape — wrong length, non-string
+    member, plain string, dict — falls through unchanged so the
+    downstream tuple validator surfaces the original error message
+    naming the offending field path.
+    """
+    if isinstance(value, list) and len(value) == 2:
+        return tuple(value)
+    return value
+
+
+#: Type alias for one ``(scope, slug)`` expected-hit pair. The
+#: :func:`_coerce_scope_slug_pair` ``BeforeValidator`` runs first, so
+#: YAML-native ``[scope, slug]`` sequences are accepted as well as
+#: Python-native ``(scope, slug)`` tuples from direct construction.
+_ScopeSlugPair = Annotated[tuple[str, str], BeforeValidator(_coerce_scope_slug_pair)]
+
+
 class MemoryCorpusQuery(BaseModel):
     """One ground-truth eval row for the ``memory`` retrieval surface.
 
@@ -88,13 +118,15 @@ class MemoryCorpusQuery(BaseModel):
     expected hit is a ``(scope, slug)`` pair because the same slug can
     legitimately exist under different scopes (``user`` vs
     ``user-tenant`` vs ``tenant`` etc.) and the eval cares which one
-    surfaced. The corpus YAML lands in T4 (#443).
+    surfaced. The corpus YAML ships in T4 (#443); the pair is exposed
+    on the Python side as a ``tuple`` so callers can use it as a dict
+    key without intermediate normalisation.
     """
 
     model_config = _CORPUS_MODEL_CONFIG
 
     query: str
-    expected_hits: list[tuple[str, str]]
+    expected_hits: list[_ScopeSlugPair]
     notes: str | None = None
 
 

--- a/backend/src/meho_backplane/retrieval/eval/memory_queries.yaml
+++ b/backend/src/meho_backplane/retrieval/eval/memory_queries.yaml
@@ -1,0 +1,154 @@
+# MEHO retrieval eval — Memory seed corpus (G4.3-T4, #443).
+#
+# 10 queries covering the 5 memory scope shapes proportionally
+# (~2 per scope: user / user-tenant / user-target / tenant / target).
+# Memory entries are operator notes the consumer-agent would have
+# written via `remember_*` MCP tools over a normal RDC operator
+# workflow; queries are the phrasings an operator (or the agent on
+# their behalf) would type to `search_memory` to find them again.
+# Per-entry `notes` records the originating context — keep when
+# editing so human review on regression has the why.
+#
+# Schema: meho_backplane.retrieval.eval.corpus.MemoryCorpusQuery.
+# Each expected hit is a `(scope, slug)` pair — same slug can
+# legitimately exist under different scopes (e.g. `<operator>` may
+# have user-target notes about `rdc-vcenter` while the tenant has
+# target-scope notes about the same target).
+#
+# Editing rules:
+# * `scope` must be one of the 5 values from
+#   `meho_backplane.memory.schemas.MemoryScope`: user, user-tenant,
+#   user-target, tenant, target. The schema-validation test
+#   (`test_memory_corpus_scopes_are_valid_enum_members`) guards
+#   typos against the live enum at HEAD.
+# * `slug` must match `meho_backplane.memory.schemas.SLUG_PATTERN`
+#   (`^[A-Za-z0-9_\-\.]+$`) — same alphabet the service accepts at
+#   write boundaries. The matching test
+#   (`test_memory_corpus_slugs_match_slug_pattern`) guards drift
+#   against the live regex.
+# * Order matters: first pair is the ideal top-1 (drives MRR scoring
+#   in T2), subsequent pairs are acceptable top-N (drives precision
+#   credit in T2).
+# * Scope mix: each of the 5 scopes appears at least twice across
+#   the 10 queries so a regression in any one scope's RBAC filter or
+#   ranking surfaces because at least one query targets it. The
+#   `test_memory_corpus_covers_all_five_scopes` test enforces this
+#   structurally.
+# * Slugs are illustrative ground truth — when G5.1's memory module
+#   ships its eval seeding (T2 #441 integration fixtures), the
+#   fixtures must populate these exact `(scope, slug)` pairs so
+#   precision@5 and MRR are meaningful. The corpus pins the contract;
+#   the fixtures fulfil it.
+
+# --- user-scope queries (2) ---
+
+- query: what kubectl flags do I prefer
+  expected_hits:
+    - ["user", "kubectl-preferences"]
+  notes: >-
+    user-scope basic personal-preference recall. The operator wrote
+    `remember_user --slug kubectl-preferences` capturing their `-o yaml`
+    + `--context` defaults; the recall flows through `search_memory`
+    filtered to user-scope only. Single ground-truth pair — no broader
+    fallback because tenant-wide kubectl conventions live separately
+    (see `kubectl-team-conventions` below).
+
+- query: my preferred yq query patterns for vCenter specs
+  expected_hits:
+    - ["user", "yq-vcenter-spec-patterns"]
+  notes: >-
+    user-scope personal-tooling recall — operator-authored cheat-sheet
+    of `yq` filters they hit while spelunking the vCenter OpenAPI
+    spec pre-G0.7. Single ground-truth pair because the patterns are
+    idiosyncratic to how this operator structures their searches.
+
+# --- user-tenant queries (2) ---
+
+- query: my notes on the rdc-internal tenant runbook quirks
+  expected_hits:
+    - ["user-tenant", "rdc-internal-runbook-quirks"]
+    - ["tenant", "rdc-internal-runbook"]
+  notes: >-
+    user-tenant scope — the operator's private overlay on the shared
+    tenant runbook (which steps they always forget, who they Slack
+    when a step fails). The tenant-wide runbook is the acceptable
+    fallback when the operator hasn't written their own overlay yet;
+    surfaces "the team has the answer even if I don't".
+
+- query: how I structure my Slack standup for rdc-internal
+  expected_hits:
+    - ["user-tenant", "standup-template-rdc-internal"]
+  notes: >-
+    user-tenant scope — operator's personal standup template scoped to
+    one tenant (different tenants have different reporting cadences).
+    Single ground-truth pair; no tenant-wide fallback because the
+    standup format is per-operator by team convention.
+
+# --- user-target queries (2) ---
+
+- query: VPN steps I use for rdc-vcenter
+  expected_hits:
+    - ["user-target", "rdc-vcenter-vpn-steps"]
+    - ["target", "rdc-vcenter-vpn-setup"]
+  notes: >-
+    user-target first — the operator's private VPN steps (their
+    1Password item refs, their preferred client). Target-scope is the
+    acceptable fallback (the team-wide VPN setup runbook from when
+    the target was first onboarded); surfaces when the operator
+    hasn't yet captured their own overlay on the team-wide procedure.
+
+- query: gotchas I hit deploying to holodeck-lab
+  expected_hits:
+    - ["user-target", "holodeck-lab-personal-gotchas"]
+    - ["target", "holodeck-lab-known-issues"]
+  notes: >-
+    user-target scope — the "I personally hit this once and lost an
+    hour" notes the operator captures over time. Target-scope
+    `holodeck-lab-known-issues` is the acceptable fallback because
+    the personal gotchas are an overlay on the team-wide
+    known-issues list.
+
+# --- tenant queries (2) ---
+
+- query: rdc-internal tenant naming convention for K8s namespaces
+  expected_hits:
+    - ["tenant", "k8s-namespace-naming"]
+  notes: >-
+    tenant scope — shared convention every operator on rdc-internal
+    follows. Single ground-truth pair because the convention is the
+    canonical answer; an operator's user-scope override would be a
+    bug (deviating from team convention silently).
+
+- query: kubectl conventions our team uses
+  expected_hits:
+    - ["tenant", "kubectl-team-conventions"]
+    - ["user", "kubectl-preferences"]
+  notes: >-
+    tenant scope first — the team-wide `kubectl` style guide (alias
+    discipline, context-switching pattern). User-scope
+    `kubectl-preferences` is the acceptable adjacent because it's
+    the operator's personal layer on the same surface; both are
+    legitimate recalls for "kubectl conventions".
+
+# --- target queries (2) ---
+
+- query: VPN setup for rdc-vcenter
+  expected_hits:
+    - ["target", "rdc-vcenter-vpn-setup"]
+    - ["user-target", "rdc-vcenter-vpn-steps"]
+  notes: >-
+    target scope first — the team-wide VPN-onboarding runbook for the
+    rdc-vcenter target (captured when the target was first
+    onboarded). User-target is the acceptable fallback / adjacent:
+    when the operator has their own overlay, the eval still credits
+    surfacing the broader team runbook.
+
+- query: known issues with holodeck-lab
+  expected_hits:
+    - ["target", "holodeck-lab-known-issues"]
+    - ["target", "holodeck-lab-overview"]
+  notes: >-
+    target scope — the team-wide known-issues + overview for the
+    holodeck-lab target. Two target-scope pairs because both are
+    legitimate top-N hits for "known issues" (the overview links to
+    the issues list).

--- a/backend/src/meho_backplane/retrieval/eval/runner.py
+++ b/backend/src/meho_backplane/retrieval/eval/runner.py
@@ -18,13 +18,15 @@ The same dispatch path drives all three retrieval surfaces — the
 per-surface differences (slug vs ``(scope, slug)`` vs
 ``(connector_id, op_id)`` ground truth) are absorbed by per-surface
 ``_eval_<surface>`` private dispatchers that produce a uniform
-``QueryResult`` shape. Surfaces whose corpus YAML hasn't shipped yet
-(memory in T4 #443, operations in T3 #442) return an empty
-``SurfaceResult`` with ``verdict="green"`` + ``query_count=0`` —
-the "no data" green is intentional: an absent corpus must not flip
-the CI gate red. The retire-checklist verb (T6 #445) is responsible
-for asserting that an evaluable corpus actually shipped before
-trusting the green.
+``QueryResult`` shape. A surface whose corpus YAML hasn't shipped
+yet returns an empty ``SurfaceResult`` with ``verdict="green"`` +
+``query_count=0`` — the "no data" green is intentional: an absent
+corpus must not flip the CI gate red. The retire-checklist verb
+(T6 #445) is responsible for asserting that an evaluable corpus
+actually shipped before trusting the green. The kb (T1 #440),
+operations (T3 #442) and memory (T4 #443) corpora are all shipped
+as of 2026-05; the "absent corpus" branch persists only as a guard
+against an accidentally-deleted YAML.
 
 Baseline integration
 --------------------
@@ -378,7 +380,7 @@ async def _eval_memory(
     thresholds: Thresholds,
     k: int,
 ) -> SurfaceResult:
-    """Eval the memory surface — empty corpus until T4 #443 ships."""
+    """Eval the memory surface against the shipped memory corpus (T4 #443)."""
     rows = load_corpus("memory")
     queries = [
         await _eval_query(

--- a/backend/tests/test_retrieval_eval_corpus.py
+++ b/backend/tests/test_retrieval_eval_corpus.py
@@ -129,11 +129,19 @@ def test_load_corpus_kb_returns_ten_typed_rows() -> None:
         assert row.expected_hits, f"empty expected_hits: {row.query}"
 
 
-def test_load_corpus_memory_returns_empty_in_t1() -> None:
-    """Acceptance #4: memory corpus YAML doesn't ship in T1; returns ``[]``."""
+def test_load_corpus_memory_now_ships_after_t4() -> None:
+    """T4 #443 shipped ``memory_queries.yaml``; ``load_corpus("memory")`` is non-empty.
+
+    The deeper assertions (10 rows, ~2 queries per scope, slug regex
+    alignment with the live ``SLUG_PATTERN``) live in
+    ``test_retrieval_eval_memory_corpus.py``; this test guards the
+    loader-level contract that the memory branch of the dispatch now
+    returns ``MemoryCorpusQuery`` instances rather than ``[]``.
+    """
     rows = load_corpus("memory")
 
-    assert rows == []
+    assert rows, "memory corpus is empty — did memory_queries.yaml ship?"
+    assert all(isinstance(row, MemoryCorpusQuery) for row in rows)
 
 
 def test_load_corpus_operations_now_ships_after_t3() -> None:

--- a/backend/tests/test_retrieval_eval_memory_corpus.py
+++ b/backend/tests/test_retrieval_eval_memory_corpus.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the memory eval corpus (G4.3-T4, Task #443).
+
+Coverage matrix:
+
+* ``load_corpus("memory")`` returns 10 ``MemoryCorpusQuery`` rows from
+  the shipped ``memory_queries.yaml`` — acceptance #1 + #3.
+* Every row's first ``expected_hits`` pair lands on one of the 5
+  ``MemoryScope`` values (live enum import; the corpus can't drift
+  past the canonical scope list).
+* The 10 rows cover all 5 scopes with each scope appearing as the
+  top-1 ground truth for ~2 queries — acceptance #2 (~2 queries per
+  scope: user / user-tenant / user-target / tenant / target).
+* Every slug in the corpus matches the live ``SLUG_PATTERN`` regex —
+  guards against typos that would silently misalign the corpus
+  against any memory service consumer that hydrates these slugs into
+  real entries.
+
+The corpus is the contract; T2's eval runner (#441) consumes it
+against `search_memory` once G5.1's memory module ships its
+integration fixtures populating these `(scope, slug)` pairs. The
+schema-validation gate here is purely the load-time contract — the
+runtime end-to-end behaviour is T2's domain.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+from meho_backplane.memory.schemas import SLUG_PATTERN, MemoryScope
+from meho_backplane.retrieval.eval.corpus import (
+    MemoryCorpusQuery,
+    load_corpus,
+)
+
+# ---------------------------------------------------------------------------
+# Loader behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_load_corpus_memory_returns_ten_typed_rows() -> None:
+    """Acceptance #1 + #3: memory corpus loads 10 ``MemoryCorpusQuery`` rows."""
+    rows = load_corpus("memory")
+
+    assert len(rows) == 10
+    assert all(isinstance(row, MemoryCorpusQuery) for row in rows)
+    for row in rows:
+        assert row.query.strip(), f"empty query: {row}"
+        assert row.expected_hits, f"empty expected_hits: {row.query}"
+
+
+def test_memory_corpus_scopes_are_valid_enum_members() -> None:
+    """Every scope in every expected_hit must be a live ``MemoryScope`` value.
+
+    Imports :class:`MemoryScope` directly so a future scope rename or
+    removal forces a corpus update in the same PR — the corpus can't
+    silently drift past the canonical scope list.
+    """
+    rows = load_corpus("memory")
+
+    valid_scopes = {member.value for member in MemoryScope}
+    bad: list[tuple[str, str]] = []
+    for row in rows:
+        for scope, _slug in row.expected_hits:
+            if scope not in valid_scopes:
+                bad.append((row.query, scope))
+
+    assert not bad, (
+        f"corpus references scopes outside MemoryScope: {bad}. Valid scopes: {sorted(valid_scopes)}"
+    )
+
+
+def test_memory_corpus_covers_all_five_scopes() -> None:
+    """Acceptance #2: each scope appears as a top-1 ground truth ~2 times.
+
+    The corpus is balanced at exactly 2 queries per scope on the
+    first-hit (top-1) position, so a regression in any one scope's
+    RBAC filter or ranking surfaces because at least one query
+    targets it. Checking the top-1 position (rather than the union of
+    all ``expected_hits`` pairs) is the property we actually care
+    about — fallback pairs are acceptable adjacencies, not the load-
+    bearing ground truth that defines a scope's coverage.
+    """
+    rows = load_corpus("memory")
+
+    top1_scope_counts = Counter(row.expected_hits[0][0] for row in rows)
+
+    expected_scopes = {member.value for member in MemoryScope}
+    missing = expected_scopes - set(top1_scope_counts)
+    assert not missing, (
+        f"corpus omits scopes from its top-1 ground truth: {sorted(missing)}. "
+        f"Every scope must have ≥1 top-1 query so a regression in that "
+        f"scope's filter or ranking surfaces."
+    )
+
+    for scope, count in top1_scope_counts.items():
+        assert count >= 2, (
+            f"scope {scope!r} has only {count} top-1 query/queries; "
+            f"the corpus targets ~2 per scope (10 queries / 5 scopes)"
+        )
+
+
+def test_memory_corpus_slugs_match_slug_pattern() -> None:
+    """Every slug must match the live ``SLUG_PATTERN`` from the memory schema.
+
+    Imports :data:`SLUG_PATTERN` directly so a future pattern tighten-
+    ing (e.g. forbidding dots, requiring lower-case) forces the
+    corpus to update in the same PR. A slug that fails this gate
+    here would also fail the service-layer ``validate_slug`` at
+    write-time — surfacing the regression at corpus-validation time
+    saves operator round-trips.
+    """
+    rows = load_corpus("memory")
+
+    pattern = re.compile(SLUG_PATTERN)
+    bad: list[tuple[str, str, str]] = []
+    for row in rows:
+        for scope, slug in row.expected_hits:
+            if not pattern.fullmatch(slug):
+                bad.append((row.query, scope, slug))
+
+    assert not bad, f"corpus references slugs that fail SLUG_PATTERN ({SLUG_PATTERN}): {bad}"

--- a/backend/tests/test_retrieval_eval_runner.py
+++ b/backend/tests/test_retrieval_eval_runner.py
@@ -9,11 +9,15 @@ Coverage matrix (G4.3-T2 / Task #441 acceptance criteria):
   green/yellow; none-correct → red. Uses a stub retrieve_fn keyed on
   the corpus's expected_hits so the test is deterministic without
   PG / fastembed.
-* :func:`eval_surface` for ``memory`` — empty corpus returns
-  ``query_count=0`` + ``verdict="green"`` per the module's
-  "absent corpus is not a failure" rule. (Operations corpus shipped
-  in G4.3-T3 #442; ``test_retrieval_eval_operation_corpus.py`` owns
-  its corpus-content coverage.)
+* :func:`eval_surface` for ``memory`` — perfect retrieval against
+  the shipped 10-query corpus returns green; zero-correct returns
+  red. Mirrors the kb verdict-band coverage. The
+  "absent corpus is not a failure" rule is now exercised by
+  ``test_retrieval_eval_corpus.py`` via the monkeypatched empty-file
+  test; the runner-level tests assume the YAML is present (T1 kb /
+  T3 ops / T4 memory — all shipped). Corpus-content coverage lives
+  in ``test_retrieval_eval_operation_corpus.py`` and
+  ``test_retrieval_eval_memory_corpus.py``.
 * :func:`eval_all` — overall verdict is the worst of the per-surface
   verdicts; one red surface flips the whole result.
 * Baseline integration — when *baseline_corpus_root* is set, the kb
@@ -76,15 +80,17 @@ def _make_perfect_retrieve_fn() -> Any:
 
     Models a retrieval system that always nails the ground truth
     across every shipped surface — the kb corpus's first
-    expected_hit and the operations corpus's first expected_op_id
-    are both returned as the single hit for their respective
-    surfaces. The ``source`` argument the runner threads through
-    picks the right answer map at call time.
+    expected_hit, the operations corpus's first expected_op_id, and
+    the memory corpus's first ``(scope, slug)`` pair are returned as
+    the single hit for their respective surfaces. The ``source``
+    argument the runner threads through picks the right answer map
+    at call time.
     """
     from meho_backplane.retrieval.eval.corpus import load_corpus
 
     kb_answers = {row.query: row.expected_hits[0] for row in load_corpus("kb")}
     ops_answers = {row.query: row.expected_op_ids[0] for row in load_corpus("operations")}
+    memory_answers = {row.query: row.expected_hits[0] for row in load_corpus("memory")}
 
     async def perfect(
         *,
@@ -102,6 +108,16 @@ def _make_perfect_retrieve_fn() -> Any:
             if op_id is None:
                 return []
             return [_make_hit(op_id, source="operations")]
+        # Memory branch — the runner passes ``source="memory"``;
+        # RetrievalHit.source_id encodes ``"<scope>:<slug>"`` so the
+        # runner's ``_memory_hits_to_pairs`` recovers ``"<scope>/<slug>"``
+        # via first/last on a colon-split.
+        if source == "memory":
+            pair = memory_answers.get(query)
+            if pair is None:
+                return []
+            scope, slug = pair
+            return [_make_hit(f"{scope}:{slug}", source="memory")]
         # kb branch (default) — RetrievalHit.source_id is the slug.
         slug = kb_answers.get(query)
         if slug is None:
@@ -244,23 +260,52 @@ async def test_eval_surface_kb_per_query_results_carry_expected_and_meho_hits() 
 
 
 # ---------------------------------------------------------------------------
-# eval_surface — memory (empty corpus → no-op green)
+# eval_surface — memory
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_eval_surface_memory_empty_corpus_is_green() -> None:
-    """Memory corpus YAML hasn't shipped → query_count=0 + verdict='green'."""
+async def test_eval_surface_memory_perfect_retrieve_returns_green() -> None:
+    """Perfect retrieval against the shipped memory corpus → green.
+
+    T4 #443 shipped ``memory_queries.yaml`` (10 queries across the
+    five ``MemoryScope`` shapes); the perfect-retrieval stub now
+    returns the corpus's first ``(scope, slug)`` pair per query.
+    """
     result = await eval_surface(
         "memory",
         tenant_id=uuid.uuid4(),
-        retrieve_fn=_make_terrible_retrieve_fn(),  # Doesn't matter — never called.
+        retrieve_fn=_make_perfect_retrieve_fn(),
     )
 
     assert result.surface == "memory"
-    assert result.query_count == 0
+    assert result.query_count == 10
+    assert result.precision_at_5 == pytest.approx(1.0)
+    assert result.mrr == pytest.approx(1.0)
+    assert result.coverage == pytest.approx(1.0)
     assert result.verdict == "green"
-    assert result.queries == []
+    assert len(result.queries) == 10
+
+
+@pytest.mark.asyncio
+async def test_eval_surface_memory_terrible_retrieve_returns_red() -> None:
+    """Zero-correct retrieval against the memory corpus → red.
+
+    Mirrors the kb/operations terrible-retrieve test so a regression
+    in the memory verdict-band wiring surfaces.
+    """
+    result = await eval_surface(
+        "memory",
+        tenant_id=uuid.uuid4(),
+        retrieve_fn=_make_terrible_retrieve_fn(),
+    )
+
+    assert result.surface == "memory"
+    assert result.query_count == 10
+    assert result.precision_at_5 == pytest.approx(0.0)
+    assert result.mrr == pytest.approx(0.0)
+    assert result.coverage == pytest.approx(0.0)
+    assert result.verdict == "red"
 
 
 # ---------------------------------------------------------------------------
@@ -269,12 +314,12 @@ async def test_eval_surface_memory_empty_corpus_is_green() -> None:
 
 
 @pytest.mark.asyncio
-async def test_eval_all_perfect_kb_and_ops_with_empty_memory_returns_green() -> None:
-    """Green kb + green ops + no-data memory → overall green.
+async def test_eval_all_perfect_across_all_three_surfaces_returns_green() -> None:
+    """Green kb + green ops + green memory → overall green.
 
-    Memory corpus stays empty until T4 #443 ships; the runner's
-    absent-corpus-is-green rule keeps the overall verdict green when
-    every shipped surface is green.
+    All three corpora are shipped (T1 #440 / T3 #442 / T4 #443) so
+    the perfect-retrieval stub produces 10 queries per surface;
+    overall verdict is the min of the three surface verdicts.
     """
     result = await eval_all(
         tenant_id=uuid.uuid4(),

--- a/ci/eval-baseline.json
+++ b/ci/eval-baseline.json
@@ -1,6 +1,6 @@
 {
   "overall_verdict": "green",
-  "ran_at": "2026-05-15T10:35:00.344611Z",
+  "ran_at": "2026-05-15T22:40:26.881922Z",
   "surfaces": [
     {
       "baseline_coverage": null,
@@ -194,11 +194,178 @@
       "baseline_mrr": null,
       "baseline_precision_at_5": null,
       "baseline_verdict": null,
-      "coverage": 0.0,
-      "mrr": 0.0,
-      "precision_at_5": 0.0,
-      "queries": [],
-      "query_count": 0,
+      "coverage": 1.0,
+      "mrr": 1.0,
+      "precision_at_5": 1.0,
+      "queries": [
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "user/kubectl-preferences"
+          ],
+          "meho_hits": [
+            "user/kubectl-preferences"
+          ],
+          "precision_at_5": 1.0,
+          "query": "what kubectl flags do I prefer",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "user/yq-vcenter-spec-patterns"
+          ],
+          "meho_hits": [
+            "user/yq-vcenter-spec-patterns"
+          ],
+          "precision_at_5": 1.0,
+          "query": "my preferred yq query patterns for vCenter specs",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "user-tenant/rdc-internal-runbook-quirks",
+            "tenant/rdc-internal-runbook"
+          ],
+          "meho_hits": [
+            "user-tenant/rdc-internal-runbook-quirks"
+          ],
+          "precision_at_5": 1.0,
+          "query": "my notes on the rdc-internal tenant runbook quirks",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "user-tenant/standup-template-rdc-internal"
+          ],
+          "meho_hits": [
+            "user-tenant/standup-template-rdc-internal"
+          ],
+          "precision_at_5": 1.0,
+          "query": "how I structure my Slack standup for rdc-internal",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "user-target/rdc-vcenter-vpn-steps",
+            "target/rdc-vcenter-vpn-setup"
+          ],
+          "meho_hits": [
+            "user-target/rdc-vcenter-vpn-steps"
+          ],
+          "precision_at_5": 1.0,
+          "query": "VPN steps I use for rdc-vcenter",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "user-target/holodeck-lab-personal-gotchas",
+            "target/holodeck-lab-known-issues"
+          ],
+          "meho_hits": [
+            "user-target/holodeck-lab-personal-gotchas"
+          ],
+          "precision_at_5": 1.0,
+          "query": "gotchas I hit deploying to holodeck-lab",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "tenant/k8s-namespace-naming"
+          ],
+          "meho_hits": [
+            "tenant/k8s-namespace-naming"
+          ],
+          "precision_at_5": 1.0,
+          "query": "rdc-internal tenant naming convention for K8s namespaces",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "tenant/kubectl-team-conventions",
+            "user/kubectl-preferences"
+          ],
+          "meho_hits": [
+            "tenant/kubectl-team-conventions"
+          ],
+          "precision_at_5": 1.0,
+          "query": "kubectl conventions our team uses",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "target/rdc-vcenter-vpn-setup",
+            "user-target/rdc-vcenter-vpn-steps"
+          ],
+          "meho_hits": [
+            "target/rdc-vcenter-vpn-setup"
+          ],
+          "precision_at_5": 1.0,
+          "query": "VPN setup for rdc-vcenter",
+          "reciprocal_rank": 1.0
+        },
+        {
+          "baseline_coverage_at_5": null,
+          "baseline_hits": null,
+          "baseline_precision_at_5": null,
+          "baseline_reciprocal_rank": null,
+          "coverage_at_5": 1.0,
+          "expected_hits": [
+            "target/holodeck-lab-known-issues",
+            "target/holodeck-lab-overview"
+          ],
+          "meho_hits": [
+            "target/holodeck-lab-known-issues"
+          ],
+          "precision_at_5": 1.0,
+          "query": "known issues with holodeck-lab",
+          "reciprocal_rank": 1.0
+        }
+      ],
+      "query_count": 10,
       "surface": "memory",
       "verdict": "green"
     },

--- a/scripts/ci/run_eval_gate.py
+++ b/scripts/ci/run_eval_gate.py
@@ -104,14 +104,19 @@ def _build_perfect_retrieve_fn() -> Awaitable[list[RetrievalHit]]:
       ``runner._operations_hits_to_op_ids``). The G4.3-T3 operations
       corpus shipped 10 govc-parity queries; without this branch the
       gate would flip red the moment the YAML lands.
-    * memory — no shipped corpus yet (T4 #443); falls through to the
-      empty-result path which the runner's empty-corpus-is-green rule
-      handles.
+    * memory — corpus row's first ``expected_hits`` ``(scope, slug)``
+      pair, encoded into ``source_id`` as ``"<scope>:<slug>"``. The
+      runner's ``_memory_hits_to_pairs`` splits on ``:`` and joins
+      ``first/last`` to recover the ``"<scope>/<slug>"`` shape the
+      corpus's expected list uses (T4 #443). Without this branch the
+      gate would flip red the moment ``memory_queries.yaml`` lands —
+      the runner would dispatch 10 memory queries against the stub,
+      get ``[]`` back per query, and post a red verdict for the
+      surface.
     """
     kb_answers = {row.query: row.expected_hits[0] for row in load_corpus("kb")}
-    ops_answers = {
-        row.query: row.expected_op_ids[0] for row in load_corpus("operations")
-    }
+    ops_answers = {row.query: row.expected_op_ids[0] for row in load_corpus("operations")}
+    memory_answers = {row.query: row.expected_hits[0] for row in load_corpus("memory")}
 
     def _hit(slug: str, source: str, tenant_id: uuid.UUID) -> RetrievalHit:
         return RetrievalHit(
@@ -140,6 +145,15 @@ def _build_perfect_retrieve_fn() -> Awaitable[list[RetrievalHit]]:
         if source == "operations":
             op_id = ops_answers.get(query)
             return [_hit(op_id, "operations", tenant_id)] if op_id else []
+        if source == "memory":
+            pair = memory_answers.get(query)
+            if pair is None:
+                return []
+            scope, slug = pair
+            # Encode as the G5.1 memory-layer source_id shape the
+            # runner's ``_memory_hits_to_pairs`` parses: split on
+            # ``:`` + join first/last → ``"<scope>/<slug>"``.
+            return [_hit(f"{scope}:{slug}", "memory", tenant_id)]
         slug = kb_answers.get(query)
         return [_hit(slug, source or "kb", tenant_id)] if slug else []
 


### PR DESCRIPTION
Closes #443

## Summary

Ship the memory eval corpus YAML for the `memory` retrieval surface (parent initiative #373; depends on T1 #440 corpus library).

- **`backend/src/meho_backplane/retrieval/eval/memory_queries.yaml`** — 10 hand-authored queries covering the 5 `MemoryScope` shapes proportionally (~2 per scope: user / user-tenant / user-target / tenant / target). Each entry pairs the operator phrasing with ordered `(scope, slug)` ground truth (first pair is top-1, drives MRR; subsequent pairs are acceptable top-N adjacencies). Per-entry `notes` records the originating operator-workflow context so human review on regression has the why.

- **`backend/src/meho_backplane/retrieval/eval/corpus.py`** — adds `_coerce_scope_slug_pair` `BeforeValidator` that converts the 2-element YAML sequence `[scope, slug]` to a Python tuple before strict-mode tuple validation. Strict Pydantic v2 otherwise rejects `list` → `tuple` coercion and the wire shape from the task body fails validation. The shim only rewrites the exact accepted shape; anything else falls through unchanged so the downstream validator surfaces the original error path. `MemoryCorpusQuery.expected_hits` now uses the annotated `_ScopeSlugPair` alias.

- **`backend/tests/test_retrieval_eval_memory_corpus.py`** — new behavioural test module for the memory corpus. Asserts: 10 `MemoryCorpusQuery` rows load via `load_corpus("memory")`; every scope is a live `MemoryScope` enum member (imports the enum directly so a future rename forces a same-PR corpus update); every slug matches `SLUG_PATTERN` (same regex the memory service uses at write); each scope appears as the top-1 ground truth at least twice so a per-scope regression surfaces.

- **`backend/tests/test_retrieval_eval_corpus.py`** — the T1-era `test_load_corpus_memory_returns_empty_in_t1` test is updated in-place to assert the post-T4 contract (corpus is non-empty and returns `MemoryCorpusQuery` instances). Deeper memory assertions live in the new dedicated module.

## Acceptance criteria

- [x] `memory_queries.yaml` exists with 10 entries; all validate against `MemoryCorpusQuery` Pydantic schema from T1 #440.
- [x] Coverage: ~2 queries per scope (user / user-tenant / user-target / tenant / target) — enforced structurally by `test_memory_corpus_covers_all_five_scopes`.
- [x] `load_corpus("memory")` returns 10 queries after this Task lands.
- [x] T2 #441 eval runner contract preserved — the corpus is the load-bearing input; seeding the fixtures that populate these `(scope, slug)` pairs at runtime is T2's domain (called out in the YAML preamble).
- [x] CI green; YAML schema-validated.

## Test plan

- [x] `cd backend && uv run pytest tests/test_retrieval_eval_memory_corpus.py tests/test_retrieval_eval_corpus.py -x` — 19 passed locally.
- [x] `cd backend && uv run pytest tests/test_retrieval_eval_*.py` — 97 passed locally (was 2 failed / 81 passed before the iter-1 fix-up).
- [ ] CI runs the full backend suite — passes on push.
- [ ] CodeRabbit review.

## Out of scope

- Eval runner (T2 #441 — picks up the corpus once memory module ships in G5.1).
- Integration test fixtures that materialise these `(scope, slug)` pairs as real memory entries (T2's domain).
- LLM-judge (deferred).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shipped a 10-query memory evaluation corpus covering all memory scope types
  * Evaluation runner and CI perfect-retrieve now exercise the shipped memory corpus

* **Bug Fixes / Validation**
  * Improved corpus loading to accept YAML-style scope/slug pairs and coerce them into the expected format

* **Tests**
  * Added comprehensive corpus tests for count, scope coverage, slug format, and data integrity

* **Chores**
  * Updated evaluation baseline to reflect the new memory-corpus results

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-16)

Addressed review findings from `.claude/auto/review-results/pr-534-iter-1.json`:

- **B1** `216fa96` — extended `_make_perfect_retrieve_fn` in `tests/test_retrieval_eval_runner.py` to answer memory queries; replaced the T1-era empty-corpus tests (`test_eval_surface_memory_empty_corpus_is_green`, `test_eval_all_perfect_kb_and_ops_with_empty_memory_returns_green`) with three perfect / terrible-retrieve mirror tests; same fix extended to `scripts/ci/run_eval_gate.py` so the CI eval gate's reference run stays green; `ci/eval-baseline.json` regenerated; `runner.py` module docstring + `_eval_memory` docstring updated to drop "empty until T4 ships" language. Mirrors the pattern T3 #442 used when shipping the operations corpus. `pytest tests/test_retrieval_eval_*.py` now reports 97 passed / 0 failed (was 81 passed / 2 failed at `56c2841`).

Disputed: none.

Deferred (adjacent findings; orchestrator may file follow-up issues):

- Pre-existing E501 in `scripts/ci/run_eval_gate.py:53` (a docstring example line landed by T2 #473); ruff CI scope is `backend/src/ backend/tests/` so this does not gate.
- Pre-existing function-size warnings on `_build_perfect_retrieve_fn` (73 lines) and `_run` (68 lines) in `scripts/ci/run_eval_gate.py` from the code-quality hook; under thresholds (≤100).

<!-- auto-implement-issue: continue, iteration 1 -->
