### PR TITLE
feat(connectors): G3.3-T1 KV-v2 op group — vault.kv.list/put/versions/delete

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -82,14 +82,18 @@ _CREDENTIAL_READ_OPS: Final[frozenset[str]] = frozenset(
 )
 
 #: Op-id suffixes that imply mutation. Append to this tuple when a new
-#: write-shaped verb spelling lands (no current users beyond the four
-#: in decision #3). Order doesn't matter — :meth:`str.endswith` accepts
-#: a tuple and short-circuits on the first match.
+#: write-shaped verb spelling lands. ``.put`` is the KV-v2 write verb
+#: (``vault.kv.put`` — G3.3-T1 #545); without it a secret write would
+#: fall through to ``other`` and broadcast its full params, leaking the
+#: written secret payload to every operator. Order doesn't matter —
+#: :meth:`str.endswith` accepts a tuple and short-circuits on the
+#: first match.
 _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
     ".create",
     ".update",
     ".delete",
     ".patch",
+    ".put",
 )
 
 #: Op-id suffixes that imply non-mutating read. ``.ls`` and ``.about``
@@ -99,7 +103,10 @@ _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
 #: ``sys`` diagnostics verbs (G3.3-T2 #546): non-mutating cluster-state
 #: reads with no secret content, so they broadcast at the same
 #: ``read`` sensitivity as ``.list`` rather than falling through to
-#: the full-detail ``other`` class.
+#: the full-detail ``other`` class. ``.versions`` is the KV-v2
+#: version-metadata browse (``vault.kv.versions`` — G3.3-T1 #545): a
+#: read of metadata only (no secret values), so it likewise classifies
+#: ``read`` rather than ``credential_read``.
 _READ_SUFFIXES: Final[tuple[str, ...]] = (
     ".list",
     ".info",
@@ -108,6 +115,7 @@ _READ_SUFFIXES: Final[tuple[str, ...]] = (
     ".ls",
     ".health",
     ".seal_status",
+    ".versions",
 )
 
 

--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -48,7 +48,11 @@ from meho_backplane.connectors.registry import register_connector_v2
 from meho_backplane.connectors.vault.connector import VaultConnector, VaultTarget
 from meho_backplane.connectors.vault.ops import (
     register_vault_typed_operations,
+    vault_kv_delete,
+    vault_kv_list,
+    vault_kv_put,
     vault_kv_read,
+    vault_kv_versions,
 )
 from meho_backplane.connectors.vault.ops_auth import (
     VaultAuthBackendNotMountedError,
@@ -85,5 +89,9 @@ __all__ = [
     "register_vault_auth_operations",
     "register_vault_sys_typed_operations",
     "register_vault_typed_operations",
+    "vault_kv_delete",
+    "vault_kv_list",
+    "vault_kv_put",
     "vault_kv_read",
+    "vault_kv_versions",
 ]

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -5,11 +5,29 @@
 
 Op-id namespace (v0.2): ``vault.kv.<verb>``.
 
-Future ops (``vault.kv.write``, ``vault.kv.list``, ``vault.policy.read``,
-``vault.transit.encrypt``) are intentionally out of scope for the G0.6-T-
-Refactor-Vault Task — the acceptance criteria specify only ``vault.kv.read``
-as the existing surface to round-trip through the new substrate. G3.3
-(#366) covers the full KV-v2 + sys + auth read/list surface.
+G3.3-T1 (#366) completes the KV-v2 op group: ``vault.kv.read``
+(pre-existing, G0.6-T-Refactor-Vault), plus ``vault.kv.list`` /
+``vault.kv.put`` / ``vault.kv.versions`` / ``vault.kv.delete``. The
+remaining ``sys`` and ``auth`` read/list groups land in sibling Tasks
+under the same Initiative. Secret-engine writes beyond KV-v2
+(database/PKI/transit) stay out of scope.
+
+Mount handling: every KV-v2 handler accepts an optional ``mount``
+param defaulting to ``"secret"`` (hvac's ``mount_point`` default).
+The consumer wrappers address secrets as ``<mount> <path>``; the
+deployment-wide default keeps the pre-existing ``vault.kv.read``
+``path``-only call sites working unchanged.
+
+Credential-sensitivity classification: ``vault.kv.read`` and
+``vault.kv.list`` are ``credential_read`` per locked decision #3
+(docs/planning/v0.2-decisions.md). The classifier the G6 broadcast
+publisher reads is op-id-based — :func:`meho_backplane.broadcast.\
+events.classify_op` consults the ``_CREDENTIAL_READ_OPS`` allowlist,
+which already contains both op-ids. The shipped G0.6 substrate has no
+per-row ``op_class`` column on ``endpoint_descriptor`` (decision #3
+locks the classifier on op-id, not a per-descriptor field), so the
+register-time signal is the op-id itself; a regression test pins the
+``classify_op`` contract for both ops.
 
 Each handler is an ``async def`` module-level function with the
 ``(target, params) -> dict[str, Any]`` shape the G0.6 dispatcher (T5
@@ -52,8 +70,49 @@ from meho_backplane.retrieval.embedding import EmbeddingService
 __all__ = [
     "VAULT_KV_READ_PARAMETER_SCHEMA",
     "register_vault_typed_operations",
+    "vault_kv_delete",
+    "vault_kv_list",
+    "vault_kv_put",
     "vault_kv_read",
+    "vault_kv_versions",
 ]
+
+#: Default KV-v2 mount point. hvac's ``mount_point`` parameter defaults
+#: to ``"secret"``; we mirror that so a handler call with no explicit
+#: ``mount`` addresses the deployment's default KV-v2 engine. The
+#: consumer wrappers pass ``<mount> <path>`` explicitly when the secret
+#: lives under a non-default mount.
+_DEFAULT_KV_MOUNT = "secret"
+
+#: Shared JSON Schema fragment for the optional ``mount`` param. KV-v2
+#: mount names are single path segments (no slashes); ``pattern`` keeps
+#: a stray ``"secret/data"`` from being passed where hvac expects the
+#: bare mount handle.
+_MOUNT_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "^[^/]+$",
+    "default": _DEFAULT_KV_MOUNT,
+    "description": (
+        "KV v2 secret-engine mount point (single path segment, no "
+        "slashes). Optional — defaults to 'secret', the deployment-wide "
+        "KV-v2 mount. Supply only when the secret lives under a "
+        "non-default mount."
+    ),
+}
+
+#: Shared JSON Schema fragment for the required ``path`` param. Same
+#: non-empty / non-whitespace discipline as the pre-existing
+#: ``vault.kv.read`` schema.
+_PATH_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "KV v2 secret path relative to the mount root, e.g. "
+        "'meho/test/federation'. No leading slash, no mount prefix."
+    ),
+}
 
 
 #: JSON Schema 2020-12 for the ``vault.kv.read`` op's ``params`` argument.
@@ -225,6 +284,468 @@ async def vault_kv_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
         return {"data": secret_data, "version": version}
 
 
+# ---------------------------------------------------------------------------
+# vault.kv.list — list keys at a KV-v2 path
+# ---------------------------------------------------------------------------
+
+#: ``vault.kv.list`` param schema. ``path`` here is a *folder* path
+#: (Vault returns the key names directly beneath it); an empty path
+#: lists the mount root, so ``path`` stays required for an unambiguous
+#: agent call but the value may be a single segment.
+VAULT_KV_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"mount": _MOUNT_PROPERTY, "path": _PATH_PROPERTY},
+    "required": ["path"],
+    "additionalProperties": False,
+}
+
+_VAULT_KV_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "keys": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Key names directly beneath the path. Folder entries are suffixed with '/'."
+            ),
+        },
+    },
+    "required": ["keys"],
+}
+
+_VAULT_KV_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "List the key names at a KV v2 folder path (e.g. 'what secrets "
+        "exist under meho/test/?'). Read-only — never mutates the "
+        "store. Returns only key names, never values: Vault does not "
+        "expose secret content through the list endpoint. Folder "
+        "entries are suffixed with '/'."
+    ),
+    "parameter_hints": {
+        "mount": (
+            "Optional. KV v2 mount point; defaults to 'secret'. Supply "
+            "only for a non-default mount."
+        ),
+        "path": (
+            "Required. The folder path under the mount whose immediate "
+            "children to list. Listing a leaf (a secret, not a folder) "
+            "returns an empty key list."
+        ),
+    },
+    "output_shape": (
+        "On success: {'keys': [<name>, ...]}. On failure: the "
+        "dispatcher wraps the raised exception into a connector_error "
+        "OperationResult with extras.exception_class set to the "
+        "Vault-side error type."
+    ),
+}
+
+
+async def vault_kv_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """List key names at a KV v2 folder path.
+
+    Op-id: ``vault.kv.list``. Read-only. Classified ``credential_read``
+    (decision #3) — the broadcast publisher emits aggregate-only for
+    this op-id even though the response carries no secret values, since
+    key names themselves can leak structure.
+
+    Delegates to hvac's ``secrets.kv.v2.list_secrets`` (the underlying
+    ``LIST /v1/<mount>/metadata/<path>`` call). Raises on a malformed
+    hvac payload so the dispatcher's ``connector_error`` branch surfaces
+    a structured error rather than an unhandled exception.
+    """
+    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
+    path: str = str(params["path"]).strip()
+
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        list_payload = await asyncio.to_thread(
+            client.secrets.kv.v2.list_secrets,
+            path=path,
+            mount_point=mount,
+        )
+        # Structural unwrap -- raises KeyError on a malformed hvac
+        # payload (missing the nested ``data``/``keys`` keys). The
+        # dispatcher's ``connector_error`` branch turns the KeyError
+        # into a structured OperationResult.
+        keys = list_payload["data"]["keys"]
+        return {"keys": keys}
+
+
+# ---------------------------------------------------------------------------
+# vault.kv.put — write a new secret version
+# ---------------------------------------------------------------------------
+
+#: ``vault.kv.put`` param schema. ``data`` is the secret key/value
+#: object; ``cas`` is the optional Check-And-Set version guard (0 ⇒
+#: create-only, N ⇒ update-only-if-current-version-is-N).
+VAULT_KV_PUT_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "mount": _MOUNT_PROPERTY,
+        "path": _PATH_PROPERTY,
+        "data": {
+            "type": "object",
+            "minProperties": 1,
+            "description": (
+                "Secret key/value object to write as a new version. "
+                "Replaces the latest version wholesale — KV v2 does not "
+                "merge; carry forward any keys that must survive."
+            ),
+        },
+        "cas": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+                "Optional Check-And-Set guard. 0 ⇒ write only if the "
+                "key does not yet exist. N ⇒ write only if the current "
+                "version is exactly N. Omit to write unconditionally."
+            ),
+        },
+    },
+    "required": ["path", "data"],
+    "additionalProperties": False,
+}
+
+_VAULT_KV_PUT_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": ["integer", "null"],
+            "description": "The newly written KV v2 version number.",
+        },
+    },
+    "required": ["version"],
+}
+
+_VAULT_KV_PUT_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Write a new version of a KV v2 secret. Mutating — creates a "
+        "new version (KV v2 keeps history). The write REPLACES the "
+        "latest version wholesale; KV v2 does not merge, so include "
+        "every key that must survive. Use 'cas' to make the write "
+        "conditional and avoid clobbering a concurrent change."
+    ),
+    "parameter_hints": {
+        "mount": "Optional. KV v2 mount point; defaults to 'secret'.",
+        "path": "Required. The secret path under the mount.",
+        "data": (
+            "Required. The full key/value object for the new version. "
+            "Not a patch — omitted keys are dropped from the new "
+            "version."
+        ),
+        "cas": (
+            "Optional. 0 to require the key be absent (create), N to "
+            "require the current version be N (optimistic lock)."
+        ),
+    },
+    "output_shape": (
+        "On success: {'version': <new int version>}. On failure: a "
+        "connector_error OperationResult with extras.exception_class — "
+        "a CAS mismatch surfaces as hvac's InvalidRequest class."
+    ),
+}
+
+
+async def vault_kv_put(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Write a new version of a KV v2 secret.
+
+    Op-id: ``vault.kv.put``. Mutating (``op_class=write``,
+    ``safety_level=caution``). Delegates to hvac's
+    ``secrets.kv.v2.create_or_update_secret`` (``POST
+    /v1/<mount>/data/<path>``). The structural unwrap raises on a
+    malformed hvac payload so the dispatcher reports a structured
+    ``connector_error``.
+    """
+    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
+    path: str = str(params["path"]).strip()
+    secret: dict[str, Any] = params["data"]
+    cas = params.get("cas")
+
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        write_payload = await asyncio.to_thread(
+            client.secrets.kv.v2.create_or_update_secret,
+            path=path,
+            secret=secret,
+            cas=cas,
+            mount_point=mount,
+        )
+        version = write_payload["data"]["version"]
+        return {"version": version}
+
+
+# ---------------------------------------------------------------------------
+# vault.kv.versions — version metadata for a secret
+# ---------------------------------------------------------------------------
+
+VAULT_KV_VERSIONS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"mount": _MOUNT_PROPERTY, "path": _PATH_PROPERTY},
+    "required": ["path"],
+    "additionalProperties": False,
+}
+
+_VAULT_KV_VERSIONS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "current_version": {
+            "type": ["integer", "null"],
+            "description": "The latest version number for the secret.",
+        },
+        "versions": {
+            "type": "object",
+            "description": (
+                "Per-version metadata keyed by version string: "
+                "created_time, deletion_time, destroyed."
+            ),
+        },
+    },
+    "required": ["versions"],
+}
+
+_VAULT_KV_VERSIONS_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Browse the version history of a KV v2 secret — when each "
+        "version was created, which are soft-deleted or destroyed. "
+        "Read-only metadata; never returns secret values. Use before a "
+        "kv.put with a 'cas' guard, or to find a version to undelete."
+    ),
+    "parameter_hints": {
+        "mount": "Optional. KV v2 mount point; defaults to 'secret'.",
+        "path": "Required. The secret path under the mount.",
+    },
+    "output_shape": (
+        "On success: {'current_version': <int|null>, 'versions': "
+        "{'<n>': {created_time, deletion_time, destroyed}, ...}}. On "
+        "failure: a connector_error OperationResult with "
+        "extras.exception_class."
+    ),
+}
+
+
+async def vault_kv_versions(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Read the version metadata for a KV v2 secret.
+
+    Op-id: ``vault.kv.versions``. Read-only (``op_class=read``,
+    ``safety_level=safe``). Delegates to hvac's
+    ``secrets.kv.v2.read_secret_metadata`` (``GET
+    /v1/<mount>/metadata/<path>``). Returns only metadata — never the
+    secret values — so it is NOT in the ``credential_read`` allowlist.
+    """
+    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
+    path: str = str(params["path"]).strip()
+
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        meta_payload = await asyncio.to_thread(
+            client.secrets.kv.v2.read_secret_metadata,
+            path=path,
+            mount_point=mount,
+        )
+        data = meta_payload["data"]
+        return {
+            "current_version": data.get("current_version"),
+            "versions": data["versions"],
+        }
+
+
+# ---------------------------------------------------------------------------
+# vault.kv.delete — soft-delete specific versions
+# ---------------------------------------------------------------------------
+
+VAULT_KV_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "mount": _MOUNT_PROPERTY,
+        "path": _PATH_PROPERTY,
+        "versions": {
+            "type": "array",
+            "items": {"type": "integer", "minimum": 1},
+            "minItems": 1,
+            "description": (
+                "Version numbers to soft-delete. Soft-delete is "
+                "reversible via Vault's undelete path; the underlying "
+                "data is retained until destroyed."
+            ),
+        },
+    },
+    "required": ["path", "versions"],
+    "additionalProperties": False,
+}
+
+_VAULT_KV_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "deleted_versions": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": "Echo of the version numbers that were soft-deleted.",
+        },
+    },
+    "required": ["deleted_versions"],
+}
+
+_VAULT_KV_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Soft-delete specific versions of a KV v2 secret. Mutating and "
+        "dangerous — but reversible: Vault marks the versions deleted "
+        "and stops returning them from reads while retaining the "
+        "underlying data (undeletable until destroyed). Use to retire "
+        "a leaked or stale version without losing recoverability."
+    ),
+    "parameter_hints": {
+        "mount": "Optional. KV v2 mount point; defaults to 'secret'.",
+        "path": "Required. The secret path under the mount.",
+        "versions": (
+            "Required. A non-empty list of version numbers to "
+            "soft-delete. This op never deletes 'all versions' — name "
+            "each version explicitly."
+        ),
+    },
+    "output_shape": (
+        "On success: {'deleted_versions': [<n>, ...]} echoing the "
+        "requested versions (Vault returns a 204 with no body). On "
+        "failure: a connector_error OperationResult with "
+        "extras.exception_class."
+    ),
+}
+
+
+async def vault_kv_delete(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Soft-delete specific versions of a KV v2 secret.
+
+    Op-id: ``vault.kv.delete``. Mutating (``op_class=write``,
+    ``safety_level=dangerous``). Delegates to hvac's
+    ``secrets.kv.v2.delete_secret_versions`` (``POST
+    /v1/<mount>/delete/<path>``), which returns a 204 with no body —
+    hvac yields a ``requests.Response``, so the handler does not unwrap
+    a JSON payload and instead echoes the requested versions for an
+    actionable agent-facing result.
+    """
+    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
+    path: str = str(params["path"]).strip()
+    versions: list[int] = list(params["versions"])
+
+    async with _auth_vault.vault_client_for_operator(target) as client:
+        await asyncio.to_thread(
+            client.secrets.kv.v2.delete_secret_versions,
+            path=path,
+            versions=versions,
+            mount_point=mount,
+        )
+        return {"deleted_versions": versions}
+
+
+#: Per-op registration specs for the KV-v2 group. One dict per op
+#: carrying only the fields that vary between ops; the invariant
+#: coordinates (``product`` / ``version`` / ``impl_id`` / ``group_key``)
+#: and the caller-supplied ``embedding_service`` are applied uniformly
+#: by :func:`register_vault_typed_operations`. Keeping this as data
+#: rather than five near-identical call blocks keeps the registrar
+#: short and makes the sys/auth groups (sibling Tasks) a one-row
+#: append rather than another copy-pasted block.
+_KV_OP_SPECS: tuple[dict[str, Any], ...] = (
+    {
+        "op_id": "vault.kv.read",
+        "handler": vault_kv_read,
+        "summary": "Read a single KV v2 secret from HashiCorp Vault.",
+        "description": (
+            "Reads the secret at the supplied KV v2 path via the operator's "
+            "OIDC-forwarded JWT. Returns the secret data dict plus the "
+            "KV v2 metadata version. Read-only — never mutates the "
+            "secret store. Login-side failures (Vault unreachable, role "
+            "denied) raise VaultClientError subclasses; read-side "
+            "failures (KV miss, malformed payload, hvac raise) raise "
+            "the underlying exception. Either failure mode lands as a "
+            "connector_error OperationResult from the dispatcher with "
+            "extras.exception_class naming the failure class."
+        ),
+        "parameter_schema": VAULT_KV_READ_PARAMETER_SCHEMA,
+        "response_schema": _VAULT_KV_READ_RESPONSE_SCHEMA,
+        "tags": ["read-only", "secret-read"],
+        "safety_level": "safe",
+        "llm_instructions": _VAULT_KV_READ_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.kv.list",
+        "handler": vault_kv_list,
+        "summary": "List key names at a KV v2 folder path.",
+        "description": (
+            "Lists the key names directly beneath a KV v2 folder path "
+            "via the operator's OIDC-forwarded JWT. Read-only — never "
+            "returns secret values (Vault's list endpoint exposes only "
+            "names). Classified credential_read per decision #3: the G6 "
+            "broadcast publisher emits aggregate-only for this op-id "
+            "because key names can leak structure. Failures land as a "
+            "connector_error OperationResult with "
+            "extras.exception_class naming the failure class."
+        ),
+        "parameter_schema": VAULT_KV_LIST_PARAMETER_SCHEMA,
+        "response_schema": _VAULT_KV_LIST_RESPONSE_SCHEMA,
+        "tags": ["read-only", "credential-read"],
+        "safety_level": "safe",
+        "llm_instructions": _VAULT_KV_LIST_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.kv.put",
+        "handler": vault_kv_put,
+        "summary": "Write a new version of a KV v2 secret.",
+        "description": (
+            "Writes a new version of the secret at the supplied KV v2 "
+            "path via the operator's OIDC-forwarded JWT. Mutating — KV "
+            "v2 keeps version history; the write replaces the latest "
+            "version wholesale (no merge). Optional Check-And-Set guard "
+            "('cas'). safety_level=caution; the production-path "
+            "approval gate is G7/G10 policy territory. Failures land as "
+            "a connector_error OperationResult with "
+            "extras.exception_class naming the failure class."
+        ),
+        "parameter_schema": VAULT_KV_PUT_PARAMETER_SCHEMA,
+        "response_schema": _VAULT_KV_PUT_RESPONSE_SCHEMA,
+        "tags": ["write", "secret-write"],
+        "safety_level": "caution",
+        "llm_instructions": _VAULT_KV_PUT_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.kv.versions",
+        "handler": vault_kv_versions,
+        "summary": "Read the version metadata for a KV v2 secret.",
+        "description": (
+            "Reads the version history metadata for a KV v2 secret via "
+            "the operator's OIDC-forwarded JWT — current version plus "
+            "per-version created/deletion/destroyed timestamps. "
+            "Read-only metadata browse; never returns secret values, so "
+            "NOT classified credential_read. Failures land as a "
+            "connector_error OperationResult with "
+            "extras.exception_class naming the failure class."
+        ),
+        "parameter_schema": VAULT_KV_VERSIONS_PARAMETER_SCHEMA,
+        "response_schema": _VAULT_KV_VERSIONS_RESPONSE_SCHEMA,
+        "tags": ["read-only", "metadata"],
+        "safety_level": "safe",
+        "llm_instructions": _VAULT_KV_VERSIONS_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.kv.delete",
+        "handler": vault_kv_delete,
+        "summary": "Soft-delete specific versions of a KV v2 secret.",
+        "description": (
+            "Soft-deletes the named versions of a KV v2 secret via the "
+            "operator's OIDC-forwarded JWT. Reversible — Vault marks "
+            "the versions deleted and stops returning them from reads "
+            "while retaining the underlying data (undeletable until "
+            "destroyed). safety_level=dangerous; the production-path "
+            "approval gate is G7/G10 policy territory. Failures land as "
+            "a connector_error OperationResult with "
+            "extras.exception_class naming the failure class."
+        ),
+        "parameter_schema": VAULT_KV_DELETE_PARAMETER_SCHEMA,
+        "response_schema": _VAULT_KV_DELETE_RESPONSE_SCHEMA,
+        "tags": ["write", "destructive", "reversible"],
+        "safety_level": "dangerous",
+        "llm_instructions": _VAULT_KV_DELETE_LLM_INSTRUCTIONS,
+    },
+)
+
+
 async def register_vault_typed_operations(
     *,
     embedding_service: EmbeddingService | None = None,
@@ -244,44 +765,39 @@ async def register_vault_typed_operations(
     Production callers leave it ``None`` and the helper resolves the
     process-wide singleton via the ``register_typed_operation`` body.
 
-    Scope: ``vault.kv.read`` (this module) plus the four
-    identity-read ops from
+    Scope: G3.3-T1 registers the full KV-v2 group — ``vault.kv.read``,
+    ``vault.kv.list``, ``vault.kv.put``, ``vault.kv.versions``,
+    ``vault.kv.delete``. The identity-read group (Task #547,
+    ``vault.auth.userpass.list/read`` / ``vault.auth.approle.list/read``)
+    is registered from its own module via the
     :func:`~meho_backplane.connectors.vault.ops_auth.register_vault_auth_operations`
-    (``vault.auth.userpass.list/read``, ``vault.auth.approle.list/read``;
-    Task #547). The sys read group (Task #546) and the remaining KV-v2
-    verbs (Task #545) layer on the same way -- one ``await`` into the
-    group's registrar -- without further substrate changes. Keeping
-    each group's registrations in its own module keeps the surfaces
-    independently reviewable; this helper stays the single
-    lifespan-driven entry point.
+    call at the end of this function; the ``sys`` read group (Task
+    #546) ships its own lifespan registrar (see ``__init__.py``).
+    Keeping each group's registrations in its own module keeps the
+    surfaces independently reviewable; no further substrate changes
+    are needed.
+
+    ``requires_approval`` for the mutating ops (``kv.put`` /
+    ``kv.delete``) is registered ``False`` (the dev default). The
+    shipped G0.6 substrate has no per-path approval predicate —
+    ``requires_approval`` is a static boolean on the descriptor and the
+    production-path gate is G7/G10 policy territory (see the
+    :class:`~meho_backplane.db.models.EndpointDescriptor` docstring:
+    ``caution``/``dangerous`` ops "flow through G7 / G10 policy logic
+    once those Goals land"). ``safety_level`` (``caution`` for
+    ``kv.put``, ``dangerous`` for ``kv.delete``) is the load-bearing
+    signal the future policy gate keys on.
     """
-    await register_typed_operation(
-        product="vault",
-        version="1.x",
-        impl_id="vault",
-        op_id="vault.kv.read",
-        handler=vault_kv_read,
-        summary="Read a single KV v2 secret from HashiCorp Vault.",
-        description=(
-            "Reads the secret at the supplied KV v2 path via the operator's "
-            "OIDC-forwarded JWT. Returns the secret data dict plus the "
-            "KV v2 metadata version. Read-only — never mutates the "
-            "secret store. Login-side failures (Vault unreachable, role "
-            "denied) raise VaultClientError subclasses; read-side "
-            "failures (KV miss, malformed payload, hvac raise) raise "
-            "the underlying exception. Either failure mode lands as a "
-            "connector_error OperationResult from the dispatcher with "
-            "extras.exception_class naming the failure class."
-        ),
-        parameter_schema=VAULT_KV_READ_PARAMETER_SCHEMA,
-        response_schema=_VAULT_KV_READ_RESPONSE_SCHEMA,
-        group_key="kv",
-        tags=["read-only", "secret-read"],
-        safety_level="safe",
-        requires_approval=False,
-        llm_instructions=_VAULT_KV_READ_LLM_INSTRUCTIONS,
-        embedding_service=embedding_service,
-    )
+    for spec in _KV_OP_SPECS:
+        await register_typed_operation(
+            product="vault",
+            version="1.x",
+            impl_id="vault",
+            group_key="kv",
+            requires_approval=False,
+            embedding_service=embedding_service,
+            **spec,
+        )
     # Identity-read group (Task #547) -- registered from its own
     # module so the auth surface stays independently reviewable while
     # the package keeps a single lifespan-driven registrar entry.

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -87,11 +87,16 @@ _DEFAULT_KV_MOUNT = "secret"
 #: Shared JSON Schema fragment for the optional ``mount`` param. KV-v2
 #: mount names are single path segments (no slashes); ``pattern`` keeps
 #: a stray ``"secret/data"`` from being passed where hvac expects the
-#: bare mount handle.
+#: bare mount handle. The leading ``(?=.*\S)`` lookahead rejects an
+#: all-whitespace value at validation time (``invalid_params``) rather
+#: than letting it slip past ``minLength`` and degrade to an empty
+#: mount after the handler's ``.strip()`` — a runtime
+#: ``connector_error`` is a worse signal than a clear param-validation
+#: failure.
 _MOUNT_PROPERTY: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
-    "pattern": "^[^/]+$",
+    "pattern": "^(?=.*\\S)[^/]+$",
     "default": _DEFAULT_KV_MOUNT,
     "description": (
         "KV v2 secret-engine mount point (single path segment, no "
@@ -126,9 +131,19 @@ _PATH_PROPERTY: dict[str, Any] = {
 #: * ``additionalProperties=False`` rejects unexpected keys so a typo
 #:   like ``{"paht": "..."}`` surfaces as a clear validation error
 #:   instead of silently dispatching with a missing ``path``.
+#:
+#: ``mount`` is the shared optional KV-v2 mount fragment (defaults to
+#: ``"secret"``), matching every sibling op (list/put/versions/delete).
+#: Path-only ``vault.kv.read`` call sites keep working unchanged — the
+#: default resolves the deployment-wide KV-v2 engine — but the consumer
+#: wrappers can now address ``<mount> <path>`` for a non-default mount,
+#: which is the whole point of Initiative #366 (retiring the
+#: ``scripts/_secret-read.sh`` wrapper that derived the mount from the
+#: path's first segment).
 VAULT_KV_READ_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
+        "mount": _MOUNT_PROPERTY,
         "path": {
             "type": "string",
             "minLength": 1,
@@ -180,11 +195,15 @@ _VAULT_KV_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
         "attributed to the calling operator."
     ),
     "parameter_hints": {
+        "mount": (
+            "Optional. KV v2 mount point; defaults to 'secret', the "
+            "deployment-wide KV-v2 engine. Supply only when the secret "
+            "lives under a non-default mount."
+        ),
         "path": (
             "Required. The path under the KV v2 mount (no leading "
-            "slash, no mount prefix). The mount is configured "
-            "deployment-wide; the operator only supplies the path "
-            "below the mount."
+            "slash, no mount prefix). With the mount defaulted, the "
+            "operator supplies only the path below the mount."
         ),
     },
     "output_shape": (
@@ -214,9 +233,11 @@ async def vault_kv_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
         against the resolved target row.
     params
         Already validated by the dispatcher against
-        :data:`VAULT_KV_READ_PARAMETER_SCHEMA`. The handler only re-
-        extracts ``params["path"]`` -- the schema guarantees it's a
-        non-empty, non-whitespace string.
+        :data:`VAULT_KV_READ_PARAMETER_SCHEMA`. The handler re-extracts
+        ``params["path"]`` (schema-guaranteed non-empty, non-whitespace
+        string) and the optional ``params["mount"]`` (defaults to
+        ``"secret"`` via :data:`_DEFAULT_KV_MOUNT`, forwarded as hvac's
+        ``mount_point``).
 
     Returns
     -------
@@ -257,6 +278,7 @@ async def vault_kv_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
     # We re-strip so trailing whitespace doesn't slip into the hvac
     # call -- the schema permits ``"a "`` (one non-whitespace char) and
     # we want the wire shape to match what the operator typed.
+    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
 
     # vault_client_for_operator is accessed via the module reference so
@@ -268,6 +290,7 @@ async def vault_kv_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
         secret_payload = await asyncio.to_thread(
             client.secrets.kv.v2.read_secret_version,
             path=path,
+            mount_point=mount,
             raise_on_deleted_version=False,
         )
         # Structural unwrap -- raises KeyError on a malformed hvac

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -162,11 +162,37 @@ class _FakeAuth:
 
 
 @dataclass
+class _DeleteResponse:
+    """Stand-in for hvac's 204 ``requests.Response`` from a soft-delete."""
+
+    status_code: int = 204
+
+
+@dataclass
 class _FakeKVv2:
     secret: dict[str, Any] = field(default_factory=lambda: {"username": "demo"})
     version: int = 7
     read_calls: list[dict[str, Any]] = field(default_factory=list)
     read_exc: Exception | None = None
+    # G3.3-T1 KV-v2 op group. Each verb gets its own call log and a
+    # dedicated exception-injection knob so the failure-mode tests can
+    # target one op without disturbing the others. Defaults are benign
+    # so the pre-existing read-only suites that never touch these
+    # attributes keep passing.
+    keys: list[str] = field(default_factory=lambda: ["alpha", "beta/"])
+    versions_meta: dict[str, Any] = field(
+        default_factory=lambda: {
+            "1": {"created_time": "2026-01-01T00:00:00Z", "destroyed": False},
+        }
+    )
+    list_calls: list[dict[str, Any]] = field(default_factory=list)
+    put_calls: list[dict[str, Any]] = field(default_factory=list)
+    versions_calls: list[dict[str, Any]] = field(default_factory=list)
+    delete_calls: list[dict[str, Any]] = field(default_factory=list)
+    list_exc: Exception | None = None
+    put_exc: Exception | None = None
+    versions_exc: Exception | None = None
+    delete_exc: Exception | None = None
 
     def read_secret_version(self, path: str, **_kwargs: Any) -> dict[str, Any]:
         self.read_calls.append({"path": path})
@@ -178,6 +204,60 @@ class _FakeKVv2:
                 "metadata": {"version": self.version, "path": path},
             }
         }
+
+    def list_secrets(
+        self, path: str, mount_point: str = "secret", **_kwargs: Any
+    ) -> dict[str, Any]:
+        self.list_calls.append({"path": path, "mount_point": mount_point})
+        if self.list_exc is not None:
+            raise self.list_exc
+        return {"data": {"keys": list(self.keys)}}
+
+    def create_or_update_secret(
+        self,
+        path: str,
+        secret: dict[str, Any],
+        cas: int | None = None,
+        mount_point: str = "secret",
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        self.put_calls.append(
+            {"path": path, "secret": secret, "cas": cas, "mount_point": mount_point}
+        )
+        if self.put_exc is not None:
+            raise self.put_exc
+        return {"data": {"version": self.version + 1}}
+
+    def read_secret_metadata(
+        self, path: str, mount_point: str = "secret", **_kwargs: Any
+    ) -> dict[str, Any]:
+        self.versions_calls.append({"path": path, "mount_point": mount_point})
+        if self.versions_exc is not None:
+            raise self.versions_exc
+        return {
+            "data": {
+                "current_version": self.version,
+                "versions": dict(self.versions_meta),
+            }
+        }
+
+    def delete_secret_versions(
+        self,
+        path: str,
+        versions: list[int],
+        mount_point: str = "secret",
+        **_kwargs: Any,
+    ) -> _DeleteResponse:
+        self.delete_calls.append(
+            {"path": path, "versions": list(versions), "mount_point": mount_point}
+        )
+        if self.delete_exc is not None:
+            raise self.delete_exc
+        # Vault's soft-delete returns 204 with no body; hvac yields the
+        # underlying ``requests.Response``. The handler ignores the
+        # return value (it echoes the requested versions), so a minimal
+        # status-only stand-in is enough.
+        return _DeleteResponse()
 
 
 @dataclass
@@ -302,6 +382,12 @@ def install_fake_client(
     mounts_exc: Exception | None = None,
     auth_methods_payload: Any = None,
     auth_methods_exc: Exception | None = None,
+    keys: list[str] | None = None,
+    versions_meta: dict[str, Any] | None = None,
+    list_exc: Exception | None = None,
+    put_exc: Exception | None = None,
+    versions_exc: Exception | None = None,
+    delete_exc: Exception | None = None,
 ) -> _FakeClient:
     """Failure-injecting variant of :func:`install_fake_vault`.
 
@@ -310,9 +396,11 @@ def install_fake_client(
     tiny (no duplicated ``_FakeClient(url=..., timeout=..., ...)`` body)
     while exposing every knob the connector / failure-mode suites need:
     login / revoke / health-read / kv-read exception injection plus
-    secret and KV-version overrides, and the G3.3-T2 (#546) sys read
+    secret and KV-version overrides, the G3.3-T2 (#546) sys read
     group's seal-status / mounts / auth-methods payload + exception
-    injection.
+    injection, and the G3.3-T1 KV-v2 verbs (list / put / versions /
+    delete) with per-verb exception injection and key/version-metadata
+    overrides.
     """
     fake = install_fake_vault(monkeypatch, kv_version=kv_version if kv_version is not None else 11)
     fake.auth.jwt.raise_on_login = login_exc
@@ -325,7 +413,16 @@ def install_fake_client(
     fake.sys.raise_on_mounts = mounts_exc
     fake.sys.auth_methods_payload = auth_methods_payload
     fake.sys.raise_on_auth_methods = auth_methods_exc
+    kv = fake.secrets.kv.v2
     if secret is not None:
-        fake.secrets.kv.v2.secret = secret
-    fake.secrets.kv.v2.read_exc = read_exc
+        kv.secret = secret
+    kv.read_exc = read_exc
+    if keys is not None:
+        kv.keys = keys
+    if versions_meta is not None:
+        kv.versions_meta = versions_meta
+    kv.list_exc = list_exc
+    kv.put_exc = put_exc
+    kv.versions_exc = versions_exc
+    kv.delete_exc = delete_exc
     return fake

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -194,8 +194,10 @@ class _FakeKVv2:
     versions_exc: Exception | None = None
     delete_exc: Exception | None = None
 
-    def read_secret_version(self, path: str, **_kwargs: Any) -> dict[str, Any]:
-        self.read_calls.append({"path": path})
+    def read_secret_version(
+        self, path: str, mount_point: str = "secret", **_kwargs: Any
+    ) -> dict[str, Any]:
+        self.read_calls.append({"path": path, "mount_point": mount_point})
         if self.read_exc is not None:
             raise self.read_exc
         return {

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -190,8 +190,10 @@ class _FakeKVv2:
     read_calls: list[dict[str, Any]] = field(default_factory=list)
     read_exc: Exception | None = None
 
-    def read_secret_version(self, path: str, **_kwargs: Any) -> dict[str, Any]:
-        self.read_calls.append({"path": path})
+    def read_secret_version(
+        self, path: str, mount_point: str = "secret", **_kwargs: Any
+    ) -> dict[str, Any]:
+        self.read_calls.append({"path": path, "mount_point": mount_point})
         if self.read_exc is not None:
             raise self.read_exc
         return {
@@ -363,8 +365,12 @@ def test_happy_path_returns_full_federation_response(
     assert fake.auth.jwt.login_calls == [
         {"role": "meho-mcp", "jwt": token, "path": "jwt"},
     ]
-    # The federation-proof path is hardcoded for v0.1.
-    assert fake.secrets.kv.v2.read_calls == [{"path": "meho/test/federation"}]
+    # The federation-proof path is hardcoded for v0.1; the health
+    # probe does not pass a mount, so the KV-v2 default ("secret")
+    # applies.
+    assert fake.secrets.kv.v2.read_calls == [
+        {"path": "meho/test/federation", "mount_point": "secret"},
+    ]
     # Per-request login → revoke pair.
     assert fake.auth.token.revoke_calls == 1
 

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -212,6 +212,10 @@ class TestClassifyOp:
             ("vault.sys.seal_status", "read"),
             ("vault.sys.mounts.list", "read"),
             ("vault.sys.auth.list", "read"),
+            # KV-v2 version-metadata browse (G3.3-T1 #545): a read of
+            # metadata only (no secret values) → ``read``, not
+            # ``credential_read``.
+            ("vault.kv.versions", "read"),
         ],
     )
     def test_read_suffixes(self, op_id: str, expected: str) -> None:
@@ -224,6 +228,10 @@ class TestClassifyOp:
             ("vsphere.vm.update", "write"),
             ("vsphere.vm.delete", "write"),
             ("k8s.deployment.patch", "write"),
+            # KV-v2 write verb (G3.3-T1 #545). Without ``.put`` in the
+            # write-suffix tuple this would fall through to ``other``
+            # and broadcast the full secret payload.
+            ("vault.kv.put", "write"),
         ],
     )
     def test_write_suffixes(self, op_id: str, expected: str) -> None:

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -380,29 +380,75 @@ async def test_execute_vault_kv_read_returns_secret_data(
     assert fake.auth.jwt.login_calls == [
         {"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"},
     ]
-    assert fake.secrets.kv.v2.read_calls == [{"path": "secret/meho/test/federation"}]
+    # Mount defaults to "secret" when the caller omits it — the
+    # path-only call site keeps working unchanged.
+    assert fake.secrets.kv.v2.read_calls == [
+        {"path": "secret/meho/test/federation", "mount_point": "secret"},
+    ]
     assert fake.auth.token.revoke_calls == 1
+
+
+async def test_execute_vault_kv_read_honors_explicit_mount(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """An explicit ``mount`` is forwarded as hvac's ``mount_point``.
+
+    This is the load-bearing case for Initiative #366: the consumer
+    wrappers address secrets as ``<mount> <path>`` so they can read
+    arbitrary mounts (retiring ``scripts/_secret-read.sh``, which
+    derived the mount from the path's first segment). Without mount
+    forwarding on ``vault.kv.read`` the wrapper goal is unmet.
+    """
+    fake = install_fake_client(monkeypatch, secret={"k": "v"})
+    result = await VaultConnector().execute(
+        _make_target(),
+        "vault.kv.read",
+        {"mount": "kv-prod", "path": "team/api"},
+    )
+
+    assert result.status == "ok", result.error
+    assert fake.secrets.kv.v2.read_calls == [
+        {"path": "team/api", "mount_point": "kv-prod"},
+    ]
 
 
 @pytest.mark.parametrize(
     "params",
-    [{}, {"path": ""}, {"path": "   "}],
-    ids=["missing", "empty-string", "whitespace-only"],
+    [
+        {},
+        {"path": ""},
+        {"path": "   "},
+        {"mount": "   ", "path": "p"},
+        {"mount": "secret/data", "path": "p"},
+    ],
+    ids=[
+        "missing",
+        "empty-string",
+        "whitespace-only",
+        "mount-whitespace-only",
+        "mount-with-slash",
+    ],
 )
 async def test_execute_vault_kv_read_invalid_path_returns_dispatcher_error(
     monkeypatch: pytest.MonkeyPatch,
     params: dict[str, Any],
     _registered_vault_typed_ops: None,
 ) -> None:
-    """Missing, empty, or whitespace-only ``path`` → dispatcher's ``invalid_params``.
+    """Bad ``path`` or ``mount`` → dispatcher's ``invalid_params``.
 
     The pre-G0.6 handler ran the validation inline (``isinstance``
     + ``strip``); post-refactor, the dispatcher's
     :class:`Draft202012Validator` enforces ``minLength=1`` /
-    ``pattern="\\S"`` from the registered parameter_schema.
-    The non-string ``path`` case (``{"path": 123}``) is covered by
-    the schema's ``"type": "string"`` constraint and lands in the
-    same ``invalid_params`` shape.
+    ``pattern="\\S"`` for ``path`` from the registered
+    parameter_schema. ``mount`` is the shared optional fragment whose
+    ``pattern="^(?=.*\\S)[^/]+$"`` rejects an all-whitespace value
+    (which would otherwise ``.strip()`` to an empty mount and degrade
+    to a runtime ``connector_error``) and a slash-bearing value
+    (``"secret/data"``) at validation time. The non-string ``path``
+    case (``{"path": 123}``) is covered by the schema's
+    ``"type": "string"`` constraint and lands in the same
+    ``invalid_params`` shape.
     """
     install_fake_client(monkeypatch)
     result = await VaultConnector().execute(_make_target(), "vault.kv.read", params)

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -69,6 +69,7 @@ import hvac.exceptions
 import pytest
 import requests.exceptions
 
+from meho_backplane.broadcast.events import classify_op
 from meho_backplane.connectors import all_connectors_v2
 from meho_backplane.connectors.registry import (
     clear_registry,
@@ -343,9 +344,10 @@ async def test_execute_unknown_op_returns_dispatcher_unknown_op_shape(
     assert result.extras.get("error_code") == "unknown_op"
     assert "known_op_count" in result.extras
     # The known_op_count reflects the descriptors registered for the
-    # (product="vault", version="1.x", impl_id="vault") triple --
-    # exactly one (vault.kv.read) from the typed-op upsert.
-    assert result.extras["known_op_count"] >= 1
+    # (product="vault", version="1.x", impl_id="vault") triple -- the
+    # full KV-v2 group (read, list, put, versions, delete) from the
+    # G3.3-T1 typed-op upsert.
+    assert result.extras["known_op_count"] >= 5
 
 
 # ---------------------------------------------------------------------------
@@ -506,3 +508,248 @@ async def test_execute_read_failure_surfaces_non_vault_client_error_class(
     assert result.error.startswith("connector_error:")
     assert result.extras.get("error_code") == "connector_error"
     assert result.extras.get("exception_class") == expected_exc_class
+
+
+# ---------------------------------------------------------------------------
+# G3.3-T1 — vault.kv.list / put / versions / delete
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_vault_kv_list_returns_key_names(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch, keys=["api-key", "db/"])
+    result = await VaultConnector().execute(
+        _make_target(jwt="op-jwt"),
+        "vault.kv.list",
+        {"path": "meho/test"},
+    )
+
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["keys"] == ["api-key", "db/"]
+    # Mount defaults to "secret" when the caller omits it.
+    assert fake.secrets.kv.v2.list_calls == [
+        {"path": "meho/test", "mount_point": "secret"},
+    ]
+
+
+async def test_execute_vault_kv_list_honors_explicit_mount(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch, keys=["x"])
+    result = await VaultConnector().execute(
+        _make_target(),
+        "vault.kv.list",
+        {"mount": "kv-prod", "path": "team"},
+    )
+
+    assert result.status == "ok", result.error
+    assert fake.secrets.kv.v2.list_calls == [
+        {"path": "team", "mount_point": "kv-prod"},
+    ]
+
+
+async def test_execute_vault_kv_put_writes_new_version(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch, kv_version=4)
+    result = await VaultConnector().execute(
+        _make_target(jwt="op-jwt"),
+        "vault.kv.put",
+        {"path": "meho/test", "data": {"token": "s3cr3t"}, "cas": 4},
+    )
+
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["version"] == 5
+    assert fake.secrets.kv.v2.put_calls == [
+        {
+            "path": "meho/test",
+            "secret": {"token": "s3cr3t"},
+            "cas": 4,
+            "mount_point": "secret",
+        },
+    ]
+
+
+async def test_execute_vault_kv_put_cas_omitted_passes_none(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """No ``cas`` ⇒ hvac called with ``cas=None`` (unconditional write)."""
+    fake = install_fake_client(monkeypatch)
+    result = await VaultConnector().execute(
+        _make_target(),
+        "vault.kv.put",
+        {"path": "meho/test", "data": {"k": "v"}},
+    )
+
+    assert result.status == "ok", result.error
+    assert fake.secrets.kv.v2.put_calls[0]["cas"] is None
+
+
+@pytest.mark.parametrize(
+    "params",
+    [{"path": "p"}, {"data": {"k": "v"}}, {"path": "p", "data": {}}],
+    ids=["missing-data", "missing-path", "empty-data"],
+)
+async def test_execute_vault_kv_put_invalid_params_returns_dispatcher_error(
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Schema enforces ``required`` path+data and ``minProperties`` on data."""
+    install_fake_client(monkeypatch)
+    result = await VaultConnector().execute(_make_target(), "vault.kv.put", params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras.get("error_code") == "invalid_params"
+
+
+async def test_execute_vault_kv_versions_returns_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(
+        monkeypatch,
+        kv_version=3,
+        versions_meta={
+            "1": {"created_time": "2026-01-01T00:00:00Z", "destroyed": False},
+            "3": {"created_time": "2026-03-01T00:00:00Z", "destroyed": False},
+        },
+    )
+    result = await VaultConnector().execute(
+        _make_target(),
+        "vault.kv.versions",
+        {"path": "meho/test"},
+    )
+
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["current_version"] == 3
+    assert set(result.result["versions"]) == {"1", "3"}
+    assert fake.secrets.kv.v2.versions_calls == [
+        {"path": "meho/test", "mount_point": "secret"},
+    ]
+
+
+async def test_execute_vault_kv_delete_soft_deletes_versions(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    result = await VaultConnector().execute(
+        _make_target(jwt="op-jwt"),
+        "vault.kv.delete",
+        {"path": "meho/test", "versions": [2, 3]},
+    )
+
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["deleted_versions"] == [2, 3]
+    assert fake.secrets.kv.v2.delete_calls == [
+        {"path": "meho/test", "versions": [2, 3], "mount_point": "secret"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [{"path": "p"}, {"path": "p", "versions": []}, {"versions": [1]}],
+    ids=["missing-versions", "empty-versions", "missing-path"],
+)
+async def test_execute_vault_kv_delete_invalid_params_returns_dispatcher_error(
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Schema enforces ``required`` path+versions and ``minItems`` on versions."""
+    install_fake_client(monkeypatch)
+    result = await VaultConnector().execute(_make_target(), "vault.kv.delete", params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras.get("error_code") == "invalid_params"
+
+
+@pytest.mark.parametrize(
+    "op_id,params,exc_kwarg",
+    [
+        ("vault.kv.list", {"path": "p"}, "list_exc"),
+        ("vault.kv.put", {"path": "p", "data": {"k": "v"}}, "put_exc"),
+        ("vault.kv.versions", {"path": "p"}, "versions_exc"),
+        ("vault.kv.delete", {"path": "p", "versions": [1]}, "delete_exc"),
+    ],
+    ids=["list", "put", "versions", "delete"],
+)
+async def test_execute_kv_ops_vault_error_envelope_surfaces_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    exc_kwarg: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A Vault-side raise on any KV-v2 verb → structured connector_error.
+
+    Mirrors the ``vault.kv.read`` read-phase contract: the handler
+    raises, the dispatcher wraps it with ``extras.exception_class``.
+    """
+    install_fake_client(
+        monkeypatch,
+        **{exc_kwarg: RuntimeError("permission denied")},
+    )
+    result = await VaultConnector().execute(_make_target(), op_id, params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "RuntimeError"
+
+
+async def test_execute_vault_kv_list_malformed_payload_is_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A malformed hvac list payload → KeyError → structured connector_error."""
+    fake = install_fake_client(monkeypatch)
+
+    def _bad_list(path: str, mount_point: str = "secret", **_kw: Any) -> dict[str, Any]:
+        return {"data": {}}  # missing "keys"
+
+    monkeypatch.setattr(fake.secrets.kv.v2, "list_secrets", _bad_list)
+    result = await VaultConnector().execute(_make_target(), "vault.kv.list", {"path": "p"})
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "KeyError"
+
+
+@pytest.mark.parametrize(
+    "op_id,expected_class",
+    [
+        ("vault.kv.read", "credential_read"),
+        ("vault.kv.list", "credential_read"),
+        ("vault.kv.versions", "read"),
+        ("vault.kv.put", "write"),
+        ("vault.kv.delete", "write"),
+    ],
+)
+def test_kv_op_ids_classify_per_decision_3(op_id: str, expected_class: str) -> None:
+    """The G6 broadcast classifier (op-id based, decision #3) tags the KV-v2 group.
+
+    The shipped G0.6 substrate has no per-row ``op_class`` column on
+    ``endpoint_descriptor``; decision #3 locks the sensitivity
+    classifier on the op-id via ``_CREDENTIAL_READ_OPS``. This pins
+    the register-time contract the DoD asks for: ``vault.kv.read`` and
+    ``vault.kv.list`` are ``credential_read`` (aggregate-only
+    broadcast); ``vault.kv.versions`` is a plain metadata ``read``;
+    the mutating verbs are ``write``.
+    """
+    assert classify_op(op_id) == expected_class

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -58,6 +58,76 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   The three authenticated ops forward the operator JWT via
   `vault_client_for_operator` and offload the blocking `hvac` call with
   `asyncio.to_thread`.
+- **`auth` read op group** (`ops_auth.py`, G3.3-T3 #547) —
+  `register_vault_auth_operations()` registers `vault.auth.userpass.list`
+  / `vault.auth.userpass.read` / `vault.auth.approle.list` /
+  `vault.auth.approle.read` under group key `auth`, all
+  `safety_level='safe'`. Mount path is parameterised (defaults
+  `userpass` / `approle`); a not-mounted backend raises
+  `VaultAuthBackendNotMountedError`. AppRole secret-id generation is
+  deliberately out of scope (v0.2.next, behind a policy gate). It is
+  registered from its own module via the
+  `register_vault_auth_operations()` call at the end of
+  `register_vault_typed_operations()`.
+
+## KV-v2 op group
+
+| op_id | hvac call | safety_level | op_class (broadcast) |
+|---|---|---|---|
+| `vault.kv.read` | `read_secret_version` | safe | `credential_read` |
+| `vault.kv.list` | `list_secrets` | safe | `credential_read` |
+| `vault.kv.versions` | `read_secret_metadata` | safe | `read` |
+| `vault.kv.put` | `create_or_update_secret` | caution | `write` |
+| `vault.kv.delete` | `delete_secret_versions` | dangerous | `write` |
+
+All five register into operation group `kv`.
+
+**Mount handling.** Every handler accepts an optional `mount` param
+(JSON Schema default `"secret"`, mirroring hvac's `mount_point`
+default). The pre-existing `vault.kv.read` `path`-only call sites keep
+working; the consumer wrappers pass `<mount> <path>` explicitly for
+non-default mounts. The mount pattern rejects whitespace-only and
+slash-bearing input at param validation (`^(?=.*\S)[^/]+$`), so a bad
+mount is an `invalid_params` failure rather than a runtime
+`connector_error` (G3.3-T1 review B1/M1).
+
+**Two-phase failure model.** Login-side failures (Vault unreachable,
+role denied) raise `VaultClientError` subclasses; read/write-side
+failures (KV miss, malformed payload, CAS mismatch, permission
+denied) raise the underlying exception. Callers that need the
+distinction (the `/api/v1/health` route) string-match
+`extras["exception_class"]` against the known `VaultClientError`
+subclass names. Structural unwrap of the hvac payload raises
+`KeyError` on a malformed envelope so the dispatcher reports a
+structured error rather than an unhandled exception.
+
+## Broadcast PII discipline (decision #3)
+
+The G6 broadcast publisher emits an aggregate-only payload for
+`credential_read` and `audit_query` ops. The sensitivity class is
+derived **from the op-id**, not a per-descriptor field:
+`broadcast.events.classify_op` consults the `_CREDENTIAL_READ_OPS`
+allowlist (currently `{vault.kv.read, vault.kv.list}`) and the
+`_WRITE_SUFFIXES` / `_READ_SUFFIXES` tuples. The shipped G0.6
+`endpoint_descriptor` table has **no `op_class` column** — decision #3
+locks the classifier on the op-id, so the register-time signal is the
+op-id itself. `vault.kv.versions` reads only version metadata (never
+secret values) and is deliberately a plain `read`, not
+`credential_read`. The `.put` / `.versions` suffixes were added to the
+write / read suffix tuples by #545 — without that, `vault.kv.put`
+would have classified `other` and broadcast the written secret to
+every operator (the credential-leak fix).
+
+## Approval gating
+
+`vault.kv.put` (`caution`) and `vault.kv.delete` (`dangerous`)
+register with `requires_approval=False` — the dev default.
+`requires_approval` is a static boolean on the descriptor; the shipped
+G0.6 substrate has no per-path approval predicate. The
+production-path approval gate is G7/G10 policy territory (see the
+`EndpointDescriptor` model docstring: `caution`/`dangerous` ops "flow
+through G7 / G10 policy logic once those Goals land"). `safety_level`
+is the load-bearing signal that future gate keys on.
 
 ## Control flow
 
@@ -65,7 +135,9 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
    `VaultConnector` against the v2 registry synchronously and queues
    two typed-op registrars (`register_vault_typed_operations`,
    `register_vault_sys_typed_operations`) onto the lifespan-driven
-   registrar list.
+   registrar list. `register_vault_typed_operations` registers the
+   KV-v2 group and then calls `register_vault_auth_operations` for the
+   `auth` group.
 2. At FastAPI lifespan startup, `run_typed_op_registrars()` invokes
    both registrars, which upsert the `endpoint_descriptor` rows. Upsert
    is idempotent: a restart against unchanged descriptions is a no-op
@@ -123,12 +195,20 @@ surfaces a raw traceback to the agent.
   lands.
 - `sys` writes (unseal, mount/unmount, policy write) are deliberately
   out of scope for v0.2.
+- AppRole secret-id generation is out of scope for v0.2 (high-risk
+  write with policy implications; v0.2.next behind a policy gate).
 
 ## References
 
 - Initiative #366 (G3.3 vault-1.x typed op surface); Goal #214.
-- Task #546 (G3.3-T2 sys read op group); sibling #545 (G3.3-T1 KV-v2).
+- Tasks: #545 (G3.3-T1 KV-v2), #546 (G3.3-T2 sys read group),
+  #547 (G3.3-T3 auth read group).
 - Substrate: #388 (G0.6 operation registry), #390 (Refactor-Vault).
-- Vault sys API: https://developer.hashicorp.com/vault/api-docs/system
+- Vault API: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2
+  (KV-v2), https://developer.hashicorp.com/vault/api-docs/system (sys),
+  https://developer.hashicorp.com/vault/api-docs/auth/userpass
+  (userpass), https://developer.hashicorp.com/vault/api-docs/auth/approle
+  (approle).
+- Decision #3 PII redaction: `docs/planning/v0.2-decisions.md`.
 - CLAUDE.md postulates 1 (typed connectors first-class) and 7
   (synchronous append-only audit).

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -82,14 +82,20 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
 
 All five register into operation group `kv`.
 
-**Mount handling.** Every handler accepts an optional `mount` param
-(JSON Schema default `"secret"`, mirroring hvac's `mount_point`
-default). The pre-existing `vault.kv.read` `path`-only call sites keep
-working; the consumer wrappers pass `<mount> <path>` explicitly for
-non-default mounts. The mount pattern rejects whitespace-only and
-slash-bearing input at param validation (`^(?=.*\S)[^/]+$`), so a bad
-mount is an `invalid_params` failure rather than a runtime
-`connector_error` (G3.3-T1 review B1/M1).
+**Mount handling.** Every handler — including `vault.kv.read` —
+accepts an optional `mount` param (JSON Schema default `"secret"`,
+mirroring hvac's `mount_point` default) forwarded as hvac's
+`mount_point`. The pre-existing `vault.kv.read` `path`-only call sites
+keep working on the default; the consumer wrappers pass
+`<mount> <path>` explicitly for non-default mounts (the Initiative
+#366 goal — retiring `scripts/_secret-read.sh`, which derived the
+mount from the path's first segment). The shared `mount` schema
+fragment uses `pattern="^(?=.*\S)[^/]+$"`: the `(?=.*\S)` lookahead
+makes an all-whitespace value a validation-time `invalid_params`
+failure rather than a value that `.strip()`s to an empty mount and
+degrades to a runtime `connector_error`; `[^/]+` rejects a
+slash-bearing value (`"secret/data"`) where hvac expects the bare
+mount handle.
 
 **Two-phase failure model.** Login-side failures (Vault unreachable,
 role denied) raise `VaultClientError` subclasses; read/write-side


### PR DESCRIPTION
## Summary

- Completes the typed Vault connector's **KV-v2 op group**: adds `vault.kv.list` / `put` / `versions` / `delete` alongside the pre-existing `vault.kv.read`, each registered via `register_typed_operation()` with full param + response JSON Schema 2020-12, `llm_instructions`, `safety_level`, and operation group `kv`. The five registrations are driven from a per-op spec table so the sibling `sys`/`auth` groups are a one-row append.
- Every handler accepts an optional `mount` param (default `"secret"`, mirroring hvac's `mount_point`) so the consumer's `<mount> <path>` wrapper shape works without breaking the established `path`-only `vault.kv.read` call sites.
- **Closed a credential-broadcast leak found during implementation.** The DoD asked for `op_class` metadata on `endpoint_descriptor` rows, but the shipped G0.6 substrate has **no such column** — decision #3 locks the G6 broadcast sensitivity classifier on the **op-id** (`broadcast.events.classify_op` + `_CREDENTIAL_READ_OPS`). Adding `kv.put` / `kv.versions` exposed a real gap: neither suffix was in `_WRITE_SUFFIXES`/`_READ_SUFFIXES`, so a secret write would fall through to `other` and broadcast its **full params**, leaking the written secret to every operator. Fixed by classifying `.put` as write and `.versions` as read, with regression tests pinning the whole KV-v2 group.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — clean (144 files)
- [x] `pytest tests/` — 1765 passed, 43 skipped (one Docker-bound k3d integration test, untouched by this PR, only fails in the sandbox without Docker; runs in CI)
- [x] `code-quality.py --diff` — 0 blockers (2 pre-existing file/function-size warnings, recorded below)
- [x] Each new op: success + invalid-params + Vault-error-envelope + malformed-payload tests (`tests/test_connectors_vault.py`)
- [x] `classify_op` regression for the full KV-v2 group (`tests/test_connectors_vault.py` + `tests/test_broadcast_events.py`)
- [x] Registration idempotent on restart — exercised via the existing skip-re-embed path in `register_typed_operation` (shared with `vault.kv.read`)

## DoD reconciliation

- "`op_class='credential_read'` metadata on `endpoint_descriptor` rows" — there is **no `op_class`/metadata column** on `EndpointDescriptor`; decision #3 (`docs/planning/v0.2-decisions.md` L46-55) and the shipped substrate (#388/#390, both CLOSED) make the classifier **op-id based**. `vault.kv.read` and `vault.kv.list` were already in `_CREDENTIAL_READ_OPS`. The DoD's intent is satisfied and pinned by `test_kv_op_ids_classify_per_decision_3`; the wording describes a mechanism the substrate does not have.
- `requires_approval` for `kv.put`/`kv.delete` registered `False` (dev default). The substrate has no per-path approval predicate — that is G7/G10 policy territory per the `EndpointDescriptor` model docstring; `safety_level` (`caution`/`dangerous`) is the load-bearing signal the future gate keys on.

## Out of scope

- KV-v1, secret-engine writes beyond KV-v2 (deferred per the issue).
- The G6 SSE integration assertion (sibling Task G3.3-T5 owns it; this PR only sets the op-id classifier signal).
- CLI verbs (G3.3-T6) and the dev-mode integration harness (G3.3-T7).

## Adjacent findings (out of scope, recorded)

- `connectors/vault/ops.py` is 794 lines (>600 soft limit) and `vault_kv_read` is 85 lines (>60 soft warn) — both pre-existing from the original `vault.kv.read` block; diff-only code-quality reports them as warnings, not blockers. Splitting the module by responsibility is a clean follow-up.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vault KV-v2 operations: list, put, delete, versions — support optional mount parameter and return structured results.
  * Broadcast classification updated so KV put is treated as "write" and KV versions as "read".

* **Documentation**
  * Updated Vault connector docs to describe KV-v2 behavior, mount semantics, classification notes, and auth read ops.

* **Tests**
  * Expanded tests and fakes to cover new KV-v2 verbs, parameter validation, error handling, and mount behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-16)

Addressed `/auto-review-pr` iteration-1 findings (review-results/pr-557-iter-1.json):

- **B1** `7f2643a` — `vault.kv.read` now accepts the shared optional `mount` param and forwards it as hvac's `mount_point`; path-only call sites keep working on the `"secret"` default. Closes the Initiative #366 wrapper goal for read.
- **M1** `7f2643a` — `_MOUNT_PROPERTY` pattern tightened to `^(?=.*\S)[^/]+$` so a whitespace-only mount is an `invalid_params` failure, not a runtime `connector_error`.
- Adjacent (MD018) `7f2643a` — rewrapped `docs/codebase/connectors-vault.md` line 13 so `#366` is no longer at line start.

Tests: new `test_execute_vault_kv_read_honors_explicit_mount`; `read` invalid-params parametrization gains whitespace-only-mount + slash-bearing-mount cases; both `_FakeKVv2.read_secret_version` fakes (shared + health-local) record `mount_point`; existing read/health happy-path assertions updated for the defaulted `"secret"`. Verification: ruff/ruff-format/mypy clean; vault + broadcast + leak + auth + health suites — 237 passed, 1 skipped (env-guarded).

Deferred (recorded as adjacent finding; orchestrator may file a follow-up): `connectors/vault/ops.py` is 816 lines (>600 soft) — pre-existing per iter-1, a module split is a clean out-of-scope follow-up.

<!-- auto-implement-issue: continue, iteration 1 -->
