### PR TITLE
feat(topology): G9.1-T3 refresh service — diff/apply + scheduled task + advisory-lock rate-limiting

### DIFF
--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -83,6 +83,10 @@ from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.operations import run_typed_op_registrars
 from meho_backplane.retrieval.embedding import get_embedding_service
 from meho_backplane.settings import parse_bool_env
+from meho_backplane.topology import (
+    start_topology_refresh_scheduler,
+    stop_topology_refresh_scheduler,
+)
 from meho_backplane.version import router as version_router
 
 _APP_NAME: Final[str] = "meho-backplane"
@@ -193,9 +197,16 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     eager_import_mcp_modules()
     # Embedding model preload (G0.4-T2 #259); loud-but-non-fatal.
     await _preload_embedding_model()
+    # Scheduled topology refresh (G9.1-T3 #450). Started after connector
+    # auto-discovery (it resolves connectors per target) so the first
+    # sweep can dispatch ``discover_topology``. The task handle is kept
+    # so shutdown can cancel + await its unwind before the DB/redis
+    # pools are disposed (a sweep mid-flight must not race pool teardown).
+    topology_scheduler_task = start_topology_refresh_scheduler()
     try:
         yield
     finally:
+        await stop_topology_refresh_scheduler(topology_scheduler_task)
         await _run_lifespan_shutdown()
 
 

--- a/backend/src/meho_backplane/metrics.py
+++ b/backend/src/meho_backplane/metrics.py
@@ -50,6 +50,18 @@ HTTP_REQUESTS_TOTAL: Counter = Counter(
     labelnames=("method", "path", "status"),
 )
 
+#: Counter for scheduled topology-refresh attempts, partitioned by
+#: ``outcome`` (``ok`` / ``error`` / ``skipped_locked``). G9.1-T3
+#: (#450): the background scheduler increments this per (tenant, target)
+#: iteration so a stuck connector or a permanently-contended advisory
+#: lock surfaces on the ``/metrics`` scrape rather than only in logs.
+#: Same module-level-singleton rationale as ``HTTP_REQUESTS_TOTAL``.
+TOPOLOGY_REFRESH_TOTAL: Counter = Counter(
+    "topology_refresh_total",
+    "Scheduled topology-refresh attempts by outcome.",
+    labelnames=("outcome",),
+)
+
 
 def render_metrics() -> tuple[bytes, str]:
     """Render the default registry as Prometheus exposition bytes.

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -267,6 +267,16 @@ class Settings(BaseModel):
         ``COMPOSITE_MAX_DEPTH`` env var. Read once per
         ``dispatch_child`` call -- no caching beyond
         :func:`get_settings`'s :func:`lru_cache`.
+    topology_refresh_interval_seconds:
+        Cadence of the G9.1-T3 background topology-refresh loop, in
+        seconds. The scheduler (registered in the FastAPI lifespan)
+        sleeps this long between full sweeps of every tenant's
+        targets. Default 3600 (1 h) matches Initiative #363's stated
+        cadence; operators on fast-moving inventories tighten it via
+        ``TOPOLOGY_REFRESH_INTERVAL_SECONDS``. Per-target failure
+        backoff is derived from this value (2x, capped at 4 h) inside
+        the scheduler, not a separate knob. Read once per loop
+        iteration through :func:`get_settings`'s cache.
     """
 
     keycloak_issuer_url: HttpUrl
@@ -300,6 +310,7 @@ class Settings(BaseModel):
     )
     broadcast_retention_hours: int = Field(default=24, gt=0)
     composite_max_depth: int = Field(default=8, gt=0)
+    topology_refresh_interval_seconds: int = Field(default=3600, gt=0)
 
     @field_validator("broadcast_redis_url")
     @classmethod
@@ -416,5 +427,8 @@ def get_settings() -> Settings:
         ),
         composite_max_depth=int(
             os.environ.get("COMPOSITE_MAX_DEPTH", "8"),
+        ),
+        topology_refresh_interval_seconds=int(
+            os.environ.get("TOPOLOGY_REFRESH_INTERVAL_SECONDS", "3600"),
         ),
     )

--- a/backend/src/meho_backplane/topology/__init__.py
+++ b/backend/src/meho_backplane/topology/__init__.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Topology graph data layer — refresh service + scheduled background task.
+
+Initiative #363 (G9.1), Task #450 (T3). This package owns the **write**
+half of the topology graph: taking a connector's
+:class:`~meho_backplane.connectors.schemas.TopologyHints` snapshot and
+reconciling it against the existing ``graph_node`` + ``graph_edge`` rows
+for one ``(tenant_id, target_id)`` scope.
+
+* :mod:`meho_backplane.topology.refresh` — :func:`refresh_target_topology`
+  resolves the target's connector, calls ``discover_topology``, diffs
+  the result against the DB, and applies inserts / updates / soft-deletes
+  in one transaction. Emits one synchronous audit row + one fail-open
+  broadcast event per refresh.
+* :mod:`meho_backplane.topology.scheduler` —
+  :func:`start_topology_refresh_scheduler` registers an
+  ``asyncio.create_task`` loop in the FastAPI lifespan that walks every
+  tenant's targets on a cadence, advisory-locked per ``(tenant, target)``
+  so two replicas never stampede the same target.
+
+Traversal reads (``dependents`` / ``dependencies`` / ``path``) are T4's
+``graph.py`` territory and are deliberately absent here.
+"""
+
+from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
+from meho_backplane.topology.scheduler import (
+    start_topology_refresh_scheduler,
+    stop_topology_refresh_scheduler,
+)
+
+__all__ = [
+    "RefreshResult",
+    "refresh_target_topology",
+    "start_topology_refresh_scheduler",
+    "stop_topology_refresh_scheduler",
+]

--- a/backend/src/meho_backplane/topology/refresh.py
+++ b/backend/src/meho_backplane/topology/refresh.py
@@ -1,0 +1,579 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""On-demand + scheduled topology refresh — diff/apply reconciliation.
+
+Initiative #363 (G9.1), Task #450 (T3). :func:`refresh_target_topology`
+is the single write path into the topology graph:
+
+1. Resolve the connector for ``target`` via the G0.6 resolver.
+2. Call ``connector.discover_topology(target)`` for a
+   :class:`~meho_backplane.connectors.schemas.TopologyHints` snapshot.
+3. Reconcile the snapshot against the existing ``graph_node`` +
+   ``graph_edge`` rows for ``(tenant_id, target_id)``:
+
+   * INSERT rows present in the snapshot but not in the DB.
+   * UPDATE ``last_seen`` (+ ``properties`` when they changed) for rows
+     in both.
+   * Soft-delete (``last_seen = NULL``) rows in the DB but absent from
+     the snapshot.
+
+   Nodes are keyed by ``(kind, name)`` (the ``graph_node`` natural key
+   within a tenant); edges by ``(from_kind, from_name, to_kind,
+   to_name, kind)``. Edge endpoints are mapped to ``graph_node.id`` via
+   the node key map built during the node pass, so an edge whose
+   endpoint the snapshot does not also carry as a node is skipped (a
+   well-formed connector always emits both).
+
+The entire reconcile runs in **one transaction**: any failure rolls the
+whole thing back, so a mid-reconcile crash never leaves the graph in a
+half-applied state. One synchronous ``audit_log`` row is written
+(``op_id="topology.refresh"``, ``op_class="read"``) and one fail-open
+broadcast event is published per refresh, mirroring the G0.6 dispatcher's
+:mod:`meho_backplane.operations._audit` discipline. Broadcast carries
+only aggregate counts — no per-resource detail — so the read-class PII
+defaults hold without a redactor pass (Initiative #363 item 11).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.broadcast import BroadcastEvent, publish_event
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.connectors.schemas import EdgeHint, NodeHint, TopologyHints
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+)
+
+__all__ = ["RefreshResult", "refresh_target_topology"]
+
+_log = structlog.get_logger(__name__)
+
+#: ``op_id`` written to ``audit_log.path`` + carried in the broadcast
+#: event. ``op_class="read"`` is passed explicitly rather than derived
+#: via :func:`~meho_backplane.broadcast.events.classify_op` because the
+#: ``.refresh`` suffix is neither a read nor a write verb suffix and
+#: would otherwise classify as ``other``.
+_REFRESH_OP_ID = "topology.refresh"
+_REFRESH_OP_CLASS = "read"
+
+#: HTTP-shaped ``audit_log`` columns reuse the dispatcher's convention:
+#: a non-HTTP write records ``method`` as a verb token and ``path`` as
+#: the canonical op_id (see :mod:`meho_backplane.operations._audit`).
+_AUDIT_METHOD = "REFRESH"
+
+
+class RefreshResult(BaseModel):
+    """Per-target reconcile outcome returned by :func:`refresh_target_topology`.
+
+    Counts are disjoint per object class: a node is counted in exactly
+    one of added / updated / removed (or none, when unchanged). The same
+    holds for edges. ``duration_ms`` is wall-clock for the whole
+    resolve + discover + reconcile + commit cycle.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    target_id: uuid.UUID
+    added_nodes: int
+    added_edges: int
+    updated_nodes: int
+    updated_edges: int
+    removed_nodes: int
+    removed_edges: int
+    duration_ms: float
+
+
+def _node_key(kind: str, name: str) -> tuple[str, str]:
+    """Natural key for a node within a ``(tenant_id, target scope)``."""
+    return (kind, name)
+
+
+def _edge_key(
+    from_kind: str,
+    from_name: str,
+    to_kind: str,
+    to_name: str,
+    kind: str,
+) -> tuple[str, str, str, str, str]:
+    """Natural key for an edge — the endpoint node keys plus the edge kind."""
+    return (from_kind, from_name, to_kind, to_name, kind)
+
+
+def _properties_differ(current: Any, incoming: Any) -> bool:
+    """Return ``True`` when the persisted ``properties`` differ from discovery.
+
+    ``GraphNode.properties`` / ``GraphEdge.properties`` round-trip as a
+    plain ``dict`` from the JSON column; the connector hands back a
+    ``MappingProxyType`` (frozen NodeHint/EdgeHint). Compare as plain
+    dicts so a proxy-vs-dict identity mismatch doesn't force a spurious
+    UPDATE every refresh.
+    """
+    return dict(current) != dict(incoming)
+
+
+async def _reconcile_nodes(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    target_id: uuid.UUID,
+    discovered_by: str,
+    nodes: tuple[NodeHint, ...],
+    now: datetime,
+) -> tuple[
+    int,
+    int,
+    int,
+    dict[tuple[str, str], uuid.UUID],
+    dict[tuple[str, str], uuid.UUID],
+]:
+    """Apply the node half of the diff. Returns counts + two key→id maps.
+
+    * ``live_key_to_id`` — only nodes present in the current snapshot
+      (inserted or kept). The edge pass resolves *discovered* edge
+      endpoints through this map; an edge pointing at a node the
+      current discovery dropped is itself dropped (soft-deleted).
+    * ``all_key_to_id`` — every node in the ``(tenant, target)`` scope,
+      including ones soft-deleted this refresh or on a prior one. The
+      edge pass needs this to map an *existing* edge's ``from/to`` node
+      ids back to keys so it can decide whether that edge is still
+      discovered (and to soft-delete it when it is not).
+    """
+    existing_rows = (
+        (
+            await session.execute(
+                select(GraphNode).where(
+                    GraphNode.tenant_id == tenant_id,
+                    GraphNode.target_id == target_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    existing_by_key = {_node_key(r.kind, r.name): r for r in existing_rows}
+
+    discovered_by_key: dict[tuple[str, str], NodeHint] = {
+        _node_key(n.kind, n.name): n for n in nodes
+    }
+
+    added = updated = removed = 0
+    live_key_to_id: dict[tuple[str, str], uuid.UUID] = {}
+    all_key_to_id: dict[tuple[str, str], uuid.UUID] = {
+        key: row.id for key, row in existing_by_key.items()
+    }
+
+    for key, hint in discovered_by_key.items():
+        row = existing_by_key.get(key)
+        if row is None:
+            new_id = uuid.uuid4()
+            session.add(
+                GraphNode(
+                    id=new_id,
+                    tenant_id=tenant_id,
+                    kind=hint.kind,
+                    name=hint.name,
+                    target_id=target_id,
+                    properties=dict(hint.properties),
+                    discovered_by=discovered_by,
+                    first_seen=now,
+                    last_seen=now,
+                )
+            )
+            live_key_to_id[key] = new_id
+            all_key_to_id[key] = new_id
+            added += 1
+            continue
+        # Present in both — refresh last_seen, and properties when changed.
+        if row.last_seen is None or _properties_differ(row.properties, hint.properties):
+            updated += 1
+        row.properties = dict(hint.properties)
+        row.last_seen = now
+        live_key_to_id[key] = row.id
+
+    for key, row in existing_by_key.items():
+        if key in discovered_by_key:
+            continue
+        if row.last_seen is None:
+            # Already soft-deleted on a prior refresh; not a fresh removal.
+            continue
+        row.last_seen = None
+        removed += 1
+
+    return added, updated, removed, live_key_to_id, all_key_to_id
+
+
+_EdgeKey = tuple[str, str, str, str, str]
+
+
+async def _load_existing_edges_by_key(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    all_node_key_to_id: dict[tuple[str, str], uuid.UUID],
+) -> dict[_EdgeKey, GraphEdge]:
+    """Index existing edges of the target by their natural key.
+
+    Loaded by ``from_node_id`` over **every** node in the
+    ``(tenant, target)`` scope (including nodes soft-deleted this
+    refresh or earlier) so an edge whose endpoint was just dropped is
+    still found and soft-deleted rather than silently orphaned.
+    """
+    all_node_ids = set(all_node_key_to_id.values())
+    if not all_node_ids:
+        return {}
+    existing_rows = (
+        (
+            await session.execute(
+                select(GraphEdge).where(
+                    GraphEdge.tenant_id == tenant_id,
+                    GraphEdge.from_node_id.in_(all_node_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    id_to_key = {v: k for k, v in all_node_key_to_id.items()}
+    out: dict[_EdgeKey, GraphEdge] = {}
+    for row in existing_rows:
+        from_key = id_to_key.get(row.from_node_id)
+        to_key = id_to_key.get(row.to_node_id)
+        if from_key is None or to_key is None:
+            continue
+        out[_edge_key(from_key[0], from_key[1], to_key[0], to_key[1], row.kind)] = row
+    return out
+
+
+def _index_discovered_edges(
+    edges: tuple[EdgeHint, ...],
+    live_node_key_to_id: dict[tuple[str, str], uuid.UUID],
+) -> dict[_EdgeKey, EdgeHint]:
+    """Index snapshot edges whose endpoints exist in the live node map.
+
+    An edge whose endpoint is not in the live snapshot (a malformed
+    connector emitting an edge without its node) is logged and dropped
+    rather than inserted as a dangling FK.
+    """
+    out: dict[_EdgeKey, EdgeHint] = {}
+    for e in edges:
+        from_id = live_node_key_to_id.get(_node_key(e.from_kind, e.from_name))
+        to_id = live_node_key_to_id.get(_node_key(e.to_kind, e.to_name))
+        if from_id is None or to_id is None:
+            _log.warning(
+                "topology_refresh_edge_dangling",
+                from_kind=e.from_kind,
+                from_name=e.from_name,
+                to_kind=e.to_kind,
+                to_name=e.to_name,
+                edge_kind=e.kind,
+            )
+            continue
+        out[_edge_key(e.from_kind, e.from_name, e.to_kind, e.to_name, e.kind)] = e
+    return out
+
+
+async def _reconcile_edges(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    discovered_by: str,
+    edges: tuple[EdgeHint, ...],
+    live_node_key_to_id: dict[tuple[str, str], uuid.UUID],
+    all_node_key_to_id: dict[tuple[str, str], uuid.UUID],
+    now: datetime,
+) -> tuple[int, int, int]:
+    """Apply the edge half of the diff against the resolved node id maps.
+
+    Discovered edge endpoints resolve through ``live_node_key_to_id``
+    (only nodes in the current snapshot); an edge whose endpoint left
+    the snapshot is treated as not-discovered and falls through to the
+    soft-delete pass.
+    """
+    existing_by_key = await _load_existing_edges_by_key(
+        session, tenant_id=tenant_id, all_node_key_to_id=all_node_key_to_id
+    )
+    discovered_by_key = _index_discovered_edges(edges, live_node_key_to_id)
+
+    added = updated = removed = 0
+
+    for key, hint in discovered_by_key.items():
+        existing_edge = existing_by_key.get(key)
+        from_id = live_node_key_to_id[_node_key(hint.from_kind, hint.from_name)]
+        to_id = live_node_key_to_id[_node_key(hint.to_kind, hint.to_name)]
+        if existing_edge is None:
+            session.add(
+                GraphEdge(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    from_node_id=from_id,
+                    to_node_id=to_id,
+                    kind=hint.kind,
+                    source="auto",
+                    properties=dict(hint.properties),
+                    discovered_by=discovered_by,
+                    first_seen=now,
+                    last_seen=now,
+                )
+            )
+            added += 1
+            continue
+        if existing_edge.last_seen is None or _properties_differ(
+            existing_edge.properties, hint.properties
+        ):
+            updated += 1
+        existing_edge.properties = dict(hint.properties)
+        existing_edge.last_seen = now
+
+    for key, row in existing_by_key.items():
+        if key in discovered_by_key:
+            continue
+        if row.last_seen is None:
+            continue
+        row.last_seen = None
+        removed += 1
+
+    return added, updated, removed
+
+
+async def _write_audit_and_broadcast(
+    *,
+    session: AsyncSession,
+    audit_id: uuid.UUID,
+    operator: Operator,
+    target_id: uuid.UUID,
+    result: RefreshResult,
+) -> None:
+    """Write the audit row in the reconcile transaction; publish fail-open.
+
+    The audit row is added to the **same** session as the reconcile so
+    the spec's "no success without a committed audit row" invariant
+    holds: if the audit insert fails the whole refresh rolls back. The
+    broadcast publish is fail-open per :func:`publish_event`'s contract
+    and is issued by the caller *after* the transaction commits.
+    """
+    counts = {
+        "added_nodes": result.added_nodes,
+        "added_edges": result.added_edges,
+        "updated_nodes": result.updated_nodes,
+        "updated_edges": result.updated_edges,
+        "removed_nodes": result.removed_nodes,
+        "removed_edges": result.removed_edges,
+    }
+    session.add(
+        AuditLog(
+            id=audit_id,
+            occurred_at=datetime.now(UTC),
+            operator_sub=operator.sub,
+            tenant_id=operator.tenant_id,
+            target_id=target_id,
+            method=_AUDIT_METHOD,
+            path=_REFRESH_OP_ID,
+            status_code=200,
+            request_id=None,
+            duration_ms=Decimal(str(round(result.duration_ms, 2))),
+            payload={
+                "op_id": _REFRESH_OP_ID,
+                "op_class": _REFRESH_OP_CLASS,
+                "target_id": str(target_id),
+                **counts,
+            },
+        )
+    )
+
+
+async def _publish_refresh_event(
+    *,
+    audit_id: uuid.UUID,
+    operator: Operator,
+    target_name: str,
+    result: RefreshResult,
+) -> None:
+    """Emit the per-refresh broadcast event. Fail-open by contract.
+
+    The payload is aggregate-only counts plus the op metadata — no node
+    or edge names — so the read-class default holds without a redactor
+    pass (Initiative #363 item 11).
+    """
+    event = BroadcastEvent(
+        event_id=uuid.uuid4(),
+        ts=datetime.now(UTC),
+        tenant_id=operator.tenant_id,
+        principal_sub=operator.sub,
+        principal_name=operator.name,
+        target_name=target_name,
+        op_id=_REFRESH_OP_ID,
+        op_class=_REFRESH_OP_CLASS,
+        result_status="ok",
+        audit_id=audit_id,
+        payload={
+            "op_class": _REFRESH_OP_CLASS,
+            "result_status": "ok",
+            "target_id": str(result.target_id),
+            "added_nodes": result.added_nodes,
+            "added_edges": result.added_edges,
+            "updated_nodes": result.updated_nodes,
+            "updated_edges": result.updated_edges,
+            "removed_nodes": result.removed_nodes,
+            "removed_edges": result.removed_edges,
+        },
+    )
+    await publish_event(event)
+
+
+async def _apply_reconcile(
+    *,
+    operator: Operator,
+    target_id: uuid.UUID,
+    discovered_by: str,
+    hints: TopologyHints,
+    audit_id: uuid.UUID,
+    started: float,
+) -> RefreshResult:
+    """Run the node + edge diff + audit write in one transaction.
+
+    A failure anywhere inside the ``session.begin()`` block raises out
+    of it, rolling everything (inserts, updates, soft-deletes, the audit
+    row) back together — the graph is never left half-applied and no
+    audit row lands for a refresh that didn't commit.
+    """
+    tenant_id = operator.tenant_id
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        now = datetime.now(UTC)
+        (
+            added_nodes,
+            updated_nodes,
+            removed_nodes,
+            live_key_to_id,
+            all_key_to_id,
+        ) = await _reconcile_nodes(
+            session,
+            tenant_id=tenant_id,
+            target_id=target_id,
+            discovered_by=discovered_by,
+            nodes=hints.nodes,
+            now=now,
+        )
+        added_edges, updated_edges, removed_edges = await _reconcile_edges(
+            session,
+            tenant_id=tenant_id,
+            discovered_by=discovered_by,
+            edges=hints.edges,
+            live_node_key_to_id=live_key_to_id,
+            all_node_key_to_id=all_key_to_id,
+            now=now,
+        )
+        result = RefreshResult(
+            target_id=target_id,
+            added_nodes=added_nodes,
+            added_edges=added_edges,
+            updated_nodes=updated_nodes,
+            updated_edges=updated_edges,
+            removed_nodes=removed_nodes,
+            removed_edges=removed_edges,
+            duration_ms=(time.perf_counter() - started) * 1000.0,
+        )
+        await _write_audit_and_broadcast(
+            session=session,
+            audit_id=audit_id,
+            operator=operator,
+            target_id=target_id,
+            result=result,
+        )
+    return result
+
+
+async def refresh_target_topology(
+    target: Any,
+    operator: Operator,
+) -> RefreshResult:
+    """Discover ``target``'s topology and reconcile it into the graph.
+
+    Resolves the connector for *target*, calls its
+    :meth:`~meho_backplane.connectors.base.Connector.discover_topology`,
+    and applies the diff against the existing ``graph_node`` +
+    ``graph_edge`` rows for ``(operator.tenant_id, target.id)`` in one
+    transaction. A failure anywhere in resolve / discover / reconcile /
+    audit rolls the whole transaction back — the graph is never left
+    half-applied and no audit row lands for a refresh that didn't
+    commit.
+
+    The audit row commits inside the reconcile transaction (synchronous
+    audit). The broadcast event publishes after commit and is fail-open.
+
+    Args:
+        target: The :class:`~meho_backplane.db.models.Target` ORM row (or
+            a duck-typed object exposing ``.id`` / ``.name`` /
+            ``.product`` / ``.fingerprint``) to refresh.
+        operator: The acting identity. Supplies the tenant scope
+            (``operator.tenant_id``) every reconciled row is written
+            under and the ``audit_log`` attribution. The scheduler
+            synthesises a per-tenant system operator; the on-demand CLI
+            path forwards the authenticated operator.
+
+    Returns:
+        A :class:`RefreshResult` with the disjoint per-class counts.
+    """
+    started = time.perf_counter()
+    target_id: uuid.UUID = target.id
+    target_name: str = getattr(target, "name", str(target_id))
+    discovered_by = getattr(target, "product", "unknown")
+    tenant_id = operator.tenant_id
+
+    connector_cls = resolve_connector(target)
+    connector: Connector = get_or_create_connector_instance(connector_cls)
+    hints: TopologyHints = await connector.discover_topology(target)
+
+    audit_id = uuid.uuid4()
+    result = await _apply_reconcile(
+        operator=operator,
+        target_id=target_id,
+        discovered_by=discovered_by,
+        hints=hints,
+        audit_id=audit_id,
+        started=started,
+    )
+
+    # Transaction committed (audit row included). Broadcast is fail-open.
+    try:
+        await _publish_refresh_event(
+            audit_id=audit_id,
+            operator=operator,
+            target_name=target_name,
+            result=result,
+        )
+    except Exception:
+        _log.exception(
+            "topology_refresh_broadcast_failed",
+            target_id=str(target_id),
+            tenant_id=str(tenant_id),
+        )
+
+    _log.info(
+        "topology_refresh_applied",
+        target_id=str(target_id),
+        tenant_id=str(tenant_id),
+        added_nodes=result.added_nodes,
+        added_edges=result.added_edges,
+        updated_nodes=result.updated_nodes,
+        updated_edges=result.updated_edges,
+        removed_nodes=result.removed_nodes,
+        removed_edges=result.removed_edges,
+        duration_ms=round(result.duration_ms, 2),
+    )
+    return result

--- a/backend/src/meho_backplane/topology/scheduler.py
+++ b/backend/src/meho_backplane/topology/scheduler.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Scheduled background topology-refresh loop.
+
+Initiative #363 (G9.1), Task #450 (T3). :func:`start_topology_refresh_scheduler`
+returns an :class:`asyncio.Task` the FastAPI lifespan owns: it sweeps
+every tenant's targets on the
+:attr:`~meho_backplane.settings.Settings.topology_refresh_interval_seconds`
+cadence, calling :func:`~meho_backplane.topology.refresh.refresh_target_topology`
+per target.
+
+Why ``asyncio.create_task`` and not APScheduler 4.x
+---------------------------------------------------
+
+Task #450's body prefers APScheduler 4.x **but explicitly allows**
+reusing an in-lifespan ``asyncio`` loop instead. APScheduler 4.x has
+never shipped a stable release — only ``4.0.0aN`` alphas, which the
+maintainer documents as "should NOT be used in production". The chassis
+ships to a production governance backplane and follows a "no new
+substrate / minimal dependencies" discipline (``CLAUDE.md``). A stdlib
+``asyncio`` loop registered in the lifespan is zero-dependency, is the
+issue's own stated fallback, and is the same shape the lifespan already
+uses for other long-lived resources. APScheduler can be revisited once
+4.x is stable and a richer scheduling need (cron expressions, persisted
+jobs) actually exists.
+
+Stampede protection
+-------------------
+
+Two backplane replicas share one Postgres. Without coordination both
+would refresh the same target every cadence, doubling discovery load on
+the vendor API. Each ``(tenant, target)`` refresh is wrapped in a
+session-level PostgreSQL advisory lock keyed on a stable 63-bit hash of
+``(tenant_id, target_id)``: ``pg_try_advisory_lock`` (non-blocking — a
+replica that loses the race skips that target this sweep rather than
+queueing) and ``pg_advisory_unlock`` on the way out. On non-PostgreSQL
+dialects (the SQLite unit-test path) the lock is a no-op: the test
+process is single-replica so there is nothing to stampede.
+
+Failure isolation + backoff
+---------------------------
+
+Every per-target refresh runs inside its own ``try`` / ``except`` so one
+bad target (unreachable connector, malformed hints) never stalls the
+rest of the sweep. A failing target is put on exponential backoff —
+``2 x interval`` per consecutive failure, capped at 4 h — tracked
+in-memory; a success clears the backoff. The next sweep skips a target
+still inside its backoff window.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import time
+import uuid
+from dataclasses import dataclass, field
+
+import structlog
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target, Tenant
+from meho_backplane.metrics import TOPOLOGY_REFRESH_TOTAL
+from meho_backplane.settings import get_settings
+from meho_backplane.topology.refresh import refresh_target_topology
+
+__all__ = [
+    "start_topology_refresh_scheduler",
+    "stop_topology_refresh_scheduler",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The acting identity for scheduler-driven refreshes. The refresh
+#: service writes one ``audit_log`` row per refresh; a stable synthetic
+#: sub makes scheduled refreshes filterable in audit queries and
+#: distinct from operator-driven ones (same pattern the connectors use
+#: for system-context operators).
+_SYSTEM_OPERATOR_SUB = "system:topology-scheduler"
+
+#: Per-target backoff ceiling: a permanently-failing target is retried
+#: at most every 4 hours regardless of how small the base interval is.
+_MAX_BACKOFF_SECONDS = 4 * 3600
+
+
+def _advisory_lock_key(tenant_id: uuid.UUID, target_id: uuid.UUID) -> int:
+    """Map a ``(tenant, target)`` pair to a stable signed-63-bit lock key.
+
+    ``pg_advisory_lock`` takes a ``bigint`` (signed 64-bit). A blake2b
+    digest of the two UUIDs gives a deterministic, well-distributed key;
+    masking to 63 bits keeps it non-negative so it round-trips through
+    asyncpg's ``bigint`` binding without overflow on the sign bit.
+    """
+    digest = hashlib.blake2b(tenant_id.bytes + target_id.bytes, digest_size=8).digest()
+    return int.from_bytes(digest, "big") & 0x7FFF_FFFF_FFFF_FFFF
+
+
+@dataclass
+class _TargetBackoff:
+    """In-memory per-target failure state for the backoff ladder."""
+
+    consecutive_failures: int = 0
+    #: ``time.monotonic()`` value before which the target is skipped.
+    skip_until: float = 0.0
+
+
+@dataclass
+class _SchedulerState:
+    """Mutable per-process scheduler state (backoff table)."""
+
+    backoff: dict[uuid.UUID, _TargetBackoff] = field(default_factory=dict)
+
+
+def _system_operator(tenant_id: uuid.UUID) -> Operator:
+    """Build the synthetic per-tenant operator scheduled refreshes run as.
+
+    ``raw_jwt`` is the empty string — scheduled refreshes never forward
+    a token to a downstream vendor (the connector uses the target's own
+    stored credentials). ``OPERATOR`` role satisfies the model's
+    required field; the refresh path does not gate on role.
+    """
+    return Operator(
+        sub=_SYSTEM_OPERATOR_SUB,
+        name=None,
+        email=None,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
+    """Acquire a session-level PG advisory lock; ``True`` on non-PG.
+
+    Returns ``True`` when the lock is held (or the dialect has no
+    advisory locks, i.e. the single-replica SQLite test path) and the
+    caller should proceed with the refresh; ``False`` when another
+    replica holds it and this target should be skipped this sweep.
+    """
+    conn = await session.connection()
+    if conn.dialect.name != "postgresql":
+        return True
+    locked = await session.scalar(text("SELECT pg_try_advisory_lock(:k)"), {"k": key})
+    return bool(locked)
+
+
+async def _advisory_unlock(session: AsyncSession, key: int) -> None:
+    """Release a session-level PG advisory lock; no-op on non-PG."""
+    conn = await session.connection()
+    if conn.dialect.name != "postgresql":
+        return
+    await session.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
+
+
+async def _refresh_one_target(
+    target: Target,
+    state: _SchedulerState,
+) -> None:
+    """Refresh a single target under its advisory lock, isolating failure.
+
+    A lock-session is opened solely to host the advisory lock for the
+    duration of the refresh (the refresh service opens its own
+    transactional session for the reconcile). The lock is released in a
+    ``finally`` so a crash mid-refresh never strands it for the rest of
+    the connection's life.
+    """
+    target_id = target.id
+    tenant_id = target.tenant_id
+    bo = state.backoff.get(target_id)
+    if bo is not None and time.monotonic() < bo.skip_until:
+        return
+
+    key = _advisory_lock_key(tenant_id, target_id)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as lock_session:
+        if not await _try_advisory_lock(lock_session, key):
+            TOPOLOGY_REFRESH_TOTAL.labels(outcome="skipped_locked").inc()
+            _log.info(
+                "topology_refresh_skipped_locked",
+                target_id=str(target_id),
+                tenant_id=str(tenant_id),
+            )
+            return
+        try:
+            await refresh_target_topology(target, _system_operator(tenant_id))
+            TOPOLOGY_REFRESH_TOTAL.labels(outcome="ok").inc()
+            state.backoff.pop(target_id, None)
+        except Exception:
+            TOPOLOGY_REFRESH_TOTAL.labels(outcome="error").inc()
+            bo = state.backoff.setdefault(target_id, _TargetBackoff())
+            bo.consecutive_failures += 1
+            interval = get_settings().topology_refresh_interval_seconds
+            delay = min(
+                interval * (2**bo.consecutive_failures),
+                _MAX_BACKOFF_SECONDS,
+            )
+            bo.skip_until = time.monotonic() + delay
+            _log.exception(
+                "topology_refresh_target_failed",
+                target_id=str(target_id),
+                tenant_id=str(tenant_id),
+                consecutive_failures=bo.consecutive_failures,
+                backoff_seconds=delay,
+            )
+        finally:
+            await _advisory_unlock(lock_session, key)
+
+
+async def _run_one_sweep(state: _SchedulerState) -> None:
+    """Walk every tenant's targets once, refreshing each in isolation.
+
+    Targets are enumerated tenant-by-tenant so the per-tenant boundary
+    the rest of the graph enforces is visible in the iteration shape
+    itself. A failure refreshing any single target is swallowed by
+    :func:`_refresh_one_target`; this sweep always completes.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_ids = list((await session.execute(select(Tenant.id))).scalars().all())
+        targets_by_tenant: dict[uuid.UUID, list[Target]] = {}
+        for tid in tenant_ids:
+            rows = list(
+                (await session.execute(select(Target).where(Target.tenant_id == tid)))
+                .scalars()
+                .all()
+            )
+            targets_by_tenant[tid] = rows
+
+    for targets in targets_by_tenant.values():
+        for target in targets:
+            await _refresh_one_target(target, state)
+
+
+async def _scheduler_loop() -> None:
+    """The forever loop: sweep, sleep one cadence, repeat.
+
+    The loop body is fully guarded so a transient failure enumerating
+    tenants/targets logs and waits for the next cadence rather than
+    killing the background task (which would silently stop all
+    scheduled refreshes until the next process restart).
+    ``asyncio.CancelledError` propagates so lifespan shutdown can stop
+    the task cleanly.
+    """
+    state = _SchedulerState()
+    _log.info(
+        "topology_refresh_scheduler_started",
+        interval_seconds=get_settings().topology_refresh_interval_seconds,
+    )
+    while True:
+        try:
+            await _run_one_sweep(state)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.exception("topology_refresh_sweep_failed")
+        await asyncio.sleep(get_settings().topology_refresh_interval_seconds)
+
+
+def start_topology_refresh_scheduler() -> asyncio.Task[None]:
+    """Start the background refresh loop and return its task.
+
+    Registered in :func:`meho_backplane.main.lifespan`. The returned
+    task is cancelled on lifespan shutdown; the caller awaits the
+    cancellation so the loop unwinds cleanly. Returning the task (rather
+    than fire-and-forgetting) keeps a strong reference alive — an
+    un-referenced task can be garbage-collected mid-flight.
+    """
+    return asyncio.create_task(_scheduler_loop(), name="topology-refresh-scheduler")
+
+
+async def stop_topology_refresh_scheduler(task: asyncio.Task[None]) -> None:
+    """Cancel the scheduler task and await its unwind.
+
+    Swallows the expected :class:`asyncio.CancelledError`; any other
+    exception surfaced during unwind propagates so a broken shutdown is
+    visible rather than silently swallowed.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/tests/test_topology_refresh.py
+++ b/backend/tests/test_topology_refresh.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G9.1-T3 topology refresh service.
+
+Coverage matrix (Task #450 acceptance criteria):
+
+* **Insert path** — a connector returning 3 nodes + 2 edges inserts
+  3 + 2 rows; :class:`RefreshResult` carries the correct counts.
+* **Unchanged path** — a second refresh with the same hints reports
+  zero added / removed and bumps ``last_seen`` only (no spurious
+  ``updated`` from a proxy-vs-dict properties comparison).
+* **Soft-delete path** — a node dropped from discovery gets
+  ``last_seen = NULL`` and ``removed_nodes == 1``; the row survives.
+* **Update path** — changed ``properties`` on an existing node take
+  the UPDATE branch; properties + ``last_seen`` are refreshed.
+* **Transactional** — a mid-reconcile failure rolls the whole
+  transaction back; the graph is byte-identical to before.
+* **Audit + broadcast** — one ``audit_log`` row per refresh with the
+  canonical ``topology.refresh`` op_id + counts; one broadcast event
+  published (mocked at :func:`publish_event`).
+* **Tenant boundary** — a refresh writes only ``(tenant_id=A)`` rows;
+  a same-named target in tenant B is untouched.
+
+The tests run against ``sqlite+aiosqlite`` via the shared engine cache
+the autouse ``_default_database_url`` fixture in :mod:`tests.conftest`
+pre-migrates to ``alembic upgrade head`` — the same shape every other
+DB-touching unit test uses. The PG-only advisory-lock path is exercised
+in :mod:`tests.test_topology_scheduler`'s non-PG no-op assertion and in
+the integration suite.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import (
+    EdgeHint,
+    NodeHint,
+    TopologyHints,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode, Target, Tenant
+from meho_backplane.operations._handler_resolve import reset_connector_instance_cache
+from meho_backplane.settings import get_settings
+from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
+
+_PUBLISH = "meho_backplane.topology.refresh.publish_event"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Isolate the connector registry + instance cache per test."""
+    clear_registry()
+    reset_connector_instance_cache()
+    yield
+    clear_registry()
+    reset_connector_instance_cache()
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeConnector(Connector):
+    """Connector whose ``discover_topology`` returns a class-level snapshot.
+
+    Tests mutate :attr:`hints` between refreshes to drive the
+    insert / update / soft-delete branches.
+    """
+
+    product = "faketopo"
+
+    hints: TopologyHints = TopologyHints(discovered_at=datetime.now(UTC))
+
+    async def fingerprint(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def execute(
+        self, target: Any, op_id: str, params: dict[str, Any]
+    ) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def discover_topology(self, target: Any) -> TopologyHints:
+        return type(self).hints
+
+
+def _register_fake() -> None:
+    register_connector_v2(
+        product="faketopo",
+        version="",
+        impl_id="",
+        cls=_FakeConnector,
+    )
+
+
+async def _seed_tenant_and_target(slug: str = "rdc-internal") -> tuple[uuid.UUID, Target]:
+    """Insert one tenant + one target for it; return ``(tenant_id, target)``."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    target = Target(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        name=f"vcenter-{slug}",
+        aliases=[],
+        product="faketopo",
+        host="vc.example.test",
+    )
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+    return tenant_id, target
+
+
+def _operator(tenant_id: uuid.UUID) -> Operator:
+    return Operator(
+        sub="op-1",
+        name="Op One",
+        email=None,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _hints_3n2e() -> TopologyHints:
+    return TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=(
+            NodeHint(kind="vm", name="vm-a", properties={"power": "on"}),
+            NodeHint(kind="vm", name="vm-b"),
+            NodeHint(kind="datastore", name="ds-1"),
+        ),
+        edges=(
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-a",
+                to_kind="datastore",
+                to_name="ds-1",
+                kind="mounts",
+            ),
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-b",
+                to_kind="datastore",
+                to_name="ds-1",
+                kind="mounts",
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Insert path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_inserts_nodes_and_edges() -> None:
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        result = await refresh_target_topology(target, _operator(tenant_id))
+
+    assert isinstance(result, RefreshResult)
+    assert result.added_nodes == 3
+    assert result.added_edges == 2
+    assert result.updated_nodes == 0
+    assert result.removed_nodes == 0
+    assert result.removed_edges == 0
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        nodes = (
+            (await session.execute(select(GraphNode).where(GraphNode.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+        edges = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(nodes) == 3
+    assert len(edges) == 2
+    assert all(n.target_id == target.id for n in nodes)
+    assert all(n.last_seen is not None for n in nodes)
+
+
+# ---------------------------------------------------------------------------
+# Unchanged path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_refresh_same_hints_is_unchanged() -> None:
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+    op = _operator(tenant_id)
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        await refresh_target_topology(target, op)
+        result = await refresh_target_topology(target, op)
+
+    assert result.added_nodes == 0
+    assert result.added_edges == 0
+    assert result.updated_nodes == 0
+    assert result.updated_edges == 0
+    assert result.removed_nodes == 0
+    assert result.removed_edges == 0
+
+
+# ---------------------------------------------------------------------------
+# Soft-delete path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dropped_node_is_soft_deleted() -> None:
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+    op = _operator(tenant_id)
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        await refresh_target_topology(target, op)
+        # Drop vm-b (and its edge) from discovery.
+        _FakeConnector.hints = TopologyHints(
+            discovered_at=datetime.now(UTC),
+            nodes=(
+                NodeHint(kind="vm", name="vm-a", properties={"power": "on"}),
+                NodeHint(kind="datastore", name="ds-1"),
+            ),
+            edges=(
+                EdgeHint(
+                    from_kind="vm",
+                    from_name="vm-a",
+                    to_kind="datastore",
+                    to_name="ds-1",
+                    kind="mounts",
+                ),
+            ),
+        )
+        result = await refresh_target_topology(target, op)
+
+    assert result.removed_nodes == 1
+    assert result.removed_edges == 1
+    assert result.added_nodes == 0
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        vm_b = (
+            await session.execute(
+                select(GraphNode).where(
+                    GraphNode.tenant_id == tenant_id,
+                    GraphNode.name == "vm-b",
+                )
+            )
+        ).scalar_one()
+    # Soft delete — row survives, last_seen nulled.
+    assert vm_b.last_seen is None
+
+
+# ---------------------------------------------------------------------------
+# Update path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_changed_properties_take_update_path() -> None:
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+    op = _operator(tenant_id)
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        await refresh_target_topology(target, op)
+        _FakeConnector.hints = TopologyHints(
+            discovered_at=datetime.now(UTC),
+            nodes=(
+                NodeHint(kind="vm", name="vm-a", properties={"power": "off"}),
+                NodeHint(kind="vm", name="vm-b"),
+                NodeHint(kind="datastore", name="ds-1"),
+            ),
+            edges=_hints_3n2e().edges,
+        )
+        result = await refresh_target_topology(target, op)
+
+    assert result.updated_nodes == 1
+    assert result.added_nodes == 0
+    assert result.removed_nodes == 0
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        vm_a = (
+            await session.execute(
+                select(GraphNode).where(
+                    GraphNode.tenant_id == tenant_id,
+                    GraphNode.name == "vm-a",
+                )
+            )
+        ).scalar_one()
+    assert vm_a.properties == {"power": "off"}
+    assert vm_a.last_seen is not None
+
+
+# ---------------------------------------------------------------------------
+# Transactional rollback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mid_reconcile_failure_rolls_back() -> None:
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+    op = _operator(tenant_id)
+
+    # Fail the audit write (last step inside the transaction) so the
+    # already-staged node/edge inserts must roll back.
+    with (
+        patch(_PUBLISH, new=AsyncMock()),
+        patch(
+            "meho_backplane.topology.refresh._write_audit_and_broadcast",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await refresh_target_topology(target, op)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        nodes = (
+            (await session.execute(select(GraphNode).where(GraphNode.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+        audit = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert nodes == []
+    assert audit == []
+
+
+# ---------------------------------------------------------------------------
+# Audit + broadcast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_emits_audit_row_and_broadcast() -> None:
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+
+    publish_mock = AsyncMock()
+    with patch(_PUBLISH, new=publish_mock):
+        await refresh_target_topology(target, _operator(tenant_id))
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.path == "topology.refresh"
+    assert row.target_id == target.id
+    assert row.payload["op_id"] == "topology.refresh"
+    assert row.payload["op_class"] == "read"
+    assert row.payload["added_nodes"] == 3
+
+    publish_mock.assert_awaited_once()
+    event = publish_mock.await_args.args[0]
+    assert event.op_id == "topology.refresh"
+    assert event.op_class == "read"
+    assert event.tenant_id == tenant_id
+    assert event.payload["added_nodes"] == 3
+    # No per-resource leak — only counts + metadata.
+    assert "nodes" not in event.payload
+    assert "name" not in event.payload
+
+
+@pytest.mark.asyncio
+async def test_broadcast_failure_does_not_fail_refresh() -> None:
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+
+    with patch(_PUBLISH, new=AsyncMock(side_effect=RuntimeError("redis down"))):
+        result = await refresh_target_topology(target, _operator(tenant_id))
+
+    # Refresh still succeeded; audit row committed.
+    assert result.added_nodes == 3
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_is_tenant_scoped() -> None:
+    _register_fake()
+    tenant_a, target_a = await _seed_tenant_and_target("tenant-a")
+    tenant_b, _target_b = await _seed_tenant_and_target("tenant-b")
+    _FakeConnector.hints = _hints_3n2e()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        await refresh_target_topology(target_a, _operator(tenant_a))
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        a_nodes = (
+            (await session.execute(select(GraphNode).where(GraphNode.tenant_id == tenant_a)))
+            .scalars()
+            .all()
+        )
+        b_nodes = (
+            (await session.execute(select(GraphNode).where(GraphNode.tenant_id == tenant_b)))
+            .scalars()
+            .all()
+        )
+    assert len(a_nodes) == 3
+    assert b_nodes == []
+    assert all(n.tenant_id == tenant_a for n in a_nodes)

--- a/backend/tests/test_topology_scheduler.py
+++ b/backend/tests/test_topology_scheduler.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G9.1-T3 scheduled topology-refresh loop.
+
+Coverage matrix (Task #450 acceptance criteria):
+
+* **Sweep iterates every tenant's targets** — a sweep with 2 targets
+  across 2 tenants calls :func:`refresh_target_topology` once per
+  target with a tenant-scoped system operator.
+* **Failure of one target doesn't stall the rest** — one target's
+  refresh raises; the other targets are still refreshed and the bad
+  one goes on backoff.
+* **Backoff window is honoured** — a target still inside its backoff
+  window is skipped on the next sweep.
+* **Advisory lock no-ops on SQLite** — the dialect gate returns
+  ``True`` (proceed) on the non-PG test path so the unit suite
+  exercises the real loop without a Postgres container.
+* **Lock-contention path** — when ``pg_try_advisory_lock`` reports the
+  lock is held elsewhere the target is skipped (no refresh call).
+* **Cadence is the configured setting** — the loop sleeps
+  ``TOPOLOGY_REFRESH_INTERVAL_SECONDS`` between sweeps.
+* **start/stop lifecycle** — the lifespan helpers create and cleanly
+  cancel the background task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target, Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.topology import scheduler as sched
+from meho_backplane.topology.scheduler import (
+    _advisory_lock_key,
+    _refresh_one_target,
+    _run_one_sweep,
+    _SchedulerState,
+    start_topology_refresh_scheduler,
+    stop_topology_refresh_scheduler,
+)
+
+_REFRESH = "meho_backplane.topology.scheduler.refresh_target_topology"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_target(slug: str, name: str) -> tuple[uuid.UUID, Target]:
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    target = Target(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        name=name,
+        aliases=[],
+        product="faketopo",
+        host="h.example.test",
+    )
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+    return tenant_id, target
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock key
+# ---------------------------------------------------------------------------
+
+
+def test_advisory_lock_key_is_deterministic_and_in_range() -> None:
+    a = uuid.uuid4()
+    b = uuid.uuid4()
+    k1 = _advisory_lock_key(a, b)
+    k2 = _advisory_lock_key(a, b)
+    assert k1 == k2
+    assert 0 <= k1 <= 0x7FFF_FFFF_FFFF_FFFF
+    # Different pair → (almost surely) different key.
+    assert _advisory_lock_key(b, a) != k1
+
+
+# ---------------------------------------------------------------------------
+# Sweep iterates every tenant's targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sweep_refreshes_every_target_across_tenants() -> None:
+    _, target_a = await _seed_target("tenant-a", "vc-a")
+    _, target_b = await _seed_target("tenant-b", "vc-b")
+
+    refreshed: list[uuid.UUID] = []
+
+    async def _fake_refresh(target: Target, operator: object) -> object:
+        refreshed.append(target.id)
+        return object()
+
+    with patch(_REFRESH, new=AsyncMock(side_effect=_fake_refresh)):
+        await _run_one_sweep(_SchedulerState())
+
+    assert sorted(refreshed) == sorted([target_a.id, target_b.id])
+
+
+@pytest.mark.asyncio
+async def test_sweep_passes_tenant_scoped_system_operator() -> None:
+    tenant_id, _target = await _seed_target("tenant-a", "vc-a")
+    seen: list[object] = []
+
+    async def _fake_refresh(t: Target, operator: object) -> object:
+        seen.append(operator)
+        return object()
+
+    with patch(_REFRESH, new=AsyncMock(side_effect=_fake_refresh)):
+        await _run_one_sweep(_SchedulerState())
+
+    assert len(seen) == 1
+    op = seen[0]
+    assert op.tenant_id == tenant_id  # type: ignore[attr-defined]
+    assert op.sub == "system:topology-scheduler"  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation + backoff
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_failing_target_does_not_stall_others() -> None:
+    _, good = await _seed_target("tenant-a", "good")
+    _, bad = await _seed_target("tenant-b", "bad")
+
+    refreshed: list[uuid.UUID] = []
+
+    async def _fake_refresh(target: Target, operator: object) -> object:
+        refreshed.append(target.id)
+        if target.id == bad.id:
+            raise RuntimeError("connector down")
+        return object()
+
+    state = _SchedulerState()
+    with patch(_REFRESH, new=AsyncMock(side_effect=_fake_refresh)):
+        await _run_one_sweep(state)
+
+    assert good.id in refreshed
+    assert bad.id in refreshed
+    # The bad target is now on backoff.
+    assert bad.id in state.backoff
+    assert state.backoff[bad.id].consecutive_failures == 1
+    assert state.backoff[bad.id].skip_until > 0
+
+
+@pytest.mark.asyncio
+async def test_target_inside_backoff_window_is_skipped() -> None:
+    _, target = await _seed_target("tenant-a", "vc-a")
+    state = _SchedulerState()
+
+    calls: list[uuid.UUID] = []
+
+    async def _fake_refresh(t: Target, operator: object) -> object:
+        calls.append(t.id)
+        return object()
+
+    # Pre-load a backoff window that has not elapsed.
+    bo = state.backoff.setdefault(target.id, sched._TargetBackoff())
+    bo.consecutive_failures = 2
+    bo.skip_until = asyncio.get_event_loop().time() + 9999
+
+    with patch(_REFRESH, new=AsyncMock(side_effect=_fake_refresh)):
+        await _refresh_one_target(target, state)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_success_clears_backoff() -> None:
+    _, target = await _seed_target("tenant-a", "vc-a")
+    state = _SchedulerState()
+    bo = state.backoff.setdefault(target.id, sched._TargetBackoff())
+    bo.consecutive_failures = 1
+    bo.skip_until = 0.0  # already elapsed
+
+    with patch(_REFRESH, new=AsyncMock(return_value=object())):
+        await _refresh_one_target(target, state)
+
+    assert target.id not in state.backoff
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_advisory_lock_noop_on_sqlite_lets_refresh_proceed() -> None:
+    _, target = await _seed_target("tenant-a", "vc-a")
+    state = _SchedulerState()
+    calls: list[uuid.UUID] = []
+
+    async def _fake_refresh(t: Target, operator: object) -> object:
+        calls.append(t.id)
+        return object()
+
+    with patch(_REFRESH, new=AsyncMock(side_effect=_fake_refresh)):
+        await _refresh_one_target(target, state)
+
+    assert calls == [target.id]
+
+
+@pytest.mark.asyncio
+async def test_locked_target_is_skipped() -> None:
+    _, target = await _seed_target("tenant-a", "vc-a")
+    state = _SchedulerState()
+    calls: list[uuid.UUID] = []
+
+    async def _fake_refresh(t: Target, operator: object) -> object:
+        calls.append(t.id)
+        return object()
+
+    with (
+        patch(
+            "meho_backplane.topology.scheduler._try_advisory_lock",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(_REFRESH, new=AsyncMock(side_effect=_fake_refresh)),
+    ):
+        await _refresh_one_target(target, state)
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Cadence + lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_sleeps_configured_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TOPOLOGY_REFRESH_INTERVAL_SECONDS", "1234")
+    get_settings.cache_clear()
+
+    sleeps: list[float] = []
+
+    async def _fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        # Stop the loop after the first sleep.
+        raise asyncio.CancelledError
+
+    with (
+        patch(
+            "meho_backplane.topology.scheduler._run_one_sweep",
+            new=AsyncMock(),
+        ),
+        patch("asyncio.sleep", new=_fake_sleep),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await sched._scheduler_loop()
+
+    assert sleeps == [1234]
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_scheduler_lifecycle() -> None:
+    with patch(
+        "meho_backplane.topology.scheduler._run_one_sweep",
+        new=AsyncMock(),
+    ):
+        task = start_topology_refresh_scheduler()
+        assert not task.done()
+        await stop_topology_refresh_scheduler(task)
+        assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_sweep_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TOPOLOGY_REFRESH_INTERVAL_SECONDS", "5")
+    get_settings.cache_clear()
+
+    sweep_calls = 0
+
+    async def _flaky_sweep(state: object) -> None:
+        nonlocal sweep_calls
+        sweep_calls += 1
+        raise RuntimeError("transient enumerate failure")
+
+    async def _fake_sleep(seconds: float) -> None:
+        # Allow exactly one sweep + sleep, then stop the loop.
+        raise asyncio.CancelledError
+
+    with (
+        patch(
+            "meho_backplane.topology.scheduler._run_one_sweep",
+            new=_flaky_sweep,
+        ),
+        patch("asyncio.sleep", new=_fake_sleep),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await sched._scheduler_loop()
+
+    # The sweep raised but the loop reached the sleep (didn't die).
+    assert sweep_calls == 1

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -1,0 +1,135 @@
+# topology — graph refresh service + scheduled background task
+
+## Overview
+
+`backend/src/meho_backplane/topology/` is the **write** half of the G9.1
+topology graph (Initiative #363). It takes a connector's discovery
+snapshot and reconciles it into the `graph_node` + `graph_edge` tables
+that G9.1-T1 (#448) created and that G9.1-T4's recursive-CTE traversal
+(`dependents` / `dependencies` / `path`) reads.
+
+Two entry points:
+
+- `refresh_target_topology(target, operator) -> RefreshResult` — one
+  on-demand refresh of a single target.
+- `start_topology_refresh_scheduler() -> asyncio.Task` — the lifespan
+  background loop that sweeps every tenant's targets on a cadence.
+
+Read paths (the three query verbs), the REST/CLI/MCP fronts, and the
+`docs/architecture/topology.md` operator doc are **out of scope** here —
+they land in G9.1-T4 through T8.
+
+## Key types
+
+### `RefreshResult` — frozen Pydantic v2
+
+Returned by `refresh_target_topology`. Per-object-class disjoint counts:
+a node is in exactly one of `added_nodes` / `updated_nodes` /
+`removed_nodes` (or none, when unchanged); same for edges.
+`duration_ms` covers the whole resolve + discover + reconcile + commit
+cycle. `target_id` echoes the refreshed target.
+
+## Control flow
+
+### `refresh_target_topology`
+
+1. `resolve_connector(target)` → `get_or_create_connector_instance(cls)`
+   (the same cached-singleton path the G0.6 dispatcher uses).
+2. `await connector.discover_topology(target)` → a `TopologyHints`
+   snapshot (nodes + edges, each with `properties`).
+3. Open one transactional session (`sessionmaker() ... session.begin()`).
+4. `_reconcile_nodes` — diff the snapshot nodes against existing
+   `graph_node` rows for `(tenant_id, target_id)`:
+   - INSERT nodes in the snapshot but not the DB.
+   - For nodes in both: refresh `last_seen`, and `properties` when they
+     changed (a no-change refresh only touches `last_seen`, so the
+     `unchanged` path reports zero `updated`).
+   - Soft-delete (set `last_seen = NULL`) nodes in the DB but absent
+     from the snapshot. A node already soft-deleted is not re-counted.
+   Returns two key→id maps: `live` (snapshot-present nodes only) and
+   `all` (every node in the target scope, including soft-deleted).
+5. `_reconcile_edges` — same diff for edges, keyed by
+   `(from_kind, from_name, to_kind, to_name, kind)`. Existing edges are
+   loaded by `from_node_id` over the **`all`** node-id set so an edge
+   whose endpoint was just dropped is still found and soft-deleted
+   rather than orphaned. Discovered edge endpoints resolve through the
+   **`live`** map; an edge whose endpoint left the snapshot falls
+   through to the soft-delete pass. A discovered edge with no matching
+   live node (a malformed connector emitting an edge without its node)
+   is logged and skipped — never inserted as a dangling FK.
+6. `_write_audit_and_broadcast` adds **one `audit_log` row to the same
+   session** — `method="REFRESH"`, `path="topology.refresh"`,
+   `payload={op_id, op_class:"read", target_id, <six counts>}`. Because
+   the audit row is in the reconcile transaction, the spec's "no
+   success without a committed audit row" invariant holds: an audit
+   failure rolls the whole refresh back.
+7. After commit, publish one `BroadcastEvent` (op_class `read`,
+   aggregate counts only — no node/edge names, so the read-class PII
+   default holds without a redactor pass). Broadcast is **fail-open**:
+   a publish exception is logged, never raised.
+
+A failure anywhere in steps 1–6 raises out of the `session.begin()`
+block, rolling everything back: no half-applied graph, no audit row.
+
+### Scheduler
+
+`_scheduler_loop` is a forever loop registered as an `asyncio.Task` in
+`main.lifespan` (after connector auto-discovery; cancelled + awaited on
+shutdown before the DB/redis pools dispose). Each iteration:
+
+- `_run_one_sweep` — enumerate tenants, then each tenant's targets, and
+  call `_refresh_one_target` per target.
+- `_refresh_one_target` — skip if inside the target's backoff window;
+  open a lock session, `pg_try_advisory_lock(hash(tenant, target))`
+  (non-blocking; on non-PostgreSQL the lock is a no-op since the test
+  process is single-replica), run the refresh, `pg_advisory_unlock` in
+  a `finally`. Success clears backoff; failure increments it
+  (`2^n × interval`, capped at 4 h) and is swallowed so one bad target
+  never stalls the sweep.
+- Sleep `TOPOLOGY_REFRESH_INTERVAL_SECONDS` (default 3600), repeat. A
+  sweep-level exception is logged and the loop continues — only
+  `CancelledError` stops it.
+
+The advisory-lock key is a blake2b digest of the two UUIDs masked to 63
+bits (non-negative, fits asyncpg's signed `bigint` binding).
+
+### Why `asyncio.create_task`, not APScheduler 4.x
+
+Task #450 prefers APScheduler 4.x but explicitly allows reusing an
+in-lifespan `asyncio` loop. As of 2026-05 APScheduler 4.x has only ever
+shipped `4.0.0aN` alphas, documented by the maintainer as "should NOT be
+used in production". The chassis ships to production and follows a "no
+new substrate / minimal dependencies" discipline, so the stdlib loop —
+the issue's own stated fallback — is the right call. Revisit if 4.x
+stabilises and a richer scheduling need (cron, persisted jobs) appears.
+
+## Dependencies
+
+- `meho_backplane.connectors.resolver.resolve_connector` +
+  `meho_backplane.operations._handler_resolve.get_or_create_connector_instance`
+  — connector resolution (G0.6).
+- `meho_backplane.connectors.schemas` — `TopologyHints` / `NodeHint` /
+  `EdgeHint` (G9.1-T2 #449).
+- `meho_backplane.db.models` — `GraphNode` / `GraphEdge` / `AuditLog` /
+  `Target` / `Tenant`.
+- `meho_backplane.broadcast` — `BroadcastEvent` / `publish_event`
+  (fail-open, G6.1).
+- `meho_backplane.settings` — `topology_refresh_interval_seconds`.
+- `meho_backplane.metrics` — `TOPOLOGY_REFRESH_TOTAL` counter
+  (`outcome` label: `ok` / `error` / `skipped_locked`).
+
+## Known issues / out of scope
+
+- Streaming refresh progress for very large topologies — v0.2 is
+  single-shot; deferred per Initiative #363.
+- Graph history / time-travel — soft-delete here only makes a node
+  invisible to default queries; the history surface is G9.3.
+- Per-connector `discover_topology` overrides — each G3.x Initiative.
+- The advisory lock is a multi-replica stampede guard only; a single
+  process serialises naturally and the SQLite test path no-ops it.
+
+## References
+
+- Task #450 (G9.1-T3), Initiative #363, prerequisites #448 / #449.
+- Audit/broadcast pattern mirrored from
+  `backend/src/meho_backplane/operations/_audit.py`.


### PR DESCRIPTION
## Summary

- Ships the **write half** of the G9.1 topology graph (Initiative #363, T3): on-demand + scheduled refresh that reconciles a connector's `TopologyHints` snapshot into the `graph_node` / `graph_edge` tables T1 (#448) created.
- `refresh_target_topology(target, operator)` — resolve connector (G0.6) → `discover_topology` → diff/apply (insert new, update `last_seen`/`properties`, soft-delete `last_seen=NULL` for dropped) in **one transaction**; synchronous audit row inside the transaction, fail-open aggregate-only broadcast after commit.
- `start_topology_refresh_scheduler()` — `asyncio.create_task` loop in the lifespan, per-`(tenant,target)` PG advisory lock against multi-replica stampede, exponential per-target backoff (2^n×interval, capped 4h) so one bad target never stalls the sweep. `TOPOLOGY_REFRESH_INTERVAL_SECONDS` setting (default 3600) + `topology_refresh_total` Prometheus counter.
- **Design note:** APScheduler 4.x was *preferred* by the task but has only ever shipped alphas the maintainer flags "should NOT be used in production". The task's own stated fallback (in-lifespan `asyncio` loop) is used — correct for a production backplane under the chassis's no-new-substrate discipline. Documented in `docs/codebase/topology.md` and the scheduler module docstring.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean (strict; 147 files)
- [x] `pytest tests/` — 1763 passed, 43 skipped (the single `test_connectors_k8s_k3d` failure is a pre-existing live-k3s testcontainers infra flake in the local sandbox, unrelated to topology — CI provisions Docker)
- [x] `code-quality.py --diff` — 0 blockers
- [x] Connector returning 3 nodes + 2 edges inserts 3 + 2 rows; correct `RefreshResult` counts — `test_first_refresh_inserts_nodes_and_edges`
- [x] Second refresh, same hints → all-zero counts (no spurious update) — `test_second_refresh_same_hints_is_unchanged`
- [x] Dropped node → `last_seen=NULL`, `removed_nodes=1`, row survives — `test_dropped_node_is_soft_deleted`
- [x] Changed `properties` → UPDATE path, properties + `last_seen` refreshed — `test_changed_properties_take_update_path`
- [x] Mid-reconcile failure rolls back; DB unchanged, no audit row — `test_mid_reconcile_failure_rolls_back`
- [x] One audit row per refresh (`topology.refresh`, op_class `read`, counts) + one broadcast event; no per-resource leak — `test_refresh_emits_audit_row_and_broadcast`
- [x] Broadcast failure does not fail the refresh — `test_broadcast_failure_does_not_fail_refresh`
- [x] Tenant boundary preserved — `test_refresh_is_tenant_scoped`
- [x] Scheduler iterates all targets per tenant; tenant-scoped system operator — `test_sweep_refreshes_every_target_across_tenants`, `test_sweep_passes_tenant_scoped_system_operator`
- [x] One failing target doesn't stall others + backoff applied/honoured/cleared — `test_one_failing_target_does_not_stall_others`, `test_target_inside_backoff_window_is_skipped`, `test_success_clears_backoff`
- [x] Advisory lock no-ops on SQLite; contended lock skips target — `test_advisory_lock_noop_on_sqlite_lets_refresh_proceed`, `test_locked_target_is_skipped`
- [x] Cadence = configured setting; loop survives a sweep exception; start/stop lifecycle — `test_loop_sleeps_configured_interval`, `test_loop_survives_sweep_exception`, `test_start_and_stop_scheduler_lifecycle`

## Out of scope

- Query verbs (`dependents`/`dependencies`/`path`) — T4 (#451).
- REST / CLI / MCP fronts — T5/T6/T7.
- Per-connector `discover_topology` overrides — each G3.x Initiative.
- `docs/architecture/topology.md` + 10k-node perf acceptance — T8 (#456). This PR ships `docs/codebase/topology.md` (module-level codebase doc) instead.
- Adjacent finding (recorded, not edited): pre-existing `settings.py:get_settings` is 74 lines (size warning, not agent-introduced); `refresh.py` is 527 lines (size warning, under the 600 block limit).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background scheduler for periodic topology refreshes
  * On-demand topology refresh operation with audit logging and post-refresh event broadcasts
  * Configurable refresh interval (default 1 hour)
  * Metrics tracking for refresh outcomes (ok/error/skipped)

* **Bug Fixes**
  * Safer startup/shutdown for the scheduler to avoid shutdown races

* **Tests**
  * Comprehensive tests for refresh logic and scheduler behavior

* **Documentation**
  * Expanded topology refresh and scheduler docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->