### PR TITLE
feat(topology): G9.1-T4 recursive-CTE query verbs (dependents/dependencies/path) + cycle detection + tenant scoping

### DIFF
--- a/backend/src/meho_backplane/topology/__init__.py
+++ b/backend/src/meho_backplane/topology/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Topology graph traversal surface (Initiative #363, G9.1).
+
+This package is the read side of the per-tenant topology graph. The
+schema and ORM models live in :mod:`meho_backplane.db.models`
+(``GraphNode`` / ``GraphEdge``, migration ``0007``, Task #448); the
+refresh service that populates them is Task #450 (T3). This package
+ships Task #451 (T4): the three recursive-CTE query verbs every
+blast-radius check and topology question goes through.
+
+Public surface:
+
+* :func:`meho_backplane.topology.query.find_dependents`
+* :func:`meho_backplane.topology.query.find_dependencies`
+* :func:`meho_backplane.topology.query.find_path`
+* :class:`meho_backplane.topology.schemas.TopologyNode`
+* :class:`meho_backplane.topology.schemas.TopologyPath`
+
+The API (T5), CLI (T6), and MCP (T7) fronts consume :mod:`query` as a
+thin shell and never re-derive the traversal or the tenant boundary.
+"""

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -53,16 +53,33 @@ Tenant scoping
 Every statement filters ``graph_node.tenant_id`` *and*
 ``graph_edge.tenant_id`` against ``operator.tenant_id`` in both the
 anchor and the recursive term. A node with the same ``(kind, name)``
-in another tenant is invisible to this tenant's traversal — the
-``(tenant_id, kind, name)`` unique index makes the root lookup
-unambiguous within the tenant.
+in another tenant is invisible to this tenant's traversal.
+
+Anchor disambiguation
+---------------------
+
+``graph_node`` uniqueness is ``(tenant_id, kind, name)`` — a ``target``
+named ``app`` and a ``vm`` named ``app`` legitimately coexist in one
+tenant. Resolving a root by ``name`` alone would anchor on *both* and
+silently traverse a merged closure of two unrelated objects. Every
+entrypoint therefore accepts an optional ``kind``: when supplied the
+anchor is pinned to ``(tenant_id, kind, name)`` (unambiguous by the
+unique index); when omitted and the name resolves to more than one
+kind in the tenant, the call raises :class:`AmbiguousNodeError` rather
+than traversing the merged closure. ``find_path`` applies the same
+contract independently to each endpoint via ``from_kind`` /
+``to_kind``.
 
 SQL parameter binding mirrors the established raw-SQL pattern in
-:mod:`meho_backplane.retrieval.retriever`: ``text()`` with ``:named``
+:mod:`meho_backplane.retrieval.retriever`: every statement is a
+fully-literal ``text("...")`` (nothing interpolated, so the SQLAlchemy
+``avoid-sqlalchemy-text`` SAST rule does not fire) with ``:named``
 binds, a ``CAST(:x AS text) IS NULL OR ...`` guard for the optional
-``kind_filter`` so one statement string serves the filtered and
-unfiltered cases, and UUIDs passed as ``str`` for the asyncpg text
-codec.
+``kind`` pin and ``kind_filter`` so one statement string serves the
+pinned/unpinned and filtered/unfiltered cases, and UUIDs passed as
+``str`` for the asyncpg text codec. The reverse and forward traversal
+directions are two separate literal statements rather than one
+f-string with the join columns swapped.
 """
 
 from __future__ import annotations
@@ -77,7 +94,34 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.topology.schemas import TopologyNode, TopologyPath
 
-__all__ = ["find_dependencies", "find_dependents", "find_path"]
+__all__ = [
+    "AmbiguousNodeError",
+    "find_dependencies",
+    "find_dependents",
+    "find_path",
+]
+
+
+class AmbiguousNodeError(ValueError):
+    """A node name resolved to more than one ``kind`` and no ``kind`` was given.
+
+    ``graph_node`` uniqueness is ``(tenant_id, kind, name)``. When a
+    traversal root (or a :func:`find_path` endpoint) is requested by
+    ``name`` alone and the tenant holds multiple kinds with that name,
+    anchoring on all of them would merge unrelated closures. The query
+    refuses instead of returning silently-wrong data; the caller must
+    re-issue with an explicit ``kind`` (or, later, an alias resolved by
+    the T5/T6 router).
+    """
+
+    def __init__(self, name: str, kinds: list[str]) -> None:
+        self.name = name
+        self.kinds = kinds
+        super().__init__(
+            f"node name {name!r} is ambiguous in this tenant — it exists "
+            f"as kinds {sorted(kinds)!r}; pass kind= to disambiguate"
+        )
+
 
 #: Default traversal depth. Matches the Task #451 contract; deep enough
 #: for real datacentre topologies (target → vm → host → datastore →
@@ -111,66 +155,143 @@ def _row_to_node(row: Row[Any]) -> TopologyNode:
     )
 
 
-def _traversal_sql(*, reverse: bool) -> Any:
-    """Build the dependents/dependencies recursive-CTE statement.
-
-    ``reverse=True`` walks edges *into* the frontier node
-    (``e.to_node_id == w.id``, step to ``e.from_node_id``) — the
-    dependents direction. ``reverse=False`` walks *out of* it
-    (``e.from_node_id == w.id``, step to ``e.to_node_id``) — the
-    dependencies direction. Only those two join columns differ; tenant
-    scoping, the optional kind filter, the depth bound, the CYCLE
-    guard, and the ``(depth, name)`` ordering are identical, so the
-    statement is built once with the join columns swapped.
-
-    The anchor row is the query root at depth 0, reached via no edge
-    (``via_edge_kind`` NULL). The depth guard in the recursive term
-    bounds an acyclic-but-deep graph; CYCLE stops true cycles; the
-    final ``NOT is_cycle`` filter drops the cycle-closing rows.
+# Reverse traversal (dependents, "what depends on me"): join edges
+# *into* the frontier node and step to their source. The outer
+# DISTINCT ON (id) collapses a node reached by several converging
+# paths to a single row at its minimum depth — CYCLE only dedupes
+# within one branch, not across converging branches of a DAG, so the
+# closure-wide collapse is what makes the result one row per node.
+# Two fully-literal statements (rather than one f-string) keep the
+# Semgrep avoid-sqlalchemy-text rule from firing: nothing is
+# interpolated, every value is a :named bind.
+_TRAVERSAL_SQL_REVERSE = text(
     """
-    if reverse:
-        join_to_frontier = "e.to_node_id = w.id"
-        step_to = "e.from_node_id"
-    else:
-        join_to_frontier = "e.from_node_id = w.id"
-        step_to = "e.to_node_id"
-
-    return text(
-        f"""
-        WITH RECURSIVE walk AS (
-            SELECT
-                n.id            AS id,
-                n.kind          AS kind,
-                n.name          AS name,
-                n.properties    AS properties,
-                0               AS depth,
-                CAST(NULL AS text) AS via_edge_kind
-            FROM graph_node n
-            WHERE n.name = :name
-              AND n.tenant_id = :tenant_id
-            UNION ALL
-            SELECT
-                n.id,
-                n.kind,
-                n.name,
-                n.properties,
-                w.depth + 1,
-                e.kind
-            FROM graph_edge e
-            JOIN walk w ON {join_to_frontier}
-            JOIN graph_node n ON n.id = {step_to}
-            WHERE e.tenant_id = :tenant_id
-              AND n.tenant_id = :tenant_id
-              AND w.depth < :depth
-              AND (CAST(:kind_filter AS text) IS NULL OR e.kind = :kind_filter)
-        ) CYCLE id SET is_cycle USING path
-        SELECT id, kind, name, properties, depth, via_edge_kind
+    WITH RECURSIVE walk AS (
+        SELECT
+            n.id            AS id,
+            n.kind          AS kind,
+            n.name          AS name,
+            n.properties    AS properties,
+            0               AS depth,
+            CAST(NULL AS text) AS via_edge_kind
+        FROM graph_node n
+        WHERE n.name = :name
+          AND n.tenant_id = :tenant_id
+          AND (CAST(:kind AS text) IS NULL OR n.kind = :kind)
+        UNION ALL
+        SELECT
+            n.id,
+            n.kind,
+            n.name,
+            n.properties,
+            w.depth + 1,
+            e.kind
+        FROM graph_edge e
+        JOIN walk w ON e.to_node_id = w.id
+        JOIN graph_node n ON n.id = e.from_node_id
+        WHERE e.tenant_id = :tenant_id
+          AND n.tenant_id = :tenant_id
+          AND w.depth < :depth
+          AND (CAST(:kind_filter AS text) IS NULL OR e.kind = :kind_filter)
+    ) CYCLE id SET is_cycle USING path
+    SELECT id, kind, name, properties, depth, via_edge_kind
+    FROM (
+        SELECT DISTINCT ON (id)
+            id, kind, name, properties, depth, via_edge_kind
         FROM walk
         WHERE depth <= :depth
           AND NOT is_cycle
-        ORDER BY depth, name
-        """
+        ORDER BY id, depth, name
+    ) deduped
+    ORDER BY depth, name
+    """
+)
+
+# Forward traversal (dependencies, "what I depend on"): the mirror —
+# join edges *out of* the frontier node and step to their target. Only
+# the two join columns differ from the reverse statement; everything
+# else (tenant scoping, kind pin, kind filter, depth bound, CYCLE
+# guard, closure-wide DISTINCT ON dedupe, ordering) is identical.
+_TRAVERSAL_SQL_FORWARD = text(
+    """
+    WITH RECURSIVE walk AS (
+        SELECT
+            n.id            AS id,
+            n.kind          AS kind,
+            n.name          AS name,
+            n.properties    AS properties,
+            0               AS depth,
+            CAST(NULL AS text) AS via_edge_kind
+        FROM graph_node n
+        WHERE n.name = :name
+          AND n.tenant_id = :tenant_id
+          AND (CAST(:kind AS text) IS NULL OR n.kind = :kind)
+        UNION ALL
+        SELECT
+            n.id,
+            n.kind,
+            n.name,
+            n.properties,
+            w.depth + 1,
+            e.kind
+        FROM graph_edge e
+        JOIN walk w ON e.from_node_id = w.id
+        JOIN graph_node n ON n.id = e.to_node_id
+        WHERE e.tenant_id = :tenant_id
+          AND n.tenant_id = :tenant_id
+          AND w.depth < :depth
+          AND (CAST(:kind_filter AS text) IS NULL OR e.kind = :kind_filter)
+    ) CYCLE id SET is_cycle USING path
+    SELECT id, kind, name, properties, depth, via_edge_kind
+    FROM (
+        SELECT DISTINCT ON (id)
+            id, kind, name, properties, depth, via_edge_kind
+        FROM walk
+        WHERE depth <= :depth
+          AND NOT is_cycle
+        ORDER BY id, depth, name
+    ) deduped
+    ORDER BY depth, name
+    """
+)
+
+# Anchor-ambiguity probe. Returns the distinct kinds a (tenant, name)
+# pair resolves to so the caller can refuse a merged-closure traversal
+# when more than one kind matches and no kind was pinned.
+_ANCHOR_KINDS_SQL = text(
+    """
+    SELECT DISTINCT kind
+    FROM graph_node
+    WHERE tenant_id = :tenant_id
+      AND name = :name
+    """
+)
+
+
+async def _assert_anchor_unambiguous(
+    session: Any,
+    *,
+    tenant_id: str,
+    name: str,
+    kind: str | None,
+) -> None:
+    """Raise :class:`AmbiguousNodeError` if *name* needs a ``kind``.
+
+    No-op when ``kind`` is supplied (the ``(tenant_id, kind, name)``
+    unique index already makes the anchor unambiguous) or when the name
+    resolves to at most one kind in the tenant. Only when ``kind`` is
+    omitted *and* the name spans multiple kinds does the traversal
+    refuse — anchoring on all of them would merge unrelated closures.
+    """
+    if kind is not None:
+        return
+    result = await session.execute(
+        _ANCHOR_KINDS_SQL,
+        {"tenant_id": tenant_id, "name": name},
     )
+    kinds = [r._mapping["kind"] for r in result.fetchall()]
+    if len(kinds) > 1:
+        raise AmbiguousNodeError(name, kinds)
 
 
 async def _traverse(
@@ -178,24 +299,33 @@ async def _traverse(
     name_or_alias: str,
     *,
     depth: int,
+    kind: str | None,
     kind_filter: str | None,
     reverse: bool,
 ) -> list[TopologyNode]:
     """Shared dependents/dependencies recursive-CTE traversal.
 
-    Delegates statement construction to :func:`_traversal_sql` and
-    runs it tenant-scoped on its own session, mirroring the
-    session-per-call shape of the memory / kb services.
+    Picks the reverse or forward literal statement and runs it
+    tenant-scoped on its own session, mirroring the session-per-call
+    shape of the memory / kb services. Resolves the anchor up front:
+    an ambiguous bare-name root (multiple kinds, no ``kind`` pin)
+    raises :class:`AmbiguousNodeError` rather than traversing a merged
+    closure.
     """
-    sql = _traversal_sql(reverse=reverse)
+    sql = _TRAVERSAL_SQL_REVERSE if reverse else _TRAVERSAL_SQL_FORWARD
+    tenant_id = str(operator.tenant_id)
 
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
+        await _assert_anchor_unambiguous(
+            session, tenant_id=tenant_id, name=name_or_alias, kind=kind
+        )
         result = await session.execute(
             sql,
             {
                 "name": name_or_alias,
-                "tenant_id": str(operator.tenant_id),
+                "tenant_id": tenant_id,
+                "kind": kind,
                 "depth": depth,
                 "kind_filter": kind_filter,
             },
@@ -209,17 +339,26 @@ async def find_dependents(
     operator: Operator,
     name_or_alias: str,
     *,
+    kind: str | None = None,
     depth: int = _DEFAULT_DEPTH,
     kind_filter: str | None = None,
 ) -> list[TopologyNode]:
     """Reverse traversal: every node that depends on *name_or_alias*.
 
-    Returns a flattened list ordered ``(depth, name)``: the root at
-    depth 0, its immediate dependents at depth 1, transitive dependents
-    at depth 2, and so on, up to and including ``depth``. ``kind_filter``
-    restricts the walk to edges of that ``graph_edge.kind``. The tenant
-    boundary is ``operator.tenant_id`` — a same-named node in another
-    tenant is never returned. Cycles terminate at the CYCLE clause.
+    Returns a flattened list ordered ``(depth, name)`` with **one row
+    per reachable node** (a node reachable by several converging paths
+    is collapsed to its minimum-depth occurrence): the root at depth 0,
+    its immediate dependents at depth 1, transitive dependents at depth
+    2, and so on, up to and including ``depth``.
+
+    ``kind`` pins the anchor to ``(tenant_id, kind, name_or_alias)``,
+    the unique index. Omit it only when the name is unique across kinds
+    in the tenant — if it is not, the call raises
+    :class:`AmbiguousNodeError` instead of merging unrelated closures.
+    ``kind_filter`` restricts the walk to edges of that
+    ``graph_edge.kind``. The tenant boundary is ``operator.tenant_id``
+    — a same-named node in another tenant is never returned. Cycles
+    terminate at the CYCLE clause.
 
     The root node itself is included (depth 0) so a caller can
     distinguish "node exists but has no dependents" (one-element list)
@@ -229,6 +368,7 @@ async def find_dependents(
         operator,
         name_or_alias,
         depth=depth,
+        kind=kind,
         kind_filter=kind_filter,
         reverse=True,
     )
@@ -238,21 +378,24 @@ async def find_dependencies(
     operator: Operator,
     name_or_alias: str,
     *,
+    kind: str | None = None,
     depth: int = _DEFAULT_DEPTH,
     kind_filter: str | None = None,
 ) -> list[TopologyNode]:
     """Forward traversal: everything *name_or_alias* depends on.
 
-    The mirror of :func:`find_dependents` — same shape, same tenant
-    scoping, same cycle safety and depth bound — with edges walked in
-    the opposite direction (out of the current node rather than into
-    it). Root included at depth 0; empty list means the node does not
-    exist in this tenant.
+    The mirror of :func:`find_dependents` — same shape, same one-row-
+    per-node closure dedupe, same ``kind`` disambiguation contract,
+    same tenant scoping, same cycle safety and depth bound — with edges
+    walked in the opposite direction (out of the current node rather
+    than into it). Root included at depth 0; empty list means the node
+    does not exist in this tenant.
     """
     return await _traverse(
         operator,
         name_or_alias,
         depth=depth,
+        kind=kind,
         kind_filter=kind_filter,
         reverse=False,
     )
@@ -287,6 +430,7 @@ _PATH_SQL = text(
         FROM graph_node n
         WHERE n.name = :from_name
           AND n.tenant_id = :tenant_id
+          AND (CAST(:from_kind AS text) IS NULL OR n.kind = :from_kind)
         UNION ALL
         SELECT
             be.dst,
@@ -303,6 +447,7 @@ _PATH_SQL = text(
       ON tn.id = w.node_id
      AND tn.name = :to_name
      AND tn.tenant_id = :tenant_id
+     AND (CAST(:to_kind AS text) IS NULL OR tn.kind = :to_kind)
     WHERE NOT w.is_cycle
     ORDER BY w.hops
     LIMIT 1
@@ -355,6 +500,8 @@ async def find_path(
     from_name: str,
     to_name: str,
     *,
+    from_kind: str | None = None,
+    to_kind: str | None = None,
     max_hops: int = _DEFAULT_MAX_HOPS,
 ) -> TopologyPath | None:
     """Shortest unweighted path from *from_name* to *to_name*.
@@ -368,6 +515,13 @@ async def find_path(
     *from_name* within ``max_hops`` (or either endpoint does not exist
     in this tenant).
 
+    ``from_kind`` / ``to_kind`` pin each endpoint to its
+    ``(tenant_id, kind, name)`` unique row. The same disambiguation
+    contract as the traversal verbs applies independently to each
+    endpoint: an unpinned name that resolves to multiple kinds in the
+    tenant raises :class:`AmbiguousNodeError` rather than letting an
+    unintended endpoint enter the search.
+
     A second resolving query materialises the node rows in path order
     so the :class:`TopologyPath` carries full :class:`TopologyNode`
     records, not bare ids.
@@ -376,12 +530,18 @@ async def find_path(
 
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
+        await _assert_anchor_unambiguous(
+            session, tenant_id=tenant_id, name=from_name, kind=from_kind
+        )
+        await _assert_anchor_unambiguous(session, tenant_id=tenant_id, name=to_name, kind=to_kind)
         path_result = await session.execute(
             _PATH_SQL,
             {
                 "tenant_id": tenant_id,
                 "from_name": from_name,
                 "to_name": to_name,
+                "from_kind": from_kind,
+                "to_kind": to_kind,
                 "max_hops": max_hops,
             },
         )

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recursive-CTE topology traversal: dependents / dependencies / path.
+
+Task #451 (G9.1-T4). The three verbs here are the read surface every
+blast-radius check and topology question in v0.2 goes through. All
+three use PostgreSQL's ``WITH RECURSIVE ... CYCLE`` clause (PG manual
+§7.8.2.2; the chassis floor is PG 16, where the clause behaves
+identically to the PG 17 reference) for cycle-safe graph traversal
+over the adjacency-list ``graph_node`` / ``graph_edge`` tables that
+migration ``0007`` (Task #448) ships.
+
+Edge-direction model
+--------------------
+
+An edge ``from_node --kind--> to_node`` reads "``from_node`` depends on
+``to_node``" (e.g. a ``vm`` ``runs-on`` a ``host``: the vm depends on
+the host). The two directed verbs follow that convention:
+
+* :func:`find_dependents` — *reverse* traversal. "What depends on me?"
+  Starting at the root, repeatedly find every node that has an edge
+  pointing *into* the current node (``edge.to_node_id == current``),
+  stepping to ``edge.from_node_id``. Depth-1 results are immediate
+  dependents, depth-2 transitive, and so on.
+* :func:`find_dependencies` — *forward* traversal. "What do I depend
+  on?" The mirror: follow edges *out of* the current node
+  (``edge.from_node_id == current``) to ``edge.to_node_id``.
+
+:func:`find_path` is an unweighted shortest-path search: every edge
+costs one hop, direction-agnostic (it walks both ``from``→``to`` and
+``to``→``from``), and returns the first path found at the minimum hop
+count or ``None`` if the target is unreachable within ``max_hops``.
+
+Cycle safety
+------------
+
+The ``CYCLE id SET is_cycle USING path`` clause makes PostgreSQL track
+the set of node ids already on each traversal branch and stop
+recursing into a node it has already visited on that branch, flagging
+the repeat row with ``is_cycle = true``. The traversal therefore
+terminates on a graph with a cycle (``A → B → A``) instead of
+recursing forever. The post-filter keeps only ``NOT is_cycle`` rows so
+the duplicate cycle-closing row is excluded from the result. A
+``depth`` bound in the recursive term is an independent second guard:
+even an acyclic but very deep / fan-out-heavy graph is capped at the
+caller's ``depth`` so a pathological topology cannot exhaust the
+server.
+
+Tenant scoping
+--------------
+
+Every statement filters ``graph_node.tenant_id`` *and*
+``graph_edge.tenant_id`` against ``operator.tenant_id`` in both the
+anchor and the recursive term. A node with the same ``(kind, name)``
+in another tenant is invisible to this tenant's traversal — the
+``(tenant_id, kind, name)`` unique index makes the root lookup
+unambiguous within the tenant.
+
+SQL parameter binding mirrors the established raw-SQL pattern in
+:mod:`meho_backplane.retrieval.retriever`: ``text()`` with ``:named``
+binds, a ``CAST(:x AS text) IS NULL OR ...`` guard for the optional
+``kind_filter`` so one statement string serves the filtered and
+unfiltered cases, and UUIDs passed as ``str`` for the asyncpg text
+codec.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.engine import Row
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.topology.schemas import TopologyNode, TopologyPath
+
+__all__ = ["find_dependencies", "find_dependents", "find_path"]
+
+#: Default traversal depth. Matches the Task #451 contract; deep enough
+#: for real datacentre topologies (target → vm → host → datastore →
+#: network rarely exceeds a handful of hops) while bounding a runaway.
+_DEFAULT_DEPTH = 16
+
+#: Default shortest-path hop ceiling. Smaller than the traversal depth
+#: default because a *path* between two named nodes is a much shorter
+#: structure than a full dependent/dependency closure.
+_DEFAULT_MAX_HOPS = 8
+
+
+def _row_to_node(row: Row[Any]) -> TopologyNode:
+    """Map a traversal result row to a :class:`TopologyNode`.
+
+    The recursive CTE projects exactly ``id, kind, name, properties,
+    depth, via_edge_kind``; ``is_cycle`` / ``path`` are CYCLE-clause
+    bookkeeping filtered out in SQL and never selected into the row.
+    ``properties`` arrives as a ``dict`` from JSONB on asyncpg (or a
+    JSON string on the rare passthrough); the model's validator
+    freezes it.
+    """
+    mapping = row._mapping
+    return TopologyNode(
+        id=mapping["id"],
+        kind=mapping["kind"],
+        name=mapping["name"],
+        properties=mapping["properties"] or {},
+        depth=mapping["depth"],
+        via_edge_kind=mapping["via_edge_kind"],
+    )
+
+
+def _traversal_sql(*, reverse: bool) -> Any:
+    """Build the dependents/dependencies recursive-CTE statement.
+
+    ``reverse=True`` walks edges *into* the frontier node
+    (``e.to_node_id == w.id``, step to ``e.from_node_id``) — the
+    dependents direction. ``reverse=False`` walks *out of* it
+    (``e.from_node_id == w.id``, step to ``e.to_node_id``) — the
+    dependencies direction. Only those two join columns differ; tenant
+    scoping, the optional kind filter, the depth bound, the CYCLE
+    guard, and the ``(depth, name)`` ordering are identical, so the
+    statement is built once with the join columns swapped.
+
+    The anchor row is the query root at depth 0, reached via no edge
+    (``via_edge_kind`` NULL). The depth guard in the recursive term
+    bounds an acyclic-but-deep graph; CYCLE stops true cycles; the
+    final ``NOT is_cycle`` filter drops the cycle-closing rows.
+    """
+    if reverse:
+        join_to_frontier = "e.to_node_id = w.id"
+        step_to = "e.from_node_id"
+    else:
+        join_to_frontier = "e.from_node_id = w.id"
+        step_to = "e.to_node_id"
+
+    return text(
+        f"""
+        WITH RECURSIVE walk AS (
+            SELECT
+                n.id            AS id,
+                n.kind          AS kind,
+                n.name          AS name,
+                n.properties    AS properties,
+                0               AS depth,
+                CAST(NULL AS text) AS via_edge_kind
+            FROM graph_node n
+            WHERE n.name = :name
+              AND n.tenant_id = :tenant_id
+            UNION ALL
+            SELECT
+                n.id,
+                n.kind,
+                n.name,
+                n.properties,
+                w.depth + 1,
+                e.kind
+            FROM graph_edge e
+            JOIN walk w ON {join_to_frontier}
+            JOIN graph_node n ON n.id = {step_to}
+            WHERE e.tenant_id = :tenant_id
+              AND n.tenant_id = :tenant_id
+              AND w.depth < :depth
+              AND (CAST(:kind_filter AS text) IS NULL OR e.kind = :kind_filter)
+        ) CYCLE id SET is_cycle USING path
+        SELECT id, kind, name, properties, depth, via_edge_kind
+        FROM walk
+        WHERE depth <= :depth
+          AND NOT is_cycle
+        ORDER BY depth, name
+        """
+    )
+
+
+async def _traverse(
+    operator: Operator,
+    name_or_alias: str,
+    *,
+    depth: int,
+    kind_filter: str | None,
+    reverse: bool,
+) -> list[TopologyNode]:
+    """Shared dependents/dependencies recursive-CTE traversal.
+
+    Delegates statement construction to :func:`_traversal_sql` and
+    runs it tenant-scoped on its own session, mirroring the
+    session-per-call shape of the memory / kb services.
+    """
+    sql = _traversal_sql(reverse=reverse)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            sql,
+            {
+                "name": name_or_alias,
+                "tenant_id": str(operator.tenant_id),
+                "depth": depth,
+                "kind_filter": kind_filter,
+            },
+        )
+        rows = result.fetchall()
+
+    return [_row_to_node(row) for row in rows]
+
+
+async def find_dependents(
+    operator: Operator,
+    name_or_alias: str,
+    *,
+    depth: int = _DEFAULT_DEPTH,
+    kind_filter: str | None = None,
+) -> list[TopologyNode]:
+    """Reverse traversal: every node that depends on *name_or_alias*.
+
+    Returns a flattened list ordered ``(depth, name)``: the root at
+    depth 0, its immediate dependents at depth 1, transitive dependents
+    at depth 2, and so on, up to and including ``depth``. ``kind_filter``
+    restricts the walk to edges of that ``graph_edge.kind``. The tenant
+    boundary is ``operator.tenant_id`` — a same-named node in another
+    tenant is never returned. Cycles terminate at the CYCLE clause.
+
+    The root node itself is included (depth 0) so a caller can
+    distinguish "node exists but has no dependents" (one-element list)
+    from "node does not exist in this tenant" (empty list).
+    """
+    return await _traverse(
+        operator,
+        name_or_alias,
+        depth=depth,
+        kind_filter=kind_filter,
+        reverse=True,
+    )
+
+
+async def find_dependencies(
+    operator: Operator,
+    name_or_alias: str,
+    *,
+    depth: int = _DEFAULT_DEPTH,
+    kind_filter: str | None = None,
+) -> list[TopologyNode]:
+    """Forward traversal: everything *name_or_alias* depends on.
+
+    The mirror of :func:`find_dependents` — same shape, same tenant
+    scoping, same cycle safety and depth bound — with edges walked in
+    the opposite direction (out of the current node rather than into
+    it). Root included at depth 0; empty list means the node does not
+    exist in this tenant.
+    """
+    return await _traverse(
+        operator,
+        name_or_alias,
+        depth=depth,
+        kind_filter=kind_filter,
+        reverse=False,
+    )
+
+
+# Bidirectional shortest-path recursive CTE. The ``bi_edge`` CTE is the
+# union of forward and reversed edges (tenant-scoped) so the walk treats
+# the graph as undirected for reachability while storage stays directed.
+# The ``node_ids`` / ``edge_kinds`` arrays accumulate the ordered route
+# so the winning row already describes the whole path; ``visited`` is the
+# CYCLE bookkeeping set (independent of ``node_ids``). The hop bound plus
+# the CYCLE guard terminate the search on cyclic graphs; ``ORDER BY hops
+# LIMIT 1`` yields a shortest path.
+_PATH_SQL = text(
+    """
+    WITH RECURSIVE
+    bi_edge AS (
+        SELECT from_node_id AS src, to_node_id AS dst, kind
+        FROM graph_edge
+        WHERE tenant_id = :tenant_id
+        UNION ALL
+        SELECT to_node_id AS src, from_node_id AS dst, kind
+        FROM graph_edge
+        WHERE tenant_id = :tenant_id
+    ),
+    walk AS (
+        SELECT
+            n.id                                   AS node_id,
+            0                                      AS hops,
+            ARRAY[n.id]                            AS node_ids,
+            CAST(ARRAY[] AS text[])                AS edge_kinds
+        FROM graph_node n
+        WHERE n.name = :from_name
+          AND n.tenant_id = :tenant_id
+        UNION ALL
+        SELECT
+            be.dst,
+            w.hops + 1,
+            w.node_ids || be.dst,
+            w.edge_kinds || be.kind
+        FROM bi_edge be
+        JOIN walk w ON be.src = w.node_id
+        WHERE w.hops < :max_hops
+    ) CYCLE node_id SET is_cycle USING visited
+    SELECT w.hops, w.node_ids, w.edge_kinds
+    FROM walk w
+    JOIN graph_node tn
+      ON tn.id = w.node_id
+     AND tn.name = :to_name
+     AND tn.tenant_id = :tenant_id
+    WHERE NOT w.is_cycle
+    ORDER BY w.hops
+    LIMIT 1
+    """
+)
+
+# Materialise the full node rows for a winning path id list. The CYCLE
+# guard already excluded repeats so the id list has no duplicates within
+# a single path; the caller re-orders the fetched rows back into path
+# sequence.
+_PATH_NODES_SQL = text(
+    """
+    SELECT id, kind, name, properties
+    FROM graph_node
+    WHERE tenant_id = :tenant_id
+      AND id = ANY(:node_ids)
+    """
+)
+
+
+def _build_path_nodes(
+    node_ids: list[UUID],
+    edge_kinds: list[str],
+    by_id: dict[UUID, Any],
+) -> tuple[TopologyNode, ...]:
+    """Assemble the ordered :class:`TopologyNode` tuple for a path.
+
+    ``node_ids`` is the path sequence; ``by_id`` maps each id to its
+    fetched node mapping. ``via_edge_kind`` is ``None`` for the root
+    (position 0) and the kind of the ``(position-1)``-th hop otherwise.
+    """
+    nodes: list[TopologyNode] = []
+    for position, node_id in enumerate(node_ids):
+        m = by_id[node_id]
+        nodes.append(
+            TopologyNode(
+                id=m["id"],
+                kind=m["kind"],
+                name=m["name"],
+                properties=m["properties"] or {},
+                depth=position,
+                via_edge_kind=None if position == 0 else edge_kinds[position - 1],
+            )
+        )
+    return tuple(nodes)
+
+
+async def find_path(
+    operator: Operator,
+    from_name: str,
+    to_name: str,
+    *,
+    max_hops: int = _DEFAULT_MAX_HOPS,
+) -> TopologyPath | None:
+    """Shortest unweighted path from *from_name* to *to_name*.
+
+    Walks edges in both directions (``from``→``to`` and ``to``→``from``)
+    so the path follows the graph's connectivity rather than only its
+    edge orientation — "is there *any* route between these two
+    objects" is the operator question this answers. Every edge costs
+    one hop (v0.2 is unweighted). Returns the first path found at the
+    minimum hop count, or ``None`` if *to_name* is unreachable from
+    *from_name* within ``max_hops`` (or either endpoint does not exist
+    in this tenant).
+
+    A second resolving query materialises the node rows in path order
+    so the :class:`TopologyPath` carries full :class:`TopologyNode`
+    records, not bare ids.
+    """
+    tenant_id = str(operator.tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        path_result = await session.execute(
+            _PATH_SQL,
+            {
+                "tenant_id": tenant_id,
+                "from_name": from_name,
+                "to_name": to_name,
+                "max_hops": max_hops,
+            },
+        )
+        winner = path_result.first()
+        if winner is None:
+            return None
+
+        node_ids: list[UUID] = list(winner._mapping["node_ids"])
+        edge_kinds: list[str] = list(winner._mapping["edge_kinds"])
+        total_hops: int = winner._mapping["hops"]
+
+        node_result = await session.execute(
+            _PATH_NODES_SQL,
+            {"tenant_id": tenant_id, "node_ids": node_ids},
+        )
+        by_id = {r._mapping["id"]: r._mapping for r in node_result.fetchall()}
+
+    nodes = _build_path_nodes(node_ids, edge_kinds, by_id)
+    return TopologyPath(nodes=nodes, total_hops=total_hops)

--- a/backend/src/meho_backplane/topology/schemas.py
+++ b/backend/src/meho_backplane/topology/schemas.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic models for topology query inputs and result shapes.
+
+Task #451 (G9.1-T4). The three query verbs in
+:mod:`meho_backplane.topology.query` return these frozen models. The
+shapes mirror the immutability discipline the connector
+:class:`~meho_backplane.connectors.schemas.NodeHint` family already
+established: ``properties`` round-trips as a plain ``dict`` over the
+wire but is wrapped in :class:`types.MappingProxyType` after validation
+so a frozen :class:`TopologyNode` is deeply immutable end to end. A
+caller cannot mutate a node's ``properties`` bag and have that leak
+back into a shared result list.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+
+__all__ = ["TopologyNode", "TopologyPath"]
+
+
+class TopologyNode(BaseModel):
+    """One ``graph_node`` row reached during a traversal.
+
+    ``depth`` is the distance from the query root: the root itself is
+    depth ``0``, its immediate dependents/dependencies are depth ``1``,
+    transitive ones depth ``2``, and so on. ``via_edge_kind`` is the
+    ``graph_edge.kind`` of the edge used to reach this node, or
+    ``None`` for the root (which is reached by no edge).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    kind: str
+    name: str
+    properties: dict[str, Any] = Field(default_factory=dict)
+    depth: int
+    via_edge_kind: str | None
+
+    @model_validator(mode="after")
+    def _freeze_properties(self) -> TopologyNode:
+        object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
+        return self
+
+    @field_serializer("properties")
+    def _serialize_properties(self, value: dict[str, Any]) -> dict[str, Any]:
+        return dict(value)
+
+
+class TopologyPath(BaseModel):
+    """An ordered shortest path between two nodes.
+
+    ``nodes`` runs from the ``from`` node (``depth == 0``) to the
+    ``to`` node (``depth == total_hops``) inclusive. ``total_hops`` is
+    the number of edges traversed, i.e. ``len(nodes) - 1``. v0.2 is
+    unweighted: every edge costs one hop.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    nodes: tuple[TopologyNode, ...]
+    total_hops: int

--- a/backend/src/meho_backplane/topology/schemas.py
+++ b/backend/src/meho_backplane/topology/schemas.py
@@ -25,6 +25,37 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_valid
 __all__ = ["TopologyNode", "TopologyPath"]
 
 
+def _deep_freeze(value: Any) -> Any:
+    """Recursively make a JSON-shaped value immutable.
+
+    ``dict`` → :class:`types.MappingProxyType` (read-only view), ``list``
+    → ``tuple``, every primitive returned unchanged. Applied to
+    ``properties`` so a frozen :class:`TopologyNode` is immutable all the
+    way down — a caller cannot reach into a nested bag and mutate shared
+    result state. The inverse is :func:`_deep_thaw`.
+    """
+    if isinstance(value, dict):
+        return MappingProxyType({k: _deep_freeze(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return tuple(_deep_freeze(v) for v in value)
+    return value
+
+
+def _deep_thaw(value: Any) -> Any:
+    """Inverse of :func:`_deep_freeze` for serialisation.
+
+    ``MappingProxyType`` → plain ``dict``, ``tuple`` → ``list``,
+    primitives unchanged, so ``model_dump`` / ``model_dump_json`` emit a
+    plain mutable JSON object rather than leaking the internal frozen
+    representation over the wire.
+    """
+    if isinstance(value, MappingProxyType):
+        return {k: _deep_thaw(v) for k, v in value.items()}
+    if isinstance(value, tuple):
+        return [_deep_thaw(v) for v in value]
+    return value
+
+
 class TopologyNode(BaseModel):
     """One ``graph_node`` row reached during a traversal.
 
@@ -46,12 +77,16 @@ class TopologyNode(BaseModel):
 
     @model_validator(mode="after")
     def _freeze_properties(self) -> TopologyNode:
-        object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
+        object.__setattr__(self, "properties", _deep_freeze(dict(self.properties)))
         return self
 
     @field_serializer("properties")
     def _serialize_properties(self, value: dict[str, Any]) -> dict[str, Any]:
-        return dict(value)
+        # `value` is always the top-level frozen mapping, so the thawed
+        # result is always a plain dict; the cast narrows _deep_thaw's
+        # intentionally-broad return for the field-serialiser contract.
+        thawed: dict[str, Any] = _deep_thaw(value)
+        return thawed
 
 
 class TopologyPath(BaseModel):
@@ -65,5 +100,14 @@ class TopologyPath(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    nodes: tuple[TopologyNode, ...]
-    total_hops: int
+    nodes: tuple[TopologyNode, ...] = Field(min_length=1)
+    total_hops: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _check_hops_match_nodes(self) -> TopologyPath:
+        expected = len(self.nodes) - 1
+        if self.total_hops != expected:
+            raise ValueError(
+                f"total_hops ({self.total_hops}) must equal len(nodes) - 1 ({expected})"
+            )
+        return self

--- a/backend/tests/integration/test_topology_query.py
+++ b/backend/tests/integration/test_topology_query.py
@@ -33,6 +33,10 @@ Coverage matrix (mirrors the Task #451 acceptance criteria):
 * ``kind_filter`` restricts the traversal to one edge kind.
 * The tenant boundary holds: a same-named node in tenant B is invisible
   to a tenant-A query.
+* A bare-name anchor that resolves to two kinds in one tenant raises
+  ``AmbiguousNodeError``; an explicit ``kind`` pins the right closure.
+* The converging-DAG dedupe holds: a node reachable by several paths
+  appears exactly once at its minimum depth.
 * A 10k-node fixture completes a depth-16 traversal in under 100 ms.
 """
 
@@ -40,6 +44,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from collections import Counter
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -49,6 +54,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import GraphEdge, GraphNode
 from meho_backplane.topology.query import (
+    AmbiguousNodeError,
     find_dependencies,
     find_dependents,
     find_path,
@@ -174,12 +180,19 @@ async def test_find_dependents_returns_reverse_closure(
     """
     nodes = await find_dependents(_operator(TENANT_A_ID), "host1")
 
+    # One row per reachable node — NOT one per path. `app` is reachable
+    # from host1 through both vm1 and vm2; a per-path traversal returns
+    # it twice. The Counter assertion (rather than a set) is what makes
+    # the converging-DAG duplicate fail loudly instead of being masked.
+    assert Counter(n.name for n in nodes) == Counter({"host1": 1, "vm1": 1, "vm2": 1, "app": 1})
+
     by_depth: dict[int, set[str]] = {}
     for n in nodes:
         by_depth.setdefault(n.depth, set()).add(n.name)
 
     assert by_depth[0] == {"host1"}
     assert by_depth[1] == {"vm1", "vm2"}
+    # app is collapsed to its minimum-depth occurrence (depth 2).
     assert by_depth[2] == {"app"}
     # Result is ordered by (depth, name).
     assert [n.depth for n in nodes] == sorted(n.depth for n in nodes)
@@ -385,6 +398,64 @@ async def test_depth_16_traversal_on_10k_nodes_under_100ms(
     assert elapsed_ms < 100.0, f"depth-16 traversal took {elapsed_ms:.1f} ms"
 
 
+@_skip_no_docker
+async def test_same_tenant_kind_collision_disambiguated_by_kind(
+    pg_engine: None,
+) -> None:
+    """Same ``name``, two ``kind``s, one tenant — bare lookup must refuse.
+
+    ``graph_node`` uniqueness is ``(tenant_id, kind, name)``. Seed a
+    ``target`` named ``svc`` with one dependent and an unrelated ``vm``
+    named ``svc`` with a different dependent. A bare-name traversal
+    cannot pick one anchor, so it raises ``AmbiguousNodeError`` rather
+    than silently merging the two closures. Pinning ``kind`` resolves
+    to exactly the requested object's closure.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        svc_target = await _seed_node(session, tenant_id=TENANT_A_ID, kind="target", name="svc")
+        svc_vm = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="svc")
+        dep_of_target = await _seed_node(
+            session, tenant_id=TENANT_A_ID, kind="vm", name="dep-of-target"
+        )
+        dep_of_vm = await _seed_node(session, tenant_id=TENANT_A_ID, kind="host", name="dep-of-vm")
+        await _seed_edge(
+            session,
+            tenant_id=TENANT_A_ID,
+            from_id=dep_of_target,
+            to_id=svc_target,
+            kind="belongs-to",
+        )
+        await _seed_edge(
+            session,
+            tenant_id=TENANT_A_ID,
+            from_id=dep_of_vm,
+            to_id=svc_vm,
+            kind="runs-on",
+        )
+
+    operator = _operator(TENANT_A_ID)
+
+    with pytest.raises(AmbiguousNodeError) as excinfo:
+        await find_dependents(operator, "svc")
+    assert sorted(excinfo.value.kinds) == ["target", "vm"]
+
+    # Pinning kind picks exactly one closure — no merge.
+    target_dependents = await find_dependents(operator, "svc", kind="target")
+    assert {n.name for n in target_dependents} == {"svc", "dep-of-target"}
+
+    vm_dependents = await find_dependents(operator, "svc", kind="vm")
+    assert {n.name for n in vm_dependents} == {"svc", "dep-of-vm"}
+
+    # find_path applies the same contract independently per endpoint.
+    with pytest.raises(AmbiguousNodeError):
+        await find_path(operator, "svc", "dep-of-target")
+    pinned = await find_path(operator, "svc", "dep-of-target", from_kind="target")
+    assert pinned is not None
+    assert pinned.total_hops == 1
+    assert {n.name for n in pinned.nodes} == {"svc", "dep-of-target"}
+
+
 def test_module_imports_cleanly() -> None:
     """Cheap collection-time smoke that runs on no-Docker sandboxes.
 
@@ -398,5 +469,6 @@ def test_module_imports_cleanly() -> None:
     assert callable(query.find_dependents)
     assert callable(query.find_dependencies)
     assert callable(query.find_path)
+    assert issubclass(query.AmbiguousNodeError, ValueError)
     assert schemas.TopologyNode.model_config["frozen"] is True
     assert schemas.TopologyPath.model_config["frozen"] is True

--- a/backend/tests/integration/test_topology_query.py
+++ b/backend/tests/integration/test_topology_query.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration tests for the recursive-CTE topology query verbs.
+
+Task #451 (G9.1-T4) acceptance suite. Every test runs against a real
+``pgvector/pgvector:pg16`` container because the query module uses
+PostgreSQL's ``WITH RECURSIVE ... CYCLE`` clause, which SQLite (the
+unit suite's per-test ``alembic upgrade head`` DB) does not implement.
+This is the same real-PG rationale, fixture wiring, and Docker-gated
+skip that :mod:`tests.integration.test_tenant_isolation` documents:
+the ``pg_engine`` fixture in :mod:`tests.integration.conftest` boots
+the container, migrates it to head, truncates the graph tables, and
+seeds the two pinned tenants ``TENANT_A_ID`` / ``TENANT_B_ID``. CI
+runners have Docker and run the whole class; agent sandboxes without
+Docker skip cleanly.
+
+Why every test body is ``async def`` with no ``@pytest.mark.asyncio``:
+``backend/pyproject.toml`` pins ``asyncio_mode = "auto"`` so the
+plugin treats every ``async def`` test as a coroutine test on the
+session loop the ``pg_engine`` asyncpg pool is bound to — same shape
+as the rest of ``tests/integration/``.
+
+Coverage matrix (mirrors the Task #451 acceptance criteria):
+
+* ``find_dependents`` against a seeded 5-node / 6-edge graph returns
+  the correct reverse closure ordered by depth.
+* ``find_dependencies`` mirrors that in the forward direction.
+* ``find_path`` returns the shortest path between reachable nodes and
+  ``None`` when unreachable within ``max_hops``.
+* The CYCLE clause makes an ``A → B → A`` graph terminate instead of
+  recursing forever.
+* ``kind_filter`` restricts the traversal to one edge kind.
+* The tenant boundary holds: a same-named node in tenant B is invisible
+  to a tenant-A query.
+* A 10k-node fixture completes a depth-16 traversal in under 100 ms.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GraphEdge, GraphNode
+from meho_backplane.topology.query import (
+    find_dependencies,
+    find_dependents,
+    find_path,
+)
+from tests.integration.conftest import DOCKER_AVAILABLE, SKIP_REASON
+
+# Match the tenant rows the ``pg_engine`` conftest fixture seeds.
+TENANT_A_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+TENANT_B_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+
+def _operator(tenant_id: uuid.UUID) -> Operator:
+    """Build a minimal :class:`Operator` pinned to *tenant_id*."""
+    return Operator(
+        sub="op-topology",
+        name=None,
+        email=None,
+        raw_jwt="not-a-real-jwt",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_node(
+    session: Any,
+    *,
+    tenant_id: uuid.UUID,
+    kind: str,
+    name: str,
+) -> uuid.UUID:
+    """Insert one ``graph_node`` and return its id.
+
+    Flushes immediately so the row exists before any ``graph_edge``
+    that references it is added — SQLAlchemy's unit-of-work otherwise
+    batches inserts in an order that can emit the edge before its
+    endpoint node and trip the ``REFERENCES graph_node(id)`` FK.
+    """
+    node = GraphNode(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        kind=kind,
+        name=name,
+        properties={"seeded": name},
+        discovered_by="test",
+    )
+    session.add(node)
+    await session.flush()
+    return node.id
+
+
+async def _seed_edge(
+    session: Any,
+    *,
+    tenant_id: uuid.UUID,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    kind: str,
+) -> None:
+    """Insert one ``graph_edge`` (``source='auto'``)."""
+    session.add(
+        GraphEdge(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            from_node_id=from_id,
+            to_node_id=to_id,
+            kind=kind,
+            source="auto",
+            discovered_by="test",
+        )
+    )
+
+
+@pytest.fixture
+async def known_graph(pg_engine: None) -> AsyncIterator[dict[str, uuid.UUID]]:
+    """Seed the canonical 5-node / 6-edge graph in tenant A.
+
+    Shape (edge ``from`` depends on ``to``)::
+
+        app  --belongs-to-->  vm1   --runs-on-->  host1  --mounts-->  ds1
+        app  --belongs-to-->  vm2   --runs-on-->  host1
+        vm1  --mounts------->  ds1
+
+    Nodes: app (target), vm1 (vm), vm2 (vm), host1 (host), ds1
+    (datastore). Edges: 6 total — two belongs-to, two runs-on, two
+    mounts. The shape gives a multi-depth reverse closure on host1
+    (vm1/vm2 at depth 1, app at depth 2) and a multi-depth forward
+    closure on app, plus a kind-filterable subgraph (the two mounts
+    edges).
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        app = await _seed_node(session, tenant_id=TENANT_A_ID, kind="target", name="app")
+        vm1 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="vm1")
+        vm2 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="vm2")
+        host1 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="host", name="host1")
+        ds1 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="datastore", name="ds1")
+        await _seed_edge(session, tenant_id=TENANT_A_ID, from_id=app, to_id=vm1, kind="belongs-to")
+        await _seed_edge(session, tenant_id=TENANT_A_ID, from_id=app, to_id=vm2, kind="belongs-to")
+        await _seed_edge(session, tenant_id=TENANT_A_ID, from_id=vm1, to_id=host1, kind="runs-on")
+        await _seed_edge(session, tenant_id=TENANT_A_ID, from_id=vm2, to_id=host1, kind="runs-on")
+        await _seed_edge(session, tenant_id=TENANT_A_ID, from_id=host1, to_id=ds1, kind="mounts")
+        await _seed_edge(session, tenant_id=TENANT_A_ID, from_id=vm1, to_id=ds1, kind="mounts")
+
+    yield {
+        "app": app,
+        "vm1": vm1,
+        "vm2": vm2,
+        "host1": host1,
+        "ds1": ds1,
+    }
+
+
+@_skip_no_docker
+async def test_find_dependents_returns_reverse_closure(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """Everything that depends on ``host1`` at depth <= 16.
+
+    vm1 and vm2 run on host1 (depth 1); app belongs to both vms so it
+    transitively depends on host1 (depth 2). The root host1 is depth 0.
+    """
+    nodes = await find_dependents(_operator(TENANT_A_ID), "host1")
+
+    by_depth: dict[int, set[str]] = {}
+    for n in nodes:
+        by_depth.setdefault(n.depth, set()).add(n.name)
+
+    assert by_depth[0] == {"host1"}
+    assert by_depth[1] == {"vm1", "vm2"}
+    assert by_depth[2] == {"app"}
+    # Result is ordered by (depth, name).
+    assert [n.depth for n in nodes] == sorted(n.depth for n in nodes)
+    # via_edge_kind: root has none; the depth-1 hops came over runs-on.
+    root = next(n for n in nodes if n.name == "host1")
+    assert root.via_edge_kind is None
+    assert all(n.via_edge_kind == "runs-on" for n in nodes if n.depth == 1)
+
+
+@_skip_no_docker
+async def test_find_dependencies_returns_forward_closure(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """Everything ``app`` depends on, forward direction.
+
+    app -> vm1, vm2 (depth 1); vm1/vm2 -> host1 and vm1 -> ds1 (depth
+    2); host1 -> ds1 (depth 3 via the vm->host->ds path).
+    """
+    nodes = await find_dependencies(_operator(TENANT_A_ID), "app")
+    names = {n.name for n in nodes}
+
+    assert names == {"app", "vm1", "vm2", "host1", "ds1"}
+    depth_by_name: dict[str, int] = {}
+    for n in nodes:
+        depth_by_name[n.name] = min(n.depth, depth_by_name.get(n.name, n.depth))
+    assert depth_by_name["app"] == 0
+    assert depth_by_name["vm1"] == 1
+    assert depth_by_name["vm2"] == 1
+    assert depth_by_name["host1"] == 2
+    assert depth_by_name["ds1"] == 2  # vm1 --mounts--> ds1 is depth 2
+
+
+@_skip_no_docker
+async def test_find_path_returns_shortest_path(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """A path from ``app`` to ``ds1`` exists and is the shortest one.
+
+    Shortest is app -> vm1 -> ds1 (2 hops) via the vm1--mounts-->ds1
+    edge; the app -> vm1 -> host1 -> ds1 route is 3 hops.
+    """
+    path = await find_path(_operator(TENANT_A_ID), "app", "ds1")
+
+    assert path is not None
+    assert path.total_hops == 2
+    assert path.nodes[0].name == "app"
+    assert path.nodes[0].depth == 0
+    assert path.nodes[0].via_edge_kind is None
+    assert path.nodes[-1].name == "ds1"
+    assert path.nodes[-1].depth == 2
+    assert len(path.nodes) == 3
+
+
+@_skip_no_docker
+async def test_find_path_returns_none_when_unreachable(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """A 1-hop ceiling cannot reach ds1 from app (shortest is 2 hops)."""
+    path = await find_path(_operator(TENANT_A_ID), "app", "ds1", max_hops=1)
+    assert path is None
+
+    # Genuinely absent target also yields None.
+    missing = await find_path(_operator(TENANT_A_ID), "app", "no-such-node")
+    assert missing is None
+
+
+@_skip_no_docker
+async def test_cycle_detection_terminates(pg_engine: None) -> None:
+    """An ``A -> B -> A`` cycle does not infinite-loop.
+
+    Without the CYCLE clause this traversal would recurse until the
+    server stack/working-memory blew. With it, PostgreSQL stops
+    recursing into an already-visited node on the branch and the
+    query returns. The result is the finite reachable set, not an
+    error and not a hang.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        a = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="cyc-a")
+        b = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="cyc-b")
+        await _seed_edge(session, tenant_id=TENANT_A_ID, from_id=a, to_id=b, kind="runs-on")
+        await _seed_edge(session, tenant_id=TENANT_A_ID, from_id=b, to_id=a, kind="runs-on")
+
+    # Bounded wall-clock guard: a non-terminating traversal would blow
+    # well past this; a correct one is sub-second.
+    started = time.monotonic()
+    deps = await find_dependencies(_operator(TENANT_A_ID), "cyc-a")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5.0
+    names = {n.name for n in deps}
+    assert names == {"cyc-a", "cyc-b"}
+
+    path = await find_path(_operator(TENANT_A_ID), "cyc-a", "cyc-b")
+    assert path is not None
+    assert path.total_hops == 1
+
+
+@_skip_no_docker
+async def test_kind_filter_restricts_traversal(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """``kind_filter='runs-on'`` walks only runs-on edges.
+
+    From host1, reverse traversal restricted to runs-on reaches vm1
+    and vm2 (the two runs-on edges) but NOT app — app's edges to the
+    vms are belongs-to, so the filtered walk cannot step past the vms.
+    """
+    nodes = await find_dependents(_operator(TENANT_A_ID), "host1", kind_filter="runs-on")
+    names = {n.name for n in nodes}
+    assert names == {"host1", "vm1", "vm2"}
+    assert "app" not in names
+
+
+@_skip_no_docker
+async def test_tenant_boundary_isolates_same_named_node(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """A ``host1`` in tenant B is invisible to tenant A's query.
+
+    Seed an unrelated tenant-B graph that also contains a node named
+    ``host1`` with a tenant-B dependent. Tenant A's find_dependents on
+    ``host1`` must return only tenant A's closure; tenant B's must
+    return only tenant B's.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        b_host = await _seed_node(session, tenant_id=TENANT_B_ID, kind="host", name="host1")
+        b_vm = await _seed_node(session, tenant_id=TENANT_B_ID, kind="vm", name="tenant-b-only-vm")
+        await _seed_edge(
+            session,
+            tenant_id=TENANT_B_ID,
+            from_id=b_vm,
+            to_id=b_host,
+            kind="runs-on",
+        )
+
+    a_nodes = await find_dependents(_operator(TENANT_A_ID), "host1")
+    a_names = {n.name for n in a_nodes}
+    assert "tenant-b-only-vm" not in a_names
+    assert a_names == {"host1", "vm1", "vm2", "app"}
+
+    b_nodes = await find_dependents(_operator(TENANT_B_ID), "host1")
+    b_names = {n.name for n in b_nodes}
+    assert b_names == {"host1", "tenant-b-only-vm"}
+    assert "app" not in b_names
+
+
+@_skip_no_docker
+async def test_depth_16_traversal_on_10k_nodes_under_100ms(
+    pg_engine: None,
+) -> None:
+    """A 10k-node fixture: a depth-16 traversal completes in < 100 ms.
+
+    Build a wide-but-shallow forest: 16 chains of ~625 nodes each
+    rooted at a single hub so a depth-16 dependents traversal from the
+    hub touches the whole structure. The assertion is on the query
+    wall-clock only (seeding is excluded) — the
+    ``graph_edge_tenant_to_idx`` / ``graph_edge_tenant_from_idx``
+    indexes migration 0007 ships are what keep the recursive join
+    sub-linear per level.
+    """
+    total = 10_000
+    chains = 16
+    per_chain = (total - 1) // chains  # ~624 nodes per chain + 1 hub
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        hub = await _seed_node(session, tenant_id=TENANT_A_ID, kind="host", name="perf-hub")
+        for c in range(chains):
+            prev = hub
+            for d in range(per_chain):
+                nxt = await _seed_node(
+                    session,
+                    tenant_id=TENANT_A_ID,
+                    kind="vm",
+                    name=f"perf-{c}-{d}",
+                )
+                # Edge points from the deeper node toward the hub so a
+                # *dependents* (reverse) walk from the hub fans out
+                # through the whole forest.
+                await _seed_edge(
+                    session,
+                    tenant_id=TENANT_A_ID,
+                    from_id=nxt,
+                    to_id=prev,
+                    kind="runs-on",
+                )
+                prev = nxt
+
+    operator = _operator(TENANT_A_ID)
+    # Warm the connection/plan once so the timed run measures steady
+    # state, not first-call connection setup.
+    await find_dependents(operator, "perf-hub", depth=1)
+
+    started = time.monotonic()
+    nodes = await find_dependents(operator, "perf-hub", depth=16)
+    elapsed_ms = (time.monotonic() - started) * 1000.0
+
+    # depth 0 hub + 16 levels across 16 chains = 1 + 16*16 = 257 nodes
+    # reachable within the depth-16 budget.
+    assert len(nodes) == 1 + chains * 16
+    assert elapsed_ms < 100.0, f"depth-16 traversal took {elapsed_ms:.1f} ms"
+
+
+def test_module_imports_cleanly() -> None:
+    """Cheap collection-time smoke that runs on no-Docker sandboxes.
+
+    Mirrors the same guard :mod:`tests.integration.test_tenant_isolation`
+    keeps: if a public symbol in the query module were renamed or
+    removed, this fails first on every sandbox, not only the
+    Docker-gated runners.
+    """
+    from meho_backplane.topology import query, schemas
+
+    assert callable(query.find_dependents)
+    assert callable(query.find_dependencies)
+    assert callable(query.find_path)
+    assert schemas.TopologyNode.model_config["frozen"] is True
+    assert schemas.TopologyPath.model_config["frozen"] is True

--- a/backend/tests/test_topology_query_schemas.py
+++ b/backend/tests/test_topology_query_schemas.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the topology query result models.
+
+Task #451 (G9.1-T4). These exercise the pure Pydantic v2 contracts of
+:class:`~meho_backplane.topology.schemas.TopologyNode` and
+:class:`~meho_backplane.topology.schemas.TopologyPath` with no database
+— so they run on every sandbox, not only the Docker-gated integration
+runners that :mod:`tests.integration.test_topology_query` needs.
+
+Coverage matrix:
+
+* ``TopologyNode.properties`` is **deeply** immutable: top-level,
+  nested-dict, and nested-list mutation all fail; ``model_dump`` /
+  ``model_dump_json`` round-trip back to a plain mutable ``dict`` /
+  ``list``.
+* ``TopologyPath`` rejects structurally invalid instances (empty
+  ``nodes``; ``total_hops`` disagreeing with ``len(nodes) - 1``) and
+  accepts a well-formed one.
+"""
+
+from __future__ import annotations
+
+import json
+from types import MappingProxyType
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from meho_backplane.topology.schemas import TopologyNode, TopologyPath
+
+
+def _node(name: str, *, depth: int = 0, properties: dict | None = None) -> TopologyNode:
+    return TopologyNode(
+        id=uuid4(),
+        kind="vm",
+        name=name,
+        properties=properties if properties is not None else {},
+        depth=depth,
+        via_edge_kind=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# M1 — TopologyNode.properties deep immutability
+# ---------------------------------------------------------------------------
+
+
+def test_node_properties_top_level_is_read_only() -> None:
+    node = _node("vm1", properties={"a": 1})
+    assert isinstance(node.properties, MappingProxyType)
+    with pytest.raises(TypeError):
+        node.properties["b"] = 2  # type: ignore[index]
+
+
+def test_node_properties_nested_dict_is_frozen() -> None:
+    node = _node("vm1", properties={"outer": {"inner": 1}})
+    assert isinstance(node.properties["outer"], MappingProxyType)
+    with pytest.raises(TypeError):
+        node.properties["outer"]["inner"] = 99  # type: ignore[index]
+
+
+def test_node_properties_nested_list_is_frozen() -> None:
+    node = _node("vm1", properties={"items": [1, 2, {"x": 3}]})
+    # Lists are frozen to tuples; the nested dict inside is a proxy too.
+    assert isinstance(node.properties["items"], tuple)
+    assert isinstance(node.properties["items"][2], MappingProxyType)
+    with pytest.raises(AttributeError):
+        node.properties["items"].append(4)  # type: ignore[attr-defined]
+
+
+def test_node_properties_serialises_back_to_plain_mutable_structures() -> None:
+    node = _node("vm1", properties={"outer": {"inner": 1}, "items": [1, {"x": 2}]})
+
+    dumped = node.model_dump()
+    props = dumped["properties"]
+    assert isinstance(props, dict)
+    assert isinstance(props["outer"], dict)
+    assert isinstance(props["items"], list)
+    assert isinstance(props["items"][1], dict)
+    # Round-tripped structure is mutable again (no proxy/tuple leaked).
+    props["outer"]["inner"] = 42
+    props["items"].append(99)
+
+    # JSON serialisation produces the same plain shape.
+    parsed = json.loads(node.model_dump_json())
+    assert parsed["properties"] == {"outer": {"inner": 1}, "items": [1, {"x": 2}]}
+    assert parsed["via_edge_kind"] is None
+
+
+# ---------------------------------------------------------------------------
+# m1 — TopologyPath structural invariants
+# ---------------------------------------------------------------------------
+
+
+def test_path_rejects_empty_nodes() -> None:
+    with pytest.raises(ValidationError):
+        TopologyPath(nodes=(), total_hops=0)
+
+
+def test_path_rejects_negative_total_hops() -> None:
+    with pytest.raises(ValidationError):
+        TopologyPath(nodes=(_node("a"),), total_hops=-1)
+
+
+def test_path_rejects_total_hops_not_matching_node_count() -> None:
+    with pytest.raises(ValidationError):
+        TopologyPath(nodes=(_node("a"), _node("b", depth=1)), total_hops=5)
+
+
+def test_path_accepts_well_formed_instance() -> None:
+    nodes = (_node("a"), _node("b", depth=1), _node("c", depth=2))
+    path = TopologyPath(nodes=nodes, total_hops=2)
+    assert path.total_hops == len(path.nodes) - 1
+
+
+def test_single_node_path_is_valid() -> None:
+    path = TopologyPath(nodes=(_node("solo"),), total_hops=0)
+    assert path.total_hops == 0
+    assert len(path.nodes) == 1

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -7,12 +7,20 @@ blast-radius check and topology question in v0.2 dispatches through. It
 ships three async query verbs and the two Pydantic value types around
 them:
 
-- `find_dependents(operator, name_or_alias, *, depth=16, kind_filter=None)`
+- `find_dependents(operator, name_or_alias, *, kind=None, depth=16, kind_filter=None)`
   — reverse traversal, "what depends on me".
-- `find_dependencies(operator, name_or_alias, *, depth=16, kind_filter=None)`
+- `find_dependencies(operator, name_or_alias, *, kind=None, depth=16, kind_filter=None)`
   — forward traversal, "what I depend on".
-- `find_path(operator, from_name, to_name, *, max_hops=8)` — shortest
-  unweighted path, or `None` if unreachable.
+- `find_path(operator, from_name, to_name, *, from_kind=None, to_kind=None, max_hops=8)`
+  — shortest unweighted path, or `None` if unreachable.
+
+Every verb returns **one row per reachable node** (a node reachable by
+several converging paths is collapsed to its minimum-depth occurrence —
+`CYCLE` alone only dedupes within a single branch). An anchor requested
+by bare `name` that resolves to more than one `kind` in the tenant
+raises `AmbiguousNodeError` rather than traversing a merged closure;
+pass the optional `kind` (or `from_kind` / `to_kind` for `find_path`) to
+pin the `(tenant_id, kind, name)` unique row.
 
 The package is **read-only**. `graph_node` / `graph_edge` rows are
 written by the refresh service (G9.1-T3, #450); the schema and ORM
@@ -55,21 +63,45 @@ An edge `from_node --kind--> to_node` reads "`from_node` depends on
   step to `e.to_node_id`.
 
 `find_dependents` and `find_dependencies` share `_traverse`, which
-delegates SQL construction to `_traversal_sql(reverse=...)` — only the
-two join columns differ; tenant scoping, the optional `kind_filter`,
-the depth bound, the CYCLE guard, and the `(depth, name)` ordering are
-identical.
+picks the reverse or forward **fully-literal** `text()` statement
+(`_TRAVERSAL_SQL_REVERSE` / `_TRAVERSAL_SQL_FORWARD`) — only the two
+join columns differ; tenant scoping, the optional `kind` anchor pin,
+the optional `kind_filter`, the depth bound, the CYCLE guard, the
+closure-wide dedupe, and the `(depth, name)` ordering are identical.
+The two statements are kept separate (rather than one f-string with the
+join columns interpolated) so the `avoid-sqlalchemy-text` SAST rule
+does not fire — nothing is interpolated, every value is a `:named`
+bind.
 
 ### Recursive CTE shape
 
 The traversal is a single `WITH RECURSIVE walk AS (...) CYCLE id SET
 is_cycle USING path` statement. The anchor row is the root at depth 0
-(`via_edge_kind` NULL). The recursive term joins `graph_edge` to the
-walk frontier, scoped on `tenant_id` on both the edge and the
-destination node, applies `CAST(:kind_filter AS text) IS NULL OR
-e.kind = :kind_filter`, and bounds `w.depth < :depth`. The final
-SELECT keeps `depth <= :depth AND NOT is_cycle` ordered by
-`(depth, name)`.
+(`via_edge_kind` NULL), filtered by `CAST(:kind AS text) IS NULL OR
+n.kind = :kind` so a pinned `kind` resolves the `(tenant_id, kind,
+name)` unique row. The recursive term joins `graph_edge` to the walk
+frontier, scoped on `tenant_id` on both the edge and the destination
+node, applies `CAST(:kind_filter AS text) IS NULL OR e.kind =
+:kind_filter`, and bounds `w.depth < :depth`. The final projection
+wraps the filtered walk in a `SELECT DISTINCT ON (id) ... ORDER BY id,
+depth, name` subquery (keeping the minimum-depth occurrence of each
+node) and re-orders the result by `(depth, name)`. `CYCLE` only
+prevents revisiting a node on the *same* branch; the `DISTINCT ON`
+collapse is what makes a converging DAG return one row per node rather
+than one row per path.
+
+### Anchor disambiguation
+
+`graph_node` uniqueness is `(tenant_id, kind, name)`. Resolving an
+anchor by `name` alone would match every kind with that name and
+silently merge unrelated closures. `_assert_anchor_unambiguous` probes
+the distinct kinds for `(tenant_id, name)` before traversing: a no-op
+when `kind` is supplied or the name maps to one kind, but a raise of
+`AmbiguousNodeError` (a `ValueError` subclass carrying `name` + the
+matched `kinds`) when `kind` is omitted and the name spans multiple
+kinds. `find_path` applies the same probe independently to each
+endpoint. Alias → name resolution remains the T5/T6 router's job; this
+substrate matches `graph_node.name` directly.
 
 The root is always included at depth 0, so callers distinguish "node
 exists but has no dependents" (one-element list) from "node does not
@@ -107,7 +139,9 @@ bound is an independent second guard against acyclic-but-deep graphs.
   `tenant_id` against it.
 - SQLAlchemy 2.0 `text()` with `:named` binds — same raw-SQL pattern
   `meho_backplane.retrieval.retriever` uses (`CAST(:x AS text) IS NULL
-  OR ...` for optional filters, UUIDs passed as `str`).
+  OR ...` for optional filters, UUIDs passed as `str`). Every statement
+  is a module-level fully-literal `text("...")`; nothing is
+  interpolated so the `avoid-sqlalchemy-text` SAST rule does not fire.
 
 ## Known issues
 
@@ -117,7 +151,11 @@ bound is an independent second guard against acyclic-but-deep graphs.
   `backend/tests/integration/test_topology_query.py` against a real
   `pgvector/pgvector:pg16` testcontainer (Docker-gated skip on
   no-Docker sandboxes; runs in CI). v0.2 production is PostgreSQL, so
-  this is a test-harness placement, not a runtime limitation.
+  this is a test-harness placement, not a runtime limitation. The pure
+  Pydantic result-model contracts (deep `properties` immutability,
+  `TopologyPath` invariants) have no DB dependency and are unit-tested
+  in `backend/tests/test_topology_query_schemas.py`, which runs on
+  every sandbox.
 - **Unweighted only.** `find_path` treats every edge as cost 1.
   Weighted-edge support is deferred to v0.2.next per #363.
 - **No alias resolution yet.** `name_or_alias` is matched against

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -1,0 +1,134 @@
+# topology — the read-side recursive-CTE graph traversal substrate
+
+## Overview
+
+`backend/src/meho_backplane/topology/` is the read surface every
+blast-radius check and topology question in v0.2 dispatches through. It
+ships three async query verbs and the two Pydantic value types around
+them:
+
+- `find_dependents(operator, name_or_alias, *, depth=16, kind_filter=None)`
+  — reverse traversal, "what depends on me".
+- `find_dependencies(operator, name_or_alias, *, depth=16, kind_filter=None)`
+  — forward traversal, "what I depend on".
+- `find_path(operator, from_name, to_name, *, max_hops=8)` — shortest
+  unweighted path, or `None` if unreachable.
+
+The package is **read-only**. `graph_node` / `graph_edge` rows are
+written by the refresh service (G9.1-T3, #450); the schema and ORM
+models are migration `0007` (G9.1-T1, #448). This package never
+inserts, updates, or deletes.
+
+The API (T5), CLI (T6), and MCP (T7) fronts consume `query.py` as a
+thin shell and never re-derive the traversal or the tenant boundary.
+
+## Key types
+
+### `TopologyNode` — frozen Pydantic v2
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `UUID` | `graph_node.id`. |
+| `kind` | `str` | `graph_node.kind` (closed enum from migration 0007). |
+| `name` | `str` | `graph_node.name`, unique within `(tenant_id, kind)`. |
+| `properties` | `dict` | `graph_node.properties` JSONB; wrapped in `MappingProxyType` after validation so the frozen model is deeply immutable, serialised back to a plain `dict`. |
+| `depth` | `int` | Distance from the query root: root = 0, immediate = 1, transitive = 2, … |
+| `via_edge_kind` | `str \| None` | The `graph_edge.kind` of the edge used to reach this node; `None` for the root. |
+
+### `TopologyPath` — frozen Pydantic v2
+
+| Field | Type | Meaning |
+|---|---|---|
+| `nodes` | `tuple[TopologyNode, ...]` | Ordered from the `from` node (`depth == 0`) to the `to` node (`depth == total_hops`). |
+| `total_hops` | `int` | Number of edges traversed; equals `len(nodes) - 1`. |
+
+## Control flow
+
+### Edge-direction model
+
+An edge `from_node --kind--> to_node` reads "`from_node` depends on
+`to_node`" (a `vm` `runs-on` a `host`: the vm depends on the host).
+
+- **dependents** (reverse): from the frontier node `w`, join edges
+  where `e.to_node_id = w.id`, step to `e.from_node_id`.
+- **dependencies** (forward): join edges where `e.from_node_id = w.id`,
+  step to `e.to_node_id`.
+
+`find_dependents` and `find_dependencies` share `_traverse`, which
+delegates SQL construction to `_traversal_sql(reverse=...)` — only the
+two join columns differ; tenant scoping, the optional `kind_filter`,
+the depth bound, the CYCLE guard, and the `(depth, name)` ordering are
+identical.
+
+### Recursive CTE shape
+
+The traversal is a single `WITH RECURSIVE walk AS (...) CYCLE id SET
+is_cycle USING path` statement. The anchor row is the root at depth 0
+(`via_edge_kind` NULL). The recursive term joins `graph_edge` to the
+walk frontier, scoped on `tenant_id` on both the edge and the
+destination node, applies `CAST(:kind_filter AS text) IS NULL OR
+e.kind = :kind_filter`, and bounds `w.depth < :depth`. The final
+SELECT keeps `depth <= :depth AND NOT is_cycle` ordered by
+`(depth, name)`.
+
+The root is always included at depth 0, so callers distinguish "node
+exists but has no dependents" (one-element list) from "node does not
+exist in this tenant" (empty list).
+
+### Path search
+
+`find_path` builds a `bi_edge` CTE — the union of forward and reversed
+tenant-scoped edges — so reachability is undirected while storage
+stays directed. The recursive `walk` accumulates `node_ids` and
+`edge_kinds` arrays; `CYCLE node_id SET is_cycle USING visited` plus
+the `hops < :max_hops` bound terminate the search. `ORDER BY hops
+LIMIT 1` yields a shortest path. A second query materialises the
+winning path's node rows; `_build_path_nodes` re-orders them into path
+sequence and attaches `depth` / `via_edge_kind`.
+
+### Cycle safety
+
+The `CYCLE` clause makes PostgreSQL track the visited-node set per
+branch and stop recursing into an already-visited node, flagging the
+repeat row `is_cycle = true` (filtered out). An `A → B → A` graph
+terminates instead of recursing forever. The `depth` / `max_hops`
+bound is an independent second guard against acyclic-but-deep graphs.
+
+## Dependencies
+
+- `meho_backplane.db.engine.get_sessionmaker` — each verb opens its
+  own `AsyncSession` (session-per-call, mirroring the memory / kb
+  services). No caller-owned session.
+- `meho_backplane.db.models.GraphNode` / `GraphEdge` — schema +
+  indexes (migration `0007`). The recursive joins ride
+  `graph_edge_tenant_from_idx` / `graph_edge_tenant_to_idx`.
+- `meho_backplane.auth.operator.Operator` — `operator.tenant_id` is
+  the only tenant boundary; every statement filters node and edge
+  `tenant_id` against it.
+- SQLAlchemy 2.0 `text()` with `:named` binds — same raw-SQL pattern
+  `meho_backplane.retrieval.retriever` uses (`CAST(:x AS text) IS NULL
+  OR ...` for optional filters, UUIDs passed as `str`).
+
+## Known issues
+
+- **PostgreSQL-only.** The `WITH RECURSIVE ... CYCLE` clause is not
+  implemented by SQLite, so these verbs cannot run on the unit
+  suite's per-test SQLite DB. Tests live in
+  `backend/tests/integration/test_topology_query.py` against a real
+  `pgvector/pgvector:pg16` testcontainer (Docker-gated skip on
+  no-Docker sandboxes; runs in CI). v0.2 production is PostgreSQL, so
+  this is a test-harness placement, not a runtime limitation.
+- **Unweighted only.** `find_path` treats every edge as cost 1.
+  Weighted-edge support is deferred to v0.2.next per #363.
+- **No alias resolution yet.** `name_or_alias` is matched against
+  `graph_node.name` directly; alias → name resolution is the API/CLI
+  router's job (T5/T6), not this substrate's.
+
+## References
+
+- Parent Initiative: G9.1 #363.
+- Prerequisite schema: G9.1-T1 #448 (migration `0007`).
+- This task: G9.1-T4 #451.
+- PostgreSQL recursive CTE + `CYCLE`:
+  <https://www.postgresql.org/docs/17/queries-with.html> §7.8.2.2
+  (identical in PG 16, the chassis floor).


### PR DESCRIPTION
## Summary

- Ships G9.1-T4: the three recursive-CTE query verbs (`find_dependents`, `find_dependencies`, `find_path`) every blast-radius check and topology question in v0.2 goes through, plus the `TopologyNode` / `TopologyPath` frozen Pydantic v2 result models.
- All three are single PostgreSQL `WITH RECURSIVE ... CYCLE` statements over the adjacency-list `graph_node` / `graph_edge` tables migration `0007` (#448) ships. The `CYCLE` clause makes traversal terminate on cyclic graphs; an independent depth/`max_hops` bound guards acyclic-but-deep topologies.
- Tenant scoping is enforced via `operator.tenant_id` on both node and edge in every CTE term — a same-named node in another tenant is invisible. SQL binding mirrors the established raw-`text()` pattern in `retrieval.retriever`.
- The verbs use PG-only syntax (SQLite has no `CYCLE` clause), so the acceptance suite lives in `tests/integration/` against a real `pgvector/pgvector:pg16` container — same real-PG rationale and fixture wiring `test_tenant_isolation` documents. The integration conftest was already prepared (truncates the graph tables, seeds two tenants).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (topology module + new test)
- [x] `mypy src/meho_backplane/topology/ --ignore-missing-imports` — clean
- [x] `code-quality.py --diff` — 0 blockers (one file-size *warning* recorded below)
- [x] `pytest tests/integration/test_topology_query.py` — 9 passed against real PG16
- [x] `find_dependents` over the seeded 5-node / 6-edge graph returns the correct reverse closure ordered by depth
- [x] `find_dependencies` mirrors it forward
- [x] `find_path` returns the shortest path; returns `None` when unreachable within `max_hops`
- [x] Cycle detection: an `A -> B -> A` graph terminates (asserted under a wall-clock guard) instead of looping
- [x] `kind_filter` restricts the traversal to one edge kind
- [x] Tenant boundary: a same-named `host1` in tenant B is not returned for tenant A's query
- [x] Performance: 10k-node fixture, depth-16 traversal completes in <100ms (asserted)
- [x] Full suite collects cleanly (1797 tests); existing topology schema/connector tests still pass

## Out of scope

- API / CLI / MCP wrappers — T5 / T6 / T7.
- Refresh service that populates the tables — T3 (#450).
- Weighted-edge support — v0.2.next.

## Notes / adjacent findings

- The issue body names the test path `backend/tests/test_topology_query.py`, but the `CYCLE` clause is PostgreSQL-only and the unit suite runs on SQLite. Tests are placed in `backend/tests/integration/test_topology_query.py` per the established codebase convention for PG-specific tests (same as `test_tenant_isolation.py`); the integration conftest was already prepared for `graph_node` / `graph_edge`.
- `code-quality.py` reports `query.py` at 406 lines (warn >400, block 600) — a non-blocking warning, recorded here; the file is under the block threshold and splitting now would fragment one cohesive traversal module.
- Sibling #450 (T3 refresh service) will also write under `topology/`; no live file collision (its worktree had not created the package yet).

Closes #451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added topology traversal queries: find dependents, find dependencies, and shortest-path search (returns None if unreachable).
  * Depth limits, edge-kind filtering, and tenant isolation supported.
  * Endpoint disambiguation by kind; ambiguous lookups now raise a clear error.
  * New immutable result types for nodes and paths.

* **Tests**
  * Integration and unit tests covering traversal correctness, cycles, disambiguation, performance, and schema immutability.

* **Documentation**
  * Added topology documentation describing query semantics and usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-16)

Addressed review findings from the iteration-1 REQUEST_CHANGES review:

- **B1** `0440770` — closure-wide `DISTINCT ON (id)` dedupe (keep min-depth); masking test tightened to a `collections.Counter` assertion.
- **B2** `0440770` — f-string `text()` replaced with two module-level fully-literal statements; Semgrep `avoid-sqlalchemy-text` no longer fires (0 findings on the topology dir, `--error` gate exits 0).
- **B3** `0440770` — optional `kind` / `from_kind` / `to_kind` threaded to pin the `(tenant_id, kind, name)` anchor; `AmbiguousNodeError` raised on a multi-kind bare-name anchor; same-tenant collision test added.
- **M1** `34ba11c` — recursive `_deep_freeze` / `_deep_thaw`; nested dict/list values now immutable, serialisation round-trips to plain dict.
- **m1** `34ba11c` — `TopologyPath` gains `Field(min_length=1)`, `Field(ge=0)`, and an after-validator enforcing `total_hops == len(nodes) - 1`.

Disputed:

- CodeRabbit's `node_aliases` EXISTS half of the bare-name finding — there is no `node_aliases` table; alias→name resolution is deferred to T5/T6 per docs/codebase/topology.md. The B3 fix addresses only the `(tenant_id, kind, name)` disambiguation the reviewer adopted.

Deferred (recorded as adjacent findings):

- `name_or_alias` parameter rename to `name` — cosmetic, recommended for a follow-up PR (the substrate never resolves aliases).
- `query.py` is 564 lines / `find_path` 66 lines / two 6-arg signatures — all below the code-quality block thresholds; the arg counts are intrinsic to the B3 kind-disambiguation contract.

<!-- auto-implement-issue: continue, iteration 1 -->
