### PR TITLE
feat(connectors): add Vault sys read op group (G3.3-T2)

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -95,13 +95,19 @@ _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
 #: Op-id suffixes that imply non-mutating read. ``.ls`` and ``.about``
 #: are the CLI-shaped verbs (``meho vsphere ls``, ``meho meho about``)
 #: that the connector layer maps to the same read class as ``.list`` /
-#: ``.get`` / ``.info``.
+#: ``.get`` / ``.info``. ``.health`` and ``.seal_status`` are the Vault
+#: ``sys`` diagnostics verbs (G3.3-T2 #546): non-mutating cluster-state
+#: reads with no secret content, so they broadcast at the same
+#: ``read`` sensitivity as ``.list`` rather than falling through to
+#: the full-detail ``other`` class.
 _READ_SUFFIXES: Final[tuple[str, ...]] = (
     ".list",
     ".info",
     ".get",
     ".about",
     ".ls",
+    ".health",
+    ".seal_status",
 )
 
 

--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -50,6 +50,9 @@ from meho_backplane.connectors.vault.ops import (
     register_vault_typed_operations,
     vault_kv_read,
 )
+from meho_backplane.connectors.vault.ops_sys import (
+    register_vault_sys_typed_operations,
+)
 from meho_backplane.operations.typed_register import register_typed_op_registrar
 
 register_connector_v2(
@@ -66,10 +69,15 @@ register_connector_v2(
 # connector subpackage has self-registered by the time the runner
 # iterates.
 register_typed_op_registrar(register_vault_typed_operations)
+# The ``sys`` read op group (G3.3-T2 #546) ships its own registrar so
+# the KV-v2 (#545) and sys surfaces register independently — no shared
+# handler state, distinct endpoint_descriptor rows.
+register_typed_op_registrar(register_vault_sys_typed_operations)
 
 __all__ = [
     "VaultConnector",
     "VaultTarget",
+    "register_vault_sys_typed_operations",
     "register_vault_typed_operations",
     "vault_kv_read",
 ]

--- a/backend/src/meho_backplane/connectors/vault/ops_sys.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_sys.py
@@ -1,0 +1,536 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault ``sys`` read op group — typed handlers + ``endpoint_descriptor``
+registration helper.
+
+Op-id namespace (v0.2): ``vault.sys.<verb>``. The four ops here are the
+read-only diagnostics surface the consumer's wrappers exercise daily:
+
+* ``vault.sys.health`` — cluster health (``GET /v1/sys/health``).
+* ``vault.sys.seal_status`` — seal state (``GET /v1/sys/seal-status``).
+* ``vault.sys.mounts.list`` — enabled secret backends (``GET /v1/sys/mounts``).
+* ``vault.sys.auth.list`` — enabled auth backends (``GET /v1/sys/auth``).
+
+All four are ``safety_level='safe'`` and classify as ``op_class='read'``
+via :func:`~meho_backplane.broadcast.events.classify_op` (the ``.health``
+and ``.seal_status`` suffixes were added to that classifier's read-suffix
+tuple so the diagnostics surface broadcasts at the same sensitivity as
+``.list`` / ``.get`` ops — there is no secret content in any of these
+payloads). ``sys`` writes (unseal, mount/unmount, policy write) are out
+of scope for v0.2.
+
+Handler shape mirrors :mod:`meho_backplane.connectors.vault.ops`: each
+handler is a module-level ``async def`` with the ``(target, params) ->
+dict`` signature the G0.6 dispatcher expects from a typed op. The
+dispatcher validates ``params`` against the registered
+``parameter_schema`` before invoking; the handler's only job is the
+Vault HTTP call plus the success-payload shape. Handlers **raise** on
+failure; the dispatcher's ``connector_error`` branch turns the raised
+exception into a structured :class:`OperationResult` with the exception
+class name in ``extras["exception_class"]`` — so an unreachable or
+sealed Vault never surfaces a raw traceback to the agent (DoD:
+structured dispatcher errors).
+
+``vault.sys.health`` is **not** a second copy of the probe-path health
+check. It reuses the exact same three seams the
+:class:`~meho_backplane.connectors.vault.connector.VaultConnector`
+``probe`` / ``fingerprint`` methods use —
+:func:`~meho_backplane.auth.vault._build_client` (unauthenticated
+client, settings-driven address/namespace/timeout),
+:func:`~meho_backplane.auth.vault._to_thread_read_health` (the
+off-event-loop ``GET /v1/sys/health`` call), and
+:func:`~meho_backplane.auth.vault._classify_health_response` (the
+200/429/472/473/501/503 → ``(ok, detail)`` contract). Sharing those
+helpers means the op and the readiness probe cannot drift: a change to
+Vault's health contract is fixed in one place. The ``_auth_vault``
+module reference (not a ``from ... import`` of the helpers) is used so
+the existing test seam — ``monkeypatch.setattr(vault_module,
+"_build_client", fake)`` — applies transparently here too.
+
+The three authenticated ops (``seal_status`` is unauthenticated on
+Vault's side, but routing it through the operator client keeps the
+audit attribution uniform and costs one extra OIDC login) forward the
+operator's JWT via
+:func:`~meho_backplane.auth.vault.vault_client_for_operator`, exactly
+like ``vault.kv.read``. Their hvac calls are wrapped in
+:func:`asyncio.to_thread` because hvac is synchronous (``requests``-
+based) and FastAPI does not auto-offload blocking I/O inside an
+``async def``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.operations.typed_register import register_typed_operation
+from meho_backplane.retrieval.embedding import EmbeddingService
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "register_vault_sys_typed_operations",
+    "vault_sys_auth_list",
+    "vault_sys_health",
+    "vault_sys_mounts_list",
+    "vault_sys_seal_status",
+]
+
+
+#: Shared empty-parameter schema. None of the four sys read ops take a
+#: parameter — they each return a fixed cluster-wide view. ``additional
+#: Properties=False`` rejects a stray key (e.g. a typo'd ``{"mount":
+#: ...}``) with a clear dispatcher-side validation error rather than
+#: silently ignoring it.
+_NO_PARAMS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+_VAULT_SYS_HEALTH_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "ok": {
+            "type": "boolean",
+            "description": (
+                "True when Vault is serving requests (HTTP 200/429/472/473); "
+                "False when sealed or uninitialized."
+            ),
+        },
+        "detail": {
+            "type": "string",
+            "description": (
+                "Structured reason string ('sealed=False', 'sealed', "
+                "'uninitialized', 'http_429', ...). Never echoes Vault's "
+                "URL or namespace."
+            ),
+        },
+        "version": {
+            "type": ["string", "null"],
+            "description": (
+                "Vault server version from the health payload, or null on a non-200 response."
+            ),
+        },
+        "cluster_name": {
+            "type": ["string", "null"],
+            "description": "Cluster name from the health payload, or null when absent.",
+        },
+        "sealed": {
+            "type": ["boolean", "null"],
+            "description": "Seal flag from the health payload, or null on a non-200 response.",
+        },
+        "initialized": {
+            "type": ["boolean", "null"],
+            "description": (
+                "Initialized flag from the health payload, or null on a non-200 response."
+            ),
+        },
+    },
+    "required": ["ok", "detail"],
+}
+
+
+_VAULT_SYS_SEAL_STATUS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "description": "Seal type, e.g. 'shamir'."},
+        "initialized": {"type": "boolean"},
+        "sealed": {"type": "boolean"},
+        "t": {"type": "integer", "description": "Unseal threshold."},
+        "n": {"type": "integer", "description": "Total key shares."},
+        "progress": {"type": "integer", "description": "Unseal-key submission progress."},
+        "version": {"type": "string"},
+        "build_date": {"type": ["string", "null"]},
+        "migration": {"type": ["boolean", "null"]},
+        "cluster_name": {"type": ["string", "null"]},
+        "cluster_id": {"type": ["string", "null"]},
+        "recovery_seal": {"type": ["boolean", "null"]},
+        "storage_type": {"type": ["string", "null"]},
+    },
+    "required": ["sealed", "initialized"],
+}
+
+
+_VAULT_SYS_MOUNTS_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "mounts": {
+            "type": "object",
+            "description": (
+                "Map of mount path ('secret/', 'cubbyhole/', ...) to the "
+                "mount descriptor (type, description, accessor, options, "
+                "config, ...). The raw 'data' object from GET /v1/sys/mounts."
+            ),
+        },
+    },
+    "required": ["mounts"],
+}
+
+
+_VAULT_SYS_AUTH_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "auth_methods": {
+            "type": "object",
+            "description": (
+                "Map of auth mount path ('token/', 'userpass/', ...) to the "
+                "method descriptor (type, description, accessor, config, "
+                "...). The raw 'data' object from GET /v1/sys/auth."
+            ),
+        },
+    },
+    "required": ["auth_methods"],
+}
+
+
+_VAULT_SYS_HEALTH_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Check whether a Vault target is reachable, unsealed, and serving "
+        "requests. Use for an operator's 'is Vault up?' / 'is Vault "
+        "sealed?' question before attempting a secret read. Read-only and "
+        "unauthenticated on Vault's side — never mutates state and never "
+        "returns secret content. Shares its implementation with the "
+        "backplane's own Vault readiness probe."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'ok': <bool>, 'detail': <str>, 'version': <str|null>, "
+        "'cluster_name': <str|null>, 'sealed': <bool|null>, "
+        "'initialized': <bool|null>}. On unreachable Vault: a "
+        "connector_error OperationResult with extras.exception_class set "
+        "to the requests/hvac error type."
+    ),
+}
+
+
+_VAULT_SYS_SEAL_STATUS_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read Vault's seal state and unseal progress (type, threshold t, "
+        "shares n, progress). Use when an operator asks about seal status "
+        "or unseal progress specifically — finer-grained than "
+        "vault.sys.health. Read-only; no secret content."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "The raw seal-status object: {'type', 'sealed', 'initialized', "
+        "'t', 'n', 'progress', 'version', ...}. On failure: a "
+        "connector_error OperationResult with extras.exception_class."
+    ),
+}
+
+
+_VAULT_SYS_MOUNTS_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "List the secret backends enabled on the Vault target (KV mounts, "
+        "transit, pki, ...). Use to discover which mount path to read "
+        "from before a vault.kv.read. Read-only; returns mount metadata, "
+        "not secret values."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'mounts': {<mount-path>: {'type', 'description', 'accessor', "
+        "'options', 'config', ...}}}. On failure: connector_error with "
+        "extras.exception_class."
+    ),
+}
+
+
+_VAULT_SYS_AUTH_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "List the auth methods enabled on the Vault target (token, "
+        "userpass, approle, jwt, ...). Use to discover the auth surface "
+        "before an identity-read op. Read-only; returns method metadata, "
+        "not credentials."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'auth_methods': {<mount-path>: {'type', 'description', "
+        "'accessor', 'config', ...}}}. On failure: connector_error with "
+        "extras.exception_class."
+    ),
+}
+
+
+async def vault_sys_health(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Read Vault cluster health — shares the probe-path implementation.
+
+    Op-id: ``vault.sys.health``.
+
+    This handler does **not** duplicate the readiness-probe health
+    check. It calls the same three
+    :mod:`meho_backplane.auth.vault` seams the
+    :meth:`~meho_backplane.connectors.vault.connector.VaultConnector.probe`
+    method uses:
+
+    * :func:`~meho_backplane.auth.vault._build_client` — an
+      unauthenticated client built from settings (address, namespace,
+      timeout). ``/v1/sys/health`` is an unauthenticated Vault
+      endpoint, so no operator JWT / OIDC login is needed; the
+      ``target`` argument is accepted to satisfy the dispatcher's
+      typed-handler contract but is intentionally unused.
+    * :func:`~meho_backplane.auth.vault._to_thread_read_health` — runs
+      hvac's blocking ``sys.read_health_status(method="GET")`` off the
+      event loop.
+    * :func:`~meho_backplane.auth.vault._classify_health_response` —
+      the canonical 200/429/472/473/501/503 → ``(ok, detail)``
+      mapping. One change to Vault's health contract is fixed once and
+      both the op and the probe inherit it.
+
+    Parameters
+    ----------
+    target
+        Unused. ``/v1/sys/health`` needs no operator credential; the
+        parameter is part of the dispatcher's typed-handler signature.
+    params
+        Validated empty object (the schema forbids any key).
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"ok": <bool>, "detail": <str>, "version": <str|None>,
+        "cluster_name": <str|None>, "sealed": <bool|None>,
+        "initialized": <bool|None>}``. The classification fields come
+        from :func:`_classify_health_response`; the descriptive fields
+        are pulled from the JSON payload when Vault returned HTTP 200
+        (a ``dict``) and are ``None`` on a non-200 response (hvac
+        returns a :class:`requests.Response` there, which carries no
+        decoded body).
+
+    Raises
+    ------
+    requests.exceptions.ConnectionError | requests.exceptions.Timeout
+        Vault unreachable (DNS/TCP/TLS/timeout). The dispatcher's
+        ``connector_error`` branch records the class name in
+        ``extras["exception_class"]`` so the agent sees a structured
+        error, not a traceback.
+    hvac.exceptions.VaultError
+        Any Vault-side error hvac raises from the health read.
+    """
+    # ``target`` is unused on purpose — see the docstring. Binding it to
+    # ``_`` documents the intent at the call boundary and keeps
+    # unused-argument linters quiet without an inline suppression.
+    _ = target
+
+    settings = get_settings()
+    client = _auth_vault._build_client(settings)
+    payload = await _auth_vault._to_thread_read_health(client)
+    ok, detail = _auth_vault._classify_health_response(payload)
+
+    # hvac returns a decoded dict only for HTTP 200; non-200 responses
+    # come back as a requests.Response with no decoded body, so the
+    # descriptive fields are None there. ``_classify_health_response``
+    # already extracted the ok/detail signal from either shape.
+    if isinstance(payload, dict):
+        return {
+            "ok": ok,
+            "detail": detail,
+            "version": payload.get("version"),
+            "cluster_name": payload.get("cluster_name"),
+            "sealed": payload.get("sealed"),
+            "initialized": payload.get("initialized"),
+        }
+    return {
+        "ok": ok,
+        "detail": detail,
+        "version": None,
+        "cluster_name": None,
+        "sealed": None,
+        "initialized": None,
+    }
+
+
+async def vault_sys_seal_status(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Read Vault's seal status (``GET /v1/sys/seal-status``).
+
+    Op-id: ``vault.sys.seal_status``.
+
+    Routes through :func:`~meho_backplane.auth.vault.vault_client_for_operator`
+    for uniform per-operator audit attribution even though the Vault
+    endpoint itself is unauthenticated. The hvac
+    ``sys.read_seal_status()`` call is offloaded with
+    :func:`asyncio.to_thread` because hvac is synchronous.
+
+    Returns the raw seal-status object verbatim (``{"type", "sealed",
+    "initialized", "t", "n", "progress", "version", ...}``).
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure (Vault unreachable, role denied). The
+        dispatcher wraps it into a ``connector_error`` result.
+    Exception
+        Any error hvac raises from the seal-status read.
+    """
+    _ = params  # schema-validated empty object; no inputs to extract.
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        return await asyncio.to_thread(client.sys.read_seal_status)
+
+
+async def vault_sys_mounts_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """List enabled secret backends (``GET /v1/sys/mounts``).
+
+    Op-id: ``vault.sys.mounts.list``.
+
+    Forwards the operator JWT via
+    :func:`~meho_backplane.auth.vault.vault_client_for_operator` (the
+    mounts list is authenticated on Vault's side). The blocking hvac
+    call runs in a worker thread.
+
+    Returns ``{"mounts": <data>}`` where ``<data>`` is the ``data``
+    object hvac returns from ``sys.list_mounted_secrets_engines()`` —
+    a map of mount path to mount descriptor. The ``mounts`` wrapper
+    key keeps the response a JSON object (JSONFlux/result-handle
+    wrapping operates on object/array shapes) and names the payload
+    for the agent.
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    Exception
+        Any error hvac raises from the mounts read.
+    """
+    _ = params
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        response = await asyncio.to_thread(client.sys.list_mounted_secrets_engines)
+        # hvac returns the full Vault envelope ({request_id, data, ...}).
+        # The mount map lives under ``data``; fall back to the whole
+        # response on the (older-hvac) chance the envelope is unwrapped.
+        mounts = response.get("data", response) if isinstance(response, dict) else response
+        return {"mounts": mounts}
+
+
+async def vault_sys_auth_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """List enabled auth methods (``GET /v1/sys/auth``).
+
+    Op-id: ``vault.sys.auth.list``.
+
+    Same shape and rationale as :func:`vault_sys_mounts_list`: operator
+    JWT forwarded, blocking hvac call offloaded, the ``data`` object
+    returned under an ``auth_methods`` wrapper key.
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    Exception
+        Any error hvac raises from the auth-methods read.
+    """
+    _ = params
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        response = await asyncio.to_thread(client.sys.list_auth_methods)
+        auth_methods = response.get("data", response) if isinstance(response, dict) else response
+        return {"auth_methods": auth_methods}
+
+
+async def register_vault_sys_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the Vault ``sys`` read ops into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list from the package
+    ``__init__`` alongside
+    :func:`~meho_backplane.connectors.vault.ops.register_vault_typed_operations`.
+    Idempotent on restart: a second call with unchanged descriptions
+    is a no-op for the embedding pipeline (the body-hash skip path in
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`).
+
+    The ``embedding_service`` test seam matches the KV-v2 registrar so
+    chassis tests can inject a stub instead of loading the ONNX model.
+    """
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.health",
+        handler=vault_sys_health,
+        summary="Check HashiCorp Vault cluster health (reachable / sealed / serving).",
+        description=(
+            "Reads GET /v1/sys/health via the unauthenticated, settings-"
+            "driven client and classifies the 200/429/472/473/501/503 "
+            "response into (ok, detail). Shares its implementation with "
+            "the backplane's Vault readiness probe — they cannot drift. "
+            "Read-only; never returns secret content. Unreachable Vault "
+            "surfaces as a connector_error OperationResult with the "
+            "requests/hvac error class in extras.exception_class."
+        ),
+        parameter_schema=_NO_PARAMS_SCHEMA,
+        response_schema=_VAULT_SYS_HEALTH_RESPONSE_SCHEMA,
+        group_key="sys",
+        tags=["read-only", "diagnostics", "health"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_VAULT_SYS_HEALTH_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.seal_status",
+        handler=vault_sys_seal_status,
+        summary="Read HashiCorp Vault seal status and unseal progress.",
+        description=(
+            "Reads GET /v1/sys/seal-status and returns the raw seal-"
+            "status object (type, sealed, initialized, threshold t, "
+            "shares n, progress, version). Read-only; no secret "
+            "content. Login/transport failures surface as a structured "
+            "connector_error OperationResult."
+        ),
+        parameter_schema=_NO_PARAMS_SCHEMA,
+        response_schema=_VAULT_SYS_SEAL_STATUS_RESPONSE_SCHEMA,
+        group_key="sys",
+        tags=["read-only", "diagnostics", "seal"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_VAULT_SYS_SEAL_STATUS_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.mounts.list",
+        handler=vault_sys_mounts_list,
+        summary="List the secret backends enabled on a HashiCorp Vault target.",
+        description=(
+            "Reads GET /v1/sys/mounts via the operator's OIDC-forwarded "
+            "JWT and returns the mount map under a 'mounts' key (path -> "
+            "{type, description, accessor, options, config, ...}). Read-"
+            "only; returns mount metadata, not secret values."
+        ),
+        parameter_schema=_NO_PARAMS_SCHEMA,
+        response_schema=_VAULT_SYS_MOUNTS_LIST_RESPONSE_SCHEMA,
+        group_key="sys",
+        tags=["read-only", "diagnostics", "mounts"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_VAULT_SYS_MOUNTS_LIST_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.auth.list",
+        handler=vault_sys_auth_list,
+        summary="List the auth methods enabled on a HashiCorp Vault target.",
+        description=(
+            "Reads GET /v1/sys/auth via the operator's OIDC-forwarded "
+            "JWT and returns the auth-method map under an 'auth_methods' "
+            "key (path -> {type, description, accessor, config, ...}). "
+            "Read-only; returns method metadata, not credentials."
+        ),
+        parameter_schema=_NO_PARAMS_SCHEMA,
+        response_schema=_VAULT_SYS_AUTH_LIST_RESPONSE_SCHEMA,
+        group_key="sys",
+        tags=["read-only", "diagnostics", "auth-methods"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_VAULT_SYS_AUTH_LIST_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -133,12 +133,43 @@ class _FakeSysBackend:
     payload: Any = None
     raise_on_read: Exception | None = None
     read_calls: list[dict[str, Any]] = field(default_factory=list)
+    # G3.3-T2 (#546) sys read op group. Each knob mirrors the
+    # ``payload`` / ``raise_on_read`` pair so the sys-op tests can
+    # inject a success body or a failure independently of the health
+    # read the connector/probe suites drive.
+    seal_status_payload: Any = None
+    raise_on_seal_status: Exception | None = None
+    seal_status_calls: int = 0
+    mounts_payload: Any = None
+    raise_on_mounts: Exception | None = None
+    mounts_calls: int = 0
+    auth_methods_payload: Any = None
+    raise_on_auth_methods: Exception | None = None
+    auth_methods_calls: int = 0
 
     def read_health_status(self, *, method: str = "HEAD", **_kwargs: Any) -> Any:
         self.read_calls.append({"method": method})
         if self.raise_on_read is not None:
             raise self.raise_on_read
         return self.payload
+
+    def read_seal_status(self) -> Any:
+        self.seal_status_calls += 1
+        if self.raise_on_seal_status is not None:
+            raise self.raise_on_seal_status
+        return self.seal_status_payload
+
+    def list_mounted_secrets_engines(self) -> Any:
+        self.mounts_calls += 1
+        if self.raise_on_mounts is not None:
+            raise self.raise_on_mounts
+        return self.mounts_payload
+
+    def list_auth_methods(self) -> Any:
+        self.auth_methods_calls += 1
+        if self.raise_on_auth_methods is not None:
+            raise self.raise_on_auth_methods
+        return self.auth_methods_payload
 
 
 @dataclass
@@ -203,6 +234,12 @@ def install_fake_client(
     secret: dict[str, Any] | None = None,
     kv_version: int | None = None,
     read_exc: Exception | None = None,
+    seal_status_payload: Any = None,
+    seal_status_exc: Exception | None = None,
+    mounts_payload: Any = None,
+    mounts_exc: Exception | None = None,
+    auth_methods_payload: Any = None,
+    auth_methods_exc: Exception | None = None,
 ) -> _FakeClient:
     """Failure-injecting variant of :func:`install_fake_vault`.
 
@@ -211,13 +248,21 @@ def install_fake_client(
     tiny (no duplicated ``_FakeClient(url=..., timeout=..., ...)`` body)
     while exposing every knob the connector / failure-mode suites need:
     login / revoke / health-read / kv-read exception injection plus
-    secret and KV-version overrides.
+    secret and KV-version overrides, and the G3.3-T2 (#546) sys read
+    group's seal-status / mounts / auth-methods payload + exception
+    injection.
     """
     fake = install_fake_vault(monkeypatch, kv_version=kv_version if kv_version is not None else 11)
     fake.auth.jwt.raise_on_login = login_exc
     fake.auth.token.raise_on_revoke = revoke_exc
     fake.sys.payload = health_payload
     fake.sys.raise_on_read = health_exc
+    fake.sys.seal_status_payload = seal_status_payload
+    fake.sys.raise_on_seal_status = seal_status_exc
+    fake.sys.mounts_payload = mounts_payload
+    fake.sys.raise_on_mounts = mounts_exc
+    fake.sys.auth_methods_payload = auth_methods_payload
+    fake.sys.raise_on_auth_methods = auth_methods_exc
     if secret is not None:
         fake.secrets.kv.v2.secret = secret
     fake.secrets.kv.v2.read_exc = read_exc

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -204,6 +204,14 @@ class TestClassifyOp:
             ("vsphere.about", "read"),
             ("k8s.pod.get", "read"),
             ("vsphere.vm.ls", "read"),
+            # Vault sys diagnostics verbs (G3.3-T2 #546): non-mutating
+            # cluster-state reads with no secret content. They must
+            # classify as ``read`` (DoD: op_class=read), not fall
+            # through to the full-detail ``other`` class.
+            ("vault.sys.health", "read"),
+            ("vault.sys.seal_status", "read"),
+            ("vault.sys.mounts.list", "read"),
+            ("vault.sys.auth.list", "read"),
         ],
     )
     def test_read_suffixes(self, op_id: str, expected: str) -> None:

--- a/backend/tests/test_connectors_vault_sys.py
+++ b/backend/tests/test_connectors_vault_sys.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the Vault ``sys`` read op group — G3.3-T2 (#546).
+
+Coverage matrix (one behaviour per test, table-driven where the shape
+repeats):
+
+* All four sys ops register into ``endpoint_descriptor`` under
+  ``(product="vault", version="1.x", impl_id="vault")`` with
+  ``safety_level='safe'``, the ``sys`` operation group, and an
+  empty-object ``parameter_schema``.
+* ``classify_op`` maps every sys op-id to ``"read"`` (DoD: the audit /
+  broadcast ``op_class`` for these ops is ``read``).
+* ``vault.sys.health`` happy path returns the shared probe-path
+  classification (``ok`` / ``detail`` from
+  :func:`~meho_backplane.auth.vault._classify_health_response`) plus
+  the descriptive fields, and drives the same ``_build_client`` /
+  ``read_health_status(method="GET")`` seam the connector ``probe``
+  uses — proving it does not duplicate the health logic.
+* ``vault.sys.health`` against a sealed Vault returns ``ok=False``.
+* ``vault.sys.health`` against an unreachable Vault surfaces the
+  dispatcher's structured ``connector_error`` (no raw traceback to
+  the agent).
+* ``vault.sys.seal_status`` / ``mounts.list`` / ``auth.list`` happy
+  paths return the expected payload shape and forward the operator JWT
+  via the ``vault_client_for_operator`` login/revoke seam.
+* Login failure (Vault unreachable / role denied) on the three
+  authenticated ops surfaces as ``connector_error`` with the
+  :class:`VaultClientError` subclass name in
+  ``extras["exception_class"]``.
+
+Test isolation mirrors ``test_connectors_vault.py``: the production
+code builds Vault clients through the single ``_build_client`` seam;
+the shared ``tests/_vault_fakes.py`` ``install_fake_client`` helper
+monkey-patches it to a controllable in-process fake — no real HTTP,
+no Vault container. The ``_clean_vault_registry`` fixture re-registers
+``VaultConnector`` (v2) and resets the dispatcher caches because
+alphabetically-earlier test files clear both registry layers via their
+own autouse fixtures.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import hvac.exceptions
+import pytest
+import requests.exceptions
+
+from meho_backplane.broadcast import classify_op
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.vault import (
+    VaultConnector,
+    VaultTarget,
+    register_vault_sys_typed_operations,
+)
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+
+@pytest.fixture(autouse=True)
+def _clean_vault_registry() -> Iterator[None]:
+    """Re-register VaultConnector (v2) + reset the dispatcher caches."""
+    clear_registry()
+    register_connector_v2(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        cls=VaultConnector,
+    )
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars needed by Settings / VaultConnector."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_vault_sys_ops(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Upsert the sys-op descriptor rows for tests that drive ``execute``."""
+    await register_vault_sys_typed_operations(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_target(jwt: str = "fake.jwt.value") -> VaultTarget:
+    return VaultTarget(raw_jwt=jwt)
+
+
+_SYS_OP_IDS = (
+    "vault.sys.health",
+    "vault.sys.seal_status",
+    "vault.sys.mounts.list",
+    "vault.sys.auth.list",
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration + classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op_id", _SYS_OP_IDS)
+async def test_sys_op_registers_with_safe_level_and_sys_group(
+    op_id: str,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Each sys op lands an endpoint_descriptor row: safe, group 'sys', empty schema."""
+    from sqlalchemy import select
+
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == "vault",
+                    EndpointDescriptor.version == "1.x",
+                    EndpointDescriptor.impl_id == "vault",
+                    EndpointDescriptor.op_id == op_id,
+                )
+            )
+        ).scalar_one()
+
+        assert row.source_kind == "typed"
+        assert row.safety_level == "safe"
+        assert row.requires_approval is False
+        assert row.parameter_schema == {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        }
+
+        group = (
+            await session.execute(select(OperationGroup).where(OperationGroup.id == row.group_id))
+        ).scalar_one()
+        assert group.group_key == "sys"
+
+
+@pytest.mark.parametrize("op_id", _SYS_OP_IDS)
+def test_sys_op_classifies_as_read(op_id: str) -> None:
+    """DoD: op_class for every sys op is ``read`` (no secret content)."""
+    assert classify_op(op_id) == "read"
+
+
+# ---------------------------------------------------------------------------
+# vault.sys.health — shares the probe-path implementation
+# ---------------------------------------------------------------------------
+
+
+async def test_health_happy_path_returns_classified_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Healthy Vault → ok=True with the shared classifier's detail + descriptive fields."""
+    fake = install_fake_client(
+        monkeypatch,
+        health_payload={
+            "initialized": True,
+            "sealed": False,
+            "version": "1.18.0",
+            "cluster_name": "meho-vault",
+        },
+    )
+    result = await VaultConnector().execute(_make_target(), "vault.sys.health", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "ok": True,
+        "detail": "sealed=False",
+        "version": "1.18.0",
+        "cluster_name": "meho-vault",
+        "sealed": False,
+        "initialized": True,
+    }
+    # Proves the op reuses the probe-path seam: the unauthenticated
+    # _build_client + read_health_status(method="GET") path, NOT a
+    # per-operator OIDC login.
+    assert fake.sys.read_calls == [{"method": "GET"}]
+    assert fake.auth.jwt.login_calls == []
+
+
+async def test_health_sealed_vault_returns_ok_false(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Sealed Vault → ok=False / detail='sealed' from the shared classifier."""
+    install_fake_client(
+        monkeypatch,
+        health_payload={"initialized": True, "sealed": True},
+    )
+    result = await VaultConnector().execute(_make_target(), "vault.sys.health", {})
+
+    assert result.status == "ok", result.error
+    assert result.result["ok"] is False
+    assert result.result["detail"] == "sealed"
+    assert result.result["sealed"] is True
+
+
+async def test_health_unreachable_vault_surfaces_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Unreachable Vault → dispatcher connector_error, not a raw traceback."""
+    install_fake_client(
+        monkeypatch,
+        health_exc=requests.exceptions.ConnectionError("dns failure"),
+    )
+    result = await VaultConnector().execute(_make_target(), "vault.sys.health", {})
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "ConnectionError"
+
+
+# ---------------------------------------------------------------------------
+# vault.sys.seal_status / mounts.list / auth.list — authenticated reads
+# ---------------------------------------------------------------------------
+
+
+async def test_seal_status_happy_path_returns_raw_object(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """seal_status returns the raw seal-status object and forwards the operator JWT."""
+    seal = {
+        "type": "shamir",
+        "initialized": True,
+        "sealed": False,
+        "t": 3,
+        "n": 5,
+        "progress": 0,
+        "version": "1.18.0",
+    }
+    fake = install_fake_client(monkeypatch, seal_status_payload=seal)
+    result = await VaultConnector().execute(_make_target(jwt="op-jwt"), "vault.sys.seal_status", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == seal
+    assert fake.sys.seal_status_calls == 1
+    assert fake.auth.jwt.login_calls == [{"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"}]
+    assert fake.auth.token.revoke_calls == 1
+
+
+async def test_mounts_list_unwraps_envelope_data(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """mounts.list returns the envelope's ``data`` under a ``mounts`` key."""
+    mounts_data = {
+        "secret/": {"type": "kv", "options": {"version": "2"}},
+        "cubbyhole/": {"type": "cubbyhole"},
+    }
+    install_fake_client(
+        monkeypatch,
+        mounts_payload={"request_id": "abc", "data": mounts_data, "warnings": None},
+    )
+    result = await VaultConnector().execute(_make_target(), "vault.sys.mounts.list", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"mounts": mounts_data}
+
+
+async def test_auth_list_unwraps_envelope_data(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """auth.list returns the envelope's ``data`` under an ``auth_methods`` key."""
+    auth_data = {
+        "token/": {"type": "token"},
+        "userpass/": {"type": "userpass"},
+    }
+    install_fake_client(
+        monkeypatch,
+        auth_methods_payload={"request_id": "def", "data": auth_data, "warnings": None},
+    )
+    result = await VaultConnector().execute(_make_target(), "vault.sys.auth.list", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"auth_methods": auth_data}
+
+
+@pytest.mark.parametrize(
+    ("op_id", "kwargs"),
+    [
+        ("vault.sys.seal_status", {"seal_status_payload": {"sealed": False}}),
+        ("vault.sys.mounts.list", {"mounts_payload": {"data": {}}}),
+        ("vault.sys.auth.list", {"auth_methods_payload": {"data": {}}}),
+    ],
+)
+@pytest.mark.parametrize(
+    ("login_exc", "expected_exc_class"),
+    [
+        (requests.exceptions.ConnectionError("no route"), "VaultUnreachableError"),
+        (hvac.exceptions.Forbidden("role denied"), "VaultRoleDeniedError"),
+    ],
+    ids=["unreachable", "role-denied"],
+)
+async def test_authenticated_sys_op_login_failure_surfaces_vault_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    kwargs: dict[str, Any],
+    login_exc: Exception,
+    expected_exc_class: str,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Login failure on an authenticated sys op → connector_error w/ VaultClientError class."""
+    install_fake_client(monkeypatch, login_exc=login_exc, **kwargs)
+    result = await VaultConnector().execute(_make_target(), op_id, {})
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == expected_exc_class

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -1,0 +1,134 @@
+# Connector: vault (HashiCorp Vault 1.x)
+
+## Overview
+
+The `vault` connector is a **typed** connector: operations are
+hand-coded Python handlers against the `hvac` SDK, registered into the
+G0.6 `endpoint_descriptor` table via `register_typed_operation()` at
+lifespan startup. It dispatches under the
+`(product="vault", version="1.x", impl_id="vault")` registry triple.
+
+Vault publishes an OpenAPI spec, but the shipped chassis already used
+hand-coded HTTP against Vault's REST (G0.2-T5 #244), so Vault stays
+typed per the minimum-disruption decision in Initiative #366. Switching
+to generic-ingested is a v0.2.next consideration if Vault's surface
+grows substantially.
+
+Auth model: `shared_service_account`. Every operator's Keycloak JWT is
+forwarded to Vault's JWT/OIDC auth method (bound to the `meho-mcp`
+role); the resulting per-request Vault token is revoked on context
+exit. The unauthenticated `/sys/health` endpoint is the one exception —
+it needs no token.
+
+Source: `backend/src/meho_backplane/connectors/vault/`.
+
+## Key types
+
+- **`VaultConnector`** (`connector.py`) — `Connector` subclass.
+  `product="vault"`, `version="1.x"`, `impl_id="vault"`. Its
+  `fingerprint` and `probe` methods read `GET /v1/sys/health` through
+  the shared `auth.vault` seams. `execute` is a thin shim that
+  delegates to the G0.6 dispatcher (parameter validation, policy gate,
+  audit, broadcast, JSONFlux) so pre-G0.6 callers keep working.
+- **`VaultTarget`** (`connector.py`) — pre-G0.3 stand-in for the
+  `Target` model; carries only `raw_jwt`.
+- **KV-v2 op group** (`ops.py`) — `register_vault_typed_operations()`
+  registers the `vault.kv.*` surface (G0.6-T-Refactor shipped
+  `vault.kv.read`; G3.3-T1 #545 adds list/put/versions/delete). Group
+  key `kv`. `vault.kv.read` / `vault.kv.list` are classified
+  `credential_read` (decision #3 — aggregate-only broadcast).
+- **`sys` read op group** (`ops_sys.py`, G3.3-T2 #546) —
+  `register_vault_sys_typed_operations()` registers four read-only
+  diagnostics ops under group key `sys`, all `safety_level='safe'`,
+  `requires_approval=False`:
+  - `vault.sys.health` — `GET /v1/sys/health`. **Shares** the
+    probe-path implementation: calls `auth.vault._build_client`
+    (unauthenticated, settings-driven), `_to_thread_read_health`, and
+    `_classify_health_response` — the same three seams
+    `VaultConnector.probe`/`fingerprint` use. No JWT needed; the
+    `target` arg is accepted to satisfy the dispatcher's typed-handler
+    signature but is unused.
+  - `vault.sys.seal_status` — `GET /v1/sys/seal-status`. Returns the
+    raw seal-status object.
+  - `vault.sys.mounts.list` — `GET /v1/sys/mounts`. Returns the
+    envelope's `data` under a `mounts` key.
+  - `vault.sys.auth.list` — `GET /v1/sys/auth`. Returns the envelope's
+    `data` under an `auth_methods` key.
+
+  The three authenticated ops forward the operator JWT via
+  `vault_client_for_operator` and offload the blocking `hvac` call with
+  `asyncio.to_thread`.
+
+## Control flow
+
+1. Importing `connectors.vault` (package `__init__.py`) registers
+   `VaultConnector` against the v2 registry synchronously and queues
+   two typed-op registrars (`register_vault_typed_operations`,
+   `register_vault_sys_typed_operations`) onto the lifespan-driven
+   registrar list.
+2. At FastAPI lifespan startup, `run_typed_op_registrars()` invokes
+   both registrars, which upsert the `endpoint_descriptor` rows. Upsert
+   is idempotent: a restart against unchanged descriptions is a no-op
+   for the embedding pipeline (body-hash skip in
+   `register_typed_operation`).
+3. A `call_operation` (CLI or MCP) dispatches via
+   `meho_backplane.operations.dispatch`, which validates params against
+   the registered `parameter_schema`, applies the policy gate, invokes
+   the typed handler, writes the synchronous audit row, publishes the
+   broadcast event, and reduces the result (JSONFlux).
+4. `op_class` for audit/broadcast is **derived from the op-id suffix**
+   by `broadcast.events.classify_op`, not passed at registration. The
+   four `sys` ops classify as `read` — `.list` was already a read
+   suffix; `.health` and `.seal_status` were added to the read-suffix
+   tuple by #546 (no secret content, so they broadcast at the same
+   sensitivity as `.list`/`.get` rather than falling through to the
+   full-detail `other` class).
+
+## Error handling
+
+Typed handlers **raise** on failure rather than returning a structured
+result. The dispatcher's `connector_error` branch turns the raised
+exception into an `OperationResult(status="error")` with the exception
+class name in `extras["exception_class"]`. Callers (e.g. the
+`/api/v1/health` route) string-match that class name to distinguish
+login-phase failure (any `VaultClientError` subclass:
+`VaultUnreachableError`, `VaultRoleDeniedError`) from read-phase
+failure (anything else). An unreachable or sealed Vault therefore never
+surfaces a raw traceback to the agent.
+
+## Dependencies
+
+- `hvac` — synchronous Vault SDK (built on `requests`); every call is
+  wrapped in `asyncio.to_thread` to keep the event loop responsive.
+- `meho_backplane.auth.vault` — the OIDC forward-auth middle link;
+  owns `_build_client`, `vault_client_for_operator`,
+  `_to_thread_read_health`, `_classify_health_response`. The
+  `_build_client` function is the single test seam (monkeypatched by
+  `tests/_vault_fakes.py`).
+- `meho_backplane.operations.typed_register` — `register_typed_operation`
+  / `register_typed_op_registrar`.
+- `meho_backplane.broadcast.events` — `classify_op` (op-id → op_class).
+
+## Known issues
+
+- `VaultTarget` is a pre-G0.3 placeholder; replace with the real
+  `Target` model once G0.3 (#224) connection-parameter resolution
+  lands. Connection params (address/namespace/timeout) currently come
+  from `get_settings()`, not the target.
+- `vault.sys.seal_status` is unauthenticated on Vault's side but is
+  routed through `vault_client_for_operator` for uniform per-operator
+  audit attribution — at the cost of one extra OIDC login + revoke per
+  call. Acceptable under v0.2 dogfood load (per-request login is
+  already the v0.1/v0.2 model); revisit if a per-operator token cache
+  lands.
+- `sys` writes (unseal, mount/unmount, policy write) are deliberately
+  out of scope for v0.2.
+
+## References
+
+- Initiative #366 (G3.3 vault-1.x typed op surface); Goal #214.
+- Task #546 (G3.3-T2 sys read op group); sibling #545 (G3.3-T1 KV-v2).
+- Substrate: #388 (G0.6 operation registry), #390 (Refactor-Vault).
+- Vault sys API: https://developer.hashicorp.com/vault/api-docs/system
+- CLAUDE.md postulates 1 (typed connectors first-class) and 7
+  (synchronous append-only audit).


### PR DESCRIPTION
## Summary

- Adds the Vault `sys` read op group (G3.3-T2): new `ops_sys.py` registers `vault.sys.health`, `vault.sys.seal_status`, `vault.sys.mounts.list`, `vault.sys.auth.list` via `register_typed_operation()` at connector init — group `sys`, `safety_level=safe`, full param/response schemas + `llm_instructions`.
- `vault.sys.health` reuses the three `auth.vault` seams `VaultConnector.probe`/`fingerprint` use (`_build_client` unauthenticated, `_to_thread_read_health`, `_classify_health_response`) rather than duplicating the readiness-probe health check — the op and the probe cannot drift.
- `op_class` is derived from the op-id suffix by `classify_op`, not passed at registration. `.list` already classified as `read`; `.health` and `.seal_status` were added to the read-suffix tuple so the (secret-free) diagnostics surface broadcasts at `read` sensitivity instead of falling through to the full-detail `other` class — satisfying the DoD's `op_class=read`.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean (3 changed source files)
- [x] `pytest tests/test_connectors_vault_sys.py tests/test_broadcast_events.py` — 65 passed
- [x] Full backend suite (`pytest tests/ --ignore=integration --ignore=acceptance`) — 1716 passed, 4 skipped
- [x] DoD: 4 ops registered with safe level + `sys` group + empty param schema — `test_sys_op_registers_with_safe_level_and_sys_group` (4 params)
- [x] DoD: every sys op classifies as `op_class=read` — `test_sys_op_classifies_as_read` (4 params)
- [x] DoD: health shares probe-path logic — `test_health_happy_path_returns_classified_payload` asserts `read_calls==[{"method":"GET"}]` and `login_calls==[]`
- [x] DoD: structured dispatcher error on unreachable/sealed/login-failure — `connector_error` + `exception_class` assertions
- [x] DoD: idempotent registration — inherits the `register_typed_operation` body-hash skip path

## Notes

- The issue body says "httpx mock"; the Vault connector path uses `hvac` (synchronous, `requests`-based), not `httpx`. Tests use the canonical `_build_client` fake seam in `tests/_vault_fakes.py` (the established Vault test isolation, monkeypatching the single HTTP-client construction point) — this satisfies the intent (mock the Vault HTTP layer, no real Vault, per-op healthy/sealed/error coverage) without mocking a library the code never calls.

## Out of scope

- KV-v2 ops (`vault.kv.list/put/versions/delete`) — sibling #545 (G3.3-T1).
- `sys` writes (unseal, mount/unmount, policy write) — out of scope for v0.2.
- CLI alias verbs (#550, G3.3-T6) and dev-mode integration harness (#551, G3.3-T7).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four Vault system diagnostic reads: health, seal status, mounts list, and auth methods.

* **Behavior Change**
  * Vault sys diagnostic op-ids are now classified as "read" for accurate non-mutating handling.

* **Documentation**
  * Added Vault connector docs explaining operation groups, auth model, and failure semantics.

* **Tests**
  * Added extensive tests and fakes covering new sys ops, happy/error paths, and classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->