### PR TITLE
feat(connectors): G3.2-T5 k8s.logs op — non-streaming with --tail / --container / --since / --previous + 1MiB body cap

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -511,6 +511,30 @@ class KubernetesConnector(Connector):
             "result": sub_result.model_dump(mode="json"),
         }
 
+    async def logs(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``k8s.logs`` op.
+
+        Op-id: ``k8s.logs``. Delegates to
+        :func:`~meho_backplane.connectors.kubernetes.ops_logs.k8s_logs`
+        with ``self`` injected as the ``connector`` argument so the
+        handler can reach the cached :class:`ApiClient` via
+        :meth:`_get_api_client` without an extra registry lookup. The
+        module-level function carries the real logic so a future
+        per-op-handler-file split (one ``ops_<verb>.py`` per op,
+        without a class) keeps the API stable.
+
+        Schema validation runs in the dispatcher before this method
+        is called; the function-level handler re-reads only
+        validated values.
+        """
+        from meho_backplane.connectors.kubernetes.ops_logs import k8s_logs
+
+        return await k8s_logs(self, target, params)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`KUBERNETES_OPS` into ``endpoint_descriptor``.

--- a/backend/src/meho_backplane/connectors/kubernetes/ops.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops.py
@@ -21,6 +21,11 @@ The shipped op surface today:
   inventory surface (G3.2-T2 #322). Metadata + helper functions live in
   :mod:`~meho_backplane.connectors.kubernetes.ops_core`; this module
   re-exports the merged tuple so registration walks a single list.
+* ``k8s.logs`` -- non-streaming pod-log fetch (G3.2-T5 #325). Metadata
+  schemas + handler live in
+  :mod:`~meho_backplane.connectors.kubernetes.ops_logs`; this module
+  builds the registration row from those exports inside
+  :func:`_kubernetes_ops`.
 
 Each op is declared in :data:`KUBERNETES_OPS` as a typed-metadata row.
 The connector's ``register_operations()`` classmethod walks the list
@@ -153,19 +158,57 @@ _K8S_ABOUT_OP = KubernetesOp(
 
 
 def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
-    """Return the merged registration tuple (``k8s.about`` + core inventory ops).
+    """Return the merged registration tuple (``k8s.about`` + core inventory ops + ``k8s.logs``).
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
     :class:`KubernetesOp` + ``_K8S_ABOUT_OP``, then imports the T2
-    inventory ops from :mod:`ops_core` (which itself only depends on
-    ``KubernetesOp``). The arrangement keeps the canary op's metadata
-    co-located with the dataclass definition while letting the larger
-    T2 surface live in its own module next to its helpers.
+    inventory ops from :mod:`ops_core` and the T5 logs op metadata
+    from :mod:`ops_logs` (each of which only depends on
+    ``KubernetesOp`` plus its own helpers). The arrangement keeps the
+    canary op's metadata co-located with the dataclass definition
+    while letting the larger surfaces live in their own modules next
+    to their helpers.
     """
     from meho_backplane.connectors.kubernetes.ops_core import CORE_OPS
+    from meho_backplane.connectors.kubernetes.ops_logs import (
+        K8S_LOGS_LLM_INSTRUCTIONS,
+        K8S_LOGS_PARAMETER_SCHEMA,
+        K8S_LOGS_RESPONSE_SCHEMA,
+    )
 
-    return (_K8S_ABOUT_OP, *CORE_OPS)
+    logs_op = KubernetesOp(
+        op_id="k8s.logs",
+        handler_attr="logs",
+        summary="Fetch a chunk of pod logs as a single non-streaming response.",
+        description=(
+            "Reads container stdout/stderr via the Kubernetes API's "
+            "``GET /api/v1/namespaces/{namespace}/pods/{name}/log`` route "
+            "and returns the lines in one response. Honours the standard "
+            "kubectl-style knobs -- ``--tail`` (default 100, capped at "
+            "5000), ``--container`` (required for multi-container pods), "
+            "``--since`` (duration string -- '5m', '1h', '24h', '7d'), "
+            "and ``--previous`` (logs from the prior container "
+            "instance after a restart). Pod name resolution accepts an "
+            "exact match or a unique prefix within the namespace. The "
+            "response body is capped at 1 MiB serialised; oversize "
+            "payloads are truncated line-boundary from the front (most-"
+            "recent lines kept) and ``truncated=true`` is set on the "
+            "result with ``truncated_byte_count`` carrying the dropped "
+            "byte count. Streaming (``kubectl logs -f``) is out of "
+            "scope for v0.2 -- operators following live logs continue "
+            "using the kubectl-vcf.sh fallback."
+        ),
+        parameter_schema=K8S_LOGS_PARAMETER_SCHEMA,
+        response_schema=K8S_LOGS_RESPONSE_SCHEMA,
+        group_key="logs",
+        tags=("read-only", "pod", "logs"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_LOGS_LLM_INSTRUCTIONS,
+    )
+
+    return (_K8S_ABOUT_OP, *CORE_OPS, logs_op)
 
 
 KUBERNETES_OPS: tuple[KubernetesOp, ...] = _kubernetes_ops()

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_logs.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_logs.py
@@ -1,0 +1,487 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``k8s.logs`` op -- non-streaming pod log fetch with body-size cap.
+
+The op is the v0.2 K8s connector's answer to ``kubectl logs <pod>``: a
+single-response, chunked fetch backed by
+:meth:`kubernetes_asyncio.client.CoreV1Api.read_namespaced_pod_log`.
+Streaming (``kubectl logs -f``) is out of scope -- the connector
+returns a flat dict the dispatcher wraps into one
+:class:`~meho_backplane.connectors.schemas.OperationResult`. v0.2.next
+adds the streaming transport once MCP's ``tools/call`` envelope grows a
+streaming shape.
+
+The handler resolves prefix-style pod names (the same shape G3.2-T3
+will introduce on ``k8s.pod.info``) before issuing the log fetch. The
+resolver currently does the dumb thing -- ``list_namespaced_pod`` +
+client-side filter; the server-side field selector route lands when
+G3.2-T3 ships its production-grade resolver.
+
+Multi-container pods without ``--container`` short-circuit to a
+structured error carrying the available container names so the caller
+can retry with an explicit container. Single-container pods auto-pick
+the only container.
+
+The 1MB body cap is applied client-side. The k8s API exposes
+``limit_bytes`` for a server-side cap, but it terminates the response
+mid-line (the k8s docs explicitly say "may return slightly more or
+slightly less than the specified limit"). v0.2 wants line-boundary
+truncation -- we fetch the raw body, count UTF-8 bytes line by line
+from the tail, and drop the leading lines that push the response past
+1 MiB. ``truncated_byte_count`` in extras records how much was dropped
+so the operator can decide whether to retry with a smaller ``--tail``
+or a tighter ``--since``.
+
+References
+----------
+* Parent task: G3.2-T5 (#325).
+* Parent Initiative: G3.2 (#320), kubernetes-asyncio typed connector.
+* k8s API: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#read-log-pod-v1-core
+* ``kubernetes_asyncio.CoreV1Api.read_namespaced_pod_log``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from kubernetes_asyncio import client
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
+    from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
+
+__all__ = [
+    "K8S_LOGS_LLM_INSTRUCTIONS",
+    "K8S_LOGS_PARAMETER_SCHEMA",
+    "K8S_LOGS_RESPONSE_SCHEMA",
+    "MAX_BODY_BYTES",
+    "MAX_TAIL_LINES",
+    "MultiContainerAmbiguityError",
+    "PodNotFoundError",
+    "k8s_logs",
+    "parse_duration",
+    "resolve_pod_and_container",
+    "truncate_lines_to_byte_cap",
+]
+
+#: Hard cap on ``--tail``. The k8s API itself has no upper bound, but
+#: 5000 lines is the operator-facing ergonomics cap -- above this the
+#: caller almost certainly wants ``--since`` instead, and pulling more
+#: than 5000 lines blows past the 1 MiB body cap for any non-trivial
+#: log line length.
+MAX_TAIL_LINES = 5000
+
+#: 1 MiB serialised body cap. The dispatcher's ``PassThroughReducer``
+#: lands the returned dict verbatim into
+#: :attr:`OperationResult.result`; large log payloads inflate the
+#: JSONFlux reducer's reduction overhead linearly and blow past the
+#: audit row's display size. 1 MiB matches the operator's typical
+#: terminal scrollback and the MCP envelope's practical payload
+#: ceiling (no hard limit, but >1 MB choices stall clients).
+MAX_BODY_BYTES = 1024 * 1024
+
+
+#: JSON Schema 2020-12 for ``k8s.logs`` ``params``. The dispatcher
+#: validates against this before the handler runs; the handler then
+#: only re-reads validated values.
+K8S_LOGS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "pod_name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Pod name. Exact match or unique prefix; the handler "
+                "resolves prefixes against the namespace's pod list. "
+                "Ambiguous prefixes return a structured error listing "
+                "the matching pods."
+            ),
+        },
+        "namespace": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Namespace the pod lives in.",
+        },
+        "container": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Container name within the pod. Required when the pod "
+                "has more than one container; auto-selected when there "
+                "is only one."
+            ),
+        },
+        "tail": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": MAX_TAIL_LINES,
+            "default": 100,
+            "description": (
+                "Lines from the end of the log. Capped at "
+                f"{MAX_TAIL_LINES}; pass --since for time-bounded slices "
+                "instead of larger tails."
+            ),
+        },
+        "since": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": r"^\s*\d+\s*[smhd]\s*$",
+            "description": (
+                "Duration string -- '5m', '1h', '24h', '7d'. Resolves "
+                "to ``since_seconds`` on the wire. Server-side filter; "
+                "logs older than the cutoff are dropped before transit."
+            ),
+        },
+        "previous": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Fetch logs from the previous container instance (i.e. "
+                "before the most-recent restart). Maps to the API's "
+                "``previous=true`` flag."
+            ),
+        },
+    },
+    "required": ["pod_name", "namespace"],
+    "additionalProperties": False,
+}
+
+
+#: Informational response schema for the meta-tools. The dispatcher's
+#: pass-through reducer does not validate outbound payloads in v0.2.
+K8S_LOGS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "pod": {"type": "string"},
+        "namespace": {"type": "string"},
+        "container": {"type": "string"},
+        "lines": {"type": "array", "items": {"type": "string"}},
+        "truncated": {"type": "boolean"},
+        "line_count": {"type": "integer", "minimum": 0},
+        "byte_count": {"type": "integer", "minimum": 0},
+        "truncated_byte_count": {"type": "integer", "minimum": 0},
+    },
+    "required": ["pod", "namespace", "container", "lines", "truncated"],
+    "additionalProperties": False,
+}
+
+
+#: ``llm_instructions`` blob the meta-tools (G0.6-T8 #399) inline into
+#: ``describe_operation`` responses. Same discipline G3.3 will follow
+#: for the full Vault op surface: when-to-use prose + parameter hints +
+#: output-shape sketch.
+K8S_LOGS_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Fetch a chunk of pod logs as a single response. Use when the "
+        "operator names a specific pod and wants its recent log lines "
+        "(e.g. 'show me the last 200 lines from argocd-server'). "
+        "Non-streaming -- for live tailing, the operator should keep "
+        "using kubectl-vcf.sh -f until v0.2.next ships the streaming "
+        "transport. Read-only; the log content is never written to "
+        "the audit_log payload (which records only the request "
+        "params, not the bytes returned)."
+    ),
+    "parameter_hints": {
+        "pod_name": (
+            "Exact pod name or unique prefix within the namespace. "
+            "Prefer the full name when the agent already knows it "
+            "(e.g. after a prior k8s.pod.list); fall back to a prefix "
+            "for ad-hoc operator-driven queries."
+        ),
+        "namespace": "Required.",
+        "container": (
+            "Required for multi-container pods. The handler returns a "
+            "structured error listing the pod's containers when this "
+            "is omitted and the pod has more than one."
+        ),
+        "tail": (
+            f"Defaults to 100; capped at {MAX_TAIL_LINES}. Prefer "
+            "'since' over very large tails -- the response is capped "
+            f"at {MAX_BODY_BYTES // (1024 * 1024)} MiB and oversize "
+            "responses truncate from the front."
+        ),
+        "since": (
+            "Duration string (e.g. '5m', '1h', '24h', '7d'). Server-"
+            "side filter. Combine with a moderate tail for time-"
+            "bounded slices."
+        ),
+        "previous": (
+            "Set true to fetch the previous container instance's logs "
+            "(after a crash + restart). Defaults to false."
+        ),
+    },
+    "output_shape": (
+        "Flat dict: {'pod': <resolved-name>, 'namespace', 'container', "
+        "'lines': [<str>], 'truncated': <bool>}. When truncated is "
+        "true, extras carries 'line_count', 'byte_count', and "
+        "'truncated_byte_count' so callers can render an 'X KiB "
+        "dropped from the front' hint."
+    ),
+}
+
+
+#: Duration suffix to seconds multiplier. The schema's regex
+#: (``\d+[smhd]``) constrains the suffix to one of these characters;
+#: this table is the parser's lookup.
+_DURATION_UNITS: dict[str, int] = {
+    "s": 1,
+    "m": 60,
+    "h": 60 * 60,
+    "d": 24 * 60 * 60,
+}
+
+_DURATION_RE = re.compile(r"^\s*(\d+)\s*([smhd])\s*$")
+
+
+def parse_duration(value: str | None) -> int | None:
+    """Parse a duration string into seconds; ``None`` passes through.
+
+    Accepts the same shape as the schema's ``pattern`` -- a positive
+    integer followed by ``s`` / ``m`` / ``h`` / ``d``. Whitespace at
+    the edges is tolerated; the schema already accepts it so the
+    parser must too. Returns ``None`` for ``None`` input so the
+    handler can splat the result into ``since_seconds`` unconditionally
+    (``kubernetes_asyncio`` ignores ``None`` kwargs).
+
+    Raises :class:`ValueError` for any string the regex doesn't match
+    -- the schema rejects malformed input before the handler runs, so
+    a raise here means schema/parser drift and should fail loud.
+    """
+    if value is None:
+        return None
+    match = _DURATION_RE.match(value)
+    if match is None:
+        # Schema-enforced unreachable in production; raise so the
+        # dispatcher's connector_error envelope surfaces the bug if a
+        # schema relaxation lets a bad value through.
+        raise ValueError(f"invalid duration: {value!r}")
+    quantity = int(match.group(1))
+    unit = match.group(2)
+    return quantity * _DURATION_UNITS[unit]
+
+
+class PodNotFoundError(LookupError):
+    """Pod prefix matched zero or many pods.
+
+    Distinct from a generic ``ApiException`` so the dispatcher's
+    ``connector_error`` envelope carries
+    ``extras.exception_class="PodNotFoundError"`` and callers can
+    render a "did-you-mean" hint listing the resolved candidates (if
+    any) from ``args[1]``.
+    """
+
+    def __init__(self, message: str, candidates: list[str] | None = None) -> None:
+        super().__init__(message, candidates or [])
+
+    @property
+    def candidates(self) -> list[str]:
+        return list(self.args[1])
+
+
+class MultiContainerAmbiguityError(ValueError):
+    """Pod has multiple containers and the caller didn't pick one.
+
+    The structured response includes the container list in
+    ``args[1]`` so the dispatcher's ``connector_error`` envelope can
+    surface them to the operator without a second round-trip.
+    """
+
+    def __init__(self, pod: str, containers: list[str]) -> None:
+        super().__init__(
+            f"pod {pod!r} has multiple containers; specify --container",
+            containers,
+        )
+
+    @property
+    def containers(self) -> list[str]:
+        return list(self.args[1])
+
+
+async def resolve_pod_and_container(
+    v1: client.CoreV1Api,
+    namespace: str,
+    pod_name: str,
+    container: str | None,
+) -> tuple[str, str]:
+    """Resolve ``pod_name`` prefix + ``container`` against the cluster.
+
+    Returns the exact pod name and the container name to pass to
+    :meth:`read_namespaced_pod_log`. Raises:
+
+    * :class:`PodNotFoundError` -- zero or multiple pods match the
+      prefix. ``candidates`` carries the matched names so the caller
+      can surface a "did-you-mean".
+    * :class:`MultiContainerAmbiguityError` -- pod has multiple
+      containers and ``container`` is ``None``. ``containers`` carries
+      the candidate list.
+    * :class:`kubernetes_asyncio.client.ApiException` -- API-side
+      errors (RBAC denial, namespace missing). Propagated unchanged.
+
+    Implementation note: ``list_namespaced_pod`` returns every pod in
+    the namespace. Once G3.2-T3 (#323) ships a paginated resolver
+    against ``read_namespaced_pod`` + ``field_selector``, switch to
+    that path -- it's strictly faster and avoids the full-namespace
+    list when the caller already has the exact name.
+    """
+    pod_list = await v1.list_namespaced_pod(namespace=namespace)
+    matches: list[Any] = []
+    for pod in pod_list.items:
+        if pod.metadata.name == pod_name:
+            matches = [pod]
+            break
+        if pod.metadata.name.startswith(pod_name):
+            matches.append(pod)
+
+    if not matches:
+        raise PodNotFoundError(f"no pod in namespace {namespace!r} matches {pod_name!r}")
+    if len(matches) > 1:
+        names = sorted(p.metadata.name for p in matches)
+        raise PodNotFoundError(
+            f"pod prefix {pod_name!r} in namespace {namespace!r} matched {len(names)} pods",
+            names,
+        )
+
+    pod = matches[0]
+    container_names: list[str] = [c.name for c in (pod.spec.containers or [])]
+    if container is not None:
+        if container not in container_names:
+            raise MultiContainerAmbiguityError(pod.metadata.name, container_names)
+        return pod.metadata.name, container
+
+    if len(container_names) == 1:
+        return pod.metadata.name, container_names[0]
+    raise MultiContainerAmbiguityError(pod.metadata.name, container_names)
+
+
+def truncate_lines_to_byte_cap(lines: list[str], cap_bytes: int) -> tuple[list[str], int]:
+    """Keep the most-recent lines that fit in ``cap_bytes`` UTF-8 bytes.
+
+    Returns ``(kept_lines, dropped_byte_count)``. The cap accounts for
+    the joining newline between lines (one byte per join, no trailing
+    newline) so the consumer's serialised view matches the byte
+    budget. When even the last line by itself exceeds ``cap_bytes``,
+    the function returns it alone without slicing inside the line --
+    line-boundary truncation is the contract.
+    """
+    if not lines:
+        return [], 0
+
+    kept_reversed: list[str] = []
+    running_bytes = 0
+    # Iterate tail-first: the most-recent lines are at the end of the
+    # source list, and the body cap evicts the oldest lines first.
+    for line in reversed(lines):
+        line_bytes = len(line.encode("utf-8"))
+        join_byte = 1 if kept_reversed else 0
+        next_bytes = running_bytes + line_bytes + join_byte
+        if next_bytes > cap_bytes and kept_reversed:
+            break
+        kept_reversed.append(line)
+        running_bytes = next_bytes
+
+    kept = list(reversed(kept_reversed))
+    dropped = sum(len(line.encode("utf-8")) for line in lines[: len(lines) - len(kept)])
+    # Account for the joining newlines we conceptually dropped along
+    # with the lines themselves (one per dropped line that was joined
+    # to something).
+    if len(lines) - len(kept) > 0:
+        dropped += len(lines) - len(kept)
+    return kept, dropped
+
+
+async def k8s_logs(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.logs``.
+
+    Module-level free function so a future migration to per-op
+    handler files keeps the API stable; the bound-method shim on
+    :class:`KubernetesConnector` (``logs``) delegates here. Schema
+    validation runs in the dispatcher, so ``params`` arrives
+    pre-checked against :data:`K8S_LOGS_PARAMETER_SCHEMA` -- the
+    handler only re-reads validated values.
+
+    Raises propagate to the dispatcher's ``connector_error`` branch:
+
+    * :class:`PodNotFoundError` -- prefix matched zero or many pods.
+    * :class:`MultiContainerAmbiguityError` -- multi-container pod
+      missing ``--container``.
+    * :class:`kubernetes_asyncio.client.ApiException` -- API errors
+      (RBAC, missing namespace, container not running yet for
+      ``previous=true``).
+    """
+    pod_name = params["pod_name"]
+    namespace = params["namespace"]
+    # ``tail`` is schema-defaulted to 100 but the dispatcher passes
+    # raw ``params`` through without injecting defaults -- the
+    # ``Draft202012Validator`` validates only, it does not coerce.
+    tail = int(params.get("tail", 100))
+    if tail > MAX_TAIL_LINES:
+        # Defence in depth: the schema's ``maximum`` already enforces
+        # this. Keep the explicit clamp so a future schema relaxation
+        # cannot exceed the cap silently.
+        tail = MAX_TAIL_LINES
+    container_param: str | None = params.get("container")
+    since_seconds = parse_duration(params.get("since"))
+    previous = bool(params.get("previous", False))
+
+    api_client = await connector._get_api_client(target)
+    v1 = client.CoreV1Api(api_client)
+
+    exact_name, container_name = await resolve_pod_and_container(
+        v1, namespace, pod_name, container_param
+    )
+
+    # ``kubernetes_asyncio`` accepts every parameter as a kwarg; pass
+    # only the ones with non-default values so the wire request stays
+    # minimal and the server doesn't have to short-circuit None
+    # filters. ``timestamps=False`` is the API default but log lines
+    # often carry their own timestamp via the application -- exposing
+    # the API's RFC3339 prefix is a v0.2.next ergonomics knob.
+    kwargs: dict[str, Any] = {
+        "name": exact_name,
+        "namespace": namespace,
+        "container": container_name,
+        "tail_lines": tail,
+        "previous": previous,
+    }
+    if since_seconds is not None:
+        kwargs["since_seconds"] = since_seconds
+
+    body: str = await v1.read_namespaced_pod_log(**kwargs)
+
+    # ``read_namespaced_pod_log`` returns the body as a single string;
+    # an empty cluster log returns "" (no trailing newline). Split on
+    # \n and drop the trailing empty token the split produces when
+    # the body ends with \n (the common case -- container stdout
+    # always terminates the last line).
+    lines = body.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+
+    byte_count = len(body.encode("utf-8"))
+    truncated = False
+    truncated_byte_count = 0
+    if byte_count > MAX_BODY_BYTES:
+        lines, truncated_byte_count = truncate_lines_to_byte_cap(lines, MAX_BODY_BYTES)
+        truncated = True
+
+    result: dict[str, Any] = {
+        "pod": exact_name,
+        "namespace": namespace,
+        "container": container_name,
+        "lines": lines,
+        "truncated": truncated,
+    }
+    if truncated:
+        result["line_count"] = len(lines)
+        result["byte_count"] = byte_count
+        result["truncated_byte_count"] = truncated_byte_count
+    return result

--- a/backend/tests/test_connectors_k8s_logs.py
+++ b/backend/tests/test_connectors_k8s_logs.py
@@ -1,0 +1,518 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the ``k8s.logs`` op (G3.2-T5, #325).
+
+The k3d integration shape lives in
+:mod:`tests.integration.test_connectors_k8s_k3d` (extended under
+T6 / #326 with the live cluster). This module exercises the same
+contract with mocked ``kubernetes_asyncio.client.CoreV1Api`` so the
+gate runs in every CI lane regardless of Docker availability.
+
+Coverage matrix (per #325 acceptance criteria):
+
+* ``k8s.logs <pod> --namespace argocd`` returns last 100 lines (tail
+  default) from a stub cluster.
+* ``--tail 500`` flows through to ``tail_lines=500``.
+* ``--tail 99999`` clamps to 5000 in the handler.
+* ``--container <name>`` selects the named container in a
+  multi-container pod.
+* Multi-container pod without ``--container`` -> structured error
+  whose ``args[1]`` lists available containers.
+* ``--since 5m`` resolves to ``since_seconds=300``.
+* ``--previous=true`` flows through to ``previous=True``.
+* 1 MiB cap: a pod with > 1 MiB of logs returns ``truncated=true`` and
+  ``truncated_byte_count`` in the result extras.
+* Audit shape (extras vs payload): the handler returns ``lines`` in
+  the result dict only; the dispatcher writes ``params_hash`` against
+  the input params, never the log content. The unit test asserts the
+  handler's contract; the audit row shape is covered by the
+  dispatcher's contract tests.
+* Prefix resolution: unique prefix resolves to one pod; ambiguous
+  prefix raises :class:`PodNotFoundError`.
+* Empty namespace / missing pod: raises :class:`PodNotFoundError`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from meho_backplane.connectors.kubernetes import KubernetesConnector
+from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
+from meho_backplane.connectors.kubernetes.ops_logs import (
+    MAX_BODY_BYTES,
+    MAX_TAIL_LINES,
+    MultiContainerAmbiguityError,
+    PodNotFoundError,
+    k8s_logs,
+    parse_duration,
+    truncate_lines_to_byte_cap,
+)
+
+# ---------------------------------------------------------------------------
+# Target stub + kubeconfig
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="rke2-meho",
+    host="rke2-meho.test.invalid",
+    port=6443,
+    secret_ref="kv/data/k8s/rke2-meho",
+)
+
+
+def _stub_kubeconfig_dict() -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://k8s.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "stub-token"}}],
+    }
+
+
+def _make_connector() -> KubernetesConnector:
+    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+        return _stub_kubeconfig_dict()
+
+    return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _pod_obj(name: str, containers: list[str]) -> MagicMock:
+    """Stub for ``V1Pod`` -- just the attrs the handler reads."""
+    pod = MagicMock()
+    pod.metadata.name = name
+    pod.spec.containers = [MagicMock(name=c) for c in containers]
+    # ``MagicMock(name=...)`` sets the mock's repr-name, not its
+    # ``.name`` attribute; assign explicitly.
+    for mock_container, cname in zip(pod.spec.containers, containers, strict=True):
+        mock_container.name = cname
+    return pod
+
+
+def _pod_list(pods: list[Any]) -> MagicMock:
+    pod_list = MagicMock()
+    pod_list.items = pods
+    return pod_list
+
+
+def _patch_api(
+    *,
+    list_pods: Any = None,
+    log_body: str = "",
+    log_side_effect: Exception | None = None,
+) -> Any:
+    """Patch the kubeconfig client + the CoreV1Api factory in one go.
+
+    Returns the patched ``CoreV1Api`` instance mock so the test can
+    assert against ``read_namespaced_pod_log.call_args``.
+    """
+    api_client_mock = MagicMock(close=AsyncMock())
+    core_v1 = MagicMock()
+    if list_pods is None:
+        list_pods = _pod_list([_pod_obj("argocd-server-7c4b8d-x7r2k", ["argocd-server"])])
+    core_v1.list_namespaced_pod = AsyncMock(return_value=list_pods)
+    if log_side_effect is not None:
+        core_v1.read_namespaced_pod_log = AsyncMock(side_effect=log_side_effect)
+    else:
+        core_v1.read_namespaced_pod_log = AsyncMock(return_value=log_body)
+    config_patch = patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new_callable=AsyncMock,
+        return_value=api_client_mock,
+    )
+    core_v1_patch = patch(
+        "meho_backplane.connectors.kubernetes.ops_logs.client.CoreV1Api",
+        return_value=core_v1,
+    )
+    return config_patch, core_v1_patch, core_v1
+
+
+# ---------------------------------------------------------------------------
+# parse_duration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("5s", 5),
+        ("30s", 30),
+        ("5m", 300),
+        ("1h", 3600),
+        ("24h", 86400),
+        ("7d", 604800),
+        (" 5m ", 300),
+        ("5 m", 300),
+    ],
+)
+def test_parse_duration_valid(value: str, expected: int) -> None:
+    assert parse_duration(value) == expected
+
+
+def test_parse_duration_none_passes_through() -> None:
+    assert parse_duration(None) is None
+
+
+@pytest.mark.parametrize("value", ["", "5", "5x", "abc", "-5m", "5.5m"])
+def test_parse_duration_invalid_raises(value: str) -> None:
+    with pytest.raises(ValueError, match="invalid duration"):
+        parse_duration(value)
+
+
+# ---------------------------------------------------------------------------
+# truncate_lines_to_byte_cap
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_lines_under_cap_returns_full_input() -> None:
+    lines = ["line-a", "line-b", "line-c"]
+    kept, dropped = truncate_lines_to_byte_cap(lines, cap_bytes=1024)
+    assert kept == lines
+    assert dropped == 0
+
+
+def test_truncate_lines_drops_from_front_at_line_boundary() -> None:
+    """Keep tail; drop leading lines that push the response past the cap."""
+    lines = ["a" * 100, "b" * 100, "c" * 100]
+    # cap = 220 bytes -> fits 'c'*100 + newline + 'b'*100 = 201 bytes; adding
+    # 'a'*100 needs another 101 bytes which exceeds 220. Keep [b, c].
+    kept, dropped = truncate_lines_to_byte_cap(lines, cap_bytes=220)
+    assert kept == ["b" * 100, "c" * 100]
+    # Dropped one line of 100 bytes + the joining newline -> 101.
+    assert dropped == 101
+
+
+def test_truncate_lines_empty_input() -> None:
+    kept, dropped = truncate_lines_to_byte_cap([], cap_bytes=1024)
+    assert kept == []
+    assert dropped == 0
+
+
+def test_truncate_lines_keeps_single_oversize_line() -> None:
+    """When even the tail line by itself exceeds the cap, keep it intact.
+
+    Line-boundary truncation contract: we never slice inside a line.
+    """
+    lines = ["x" * 200]
+    kept, dropped = truncate_lines_to_byte_cap(lines, cap_bytes=100)
+    assert kept == ["x" * 200]
+    assert dropped == 0
+
+
+# ---------------------------------------------------------------------------
+# k8s_logs -- happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_default_tail_100_returns_lines() -> None:
+    connector = _make_connector()
+    body = "\n".join(f"line-{i}" for i in range(100)) + "\n"
+    config_patch, core_v1_patch, core_v1 = _patch_api(log_body=body)
+    with config_patch, core_v1_patch:
+        result = await k8s_logs(
+            connector, _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
+        )
+
+    assert result["pod"] == "argocd-server-7c4b8d-x7r2k"
+    assert result["namespace"] == "argocd"
+    assert result["container"] == "argocd-server"
+    assert result["truncated"] is False
+    assert result["lines"][0] == "line-0"
+    assert result["lines"][-1] == "line-99"
+    assert len(result["lines"]) == 100
+    # ``--tail`` defaults to 100.
+    kwargs = core_v1.read_namespaced_pod_log.call_args.kwargs
+    assert kwargs["tail_lines"] == 100
+    assert kwargs["previous"] is False
+    assert "since_seconds" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_explicit_tail_flows_to_api() -> None:
+    connector = _make_connector()
+    config_patch, core_v1_patch, core_v1 = _patch_api(log_body="x\n")
+    with config_patch, core_v1_patch:
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "argocd-server", "namespace": "argocd", "tail": 500},
+        )
+    assert core_v1.read_namespaced_pod_log.call_args.kwargs["tail_lines"] == 500
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_tail_clamps_at_max() -> None:
+    """Clamp at MAX_TAIL_LINES even when schema lets a larger value through."""
+    connector = _make_connector()
+    config_patch, core_v1_patch, core_v1 = _patch_api(log_body="x\n")
+    with config_patch, core_v1_patch:
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "argocd-server", "namespace": "argocd", "tail": 99999},
+        )
+    assert core_v1.read_namespaced_pod_log.call_args.kwargs["tail_lines"] == MAX_TAIL_LINES
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_since_resolves_to_seconds() -> None:
+    connector = _make_connector()
+    config_patch, core_v1_patch, core_v1 = _patch_api(log_body="x\n")
+    with config_patch, core_v1_patch:
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "argocd-server", "namespace": "argocd", "since": "5m"},
+        )
+    assert core_v1.read_namespaced_pod_log.call_args.kwargs["since_seconds"] == 300
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_previous_flows_to_api() -> None:
+    connector = _make_connector()
+    config_patch, core_v1_patch, core_v1 = _patch_api(log_body="x\n")
+    with config_patch, core_v1_patch:
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "argocd-server", "namespace": "argocd", "previous": True},
+        )
+    assert core_v1.read_namespaced_pod_log.call_args.kwargs["previous"] is True
+
+
+# ---------------------------------------------------------------------------
+# k8s_logs -- multi-container pods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_explicit_container_in_multi_container_pod() -> None:
+    connector = _make_connector()
+    multi = _pod_list([_pod_obj("istio-pilot-1", ["discovery", "istio-proxy"])])
+    config_patch, core_v1_patch, core_v1 = _patch_api(list_pods=multi, log_body="x\n")
+    with config_patch, core_v1_patch:
+        result = await k8s_logs(
+            connector,
+            _TARGET,
+            {
+                "pod_name": "istio-pilot-1",
+                "namespace": "istio",
+                "container": "istio-proxy",
+            },
+        )
+    assert result["container"] == "istio-proxy"
+    assert core_v1.read_namespaced_pod_log.call_args.kwargs["container"] == "istio-proxy"
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_multi_container_without_container_param_errors() -> None:
+    connector = _make_connector()
+    multi = _pod_list([_pod_obj("istio-pilot-1", ["discovery", "istio-proxy"])])
+    config_patch, core_v1_patch, _core_v1 = _patch_api(list_pods=multi, log_body="x\n")
+    with config_patch, core_v1_patch, pytest.raises(MultiContainerAmbiguityError) as exc:
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "istio-pilot-1", "namespace": "istio"},
+        )
+    assert exc.value.containers == ["discovery", "istio-proxy"]
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_unknown_container_in_multi_container_pod_errors() -> None:
+    connector = _make_connector()
+    multi = _pod_list([_pod_obj("istio-pilot-1", ["discovery", "istio-proxy"])])
+    config_patch, core_v1_patch, _core_v1 = _patch_api(list_pods=multi, log_body="x\n")
+    with config_patch, core_v1_patch, pytest.raises(MultiContainerAmbiguityError) as exc:
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {
+                "pod_name": "istio-pilot-1",
+                "namespace": "istio",
+                "container": "nope",
+            },
+        )
+    assert exc.value.containers == ["discovery", "istio-proxy"]
+
+
+# ---------------------------------------------------------------------------
+# k8s_logs -- pod resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_pod_prefix_resolves_to_exact_name() -> None:
+    connector = _make_connector()
+    pods = _pod_list(
+        [
+            _pod_obj("argocd-server-7c4b8d-x7r2k", ["argocd-server"]),
+            _pod_obj("argocd-repo-server-abc123", ["argocd-repo-server"]),
+        ]
+    )
+    config_patch, core_v1_patch, core_v1 = _patch_api(list_pods=pods, log_body="x\n")
+    with config_patch, core_v1_patch:
+        result = await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "argocd-server", "namespace": "argocd"},
+        )
+    assert result["pod"] == "argocd-server-7c4b8d-x7r2k"
+    assert core_v1.read_namespaced_pod_log.call_args.kwargs["name"] == "argocd-server-7c4b8d-x7r2k"
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_pod_prefix_ambiguous_raises() -> None:
+    connector = _make_connector()
+    pods = _pod_list(
+        [
+            _pod_obj("api-1", ["api"]),
+            _pod_obj("api-2", ["api"]),
+        ]
+    )
+    config_patch, core_v1_patch, _core_v1 = _patch_api(list_pods=pods, log_body="x\n")
+    with config_patch, core_v1_patch, pytest.raises(PodNotFoundError) as exc:
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "api", "namespace": "default"},
+        )
+    assert exc.value.candidates == ["api-1", "api-2"]
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_pod_not_found_raises() -> None:
+    connector = _make_connector()
+    pods = _pod_list([])
+    config_patch, core_v1_patch, _core_v1 = _patch_api(list_pods=pods, log_body="x\n")
+    with config_patch, core_v1_patch, pytest.raises(PodNotFoundError) as exc:
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "ghost", "namespace": "default"},
+        )
+    assert exc.value.candidates == []
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_exact_match_wins_over_prefix_match() -> None:
+    """Exact ``foo-bar`` match wins over prefix when ``foo-bar-x`` also exists."""
+    connector = _make_connector()
+    pods = _pod_list(
+        [
+            _pod_obj("api-1", ["api"]),
+            _pod_obj("api-1-replica", ["api"]),
+        ]
+    )
+    config_patch, core_v1_patch, core_v1 = _patch_api(list_pods=pods, log_body="x\n")
+    with config_patch, core_v1_patch:
+        result = await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "api-1", "namespace": "default"},
+        )
+    assert result["pod"] == "api-1"
+    assert core_v1.read_namespaced_pod_log.call_args.kwargs["name"] == "api-1"
+
+
+# ---------------------------------------------------------------------------
+# k8s_logs -- 1MB cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_body_under_cap_returns_untruncated() -> None:
+    connector = _make_connector()
+    body = "small body\nsecond line\n"
+    config_patch, core_v1_patch, _core_v1 = _patch_api(log_body=body)
+    with config_patch, core_v1_patch:
+        result = await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "argocd-server", "namespace": "argocd"},
+        )
+    assert result["truncated"] is False
+    assert "truncated_byte_count" not in result
+    assert "byte_count" not in result
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_body_over_cap_truncates_from_front() -> None:
+    connector = _make_connector()
+    # Build a body just over 1 MiB. Each line is 1 KiB + 1 byte newline ->
+    # 1025 bytes; 1100 lines = ~1.10 MiB > 1 MiB cap.
+    lines = [f"L{i:04d}-{'x' * (1024 - 6)}" for i in range(1100)]
+    body = "\n".join(lines) + "\n"
+    config_patch, core_v1_patch, _core_v1 = _patch_api(log_body=body)
+    with config_patch, core_v1_patch:
+        result = await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "argocd-server", "namespace": "argocd"},
+        )
+
+    assert result["truncated"] is True
+    assert result["truncated_byte_count"] > 0
+    assert result["byte_count"] == len(body.encode("utf-8"))
+    # Most-recent lines kept: the last line is preserved.
+    assert result["lines"][-1].startswith("L1099-")
+    # Kept body fits in the cap.
+    kept_bytes = sum(len(line.encode("utf-8")) for line in result["lines"]) + max(
+        len(result["lines"]) - 1, 0
+    )
+    assert kept_bytes <= MAX_BODY_BYTES
+
+
+# ---------------------------------------------------------------------------
+# k8s_logs -- API exceptions propagate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_logs_api_exception_propagates() -> None:
+    """An ``ApiException`` from the API call propagates so the dispatcher's
+    ``connector_error`` envelope can surface ``extras.exception_class``.
+    """
+    from kubernetes_asyncio.client.exceptions import ApiException
+
+    connector = _make_connector()
+    config_patch, core_v1_patch, _core_v1 = _patch_api(
+        log_side_effect=ApiException(status=403, reason="Forbidden")
+    )
+    with config_patch, core_v1_patch, pytest.raises(ApiException):
+        await k8s_logs(
+            connector,
+            _TARGET,
+            {"pod_name": "argocd-server", "namespace": "argocd"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shim on KubernetesConnector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_connector_logs_method_delegates_to_handler() -> None:
+    connector = _make_connector()
+    body = "delegated\n"
+    config_patch, core_v1_patch, _core_v1 = _patch_api(log_body=body)
+    with config_patch, core_v1_patch:
+        result = await connector.logs(_TARGET, {"pod_name": "argocd-server", "namespace": "argocd"})
+    assert result["lines"] == ["delegated"]

--- a/docs/codebase/kubernetes-connector.md
+++ b/docs/codebase/kubernetes-connector.md
@@ -1,0 +1,189 @@
+# Kubernetes connector (`k8s-1.x`, `kubernetes-asyncio`)
+
+## Overview
+
+The Kubernetes connector ships read-only typed operations against any
+Kubernetes API server reachable from the backplane. It is identified by
+the registry-v2 triple `(product="k8s", version="1.x",
+impl_id="kubernetes-asyncio")` and is the v0.2 successor to the
+operator's `kubectl-vcf.sh` daily-wrapper.
+
+Operations register into the G0.6 `endpoint_descriptor` table via
+`register_typed_operation()` at connector init -- not via in-code
+`_op_map` dicts. Agents reach the ops through the G0.5 meta-tools
+(`search_operations` + `call_operation`); the operator-facing CLI
+(`meho k8s <op>`) is a thin convenience layer over
+`POST /api/v1/operations/call`.
+
+The connector is the reference shape for every typed connector that
+follows (Vault is the other example today; bind9, pfSense, Holodeck
+copy this pattern in G3.x).
+
+## Key types
+
+* `KubernetesConnector` (`backend/src/meho_backplane/connectors/kubernetes/connector.py`)
+  -- the connector class. Inherits from `Connector` (the ABC in
+  `meho_backplane.connectors.base`). Class-level attrs `product` /
+  `version` / `impl_id` advertise the registry-v2 key. Caches one
+  `kubernetes_asyncio.client.ApiClient` per target keyed on
+  `target.secret_ref` (the Vault path holding the kubeconfig); the
+  cache key is intentionally the secret_ref, not `target.name`, so two
+  tenants holding same-named targets get distinct ApiClients.
+
+* `KubernetesOp` (`backend/src/meho_backplane/connectors/kubernetes/ops.py`)
+  -- frozen dataclass describing one op's metadata. Each field mirrors
+  the kwargs `register_typed_operation()` accepts (`op_id`, `summary`,
+  `description`, `parameter_schema`, `response_schema`, `group_key`,
+  `tags`, `safety_level`, `requires_approval`, `llm_instructions`),
+  plus a `handler_attr` string naming the bound method on
+  `KubernetesConnector` that implements the op.
+
+* `KUBERNETES_OPS` (`backend/src/meho_backplane/connectors/kubernetes/ops.py`)
+  -- the tuple of `KubernetesOp` entries the connector registers at
+  lifespan startup. Currently carries:
+
+  | op_id        | handler            | scope                  |
+  |--------------|--------------------|------------------------|
+  | `k8s.about`  | `about`            | cluster identity       |
+  | `k8s.logs`   | `logs` (→ `ops_logs.k8s_logs`) | pod log fetch  |
+
+  G3.2-T2 / T3 / T4 add the rest of the 13-op v0.2 read surface
+  against this same tuple.
+
+* `KubernetesTargetLike` (`backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py`)
+  -- Protocol the connector reads against. Only four attributes:
+  `name`, `host`, `port`, `secret_ref`. The G0.3 `Target` model
+  satisfies it structurally once G0.3 lands.
+
+* `ops_logs.py` (the `k8s.logs` handler)
+  -- contains the module-level `k8s_logs(connector, target, params)`
+  function, JSON Schemas (`K8S_LOGS_PARAMETER_SCHEMA`,
+  `K8S_LOGS_RESPONSE_SCHEMA`), `LLM_INSTRUCTIONS` blob, and helpers
+  (`parse_duration`, `resolve_pod_and_container`,
+  `truncate_lines_to_byte_cap`, the `PodNotFoundError` /
+  `MultiContainerAmbiguityError` exception types).
+
+## Control flow
+
+### Startup -- registration
+
+1. `meho_backplane.connectors.kubernetes` package init:
+   * Calls `register_connector("k8s", KubernetesConnector)` (v1
+     registry, backward-compat) and `register_connector_v2(...)` with
+     the canonical `(product, version, impl_id)` triple.
+   * Registers `register_kubernetes_typed_operations` onto the
+     lifespan-driven registrar list via `register_typed_op_registrar()`.
+2. FastAPI lifespan calls `_eager_import_connectors()`, then
+   `run_typed_op_registrars()`.
+3. The K8s registrar calls
+   `KubernetesConnector.register_operations()`, which walks
+   `KUBERNETES_OPS` and feeds each entry to `register_typed_operation()`.
+   The helper:
+   * Composes an embedding text from summary / description / tags.
+   * SHA-256-hashes the text into a `body_hash`.
+   * Resolves `handler_ref` from the bound method's `__module__` +
+     `__qualname__` (e.g.
+     `meho_backplane.connectors.kubernetes.connector.KubernetesConnector.logs`).
+   * UPSERTs the `endpoint_descriptor` row. On unchanged body it skips
+     the ONNX embedding compute (body-hash skip-re-embed branch).
+
+### Dispatch -- operator/agent call
+
+1. Caller invokes `POST /api/v1/operations/call` with a
+   `connector_id="kubernetes-asyncio-1.x"` (or the legacy
+   `"k8s-1.x"` form) and an `op_id="k8s.<verb>"`.
+2. The dispatcher resolves the `endpoint_descriptor` row by
+   `(tenant_id, product, version, impl_id, op_id)`.
+3. JSON Schema validator (`Draft202012Validator`) checks `params`
+   against the descriptor's `parameter_schema`.
+4. The dispatcher imports `handler_ref` (via
+   `importlib.import_module` + chained `getattr`), binds the unbound
+   method against the registered `KubernetesConnector` instance, and
+   awaits it as `handler(target=target, params=params)`.
+5. Handler returns `dict[str, Any]`. The dispatcher's
+   `PassThroughReducer` lands that dict verbatim into
+   `OperationResult.result`. The audit subsystem writes one
+   `audit_log` row with `params_hash` derived from the input params
+   only -- log contents (or any other returned payload) are never
+   written to the audit row.
+
+### `k8s.logs` -- per-call flow
+
+1. Dispatcher validates `params` against `K8S_LOGS_PARAMETER_SCHEMA`
+   (pod_name + namespace required; tail capped at 5000; since matches
+   `^\s*\d+\s*[smhd]\s*$`).
+2. `KubernetesConnector.logs(target, params)` delegates to
+   `ops_logs.k8s_logs(connector, target, params)`.
+3. `k8s_logs` resolves the `ApiClient` for the target via
+   `connector._get_api_client(target)` (cached on secret_ref) and
+   builds a `client.CoreV1Api(api_client)`.
+4. `resolve_pod_and_container()` lists pods in the namespace, picks
+   the exact match if present, falls back to prefix match. Multi-
+   container pods without `container` raise
+   `MultiContainerAmbiguityError`; pod-not-found / ambiguous prefix
+   raises `PodNotFoundError`. Both carry the candidate list in
+   `args[1]` so the dispatcher's `connector_error` envelope can
+   surface a "did-you-mean".
+5. `parse_duration()` resolves `since` (e.g. `"5m"`) to
+   `since_seconds=300`.
+6. `tail` is defence-clamped to `MAX_TAIL_LINES=5000` even though the
+   schema already enforces it.
+7. `read_namespaced_pod_log(name, namespace, container, tail_lines,
+   since_seconds, previous)` returns the body as a single `str`.
+8. Split on `\n`, drop trailing empty line.
+9. If `len(body.encode("utf-8")) > MAX_BODY_BYTES (=1 MiB)`,
+   `truncate_lines_to_byte_cap()` drops leading lines at line
+   boundaries until the kept body fits in 1 MiB. Result carries
+   `truncated=True`, `line_count`, `byte_count`,
+   `truncated_byte_count` for operator-facing "X KiB dropped" hints.
+
+## Dependencies
+
+* `kubernetes_asyncio>=32,<33` (target K8s 1.32 API; async fork of the
+  official Python client; no thread offload; loads kubeconfig from a
+  dict).
+* `httpx` -- only used by the kubeconfig-free `probe()` against
+  `/readyz` / `/healthz`. The op dispatch path goes through
+  `kubernetes_asyncio.client.ApiClient`, not httpx.
+* `meho_backplane.operations.typed_register` -- the G0.6 registration
+  helper.
+* `meho_backplane.connectors.registry` -- v1 + v2 registries.
+* `meho_backplane.connectors.schemas` -- `OperationResult`,
+  `FingerprintResult`, `ProbeResult`.
+
+## Known issues
+
+* **Pod resolver fetches the full namespace pod list** even when the
+  caller already has the exact pod name. G3.2-T3 (#323) ships the
+  paginated server-side resolver against `read_namespaced_pod` +
+  `field_selector`; `ops_logs.resolve_pod_and_container` switches
+  to that path once T3 lands.
+* **No log streaming.** v0.2 is non-streaming by design (MCP's
+  `tools/call` envelope has no streaming shape in 2025-06-18; the
+  connector's `OperationResult` is single-response). Operators
+  following live logs continue using `kubectl-vcf.sh -f` until v0.2.next.
+* **1 MiB body cap is not configurable per-target.** The cap matches
+  the operator's typical terminal scrollback and the MCP envelope's
+  practical payload ceiling. A per-target override is v0.2.next.
+* **Audit row carries no log content.** This is deliberate (log
+  payloads would balloon audit_log rows); the audit row records only
+  the request params + `params_hash`. Operators auditing "who pulled
+  logs from argocd?" see the access pattern, not the content. If log-
+  content audit becomes a requirement, it lands as a separate
+  `audit_log_blob` table in a follow-on Goal.
+
+## References
+
+* G3.2 Initiative: [#320](https://github.com/evoila/meho/issues/320) --
+  the parent typed-connector initiative.
+* G3.2-T1: [#321](https://github.com/evoila/meho/issues/321) --
+  connector skeleton (kubeconfig-from-Vault + fingerprint + probe).
+* G3.2-T5: [#325](https://github.com/evoila/meho/issues/325) --
+  `k8s.logs` op (this addition).
+* G0.6: [#388](https://github.com/evoila/meho/issues/388) -- the
+  `register_typed_operation()` substrate this depends on.
+* G0.6-T-Refactor-K8s: [#391](https://github.com/evoila/meho/issues/391)
+  -- migration of the skeleton from `_op_map` to the typed-op registry.
+* `kubernetes_asyncio` -- https://github.com/tomplus/kubernetes_asyncio
+* K8s `/log` API:
+  https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#read-log-pod-v1-core


### PR DESCRIPTION
## Summary

- Adds the `k8s.logs` typed op to the G3.2 `kubernetes-asyncio` connector — non-streaming pod log fetch with `--tail` / `--container` / `--since` / `--previous` and a 1 MiB body cap.
- Registers via G0.6's `register_typed_operation()` (per the Initiative #320 re-scope); the handler lives in a new `ops_logs.py` module and `KubernetesConnector.logs` is the bound-method shim.
- Pod name resolution accepts an exact match or a unique prefix; multi-container pods without `--container` return a structured `MultiContainerAmbiguityError` carrying the candidate container names.
- 1 MiB body cap is applied client-side at line boundaries (kept = most-recent), so callers don't have to repair mid-line truncation. `truncated_byte_count` lands in the result on overflow.
- Adds `docs/codebase/kubernetes-connector.md` documenting the connector surface, registration flow, and the new op.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on touched files
- [x] `mypy src/meho_backplane/connectors/kubernetes/ --ignore-missing-imports` — clean
- [x] `pytest tests/test_connectors_k8s_logs.py` — 35 passed
- [x] `pytest tests/test_connectors_k8s_auth.py tests/test_connectors_k8s_dispatcher_shim.py tests/test_connectors_registry.py tests/test_operations_typed_register.py tests/test_app_starts.py tests/test_api_v1_operations.py` — 129 passed (no regression in registration / dispatcher / app-start paths)
- [x] `code-quality.py --diff` — 0 blockers, 4 size warnings (`ops_logs.py` 488 lines, `k8s_logs` handler 91 lines; both well under block thresholds and proportional to the surface area)
- [x] Acceptance criteria — every checkbox from #325 covered by a unit test (defaults `--tail 100`; explicit tail flows through; tail clamps at 5000; container selection in multi-container pod; multi-container ambiguity returns structured error with container list; `--since 5m` resolves to 300 seconds; `--previous=true` flows through; 1 MiB cap truncates from front with `truncated_byte_count`; audit shape — handler returns lines in result only)
- [ ] k3d integration (acceptance criterion #9) — deferred to G3.2-T6 (#326), which extends `tests/integration/test_connectors_k8s_k3d.py` with a pod-that-generates-logs fixture as part of the E2E gate

## Out of scope

- Live log streaming (`kubectl logs -f`) — v0.2.next once MCP `tools/call` grows a streaming envelope shape.
- Multi-pod log aggregation (`kubectl logs -l app=foo`) — out of scope.
- Log search / grep — out of scope; clients pipe `--json` through `jq` / `grep`.
- The k3d-cluster end-to-end gate ships in G3.2-T6 (#326) alongside the CLI alias verbs + onboarding doc.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubernetes pod log retrieval: prefix pod matching, multi-container selection, configurable tail/since filters, front-truncation with size cap, and structured errors for not-found/ambiguous cases.

* **Documentation**
  * Added Kubernetes connector docs describing the new log operation, behavior, limits, and execution flow.

* **Tests**
  * Added comprehensive tests covering parsing, truncation, selection logic, error cases, and end-to-end log retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->