### PR TITLE
fix(connectors): unblock v0.2 vCenter REST generic dispatch (resolver + mount + respx)

### DIFF
--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -65,8 +65,35 @@ class HttpConnector(Connector):
                 self._clients[target.name] = httpx.AsyncClient(
                     base_url=self._base_url(target),
                     timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
+                    # Follow 301/302/307/308. Vendor REST surfaces
+                    # routinely canonicalise to a trailing slash with a
+                    # 301 (the govmomi/vcsim legacy ``/rest`` mount does
+                    # this; some real appliances do too behind a
+                    # normalising reverse proxy). httpx defaults to
+                    # not following — a connector that 500s on a benign
+                    # 301 is needlessly fragile. Idempotent verbs are
+                    # safe to replay on redirect; non-idempotent ones
+                    # go through ``_post_json`` which the vendor APIs
+                    # don't 301 mid-write.
+                    follow_redirects=True,
                 )
             return self._clients[target.name]
+
+    async def mount_op_path(self, target: Target, path: str) -> str:
+        """Map an ingested-descriptor *path* onto the wire path for *target*.
+
+        Dispatcher hook for ``source_kind='ingested'`` ops: the G0.7
+        pipeline stores spec-relative descriptor paths, and some vendor
+        APIs expose those under a mount prefix the spec omits (vCenter
+        REST: ``/api`` on modern, ``/rest`` on legacy/vcsim). The
+        default is identity — most ingested APIs are reachable at the
+        descriptor path verbatim. Vendor connectors that need a mount
+        (see ``VmwareRestConnector``) override this; the override is a
+        separate seam from ``_request_json`` / ``_post_json`` so their
+        tenacity ``@retry`` wrapper stays intact.
+        """
+        del target
+        return path
 
     def _base_url(self, target: Target) -> str:
         scheme = "https"

--- a/backend/src/meho_backplane/connectors/resolver.py
+++ b/backend/src/meho_backplane/connectors/resolver.py
@@ -15,10 +15,13 @@ Resolution input
 The resolver reads two attributes from ``target``:
 
 * ``target.product`` — product slug (matches ``Connector.product``).
-* ``target.fingerprint.version`` — version string from the most recent
-  fingerprint of this target (e.g. ``"9.0.2"``). Optional — when
-  unknown, the resolver falls back to v1-style entries (entries
-  registered with ``version=""``).
+* ``target.fingerprint`` → ``version`` — version string from the most
+  recent probe of this target (e.g. ``"9.0.2"``). In production
+  ``target.fingerprint`` is a JSON **dict** (the probe route persists
+  ``FingerprintResult.model_dump(mode="json")``); duck-typed test
+  targets may instead expose an object with ``.version``. The resolver
+  reads both shapes. Optional — when unknown, the resolver falls back
+  to v1-style entries (entries registered with ``version=""``).
 
 A third, optional attribute participates in the tie-break:
 
@@ -75,6 +78,7 @@ to make the binding visible in ``pyproject.toml``.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -330,11 +334,24 @@ def _run_tie_break_ladder(
 
 
 def _resolve_target_version(target: Any) -> str | None:
-    """Pull ``target.fingerprint.version`` if present; tolerate absence."""
+    """Pull the target's fingerprinted version, tolerating absence.
+
+    ``target.fingerprint`` is a JSON **dict** in production: the probe
+    route persists ``FingerprintResult.model_dump(mode="json")`` to the
+    ``Target.fingerprint`` column, so the ORM hands the resolver a
+    ``Mapping``, not an object. Tests (and the module docstring's
+    duck-typed contract) may instead supply an object exposing
+    ``.version``. Read both shapes — dict via key access, object via
+    attribute access — so a real probed target resolves the same way a
+    duck-typed test target does. Reading only the attribute form (the
+    prior behaviour) made every versioned connector unresolvable for
+    every real target, since ``getattr(dict, "version", None)`` is
+    always ``None``.
+    """
     fp = getattr(target, "fingerprint", None)
     if fp is None:
         return None
-    version = getattr(fp, "version", None)
+    version = fp.get("version") if isinstance(fp, Mapping) else getattr(fp, "version", None)
     if not isinstance(version, str) or not version:
         return None
     return version

--- a/backend/src/meho_backplane/connectors/vmware_rest/_mount.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/_mount.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vCenter REST endpoint topology — session paths + op mount mapping.
+
+Extracted from ``connector.py`` to keep that module within the
+code-quality size budget. This module owns one cohesive concern:
+*where vCenter exposes its REST surface*, and how a spec-relative
+ingested-descriptor path maps onto the mount a given target actually
+serves.
+
+Modern vCenter (8.0+) serves the automation API under ``/api`` and
+mints sessions at ``POST /api/session``. Older vCenter and the
+``vmware/vcsim`` simulator serve the legacy ``/rest`` mount; vcsim
+only registers ``POST /rest/com/vmware/cis/session`` (per
+``govmomi/vapi/simulator``). The connector discovers which mount is
+live per-target during session establishment (the modern→legacy 404
+fallback in ``VmwareRestConnector._session_token``) and uses
+:func:`mounted_path` to route every subsequent ingested op to the
+same mount.
+
+Ingested descriptors carry *spec-relative* paths — the G0.7 pipeline
+strips the OpenAPI server base, so the canary's op_ids are
+``GET:/vcenter/vm`` (not ``GET:/api/vcenter/vm``). Mapping that onto
+``/api`` vs ``/rest`` is connector-owned vendor knowledge; the
+generic dispatcher stays vendor-neutral (CLAUDE.md postulate 5).
+"""
+
+from __future__ import annotations
+
+SESSION_PATH_MODERN = "/api/session"
+SESSION_PATH_LEGACY = "/rest/com/vmware/cis/session"
+
+API_MOUNT_MODERN = "/api"
+API_MOUNT_LEGACY = "/rest"
+_KNOWN_API_MOUNT_PREFIXES = (f"{API_MOUNT_MODERN}/", f"{API_MOUNT_LEGACY}/")
+
+__all__ = [
+    "API_MOUNT_LEGACY",
+    "API_MOUNT_MODERN",
+    "SESSION_PATH_LEGACY",
+    "SESSION_PATH_MODERN",
+    "api_mount_for_session_path",
+    "mounted_path",
+]
+
+
+def api_mount_for_session_path(session_path: str) -> str:
+    """Map an established session path to its REST API mount prefix.
+
+    ``/api/session`` → ``/api`` (modern); the legacy
+    ``/rest/com/vmware/cis/session`` → ``/rest``. Defaults to the
+    modern mount when the recorded path is neither known constant so a
+    future session-path addition fails toward the production-correct
+    mount rather than silently misrouting every op to ``/rest``.
+    """
+    if session_path == SESSION_PATH_LEGACY:
+        return API_MOUNT_LEGACY
+    return API_MOUNT_MODERN
+
+
+def mounted_path(session_path: str, descriptor_path: str) -> str:
+    """Return *descriptor_path* prefixed with the mount *session_path* implies.
+
+    A path already carrying a known mount prefix (``/api/...`` /
+    ``/rest/...``) is returned unchanged so an explicitly-mounted
+    descriptor isn't double-prefixed. Otherwise the spec-relative path
+    is normalised to a leading slash and prefixed with the mount the
+    target's established session path selects.
+    """
+    if descriptor_path.startswith(_KNOWN_API_MOUNT_PREFIXES):
+        return descriptor_path
+    mount = api_mount_for_session_path(session_path)
+    normalised = descriptor_path if descriptor_path.startswith("/") else f"/{descriptor_path}"
+    return f"{mount}{normalised}"

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -93,6 +93,11 @@ from meho_backplane.connectors.schemas import (
     OperationResult,
     ProbeResult,
 )
+from meho_backplane.connectors.vmware_rest._mount import (
+    SESSION_PATH_LEGACY,
+    SESSION_PATH_MODERN,
+    mounted_path,
+)
 from meho_backplane.connectors.vmware_rest.session import (
     VsphereSessionLoader,
     VsphereTargetLike,
@@ -122,20 +127,13 @@ _SESSION_HEADER = "vmware-api-session-id"
 # and a defensive read here costs nothing.
 _SESSION_TOKEN_OBJECT_KEY = "value"
 
-# Session endpoints. Modern vCenter (7.0+) lives at ``/api/session``;
-# the legacy ``/rest/com/vmware/cis/session`` path is still served by
-# real vCenter for backward-compat and is the *only* path the upstream
-# ``vmware/vcsim`` simulator registers (its ``vapi/simulator`` package
-# wires the handler at ``rest.Path + internal.SessionPath`` =
-# ``/rest`` + ``/com/vmware/cis/session`` and does not also mount under
-# ``/api/``). The connector tries the modern path first and falls back
-# to the legacy path on 404 so production targets (which serve both)
-# pay no extra round-trip while vcsim integration tests stay green.
-# The established path is cached per-target in ``self._session_paths``
-# so the DELETE in ``aclose()`` targets the same endpoint that minted
-# the token.
-_SESSION_PATH_MODERN = "/api/session"
-_SESSION_PATH_LEGACY = "/rest/com/vmware/cis/session"
+# Session endpoints + the spec-relative-op → /api-or-/rest mount
+# mapping live in ``._mount`` (extracted to keep this module within
+# the code-quality size budget; see that module's docstring for the
+# full modern-vs-legacy + vcsim rationale). ``SESSION_PATH_MODERN`` /
+# ``SESSION_PATH_LEGACY`` drive session establishment + the
+# ``aclose()`` revoke; ``mounted_path`` maps an ingested descriptor
+# path onto the mount the target's established session selected.
 
 # Verbs that go through HttpConnector._request_json's tenacity retry
 # decorator. Non-idempotent verbs (POST / PUT / PATCH / DELETE) route
@@ -247,7 +245,7 @@ class VmwareRestConnector(HttpConnector):
         # :meth:`aclose` can DELETE against the same path. Production
         # vCenter serves both ``/api/session`` and the legacy
         # ``/rest/com/vmware/cis/session``; vcsim serves only the legacy
-        # path. See ``_SESSION_PATH_MODERN`` / ``_SESSION_PATH_LEGACY``
+        # path. See ``SESSION_PATH_MODERN`` / ``SESSION_PATH_LEGACY``
         # for the rationale and source citations.
         self._session_paths: dict[str, str] = {}
         self._session_lock = asyncio.Lock()
@@ -279,6 +277,34 @@ class VmwareRestConnector(HttpConnector):
             )
         token = await self._session_token(target)
         return {_SESSION_HEADER: token}
+
+    async def mount_op_path(self, target: VsphereTargetLike, path: str) -> str:
+        """Map a spec-relative ingested-op *path* onto *target*'s live mount.
+
+        Overrides the identity :meth:`HttpConnector.mount_op_path` hook
+        the dispatcher calls for ``source_kind='ingested'`` ops. Ingested
+        descriptors carry spec-relative paths (``/vcenter/vm``); the
+        vCenter REST API is mounted at ``/api`` on modern vCenter and
+        ``/rest`` on legacy vCenter / vcsim. Establishing the session is
+        what records the live mount in :attr:`_session_paths` (the
+        modern→legacy 404 fallback in :meth:`_session_token`); it's
+        idempotent + cached, so calling it here costs nothing on the
+        warm path and is what lets the *first* op against a legacy-only
+        target (vcsim) mount correctly instead of defaulting to ``/api``
+        and 404ing. The pure mapping — including the already-mounted
+        pass-through — lives in :func:`._mount.mounted_path`.
+
+        This is a dedicated dispatcher hook rather than a
+        ``_request_json`` / ``_post_json`` override on purpose: those
+        carry tenacity's ``@retry`` (and the ``.retry`` attribute that
+        retry-aware tests + callers introspect), and ``fingerprint()``
+        reaches ``GET /api/about`` through ``_get_json`` *pre-session*
+        — overriding the transport methods would both strip ``.retry``
+        and force a spurious session establish on the pre-auth probe.
+        """
+        await self._session_token(target)
+        session_path = self._session_paths.get(target.name, SESSION_PATH_MODERN)
+        return mounted_path(session_path, path)
 
     async def _session_token(self, target: VsphereTargetLike) -> str:
         """Return the cached session token for *target*, establishing one on first use.
@@ -321,14 +347,14 @@ class VmwareRestConnector(HttpConnector):
                     "{'username': str, 'password': str}"
                 ) from exc
             auth = (username, password)
-            resp = await client.post(_SESSION_PATH_MODERN, auth=auth)
-            established_path = _SESSION_PATH_MODERN
+            resp = await client.post(SESSION_PATH_MODERN, auth=auth)
+            established_path = SESSION_PATH_MODERN
             if resp.status_code == 404:
                 # Modern endpoint not served (vcsim, very old vCenter,
                 # or a reverse-proxy that hasn't been updated). Try the
                 # legacy path before declaring failure.
-                resp = await client.post(_SESSION_PATH_LEGACY, auth=auth)
-                established_path = _SESSION_PATH_LEGACY
+                resp = await client.post(SESSION_PATH_LEGACY, auth=auth)
+                established_path = SESSION_PATH_LEGACY
             try:
                 resp.raise_for_status()
             except httpx.HTTPStatusError as exc:
@@ -517,7 +543,7 @@ class VmwareRestConnector(HttpConnector):
             # ``_session_token``; the default keeps shutdown safe if
             # a future code path ever caches a token without recording
             # its endpoint.
-            revoke_path = paths.get(target_name, _SESSION_PATH_MODERN)
+            revoke_path = paths.get(target_name, SESSION_PATH_MODERN)
             try:
                 resp = await client.request(
                     "DELETE",

--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -156,6 +156,14 @@ async def dispatch_ingested(
         params,
     )
     substituted = _substitute_path(path_template, path_params)
+    # Vendor connectors may expose ingested ops under a mount prefix
+    # the spec omits (vCenter REST: ``/api`` modern / ``/rest`` legacy).
+    # ``mount_op_path`` defaults to identity on HttpConnector; the
+    # getattr keeps this branch tolerant of a connector that predates
+    # the hook rather than hard-failing on a missing attribute.
+    mount_op_path = getattr(connector, "mount_op_path", None)
+    if mount_op_path is not None:
+        substituted = await mount_op_path(target, substituted)
     raw_jwt = operator.raw_jwt
     if method in ("GET", "HEAD", "OPTIONS"):
         request_json = getattr(connector, "_request_json", None)

--- a/backend/tests/acceptance/_canary_fixtures.py
+++ b/backend/tests/acceptance/_canary_fixtures.py
@@ -26,45 +26,52 @@ through the dispatcher and returns ok against vcsim".
 This module inserts only the descriptor rows each dispatch test
 actually probes, with hand-authored ``method`` / ``path`` /
 ``handler_ref`` triples; no LLM, no embeddings, no grouping pass.
-Tests that need search-quality (the agent-flow E2E) drive their
-own copy of the canary's ingest pattern -- see
-:mod:`tests.acceptance.test_vmware_rest_agent_flow_e2e` for that
-path.
 
-The agent-flow E2E test does NOT consume this module's fixture; it
-uses the canary's ingest pattern (copied compactly) so the
-:func:`~meho_backplane.operations.meta_tools.search_operations` call
-has BM25 + cosine signal to rank against. Both paths converge on the
-same patched :class:`VmwareRestConnector` instance.
+All three vcsim dispatch modules consume :func:`ingested_canary_vcsim`
+directly, including
+:mod:`tests.acceptance.test_vmware_rest_agent_flow_e2e`: its
+:func:`~meho_backplane.operations.meta_tools.search_operations` step
+ranks over the seeded :data:`DISPATCH_DESCRIPTORS` summary strings on
+BM25 alone (the minimal six-op set is enough to rank
+``GET:/vcenter/vm`` first for "list virtual machines"; the full-corpus
+search-quality assertion stays in ``test_g07_vsphere_canary.py``). All
+paths converge on the same patched :class:`VmwareRestConnector`
+instance.
 """
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from uuid import UUID
 
 import pytest
+import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import FingerprintResult
 from meho_backplane.connectors.vmware_rest import VmwareRestConnector
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup, Target
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
-from tests.acceptance._vcsim import VcsimEndpoint, patch_vmware_connector_for_vcsim
 
 __all__ = [
+    "CANARY_BASE_URL",
     "CANARY_CONNECTOR_ID",
+    "CANARY_FINGERPRINT",
     "CANARY_IMPL_ID",
     "CANARY_OPERATOR_TENANT",
     "CANARY_PRODUCT",
     "CANARY_VERSION",
+    "CANARY_VMS",
     "DISPATCH_DESCRIPTORS",
     "VCSIM_TARGET_NAME",
     "IngestedCanaryVcsim",
     "ingested_canary_vcsim",
+    "prewarmed_embeddings",
 ]
 
 #: Connector triple under test. Matches the canary's constants in
@@ -83,6 +90,54 @@ CANARY_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000ff")
 #: Name used for the seeded vcsim Target row. Tests refer to vcsim by
 #: this stable name rather than synthesising one per test.
 VCSIM_TARGET_NAME: str = "vcsim-acceptance"
+
+#: Probe fingerprint persisted on the seeded :class:`Target`.
+#:
+#: The G0.6 resolver
+#: (:func:`~meho_backplane.connectors.resolver.resolve_connector`) binds
+#: a target to a connector implementation by matching the target's
+#: ``product`` + fingerprinted ``version`` against each connector's
+#: advertised ``supported_version_range``. ``VmwareRestConnector``
+#: advertises ``">=8.5,<10.0"``, so a target with **no** fingerprint
+#: resolves to *zero* candidates → ``NoMatchingConnector`` →
+#: ``no_connector``. A real operator-registered vSphere target always
+#: carries a probe fingerprint (CLAUDE.md postulate 3 — "targets are
+#: matched to connectors via fingerprint"); seeding one here makes the
+#: fixture represent a *probed* target rather than a half-registered
+#: one. Stored as ``FingerprintResult.model_dump(mode="json")`` — the
+#: exact dict shape the probe route persists to ``Target.fingerprint``.
+CANARY_FINGERPRINT: dict[str, object] = FingerprintResult(
+    vendor="VMware, Inc.",
+    product="vcenter",
+    version=CANARY_VERSION,
+    build="24021000",
+    reachable=True,
+    probed_at=datetime(2026, 5, 15, 12, 0, 0, tzinfo=UTC),
+    probe_method="rest-probe",
+).model_dump(mode="json")
+
+#: Base URL the seeded :class:`Target` points at. Port 443 keeps
+#: ``HttpConnector._base_url`` from appending a ``:port`` suffix, so
+#: the respx router's ``base_url`` matches the connector's client URL
+#: exactly. ``.test.invalid`` (RFC 6761 reserved) guarantees no real
+#: network egress even if respx interception ever regressed.
+CANARY_BASE_URL: str = "https://vcenter-canary.test.invalid"
+
+#: vCenter REST's modern ``GET /api/vcenter/vm`` returns a bare JSON
+#: array. 50 rows matches what the historical vcsim seed topology
+#: would have produced, so the agent-flow + JSONFlux assertions
+#: (``len(vms) == 50`` / ``handle.total_rows == 50``) are unchanged by
+#: the move off vcsim.
+CANARY_VMS: list[dict[str, object]] = [
+    {
+        "vm": f"vm-{i}",
+        "name": f"canary-vm-{i:02d}",
+        "power_state": "POWERED_ON" if i % 3 else "POWERED_OFF",
+        "cpu_count": 2,
+        "memory_size_MiB": 4096,
+    }
+    for i in range(50)
+]
 
 
 #: Descriptor rows the dispatch smoke + JSONFlux force-mode tests
@@ -144,7 +199,7 @@ class IngestedCanaryVcsim:
     operator: Operator
     connector_id: str
     target_name: str
-    endpoint: VcsimEndpoint
+    base_url: str
 
 
 async def _insert_dispatch_descriptors(
@@ -206,6 +261,40 @@ async def _insert_dispatch_descriptors(
 
 
 @pytest.fixture
+async def prewarmed_embeddings(pg_engine: None) -> None:
+    """Load the fastembed model before any respx router is active.
+
+    Depends on ``pg_engine`` (not for the DB, but because that fixture
+    chain populates the integration settings env —
+    ``KEYCLOAK_ISSUER_URL`` et al. — that
+    :func:`get_embedding_service` reads via ``get_settings()``).
+    Tests listing this before ``ingested_canary_vcsim`` therefore get:
+    env ready → model loaded (real network, no respx) → router opens.
+
+    ``search_operations`` (agent-flow step 3) embeds the query via the
+    cached :func:`~meho_backplane.retrieval.embedding.get_embedding_service`
+    singleton. fastembed fetches the ~120 MB ONNX model from
+    huggingface.co on first use; the conftest points the cache at a
+    per-test tmpdir, so that fetch is real network. If it happens
+    while :func:`ingested_canary_vcsim`'s respx router is active,
+    respx's transport patching corrupts the multi-request model
+    download (``Could not load model from any source``). Loading the
+    model *here* — before the router's context manager opens — means
+    the in-process singleton already holds it, so the search under
+    respx does zero network.
+
+    Only the agent-flow test depends on this. The dispatch-only smoke
+    / JSONFlux tests call ``call_operation`` with a known op_id (no
+    embedding path) and deliberately skip the cost. Tests that want it
+    must list this fixture **before** ``ingested_canary_vcsim`` in
+    their signature so it's set up before the router opens.
+    """
+    from meho_backplane.retrieval.embedding import get_embedding_service
+
+    await get_embedding_service().encode_one("vmware rest connector warm-up")
+
+
+@pytest.fixture
 def acceptance_operator() -> Operator:
     """Frozen :class:`Operator` the dispatch tests act as.
 
@@ -222,37 +311,96 @@ def acceptance_operator() -> Operator:
     )
 
 
+async def _vcenter_rest_session_loader(_target: object) -> dict[str, str]:
+    """Stub session loader — bypasses the not-yet-wired Vault read.
+
+    The respx router accepts any HTTP basic pair (it never validates
+    the credentials), so the values are illustrative only.
+    """
+    return {"username": "canary-svc", "password": "canary-pw"}
+
+
+def _register_vcenter_rest_routes(mock: respx.MockRouter) -> None:
+    """Register the modern (``/api``) vCenter REST surface on *mock*.
+
+    The router answers the connector's session establishment
+    (``POST /api/session`` → token; the modern path 200s so the G0.6
+    resolver-side mount resolves to ``/api``), the ``aclose()`` revoke
+    (``DELETE /api/session``), and the read ops the three dispatch
+    modules probe. ``assert_all_called=False`` on the router (set by
+    the fixture) means a test that exercises only one op doesn't trip
+    on the unused routes.
+    """
+    mock.post("/api/session").respond(200, json="canary-session-token")
+    mock.delete("/api/session").respond(204)
+    mock.get("/api/about").respond(
+        200,
+        json={
+            "product": "VMware vCenter Server",
+            "version": CANARY_VERSION,
+            "build": "24021000",
+            "product_line_id": "vpx",
+            "api_type": "vcenter",
+        },
+    )
+    mock.get("/api/vcenter/vm").respond(200, json=CANARY_VMS)
+    mock.get("/api/vcenter/cluster").respond(
+        200, json=[{"cluster": "domain-c1", "name": "canary-cluster"}]
+    )
+    mock.get("/api/vcenter/host").respond(
+        200, json=[{"host": "host-1", "name": "canary-esx-01"}]
+    )
+    mock.get("/api/vcenter/datastore").respond(
+        200, json=[{"datastore": "datastore-1", "name": "canary-ds-01"}]
+    )
+    mock.get("/api/vcenter/network").respond(
+        200, json=[{"network": "network-1", "name": "VM Network"}]
+    )
+
+
 @pytest.fixture
 async def ingested_canary_vcsim(
     pg_engine: None,
     acceptance_operator: Operator,
-    vcsim_endpoint: VcsimEndpoint,
 ) -> AsyncIterator[IngestedCanaryVcsim]:
-    """Yield a dispatcher-ready vcsim setup.
+    """Yield a dispatcher-ready vmware-rest setup over a respx-mocked vCenter.
+
+    The fixture name is retained for call-site stability across the
+    three dispatch modules; the transport is **respx**, not vcsim.
+    govmomi's vcsim does not implement the vCenter REST *resource*
+    API (``/api/vcenter/vm`` and friends 404 — it only stubs the
+    vAPI session/tagging/content-library subset + the SOAP surface),
+    so a vcsim-backed dispatch test of ``GET:/vcenter/vm`` is not
+    satisfiable. respx mocks the exact modern REST surface the
+    connector calls, so the full agent-flow chain (resolve → group →
+    search → ``call_operation`` dispatch) is still exercised
+    end-to-end against a realistic wire contract.
 
     Setup steps:
 
-    1. Insert built-in :class:`EndpointDescriptor` rows for every
-       op in :data:`DISPATCH_DESCRIPTORS` (under one enabled
+    1. Insert built-in :class:`EndpointDescriptor` rows for every op
+       in :data:`DISPATCH_DESCRIPTORS` (under one enabled
        :class:`OperationGroup`).
-    2. Seed a :class:`Target` row pointing at the live vcsim
-       endpoint (host/port/auth_model).
+    2. Seed a :class:`Target` (with a probe :data:`CANARY_FINGERPRINT`
+       so the resolver binds the versioned connector) pointing at
+       :data:`CANARY_BASE_URL`.
     3. Resolve + cache the :class:`VmwareRestConnector` instance the
-       dispatcher will use; patch its ``_session_loader`` to return
-       vcsim's no-auth credentials and its ``_http_client`` to skip
-       TLS verification of vcsim's self-signed cert.
+       dispatcher will use and patch only its ``_session_loader``
+       (no Vault in the acceptance suite). The httpx client is *not*
+       patched — respx intercepts it transparently.
+    4. Activate a respx router for :data:`CANARY_BASE_URL` and
+       register the modern vCenter REST surface.
 
-    Teardown:
+    Teardown (inside the active respx router so the ``DELETE``
+    session-revoke is intercepted):
 
-    1. ``aclose()`` the patched connector instance (releases the
-       httpx pool, revokes cached sessions).
-    2. ``reset_dispatcher_caches()`` so the next test sees a fresh,
-       unpatched instance.
+    1. ``aclose()`` the connector instance.
+    2. ``reset_dispatcher_caches()`` so the next test sees a fresh
+       instance.
 
     The :class:`VmwareRestConnector` registration survives across
-    tests under normal operation (no test runs ``clear_registry()``
-    against the v2 registry); the fixture re-imports the
-    ``vmware_rest`` package on demand if a sibling test wiped the
+    tests under normal operation; the fixture re-imports the
+    ``vmware_rest`` package on demand if a sibling test wiped the v2
     registry (the G0.7 canary's autouse cleanup does this).
     """
     await _insert_dispatch_descriptors(DISPATCH_DESCRIPTORS)
@@ -264,13 +412,14 @@ async def ingested_canary_vcsim(
             name=VCSIM_TARGET_NAME,
             aliases=[],
             product=CANARY_PRODUCT,
-            host=vcsim_endpoint.host,
-            port=vcsim_endpoint.port,
+            host=CANARY_BASE_URL.removeprefix("https://"),
+            port=443,
             fqdn=None,
-            secret_ref="kv/data/vsphere/vcsim-acceptance",
+            secret_ref="kv/data/vsphere/vcenter-canary",
             auth_model="shared_service_account",
             vpn_required=False,
             extras={},
+            fingerprint=CANARY_FINGERPRINT,
             notes="seeded by tests.acceptance._canary_fixtures.ingested_canary_vcsim",
         )
         session.add(target)
@@ -299,21 +448,36 @@ async def ingested_canary_vcsim(
         f"got {connector_cls!r}"
     )
 
-    # Materialise the cached instance the dispatcher will use, then
-    # patch it. ``get_or_create_connector_instance`` lazily
-    # constructs ``VmwareRestConnector()`` on first call; the default
-    # ``_session_loader`` is the not-yet-implemented Vault reader,
-    # which the patch immediately replaces.
+    # Materialise the cached instance the dispatcher will use; replace
+    # only the Vault-backed session loader. respx intercepts the
+    # connector's own httpx client, so ``_http_client`` is left intact
+    # (which keeps the production follow-redirects + pooling code on
+    # the exercised path).
     instance = get_or_create_connector_instance(connector_cls)
-    patch_vmware_connector_for_vcsim(instance, vcsim_endpoint)
+    instance._session_loader = _vcenter_rest_session_loader
 
-    try:
-        yield IngestedCanaryVcsim(
-            operator=acceptance_operator,
-            connector_id=CANARY_CONNECTOR_ID,
-            target_name=VCSIM_TARGET_NAME,
-            endpoint=vcsim_endpoint,
-        )
-    finally:
-        await instance.aclose()
-        reset_dispatcher_caches()
+    # ``assert_all_mocked=False``: requests that don't match a
+    # registered route (notably fastembed's one-time model fetch from
+    # huggingface.co, which ``search_operations`` triggers in the
+    # agent-flow test) pass through to the real transport rather than
+    # raising — matching how the rest of the embedding-using
+    # acceptance suite already behaves (the conftest points the
+    # fastembed cache at a per-test tmpdir; the download is real).
+    # ``assert_all_called=False``: a test that exercises one op
+    # doesn't trip on the other registered routes.
+    async with respx.mock(
+        base_url=CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_vcenter_rest_routes(mock)
+        try:
+            yield IngestedCanaryVcsim(
+                operator=acceptance_operator,
+                connector_id=CANARY_CONNECTOR_ID,
+                target_name=VCSIM_TARGET_NAME,
+                base_url=CANARY_BASE_URL,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()

--- a/backend/tests/acceptance/_vcsim.py
+++ b/backend/tests/acceptance/_vcsim.py
@@ -387,6 +387,12 @@ def patch_vmware_connector_for_vcsim(
                     base_url=base_url,
                     timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
                     verify=ssl_ctx,
+                    # Mirror production HttpConnector._http_client:
+                    # vcsim's legacy ``/rest`` mount 301s missing
+                    # trailing slashes, so the patched client must
+                    # follow redirects too or the dispatch leg sees a
+                    # spurious HTTPStatusError instead of vcsim data.
+                    follow_redirects=True,
                 )
             return clients[target.name]
 

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -60,6 +60,7 @@ from tests.acceptance._canary_fixtures import (
     IngestedCanaryVcsim,
     acceptance_operator,
     ingested_canary_vcsim,
+    prewarmed_embeddings,
 )
 from tests.acceptance._vcsim import (
     DEFAULT_VCSIM_TOPOLOGY,
@@ -88,6 +89,7 @@ __all__ = [
     "ingested_canary_vcsim",
     "integration_env",
     "pg_engine",
+    "prewarmed_embeddings",
     "vcsim_endpoint",
 ]
 

--- a/backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py
+++ b/backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py
@@ -55,6 +55,7 @@ from tests.acceptance._canary_fixtures import (
 
 
 async def test_agent_flow_end_to_end_against_vcsim(
+    prewarmed_embeddings: None,
     ingested_canary_vcsim: IngestedCanaryVcsim,
 ) -> None:
     """The four-step agent chain produces real vcsim data on call_operation.
@@ -147,6 +148,7 @@ async def test_agent_flow_end_to_end_against_vcsim(
 
 
 async def test_search_operations_unknown_connector_returns_no_hits(
+    prewarmed_embeddings: None,
     ingested_canary_vcsim: IngestedCanaryVcsim,
 ) -> None:
     """An unknown connector_id returns an empty hit list, not an error.

--- a/backend/tests/acceptance/test_vmware_rest_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_vmware_rest_dispatch_smoke.py
@@ -1,23 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""G3.1-T8 dispatch smoke — read-only vmware-rest ops against vcsim.
+"""G3.1-T8 dispatch smoke — read-only vmware-rest ops over respx.
 
 Closes the "Step 7" gap the G0.7 canary runbook flagged: the
 :class:`~meho_backplane.connectors.vmware_rest.VmwareRestConnector`
 (merged in #498) dispatches 5 representative read ops against a
-running vcsim and the dispatcher returns a structured
-:class:`~meho_backplane.connectors.schemas.OperationResult` for each
-one. The smoke test verifies the dispatch leg end-to-end:
+respx-mocked modern vCenter REST surface and the dispatcher returns
+a structured :class:`~meho_backplane.connectors.schemas.OperationResult`
+for each one.
+
+Why respx and not vcsim: govmomi's vcsim does not implement the
+vCenter REST *resource* API — ``/api/vcenter/{vm,cluster,host,...}``
+all 404; it only stubs the vAPI session/tagging/content-library
+subset plus the SOAP surface. A vcsim-backed dispatch test of these
+ops is therefore unsatisfiable. respx mocks the exact wire contract
+the connector calls (see ``_canary_fixtures._register_vcenter_rest_routes``)
+so the dispatch leg is still exercised end-to-end:
 
 - Connector resolved by ``(product, version, impl_id)`` triple via the
-  v2 registry.
+  v2 registry (the seeded :class:`Target` carries a probe fingerprint
+  so the version-range resolver binds it).
 - Session lifecycle exercised:
   :meth:`VmwareRestConnector.auth_headers` mints a ``vmware-api-session-id``
-  via ``POST /api/session`` against vcsim's no-auth surface.
-- Per-op HTTP request fires through the connector's pooled
-  :class:`httpx.AsyncClient` with TLS verification disabled (vcsim's
-  self-signed cert).
+  via ``POST /api/session``.
+- Per-op HTTP request fires through the connector's real pooled
+  :class:`httpx.AsyncClient` (respx intercepts at the transport
+  layer; the production follow-redirects + pooling code stays on the
+  exercised path).
 - :func:`~meho_backplane.operations.dispatcher.dispatch` produces a
   ``status='ok'`` result for every probed op.
 
@@ -31,24 +41,21 @@ list.
 
 Skip conditions:
 
-* No vcsim — the ``vcsim_endpoint`` fixture in conftest skips with a
-  clear reason when neither ``MEHO_VCSIM_URL`` nor a Docker socket
-  resolves.
-* No vCenter OpenAPI spec — ingestion needs ``vcenter.yaml`` to
-  populate the dispatchable ``endpoint_descriptor`` rows; without it
-  the test skips with the canary's standard reason.
+* No Postgres — the ``pg_engine`` fixture skips when the integration
+  database isn't reachable (same gate as every DB-backed acceptance
+  test). There is no Docker/vcsim dependency anymore: respx runs
+  in-process.
 
-Why ingestion is part of the smoke test
-=======================================
+Why these are **ingested** ops
+==============================
 
-The smoke test dispatches **ingested** ops (``source_kind='ingested'``)
-rather than typed ones, because the production agent surface for
-vmware-rest is the ingested corpus (T3 #520 landed ``vcenter.yaml``
-ingestion full). Bypassing ingestion with hand-rolled descriptor
-rows would prove the dispatcher works in isolation but not the
-production-shipped read path. The cost (one ingest per test run) is
-paid once via the session-scoped :class:`~tests.acceptance._canary_fixtures._IngestedCanary`
-helper.
+The smoke test dispatches ``source_kind='ingested'`` ops because the
+production agent surface for vmware-rest is the ingested corpus. The
+descriptor rows are seeded directly by
+:func:`~tests.acceptance._canary_fixtures._insert_dispatch_descriptors`
+(a minimal six-op set, no LLM/embeddings) — the full-corpus
+``vcenter.yaml`` ingest path is the G0.7 canary's job; this module
+only needs dispatchable rows.
 """
 
 from __future__ import annotations
@@ -58,7 +65,6 @@ import pytest
 from meho_backplane.auth.operator import Operator
 from meho_backplane.operations.meta_tools import call_operation
 from tests.acceptance._canary_fixtures import IngestedCanaryVcsim
-from tests.acceptance._vcsim import VcsimEndpoint
 
 #: Read-only ops the smoke test dispatches. Every one is a
 #: ``GET`` against an inventory endpoint vcsim implements; each
@@ -79,16 +85,15 @@ SMOKE_OP_IDS: tuple[str, ...] = (
 async def test_dispatch_smoke_op_returns_ok(
     op_id: str,
     ingested_canary_vcsim: IngestedCanaryVcsim,
-    vcsim_endpoint: VcsimEndpoint,
 ) -> None:
-    """Each probed op dispatches against vcsim and returns ``status='ok'``.
+    """Each probed op dispatches over respx and returns ``status='ok'``.
 
     Per-op parameterisation surfaces in CI's report as one test
     case per op; a single regressing op fails its own case and
     leaves the others green. Asserting only ``status='ok'`` (not
-    the shape of ``result``) keeps the smoke test resilient to
-    vcsim's release-to-release inventory shape variance — the
-    JSONFlux force-mode and agent-flow tests cover shape.
+    the shape of ``result``) keeps the smoke test focused on the
+    dispatch leg — the JSONFlux force-mode and agent-flow tests
+    cover payload shape.
 
     ``call_operation`` is the agent surface so the smoke test
     drives the same code path the LLM-driven agent would, not the
@@ -111,7 +116,7 @@ async def test_dispatch_smoke_op_returns_ok(
     )
 
     assert result["status"] == "ok", (
-        f"op {op_id!r} failed against vcsim at "
-        f"{vcsim_endpoint.base_url}: {result.get('error')!r}; "
+        f"op {op_id!r} failed against the respx-mocked vCenter at "
+        f"{ingested_canary_vcsim.base_url}: {result.get('error')!r}; "
         f"full result={result!r}"
     )

--- a/backend/tests/test_connectors_resolver.py
+++ b/backend/tests/test_connectors_resolver.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -154,6 +155,72 @@ def test_resolve_outside_advertised_range_returns_no_match() -> None:
         cls=_VmwareRest9,
     )
     target = _FakeTarget(product="vmware", fingerprint=_fingerprint("8.0.0"))
+    with pytest.raises(NoMatchingConnector, match="vmware"):
+        resolve_connector(target)
+
+
+# ---------------------------------------------------------------------------
+# Production fingerprint shape — a JSON dict, not a duck-typed object
+# ---------------------------------------------------------------------------
+#
+# Regression guard for the v0.2 ship blocker: the ORM stores
+# ``Target.fingerprint`` as ``FingerprintResult.model_dump(mode="json")``
+# — a plain dict. The resolver previously read the version with
+# ``getattr(fp, "version", None)``, which is always ``None`` on a dict,
+# so *every* real probed target failed to match any versioned connector
+# (→ ``NoMatchingConnector`` → ``no_connector`` at dispatch). Every
+# pre-existing resolver test used the duck-typed ``_FakeFingerprint``
+# object, so the dict path had zero coverage and shipped broken. These
+# two tests pin the production shape.
+
+
+@dataclass
+class _DictFingerprintTarget:
+    """Target whose ``fingerprint`` is the real JSON dict, not an object."""
+
+    product: str
+    fingerprint: dict[str, object] | None = None
+    preferred_impl_id: str | None = None
+
+
+def test_resolve_reads_version_from_dict_fingerprint() -> None:
+    """A probed target (dict fingerprint) resolves the versioned connector."""
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_VmwareRest9,
+    )
+    fingerprint = FingerprintResult(
+        vendor="VMware, Inc.",
+        product="vcenter",
+        version="9.0.2",
+        reachable=True,
+        probed_at=datetime(2026, 5, 15, tzinfo=UTC),
+        probe_method="rest-probe",
+    ).model_dump(mode="json")
+    target = _DictFingerprintTarget(product="vmware", fingerprint=fingerprint)
+    assert resolve_connector(target) is _VmwareRest9
+
+
+def test_resolve_dict_fingerprint_without_version_skips_versioned_connector() -> None:
+    """A dict fingerprint missing ``version`` matches no versioned connector.
+
+    Mirrors the pre-fingerprint window: a target row exists but the
+    probe hasn't populated a version yet. A versioned connector must
+    not bind on no version (the resolver's documented contract); the
+    failure mode is a clean ``NoMatchingConnector``, not a wrong bind.
+    """
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_VmwareRest9,
+    )
+    target = _DictFingerprintTarget(
+        product="vmware",
+        fingerprint={"vendor": "VMware, Inc.", "product": "vcenter", "reachable": True},
+    )
     with pytest.raises(NoMatchingConnector, match="vmware"):
         resolve_connector(target)
 


### PR DESCRIPTION
## Why

`main`'s `ci.yml` has been **red since #525 (2026-05-15)** — the G3.1-T8 agent-flow E2E acceptance test never passed. v0.2's literal ship gate (roadmap Done-when #3/#4: agent dispatches vCenter ops via `call_operation`) was therefore unmet despite the board showing G3.1 #227 / G0.7 #389 closed. Root-caused a chain of real defects the original `no_connector` error was masking.

## Production defects fixed (`a632cf1`)

1. **Resolver dict-fingerprint bug.** `Target.fingerprint` is persisted as `FingerprintResult.model_dump(mode="json")` — a JSON dict — but `_resolve_target_version` did `getattr(fp, "version")`, always `None` on a dict. **Every versioned connector was unresolvable for every real probed target** (`no_connector`) — a prod defect, not just a test issue. Existing resolver tests only used duck-typed objects, so the dict path had zero coverage and shipped broken. Added dict-shape regression tests.
2. **No vCenter REST mount on ingested ops.** Descriptors are spec-relative (`/vcenter/vm`); vCenter mounts the automation API at `/api` (modern) / `/rest` (legacy). New `_mount.py` + a `mount_op_path` dispatcher hook (identity default on `HttpConnector`, overridden in `VmwareRestConnector`) maps the path onto the live mount discovered at session establishment. Deliberately a separate seam from `_request_json`/`_post_json` so their tenacity `@retry` (and `.retry` attr) and `fingerprint()`'s pre-auth probe are untouched.
3. **httpx didn't follow redirects.** vCenter/vcsim 301-canonicalize a missing trailing slash → benign 301 surfaced as a 500. Enabled `follow_redirects`.

## Acceptance suite vcsim → respx (`101a1ee`)

Empirically probed `vmware/vcsim`: it does **not** implement the vCenter REST resource API (every `/api/vcenter/*` 404s — only the vAPI session/tagging/content-library subset + SOAP). The G3.1-T8 dispatch tests asserting `GET:/vcenter/vm` → 50 VMs were **unsatisfiable since #525**. Migrated the 3 dispatch modules off vcsim/testcontainers onto a respx-mocked modern vCenter REST surface — full agent-flow chain still exercised E2E, no Docker dependency. Added a `prewarmed_embeddings` fixture (loads the fastembed model before the respx router opens; only the search-using agent-flow tests opt in).

## Verification

- `ruff` + `mypy` clean (144 src files).
- All 8 G3.1-T8 dispatch tests green via respx.
- Full acceptance suite: **94 passed, 36 skipped**, no g07/audit regressions.
- Blast-radius unit sweep: **640 passed**; the 4 residual failures triaged as pre-existing-on-`main` (vcsim integration), Docker-env (k3d), or flaky-in-isolation (passes alone) — none introduced here.

## Follow-up (separate, tracked)

- Roadmap `Done-when #4` ("13 composites E2E against vcsim") is unsatisfiable as written — being corrected via a board ticket; G3.1 #227 / G0.7-T8 #408 / #525 closure to be re-validated against the corrected gate.
- `runner-smoke` Harbor-TLS red is **post-merge non-gating** consumer infra (runner container lacks internal-CA trust for host `curl`; MEHO.HelmCharts / meho-internal#75 AC#3) — not an `evoila/meho` code defect; not band-aided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP client now properly follows redirects for improved request reliability.
  * Fixed version resolution from fingerprint data to support both production and test scenarios.

* **Tests**
  * Enhanced acceptance test infrastructure with improved vCenter REST endpoint mocking.
  * Added regression tests for connector resolution with dict-based fingerprints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->