### PR TITLE
fix(test): ruff-format _canary_fixtures.py — unbreak ci.yml format gate (follow-up to #535)

### DIFF
--- a/backend/tests/acceptance/_canary_fixtures.py
+++ b/backend/tests/acceptance/_canary_fixtures.py
@@ -347,9 +347,7 @@ def _register_vcenter_rest_routes(mock: respx.MockRouter) -> None:
     mock.get("/api/vcenter/cluster").respond(
         200, json=[{"cluster": "domain-c1", "name": "canary-cluster"}]
     )
-    mock.get("/api/vcenter/host").respond(
-        200, json=[{"host": "host-1", "name": "canary-esx-01"}]
-    )
+    mock.get("/api/vcenter/host").respond(200, json=[{"host": "host-1", "name": "canary-esx-01"}])
     mock.get("/api/vcenter/datastore").respond(
         200, json=[{"datastore": "datastore-1", "name": "canary-ds-01"}]
     )


### PR DESCRIPTION
## Why

PR #535 fixed the v0.2 vCenter-REST dispatch defects, but `ci.yml` stayed **red on `main`** (`49c71ae` onward). Root cause: the respx migration left `backend/tests/acceptance/_canary_fixtures.py` not `ruff format`-clean. `ruff check` (lint) passed — which is what was verified locally — but `ci.yml` runs **`ruff format --check src/ tests/` as a separate step**, which failed there. The job exits before the pytest step, so the agent-flow fix never actually got a green gate.

## Fix

`uv run ruff format backend/tests/acceptance/_canary_fixtures.py` — whitespace/quote/wrap reflow only. No behavior change.

## Verification (local, this branch)

- `ruff check src/ tests/` → all passed
- `ruff format --check src/ tests/` → **285 files already formatted** (was: 1 would reformat)
- `mypy src/` → success, 144 files
- `pytest` the v0.2 surface (3 dispatch modules + resolver regression tests) → **28 passed**

This is the last blocker between `main` and a green `ci.yml`; the PR's own CI run is the authoritative confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal test code restructuring with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->