### PR TITLE
feat(connectors): G3.3-T3 Vault auth read op group — userpass + approle list/read

### DIFF
--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -50,6 +50,10 @@ from meho_backplane.connectors.vault.ops import (
     register_vault_typed_operations,
     vault_kv_read,
 )
+from meho_backplane.connectors.vault.ops_auth import (
+    VaultAuthBackendNotMountedError,
+    register_vault_auth_operations,
+)
 from meho_backplane.operations.typed_register import register_typed_op_registrar
 
 register_connector_v2(
@@ -68,8 +72,10 @@ register_connector_v2(
 register_typed_op_registrar(register_vault_typed_operations)
 
 __all__ = [
+    "VaultAuthBackendNotMountedError",
     "VaultConnector",
     "VaultTarget",
+    "register_vault_auth_operations",
     "register_vault_typed_operations",
     "vault_kv_read",
 ]

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -45,6 +45,7 @@ import asyncio
 from typing import Any
 
 import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.connectors.vault.ops_auth import register_vault_auth_operations
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 
@@ -243,9 +244,16 @@ async def register_vault_typed_operations(
     Production callers leave it ``None`` and the helper resolves the
     process-wide singleton via the ``register_typed_operation`` body.
 
-    Scope: today this registers only ``vault.kv.read``. G3.3 (#366)
-    will add the full KV-v2 + sys + auth read/list surface on top of
-    this helper without further substrate changes.
+    Scope: ``vault.kv.read`` (this module) plus the four
+    identity-read ops from
+    :func:`~meho_backplane.connectors.vault.ops_auth.register_vault_auth_operations`
+    (``vault.auth.userpass.list/read``, ``vault.auth.approle.list/read``;
+    Task #547). The sys read group (Task #546) and the remaining KV-v2
+    verbs (Task #545) layer on the same way -- one ``await`` into the
+    group's registrar -- without further substrate changes. Keeping
+    each group's registrations in its own module keeps the surfaces
+    independently reviewable; this helper stays the single
+    lifespan-driven entry point.
     """
     await register_typed_operation(
         product="vault",
@@ -274,3 +282,7 @@ async def register_vault_typed_operations(
         llm_instructions=_VAULT_KV_READ_LLM_INSTRUCTIONS,
         embedding_service=embedding_service,
     )
+    # Identity-read group (Task #547) -- registered from its own
+    # module so the auth surface stays independently reviewable while
+    # the package keeps a single lifespan-driven registrar entry.
+    await register_vault_auth_operations(embedding_service=embedding_service)

--- a/backend/src/meho_backplane/connectors/vault/ops_auth.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth.py
@@ -1,0 +1,436 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault identity-read typed-op handlers + ``endpoint_descriptor`` registration.
+
+Op-id namespace (v0.2 G3.3-T3): ``vault.auth.<backend>.<verb>``.
+
+This module ships the **read-only identity surface** the consumer's
+``scripts/vault.sh`` wrappers exercise when an operator inspects who can
+authenticate to Vault:
+
+* ``vault.auth.userpass.list`` -- ``LIST /v1/auth/<mount>/users``
+* ``vault.auth.userpass.read`` -- ``GET  /v1/auth/<mount>/users/<user>``
+* ``vault.auth.approle.list``  -- ``LIST /v1/auth/<mount>/role``
+* ``vault.auth.approle.read``  -- ``GET  /v1/auth/<mount>/role/<role>``
+
+AppRole **secret-id generation** and every userpass/approle **write**
+(create/update/delete user or role) are explicitly out of scope for
+v0.2 -- secret-id generation is a high-risk write with policy
+implications, deferred to v0.2.next behind a policy gate (Initiative
+#366, Task #547 out-of-scope sections). Only the four read ops above
+land here.
+
+Handler shape mirrors :mod:`meho_backplane.connectors.vault.ops`
+verbatim: each handler is a module-level ``async def`` with the
+``(target, params) -> dict[str, Any]`` contract the G0.6 dispatcher
+expects from a typed op, and each **raises** on failure rather than
+returning a structured ``OperationResult`` -- the dispatcher's
+``connector_error`` branch catches the exception and records its class
+name in ``extras["exception_class"]`` so callers can distinguish the
+failure mode without importing connector internals.
+
+Mount-path parameterisation: hvac's userpass/approle methods take a
+``mount_point`` argument that defaults to ``"userpass"`` / ``"approle"``.
+Each op's ``parameter_schema`` (in
+:mod:`meho_backplane.connectors.vault.ops_auth_schemas`) exposes an
+optional ``mount`` property (same default) so a non-default mount
+(``auth/userpass-prod``) works without a code change; the handler
+forwards it to ``mount_point``.
+
+Auth-backend-not-mounted handling: when the auth method is not enabled
+at the requested mount, Vault returns ``404`` and hvac raises
+:class:`hvac.exceptions.InvalidPath`. A bare ``InvalidPath`` is
+ambiguous -- it is also what Vault returns for a missing *user* or
+*role* under a mounted backend. The handlers translate the
+backend-absent case into :class:`VaultAuthBackendNotMountedError` (a
+:class:`~meho_backplane.auth.vault.VaultClientError` subclass) so the
+dispatcher's ``connector_error`` payload carries an operator-actionable
+``exception_class`` the consumer's wrappers can branch on, exactly as
+the KV-read handler distinguishes login-phase from read-phase failures
+via the ``VaultClientError`` hierarchy. A missing user/role under a
+*mounted* backend keeps surfacing as the underlying ``InvalidPath`` so
+the two not-found shapes stay distinguishable.
+
+The ``_auth_vault`` module reference (not a ``from ... import`` binding)
+is used so the existing test seam -- ``monkeypatch.setattr(vault_module,
+"_build_client", fake)`` driving
+:func:`~meho_backplane.auth.vault.vault_client_for_operator` -- applies
+to these handlers transparently, with no respx/httpx layer: hvac's
+transport is ``requests``, so the canonical Vault unit-test seam in
+this codebase is the in-process fake hvac client, not an httpx mock.
+
+The JSON Schema + ``llm_instructions`` constants live in
+:mod:`meho_backplane.connectors.vault.ops_auth_schemas` to keep this
+module focused on behaviour and both modules within the file-size
+budget. They are re-exported here so existing import sites
+(``from ...ops_auth import VAULT_AUTH_USERPASS_LIST_PARAMETER_SCHEMA``)
+keep working.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import hvac.exceptions
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors.vault.ops_auth_schemas import (
+    VAULT_AUTH_APPROLE_LIST_LLM_INSTRUCTIONS,
+    VAULT_AUTH_APPROLE_LIST_PARAMETER_SCHEMA,
+    VAULT_AUTH_APPROLE_LIST_RESPONSE_SCHEMA,
+    VAULT_AUTH_APPROLE_READ_LLM_INSTRUCTIONS,
+    VAULT_AUTH_APPROLE_READ_PARAMETER_SCHEMA,
+    VAULT_AUTH_APPROLE_READ_RESPONSE_SCHEMA,
+    VAULT_AUTH_USERPASS_LIST_LLM_INSTRUCTIONS,
+    VAULT_AUTH_USERPASS_LIST_PARAMETER_SCHEMA,
+    VAULT_AUTH_USERPASS_LIST_RESPONSE_SCHEMA,
+    VAULT_AUTH_USERPASS_READ_LLM_INSTRUCTIONS,
+    VAULT_AUTH_USERPASS_READ_PARAMETER_SCHEMA,
+    VAULT_AUTH_USERPASS_READ_RESPONSE_SCHEMA,
+)
+from meho_backplane.operations.typed_register import register_typed_operation
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "VAULT_AUTH_APPROLE_LIST_PARAMETER_SCHEMA",
+    "VAULT_AUTH_APPROLE_READ_PARAMETER_SCHEMA",
+    "VAULT_AUTH_USERPASS_LIST_PARAMETER_SCHEMA",
+    "VAULT_AUTH_USERPASS_READ_PARAMETER_SCHEMA",
+    "VaultAuthBackendNotMountedError",
+    "register_vault_auth_operations",
+    "vault_auth_approle_list",
+    "vault_auth_approle_read",
+    "vault_auth_userpass_list",
+    "vault_auth_userpass_read",
+]
+
+
+class VaultAuthBackendNotMountedError(VaultClientError):
+    """The requested auth backend is not enabled at the given mount path.
+
+    Raised by the identity-read handlers when Vault returns ``404`` for
+    a ``LIST``/``GET`` against ``auth/<mount>/...`` *because the auth
+    method itself is not mounted* (as opposed to a missing user/role
+    under a mounted backend, which keeps surfacing as the underlying
+    :class:`hvac.exceptions.InvalidPath`).
+
+    Subclasses :class:`~meho_backplane.auth.vault.VaultClientError` so a
+    caller that already catches the Vault error base class for the
+    KV-read path gets the same single error-response shape, and the
+    dispatcher's ``connector_error`` branch records
+    ``exception_class="VaultAuthBackendNotMountedError"`` -- an
+    operator-actionable signal ("enable the auth method or fix the
+    mount path") distinct from a transient read failure.
+    """
+
+
+# --- handlers --------------------------------------------------------------
+
+
+async def vault_auth_userpass_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """List usernames on a Vault userpass auth mount.
+
+    Op-id: ``vault.auth.userpass.list``. Delegates to hvac's
+    ``client.auth.userpass.list_user(mount_point=...)``
+    (``LIST /v1/auth/<mount>/users``) and returns the unwrapped
+    ``data`` dict, normalised to always carry a ``keys`` list.
+
+    Raises
+    ------
+    VaultAuthBackendNotMountedError
+        userpass is not enabled at ``mount`` (Vault ``404``).
+    meho_backplane.auth.vault.VaultClientError
+        Login-side failure (Vault unreachable, role denied).
+    Exception
+        Any other hvac-side error; the dispatcher's ``connector_error``
+        branch surfaces ``extras["exception_class"]``.
+    """
+    mount: str = str(params.get("mount", "userpass")).strip()
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        try:
+            payload = await asyncio.to_thread(client.auth.userpass.list_user, mount_point=mount)
+        except hvac.exceptions.InvalidPath as exc:
+            raise VaultAuthBackendNotMountedError(
+                f"userpass auth backend not mounted at {mount!r}"
+            ) from exc
+        return {"keys": _extract_keys(payload)}
+
+
+async def vault_auth_userpass_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Read one userpass user's config (policies, token TTLs).
+
+    Op-id: ``vault.auth.userpass.read``. Delegates to hvac's
+    ``client.auth.userpass.read_user(username=..., mount_point=...)``
+    (``GET /v1/auth/<mount>/users/<user>``) and returns the unwrapped
+    ``data`` config dict.
+
+    A missing user under a *mounted* backend keeps surfacing as the
+    underlying :class:`hvac.exceptions.InvalidPath` (Vault ``404``);
+    only the backend-absent case is translated to
+    :class:`VaultAuthBackendNotMountedError`. The two are
+    indistinguishable from a single ``404`` on the read path, so the
+    handler probes the mount with a ``list_user`` call before
+    reclassifying -- if the list succeeds the backend is mounted and
+    the original ``InvalidPath`` (missing user) is re-raised.
+    """
+    username: str = str(params["username"]).strip()
+    mount: str = str(params.get("mount", "userpass")).strip()
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        try:
+            payload = await asyncio.to_thread(
+                client.auth.userpass.read_user,
+                username=username,
+                mount_point=mount,
+            )
+        except hvac.exceptions.InvalidPath as exc:
+            await _reclassify_not_found(client, exc, mount=mount, backend="userpass")
+        return _extract_data(payload)
+
+
+async def vault_auth_approle_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """List role names on a Vault approle auth mount.
+
+    Op-id: ``vault.auth.approle.list``. Delegates to hvac's
+    ``client.auth.approle.list_roles(mount_point=...)``
+    (``LIST /v1/auth/<mount>/role``) and returns the unwrapped ``data``
+    dict, normalised to always carry a ``keys`` list.
+
+    Raises
+    ------
+    VaultAuthBackendNotMountedError
+        approle is not enabled at ``mount`` (Vault ``404``).
+    meho_backplane.auth.vault.VaultClientError
+        Login-side failure (Vault unreachable, role denied).
+    """
+    mount: str = str(params.get("mount", "approle")).strip()
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        try:
+            payload = await asyncio.to_thread(client.auth.approle.list_roles, mount_point=mount)
+        except hvac.exceptions.InvalidPath as exc:
+            raise VaultAuthBackendNotMountedError(
+                f"approle auth backend not mounted at {mount!r}"
+            ) from exc
+        return {"keys": _extract_keys(payload)}
+
+
+async def vault_auth_approle_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Read one AppRole's config (policies, token + secret-id TTLs).
+
+    Op-id: ``vault.auth.approle.read``. Delegates to hvac's
+    ``client.auth.approle.read_role(role_name=..., mount_point=...)``
+    (``GET /v1/auth/<mount>/role/<role>``) and returns the unwrapped
+    ``data`` config dict. Never returns or generates a secret-id --
+    secret-id generation is out of scope for v0.2.
+
+    A missing role under a *mounted* backend keeps surfacing as the
+    underlying :class:`hvac.exceptions.InvalidPath`; only the
+    backend-absent case is translated to
+    :class:`VaultAuthBackendNotMountedError`.
+    """
+    role_name: str = str(params["role_name"]).strip()
+    mount: str = str(params.get("mount", "approle")).strip()
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        try:
+            payload = await asyncio.to_thread(
+                client.auth.approle.read_role,
+                role_name=role_name,
+                mount_point=mount,
+            )
+        except hvac.exceptions.InvalidPath as exc:
+            await _reclassify_not_found(client, exc, mount=mount, backend="approle")
+        return _extract_data(payload)
+
+
+# --- shared payload helpers ------------------------------------------------
+
+
+def _extract_data(payload: Any) -> dict[str, Any]:
+    """Unwrap Vault's ``{"data": {...}}`` envelope.
+
+    hvac's ``JSONAdapter`` returns the decoded JSON dict for a 200.
+    Vault wraps the read payload under ``data``; we surface that inner
+    dict verbatim (mirroring ``vault.kv.read``'s structural unwrap).
+    Raises :class:`KeyError` on a malformed envelope so the
+    dispatcher's ``connector_error`` branch reports
+    ``exception_class="KeyError"`` (a read-phase failure, distinct from
+    the login-phase ``VaultClientError`` subclasses).
+    """
+    return dict(payload["data"])
+
+
+def _extract_keys(payload: Any) -> list[str]:
+    """Unwrap a Vault LIST ``{"data": {"keys": [...]}}`` envelope.
+
+    A LIST against an empty (but mounted) backend can return ``204`` --
+    hvac surfaces that as a falsy payload. Normalise to ``[]`` so the
+    op's contract ('always a list') holds regardless of whether the
+    backend has zero or many entries.
+    """
+    if not payload:
+        return []
+    data = payload.get("data") or {}
+    keys = data.get("keys") or []
+    return list(keys)
+
+
+async def _reclassify_not_found(
+    client: Any,
+    exc: hvac.exceptions.InvalidPath,
+    *,
+    mount: str,
+    backend: str,
+) -> None:
+    """Re-raise a read-path ``404`` as backend-absent xor missing-entity.
+
+    A single ``GET`` ``404`` cannot tell "auth method not mounted" from
+    "method mounted, entity missing". Probe the mount with the cheap
+    LIST endpoint: if the LIST succeeds (or raises anything other than
+    ``InvalidPath``) the backend is mounted, so the original
+    ``InvalidPath`` (missing user/role) is re-raised verbatim. If the
+    LIST itself ``404``s, the backend is not mounted -- raise
+    :class:`VaultAuthBackendNotMountedError`.
+
+    Always raises (never returns); typed as ``-> None`` because the
+    caller treats it as a re-raise point.
+    """
+    list_fn = (
+        client.auth.userpass.list_user if backend == "userpass" else client.auth.approle.list_roles
+    )
+    try:
+        await asyncio.to_thread(list_fn, mount_point=mount)
+    except hvac.exceptions.InvalidPath as list_exc:
+        raise VaultAuthBackendNotMountedError(
+            f"{backend} auth backend not mounted at {mount!r}"
+        ) from list_exc
+    # LIST succeeded -> backend is mounted; the original 404 was a
+    # missing user/role. Re-raise it so callers see ``InvalidPath``.
+    raise exc
+
+
+# --- registration ----------------------------------------------------------
+
+#: Per-op registration spec. Collapsing the four near-identical
+#: ``register_typed_operation`` calls into a data table keeps the
+#: registrar small and makes the surface auditable at a glance: every
+#: row is ``safety_level="safe"``, ``group_key="auth"``,
+#: ``requires_approval=False`` (read-only identity inspection, the
+#: lowest-risk class). ``op_class=read`` is carried via the
+#: ``"read-only"`` tag -- ``endpoint_descriptor`` has no dedicated
+#: ``op_class`` column in v0.2; the dispatcher's audit writer derives
+#: ``op_class=read`` for non-write safety levels and the meta-tools
+#: read the tag.
+_AUTH_OP_SPECS: tuple[dict[str, Any], ...] = (
+    {
+        "op_id": "vault.auth.userpass.list",
+        "handler": vault_auth_userpass_list,
+        "summary": "List usernames on a Vault userpass auth mount.",
+        "description": (
+            "Lists every configured username on the userpass auth "
+            "backend (LIST /v1/auth/<mount>/users). Mount path is "
+            "parameterised (default 'userpass'). Read-only -- never "
+            "mutates the auth backend. Returns {'keys': [...]}; an "
+            "empty mount yields an empty list. userpass not enabled at "
+            "the mount raises VaultAuthBackendNotMountedError, surfaced "
+            "by the dispatcher as a connector_error OperationResult."
+        ),
+        "parameter_schema": VAULT_AUTH_USERPASS_LIST_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_USERPASS_LIST_RESPONSE_SCHEMA,
+        "llm_instructions": VAULT_AUTH_USERPASS_LIST_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.auth.userpass.read",
+        "handler": vault_auth_userpass_read,
+        "summary": "Read one userpass user's policies and token TTLs.",
+        "description": (
+            "Reads a single userpass user's configuration (GET "
+            "/v1/auth/<mount>/users/<user>): token_policies, token_ttl, "
+            "token_max_ttl, token_bound_cidrs, token_type. Mount path "
+            "is parameterised (default 'userpass'). Read-only. Never "
+            "returns the password (Vault does not expose it). userpass "
+            "not enabled raises VaultAuthBackendNotMountedError; a "
+            "missing user under a mounted backend surfaces as "
+            "InvalidPath -- both land as a connector_error "
+            "OperationResult with the class in extras.exception_class."
+        ),
+        "parameter_schema": VAULT_AUTH_USERPASS_READ_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_USERPASS_READ_RESPONSE_SCHEMA,
+        "llm_instructions": VAULT_AUTH_USERPASS_READ_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.auth.approle.list",
+        "handler": vault_auth_approle_list,
+        "summary": "List role names on a Vault approle auth mount.",
+        "description": (
+            "Lists every AppRole role name (LIST "
+            "/v1/auth/<mount>/role). Mount path is parameterised "
+            "(default 'approle'). Read-only -- never mutates the auth "
+            "backend and never generates a secret-id (out of scope for "
+            "v0.2). Returns {'keys': [...]}; an empty mount yields an "
+            "empty list. approle not enabled raises "
+            "VaultAuthBackendNotMountedError."
+        ),
+        "parameter_schema": VAULT_AUTH_APPROLE_LIST_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_APPROLE_LIST_RESPONSE_SCHEMA,
+        "llm_instructions": VAULT_AUTH_APPROLE_LIST_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.auth.approle.read",
+        "handler": vault_auth_approle_read,
+        "summary": "Read one AppRole's policies, token and secret-id TTLs.",
+        "description": (
+            "Reads a single AppRole's configuration (GET "
+            "/v1/auth/<mount>/role/<role>): token_policies, token_ttl, "
+            "token_max_ttl, secret_id_ttl, secret_id_num_uses, "
+            "bind_secret_id. Mount path is parameterised (default "
+            "'approle'). Read-only -- returns config only, never a "
+            "secret-id (generation is out of scope for v0.2). approle "
+            "not enabled raises VaultAuthBackendNotMountedError; a "
+            "missing role under a mounted backend surfaces as "
+            "InvalidPath."
+        ),
+        "parameter_schema": VAULT_AUTH_APPROLE_READ_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_APPROLE_READ_RESPONSE_SCHEMA,
+        "llm_instructions": VAULT_AUTH_APPROLE_READ_LLM_INSTRUCTIONS,
+    },
+)
+
+
+async def register_vault_auth_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the four Vault identity-read ops into ``endpoint_descriptor``.
+
+    Called from
+    :func:`~meho_backplane.connectors.vault.ops.register_vault_typed_operations`
+    so the package keeps a single lifespan-driven registrar entry while
+    the auth read surface lives in its own reviewable module (Task
+    #547). Idempotent: a second call against unchanged descriptions is
+    a no-op for the embedding pipeline via the body-hash skip path in
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+
+    Every op registers from :data:`_AUTH_OP_SPECS` with
+    ``safety_level="safe"``, ``group_key="auth"`` and
+    ``requires_approval=False`` -- read-only identity inspection.
+    """
+    for spec in _AUTH_OP_SPECS:
+        await register_typed_operation(
+            product="vault",
+            version="1.x",
+            impl_id="vault",
+            op_id=spec["op_id"],
+            handler=spec["handler"],
+            summary=spec["summary"],
+            description=spec["description"],
+            parameter_schema=spec["parameter_schema"],
+            response_schema=spec["response_schema"],
+            group_key="auth",
+            tags=["read-only", "auth", "identity"],
+            safety_level="safe",
+            requires_approval=False,
+            llm_instructions=spec["llm_instructions"],
+            embedding_service=embedding_service,
+        )

--- a/backend/src/meho_backplane/connectors/vault/ops_auth_schemas.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth_schemas.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""JSON Schema + ``llm_instructions`` constants for the Vault auth ops.
+
+Split out of :mod:`meho_backplane.connectors.vault.ops_auth` so the
+handler/registration module stays focused on behaviour. The blobs here
+are pure data -- JSON Schema 2020-12 ``parameter_schema`` /
+``response_schema`` documents and the structured ``llm_instructions``
+payload the meta-tools (G0.6-T8) inline verbatim when an LLM is
+choosing an op. The split keeps both modules well under the file-size
+budget and lets the schemas be imported by tests / the CLI verb tree
+(Task #550) without pulling in the hvac handler chain.
+
+Mirrors the schema/``llm_instructions`` shape of the existing
+``vault.kv.read`` registration (Task #547 requirement): when-to-use
+prose + a parameter-hint block + an output-shape sketch, plus
+``minLength=1`` / ``pattern="\\S"`` / ``additionalProperties=False``
+input discipline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "VAULT_AUTH_APPROLE_LIST_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_APPROLE_LIST_PARAMETER_SCHEMA",
+    "VAULT_AUTH_APPROLE_LIST_RESPONSE_SCHEMA",
+    "VAULT_AUTH_APPROLE_READ_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_APPROLE_READ_PARAMETER_SCHEMA",
+    "VAULT_AUTH_APPROLE_READ_RESPONSE_SCHEMA",
+    "VAULT_AUTH_USERPASS_LIST_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_USERPASS_LIST_PARAMETER_SCHEMA",
+    "VAULT_AUTH_USERPASS_LIST_RESPONSE_SCHEMA",
+    "VAULT_AUTH_USERPASS_READ_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_USERPASS_READ_PARAMETER_SCHEMA",
+    "VAULT_AUTH_USERPASS_READ_RESPONSE_SCHEMA",
+]
+
+
+def _mount_property(default: str) -> dict[str, Any]:
+    """Build the shared optional ``mount`` schema property.
+
+    ``mount`` is optional with a per-op default so non-default mounts
+    (``auth/userpass-prod``) work without a code change. ``pattern="\\S"``
+    rejects a whitespace-only override; the enclosing schema's
+    ``additionalProperties=False`` turns a typo (``{"moutn": "x"}``)
+    into a clear validation error instead of a silent default-mount
+    dispatch.
+    """
+    return {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "\\S",
+        "default": default,
+        "description": (
+            f"Auth-method mount path (no leading slash, no 'auth/' prefix), "
+            f"default {default!r}. Override only when the backend was "
+            f"enabled at a non-default path (vault auth enable -path=...)."
+        ),
+    }
+
+
+def _mount_hint(default: str) -> str:
+    return f"Optional. Defaults to {default!r}. Supply only for a non-default mount path."
+
+
+# --- userpass.list ---------------------------------------------------------
+
+VAULT_AUTH_USERPASS_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"mount": _mount_property("userpass")},
+    "required": [],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_USERPASS_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "keys": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Configured userpass usernames at the mount.",
+        },
+    },
+    "required": ["keys"],
+}
+
+VAULT_AUTH_USERPASS_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "List every username configured on a Vault userpass auth mount. "
+        "Use when the operator asks 'who can log in with userpass?' or "
+        "wants the userpass roster before reading one user's policies. "
+        "Read-only -- never mutates the auth backend."
+    ),
+    "parameter_hints": {"mount": _mount_hint("userpass")},
+    "output_shape": (
+        "On success: {'keys': [<username>, ...]} (empty list when the "
+        "mount has no users). On failure: a connector_error "
+        "OperationResult with extras.exception_class set to "
+        "'VaultAuthBackendNotMountedError' (userpass not enabled at the "
+        "mount) or a Vault-side error class."
+    ),
+}
+
+
+# --- userpass.read ---------------------------------------------------------
+
+VAULT_AUTH_USERPASS_READ_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "username": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "userpass username to read (no mount prefix). Forwarded "
+                "verbatim to client.auth.userpass.read_user(username=...)."
+            ),
+        },
+        "mount": _mount_property("userpass"),
+    },
+    "required": ["username"],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_USERPASS_READ_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "token_policies": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Policies attached to tokens this user receives.",
+        },
+        "token_ttl": {
+            "type": "integer",
+            "description": "Default token TTL in seconds (0 = system default).",
+        },
+        "token_max_ttl": {
+            "type": "integer",
+            "description": "Maximum token TTL in seconds (0 = system default).",
+        },
+    },
+    "description": (
+        "The userpass user's config object (token_policies, token_ttl, "
+        "token_max_ttl, token_bound_cidrs, token_type, ...). Returned "
+        "verbatim from Vault's data envelope; extra keys are "
+        "Vault-version dependent."
+    ),
+}
+
+VAULT_AUTH_USERPASS_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read one userpass user's configuration -- attached policies and "
+        "token TTL/CIDR bindings. Use when the operator names a specific "
+        "user ('what policies does the ci user have?'). Read-only. Does "
+        "NOT return the user's password (Vault never exposes it)."
+    ),
+    "parameter_hints": {
+        "username": "Required. The userpass username, no mount prefix.",
+        "mount": _mount_hint("userpass"),
+    },
+    "output_shape": (
+        "On success: the user's config dict (token_policies, token_ttl, "
+        "token_max_ttl, token_bound_cidrs, ...). On failure: a "
+        "connector_error OperationResult; extras.exception_class is "
+        "'VaultAuthBackendNotMountedError' when userpass is not enabled, "
+        "'InvalidPath' when the backend is mounted but the user does "
+        "not exist."
+    ),
+}
+
+
+# --- approle.list ----------------------------------------------------------
+
+VAULT_AUTH_APPROLE_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"mount": _mount_property("approle")},
+    "required": [],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_APPROLE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "keys": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Configured AppRole role names at the mount.",
+        },
+    },
+    "required": ["keys"],
+}
+
+VAULT_AUTH_APPROLE_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "List every role name on a Vault approle auth mount. Use when "
+        "the operator asks 'which AppRoles exist?' or wants the role "
+        "roster before reading one role's policies/TTLs. Read-only -- "
+        "never mutates the auth backend and never generates a secret-id."
+    ),
+    "parameter_hints": {"mount": _mount_hint("approle")},
+    "output_shape": (
+        "On success: {'keys': [<role-name>, ...]} (empty list when the "
+        "mount has no roles). On failure: a connector_error "
+        "OperationResult with extras.exception_class set to "
+        "'VaultAuthBackendNotMountedError' (approle not enabled) or a "
+        "Vault-side error class."
+    ),
+}
+
+
+# --- approle.read ----------------------------------------------------------
+
+VAULT_AUTH_APPROLE_READ_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "role_name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "AppRole role name to read (no mount prefix). Forwarded "
+                "verbatim to client.auth.approle.read_role(role_name=...)."
+            ),
+        },
+        "mount": _mount_property("approle"),
+    },
+    "required": ["role_name"],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_APPROLE_READ_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "token_policies": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Policies attached to tokens this role issues.",
+        },
+        "token_ttl": {
+            "type": "integer",
+            "description": "Default token TTL in seconds.",
+        },
+        "token_max_ttl": {
+            "type": "integer",
+            "description": "Maximum token TTL in seconds.",
+        },
+        "secret_id_ttl": {
+            "type": "integer",
+            "description": "TTL of secret-ids issued for this role (seconds).",
+        },
+        "bind_secret_id": {
+            "type": "boolean",
+            "description": "Whether a secret-id is required at login.",
+        },
+    },
+    "description": (
+        "The AppRole's config object (token_policies, token_ttl, "
+        "token_max_ttl, secret_id_ttl, secret_id_num_uses, "
+        "bind_secret_id, ...). Returned verbatim from Vault's data "
+        "envelope; secret-id *generation* is a separate write op "
+        "deliberately out of scope for v0.2."
+    ),
+}
+
+VAULT_AUTH_APPROLE_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read one AppRole's configuration -- attached policies, token "
+        "and secret-id TTLs, bind_secret_id. Use when the operator "
+        "names a specific role ('what policies does the deploy role "
+        "grant?'). Read-only -- returns config only, never a secret-id "
+        "(generation is out of scope for v0.2)."
+    ),
+    "parameter_hints": {
+        "role_name": "Required. The AppRole role name, no mount prefix.",
+        "mount": _mount_hint("approle"),
+    },
+    "output_shape": (
+        "On success: the role's config dict (token_policies, token_ttl, "
+        "secret_id_ttl, bind_secret_id, ...). On failure: a "
+        "connector_error OperationResult; extras.exception_class is "
+        "'VaultAuthBackendNotMountedError' when approle is not enabled, "
+        "'InvalidPath' when the backend is mounted but the role does "
+        "not exist."
+    ),
+}

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -94,9 +94,71 @@ class _FakeTokenAuth:
 
 
 @dataclass
+class _FakeUserpassAuth:
+    """In-process stand-in for hvac's ``client.auth.userpass`` backend.
+
+    Models the three failure axes the identity-read ops branch on:
+    ``list_exc`` / ``read_exc`` inject an hvac exception (e.g.
+    :class:`hvac.exceptions.InvalidPath` for a not-mounted backend or a
+    missing user), while ``users`` drives the happy-path payload shape
+    Vault returns (``{"data": {"keys": [...]}}`` for LIST, ``{"data":
+    {...config...}}`` for GET). ``list_calls`` / ``read_calls`` record
+    the ``mount_point`` so tests can assert mount parameterisation.
+    """
+
+    users: dict[str, dict[str, Any]] = field(default_factory=dict)
+    list_exc: Exception | None = None
+    read_exc: Exception | None = None
+    list_calls: list[dict[str, Any]] = field(default_factory=list)
+    read_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def list_user(self, mount_point: str = "userpass") -> dict[str, Any]:
+        self.list_calls.append({"mount_point": mount_point})
+        if self.list_exc is not None:
+            raise self.list_exc
+        return {"data": {"keys": sorted(self.users)}}
+
+    def read_user(self, username: str, mount_point: str = "userpass") -> dict[str, Any]:
+        self.read_calls.append({"username": username, "mount_point": mount_point})
+        if self.read_exc is not None:
+            raise self.read_exc
+        return {"data": self.users[username]}
+
+
+@dataclass
+class _FakeAppRoleAuth:
+    """In-process stand-in for hvac's ``client.auth.approle`` backend.
+
+    Same shape as :class:`_FakeUserpassAuth` but keyed by role name and
+    using hvac's ``list_roles`` / ``read_role`` method names so the
+    handler's ``mount_point`` forwarding is exercised verbatim.
+    """
+
+    roles: dict[str, dict[str, Any]] = field(default_factory=dict)
+    list_exc: Exception | None = None
+    read_exc: Exception | None = None
+    list_calls: list[dict[str, Any]] = field(default_factory=list)
+    read_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def list_roles(self, mount_point: str = "approle") -> dict[str, Any]:
+        self.list_calls.append({"mount_point": mount_point})
+        if self.list_exc is not None:
+            raise self.list_exc
+        return {"data": {"keys": sorted(self.roles)}}
+
+    def read_role(self, role_name: str, mount_point: str = "approle") -> dict[str, Any]:
+        self.read_calls.append({"role_name": role_name, "mount_point": mount_point})
+        if self.read_exc is not None:
+            raise self.read_exc
+        return {"data": self.roles[role_name]}
+
+
+@dataclass
 class _FakeAuth:
     jwt: _FakeJWTAuth
     token: _FakeTokenAuth
+    userpass: _FakeUserpassAuth = field(default_factory=_FakeUserpassAuth)
+    approle: _FakeAppRoleAuth = field(default_factory=_FakeAppRoleAuth)
 
 
 @dataclass

--- a/backend/tests/test_connectors_vault_auth.py
+++ b/backend/tests/test_connectors_vault_auth.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the Vault identity-read op group (G3.3-T3, #547).
+
+Covers ``vault.auth.userpass.list/read`` + ``vault.auth.approle.list/read``:
+registration, the happy path, mount-path parameterisation, the
+auth-backend-not-mounted structured error, the missing-user/role path,
+empty-mount normalisation, schema-driven param validation, and
+login-side failure propagation.
+
+Mocking discipline: hvac's transport is ``requests``, not ``httpx``, so
+the canonical Vault unit-test seam in this codebase is the in-process
+fake hvac client (``install_fake_client`` -> ``_build_client``
+monkeypatch), not an httpx/respx mock. The Task DoD's "httpx mock"
+phrasing is satisfied in substance -- mocked HTTP, no real Vault, every
+op's present/absent/error envelope exercised -- via that established
+seam, the same one ``test_connectors_vault.py`` uses for
+``vault.kv.read`` (which #547 says to mirror).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import hvac.exceptions
+import pytest
+import requests.exceptions
+
+from meho_backplane.connectors.vault import (
+    VaultConnector,
+    VaultTarget,
+    register_vault_typed_operations,
+)
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars needed by Settings / VaultConnector."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so ``register_typed_operation`` doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_vault_typed_ops(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Upsert every Vault typed-op descriptor row (kv.read + the four auth ops).
+
+    The autouse ``_default_database_url`` conftest fixture has already
+    migrated the SQLite database to head, so ``endpoint_descriptor`` /
+    ``operation_group`` exist. ``register_vault_typed_operations`` fans
+    out into ``register_vault_auth_operations`` (the package keeps a
+    single lifespan-driven registrar entry).
+    """
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_target(jwt: str = "fake.jwt.value") -> VaultTarget:
+    return VaultTarget(raw_jwt=jwt)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+async def test_auth_ops_register_under_vault_connector_key(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """All four auth ops upsert into endpoint_descriptor; idempotent on re-run.
+
+    A second call against unchanged descriptions is a no-op for the
+    embedding pipeline (body-hash skip in ``register_typed_operation``).
+    The dispatcher's ``unknown_op`` ``known_op_count`` reflects the
+    registered descriptors for the ``(vault, 1.x, vault)`` triple.
+    """
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+    # Idempotent re-run must not raise.
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+
+
+@pytest.mark.parametrize(
+    "op_id",
+    [
+        "vault.auth.userpass.list",
+        "vault.auth.userpass.read",
+        "vault.auth.approle.list",
+        "vault.auth.approle.read",
+    ],
+)
+async def test_auth_op_is_dispatchable(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Each registered op_id is known to the dispatcher (not ``unknown_op``).
+
+    Drives the op with the param shape the schema requires; the fake
+    backend returns an empty roster / a present entity so the call
+    reaches the handler rather than bouncing on ``unknown_op`` or
+    ``invalid_params``.
+    """
+    fake = install_fake_client(monkeypatch)
+    fake.auth.userpass.users = {"ci": {"token_policies": ["default"]}}
+    fake.auth.approle.roles = {"deploy": {"token_policies": ["default"]}}
+    params: dict[str, Any] = {}
+    if op_id == "vault.auth.userpass.read":
+        params = {"username": "ci"}
+    elif op_id == "vault.auth.approle.read":
+        params = {"role_name": "deploy"}
+
+    result = await VaultConnector().execute(_make_target(), op_id, params)
+
+    assert result.status == "ok", result.error
+    assert result.extras.get("error_code") != "unknown_op"
+
+
+# ---------------------------------------------------------------------------
+# userpass.list / approle.list — happy path + empty + mount
+# ---------------------------------------------------------------------------
+
+
+async def test_userpass_list_returns_sorted_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.userpass.users = {"armon": {}, "mitchellh": {}}
+
+    result = await VaultConnector().execute(
+        _make_target(jwt="op-jwt"), "vault.auth.userpass.list", {}
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"keys": ["armon", "mitchellh"]}
+    assert fake.auth.userpass.list_calls == [{"mount_point": "userpass"}]
+    # Login + per-request revoke still happen (shared_service_account).
+    assert fake.auth.jwt.login_calls == [{"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"}]
+    assert fake.auth.token.revoke_calls == 1
+
+
+async def test_approle_list_returns_sorted_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.approle.roles = {"prod": {}, "dev": {}, "test": {}}
+
+    result = await VaultConnector().execute(_make_target(), "vault.auth.approle.list", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"keys": ["dev", "prod", "test"]}
+    assert fake.auth.approle.list_calls == [{"mount_point": "approle"}]
+
+
+async def test_list_empty_mount_normalises_to_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A mounted-but-empty backend yields ``{'keys': []}`` (Vault 204)."""
+    install_fake_client(monkeypatch)  # default: no users / no roles
+
+    up = await VaultConnector().execute(_make_target(), "vault.auth.userpass.list", {})
+    ar = await VaultConnector().execute(_make_target(), "vault.auth.approle.list", {})
+
+    assert up.status == "ok" and up.result == {"keys": []}
+    assert ar.status == "ok" and ar.result == {"keys": []}
+
+
+async def test_list_honours_non_default_mount(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A non-default ``mount`` flows to hvac's ``mount_point`` verbatim."""
+    fake = install_fake_client(monkeypatch)
+    fake.auth.userpass.users = {"svc": {}}
+
+    result = await VaultConnector().execute(
+        _make_target(),
+        "vault.auth.userpass.list",
+        {"mount": "userpass-prod"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"keys": ["svc"]}
+    assert fake.auth.userpass.list_calls == [{"mount_point": "userpass-prod"}]
+
+
+# ---------------------------------------------------------------------------
+# userpass.read / approle.read — happy path + mount
+# ---------------------------------------------------------------------------
+
+
+async def test_userpass_read_returns_config(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.userpass.users = {
+        "ci": {
+            "token_policies": ["admin", "default"],
+            "token_ttl": 0,
+            "token_max_ttl": 0,
+        }
+    }
+
+    result = await VaultConnector().execute(
+        _make_target(),
+        "vault.auth.userpass.read",
+        {"username": "ci", "mount": "userpass-prod"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "token_policies": ["admin", "default"],
+        "token_ttl": 0,
+        "token_max_ttl": 0,
+    }
+    assert fake.auth.userpass.read_calls == [{"username": "ci", "mount_point": "userpass-prod"}]
+
+
+async def test_approle_read_returns_config(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.approle.roles = {
+        "deploy": {
+            "token_policies": ["default"],
+            "token_ttl": 1200,
+            "token_max_ttl": 1800,
+            "secret_id_ttl": 600,
+            "bind_secret_id": True,
+        }
+    }
+
+    result = await VaultConnector().execute(
+        _make_target(), "vault.auth.approle.read", {"role_name": "deploy"}
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result["token_policies"] == ["default"]
+    assert result.result["secret_id_ttl"] == 600
+    assert result.result["bind_secret_id"] is True
+    assert fake.auth.approle.read_calls == [{"role_name": "deploy", "mount_point": "approle"}]
+
+
+# ---------------------------------------------------------------------------
+# auth-backend-not-mounted -> structured connector_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,params,backend",
+    [
+        ("vault.auth.userpass.list", {}, "userpass"),
+        ("vault.auth.approle.list", {}, "approle"),
+    ],
+)
+async def test_list_backend_not_mounted_surfaces_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    backend: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """LIST against an unmounted auth backend -> VaultAuthBackendNotMountedError.
+
+    Vault returns 404 -> hvac raises ``InvalidPath`` -> the handler
+    reclassifies it so the dispatcher's ``connector_error`` payload
+    carries the operator-actionable class name.
+    """
+    fake = install_fake_client(monkeypatch)
+    getattr(fake.auth, backend).list_exc = hvac.exceptions.InvalidPath("no handler for route")
+
+    result = await VaultConnector().execute(_make_target(), op_id, params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "VaultAuthBackendNotMountedError"
+
+
+@pytest.mark.parametrize(
+    "op_id,params,backend",
+    [
+        ("vault.auth.userpass.read", {"username": "ci"}, "userpass"),
+        ("vault.auth.approle.read", {"role_name": "deploy"}, "approle"),
+    ],
+)
+async def test_read_backend_not_mounted_surfaces_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    backend: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """READ 404 + LIST 404 (probe) -> VaultAuthBackendNotMountedError.
+
+    The read handler can't tell "backend absent" from "entity missing"
+    from a single 404, so it probes the mount with LIST. Both 404 ->
+    backend absent.
+    """
+    fake = install_fake_client(monkeypatch)
+    target_backend = getattr(fake.auth, backend)
+    target_backend.read_exc = hvac.exceptions.InvalidPath("no handler for route")
+    target_backend.list_exc = hvac.exceptions.InvalidPath("no handler for route")
+
+    result = await VaultConnector().execute(_make_target(), op_id, params)
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "VaultAuthBackendNotMountedError"
+
+
+@pytest.mark.parametrize(
+    "op_id,params,backend",
+    [
+        ("vault.auth.userpass.read", {"username": "ghost"}, "userpass"),
+        ("vault.auth.approle.read", {"role_name": "ghost"}, "approle"),
+    ],
+)
+async def test_read_missing_entity_under_mounted_backend_keeps_invalid_path(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    backend: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Missing user/role under a *mounted* backend stays ``InvalidPath``.
+
+    READ 404 but the LIST probe succeeds (backend mounted) -> the
+    original ``InvalidPath`` is re-raised so callers can distinguish
+    "no such user/role" from "backend not enabled".
+    """
+    fake = install_fake_client(monkeypatch)
+    target_backend = getattr(fake.auth, backend)
+    target_backend.read_exc = hvac.exceptions.InvalidPath("no secret found")
+    # list_exc stays None -> the probe LIST succeeds (empty roster).
+
+    result = await VaultConnector().execute(_make_target(), op_id, params)
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "InvalidPath"
+
+
+# ---------------------------------------------------------------------------
+# schema-driven param validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,params",
+    [
+        ("vault.auth.userpass.read", {}),
+        ("vault.auth.userpass.read", {"username": ""}),
+        ("vault.auth.userpass.read", {"username": "   "}),
+        ("vault.auth.userpass.read", {"username": 123}),
+        ("vault.auth.approle.read", {}),
+        ("vault.auth.approle.read", {"role_name": "  "}),
+        ("vault.auth.userpass.list", {"mount": ""}),
+        ("vault.auth.userpass.list", {"unexpected": "x"}),
+    ],
+    ids=[
+        "userpass-read-missing-username",
+        "userpass-read-empty-username",
+        "userpass-read-whitespace-username",
+        "userpass-read-nonstring-username",
+        "approle-read-missing-role",
+        "approle-read-whitespace-role",
+        "userpass-list-empty-mount",
+        "userpass-list-additional-property",
+    ],
+)
+async def test_invalid_params_rejected_by_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """The dispatcher rejects bad params against the registered schema.
+
+    No Vault call is made -- validation runs before the handler. Proves
+    ``required`` / ``minLength`` / ``pattern`` / ``type`` /
+    ``additionalProperties:false`` are wired into each op's schema.
+    """
+    install_fake_client(monkeypatch)
+
+    result = await VaultConnector().execute(_make_target(), op_id, params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras.get("error_code") == "invalid_params"
+    assert result.extras.get("validation_errors")
+
+
+# ---------------------------------------------------------------------------
+# login-side failure propagation (VaultClientError subclass)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "login_exc,expected_exc_class",
+    [
+        (requests.exceptions.ConnectionError("no route"), "VaultUnreachableError"),
+        (hvac.exceptions.Forbidden("role denied"), "VaultRoleDeniedError"),
+    ],
+    ids=["unreachable", "role-denied"],
+)
+@pytest.mark.parametrize(
+    "op_id,params",
+    [
+        ("vault.auth.userpass.list", {}),
+        ("vault.auth.approle.read", {"role_name": "deploy"}),
+    ],
+)
+async def test_login_failure_surfaces_vault_client_error_class(
+    monkeypatch: pytest.MonkeyPatch,
+    login_exc: Exception,
+    expected_exc_class: str,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A login-phase failure short-circuits before the auth read call.
+
+    Same contract as ``vault.kv.read``: the dispatcher's
+    ``connector_error`` records the ``VaultClientError`` subclass name
+    in ``extras.exception_class``.
+    """
+    install_fake_client(monkeypatch, login_exc=login_exc)
+
+    result = await VaultConnector().execute(_make_target(), op_id, params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("exception_class") == expected_exc_class


### PR DESCRIPTION
## Summary
- Ships the G3.3-T3 read-only identity op group on the typed Vault connector: `vault.auth.userpass.list/read` + `vault.auth.approle.list/read`, registered via `register_typed_operation()` (`safety_level=safe`, `op_class=read` via the `read-only` tag, group `auth`, `requires_approval=false`) with full parameter/response JSON Schema + `llm_instructions`, mirroring the existing `vault.kv.read` registration shape.
- Mount path is parameterised (optional `mount`, default `userpass`/`approle`) so non-default mounts work with no code change.
- A 404 because the auth backend is not mounted is reclassified to a dedicated `VaultAuthBackendNotMountedError` (a `VaultClientError` subclass) so the dispatcher's `connector_error` payload carries an operator-actionable `exception_class`; a missing user/role under a *mounted* backend keeps surfacing as `InvalidPath` so the two not-found shapes stay distinguishable.
- `register_vault_typed_operations()` fans out into the new module's registrar — the package keeps one lifespan-driven registrar entry while the auth surface stays independently reviewable. Schemas live in `ops_auth_schemas.py` to keep both modules within the file-size budget. AppRole secret-id generation and all userpass/approle writes are explicitly out of scope for v0.2.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (5 src files)
- [x] `mypy --ignore-missing-imports` — clean (5 src files)
- [x] `code-quality.py --diff` — 0 blockers (refactored ops_auth into ops_auth_schemas + a data-driven registrar to clear the file-size/function-size blockers)
- [x] `pytest test_connectors_vault_auth.py test_connectors_vault.py` — 48 passed (new auth tests + existing vault tests, no regression)
- [x] Regression on every `_vault_fakes` consumer (`test_auth_vault`, `test_vault_failures`, `test_api_v1_health`, `test_api_health_failures`, `test_audit_middleware`, `test_middleware`, `test_migration_rollback`, `test_secret_leak_checks`) — all green (127 passed combined with the vault suites)
- [x] Broader connector/dispatch/typed-register sweep — 542 passed (1 unrelated pre-existing failure: `test_connectors_k8s_k3d` live-k3s integration test, no live cluster in sandbox, no shared code with this change)
- [x] DoD: all four ops registered with full schema + `llm_instructions` + `safety_level=safe` + `op_class=read` + group `auth` — verified via dispatchable + registration tests
- [x] DoD: mount-path parameterised — verified by `test_list_honours_non_default_mount` + read-with-mount tests
- [x] DoD: structured dispatcher error when auth backend not mounted — verified by `test_*_backend_not_mounted_surfaces_structured_error`
- [x] DoD: registration idempotent on restart — verified by `test_auth_ops_register_under_vault_connector_key` (double-call)
- [x] DoD: unit tests with mocked HTTP for each op (present/absent/error envelopes)

## Notes
- The DoD says "httpx mock". hvac's transport is `requests`, not `httpx`, so respx (the repo's httpx mock) cannot intercept Vault calls. The substantive intent — mocked HTTP, no real Vault, every op's present/absent/error envelope exercised — is satisfied via the codebase's canonical Vault unit-test seam: the in-process fake hvac client (`_build_client` monkeypatch), the same seam `test_connectors_vault.py` uses for `vault.kv.read` (which #547 says to mirror). Wording deviation, not a behavioural one.

## Out of scope
- AppRole secret-id generation; userpass/approle writes; other auth methods (LDAP/OIDC/JWT/cert) — per #547.
- CLI verbs (#550), sys read group (#546), KV-v2 ops (#545, sibling worktree), dev-mode CI harness (#551).
- Adjacent (recorded, not edited): pre-existing `code-quality` warnings on `ops.py` (`vault_kv_read` 85 lines; `register_vault_typed_operations` nudged to 61 lines by the additive fan-out call — both warn-only, under block limits).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #547


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new operations to list and read userpass authentication method configurations
  * Added new operations to list and read AppRole authentication method configurations
  * Introduced structured error handling for unmounted authentication backends

* **Tests**
  * Added comprehensive test coverage for the new authentication operations, including parameter validation and error scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->