### PR TITLE
feat(topology): G9.1-T5 REST API surface — 5 routes for topology + targets-discover

### DIFF
--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -65,16 +65,19 @@ from datetime import UTC, datetime
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
-from meho_backplane.connectors.registry import get_connector
-from meho_backplane.connectors.schemas import AuthModel, FingerprintResult
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import all_connectors_v2, get_connector
+from meho_backplane.connectors.schemas import AuthModel, CandidateHint, FingerprintResult
 from meho_backplane.db.engine import get_session
 from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.targets.resolver import resolve_target
 from meho_backplane.targets.schemas import Target, TargetCreate, TargetSummary, TargetUpdate
 
@@ -89,6 +92,47 @@ router = APIRouter(prefix="/api/v1/targets", tags=["targets"])
 #: :mod:`meho_backplane.api.v1.retrieve`.
 _require_operator = Depends(require_role(TenantRole.OPERATOR))
 _require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+
+#: Canonical op id for the discover route's audit row + broadcast.
+#: ``.discover`` is not one of the broadcast classifier's read/write
+#: verb suffixes, so the explicit ``audit_op_class="read"`` override
+#: this constant pairs with is load-bearing (mirrors the ``kb.show``
+#: rationale in :mod:`meho_backplane.api.v1.kb`).
+_DISCOVER_OP_ID = "targets.discover"
+
+
+class SkippedConnector(BaseModel):
+    """One connector that did not contribute candidates for a product.
+
+    ``name`` is the connector implementation key (the ``impl_id`` from
+    the v2 registry, or the class name for a v1-only registration).
+    ``reason`` is a short human string — ``"no candidates"`` when the
+    connector ran cleanly but inferred nothing, or the exception class
+    + message when ``list_candidates`` raised (one bad connector must
+    not fail the whole discover sweep).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    reason: str
+
+
+class TargetsDiscoverResult(BaseModel):
+    """Aggregated discover output across every connector for a product.
+
+    ``discovered`` is the merged candidate list from every connector
+    registered for the requested product; ``skipped`` records the
+    connectors that contributed nothing (clean-but-empty or errored).
+    The verb never auto-creates ``targets`` rows — the operator reviews
+    ``discovered`` and runs ``meho targets create`` (Initiative #363:
+    auto-registration is v0.2.next).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    discovered: list[CandidateHint]
+    skipped: list[SkippedConnector]
 
 
 def _to_summary(t: TargetORM) -> TargetSummary:
@@ -149,6 +193,100 @@ async def list_targets(
     stmt = stmt.order_by(TargetORM.name).limit(limit)
     result = await session.execute(stmt)
     return [_to_summary(t) for t in result.scalars().all()]
+
+
+@router.get("/discover", response_model=TargetsDiscoverResult)
+async def discover_targets(
+    product: str = Query(...),
+    seed_target: str | None = Query(default=None),
+    operator: Operator = _require_operator,
+    session: AsyncSession = Depends(get_session),
+) -> TargetsDiscoverResult:
+    """Discover potentially-reachable targets for a *product*.
+
+    Iterates every connector implementation registered for *product*
+    and calls
+    :meth:`~meho_backplane.connectors.base.Connector.list_candidates`
+    on each, merging the results. ``seed_target`` (optional) scopes the
+    discovery to one already-registered target's reach (e.g. peer
+    Kubernetes clusters in the same kubeconfig context tree); it is
+    resolved tenant-scoped via
+    :func:`~meho_backplane.targets.resolver.resolve_target` so a
+    principal can only seed from a target in their own tenant
+    (cross-tenant seeding is impossible). 404 with near-misses when the
+    seed name does not resolve.
+
+    The verb is **read-only** — it returns candidates, never creates
+    ``targets`` rows (Initiative #363: auto-registration is v0.2.next;
+    the operator runs ``meho targets create`` after review). One
+    connector raising does not fail the sweep: it is recorded in
+    ``skipped`` with the exception summary and the rest still run.
+
+    Registered **before** ``GET /{name}`` on the same router so the
+    literal ``/discover`` segment is matched as this route rather than
+    captured as a target name by the parametrised describe route
+    (FastAPI resolves routes in declaration order).
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_DISCOVER_OP_ID,
+        audit_op_class="read",
+    )
+
+    seed: TargetORM | None = None
+    if seed_target is not None:
+        # resolve_target raises HTTPException(404/409) directly and
+        # binds target_id into contextvars for the audit row.
+        seed = await resolve_target(session, operator.tenant_id, seed_target)
+
+    # Enumerate every connector implementation registered for the
+    # product. The v2 registry keys on (product, version, impl_id) and
+    # subsumes v1 registrations (as (product, "", "")), so one pass
+    # covers connectors registered by either entry point. Dedupe by
+    # connector class so a product with one impl registered under both
+    # registry layers is not probed twice.
+    impls: dict[type[Connector], str] = {}
+    for (reg_product, version, impl_id), cls in all_connectors_v2().items():
+        if reg_product != product:
+            continue
+        # Human-meaningful label: prefer impl_id, fall back to a
+        # version tag, then the class name (v1-only registration keys
+        # both fields empty).
+        label = impl_id or version or cls.__name__
+        impls.setdefault(cls, label)
+
+    discovered: list[CandidateHint] = []
+    skipped: list[SkippedConnector] = []
+
+    for cls, label in impls.items():
+        connector = get_or_create_connector_instance(cls)
+        try:
+            candidates = await connector.list_candidates(seed)
+        except Exception as exc:
+            # One bad connector must not abort the whole sweep — record
+            # the failure and continue with the remaining connectors.
+            _log.warning(
+                "targets_discover_connector_failed",
+                product=product,
+                connector=label,
+                tenant_id=str(operator.tenant_id),
+                error=repr(exc),
+            )
+            skipped.append(SkippedConnector(name=label, reason=f"{type(exc).__name__}: {exc}"))
+            continue
+        if candidates:
+            discovered.extend(candidates)
+        else:
+            skipped.append(SkippedConnector(name=label, reason="no candidates"))
+
+    _log.info(
+        "targets_discover_completed",
+        product=product,
+        tenant_id=str(operator.tenant_id),
+        connectors=len(impls),
+        discovered=len(discovered),
+        skipped=len(skipped),
+    )
+    return TargetsDiscoverResult(discovered=discovered, skipped=skipped)
 
 
 @router.get("/{name}", response_model=Target)

--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/topology*`` — REST front for the G9.1 topology graph.
+
+G9.1-T5 (#453) of Initiative #363. Four routes that wrap the merged
+T3 (#450) refresh service and T4 (#451) recursive-CTE query verbs:
+
+* ``GET  /api/v1/topology/dependents/{name}``   — reverse closure
+  ("what depends on me"). Wraps :func:`find_dependents`.
+* ``GET  /api/v1/topology/dependencies/{name}`` — forward closure
+  ("what I depend on"). Wraps :func:`find_dependencies`.
+* ``GET  /api/v1/topology/path``                — shortest unweighted
+  path between two named nodes, or ``null`` when unreachable. Wraps
+  :func:`find_path`.
+* ``POST /api/v1/topology/refresh/{target_name}`` — on-demand
+  rediscovery of one target's topology. Wraps
+  :func:`refresh_target_topology`.
+
+The fifth route (``GET /api/v1/targets/discover``) lives on the
+targets router (:mod:`meho_backplane.api.v1.targets`) so it sits under
+the canonical ``/api/v1/targets`` prefix next to the other
+target-scoped verbs.
+
+RBAC
+----
+
+Every route requires ``operator`` minimum (``read_only`` gets 403 via
+:func:`require_role`). ``refresh`` writes to ``graph_node`` /
+``graph_edge`` but never to ``targets``; per the Initiative #363
+acceptance criteria v0.2 keeps it ``operator`` (the curated-edge
+writes that would warrant ``tenant_admin`` land in G9.2).
+
+Tenant scoping
+--------------
+
+There is no surface that accepts a ``tenant_id`` from the path, query
+string, or body. The query verbs filter ``graph_node.tenant_id`` and
+``graph_edge.tenant_id`` against ``operator.tenant_id`` in both the
+anchor and the recursive term; ``refresh`` resolves the target
+tenant-scoped via :func:`resolve_target` and the reconcile writes
+every row under ``operator.tenant_id``. A same-named node or target in
+another tenant is invisible — cross-tenant traversal *and*
+cross-tenant refresh are impossible by construction.
+
+Audit + broadcast
+-----------------
+
+Each route binds ``audit_op_id`` / ``audit_op_class`` into structlog
+contextvars *before* the service call so the chassis
+:class:`~meho_backplane.audit.AuditMiddleware` row (and the broadcast
+event it derives) carry the canonical op identity even if the handler
+raises mid-call. The read verbs bind ``topology.dependents`` /
+``topology.dependencies`` / ``topology.path`` with
+``op_class="read"``. The refresh route binds ``topology.refresh`` /
+``op_class="read"`` for the HTTP-level row; the refresh *service*
+additionally writes its own domain-level audit row + one broadcast
+event with the per-target node/edge counts (Initiative #363 item 11) —
+the two rows are intentional, mirroring how the operations dispatcher
+writes a domain row alongside the middleware's HTTP row.
+
+The ``.dependents`` / ``.dependencies`` / ``.path`` / ``.refresh``
+suffixes are none of the broadcast classifier's read/write verb
+suffixes, so the explicit ``audit_op_class="read"`` override is
+load-bearing — without it the classifier would default to
+``op_class="other"`` and emit the full request payload instead of a
+read-shaped trace.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.db.engine import get_session
+from meho_backplane.targets.resolver import resolve_target
+from meho_backplane.topology.query import (
+    AmbiguousNodeError,
+    find_dependencies,
+    find_dependents,
+    find_path,
+)
+from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
+from meho_backplane.topology.schemas import TopologyNode, TopologyPath
+
+__all__ = ["router"]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/topology", tags=["topology"])
+
+#: Module-level Depends closure — required to satisfy ruff B008 (a
+#: mutable call in a default-argument position is disallowed). Same
+#: pattern :mod:`meho_backplane.api.v1.targets` /
+#: :mod:`meho_backplane.api.v1.retrieve` established.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+
+#: Canonical op identifiers bound into ``audit_op_id`` per route.
+#: Pinned as module constants so the contract is greppable from tests +
+#: G8 dashboards and a typo surfaces at first call rather than as a
+#: silent broadcast under the wrong op_id. Mirrors ``_KB_OP_IDS`` in
+#: :mod:`meho_backplane.api.v1.kb`.
+_OP_DEPENDENTS = "topology.dependents"
+_OP_DEPENDENCIES = "topology.dependencies"
+_OP_PATH = "topology.path"
+_OP_REFRESH = "topology.refresh"
+
+#: Bounds mirror the service-layer defaults (``query._DEFAULT_DEPTH`` /
+#: ``query._DEFAULT_MAX_HOPS``); the ceilings cap a pathological
+#: traversal at the HTTP boundary so a hostile ``depth`` query param
+#: cannot ask the recursive CTE to walk an unbounded closure (#363
+#: performance discipline — depth-16 default, hard ceiling here).
+_DEPTH_DEFAULT = 16
+_DEPTH_MAX = 64
+_MAX_HOPS_DEFAULT = 8
+_MAX_HOPS_MAX = 32
+
+
+@router.get("/dependents/{name}", response_model=list[TopologyNode])
+async def dependents(
+    name: str,
+    depth: int = Query(default=_DEPTH_DEFAULT, ge=1, le=_DEPTH_MAX),
+    kind: str | None = Query(default=None),
+    kind_filter: str | None = Query(default=None),
+    operator: Operator = _require_operator,
+) -> list[TopologyNode]:
+    """Reverse closure: every node that depends on *name*.
+
+    Wraps :func:`~meho_backplane.topology.query.find_dependents`. The
+    root node is included at depth 0 so a caller can distinguish "node
+    exists but has no dependents" (one-element list) from "node does
+    not exist in this tenant" (empty list).
+
+    ``kind`` pins the anchor to the ``(tenant_id, kind, name)`` unique
+    row; omit it only when *name* is unique across kinds in the tenant.
+    A bare *name* that resolves to multiple kinds returns 409
+    (``ambiguous_node``) rather than silently merging unrelated
+    closures. ``kind_filter`` restricts the walk to edges of that
+    ``graph_edge.kind``.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_DEPENDENTS,
+        audit_op_class="read",
+    )
+    try:
+        return await find_dependents(
+            operator,
+            name,
+            kind=kind,
+            depth=depth,
+            kind_filter=kind_filter,
+        )
+    except AmbiguousNodeError as exc:
+        raise _ambiguous_node_http(exc) from exc
+
+
+@router.get("/dependencies/{name}", response_model=list[TopologyNode])
+async def dependencies(
+    name: str,
+    depth: int = Query(default=_DEPTH_DEFAULT, ge=1, le=_DEPTH_MAX),
+    kind: str | None = Query(default=None),
+    kind_filter: str | None = Query(default=None),
+    operator: Operator = _require_operator,
+) -> list[TopologyNode]:
+    """Forward closure: everything *name* depends on.
+
+    The mirror of :func:`dependents` — same shape, same one-row-per-
+    node closure dedupe, same ``kind`` disambiguation contract, same
+    tenant scoping — walking edges out of the current node rather than
+    into it. Wraps
+    :func:`~meho_backplane.topology.query.find_dependencies`.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_DEPENDENCIES,
+        audit_op_class="read",
+    )
+    try:
+        return await find_dependencies(
+            operator,
+            name,
+            kind=kind,
+            depth=depth,
+            kind_filter=kind_filter,
+        )
+    except AmbiguousNodeError as exc:
+        raise _ambiguous_node_http(exc) from exc
+
+
+@router.get("/path", response_model=TopologyPath | None)
+async def path(
+    from_name: str = Query(..., alias="from"),
+    to_name: str = Query(..., alias="to"),
+    from_kind: str | None = Query(default=None),
+    to_kind: str | None = Query(default=None),
+    max_hops: int = Query(default=_MAX_HOPS_DEFAULT, ge=1, le=_MAX_HOPS_MAX),
+    operator: Operator = _require_operator,
+) -> TopologyPath | None:
+    """Shortest unweighted path from ``from`` to ``to``, or ``null``.
+
+    Wraps :func:`~meho_backplane.topology.query.find_path`. The query
+    params are ``from`` / ``to`` (matching the Initiative #363 route
+    spec ``?from=A&to=B``); the handler binds them via ``alias`` since
+    ``from`` is a Python keyword. Walks edges in both directions so the
+    path follows the graph's connectivity rather than only its edge
+    orientation. Returns ``null`` (HTTP 200) when *to* is unreachable
+    from *from* within ``max_hops`` or either endpoint does not exist
+    in this tenant — unreachability is a valid answer, not an error.
+
+    ``from_kind`` / ``to_kind`` pin each endpoint independently; an
+    unpinned name resolving to multiple kinds returns 409
+    (``ambiguous_node``).
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_PATH,
+        audit_op_class="read",
+    )
+    try:
+        return await find_path(
+            operator,
+            from_name,
+            to_name,
+            from_kind=from_kind,
+            to_kind=to_kind,
+            max_hops=max_hops,
+        )
+    except AmbiguousNodeError as exc:
+        raise _ambiguous_node_http(exc) from exc
+
+
+@router.post("/refresh/{target_name}", response_model=RefreshResult)
+async def refresh(
+    target_name: str,
+    operator: Operator = _require_operator,
+    session: AsyncSession = Depends(get_session),
+) -> RefreshResult:
+    """Rediscover *target_name*'s topology and reconcile it into the graph.
+
+    Wraps :func:`~meho_backplane.topology.refresh.refresh_target_topology`.
+    *target_name* is resolved tenant-scoped via
+    :func:`~meho_backplane.targets.resolver.resolve_target` (alias-
+    aware, 404 with near-misses when nothing matches) — so a principal
+    can only ever refresh a target in their own tenant and the
+    reconcile writes every row under ``operator.tenant_id``.
+    Cross-tenant refresh is impossible: there is no path by which a
+    target id from another tenant reaches the service.
+
+    The refresh service writes its own domain-level ``audit_log`` row
+    (``op_id="topology.refresh"``, ``op_class="read"``, the per-target
+    node/edge counts in ``payload``) and publishes one fail-open
+    broadcast event inside its own transaction; this route binds the
+    same op identity for the chassis HTTP-level audit row so both rows
+    classify consistently.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_REFRESH,
+        audit_op_class="read",
+    )
+    target = await resolve_target(session, operator.tenant_id, target_name)
+    result = await refresh_target_topology(target, operator)
+    _log.info(
+        "topology_refresh_route_completed",
+        target_id=str(result.target_id),
+        tenant_id=str(operator.tenant_id),
+        added_nodes=result.added_nodes,
+        added_edges=result.added_edges,
+        removed_nodes=result.removed_nodes,
+        removed_edges=result.removed_edges,
+    )
+    return result
+
+
+def _ambiguous_node_http(exc: AmbiguousNodeError) -> HTTPException:
+    """Map :class:`AmbiguousNodeError` to a 409 with the candidate kinds.
+
+    The query layer raises a plain :class:`ValueError` subclass when a
+    bare-name anchor resolves to more than one ``kind``. Surfacing it
+    as a 409 (rather than letting it become an unhandled 500) lets the
+    caller re-issue with an explicit ``kind`` — the same recovery the
+    CLI/MCP fronts will offer. The ambiguous kinds are echoed in
+    ``detail`` so the client can present the choice without a second
+    round trip.
+    """
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "error": "ambiguous_node",
+            "name": exc.name,
+            "kinds": sorted(exc.kinds),
+        },
+    )

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -61,6 +61,7 @@ from meho_backplane.api.v1.retrieve_eval import router as api_v1_retrieve_eval_r
 from meho_backplane.api.v1.retrieve_retire import router as api_v1_retrieve_retire_router
 from meho_backplane.api.v1.retrieve_usage import router as api_v1_retrieve_usage_router
 from meho_backplane.api.v1.targets import router as api_v1_targets_router
+from meho_backplane.api.v1.topology import router as api_v1_topology_router
 from meho_backplane.api.well_known import router as well_known_router
 from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.jwt import keycloak_readiness_probe
@@ -285,7 +286,17 @@ app.include_router(api_v1_retrieve_eval_router)
 app.include_router(api_v1_retrieve_retire_router)
 # G0.3-T3 (#254) — targets CRUD surface. All 5 routes are tenant-scoped
 # via the JWT's tenant_id claim; cross-tenant reads are impossible.
+# G9.1-T5 (#453) extends this router with GET /api/v1/targets/discover
+# (registered before GET /{name} so the literal path wins).
 app.include_router(api_v1_targets_router)
+# G9.1-T5 (#453) — topology REST surface at /api/v1/topology*. Three
+# query routes (dependents / dependencies / path) wrapping the T4
+# recursive-CTE verbs + POST /refresh/{target_name} wrapping the T3
+# refresh service. Operator role minimum; tenant-scoped via the JWT's
+# tenant_id claim (the query verbs filter graph_node/graph_edge
+# tenant_id; refresh resolves the target tenant-scoped). The fifth
+# route (GET /api/v1/targets/discover) lives on the targets router.
+app.include_router(api_v1_topology_router)
 # G6.1-T4 (#310) -- Server-Sent Events feed at `GET /api/v1/feed`.
 # Streams events XADD'd by T3's publish-on-write hook onto
 # `meho:feed:{tenant_id}`. Same RBAC gate as /api/v1/retrieve

--- a/backend/tests/integration/test_topology_api.py
+++ b/backend/tests/integration/test_topology_api.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end ``/api/v1/topology*`` + ``/api/v1/targets/discover`` tests.
+
+G9.1-T5 (#453) acceptance criteria that need real PG (not SQLite):
+
+* **All 5 routes end-to-end against a real backplane.** The three
+  query routes use PostgreSQL's ``WITH RECURSIVE ... CYCLE`` clause
+  (SQLite does not implement it); the refresh route resolves a
+  connector, calls ``discover_topology``, and reconciles the snapshot
+  into ``graph_node`` / ``graph_edge`` in a real transaction. Every
+  route is driven through the production auth + audit middleware
+  chain.
+* **Tenant boundary verified across all 5 routes.** Two seeded tenants
+  with overlapping node + target names; each tenant's queries return
+  only their own rows; a tenant-B refresh writes only tenant-B rows;
+  cross-tenant refresh is impossible (the target name resolves
+  tenant-scoped, so tenant B cannot even name tenant A's target).
+* **Audit rows land in real PG.** The refresh route's domain-level
+  ``topology.refresh`` audit row + the chassis HTTP-level row both
+  commit through the testcontainer.
+
+Same ``httpx.AsyncClient`` + ``ASGITransport`` rationale as
+``tests/integration/test_kb_routes_pg.py``: the asyncpg pool the
+``pg_engine`` fixture creates is bound to the pytest-asyncio loop, so
+the request → handler → pool path must stay single-loop.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector
+from meho_backplane.connectors.schemas import (
+    CandidateHint,
+    EdgeHint,
+    FingerprintResult,
+    NodeHint,
+    OperationResult,
+    ProbeResult,
+    TopologyHints,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GraphEdge, GraphNode
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+from .conftest import DOCKER_AVAILABLE, SKIP_REASON, build_integration_app
+
+# Pinned tenant UUIDs match the seed rows the ``pg_engine`` conftest
+# fixture inserts.
+TENANT_A_ID = "11111111-1111-1111-1111-111111111111"
+TENANT_B_ID = "22222222-2222-2222-2222-222222222222"
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+_PRODUCT = "topo-test-product"
+
+
+# ---------------------------------------------------------------------------
+# A deterministic connector whose discover_topology returns a fixed
+# snapshot keyed off the target name so two tenants get disjoint graphs.
+# ---------------------------------------------------------------------------
+
+
+class _TopoTestConnector(Connector):
+    """Fake connector: stable topology snapshot + one discover candidate."""
+
+    product = _PRODUCT
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:
+        raise NotImplementedError
+
+    async def discover_topology(self, target: Any) -> TopologyHints:
+        # Two-edge chain rooted at the target node: <name> --belongs-to-->
+        # vm-<name> --runs-on--> host-<name>. The target node's name is
+        # the target's own name so the query routes can anchor on it.
+        tname = target.name
+        return TopologyHints(
+            nodes=(
+                NodeHint(kind="target", name=tname),
+                NodeHint(kind="vm", name=f"vm-{tname}"),
+                NodeHint(kind="host", name=f"host-{tname}"),
+            ),
+            edges=(
+                EdgeHint(
+                    from_kind="target",
+                    from_name=tname,
+                    to_kind="vm",
+                    to_name=f"vm-{tname}",
+                    kind="belongs-to",
+                ),
+                EdgeHint(
+                    from_kind="vm",
+                    from_name=f"vm-{tname}",
+                    to_kind="host",
+                    to_name=f"host-{tname}",
+                    kind="runs-on",
+                ),
+            ),
+            discovered_at=datetime.now(UTC),
+        )
+
+    async def list_candidates(self, seed_target: Any | None = None) -> list[CandidateHint]:
+        return [
+            CandidateHint(
+                name="discovered-host",
+                host="10.9.9.9",
+                port=443,
+                evidence={"seed": getattr(seed_target, "name", None)},
+                confidence="medium",
+            )
+        ]
+
+
+@pytest.fixture
+def topo_app(pg_engine: None) -> AsyncIterator[FastAPI]:
+    """Integration app + topology + targets routers; fake connector registered."""
+    from meho_backplane.api.v1.targets import router as targets_router
+    from meho_backplane.api.v1.topology import router as topology_router
+
+    clear_registry()
+    _CONNECTOR_INSTANCE_CACHE.clear()
+    register_connector(_PRODUCT, _TopoTestConnector)
+
+    app = build_integration_app()
+    app.include_router(topology_router)
+    app.include_router(targets_router)
+    yield app
+
+    clear_registry()
+    _CONNECTOR_INSTANCE_CACHE.clear()
+
+
+def _make_async_client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    )
+
+
+def _operator_token(*, tenant_id: str, sub: str = "op") -> tuple[object, str]:
+    from tests._oidc_jwt_helpers import make_rsa_keypair, mint_token
+
+    key = make_rsa_keypair(f"kid-op-{sub}")
+    token = mint_token(
+        key,
+        sub=sub,
+        tenant_role=TenantRole.OPERATOR.value,
+        tenant_id=tenant_id,
+    )
+    return key, token
+
+
+def _authed(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _insert_target(*, tenant_id: str, name: str) -> uuid.UUID:
+    """Insert a TargetORM row for *tenant_id* and return its id."""
+    tid = uuid.uuid4()
+    now = datetime.now(UTC)
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        session.add(
+            TargetORM(
+                id=tid,
+                tenant_id=uuid.UUID(tenant_id),
+                name=name,
+                product=_PRODUCT,
+                host="10.0.0.1",
+                aliases=[],
+                port=None,
+                fqdn=None,
+                secret_ref=None,
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                notes=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    return tid
+
+
+async def _count_graph_rows(tenant_id: str) -> tuple[int, int]:
+    """Return (node_count, edge_count) for *tenant_id*."""
+    from sqlalchemy import func, select
+
+    sm = get_sessionmaker()
+    async with sm() as session:
+        nodes = await session.execute(
+            select(func.count())
+            .select_from(GraphNode)
+            .where(GraphNode.tenant_id == uuid.UUID(tenant_id))
+        )
+        edges = await session.execute(
+            select(func.count())
+            .select_from(GraphEdge)
+            .where(GraphEdge.tenant_id == uuid.UUID(tenant_id))
+        )
+    return int(nodes.scalar_one()), int(edges.scalar_one())
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — all 5 routes end-to-end against a real backplane
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_all_five_routes_end_to_end(topo_app: FastAPI) -> None:
+    """Refresh seeds the graph; the query + discover routes read it back."""
+    from tests._oidc_jwt_helpers import mock_discovery_and_jwks, public_jwks
+
+    await _insert_target(tenant_id=TENANT_A_ID, name="vc-a")
+    key, token = _operator_token(tenant_id=TENANT_A_ID, sub="op-a")
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        async with _make_async_client(topo_app) as client:
+            # --- 1. POST /api/v1/topology/refresh/{target_name} ---
+            refresh_resp = await client.post(
+                "/api/v1/topology/refresh/vc-a",
+                headers=_authed(token),
+            )
+            assert refresh_resp.status_code == 200, refresh_resp.text
+            rr = refresh_resp.json()
+            assert rr["added_nodes"] == 3
+            assert rr["added_edges"] == 2
+
+            # --- 2. GET /api/v1/topology/dependents/{name} ---
+            # host-vc-a is depended on by vm-vc-a (depth 1) and
+            # transitively by vc-a (depth 2). Root included at depth 0.
+            dep_resp = await client.get(
+                "/api/v1/topology/dependents/host-vc-a",
+                headers=_authed(token),
+            )
+            assert dep_resp.status_code == 200, dep_resp.text
+            names = {n["name"]: n["depth"] for n in dep_resp.json()}
+            assert names == {"host-vc-a": 0, "vm-vc-a": 1, "vc-a": 2}
+
+            # --- 3. GET /api/v1/topology/dependencies/{name} ---
+            # vc-a depends on vm-vc-a (depth 1) and host-vc-a (depth 2).
+            deps_resp = await client.get(
+                "/api/v1/topology/dependencies/vc-a",
+                headers=_authed(token),
+            )
+            assert deps_resp.status_code == 200, deps_resp.text
+            dnames = {n["name"]: n["depth"] for n in deps_resp.json()}
+            assert dnames == {"vc-a": 0, "vm-vc-a": 1, "host-vc-a": 2}
+
+            # --- 4. GET /api/v1/topology/path?from=A&to=B ---
+            path_resp = await client.get(
+                "/api/v1/topology/path?from=vc-a&to=host-vc-a",
+                headers=_authed(token),
+            )
+            assert path_resp.status_code == 200, path_resp.text
+            path = path_resp.json()
+            assert path["total_hops"] == 2
+            assert [n["name"] for n in path["nodes"]] == [
+                "vc-a",
+                "vm-vc-a",
+                "host-vc-a",
+            ]
+
+            # path to an unreachable node → 200 null
+            none_resp = await client.get(
+                "/api/v1/topology/path?from=vc-a&to=ghost",
+                headers=_authed(token),
+            )
+            assert none_resp.status_code == 200
+            assert none_resp.json() is None
+
+            # --- 5. GET /api/v1/targets/discover?product=X ---
+            disc_resp = await client.get(
+                f"/api/v1/targets/discover?product={_PRODUCT}&seed_target=vc-a",
+                headers=_authed(token),
+            )
+            assert disc_resp.status_code == 200, disc_resp.text
+            disc = disc_resp.json()
+            assert [c["name"] for c in disc["discovered"]] == ["discovered-host"]
+            assert disc["discovered"][0]["evidence"]["seed"] == "vc-a"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — tenant boundary holds across all 5 routes
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_tenant_boundary_holds_across_all_routes(topo_app: FastAPI) -> None:
+    """Overlapping target names; each tenant only ever sees its own graph.
+
+    Both tenants register a target literally named ``shared``. Tenant A
+    refreshes; tenant B's dependents query for the same node name
+    returns 404-empty (the node exists only in tenant A). A tenant-B
+    refresh writes only tenant-B rows. Cross-tenant refresh is
+    impossible: tenant B's ``resolve_target`` can never name tenant
+    A's target.
+    """
+    from tests._oidc_jwt_helpers import mock_discovery_and_jwks, public_jwks
+
+    await _insert_target(tenant_id=TENANT_A_ID, name="shared")
+    await _insert_target(tenant_id=TENANT_B_ID, name="shared")
+    key_a, token_a = _operator_token(tenant_id=TENANT_A_ID, sub="op-a")
+    key_b, token_b = _operator_token(tenant_id=TENANT_B_ID, sub="op-b")
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key_a, key_b))
+        async with _make_async_client(topo_app) as client:
+            # Tenant A refreshes its "shared" target.
+            ra = await client.post(
+                "/api/v1/topology/refresh/shared",
+                headers=_authed(token_a),
+            )
+            assert ra.status_code == 200, ra.text
+            assert ra.json()["added_nodes"] == 3
+
+            # Tenant A sees its graph.
+            da = await client.get(
+                "/api/v1/topology/dependencies/shared",
+                headers=_authed(token_a),
+            )
+            assert da.status_code == 200
+            assert {n["name"] for n in da.json()} == {
+                "shared",
+                "vm-shared",
+                "host-shared",
+            }
+
+            # Tenant B has NOT refreshed — its "shared" node does not
+            # exist, so its query is empty (not tenant A's graph).
+            db = await client.get(
+                "/api/v1/topology/dependencies/shared",
+                headers=_authed(token_b),
+            )
+            assert db.status_code == 200
+            assert db.json() == []
+
+            # Tenant B refreshes its own "shared" target — only
+            # tenant-B rows are written; tenant A's row count is
+            # unchanged.
+            a_nodes_before, a_edges_before = await _count_graph_rows(TENANT_A_ID)
+            rb = await client.post(
+                "/api/v1/topology/refresh/shared",
+                headers=_authed(token_b),
+            )
+            assert rb.status_code == 200, rb.text
+            assert rb.json()["added_nodes"] == 3
+
+            a_nodes_after, a_edges_after = await _count_graph_rows(TENANT_A_ID)
+            assert (a_nodes_after, a_edges_after) == (
+                a_nodes_before,
+                a_edges_before,
+            )
+            b_nodes, b_edges = await _count_graph_rows(TENANT_B_ID)
+            assert (b_nodes, b_edges) == (3, 2)

--- a/backend/tests/test_api_v1_targets_discover.py
+++ b/backend/tests/test_api_v1_targets_discover.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``GET /api/v1/targets/discover``.
+
+G9.1-T5 / Task #453. The discover route lives on the targets router
+(under the ``/api/v1/targets`` prefix) but is exercised separately
+here because its dependency surface (the connector registry +
+``list_candidates`` hook) is distinct from the CRUD routes covered by
+``test_api_v1_targets.py``.
+
+Coverage matrix:
+
+* **Route mounting + ordering** — ``/api/v1/targets/discover`` appears
+  in the OpenAPI doc, and the literal ``/discover`` segment is matched
+  as this route rather than captured as a target name by
+  ``GET /{name}`` (declaration order is load-bearing).
+* **Merge** — candidates from every connector registered for the
+  product are merged into ``discovered``.
+* **Skipped** — a connector that returns nothing is recorded in
+  ``skipped`` with ``reason="no candidates"``; a connector that
+  raises is recorded with the exception summary and does NOT abort
+  the sweep (the other connectors still run).
+* **seed_target** — when supplied, it is resolved tenant-scoped and
+  forwarded to ``list_candidates``; an unknown seed name 404s.
+* **RBAC** — ``operator`` minimum; ``read_only`` gets 403.
+* **Unauthenticated** — 401 without a token.
+* **Audit op_id** — the audit row's payload carries
+  ``op_id="targets.discover"`` + ``op_class="read"``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.api.v1.targets import router as targets_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import (
+    CandidateHint,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+from ._targets_helpers import _insert_target
+
+_TENANT_ID = UUID("11111111-1111-1111-1111-111111111111")
+_PRODUCT = "discover-product"
+
+
+# ---------------------------------------------------------------------------
+# Settings + cache fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Empty both registry layers + the connector-instance cache.
+
+    The discover route resolves connector instances through the
+    module-level ``_CONNECTOR_INSTANCE_CACHE``; clearing it keeps a
+    fake connector from one test leaking into the next.
+    """
+    clear_registry()
+    _CONNECTOR_INSTANCE_CACHE.clear()
+    yield
+    clear_registry()
+    _CONNECTOR_INSTANCE_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# App + JWT helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(targets_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def _token(role: TenantRole, *, tenant_id: UUID = _TENANT_ID, sub: str = "op-1") -> tuple[Any, str]:
+    key = _make_rsa_keypair(f"kid-{role.value}-{sub}")
+    token = _mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(tenant_id))
+    return key, token
+
+
+def _authed(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Fake connectors
+# ---------------------------------------------------------------------------
+
+
+class _BaseFakeConnector(Connector):
+    product = _PRODUCT
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:
+        raise NotImplementedError
+
+
+class _CandidatesConnector(_BaseFakeConnector):
+    async def list_candidates(self, seed_target: Any | None = None) -> list[CandidateHint]:
+        return [
+            CandidateHint(
+                name="esxi-7",
+                host="10.0.0.7",
+                port=443,
+                evidence={"source": "vcenter", "seed": getattr(seed_target, "name", None)},
+                confidence="high",
+            )
+        ]
+
+
+class _EmptyConnector(_BaseFakeConnector):
+    async def list_candidates(self, seed_target: Any | None = None) -> list[CandidateHint]:
+        return []
+
+
+class _RaisingConnector(_BaseFakeConnector):
+    async def list_candidates(self, seed_target: Any | None = None) -> list[CandidateHint]:
+        raise RuntimeError("connector exploded")
+
+
+async def _audit_rows_for_path(path: str) -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).where(AuditLog.path == path))
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Route mounting + ordering
+# ---------------------------------------------------------------------------
+
+
+def test_discover_route_mounted_and_ordered_before_describe() -> None:
+    """``/discover`` appears in OpenAPI and precedes ``/{name}`` on the router."""
+    from meho_backplane.main import app
+
+    paths = app.openapi()["paths"]
+    assert "/api/v1/targets/discover" in paths
+    assert "get" in paths["/api/v1/targets/discover"]
+
+    # Declaration order on the router: the literal /discover route must
+    # come before the parametrised /{name} route or FastAPI captures
+    # "discover" as a target name.
+    route_paths = [getattr(r, "path", "") for r in targets_router.routes]
+    disc = route_paths.index("/api/v1/targets/discover")
+    by_name = route_paths.index("/api/v1/targets/{name}")
+    assert disc < by_name
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_discover_unauthenticated_returns_401(client: TestClient) -> None:
+    assert client.get("/api/v1/targets/discover?product=x").status_code == 401
+
+
+def test_discover_readonly_returns_403(client: TestClient) -> None:
+    key, token = _token(TenantRole.READ_ONLY)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            f"/api/v1/targets/discover?product={_PRODUCT}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 403
+
+
+def test_discover_missing_product_returns_422(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/targets/discover", headers=_authed(token))
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Merge + skipped behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_discover_merges_candidates_across_connectors(client: TestClient) -> None:
+    """Candidates from every connector for the product are merged."""
+    register_connector_v2(
+        product=_PRODUCT, version="9.0", impl_id="impl-a", cls=_CandidatesConnector
+    )
+    register_connector_v2(product=_PRODUCT, version="8.0", impl_id="impl-b", cls=_EmptyConnector)
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            f"/api/v1/targets/discover?product={_PRODUCT}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [c["name"] for c in body["discovered"]] == ["esxi-7"]
+    assert body["discovered"][0]["confidence"] == "high"
+    # The empty connector lands in skipped with the clean-but-empty reason.
+    skipped = {s["name"]: s["reason"] for s in body["skipped"]}
+    assert skipped["impl-b"] == "no candidates"
+
+
+def test_discover_records_raising_connector_and_continues(client: TestClient) -> None:
+    """One connector raising does not abort the sweep — it is skipped."""
+    register_connector_v2(product=_PRODUCT, version="9.0", impl_id="good", cls=_CandidatesConnector)
+    register_connector_v2(product=_PRODUCT, version="8.0", impl_id="bad", cls=_RaisingConnector)
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            f"/api/v1/targets/discover?product={_PRODUCT}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # The good connector still contributed despite the bad one raising.
+    assert [c["name"] for c in body["discovered"]] == ["esxi-7"]
+    skipped = {s["name"]: s["reason"] for s in body["skipped"]}
+    assert "RuntimeError: connector exploded" in skipped["bad"]
+
+
+def test_discover_unknown_product_returns_empty(client: TestClient) -> None:
+    """A product with no registered connectors returns empty lists, not 404."""
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/targets/discover?product=nonexistent",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"discovered": [], "skipped": []}
+
+
+# ---------------------------------------------------------------------------
+# seed_target resolution
+# ---------------------------------------------------------------------------
+
+
+def test_discover_with_seed_target_resolves_and_forwards(client: TestClient) -> None:
+    """A valid seed_target is resolved tenant-scoped and passed to list_candidates."""
+    import asyncio
+
+    asyncio.run(
+        _insert_target(
+            tenant_id=_TENANT_ID,
+            name="seed-vc",
+            product=_PRODUCT,
+            host="10.0.0.1",
+        )
+    )
+    register_connector_v2(
+        product=_PRODUCT, version="9.0", impl_id="impl-a", cls=_CandidatesConnector
+    )
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            f"/api/v1/targets/discover?product={_PRODUCT}&seed_target=seed-vc",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # _CandidatesConnector echoes the seed name into evidence; proves
+    # the resolved target (not the raw string) reached the hook.
+    assert body["discovered"][0]["evidence"]["seed"] == "seed-vc"
+
+
+def test_discover_unknown_seed_target_returns_404(client: TestClient) -> None:
+    register_connector_v2(
+        product=_PRODUCT, version="9.0", impl_id="impl-a", cls=_CandidatesConnector
+    )
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            f"/api/v1/targets/discover?product={_PRODUCT}&seed_target=ghost",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Audit op_id binding
+# ---------------------------------------------------------------------------
+
+
+async def test_discover_binds_canonical_op_id(client: TestClient) -> None:
+    """The audit row's payload carries op_id=targets.discover + op_class=read."""
+    register_connector_v2(
+        product=_PRODUCT, version="9.0", impl_id="impl-a", cls=_CandidatesConnector
+    )
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            f"/api/v1/targets/discover?product={_PRODUCT}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200, resp.text
+
+    rows = await _audit_rows_for_path("/api/v1/targets/discover")
+    assert len(rows) == 1
+    payload = rows[0].payload or {}
+    assert payload.get("op_id") == "targets.discover"
+    assert payload.get("op_class") == "read"

--- a/backend/tests/test_api_v1_topology.py
+++ b/backend/tests/test_api_v1_topology.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.topology`.
+
+Coverage matrix (G9.1-T5 / Task #453 acceptance criteria):
+
+* **Route mounting** — the four topology routes appear on
+  :mod:`meho_backplane.main`'s app and in the OpenAPI document.
+* **dependents / dependencies / path** — each route wraps its T4 verb,
+  forwards the query params (depth / kind / kind_filter / max_hops),
+  and serialises the frozen result model over the wire.
+* **path returns null** — an unreachable pair yields HTTP 200 with a
+  ``null`` body (unreachability is a valid answer, not an error).
+* **Ambiguous anchor → 409** — :class:`AmbiguousNodeError` from the
+  query layer surfaces as 409 ``ambiguous_node`` with the candidate
+  kinds, not an unhandled 500.
+* **refresh** — wraps the T3 service; the resolved target is passed
+  through; the :class:`RefreshResult` is returned verbatim.
+* **RBAC** — every route requires ``operator`` minimum; ``read_only``
+  gets 403.
+* **Unauthenticated** — every route returns 401 without a token.
+* **Audit op_id binding** — each route binds the canonical
+  ``audit_op_id`` + ``audit_op_class="read"`` so the audit row + the
+  broadcast classifier carry the right identity.
+
+The T4 query verbs use PostgreSQL's ``WITH RECURSIVE ... CYCLE`` and
+the T3 refresh service resolves a connector + writes the graph; both
+are patched at the route's import site here. End-to-end coverage
+against a real pgvector cluster lives in
+``tests/integration/test_topology_api.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.api.v1.topology import router as topology_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+from meho_backplane.topology.query import AmbiguousNodeError
+from meho_backplane.topology.refresh import RefreshResult
+from meho_backplane.topology.schemas import TopologyNode, TopologyPath
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+_TENANT_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+# ---------------------------------------------------------------------------
+# Settings + JWKS cache fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+# ---------------------------------------------------------------------------
+# App + JWT helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(topology_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def _token(role: TenantRole, *, tenant_id: UUID = _TENANT_ID, sub: str = "op-1") -> tuple[Any, str]:
+    key = _make_rsa_keypair(f"kid-{role.value}-{sub}")
+    token = _mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(tenant_id))
+    return key, token
+
+
+def _authed(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_node(name: str, kind: str = "host", depth: int = 0) -> TopologyNode:
+    return TopologyNode(
+        id=uuid.uuid4(),
+        kind=kind,
+        name=name,
+        properties={"seeded": name},
+        depth=depth,
+        via_edge_kind=None if depth == 0 else "runs-on",
+    )
+
+
+async def _audit_rows_for_path(path: str) -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).where(AuditLog.path == path))
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Route mounting
+# ---------------------------------------------------------------------------
+
+
+def test_all_topology_routes_mounted_on_main_app() -> None:
+    """The four topology routes appear on the prod app + OpenAPI doc."""
+    from meho_backplane.main import app
+
+    expected = {
+        "/api/v1/topology/dependents/{name}",
+        "/api/v1/topology/dependencies/{name}",
+        "/api/v1/topology/path",
+        "/api/v1/topology/refresh/{target_name}",
+    }
+    actual = {getattr(r, "path", None) for r in app.routes}
+    assert not (expected - actual), f"missing: {expected - actual}"
+
+    paths = app.openapi()["paths"]
+    assert "get" in paths["/api/v1/topology/dependents/{name}"]
+    assert "get" in paths["/api/v1/topology/dependencies/{name}"]
+    assert "get" in paths["/api/v1/topology/path"]
+    assert "post" in paths["/api/v1/topology/refresh/{target_name}"]
+
+
+# ---------------------------------------------------------------------------
+# Unauthenticated → 401
+# ---------------------------------------------------------------------------
+
+
+def test_dependents_unauthenticated_returns_401(client: TestClient) -> None:
+    assert client.get("/api/v1/topology/dependents/app").status_code == 401
+
+
+def test_dependencies_unauthenticated_returns_401(client: TestClient) -> None:
+    assert client.get("/api/v1/topology/dependencies/app").status_code == 401
+
+
+def test_path_unauthenticated_returns_401(client: TestClient) -> None:
+    assert client.get("/api/v1/topology/path?from=a&to=b").status_code == 401
+
+
+def test_refresh_unauthenticated_returns_401(client: TestClient) -> None:
+    assert client.post("/api/v1/topology/refresh/app").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# RBAC — read_only gets 403
+# ---------------------------------------------------------------------------
+
+
+def test_dependents_readonly_returns_403(client: TestClient) -> None:
+    key, token = _token(TenantRole.READ_ONLY)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/dependents/app", headers=_authed(token))
+    assert resp.status_code == 403
+
+
+def test_refresh_readonly_returns_403(client: TestClient) -> None:
+    key, token = _token(TenantRole.READ_ONLY)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post("/api/v1/topology/refresh/app", headers=_authed(token))
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# dependents / dependencies — wrap the T4 verb + serialise
+# ---------------------------------------------------------------------------
+
+
+def test_dependents_wraps_find_dependents_and_forwards_params(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    nodes = [_make_node("host1", "host", 0), _make_node("vm1", "vm", 1)]
+    fake = AsyncMock(return_value=nodes)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.find_dependents", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/dependents/host1?depth=8&kind=host&kind_filter=runs-on",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [n["name"] for n in body] == ["host1", "vm1"]
+    assert body[1]["via_edge_kind"] == "runs-on"
+    # The query params are forwarded as keyword args to the T4 verb.
+    _, kwargs = fake.call_args
+    assert kwargs == {"kind": "host", "depth": 8, "kind_filter": "runs-on"}
+    assert fake.call_args.args[1] == "host1"
+
+
+def test_dependencies_wraps_find_dependencies(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(return_value=[_make_node("app", "target", 0)])
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.find_dependencies", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/dependencies/app", headers=_authed(token))
+    assert resp.status_code == 200, resp.text
+    assert [n["name"] for n in resp.json()] == ["app"]
+    # Default depth (16) is forwarded when the query param is omitted.
+    assert fake.call_args.kwargs["depth"] == 16
+
+
+def test_dependents_depth_above_ceiling_returns_422(client: TestClient) -> None:
+    """A hostile ``depth`` over the HTTP ceiling is rejected at the boundary."""
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/dependents/app?depth=999",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 422
+
+
+def test_dependents_ambiguous_node_returns_409(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(side_effect=AmbiguousNodeError("app", ["target", "vm"]))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.find_dependents", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/dependents/app", headers=_authed(token))
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error"] == "ambiguous_node"
+    assert detail["name"] == "app"
+    assert detail["kinds"] == ["target", "vm"]
+
+
+# ---------------------------------------------------------------------------
+# path — wrap find_path; null when unreachable
+# ---------------------------------------------------------------------------
+
+
+def test_path_returns_serialised_path(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    tp = TopologyPath(
+        nodes=(_make_node("a", "host", 0), _make_node("b", "vm", 1)),
+        total_hops=1,
+    )
+    fake = AsyncMock(return_value=tp)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.find_path", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/path?from=a&to=b&max_hops=5",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total_hops"] == 1
+    assert [n["name"] for n in body["nodes"]] == ["a", "b"]
+    # `from` / `to` query params are forwarded positionally.
+    assert fake.call_args.args[1:] == ("a", "b")
+    assert fake.call_args.kwargs["max_hops"] == 5
+
+
+def test_path_unreachable_returns_200_null(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(return_value=None)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.find_path", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/path?from=a&to=z", headers=_authed(token))
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+def test_path_missing_required_query_param_returns_422(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/path?from=a", headers=_authed(token))
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# refresh — wrap the T3 service
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_wraps_service_and_returns_result(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    target_id = uuid.uuid4()
+
+    class _FakeTarget:
+        id = target_id
+        name = "vc-1"
+        product = "vmware-rest"
+
+    result = RefreshResult(
+        target_id=target_id,
+        added_nodes=3,
+        added_edges=2,
+        updated_nodes=1,
+        updated_edges=0,
+        removed_nodes=0,
+        removed_edges=0,
+        duration_ms=12.5,
+    )
+    resolve = AsyncMock(return_value=_FakeTarget())
+    refresh = AsyncMock(return_value=result)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.resolve_target", resolve),
+        patch("meho_backplane.api.v1.topology.refresh_target_topology", refresh),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post("/api/v1/topology/refresh/vc-1", headers=_authed(token))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["target_id"] == str(target_id)
+    assert body["added_nodes"] == 3
+    # The resolved target (not the raw name) is handed to the service.
+    assert refresh.call_args.args[0].name == "vc-1"
+    # resolve_target is tenant-scoped to the JWT's tenant_id.
+    assert resolve.call_args.args[1] == _TENANT_ID
+    assert resolve.call_args.args[2] == "vc-1"
+
+
+# ---------------------------------------------------------------------------
+# Audit op_id binding — read class on every route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "http_path", "target_module_symbol", "op_id"),
+    [
+        (
+            "/api/v1/topology/dependents/app",
+            "/api/v1/topology/dependents/app",
+            "find_dependents",
+            "topology.dependents",
+        ),
+        (
+            "/api/v1/topology/dependencies/app",
+            "/api/v1/topology/dependencies/app",
+            "find_dependencies",
+            "topology.dependencies",
+        ),
+    ],
+)
+async def test_read_route_binds_canonical_op_id(
+    client: TestClient,
+    url: str,
+    http_path: str,
+    target_module_symbol: str,
+    op_id: str,
+) -> None:
+    """The audit row's payload carries the canonical op_id + op_class=read.
+
+    ``audit_log.path`` is the raw HTTP path (the chassis convention);
+    the canonical op id the route binds via ``audit_op_id`` lands in
+    ``payload["op_id"]`` — mirrors the kb-route audit assertions.
+    """
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(return_value=[_make_node("app", "target", 0)])
+    with (
+        respx.mock as mock_router,
+        patch(f"meho_backplane.api.v1.topology.{target_module_symbol}", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(url, headers=_authed(token))
+    assert resp.status_code == 200, resp.text
+
+    rows = await _audit_rows_for_path(http_path)
+    assert len(rows) == 1
+    payload = rows[0].payload or {}
+    assert payload.get("op_id") == op_id
+    assert payload.get("op_class") == "read"

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -33,9 +33,11 @@ tenant raises `AmbiguousNodeError`; pass the optional `kind` (or
 `from_kind` / `to_kind` for `find_path`) to pin the `(tenant_id, kind,
 name)` unique row. The read package never inserts, updates, or deletes.
 
-The REST/CLI/MCP fronts (T5/T6/T7) and the `docs/architecture/topology.md`
-operator doc are out of scope here — they consume `query.py` as a thin
-shell and land in G9.1-T5 through T8.
+The REST front (T5, #453) is landed and documented below ("REST API
+surface"). The CLI/MCP fronts (T6/T7) and the
+`docs/architecture/topology.md` operator doc remain out of scope here —
+they consume `query.py` / `refresh.py` as a thin shell and land in
+G9.1-T6 through T8.
 
 ## Key types
 
@@ -215,6 +217,65 @@ repeat row `is_cycle = true` (filtered out). An `A → B → A` graph
 terminates instead of recursing forever. The `depth` / `max_hops`
 bound is an independent second guard against acyclic-but-deep graphs.
 
+## REST API surface (T5, #453)
+
+`backend/src/meho_backplane/api/v1/topology.py` is the HTTP front for
+the read + write halves. Five routes total — four on the topology
+router, one on the targets router:
+
+| Method + path | Wraps | op_id | RBAC |
+|---|---|---|---|
+| `GET /api/v1/topology/dependents/{name}` | `find_dependents` | `topology.dependents` | operator |
+| `GET /api/v1/topology/dependencies/{name}` | `find_dependencies` | `topology.dependencies` | operator |
+| `GET /api/v1/topology/path?from=A&to=B` | `find_path` | `topology.path` | operator |
+| `POST /api/v1/topology/refresh/{target_name}` | `refresh_target_topology` | `topology.refresh` | operator |
+| `GET /api/v1/targets/discover?product=X` | `Connector.list_candidates` | `targets.discover` | operator |
+
+Load-bearing details:
+
+- **Route ordering.** `GET /api/v1/targets/discover` is declared on
+  the targets router *before* `GET /api/v1/targets/{name}`. FastAPI
+  resolves routes in declaration order, so the literal `/discover`
+  segment must come first or it is captured as a target name.
+- **`path` query params.** The route binds `?from=` / `?to=` via
+  Pydantic `alias` because `from` is a Python keyword. An unreachable
+  pair returns HTTP 200 with a `null` body — unreachability is a valid
+  answer, not an error.
+- **Ambiguous anchor.** `AmbiguousNodeError` (a `ValueError` from the
+  query layer) is mapped to HTTP 409 `ambiguous_node` with the
+  candidate kinds echoed in `detail` so the caller can re-issue with
+  an explicit `kind`.
+- **Depth/hop ceilings.** The route caps `depth` at 64 and `max_hops`
+  at 32 at the HTTP boundary (over the service defaults of 16 / 8) so
+  a hostile query param cannot ask the recursive CTE to walk an
+  unbounded closure (#363 performance discipline).
+- **`refresh` audit.** The route binds `audit_op_id="topology.refresh"`
+  / `audit_op_class="read"` for the chassis HTTP-level audit row; the
+  refresh *service* additionally writes its own domain-level audit row
+  + one broadcast event with the per-target counts. The two rows are
+  intentional — same shape as the operations dispatcher writing a
+  domain row alongside the middleware's HTTP row.
+- **`targets/discover`.** Iterates every connector implementation
+  registered for the product (the v2 registry, which subsumes v1
+  registrations; deduped by connector class), calls `list_candidates`
+  on each, and merges the results. One connector raising is recorded
+  in `skipped` with the exception summary and does not abort the
+  sweep. `seed_target` (optional) is resolved tenant-scoped before
+  being forwarded. The verb never creates `targets` rows
+  (auto-registration is v0.2.next per #363).
+- **Tenant scoping.** No route accepts a `tenant_id` from the path,
+  query string, or body. The query verbs filter on
+  `operator.tenant_id`; `refresh` / `discover` resolve targets
+  tenant-scoped via `resolve_target`. Cross-tenant traversal *and*
+  cross-tenant refresh are impossible by construction (proven by the
+  two-tenant integration test).
+
+Tests: `backend/tests/test_api_v1_topology.py` +
+`backend/tests/test_api_v1_targets_discover.py` (service layer patched,
+SQLite); `backend/tests/integration/test_topology_api.py` (all 5 routes
+end-to-end + the cross-tenant boundary against a real
+`pgvector/pgvector:pg16` container).
+
 ## Dependencies
 
 - `meho_backplane.connectors.resolver.resolve_connector` +
@@ -255,9 +316,12 @@ bound is an independent second guard against acyclic-but-deep graphs.
   `backend/tests/test_topology_query_schemas.py`.
 - **Unweighted only.** `find_path` treats every edge as cost 1.
   Weighted-edge support is deferred to v0.2.next per #363.
-- **No alias resolution yet.** `name_or_alias` is matched against
-  `graph_node.name` directly; alias → name resolution is the API/CLI
-  router's job (T5/T6), not this substrate's.
+- **No graph-node alias resolution yet.** `name_or_alias` is matched
+  against `graph_node.name` directly. The T5 query routes pass the
+  path/query name straight through — they do *not* alias-resolve graph
+  nodes (only the `refresh` / `targets/discover` routes alias-resolve
+  the *target* via `resolve_target`). Graph-node alias → name
+  resolution is deferred to the CLI/MCP fronts (T6/T7).
 - Streaming refresh progress for very large topologies — v0.2 is
   single-shot; deferred per Initiative #363.
 - Graph history / time-travel — soft-delete here only makes a node


### PR DESCRIPTION
## Summary

- Ships the **REST API surface** for G9.1 topology + targets-discover (Initiative #363, T5): 5 routes wrapping the merged T3 (#450) refresh service and T4 (#451) recursive-CTE query verbs.
- 4 routes on a new `/api/v1/topology` router (`GET dependents/{name}`, `GET dependencies/{name}`, `GET path?from=A&to=B`, `POST refresh/{target_name}`) + `GET /api/v1/targets/discover?product=X` on the existing targets router.
- `GET /api/v1/targets/discover` is declared **before** `GET /api/v1/targets/{name}` so FastAPI matches the literal segment rather than capturing `discover` as a target name (declaration order is load-bearing).
- Operator-gated, tenant-scoped end to end: query verbs filter on `operator.tenant_id`; `refresh`/`discover` resolve targets tenant-scoped via `resolve_target`, so cross-tenant traversal **and** cross-tenant refresh are impossible by construction. Each route binds the canonical `audit_op_id` + `audit_op_class="read"` so the audit row and the broadcast classifier carry the right identity.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — Success, 151 files
- [x] `pytest tests/ --ignore=tests/integration` — **1800 passed, 40 skipped**
- [x] `code-quality.py --diff` — exit 0 (5 warnings, no blockers)
- [x] **AC: all 5 routes mounted + visible in OpenAPI** — `test_all_topology_routes_mounted_on_main_app` + `test_discover_route_mounted_and_ordered_before_describe`
- [x] **AC: each query route wraps the T4 service; assertions vs seeded graph** — `tests/integration/test_topology_api.py::test_all_five_routes_end_to_end` (real `pgvector/pgvector:pg16`)
- [x] **AC: refresh wraps T3; tenant boundary enforced** — same integration test + `test_tenant_boundary_holds_across_all_routes`
- [x] **AC: targets/discover iterates registered connectors + merges** — `test_discover_merges_candidates_across_connectors`, `test_discover_records_raising_connector_and_continues`
- [x] **AC: RBAC operator on read routes** — `test_*_readonly_returns_403`; **AC: audit + broadcast per call** — `test_read_route_binds_canonical_op_id`, `test_discover_binds_canonical_op_id`
- [x] **AC: tenant boundary verified across all 5 routes** — `test_tenant_boundary_holds_across_all_routes` (overlapping target names; tenant-B refresh writes only tenant-B rows; tenant A's row count unchanged)
- [x] **AC: integration test (PG) covers all 5 routes end-to-end** — 2 integration tests pass against a real container

## Out of scope

- CLI verbs (T6 #454), MCP meta-tools (T7 #455), service layer (T3 #450 / T4 #451 — merged), ABC extension (T2 #449), schema (T1 #448) — per the issue body.
- Adjacent findings (recorded, not addressed): `discover_targets` is 91 lines (mostly docstring; warn-only) and `topology.path` has 6 route params (PLR0913 warn-only, intrinsic to a FastAPI multi-query-param route — consistent with existing `list_targets`); `main.py` is 404 lines (pre-existing, untouched by this change beyond two `include_router` lines).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #453


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/api/v1/targets/discover` endpoint to discover available targets for a product with optional seed target support
  * Added topology REST API with query endpoints for finding dependents, dependencies, and shortest paths between nodes
  * Added topology refresh endpoint to update system topology data
  * Connectors that fail during discovery are now logged and don't interrupt the discovery process

* **Documentation**
  * Updated topology documentation with REST API surface details and query behavior guidelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->