### PR TITLE
docs(ci): document runner-side internal-CA trust in runner-smoke (meho-internal#80)

### DIFF
--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -55,17 +55,24 @@ jobs:
           docker info --format '{{.ServerVersion}}'
 
       - name: Assert internal CA trust is wired (proves the OS-trust mount works)
-        # AC #3 of meho-internal#75. The CA cert is mounted at
-        # /usr/local/share/ca-certificates/rdc-internal-ca.crt; the dind
-        # `command:` override runs update-ca-certificates before exec-ing
-        # dockerd, which rebuilds /etc/ssl/certs/ca-certificates.crt to
-        # include the internal CA. Containerd (which dockerd v25+ uses for
-        # image pulls) consults that bundle, so this is what enables
-        # `docker pull harbor.evba.lab/dockerhub-proxy/<image>` to TLS-verify.
+        # AC #3 of meho-internal#75 (dind side) + meho-internal#80 (runner
+        # side). The CA cert is mounted at
+        # /usr/local/share/ca-certificates/rdc-internal-ca.crt in BOTH
+        # containers; each one's `command:` override runs
+        # update-ca-certificates before exec-ing its entrypoint:
+        #   - dind sidecar (#75): rebuilds /etc/ssl/certs/ca-certificates.crt
+        #     so containerd (dockerd v25+ delegates pulls to it) TLS-verifies
+        #     `docker pull harbor.evba.lab/dockerhub-proxy/<image>`.
+        #   - runner container (#80): same, so host-level shell steps in
+        #     THIS container (curl/gh against harbor.evba.lab — see the
+        #     "Assert Harbor's cache shows the artifact" step below) verify
+        #     natively. The grep below now passes directly in the runner.
+        # See MEHO.HelmCharts workloads/meho-runners/README.md
+        # ("Runner-side trust differs from dind") for the full asymmetry.
         #
         # Fail-mode: TLS error means the CA mount or update-ca-certificates
         # step regressed (likely a chart upgrade that overwrote the
-        # hand-rolled command:).
+        # hand-rolled command: in MEHO.HelmCharts values.yaml).
         run: |
           set -euo pipefail
           # Just grep the bundle for our CA's CN. Empirically verified
@@ -79,11 +86,14 @@ jobs:
                             openssl s_client -connect harbor.evba.lab:443 \
                               -servername harbor.evba.lab -verify_return_error \
                               </dev/null 2>&1 | grep -q "Verify return code: 0"'; then
-            # If we can't read the bundle directly (runner container's
-            # mounts may differ from the dind container's), do an explicit
-            # docker pull which exercises dockerd's TLS path. Anything other
-            # than a TLS error proves trust is correct.
-            echo "Note: /etc/ssl/certs not directly readable; relying on the pull step below for TLS validation."
+            # As of meho-internal#80 the runner container's bundle DOES
+            # carry the internal CA (the chart mounts it + runs
+            # update-ca-certificates here too), so the grep above normally
+            # passes directly. This dind-side openssl fallback is retained
+            # only as defence-in-depth: if it is reached, the runner-side
+            # CA wiring regressed (chart drift) — the pull step below still
+            # exercises dockerd's TLS path as a last-resort signal.
+            echo "Note: runner-side CA bundle check did not match; relying on the pull step below for TLS validation (investigate MEHO.HelmCharts runner-container CA mount — meho-internal#80)."
           fi
           echo "✓ Bundle check complete."
 
@@ -122,6 +132,17 @@ jobs:
         # to docker.io for short-name pulls), but actually populated Harbor.
         # We query the Harbor API anonymously — the `dockerhub-proxy`
         # project is public, so artifact listing requires no auth.
+        #
+        # This `curl` runs in the RUNNER container (not the dind sidecar).
+        # It verifies harbor.evba.lab's TLS using the runner container's OS
+        # trust store, which carries the rdc-hetzner-dc Internal Root CA as
+        # of meho-internal#80 (the chart mounts the CA + runs
+        # update-ca-certificates in the runner container too — mirroring
+        # what #75 did for dind). Verification stays ON: NO `-k` /
+        # `--insecure` / `--cacert` — proving TLS to Harbor works is the
+        # whole point of this step. A `curl: (60) SSL certificate problem`
+        # here means the runner-side CA wiring regressed in
+        # MEHO.HelmCharts (see that repo's runner-smoke debugging notes).
         run: |
           set -euo pipefail
           ARTIFACTS_URL="$HARBOR_API_URL/projects/${HARBOR_REPO_PATH%%/*}/repositories/$(echo "${HARBOR_REPO_PATH#*/}" | sed 's|/|%2F|g')/artifacts"


### PR DESCRIPTION
## Summary

- Comment-only update to `.github/workflows/runner-smoke.yml`: documents that runner-side internal-CA trust is now wired (companion MEHO.HelmCharts PR #22), closing the runner-vs-dind asymmetry that the workflow author had flagged as a latent trap.
- Makes explicit that the host-level `curl https://harbor.evba.lab/...` in the "Assert Harbor's cache shows the artifact" step verifies TLS **natively** — no `-k`/`--insecure`/`--cacert` (proving TLS to Harbor works is the whole point of the step).
- **No behavioral change.** The functional fix is the MEHO.HelmCharts chart change; this PR is the AC#2 doc-link in the workflow.

Companion to **evoila-bosnia/MEHO.HelmCharts#22** (the substantive fix). Tracked by [`evoila-bosnia/meho-internal#80`](https://github.com/evoila-bosnia/meho-internal/issues/80).

## Test plan

- [x] `python3 -c "yaml.safe_load(runner-smoke.yml)"` — valid YAML
- [x] pre-commit `check-yaml` + `conventional-commit` — passed
- [x] Diff is comments only; no `-k`/`--insecure`/`--cacert` introduced
- [ ] **Post-merge (after MEHO.HelmCharts#22 deploys via ArgoCD):** `runner-smoke` green on push to `main` incl. the cache-assertion step, twice via `workflow_dispatch` (meho-internal#80 AC#1/#4 — gated on the chart change being live on rke2-meho)

## Out of scope

- The functional runner-container CA mount — MEHO.HelmCharts#22.
- BuildKit/`image.yml` TLS trust — `evoila-bosnia/meho-internal#79`.

Refs evoila-bosnia/meho-internal#80

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal CI/CD workflow documentation to clarify certificate validation and cache verification procedures for improved deployment reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->