### PR TITLE
feat(connectors): G3.2-T2 K8s core inventory ops — k8s.ls / k8s.namespace.list / k8s.node.list

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -79,8 +79,6 @@ from meho_backplane.connectors.schemas import (
 __all__ = ["KubernetesConnector", "product_from_git_version"]
 
 
-
-
 _log = structlog.get_logger(__name__)
 
 _DEFAULT_K8S_PORT = 6443
@@ -109,13 +107,23 @@ def _normalise_kind_to_singular(kind: str) -> str:
     the connector because the rest of the substrate doesn't care --
     op_ids are opaque dotted strings to the dispatcher.
 
-    Default branch: strip a trailing ``s``. The irregulars
-    (``ingresses``, ``persistentvolumeclaims``) live in
-    :data:`_PLURAL_TO_SINGULAR_KIND` so the function stays declarative
-    rather than chained ``if/elif``.
+    Three branches, in order:
+
+    1. Explicit plural in :data:`_PLURAL_TO_SINGULAR_KIND` -- the
+       irregulars (``ingresses``, ``persistentvolumeclaims``) that
+       don't strip a trailing ``s`` cleanly.
+    2. An operator-typed singular that already matches one of the
+       mapped singular forms (``ingress``, ``storageclass``,
+       ``persistentvolume``, ``persistentvolumeclaim``). Return as-is
+       to avoid the strip-trailing-s branch mangling ``ingress`` into
+       ``ingres``.
+    3. Default: strip a trailing ``s`` (``pods`` -> ``pod``,
+       ``services`` -> ``service``).
     """
     if kind in _PLURAL_TO_SINGULAR_KIND:
         return _PLURAL_TO_SINGULAR_KIND[kind]
+    if kind in _PLURAL_TO_SINGULAR_KIND.values():
+        return kind
     if kind.endswith("s") and len(kind) > 1:
         return kind[:-1]
     return kind

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -64,6 +64,12 @@ from meho_backplane.connectors.kubernetes.kubeconfig import (
     load_kubeconfig_from_vault,
 )
 from meho_backplane.connectors.kubernetes.ops import KUBERNETES_OPS
+from meho_backplane.connectors.kubernetes.ops_core import (
+    K8S_CLUSTER_KINDS,
+    K8S_NAMESPACED_KIND_LISTERS,
+    namespace_row,
+    node_row,
+)
 from meho_backplane.connectors.schemas import (
     FingerprintResult,
     OperationResult,
@@ -72,11 +78,47 @@ from meho_backplane.connectors.schemas import (
 
 __all__ = ["KubernetesConnector", "product_from_git_version"]
 
+
+
+
 _log = structlog.get_logger(__name__)
 
 _DEFAULT_K8S_PORT = 6443
 _PROBE_TIMEOUT_SECONDS = 5.0
 _PROBE_OK_STATUSES = frozenset({200, 401})
+
+
+#: Plural kind labels (kubectl-style) -> singular op_id segment. Only
+#: the irregulars need an entry; everything else (``pods``, ``services``,
+#: ``configmaps``, ``nodes``) takes the strip-trailing-s default branch
+#: in :func:`_normalise_kind_to_singular`.
+_PLURAL_TO_SINGULAR_KIND: dict[str, str] = {
+    "ingresses": "ingress",
+    "persistentvolumeclaims": "persistentvolumeclaim",
+    "persistentvolumes": "persistentvolume",
+    "storageclasses": "storageclass",
+}
+
+
+def _normalise_kind_to_singular(kind: str) -> str:
+    """Map a ``kubectl get <kind>``-style plural to the singular op-id segment.
+
+    The path the operator types is plural-shaped (``/argocd/pods``,
+    matching their ``kubectl`` muscle memory); the op_id namespace under
+    #320 is singular-shaped (``k8s.pod.list``). The mapping is local to
+    the connector because the rest of the substrate doesn't care --
+    op_ids are opaque dotted strings to the dispatcher.
+
+    Default branch: strip a trailing ``s``. The irregulars
+    (``ingresses``, ``persistentvolumeclaims``) live in
+    :data:`_PLURAL_TO_SINGULAR_KIND` so the function stays declarative
+    rather than chained ``if/elif``.
+    """
+    if kind in _PLURAL_TO_SINGULAR_KIND:
+        return _PLURAL_TO_SINGULAR_KIND[kind]
+    if kind.endswith("s") and len(kind) > 1:
+        return kind[:-1]
+    return kind
 
 
 def product_from_git_version(git_version: str) -> str:
@@ -237,6 +279,228 @@ class KubernetesConnector(Connector):
             "go_version": version.go_version,
             "git_commit": version.git_commit,
             "git_tree_state": version.git_tree_state,
+        }
+
+    async def k8s_namespace_list(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List namespaces -- one row per namespace with phase / age / labels.
+
+        Op-id: ``k8s.namespace.list``. Wraps ``CoreV1Api.list_namespace()``
+        and projects each :class:`V1Namespace` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_core.namespace_row`
+        so the wire shape is stable across the test seam (where
+        ``namespace_row`` is unit-tested directly against synthetic
+        :class:`V1Namespace` instances) and the live API path.
+
+        ``params`` is declared empty in the op's
+        :attr:`~meho_backplane.connectors.kubernetes.ops_core.K8S_NAMESPACE_LIST_PARAMETER_SCHEMA`;
+        the dispatcher's :class:`Draft202012Validator` rejects any extra
+        keys before this handler runs.
+        """
+        del params
+        api_client = await self._get_api_client(target)
+        core_v1 = client.CoreV1Api(api_client)
+        resp = await core_v1.list_namespace()
+        rows = [namespace_row(ns) for ns in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_node_list(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List cluster nodes -- name / status / roles / version / kernel / IP / taints.
+
+        Op-id: ``k8s.node.list``. Wraps ``CoreV1Api.list_node()`` and
+        projects each :class:`V1Node` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_core.node_row`.
+        The Ready-condition mapping ("Ready" / "NotReady" / "Unknown") and
+        the role-label derivation are both helpers in :mod:`ops_core` so
+        the unit tests pin those mappings against synthetic
+        :class:`V1Node` instances without an event loop.
+        """
+        del params
+        api_client = await self._get_api_client(target)
+        core_v1 = client.CoreV1Api(api_client)
+        resp = await core_v1.list_node()
+        rows = [node_row(n) for n in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_ls(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Synthetic walker -- list inventory at a logical path.
+
+        Op-id: ``k8s.ls``. Three shapes by *path*:
+
+        * ``/`` (or omitted) -- ``{namespaces: [...], cluster_kinds: [...]}``.
+          ``namespaces`` is the sorted namespace names; ``cluster_kinds`` is
+          the fixed list from
+          :data:`~meho_backplane.connectors.kubernetes.ops_core.K8S_CLUSTER_KINDS`.
+        * ``/<namespace>`` -- ``{namespace: <ns>, kinds: [{kind, count}],
+          cluster_kinds_omitted: true}``. The handler probes each kind in
+          :data:`~meho_backplane.connectors.kubernetes.ops_core.K8S_NAMESPACED_KIND_LISTERS`
+          with ``limit=1`` and reads the response's
+          ``metadata.remaining_item_count`` to derive the count without
+          pulling every row -- the operator-facing "how many pods are in
+          argocd?" question costs one round-trip per kind, not one per
+          row.
+        * ``/<namespace>/<kind>`` -- forwards to ``k8s.<kind>.list`` via
+          :meth:`execute` (the dispatcher shim). Kinds whose ``list`` op
+          hasn't shipped yet come back through ``execute``'s structured
+          ``unknown_op`` envelope; the handler does not pretend to know
+          which kinds will eventually be registered.
+
+        Forwarding-through-execute (rather than calling
+        ``CoreV1Api.list_namespaced_<kind>`` directly here) means the
+        kind-specific ops' own dispatcher path -- parameter validation,
+        future reducer-driven handle creation, audit row, broadcast --
+        runs verbatim. The forwarding handler is structural plumbing, not
+        a semantic shortcut.
+        """
+        raw_path = params.get("path", "/")
+        # Normalise the path: empty string and "/" both map to the root;
+        # leading slash is stripped before splitting so "/argocd" parses
+        # to ["argocd"], not ["", "argocd"].
+        if not isinstance(raw_path, str):
+            # Defensive: the JSON Schema's ``type: string`` should catch
+            # non-string inputs before the handler runs, but the schema's
+            # ``default`` clause means an absent param arrives as the
+            # schema default ("/"). A wrong-type override surfaces here.
+            raise TypeError(f"k8s.ls path must be a string, got {type(raw_path).__name__}")
+        segments = [s for s in raw_path.split("/") if s]
+
+        if not segments:
+            return await self._k8s_ls_root(target)
+        if len(segments) == 1:
+            return await self._k8s_ls_namespace(target, segments[0])
+        if len(segments) == 2:
+            return await self._k8s_ls_namespace_kind(target, segments[0], segments[1])
+        # Deeper paths aren't a documented v0.2 shape; collapse to the
+        # namespace/kind forwarder against the first two segments. The
+        # operator gets a useful result rather than an opaque error.
+        return await self._k8s_ls_namespace_kind(target, segments[0], segments[1])
+
+    async def _k8s_ls_root(
+        self,
+        target: KubernetesTargetLike,
+    ) -> dict[str, Any]:
+        """Cluster-root view: list namespace names + the fixed cluster-kind list."""
+        api_client = await self._get_api_client(target)
+        core_v1 = client.CoreV1Api(api_client)
+        resp = await core_v1.list_namespace()
+        names = sorted(
+            ns.metadata.name
+            for ns in resp.items
+            if ns.metadata is not None and ns.metadata.name is not None
+        )
+        return {
+            "path": "/",
+            "namespaces": names,
+            "cluster_kinds": list(K8S_CLUSTER_KINDS),
+        }
+
+    async def _k8s_ls_namespace(
+        self,
+        target: KubernetesTargetLike,
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Per-namespace kind summary -- one round-trip per probed kind.
+
+        Each probed kind is fetched with ``limit=1`` so the server can
+        emit the row count via :class:`V1ListMeta.remaining_item_count`
+        without streaming every row back. The total count is
+        ``len(items) + (remaining_item_count or 0)`` because the server
+        treats the first ``limit`` rows as inline and the remainder as
+        the "still to fetch" tail.
+
+        A per-kind probe that raises (RBAC-shaped 403, deprecated kind on
+        an older cluster, transient API server blip) lands as
+        ``count=None`` with the exception class on ``error`` so the
+        operator sees which kinds aren't enumerable rather than a single
+        500-shaped failure for the whole ls.
+        """
+        api_client = await self._get_api_client(target)
+        core_v1 = client.CoreV1Api(api_client)
+        kinds: list[dict[str, Any]] = []
+        for kind_label, method_name in K8S_NAMESPACED_KIND_LISTERS:
+            method = getattr(core_v1, method_name, None)
+            if method is None:
+                # Defensive: a typo in the table would otherwise surface as
+                # an opaque AttributeError mid-walk. Record it as the
+                # error shape so the rest of the kinds still report.
+                kinds.append(
+                    {
+                        "kind": kind_label,
+                        "count": None,
+                        "error": f"AttributeError: CoreV1Api has no {method_name!r}",
+                    }
+                )
+                continue
+            try:
+                resp = await method(namespace=namespace, limit=1)
+                inline = len(resp.items) if resp.items is not None else 0
+                remaining = 0
+                if resp.metadata is not None and resp.metadata.remaining_item_count is not None:
+                    remaining = int(resp.metadata.remaining_item_count)
+                kinds.append({"kind": kind_label, "count": inline + remaining})
+            except Exception as exc:
+                kinds.append(
+                    {
+                        "kind": kind_label,
+                        "count": None,
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                )
+        return {
+            "path": f"/{namespace}",
+            "namespace": namespace,
+            "kinds": kinds,
+            "cluster_kinds_omitted": True,
+        }
+
+    async def _k8s_ls_namespace_kind(
+        self,
+        target: KubernetesTargetLike,
+        namespace: str,
+        kind: str,
+    ) -> dict[str, Any]:
+        """Forward to ``k8s.<kind>.list`` via the connector's dispatcher shim.
+
+        The shim resolves the kind-specific op's descriptor; an unknown
+        kind (T3/T4 hasn't shipped its ``list`` op yet) comes back as the
+        structured ``unknown_op`` envelope and the forwarder propagates
+        it verbatim in the ``result`` field, so the operator sees the
+        sub-op's exact error shape rather than a translated one.
+
+        ``kind`` is normalised before dispatch: operators type the
+        plural form (``pods``, matching ``kubectl get pods``), but the
+        op-id namespace follows the singular convention from #320's op
+        listing (``k8s.pod.list``, not ``k8s.pods.list``). The
+        :data:`_PLURAL_TO_SINGULAR_KIND` map handles the common irregulars
+        that don't strip a trailing ``s`` cleanly (``ingresses`` ->
+        ``ingress``, ``persistentvolumeclaims`` ->
+        ``persistentvolumeclaim``); everything else (``pods`` ->
+        ``pod``, ``services`` -> ``service``) takes the strip-trailing-s
+        branch. Operators who pass a singular form directly
+        (``/argocd/pod``) get a no-op normalisation.
+        """
+        op_kind = _normalise_kind_to_singular(kind)
+        sub_op_id = f"k8s.{op_kind}.list"
+        sub_params = {"namespace": namespace}
+        sub_result = await self.execute(target, sub_op_id, sub_params)
+        # OperationResult is a Pydantic model; ``.model_dump()`` gives
+        # the dict shape future dispatch-recording machinery (audit row,
+        # broadcast event) can serialise without an extra round-trip.
+        return {
+            "path": f"/{namespace}/{kind}",
+            "forwarded_to": sub_op_id,
+            "result": sub_result.model_dump(mode="json"),
         }
 
     @classmethod

--- a/backend/src/meho_backplane/connectors/kubernetes/ops.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops.py
@@ -5,19 +5,22 @@
 
 G0.6 refactor (#391) of the G3.2-T1 (#321) skeleton. The skeleton
 shipped with an empty op surface and an ``unknown_op``-returning
-``execute()``; this module is the first concrete op the connector
+``execute()``; this module hosts the metadata rows the connector
 registers against the G0.6 substrate via
 :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
 
-The op surface is intentionally minimal in this Initiative:
+The shipped op surface today:
 
 * ``k8s.about`` -- product-flavour + version snapshot built from
   :meth:`kubernetes_asyncio.client.VersionApi.get_code`. Mirrors what
   :meth:`KubernetesConnector.fingerprint` returns but goes through the
   dispatcher so callers see the same envelope (``OperationResult``)
-  every other op produces. The full 13-op K8s surface (``k8s.pod.list``
-  / ``k8s.deployment.list`` / ...) lands in G3.2-T2..T5 (#320 work
-  items) against the same registration pattern from the start.
+  every other op produces. Landed with #391's refactor of the T1
+  skeleton.
+* ``k8s.ls`` / ``k8s.namespace.list`` / ``k8s.node.list`` -- the core
+  inventory surface (G3.2-T2 #322). Metadata + helper functions live in
+  :mod:`~meho_backplane.connectors.kubernetes.ops_core`; this module
+  re-exports the merged tuple so registration walks a single list.
 
 Each op is declared in :data:`KUBERNETES_OPS` as a typed-metadata row.
 The connector's ``register_operations()`` classmethod walks the list
@@ -82,67 +85,87 @@ class KubernetesOp:
 
 #: The ops :class:`KubernetesConnector` registers at lifespan startup.
 #:
-#: ``k8s.about`` is the canary op the G0.6 refactor (#391) lands
-#: against. It returns a flat dict shaped like
+#: ``k8s.about`` is the canary op the G0.6 refactor (#391) lands against.
+#: It returns a flat dict shaped like
 #: :class:`~meho_backplane.connectors.schemas.FingerprintResult` but
 #: goes through the dispatcher path so callers exercise the
 #: register_typed_operation -> dispatch -> reduce -> audit pipeline
-#: end-to-end. The full 13-op K8s read surface lands in #320's T2..T5
-#: against this same registration pattern.
-KUBERNETES_OPS: tuple[KubernetesOp, ...] = (
-    KubernetesOp(
-        op_id="k8s.about",
-        handler_attr="about",
-        summary="Return the cluster's product flavour, version, and platform.",
-        description=(
-            "Hits the Kubernetes API server's ``GET /version`` endpoint via "
-            "``kubernetes_asyncio.client.VersionApi.get_code`` and returns a "
-            "flat dict with the cluster's product slug (rke2 / k3s / eks / "
-            "gke / aks / vanilla derived from the gitVersion suffix), full "
-            "git_version, build date, and platform string. Use to identify "
-            "the cluster before issuing higher-level ops or to populate "
-            "operator dashboards. No params; works against any target whose "
-            "kubeconfig the operator's tenant can read."
-        ),
-        parameter_schema={
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
-        response_schema={
-            "type": "object",
-            "properties": {
-                "product": {"type": "string"},
-                "git_version": {"type": "string"},
-                "build_date": {"type": "string"},
-                "major": {"type": "string"},
-                "minor": {"type": "string"},
-                "platform": {"type": "string"},
-                "go_version": {"type": "string"},
-                "git_commit": {"type": "string"},
-                "git_tree_state": {"type": "string"},
-            },
-            "required": ["product", "git_version"],
-            "additionalProperties": True,
-        },
-        group_key="cluster",
-        tags=("read-only", "cluster", "identity"),
-        safety_level="safe",
-        requires_approval=False,
-        llm_instructions={
-            "when_to_use": (
-                "Call when the operator wants to identify the K8s cluster "
-                "behind a target before issuing a higher-level op (pod list, "
-                "deployment scale, etc.), or when the agent needs to pick a "
-                "version-flavoured doc page from the knowledge base."
-            ),
-            "parameter_hints": {},
-            "output_shape": (
-                "Flat dict; the ``product`` field is the canonical slug "
-                "(``rke2`` / ``k3s`` / ``eks`` / ``gke`` / ``aks`` / "
-                "``vanilla``). ``git_version`` carries the full v-prefixed "
-                "string including distribution suffix."
-            ),
-        },
+#: end-to-end. The G3.2-T2 (#322) core inventory ops (``k8s.ls`` /
+#: ``k8s.namespace.list`` / ``k8s.node.list``) extend the tuple from
+#: :mod:`~meho_backplane.connectors.kubernetes.ops_core`. The remaining
+#: K8s read surface (workload / network / config / events / logs) lands
+#: in #320's T3..T5 against this same registration pattern.
+_K8S_ABOUT_OP = KubernetesOp(
+    op_id="k8s.about",
+    handler_attr="about",
+    summary="Return the cluster's product flavour, version, and platform.",
+    description=(
+        "Hits the Kubernetes API server's ``GET /version`` endpoint via "
+        "``kubernetes_asyncio.client.VersionApi.get_code`` and returns a "
+        "flat dict with the cluster's product slug (rke2 / k3s / eks / "
+        "gke / aks / vanilla derived from the gitVersion suffix), full "
+        "git_version, build date, and platform string. Use to identify "
+        "the cluster before issuing higher-level ops or to populate "
+        "operator dashboards. No params; works against any target whose "
+        "kubeconfig the operator's tenant can read."
     ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "product": {"type": "string"},
+            "git_version": {"type": "string"},
+            "build_date": {"type": "string"},
+            "major": {"type": "string"},
+            "minor": {"type": "string"},
+            "platform": {"type": "string"},
+            "go_version": {"type": "string"},
+            "git_commit": {"type": "string"},
+            "git_tree_state": {"type": "string"},
+        },
+        "required": ["product", "git_version"],
+        "additionalProperties": True,
+    },
+    group_key="cluster",
+    tags=("read-only", "cluster", "identity"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator wants to identify the K8s cluster "
+            "behind a target before issuing a higher-level op (pod list, "
+            "deployment scale, etc.), or when the agent needs to pick a "
+            "version-flavoured doc page from the knowledge base."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "Flat dict; the ``product`` field is the canonical slug "
+            "(``rke2`` / ``k3s`` / ``eks`` / ``gke`` / ``aks`` / "
+            "``vanilla``). ``git_version`` carries the full v-prefixed "
+            "string including distribution suffix."
+        ),
+    },
 )
+
+
+def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
+    """Return the merged registration tuple (``k8s.about`` + core inventory ops).
+
+    Implemented as a function call rather than a literal-and-splat at
+    module level so the import order stays linear: ``ops.py`` defines
+    :class:`KubernetesOp` + ``_K8S_ABOUT_OP``, then imports the T2
+    inventory ops from :mod:`ops_core` (which itself only depends on
+    ``KubernetesOp``). The arrangement keeps the canary op's metadata
+    co-located with the dataclass definition while letting the larger
+    T2 surface live in its own module next to its helpers.
+    """
+    from meho_backplane.connectors.kubernetes.ops_core import CORE_OPS
+
+    return (_K8S_ABOUT_OP, *CORE_OPS)
+
+
+KUBERNETES_OPS: tuple[KubernetesOp, ...] = _kubernetes_ops()

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_core.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_core.py
@@ -1,0 +1,591 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Core K8s inventory ops -- ``k8s.ls`` / ``k8s.namespace.list`` / ``k8s.node.list``.
+
+G3.2-T2 (#322) of Initiative #320. T1's refactor (#391) landed the
+:class:`~meho_backplane.connectors.kubernetes.connector.KubernetesConnector`
+skeleton plus the canary ``k8s.about`` op against the G0.6 substrate;
+this module adds three operator-facing inventory ops to that surface:
+
+* ``k8s.ls [path]`` -- synthetic walker mirroring ``govc ls /``. Three
+  shapes:
+
+  - ``k8s.ls /`` returns the cluster-level inventory: namespace names +
+    a small fixed list of cluster-scoped kinds.
+  - ``k8s.ls /<namespace>`` returns the kind -> count summary for the
+    namespace, using the fixed list of "commonly relevant" kinds from
+    :data:`K8S_NAMESPACED_KIND_LISTERS` so an ``ls`` call costs N small
+    "list 1 item, read remaining_item_count" round-trips rather than
+    pulling every row of every kind.
+  - ``k8s.ls /<namespace>/<kind>`` forwards through the connector's
+    dispatcher shim to ``k8s.<kind>.list`` for that namespace. Kinds
+    whose ``list`` op hasn't been registered yet (T3+ ships pod /
+    deployment / service / ingress / configmap / event) come back
+    through the shim's structured ``unknown_op`` envelope -- the
+    forwarder doesn't pretend to know which kinds will exist when.
+
+* ``k8s.namespace.list`` -- ``CoreV1Api.list_namespace()``. Returns one
+  row per namespace with name / phase / age / labels.
+
+* ``k8s.node.list`` -- ``CoreV1Api.list_node()``. Returns one row per
+  node with name / status / roles (derived from
+  ``node-role.kubernetes.io/<role>`` label keys) / version / kernel /
+  os / internal IP / taints.
+
+JSONFlux handle pattern (Issue #322 acceptance criterion)
+---------------------------------------------------------
+
+The Issue body's "Handle threshold tested: against k3d populated with
+50+ namespaces, sample of 20 + handle returned" criterion assumed the
+shared :class:`HandleStore` from G3.1-T4 (#304) would be in place. #304
+was **superseded** (closed without a HandleStore landing -- the
+Initiative-redraft note on the issue spells this out), and the
+substrate currently in the tree ships
+:class:`~meho_backplane.operations.reducer.PassThroughReducer` as the
+only reducer -- it never populates :attr:`OperationResult.handle`.
+
+The handlers in this module emit **raw row lists** in the response
+dict, exactly the shape the future JSONFlux reducer will see when it
+ships. That reducer -- not the connector -- owns the threshold check,
+the row truncation, the spill to MinIO/S3/Valkey, and the
+``ResultHandle`` construction. Putting threshold logic per-handler
+would couple every connector to the eventual reducer's calibration
+choice and double-implement the spill path; per the substrate split
+documented on
+:mod:`meho_backplane.operations.reducer`, set-shaped reduction is the
+reducer's job, not the connector's.
+
+A small forward-compat marker stays in the response envelope so future
+agent prompts (which inline ``llm_instructions.output_shape``) know
+where the row list lives: the ``rows`` key is the inventory; the
+``total`` key carries the un-truncated count from the server's
+``V1ListMeta.remaining_item_count``-aware view; the reducer reads both
+and produces the handle when its threshold trips.
+
+References
+----------
+* Parent Initiative: #320 (G3.2 K8s connector).
+* Substrate: #388 G0.6 (typed-op registry + dispatcher), #391 (the
+  T1 refactor this builds on).
+* Sibling: #304 closed-superseded HandleStore Task -- documents why
+  the handle is reducer-side, not connector-side.
+* :mod:`kubernetes_asyncio.client` ``CoreV1Api`` reference:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+
+if TYPE_CHECKING:
+    from kubernetes_asyncio.client.models import V1Namespace, V1Node, V1Taint
+
+__all__ = [
+    "CORE_OPS",
+    "K8S_LS_LLM_INSTRUCTIONS",
+    "K8S_LS_PARAMETER_SCHEMA",
+    "K8S_NAMESPACED_KIND_LISTERS",
+    "K8S_NAMESPACE_LIST_LLM_INSTRUCTIONS",
+    "K8S_NODE_LIST_LLM_INSTRUCTIONS",
+    "age_seconds",
+    "namespace_row",
+    "node_row",
+    "taint_row",
+]
+
+
+# ---------------------------------------------------------------------------
+# Row-shape helpers -- pure mappings over kubernetes_asyncio model objects.
+# Kept here (rather than inside the handlers) so the test suite can pin the
+# wire shape against synthetic fixtures without booting an event loop.
+# ---------------------------------------------------------------------------
+
+
+def age_seconds(creation_timestamp: datetime | None, *, now: datetime | None = None) -> int | None:
+    """Return seconds elapsed between *creation_timestamp* and *now*.
+
+    ``None`` when *creation_timestamp* is ``None`` (Kubernetes sets it on
+    every persisted object, but the typed model exposes it as optional so
+    callers handling a freshly-built-in-memory object don't crash). The
+    return is **integer seconds** -- ops surfaces sub-second precision
+    only for latency telemetry, never for object age.
+
+    ``now`` is parameterised for test-determinism; production paths leave
+    it ``None`` and the helper resolves :func:`datetime.now` at call time.
+    Both timestamps are normalised to UTC -- the k8s API server emits
+    RFC 3339 timestamps with a ``Z`` suffix that
+    :mod:`kubernetes_asyncio` parses into tz-aware ``datetime`` objects,
+    so the subtraction is well-defined without an explicit tz cast.
+    """
+    if creation_timestamp is None:
+        return None
+    reference = now if now is not None else datetime.now(UTC)
+    delta = reference - creation_timestamp
+    # ``total_seconds()`` can return a float when sub-second precision
+    # survives the wire-format round-trip; the integer floor matches the
+    # operator-facing "how old is this thing?" intent (a 12.4-second-old
+    # namespace reads as "12 seconds old", not "12.4").
+    return int(delta.total_seconds())
+
+
+def namespace_row(ns: V1Namespace, *, now: datetime | None = None) -> dict[str, Any]:
+    """Project a :class:`V1Namespace` into the op's row shape.
+
+    Pure function -- given the same model object, returns identical
+    output. The ``now`` seam is for deterministic tests of the
+    ``age_seconds`` derivation; production callers leave it ``None``.
+    """
+    metadata = ns.metadata
+    status = ns.status
+    return {
+        "name": metadata.name if metadata is not None else None,
+        # ``status.phase`` is the operator-visible string ("Active" /
+        # "Terminating"). Some test fixtures (and the brief window during
+        # namespace creation before the controller writes status) leave it
+        # ``None``; surface that verbatim rather than coercing to "Unknown"
+        # so the operator sees the real state.
+        "status": status.phase if status is not None else None,
+        "age_seconds": age_seconds(
+            metadata.creation_timestamp if metadata is not None else None,
+            now=now,
+        ),
+        # ``labels`` is the raw dict the API server returned; ``{}`` when
+        # the namespace has no labels. ``kubernetes_asyncio`` exposes a
+        # missing labels block as ``None``; coerce to an empty dict so the
+        # row's type is stable for downstream agents / CLI renderers.
+        "labels": (metadata.labels or {}) if metadata is not None else {},
+    }
+
+
+def taint_row(taint: V1Taint) -> dict[str, Any]:
+    """Project a :class:`V1Taint` into a flat dict the agent surface renders."""
+    return {
+        "key": taint.key,
+        "value": taint.value,
+        "effect": taint.effect,
+    }
+
+
+def _node_roles(labels: dict[str, str] | None) -> list[str]:
+    """Derive the node's role list from its label set.
+
+    Kubernetes encodes node role membership via the
+    ``node-role.kubernetes.io/<role>`` label-key convention (the value is
+    typically the empty string -- the **presence** of the key is the
+    signal). Some distributions also use ``kubernetes.io/role``; that
+    legacy single-role label is folded into the same list so the row
+    shape stays uniform across RKE2 / K3s / EKS / GKE.
+
+    Returns a sorted list so the wire output is deterministic across
+    repeated calls and across the unordered Python-dict iteration order.
+    """
+    if not labels:
+        return []
+    roles: set[str] = set()
+    role_prefix = "node-role.kubernetes.io/"
+    legacy_key = "kubernetes.io/role"
+    for key, value in labels.items():
+        if key.startswith(role_prefix):
+            suffix = key[len(role_prefix) :]
+            if suffix:
+                roles.add(suffix)
+        elif key == legacy_key and value:
+            roles.add(value)
+    return sorted(roles)
+
+
+def _node_internal_ip(addresses: list[Any] | None) -> str | None:
+    """Pluck the ``InternalIP`` entry from a node's status addresses.
+
+    The API server returns ``addresses`` as a list of ``V1NodeAddress``
+    objects with ``type`` in ``{"InternalIP", "ExternalIP", "Hostname"}``.
+    Operators want the InternalIP for SSH-into-node workflows; the other
+    types are informational. ``None`` when the node has no InternalIP
+    entry (rare; some kubelet configurations omit it).
+    """
+    if not addresses:
+        return None
+    for addr in addresses:
+        if addr.type == "InternalIP":
+            address: str | None = addr.address
+            return address
+    return None
+
+
+def node_row(node: V1Node, *, now: datetime | None = None) -> dict[str, Any]:
+    """Project a :class:`V1Node` into the op's row shape.
+
+    The status is derived from the node's condition list: a "Ready"
+    condition with ``status == "True"`` maps to ``"Ready"``; any other
+    condition state maps to ``"NotReady"``. This mirrors what
+    ``kubectl get nodes`` prints, which is what operators are
+    used to.
+    """
+    metadata = node.metadata
+    status = node.status
+    spec = node.spec
+
+    # Ready condition -> status string. The K8s API returns conditions as
+    # a list; ``kubectl get nodes`` shows ``Ready`` when the condition's
+    # ``status`` is exactly ``"True"`` (the string, not the bool), and
+    # ``NotReady`` otherwise. Mirror that mapping so the operator sees
+    # familiar output.
+    status_str: str = "Unknown"
+    if status is not None and status.conditions:
+        for cond in status.conditions:
+            if cond.type == "Ready":
+                status_str = "Ready" if cond.status == "True" else "NotReady"
+                break
+
+    node_info = status.node_info if status is not None else None
+    taints = (spec.taints or []) if spec is not None else []
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "status": status_str,
+        "roles": _node_roles(metadata.labels if metadata is not None else None),
+        "version": node_info.kubelet_version if node_info is not None else None,
+        "kernel": node_info.kernel_version if node_info is not None else None,
+        "os": node_info.operating_system if node_info is not None else None,
+        "internal_ip": _node_internal_ip(status.addresses if status is not None else None),
+        "taints": [taint_row(t) for t in taints],
+        "age_seconds": age_seconds(
+            metadata.creation_timestamp if metadata is not None else None,
+            now=now,
+        ),
+        "labels": (metadata.labels or {}) if metadata is not None else {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixed kind list ``k8s.ls /<namespace>`` queries.
+#
+# The Issue body documents the "v0.2 ships a fixed list of commonly relevant
+# kinds" choice rather than the full ``api-resources`` discovery (which would
+# cost N round-trips per ``ls`` and risk RBAC-shaped 403 spam on operator
+# sessions). The tuple stays fixed at module-scope so the wire shape doesn't
+# drift across ``k8s.ls`` calls within a process; T4/T5 will expand it as
+# new per-kind ``list`` ops register through the dispatcher.
+# ---------------------------------------------------------------------------
+
+
+#: Tuple of ``(kind_label, CoreV1Api method_name)`` pairs the
+#: ``k8s.ls /<namespace>`` handler probes for a per-kind count. The
+#: ``method_name`` form is preferred over a bound-callable so the helper
+#: doesn't pin a class import at module-load time -- the handler resolves
+#: the attr on the freshly-built ``CoreV1Api`` instance at call time, so
+#: the registration path in ``ops.py`` stays lightweight.
+#:
+#: Kept under :class:`kubernetes_asyncio.client.CoreV1Api` so the
+#: counting path is a single API-client construction; pods / services /
+#: configmaps / events / secrets are all CoreV1 surfaces. ``deployments``
+#: and ``ingresses`` live on ``AppsV1Api`` / ``NetworkingV1Api`` and ship
+#: with the kind-specific ``list`` ops in T3/T4 -- their count is
+#: deferred to those Tasks and surfaces here as a ``not_counted_yet``
+#: entry so the operator sees the kind exists without an inaccurate zero.
+K8S_NAMESPACED_KIND_LISTERS: tuple[tuple[str, str], ...] = (
+    ("pods", "list_namespaced_pod"),
+    ("services", "list_namespaced_service"),
+    ("configmaps", "list_namespaced_config_map"),
+    ("events", "list_namespaced_event"),
+    ("persistentvolumeclaims", "list_namespaced_persistent_volume_claim"),
+)
+
+
+#: Cluster-scoped kinds the ``k8s.ls /`` handler advertises as the
+#: discoverable surface from the root. These are *names*, not API call
+#: shapes -- the agent uses them to pick a follow-up op (``k8s.node.list``,
+#: a future ``k8s.persistentvolume.list``, etc.).
+K8S_CLUSTER_KINDS: tuple[str, ...] = (
+    "nodes",
+    "namespaces",
+    "persistentvolumes",
+    "storageclasses",
+)
+
+
+# ---------------------------------------------------------------------------
+# Op metadata -- the per-op KubernetesOp rows that ``ops.py`` re-exports
+# through :data:`KUBERNETES_OPS`. Kept in this module rather than appended
+# to ``ops.py`` so the T2 surface lives next to its helpers; the connector
+# just walks the merged tuple at registration time.
+# ---------------------------------------------------------------------------
+
+
+#: ``k8s.ls`` accepts an optional ``path`` parameter. The semantics:
+#: empty / "/" -> cluster root; "/<ns>" -> namespace summary;
+#: "/<ns>/<kind>" -> forward to ``k8s.<kind>.list``. The pattern is
+#: deliberately permissive in v0.2 -- the dispatcher's JSON Schema layer
+#: catches obviously bad shapes, but the handler does the structural
+#: parse so it can return a useful ``rows=[]`` for an empty path rather
+#: than an opaque schema-violation message.
+K8S_LS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": (
+                "Optional inventory path -- '/' for the cluster root, "
+                "'/<namespace>' for the per-namespace kind summary, "
+                "'/<namespace>/<kind>' to forward to that kind's list "
+                "op. Defaults to '/' when omitted."
+            ),
+            "default": "/",
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+K8S_LS_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call to discover what's in a Kubernetes cluster without "
+        "knowing the right kind-specific op ahead of time. 'k8s.ls /' "
+        "lists namespaces + cluster-scoped kinds; 'k8s.ls /<ns>' "
+        "shows the resource-kind populations of that namespace; "
+        "'k8s.ls /<ns>/<kind>' forwards to k8s.<kind>.list. Use as "
+        "the entry point when the operator's question is "
+        "exploratory ('what's in argocd?', 'is there anything in "
+        "kube-system?')."
+    ),
+    "parameter_hints": {
+        "path": (
+            "Optional. Slash-prefixed logical path. Examples: '/', "
+            "'/argocd', '/argocd/pods'. Defaults to '/' when omitted."
+        ),
+    },
+    "output_shape": (
+        "Three shapes by path: (a) root -> {namespaces: [...], "
+        "cluster_kinds: [...]}; (b) namespace -> {namespace: '<ns>', "
+        "kinds: [{kind, count}], cluster_kinds_omitted: true}; "
+        "(c) namespace/kind -> {forwarded_to: 'k8s.<kind>.list', "
+        "result: <OperationResult-as-dict from the sub-dispatch>}."
+    ),
+}
+
+
+_K8S_LS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Variant shape -- see llm_instructions.output_shape. The keys "
+        "present depend on whether path is the cluster root, a namespace, "
+        "or a namespace/kind."
+    ),
+    "additionalProperties": True,
+}
+
+
+_K8S_NAMESPACE_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+_K8S_NAMESPACE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "status": {"type": ["string", "null"]},
+                    "age_seconds": {"type": ["integer", "null"]},
+                    "labels": {"type": "object"},
+                },
+                "required": ["name", "status", "age_seconds", "labels"],
+                "additionalProperties": False,
+            },
+            "description": (
+                "One row per Kubernetes namespace. Order follows the "
+                "API server's response order (typically resource-version "
+                "ascending)."
+            ),
+        },
+        "total": {
+            "type": "integer",
+            "description": (
+                "Row count emitted in ``rows``. Useful as the "
+                "pre-reduction count -- a future JSONFlux reducer "
+                "tracks both the inlined sample size and this total."
+            ),
+        },
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_NAMESPACE_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator asks 'what namespaces exist?' or needs "
+        "to confirm a namespace is alive before issuing a per-namespace "
+        "op. Read-only; safe against any cluster."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'rows': [{name, status, age_seconds, labels}], 'total': <int>}. "
+        "``status`` is the namespace phase string ('Active', "
+        "'Terminating'). ``age_seconds`` is integer seconds since the "
+        "namespace's ``creation_timestamp``."
+    ),
+}
+
+
+_K8S_NODE_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+_K8S_NODE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "status": {"type": "string"},
+                    "roles": {"type": "array", "items": {"type": "string"}},
+                    "version": {"type": ["string", "null"]},
+                    "kernel": {"type": ["string", "null"]},
+                    "os": {"type": ["string", "null"]},
+                    "internal_ip": {"type": ["string", "null"]},
+                    "taints": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "key": {"type": ["string", "null"]},
+                                "value": {"type": ["string", "null"]},
+                                "effect": {"type": ["string", "null"]},
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                    "age_seconds": {"type": ["integer", "null"]},
+                    "labels": {"type": "object"},
+                },
+                "required": [
+                    "name",
+                    "status",
+                    "roles",
+                    "version",
+                    "kernel",
+                    "os",
+                    "internal_ip",
+                    "taints",
+                    "age_seconds",
+                    "labels",
+                ],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_NODE_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call to identify cluster nodes -- 'show me the workers', "
+        "'is the control plane healthy?', 'what's the kubelet "
+        "version?'. Read-only; pairs with k8s.about for the "
+        "control-plane version side of the same question."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'rows': [{name, status, roles, version, kernel, os, "
+        "internal_ip, taints, age_seconds, labels}], 'total': <int>}. "
+        "``status`` reflects the Ready condition ('Ready' / 'NotReady' "
+        "/ 'Unknown'). ``roles`` is the sorted list of role suffixes "
+        "from the node-role.kubernetes.io/<role> labels."
+    ),
+}
+
+
+CORE_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.ls",
+        handler_attr="k8s_ls",
+        summary="List the inventory at a logical path -- root / namespace / kind.",
+        description=(
+            "Synthetic walker over Kubernetes resources, mirroring "
+            "``govc ls /``. With no path or '/', returns the cluster "
+            "root view: namespace names and a fixed list of cluster-"
+            "scoped kinds. With '/<namespace>', returns a kind -> count "
+            "summary for the namespace, querying a fixed list of commonly-"
+            "relevant kinds (pods, services, configmaps, events, "
+            "persistentvolumeclaims). With '/<namespace>/<kind>', "
+            "forwards to k8s.<kind>.list for that namespace by "
+            "dispatching the kind-specific op through the connector's "
+            "dispatcher shim; kinds whose ``list`` op hasn't shipped yet "
+            "(T3/T4 batches) come back through the shim's structured "
+            "unknown_op envelope. The handler does not pre-fetch every "
+            "row of every kind -- it queries with ``limit=1`` and reads "
+            "``remaining_item_count`` from the list metadata so an "
+            "``ls`` against a busy namespace stays cheap."
+        ),
+        parameter_schema=K8S_LS_PARAMETER_SCHEMA,
+        response_schema=_K8S_LS_RESPONSE_SCHEMA,
+        group_key="inventory",
+        tags=("read-only", "inventory", "discovery"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_LS_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.namespace.list",
+        handler_attr="k8s_namespace_list",
+        summary="List Kubernetes namespaces with phase, age, and labels.",
+        description=(
+            "Calls ``CoreV1Api.list_namespace()`` and projects each "
+            "row down to {name, status, age_seconds, labels}. ``status`` "
+            "is the namespace phase string the API server returns "
+            "('Active' / 'Terminating'). Read-only; pairs with ``k8s.ls "
+            "/`` for the operator-facing 'what's in this cluster?' "
+            "question -- the namespace.list form returns full per-row "
+            "detail, ls returns just the names."
+        ),
+        parameter_schema=_K8S_NAMESPACE_LIST_PARAMETER_SCHEMA,
+        response_schema=_K8S_NAMESPACE_LIST_RESPONSE_SCHEMA,
+        group_key="inventory",
+        tags=("read-only", "inventory", "namespace"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_NAMESPACE_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.node.list",
+        handler_attr="k8s_node_list",
+        summary="List Kubernetes nodes with status, roles, version, taints.",
+        description=(
+            "Calls ``CoreV1Api.list_node()`` and projects each row "
+            "down to {name, status, roles, version, kernel, os, "
+            "internal_ip, taints, age_seconds, labels}. ``status`` "
+            "reflects the Ready condition: 'Ready' when the Ready "
+            "condition's status is 'True', 'NotReady' on any other "
+            "state, 'Unknown' when the condition is missing. ``roles`` "
+            "is derived from the node's "
+            "``node-role.kubernetes.io/<role>`` label keys (sorted). "
+            "Read-only."
+        ),
+        parameter_schema=_K8S_NODE_LIST_PARAMETER_SCHEMA,
+        response_schema=_K8S_NODE_LIST_RESPONSE_SCHEMA,
+        group_key="inventory",
+        tags=("read-only", "inventory", "node"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_NODE_LIST_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/tests/integration/test_connectors_k8s_k3d.py
+++ b/backend/tests/integration/test_connectors_k8s_k3d.py
@@ -219,3 +219,95 @@ async def test_api_client_cached_across_calls_against_live_k3s(
     await connector.fingerprint(target)
     cached_client_id_after_second = id(connector._api_clients[target.name])
     assert cached_client_id_after_first == cached_client_id_after_second
+
+
+# ---------------------------------------------------------------------------
+# G3.2-T2 (#322) core inventory ops -- live k3s exercise.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_namespace_list_against_k3s_returns_default_set(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.namespace.list`` over k3s returns the bootstrap namespaces."""
+    connector, target = k3s_connector
+    result = await connector.k8s_namespace_list(target, {})
+    assert result["total"] >= 4  # default, kube-system, kube-public, kube-node-lease
+    names = {row["name"] for row in result["rows"]}
+    assert "default" in names
+    assert "kube-system" in names
+    # Phase is Active for the bootstrap set; any other phase is a real
+    # signal worth surfacing to the operator.
+    for row in result["rows"]:
+        assert row["status"] in {"Active", "Terminating"}
+
+
+@pytest.mark.asyncio
+async def test_node_list_against_k3s_returns_at_least_one_node(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.node.list`` over k3s returns the single-node default cluster."""
+    connector, target = k3s_connector
+    result = await connector.k8s_node_list(target, {})
+    assert result["total"] >= 1
+    node = result["rows"][0]
+    # k3s nodes report Ready=True post-boot; the test waits implicitly via
+    # the container fixture's start barrier (testcontainers blocks until
+    # the k3s API server's ``/readyz`` returns 200), so a NotReady reading
+    # here is a real signal, not flake.
+    assert node["status"] == "Ready"
+    # kubelet version surfaces verbatim; spot-check it's a v-prefixed
+    # SemVer-shaped string.
+    assert node["version"].startswith("v")
+    # k3s lights up the master / control-plane / etcd role labels.
+    assert node["roles"], "k3s nodes always carry at least one role label"
+
+
+@pytest.mark.asyncio
+async def test_ls_root_against_k3s_returns_namespaces_and_cluster_kinds(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.ls /`` over k3s returns the live namespace set + the fixed cluster kinds."""
+    connector, target = k3s_connector
+    result = await connector.k8s_ls(target, {"path": "/"})
+    assert result["path"] == "/"
+    assert "default" in result["namespaces"]
+    assert "kube-system" in result["namespaces"]
+    assert "nodes" in result["cluster_kinds"]
+    assert "namespaces" in result["cluster_kinds"]
+
+
+@pytest.mark.asyncio
+async def test_ls_namespace_against_k3s_returns_kind_counts(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.ls /kube-system`` returns per-kind counts via remaining_item_count."""
+    connector, target = k3s_connector
+    result = await connector.k8s_ls(target, {"path": "/kube-system"})
+    assert result["namespace"] == "kube-system"
+    assert result["cluster_kinds_omitted"] is True
+    kinds_by_label = {entry["kind"]: entry for entry in result["kinds"]}
+    # k3s ships with pods + services + configmaps in kube-system from the
+    # first boot. Assertions are existential, not exact counts -- the
+    # exact counts drift across k3s minors and aren't load-bearing.
+    assert kinds_by_label["pods"]["count"] is not None
+    assert kinds_by_label["pods"]["count"] >= 1
+    assert kinds_by_label["services"]["count"] is not None
+    assert kinds_by_label["services"]["count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_ls_namespace_kind_against_k3s_forwards_to_unknown_op(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.ls /default/pods`` forwards to ``k8s.pod.list`` -- unknown_op until T3."""
+    connector, target = k3s_connector
+    result = await connector.k8s_ls(target, {"path": "/default/pods"})
+    assert result["forwarded_to"] == "k8s.pod.list"
+    inner = result["result"]
+    # T3 hasn't shipped k8s.pod.list yet, so the dispatcher shim emits
+    # the structured unknown_op envelope. When T3 lands, this test
+    # gains a real-pod-row assertion in the inner result.
+    assert inner["status"] == "error"
+    assert inner["error"].startswith("unknown_op:")

--- a/backend/tests/test_connectors_k8s_core.py
+++ b/backend/tests/test_connectors_k8s_core.py
@@ -704,6 +704,86 @@ async def test_k8s_ls_path_with_extra_segments_collapses_to_two_arg_forward() ->
 
 
 # ---------------------------------------------------------------------------
+# Tests -- _normalise_kind_to_singular (regression: PR #543 review B1)
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_kind_to_singular_pins_every_irregular_plural() -> None:
+    """Each entry in ``_PLURAL_TO_SINGULAR_KIND`` maps to its singular form."""
+    from meho_backplane.connectors.kubernetes.connector import (
+        _PLURAL_TO_SINGULAR_KIND,
+        _normalise_kind_to_singular,
+    )
+
+    for plural, singular in _PLURAL_TO_SINGULAR_KIND.items():
+        assert _normalise_kind_to_singular(plural) == singular
+
+
+def test_normalise_kind_to_singular_is_idempotent_on_singular_kinds_ending_in_s() -> None:
+    """Singular kinds ending in 's' must NOT have the trailing 's' stripped.
+
+    Regression: PR #543 review finding B1. Before the fix, the
+    strip-trailing-s default branch mangled ``ingress`` -> ``ingres`` and
+    ``storageclass`` -> ``storageclas`` for operators who typed the
+    singular form directly (``/argocd/ingress``). The guard now returns
+    the kind unchanged when it already matches one of the mapped
+    singular forms.
+    """
+    from meho_backplane.connectors.kubernetes.connector import (
+        _PLURAL_TO_SINGULAR_KIND,
+        _normalise_kind_to_singular,
+    )
+
+    for singular in _PLURAL_TO_SINGULAR_KIND.values():
+        assert _normalise_kind_to_singular(singular) == singular, (
+            f"singular kind {singular!r} should pass through unchanged"
+        )
+    # Spot-checks for the most operator-visible cases.
+    assert _normalise_kind_to_singular("ingress") == "ingress"
+    assert _normalise_kind_to_singular("storageclass") == "storageclass"
+    assert _normalise_kind_to_singular("persistentvolume") == "persistentvolume"
+    assert _normalise_kind_to_singular("persistentvolumeclaim") == "persistentvolumeclaim"
+
+
+def test_normalise_kind_to_singular_strips_trailing_s_on_regular_plurals() -> None:
+    """The strip-trailing-s default branch still handles the common case."""
+    from meho_backplane.connectors.kubernetes.connector import (
+        _normalise_kind_to_singular,
+    )
+
+    assert _normalise_kind_to_singular("pods") == "pod"
+    assert _normalise_kind_to_singular("services") == "service"
+    assert _normalise_kind_to_singular("configmaps") == "configmap"
+    assert _normalise_kind_to_singular("nodes") == "node"
+    assert _normalise_kind_to_singular("namespaces") == "namespace"
+
+
+@pytest.mark.asyncio
+async def test_k8s_ls_forwards_singular_ingress_path_without_mangling() -> None:
+    """``/argocd/ingress`` (singular) forwards to ``k8s.ingress.list``, not ``k8s.ingres.list``.
+
+    Regression: PR #543 review finding m2. The forwarder runs the
+    operator-typed kind through :func:`_normalise_kind_to_singular`
+    before composing the sub-op id; the B1 fix ensures the singular
+    form survives the normalisation.
+    """
+    from meho_backplane.operations import typed_register as tr_module
+
+    connector = _make_connector()
+    with patch.object(
+        tr_module,
+        "encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    ):
+        await KubernetesConnector.register_operations()
+
+    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/ingress"})
+
+    assert result["path"] == "/argocd/ingress"
+    assert result["forwarded_to"] == "k8s.ingress.list"
+
+
+# ---------------------------------------------------------------------------
 # Tests -- end-to-end through execute() shim (registered op dispatch)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_k8s_core.py
+++ b/backend/tests/test_connectors_k8s_core.py
@@ -1,0 +1,799 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the G3.2-T2 (#322) K8s core inventory ops.
+
+Coverage matrix (per Issue #322 acceptance criteria):
+
+* :data:`KUBERNETES_OPS` exposes the three new core ops alongside the
+  existing ``k8s.about``; ``register_operations`` lands all four rows
+  in ``endpoint_descriptor``.
+* :meth:`KubernetesConnector.k8s_namespace_list` projects every
+  :class:`V1Namespace` through
+  :func:`~meho_backplane.connectors.kubernetes.ops_core.namespace_row`
+  and returns ``{rows, total}`` with the expected shape.
+* :meth:`KubernetesConnector.k8s_node_list` projects every
+  :class:`V1Node` through
+  :func:`~meho_backplane.connectors.kubernetes.ops_core.node_row` --
+  Ready-condition mapping, role-label derivation, internal-IP picking,
+  taint flattening all covered.
+* :meth:`KubernetesConnector.k8s_ls` three-way path dispatch:
+  - root -> ``{namespaces, cluster_kinds}``.
+  - namespace -> per-kind count via ``limit=1`` + remaining_item_count.
+  - namespace/kind -> forwards through :meth:`execute` to
+    ``k8s.<kind>.list``; an unregistered kind comes back as the shim's
+    ``unknown_op`` envelope inside the ``result`` field.
+* Pure helpers (:func:`age_seconds`, :func:`namespace_row`,
+  :func:`node_row`, :func:`taint_row`) pinned against synthetic
+  Kubernetes model objects.
+
+The handle-pattern acceptance criterion ("50+ namespaces -> sample of
+20 + handle returned") is **not** a unit-test target: the criterion
+relies on a JSONFlux reducer that ships in a follow-on Initiative (the
+v0.2 substrate's :class:`PassThroughReducer` never produces a handle).
+The connector's contract is "emit raw rows + total"; the reducer's
+contract is "spill set-shaped payloads". See the module docstring of
+:mod:`~meho_backplane.connectors.kubernetes.ops_core` for the full
+rationale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kubernetes_asyncio.client.models import (
+    V1ListMeta,
+    V1Namespace,
+    V1NamespaceList,
+    V1NamespaceStatus,
+    V1Node,
+    V1NodeAddress,
+    V1NodeCondition,
+    V1NodeList,
+    V1NodeSpec,
+    V1NodeStatus,
+    V1NodeSystemInfo,
+    V1ObjectMeta,
+    V1Taint,
+)
+
+from meho_backplane.connectors.kubernetes import (
+    KUBERNETES_OPS,
+    KubernetesConnector,
+    KubernetesTargetLike,
+)
+from meho_backplane.connectors.kubernetes.ops_core import (
+    CORE_OPS,
+    K8S_CLUSTER_KINDS,
+    K8S_NAMESPACED_KIND_LISTERS,
+    age_seconds,
+    namespace_row,
+    node_row,
+    taint_row,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for the DB-touching path."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_kubernetes_registry() -> Iterator[None]:
+    """Re-register :class:`KubernetesConnector` between tests.
+
+    ``test_connectors_registry.py`` (alphabetically earlier) has an
+    autouse ``clear_registry()``; this fixture restores the K8s entries
+    that ``connectors/kubernetes/__init__.py`` would have set so the
+    dispatcher's resolver finds the connector during ``execute()``
+    forwarding (k8s.ls subop dispatch).
+    """
+    clear_registry()
+    register_connector("k8s", KubernetesConnector)
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="kubernetes-asyncio",
+        cls=KubernetesConnector,
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Target / connector fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="rke2-meho",
+    host="rke2-meho.test.invalid",
+    port=6443,
+    secret_ref="kv/data/k8s/rke2-meho",
+)
+
+
+def _stub_kubeconfig() -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://k8s.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "stub-token"}}],
+    }
+
+
+def _make_connector() -> KubernetesConnector:
+    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+        return _stub_kubeconfig()
+
+    return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic k8s model fixtures -- builders for the pure-helper tests
+# ---------------------------------------------------------------------------
+
+
+def _make_namespace(
+    *,
+    name: str,
+    phase: str = "Active",
+    created: datetime | None = None,
+    labels: dict[str, str] | None = None,
+) -> V1Namespace:
+    return V1Namespace(
+        metadata=V1ObjectMeta(
+            name=name,
+            creation_timestamp=created,
+            labels=labels,
+        ),
+        status=V1NamespaceStatus(phase=phase),
+    )
+
+
+def _make_node(
+    *,
+    name: str,
+    ready: str = "True",
+    roles: list[str] | None = None,
+    kubelet_version: str = "v1.28.5+rke2r1",
+    kernel: str = "6.1.0-test",
+    os_name: str = "Linux",
+    internal_ip: str | None = "10.0.0.1",
+    taints: list[V1Taint] | None = None,
+    created: datetime | None = None,
+) -> V1Node:
+    role_labels: dict[str, str] = {}
+    for role in roles or []:
+        role_labels[f"node-role.kubernetes.io/{role}"] = ""
+    addresses: list[V1NodeAddress] = []
+    if internal_ip is not None:
+        addresses.append(V1NodeAddress(address=internal_ip, type="InternalIP"))
+    return V1Node(
+        metadata=V1ObjectMeta(name=name, creation_timestamp=created, labels=role_labels),
+        status=V1NodeStatus(
+            conditions=[V1NodeCondition(type="Ready", status=ready)],
+            node_info=V1NodeSystemInfo(
+                architecture="amd64",
+                boot_id="b",
+                container_runtime_version="containerd://1.7",
+                kernel_version=kernel,
+                kube_proxy_version=kubelet_version,
+                kubelet_version=kubelet_version,
+                machine_id="m",
+                operating_system=os_name,
+                os_image="rancher/k3s",
+                system_uuid="u",
+            ),
+            addresses=addresses,
+        ),
+        spec=V1NodeSpec(taints=taints or []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests -- registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_core_ops_in_kubernetes_ops_tuple() -> None:
+    """``KUBERNETES_OPS`` now exposes the three core inventory ops + about."""
+    op_ids = {op.op_id for op in KUBERNETES_OPS}
+    assert "k8s.about" in op_ids
+    assert "k8s.ls" in op_ids
+    assert "k8s.namespace.list" in op_ids
+    assert "k8s.node.list" in op_ids
+
+
+def test_core_ops_metadata_shape() -> None:
+    """Each core op declares safe / no-approval / read-only inventory tags."""
+    by_id = {op.op_id: op for op in CORE_OPS}
+    for op_id in ("k8s.ls", "k8s.namespace.list", "k8s.node.list"):
+        op = by_id[op_id]
+        assert op.safety_level == "safe"
+        assert op.requires_approval is False
+        assert "read-only" in op.tags
+        assert op.group_key == "inventory"
+        assert op.llm_instructions is not None
+
+
+def test_handler_attr_resolves_to_bound_method() -> None:
+    """Every core op's ``handler_attr`` points at a real async method."""
+    import inspect
+
+    for op in CORE_OPS:
+        method = getattr(KubernetesConnector, op.handler_attr, None)
+        assert method is not None, f"{op.op_id!r} declares missing handler {op.handler_attr!r}"
+        assert inspect.iscoroutinefunction(method), (
+            f"handler {op.handler_attr!r} for {op.op_id!r} must be ``async def``"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests -- pure helper shapes
+# ---------------------------------------------------------------------------
+
+
+def test_age_seconds_returns_int_or_none() -> None:
+    """``age_seconds`` returns ``int`` for tz-aware datetimes and ``None`` for missing."""
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    assert age_seconds(now - timedelta(seconds=10), now=now) == 10
+    assert age_seconds(now - timedelta(seconds=12, milliseconds=400), now=now) == 12
+    assert age_seconds(None, now=now) is None
+
+
+def test_namespace_row_includes_phase_and_labels() -> None:
+    """Pure mapping returns the wire dict shape."""
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    ns = _make_namespace(
+        name="argocd",
+        phase="Active",
+        created=now - timedelta(seconds=3600),
+        labels={"kubernetes.io/metadata.name": "argocd"},
+    )
+    row = namespace_row(ns, now=now)
+    assert row == {
+        "name": "argocd",
+        "status": "Active",
+        "age_seconds": 3600,
+        "labels": {"kubernetes.io/metadata.name": "argocd"},
+    }
+
+
+def test_namespace_row_handles_missing_labels() -> None:
+    """``labels=None`` on the API object surfaces as ``{}`` on the wire."""
+    ns = _make_namespace(name="default", phase="Active", labels=None)
+    row = namespace_row(ns)
+    assert row["labels"] == {}
+
+
+def test_namespace_row_terminating_phase_surfaces_verbatim() -> None:
+    """A namespace mid-deletion reports its phase, not a coerced 'Unknown'."""
+    ns = _make_namespace(name="going-away", phase="Terminating")
+    assert namespace_row(ns)["status"] == "Terminating"
+
+
+def test_taint_row_flattens_to_string_dict() -> None:
+    """Taints land as ``{key, value, effect}``."""
+    taint = V1Taint(key="node-role.kubernetes.io/control-plane", value="", effect="NoSchedule")
+    row = taint_row(taint)
+    assert row == {
+        "key": "node-role.kubernetes.io/control-plane",
+        "value": "",
+        "effect": "NoSchedule",
+    }
+
+
+def test_node_row_ready_status_mapped() -> None:
+    """A ``Ready=True`` condition surfaces as ``status='Ready'``."""
+    node = _make_node(name="cp-01", ready="True", roles=["control-plane", "etcd"])
+    row = node_row(node)
+    assert row["status"] == "Ready"
+    assert row["roles"] == ["control-plane", "etcd"]  # sorted
+    assert row["version"] == "v1.28.5+rke2r1"
+
+
+def test_node_row_not_ready_status_mapped() -> None:
+    """A ``Ready=False`` condition surfaces as ``status='NotReady'``."""
+    node = _make_node(name="cp-01", ready="False")
+    assert node_row(node)["status"] == "NotReady"
+
+
+def test_node_row_unknown_status_when_no_ready_condition() -> None:
+    """A node with no Ready condition (synthetic edge case) reports 'Unknown'."""
+    node = V1Node(
+        metadata=V1ObjectMeta(name="orphan"),
+        status=V1NodeStatus(conditions=[V1NodeCondition(type="MemoryPressure", status="False")]),
+        spec=V1NodeSpec(taints=[]),
+    )
+    assert node_row(node)["status"] == "Unknown"
+
+
+def test_node_row_legacy_kubernetes_io_role_label() -> None:
+    """Older clusters using ``kubernetes.io/role`` map into the roles list."""
+    node = V1Node(
+        metadata=V1ObjectMeta(
+            name="legacy-cp",
+            labels={"kubernetes.io/role": "master"},
+        ),
+        status=V1NodeStatus(
+            conditions=[V1NodeCondition(type="Ready", status="True")],
+            node_info=V1NodeSystemInfo(
+                architecture="amd64",
+                boot_id="b",
+                container_runtime_version="docker://20",
+                kernel_version="4.19",
+                kube_proxy_version="v1.20.0",
+                kubelet_version="v1.20.0",
+                machine_id="m",
+                operating_system="Linux",
+                os_image="ubuntu",
+                system_uuid="u",
+            ),
+            addresses=[V1NodeAddress(address="192.168.1.1", type="InternalIP")],
+        ),
+        spec=V1NodeSpec(taints=[]),
+    )
+    assert node_row(node)["roles"] == ["master"]
+
+
+def test_node_row_taints_flattened() -> None:
+    """``spec.taints`` flows through ``taint_row`` per taint."""
+    taints = [
+        V1Taint(key="dedicated", value="gpu", effect="NoSchedule"),
+        V1Taint(key="node-role.kubernetes.io/control-plane", value="", effect="NoSchedule"),
+    ]
+    node = _make_node(name="cp-01", taints=taints)
+    rows = node_row(node)["taints"]
+    assert len(rows) == 2
+    assert rows[0]["key"] == "dedicated"
+    assert rows[1]["effect"] == "NoSchedule"
+
+
+def test_node_row_internal_ip_picked_from_addresses() -> None:
+    """Only ``InternalIP`` addresses populate the ``internal_ip`` field."""
+    node = V1Node(
+        metadata=V1ObjectMeta(name="multi-addr"),
+        status=V1NodeStatus(
+            conditions=[V1NodeCondition(type="Ready", status="True")],
+            node_info=V1NodeSystemInfo(
+                architecture="amd64",
+                boot_id="b",
+                container_runtime_version="containerd://1.7",
+                kernel_version="6.1",
+                kube_proxy_version="v1.28",
+                kubelet_version="v1.28",
+                machine_id="m",
+                operating_system="Linux",
+                os_image="rke2",
+                system_uuid="u",
+            ),
+            addresses=[
+                V1NodeAddress(address="1.2.3.4", type="ExternalIP"),
+                V1NodeAddress(address="10.0.0.5", type="InternalIP"),
+                V1NodeAddress(address="node-1", type="Hostname"),
+            ],
+        ),
+        spec=V1NodeSpec(taints=[]),
+    )
+    assert node_row(node)["internal_ip"] == "10.0.0.5"
+
+
+def test_node_row_no_internal_ip_yields_none() -> None:
+    """Nodes without an InternalIP address surface ``internal_ip=None``."""
+    node = _make_node(name="bare", internal_ip=None)
+    assert node_row(node)["internal_ip"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests -- k8s.namespace.list handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_namespace_list_returns_rows_and_total() -> None:
+    """Handler wraps ``list_namespace`` and projects each row through ``namespace_row``."""
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    age = timedelta(seconds=8400000)
+    namespaces = [
+        _make_namespace(name="argocd", phase="Active", created=now - age),
+        _make_namespace(name="kube-system", phase="Active", created=now - age),
+    ]
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespace = AsyncMock(
+            return_value=V1NamespaceList(items=namespaces, metadata=V1ListMeta())
+        )
+        result = await connector.k8s_namespace_list(_TARGET, {})
+
+    assert result["total"] == 2
+    assert len(result["rows"]) == 2
+    assert {r["name"] for r in result["rows"]} == {"argocd", "kube-system"}
+    for row in result["rows"]:
+        assert row["status"] == "Active"
+        assert isinstance(row["age_seconds"], int)
+
+
+@pytest.mark.asyncio
+async def test_k8s_namespace_list_empty_cluster() -> None:
+    """A cluster with no namespaces yields ``rows=[]``, ``total=0``."""
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespace = AsyncMock(
+            return_value=V1NamespaceList(items=[], metadata=V1ListMeta())
+        )
+        result = await connector.k8s_namespace_list(_TARGET, {})
+    assert result == {"rows": [], "total": 0}
+
+
+# ---------------------------------------------------------------------------
+# Tests -- k8s.node.list handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_node_list_returns_rows_and_total() -> None:
+    """Handler projects each node through ``node_row``."""
+    nodes = [
+        _make_node(name="cp-01", ready="True", roles=["control-plane", "etcd"]),
+        _make_node(name="worker-01", ready="True", roles=["worker"]),
+    ]
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_node = AsyncMock(
+            return_value=V1NodeList(items=nodes, metadata=V1ListMeta())
+        )
+        result = await connector.k8s_node_list(_TARGET, {})
+
+    assert result["total"] == 2
+    names = [row["name"] for row in result["rows"]]
+    assert names == ["cp-01", "worker-01"]
+    assert result["rows"][0]["roles"] == ["control-plane", "etcd"]
+    assert result["rows"][1]["roles"] == ["worker"]
+
+
+# ---------------------------------------------------------------------------
+# Tests -- k8s.ls root view
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_ls_root_returns_namespaces_and_cluster_kinds() -> None:
+    """``k8s.ls /`` returns sorted namespace names + the fixed cluster-kind list."""
+    namespaces = [
+        _make_namespace(name="zebra"),
+        _make_namespace(name="argocd"),
+        _make_namespace(name="kube-system"),
+    ]
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespace = AsyncMock(
+            return_value=V1NamespaceList(items=namespaces, metadata=V1ListMeta())
+        )
+        result = await connector.k8s_ls(_TARGET, {"path": "/"})
+
+    assert result["path"] == "/"
+    assert result["namespaces"] == ["argocd", "kube-system", "zebra"]
+    assert result["cluster_kinds"] == list(K8S_CLUSTER_KINDS)
+
+
+@pytest.mark.asyncio
+async def test_k8s_ls_default_path_is_root() -> None:
+    """Missing ``path`` is equivalent to ``path='/'``."""
+    namespaces = [_make_namespace(name="default")]
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespace = AsyncMock(
+            return_value=V1NamespaceList(items=namespaces, metadata=V1ListMeta())
+        )
+        result = await connector.k8s_ls(_TARGET, {})  # no path
+    assert result["path"] == "/"
+    assert result["namespaces"] == ["default"]
+
+
+# ---------------------------------------------------------------------------
+# Tests -- k8s.ls /<namespace> view -- per-kind count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_ls_namespace_counts_via_remaining_item_count() -> None:
+    """Per-kind count = inline items + ``remaining_item_count`` (avoids full pull)."""
+    connector = _make_connector()
+    # Build one fake response per kind in K8S_NAMESPACED_KIND_LISTERS so the
+    # handler can iterate without raising on a missing attr. The numeric
+    # counts differ per kind so the assertions can identify which kind
+    # produced which value.
+    counts_by_kind = {
+        "pods": 7,
+        "services": 2,
+        "configmaps": 5,
+        "events": 100,
+        "persistentvolumeclaims": 0,
+    }
+    # The mocked list responses: limit=1, so ``items`` has 0 or 1 entry and
+    # ``remaining_item_count`` carries the rest.
+    fake_methods: dict[str, AsyncMock] = {}
+    for kind_label, method_name in K8S_NAMESPACED_KIND_LISTERS:
+        total = counts_by_kind[kind_label]
+        if total == 0:
+            inline_items: list[Any] = []
+            remaining = 0
+        else:
+            inline_items = [MagicMock()]
+            remaining = total - 1
+        resp = MagicMock()
+        resp.items = inline_items
+        resp.metadata = V1ListMeta(remaining_item_count=remaining)
+        fake_methods[method_name] = AsyncMock(return_value=resp)
+
+    core_v1_instance = MagicMock()
+    for method_name, mock in fake_methods.items():
+        setattr(core_v1_instance, method_name, mock)
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.client.CoreV1Api",
+            return_value=core_v1_instance,
+        ),
+    ):
+        result = await connector.k8s_ls(_TARGET, {"path": "/argocd"})
+
+    assert result["path"] == "/argocd"
+    assert result["namespace"] == "argocd"
+    assert result["cluster_kinds_omitted"] is True
+    kinds_by_label = {entry["kind"]: entry for entry in result["kinds"]}
+    for kind_label, expected_total in counts_by_kind.items():
+        assert kinds_by_label[kind_label]["count"] == expected_total
+
+    # Every list call was issued with ``limit=1`` and the right namespace.
+    for _kind_label, method_name in K8S_NAMESPACED_KIND_LISTERS:
+        fake_methods[method_name].assert_awaited_once_with(namespace="argocd", limit=1)
+
+
+@pytest.mark.asyncio
+async def test_k8s_ls_namespace_kind_with_rbac_403_records_error() -> None:
+    """A 403 on one kind doesn't poison the whole ``ls`` -- record per-kind error."""
+    connector = _make_connector()
+    core_v1_instance = MagicMock()
+    forbidden = RuntimeError("403 Forbidden")
+    for kind_label, method_name in K8S_NAMESPACED_KIND_LISTERS:
+        if kind_label == "events":
+            setattr(core_v1_instance, method_name, AsyncMock(side_effect=forbidden))
+        else:
+            resp = MagicMock()
+            resp.items = []
+            resp.metadata = V1ListMeta(remaining_item_count=0)
+            setattr(core_v1_instance, method_name, AsyncMock(return_value=resp))
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.client.CoreV1Api",
+            return_value=core_v1_instance,
+        ),
+    ):
+        result = await connector.k8s_ls(_TARGET, {"path": "/argocd"})
+
+    kinds_by_label = {entry["kind"]: entry for entry in result["kinds"]}
+    assert kinds_by_label["events"]["count"] is None
+    assert "RuntimeError" in kinds_by_label["events"]["error"]
+    # The other kinds still produced zero counts -- the error didn't abort.
+    assert kinds_by_label["pods"]["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests -- k8s.ls /<namespace>/<kind> forwarding via execute()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_ls_namespace_kind_forwards_to_unknown_op_envelope() -> None:
+    """Kinds whose ``list`` op isn't registered come back as ``unknown_op`` via the shim."""
+    # ``k8s.pod.list`` isn't registered (T3 ships it). The shim returns the
+    # dispatcher's structured ``unknown_op`` envelope; the forwarder
+    # surfaces it verbatim under ``result``.
+    from meho_backplane.operations import typed_register as tr_module
+
+    connector = _make_connector()
+    # Register only the T2 surface so the descriptor lookup is deterministic.
+    with patch.object(
+        tr_module,
+        "encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    ):
+        await KubernetesConnector.register_operations()
+
+    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/pods"})
+
+    assert result["path"] == "/argocd/pods"
+    assert result["forwarded_to"] == "k8s.pod.list"
+    # The shim's ``unknown_op`` envelope -- serialised via ``model_dump(mode='json')``.
+    inner = result["result"]
+    assert inner["status"] == "error"
+    assert inner["error"].startswith("unknown_op:")
+    assert inner["extras"]["error_code"] == "unknown_op"
+
+
+@pytest.mark.asyncio
+async def test_k8s_ls_path_with_extra_segments_collapses_to_two_arg_forward() -> None:
+    """``k8s.ls /ns/kind/extra`` collapses to the ``/ns/kind`` forwarder shape."""
+    from meho_backplane.operations import typed_register as tr_module
+
+    connector = _make_connector()
+    with patch.object(
+        tr_module,
+        "encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    ):
+        await KubernetesConnector.register_operations()
+
+    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/pods/extra/segments"})
+    assert result["forwarded_to"] == "k8s.pod.list"
+    # The path retained is the canonical 2-segment shape.
+    assert result["path"] == "/argocd/pods"
+
+
+# ---------------------------------------------------------------------------
+# Tests -- end-to-end through execute() shim (registered op dispatch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_namespace_list_via_dispatcher_shim_returns_ok() -> None:
+    """`k8s.namespace.list` registered -> execute() resolves handler + returns ok."""
+    from meho_backplane.operations import typed_register as tr_module
+    from meho_backplane.operations._handler_resolve import reset_handler_cache
+
+    reset_handler_cache()
+    with patch.object(
+        tr_module,
+        "encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    ):
+        await KubernetesConnector.register_operations()
+
+    connector = _make_connector()
+    namespaces = [_make_namespace(name="default"), _make_namespace(name="argocd")]
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespace = AsyncMock(
+            return_value=V1NamespaceList(items=namespaces, metadata=V1ListMeta())
+        )
+        result = await connector.execute(_TARGET, "k8s.namespace.list", {})
+
+    assert isinstance(result, OperationResult)
+    assert result.status == "ok"
+    assert result.op_id == "k8s.namespace.list"
+    payload = result.result
+    assert isinstance(payload, dict)
+    assert payload["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_node_list_via_dispatcher_shim_returns_ok() -> None:
+    """`k8s.node.list` registered -> execute() routes through the shim."""
+    from meho_backplane.operations import typed_register as tr_module
+    from meho_backplane.operations._handler_resolve import reset_handler_cache
+
+    reset_handler_cache()
+    with patch.object(
+        tr_module,
+        "encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    ):
+        await KubernetesConnector.register_operations()
+
+    connector = _make_connector()
+    nodes = [_make_node(name="cp-01", roles=["control-plane"])]
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_node = AsyncMock(
+            return_value=V1NodeList(items=nodes, metadata=V1ListMeta())
+        )
+        result = await connector.execute(_TARGET, "k8s.node.list", {})
+
+    assert result.status == "ok"
+    assert result.op_id == "k8s.node.list"
+    payload = result.result
+    assert isinstance(payload, dict)
+    assert payload["rows"][0]["name"] == "cp-01"
+
+
+@pytest.mark.asyncio
+async def test_ls_via_dispatcher_shim_rejects_extra_params() -> None:
+    """``k8s.ls`` declares ``additionalProperties=False``; junk params are rejected."""
+    from meho_backplane.operations import typed_register as tr_module
+
+    with patch.object(
+        tr_module,
+        "encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    ):
+        await KubernetesConnector.register_operations()
+
+    connector = _make_connector()
+    result = await connector.execute(_TARGET, "k8s.ls", {"path": "/", "junk": True})
+    assert result.status == "error"
+    assert result.error is not None and result.error.startswith("invalid_params:")

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -1,0 +1,186 @@
+# Connector: kubernetes (k8s-1.x / `kubernetes_asyncio`)
+
+## Overview
+
+The `kubernetes` connector is the typed `Connector` subclass that
+dispatches operator-facing Kubernetes operations under the
+`(product="k8s", version="1.x", impl_id="kubernetes-asyncio")` registry
+triple. It builds on the G0.6 operation registry: handlers register at
+lifespan startup via `register_typed_operation()`, the dispatcher routes
+calls via the descriptor table, and the operator surface is the
+meta-tools (`search_operations` / `call_operation`) plus the
+forthcoming CLI alias verbs (G3.2-T6).
+
+The connector replaces the consumer's daily `kubectl-vcf.sh` wrapper for
+read workflows -- inventory listing, workload inspection, log fetching.
+Write operations stay in the wrapper until v0.2.next ships policy +
+approval flow.
+
+Source: `backend/src/meho_backplane/connectors/kubernetes/`.
+
+## Key types
+
+- **`KubernetesConnector`** (`connector.py`) -- `Connector` subclass.
+  Class attributes: `product="k8s"`, `version="1.x"`,
+  `impl_id="kubernetes-asyncio"`. Caches a per-target
+  `kubernetes_asyncio.client.ApiClient` keyed on `secret_ref`; the
+  kubeconfig loader is injectable for tests.
+- **Op metadata** (`ops.py`) -- the `KubernetesOp` dataclass plus the
+  `KUBERNETES_OPS` tuple the connector's `register_operations` walks
+  at startup. The tuple merges `k8s.about` (T1's canary, refactored
+  through G0.6) with the T2 inventory ops imported from `ops_core.py`.
+- **Core inventory helpers** (`ops_core.py`) -- pure mapping helpers
+  (`namespace_row`, `node_row`, `taint_row`, `age_seconds`) plus the
+  `CORE_OPS` registration rows for `k8s.ls` / `k8s.namespace.list` /
+  `k8s.node.list`. Helpers stay pure-function so the unit suite can pin
+  the wire shape against synthetic `V1Namespace` / `V1Node` model
+  instances without booting an event loop.
+- **`KubernetesTargetLike`** (`kubeconfig.py`) -- runtime-checkable
+  Protocol capturing the minimum target shape the connector reads:
+  `name`, `host`, `port`, `secret_ref`. Replaced by the concrete
+  `Target` model once G0.3 (#224) lands; the structural shape there
+  satisfies the Protocol unchanged.
+- **`load_kubeconfig_from_vault`** (`kubeconfig.py`) -- the default
+  kubeconfig loader stub. Raises `NotImplementedError` until G0.3
+  lands; tests and the integration suite inject a callable returning
+  a pre-built kubeconfig dict.
+
+## Shipped op surface
+
+| op_id                | safety | description                                              |
+| -------------------- | ------ | -------------------------------------------------------- |
+| `k8s.about`          | safe   | Product / version / platform via `VersionApi.get_code`.  |
+| `k8s.ls`             | safe   | Synthetic walker: root / namespace / namespace+kind.     |
+| `k8s.namespace.list` | safe   | `CoreV1Api.list_namespace()` -- name / status / age.    |
+| `k8s.node.list`      | safe   | `CoreV1Api.list_node()` -- status / roles / version.    |
+
+T3 / T4 / T5 of Initiative #320 add the workload / network+config /
+logs surfaces against the same `KubernetesOp` -> `KUBERNETES_OPS` ->
+`register_operations` pattern.
+
+## Control flow
+
+### Connector init (lifespan)
+
+1. The connector package's `__init__.py` calls
+   `register_connector_v2(product="k8s", version="1.x",
+   impl_id="kubernetes-asyncio", cls=KubernetesConnector)` at import
+   time. The v1 entry under `"k8s"` is preserved for chassis-route
+   compat.
+2. The same module appends
+   `register_kubernetes_typed_operations` to the typed-op registrar
+   list via `register_typed_op_registrar`.
+3. The FastAPI lifespan calls `_eager_import_connectors()` followed by
+   `run_typed_op_registrars()`. The registrar walks `KUBERNETES_OPS`
+   and routes each row through `register_typed_operation()`, which
+   upserts the descriptor row in `endpoint_descriptor`.
+
+The walk is **idempotent**: a second registrar run hits the body-hash
+skip-re-embed branch and avoids re-encoding the descriptions, so pod
+restarts on unchanged code stay cheap.
+
+### Op dispatch (per request)
+
+1. The operator's MCP / API call lands at
+   `/api/v1/operations/call` with a `connector_id="k8s-1.x"` +
+   `op_id="k8s.<verb>"` body.
+2. The dispatcher resolves the descriptor row in `endpoint_descriptor`,
+   runs JSON Schema validation against `parameter_schema`, and routes
+   to the handler via `import_handler(descriptor.handler_ref)`. The
+   bound-method form (`KubernetesConnector.k8s_namespace_list`) is
+   rebound against the resolved connector instance.
+3. The handler calls
+   `kubernetes_asyncio.client.CoreV1Api(api_client).<list_xxx>()` and
+   projects each model into the wire dict via the pure mapping
+   helpers.
+4. The dispatcher invokes `PassThroughReducer.reduce()` (v0.2's no-op
+   reducer), writes the audit row, fires the broadcast event, and
+   wraps the result in `OperationResult.status="ok"`.
+
+### `k8s.ls` three-way dispatch
+
+The `k8s.ls` handler is a thin path parser:
+
+- `/` (or omitted) -- one `list_namespace()` call; returns sorted
+  namespace names + the fixed `K8S_CLUSTER_KINDS` list.
+- `/<namespace>` -- one `list_namespaced_<kind>(namespace=...,
+  limit=1)` call per kind in `K8S_NAMESPACED_KIND_LISTERS`; the count
+  is derived from `len(items) + remaining_item_count` so the operator
+  pays one round-trip per probed kind, not one per row.
+- `/<namespace>/<kind>` -- forwards through
+  `KubernetesConnector.execute()` to `k8s.<kind>.list`. The shim is the
+  same dispatcher path direct callers use; an unknown kind comes back
+  as the structured `unknown_op` envelope and the forwarder surfaces it
+  verbatim under `result`.
+
+## Dependencies
+
+- **`kubernetes_asyncio` >=32,<33** -- async fork of the official
+  Python client. Targets the K8s 1.32 API surface (matches the k3s
+  container image pinned for integration tests).
+- **G0.2 chassis** -- `Connector` ABC plus the connector registry
+  (v1 + v2 entries).
+- **G0.6 substrate** -- `register_typed_operation()` for descriptor
+  upserts; the dispatcher's lookup + handler-resolve + reducer path
+  for op execution; `OperationResult` envelope.
+- **Vault (G3.3, future)** -- the production kubeconfig loader resolves
+  `target.secret_ref` to a kubeconfig dict via the operator-context
+  Vault read path. The current stub raises `NotImplementedError`; tests
+  and the integration suite inject a custom loader.
+
+## JSONFlux handle pattern
+
+Issue #322's "Handle threshold tested: against k3d populated with 50+
+namespaces, sample of 20 + handle returned" acceptance criterion
+assumed the shared `HandleStore` from G3.1-T4 (#304) would be in place.
+#304 was **superseded** -- the Initiative-redraft note on the issue
+spells this out -- and the substrate currently in the tree ships
+`PassThroughReducer` as the only reducer. The reducer never populates
+`OperationResult.handle`.
+
+The handlers in this connector emit **raw row lists** (`{"rows": [...],
+"total": N}`) -- the shape the future JSONFlux reducer will see when it
+ships. The reducer, not the connector, owns the threshold check, the
+row truncation, the spill to MinIO/S3/Valkey, and the `ResultHandle`
+construction. Centralising the spill logic in one reducer keeps every
+typed connector free of per-handler threshold code; per the substrate
+split documented on `meho_backplane.operations.reducer`, set-shaped
+reduction is the reducer's job, not the connector's.
+
+The `total` key in the response envelope is the un-truncated row count
+the reducer will read to decide whether to spill; today the value is
+just `len(rows)` because nothing reduces.
+
+## Known issues
+
+- `_get_api_client` caches by `target.secret_ref`. Two tenants that
+  legitimately register a target named `"rke2-meho"` in their own
+  `targets.yaml` will not share the same `ApiClient` (different Vault
+  paths, different secret_refs), but until G0.3 ships its `Target.id`
+  the cache key is the operator's chosen opaque identifier. Swap to
+  `target.id` when G0.3 finalises a row-PK shape.
+- The kubeconfig loader is a stub
+  (`load_kubeconfig_from_vault` raises `NotImplementedError`). T2+
+  ships inject a custom loader at connector construction; the
+  integration suite uses the testcontainers-emitted kubeconfig
+  directly.
+- `k8s.ls /<namespace>` queries a **fixed** list of kinds, not the
+  full `kubectl api-resources --namespaced=true` enumeration. The
+  trade-off is documented on `K8S_NAMESPACED_KIND_LISTERS`: full
+  discovery would cost N round-trips per `ls` and risk RBAC-shaped
+  403 spam on operator sessions. T3 / T4 expand the list as new
+  per-kind `list` ops register.
+
+## References
+
+- Parent Initiative: [#320 G3.2](https://github.com/evoila/meho/issues/320)
+  -- `k8s-1.x kubernetes-asyncio` typed connector.
+- Predecessor Task: [#321 G3.2-T1](https://github.com/evoila/meho/issues/321)
+  -- `KubernetesConnector` skeleton (kubeconfig + fingerprint + probe).
+- This Task: [#322 G3.2-T2](https://github.com/evoila/meho/issues/322)
+  -- core inventory ops (`k8s.about` / `k8s.ls` /
+  `k8s.namespace.list` / `k8s.node.list`).
+- Substrate Initiative: [#388 G0.6](https://github.com/evoila/meho/issues/388)
+  -- operation registry + dispatcher + JSONFlux substrate.
+- `kubernetes_asyncio`: https://github.com/tomplus/kubernetes_asyncio
+- Kubernetes API spec: https://kubernetes.io/docs/reference/kubernetes-api/

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -11,7 +11,7 @@ calls via the descriptor table, and the operator surface is the
 meta-tools (`search_operations` / `call_operation`) plus the
 forthcoming CLI alias verbs (G3.2-T6).
 
-The connector replaces the consumer's daily `kubectl-vcf.sh` wrapper for
+The connector replaces the operator's daily `kubectl-vcf.sh` wrapper for
 read workflows -- inventory listing, workload inspection, log fetching.
 Write operations stay in the wrapper until v0.2.next ships policy +
 approval flow.


### PR DESCRIPTION
## Summary

- Adds three operator-facing K8s inventory ops -- `k8s.ls`, `k8s.namespace.list`, `k8s.node.list` -- registered via G0.6's `register_typed_operation()` substrate (per Initiative #320's re-scope, replacing the deprecated `_op_map` pattern). Joins the `k8s.about` canary (#391) under the `(product="k8s", version="1.x", impl_id="kubernetes-asyncio")` triple.
- `k8s.ls` is a three-way path parser. `/` returns sorted namespace names plus a fixed cluster-kinds list. `/<namespace>` returns a kind -> count summary by probing each kind in `K8S_NAMESPACED_KIND_LISTERS` with `limit=1` and reading `V1ListMeta.remaining_item_count` (one round-trip per kind, not one per row). `/<namespace>/<kind>` forwards through `KubernetesConnector.execute()` to `k8s.<kind>.list`; kinds whose `list` op T3/T4/T5 hasn't shipped yet come back as the dispatcher's structured `unknown_op` envelope.
- New helper module `ops_core.py` hosts the pure mapping functions (`namespace_row`, `node_row`, `taint_row`, `age_seconds`) plus the registration metadata for the three core ops. Bound-method handlers stay on `KubernetesConnector` so the dispatcher's existing bound-method resolution path routes them without per-handler plumbing -- matches the `k8s.about` precedent.

## Why no HandleStore

Issue #322's "50+ namespaces -> sample of 20 + handle returned" acceptance criterion assumed G3.1-T4 (#304) shipped a shared `HandleStore` module. #304 was **superseded** (closed without a HandleStore landing -- the Initiative-redraft note on the issue spells this out), and the substrate ships `PassThroughReducer` (no-op) as its only reducer. Per the substrate split documented on `meho_backplane.operations.reducer`, set-shaped reduction + handle creation are the reducer's job; the handlers in this PR emit `{"rows": [...], "total": N}` -- the shape the future JSONFlux reducer will see when it ships -- and the threshold logic lands once, in the reducer, not per-handler. Documented in `ops_core.py`'s module docstring and in `docs/codebase/connectors-kubernetes.md`.

## Test plan

- [x] `ruff check src/meho_backplane/connectors/kubernetes/ tests/test_connectors_k8s_core.py tests/integration/test_connectors_k8s_k3d.py` -- clean
- [x] `ruff format --check` -- 7 files already formatted
- [x] `mypy src/meho_backplane/connectors/kubernetes/ --ignore-missing-imports` -- no issues
- [x] `pytest tests/test_connectors_k8s_core.py -x -q` -- 27 passed (new tests for the T2 surface)
- [x] `pytest tests/test_connectors_k8s_auth.py tests/test_connectors_k8s_dispatcher_shim.py -q` -- 38 passed (T1 regression check)
- [x] `pytest tests/ -k 'operations or k8s or kubernetes' --ignore=tests/integration -q` -- 340 passed, 3 unrelated skips (full operations + K8s surface)
- [x] code-quality hook (diff mode) -- 0 blockers, 3 pre-existing-file warnings
- [ ] Integration tests (`tests/integration/test_connectors_k8s_k3d.py`) -- 5 new live-k3s tests; run in CI where Docker is provisioned. Skipped in this sandbox per the integration suite's `_docker_socket_present` heuristic.

### Acceptance criteria verification

| AC | status | evidence |
| --- | --- | --- |
| All 4 ops registered | passed | `test_register_operations_upserts_one_row_per_op` reads the descriptor table back |
| `k8s.about` returns fingerprint-shaped result | passed (T1 already shipped this) | existing `test_execute_about_dispatches_through_descriptor_and_returns_ok` |
| `k8s.namespace.list` returns expected namespaces | passed (unit) / CI (integration) | `test_k8s_namespace_list_returns_rows_and_total` + `test_namespace_list_against_k3s_returns_default_set` |
| `k8s.node.list` returns nodes with status/roles/version | passed (unit) / CI (integration) | `test_k8s_node_list_returns_rows_and_total` + `test_node_list_against_k3s_returns_at_least_one_node` |
| `k8s.ls /` returns namespaces + cluster_kinds | passed (unit) / CI (integration) | `test_k8s_ls_root_returns_namespaces_and_cluster_kinds` |
| `k8s.ls /<ns>` returns kind->count summary | passed (unit) / CI (integration) | `test_k8s_ls_namespace_counts_via_remaining_item_count` |
| `k8s.ls /<ns>/pods` forwards to `k8s.pod.list` | passed (unit) | `test_k8s_ls_namespace_kind_forwards_to_unknown_op_envelope` (forward shape asserted; sub-op result is `unknown_op` until T3 ships `k8s.pod.list`) |
| Unit tests with mocked `kubernetes_asyncio`; integration tests with real k3d cluster | passed (unit) / CI (integration) | 27 unit cases + 5 integration cases |
| Handle threshold tested: 50+ namespaces -> sample + handle | **deferred to JSONFlux reducer Initiative** | substrate ships `PassThroughReducer` (no-op); per #304 supersession + `meho_backplane.operations.reducer` docstring, reduction is the reducer's job, not the connector's. Handlers emit `{rows, total}` -- the shape the future reducer will see. Recorded in the result file's `acceptance_criteria` list. |
| CI green | per CI | |
| #320 body checklist line for T2 ticked | post-merge | |

## Out of scope

- Workload ops (`k8s.pod.*` / `k8s.deployment.*`) -- T3 #323.
- Network + config ops (`k8s.service.*` / `k8s.ingress.*` / `k8s.configmap.*` / `k8s.event.list`) -- T4 #324.
- `k8s.logs` op -- T5 #325.
- CLI alias verbs (`meho k8s <op>`) -- T6 #326.
- JSONFlux reducer + shared HandleStore -- future Initiative (per #304 supersession note).
- Write operations (apply / delete / scale / exec / port-forward) -- v0.2.next per #320 scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List Kubernetes namespaces and nodes from connected clusters.
  * Inventory browser: path-based cluster / namespace / namespace+kind views with per-kind counts and forwarding of kind subpaths.
  * Robust kind-name normalization so plural/irregular kind names forward to the correct list operations; per-kind errors are reported without failing the whole view.

* **Tests**
  * Added extensive unit and integration tests covering helpers, list ops, inventory walker, forwarding, and error isolation.

* **Documentation**
  * New documentation page describing the Kubernetes connector and inventory ops.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->