### PR TITLE
feat(connectors): G3.2-T4 K8s network + config + event ops — service / ingress / configmap (keys-only list, data on info) + events

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -337,6 +337,149 @@ class KubernetesConnector(Connector):
         rows = [node_row(n) for n in resp.items]
         return {"rows": rows, "total": len(rows)}
 
+    async def k8s_service_list(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List services in a namespace -- name / type / cluster_ip / ports / selector.
+
+        Op-id: ``k8s.service.list``. Wraps
+        ``CoreV1Api.list_namespaced_service(namespace)`` and projects
+        each :class:`V1Service` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_network.service_row`.
+        The helper is pure so the unit suite pins the wire shape against
+        synthetic fixtures without booting an event loop.
+        """
+        from meho_backplane.connectors.kubernetes.ops_network import service_row
+
+        api_client = await self._get_api_client(target)
+        core_v1 = client.CoreV1Api(api_client)
+        resp = await core_v1.list_namespaced_service(namespace=params["namespace"])
+        rows = [service_row(s) for s in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_ingress_list(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List ingresses in a namespace -- class / hosts / TLS hosts / rules.
+
+        Op-id: ``k8s.ingress.list``. Wraps
+        ``NetworkingV1Api.list_namespaced_ingress(namespace)`` and
+        projects each :class:`V1Ingress` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_network.ingress_row`.
+        """
+        from meho_backplane.connectors.kubernetes.ops_network import ingress_row
+
+        api_client = await self._get_api_client(target)
+        networking_v1 = client.NetworkingV1Api(api_client)
+        resp = await networking_v1.list_namespaced_ingress(namespace=params["namespace"])
+        rows = [ingress_row(i) for i in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_configmap_list(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List configmaps in a namespace -- **keys only, no values**.
+
+        Op-id: ``k8s.configmap.list``. Wraps
+        ``CoreV1Api.list_namespaced_config_map(namespace)`` and projects
+        each :class:`V1ConfigMap` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_config.configmap_list_row`,
+        which deliberately omits ``data`` / ``binary_data`` values.
+        Operators wanting values call ``k8s.configmap.info`` per
+        configmap so the audit row records the targeted read.
+        """
+        from meho_backplane.connectors.kubernetes.ops_config import configmap_list_row
+
+        api_client = await self._get_api_client(target)
+        core_v1 = client.CoreV1Api(api_client)
+        resp = await core_v1.list_namespaced_config_map(namespace=params["namespace"])
+        rows = [configmap_list_row(cm) for cm in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_configmap_info(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Read a single configmap with full data + binary_data.
+
+        Op-id: ``k8s.configmap.info``. Wraps
+        ``CoreV1Api.read_namespaced_config_map(name, namespace)`` and
+        projects the result through
+        :func:`~meho_backplane.connectors.kubernetes.ops_config.configmap_info`.
+        Counterpart to ``k8s.configmap.list``; the targeted read records
+        a per-configmap audit row.
+        """
+        from meho_backplane.connectors.kubernetes.ops_config import configmap_info
+
+        api_client = await self._get_api_client(target)
+        core_v1 = client.CoreV1Api(api_client)
+        cm = await core_v1.read_namespaced_config_map(
+            name=params["name"], namespace=params["namespace"]
+        )
+        return configmap_info(cm)
+
+    async def k8s_event_list(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List events in a namespace, sorted most-recent-first, truncated to ``limit``.
+
+        Op-id: ``k8s.event.list``. Wraps
+        ``CoreV1Api.list_namespaced_event(namespace, field_selector=..., limit=...)``
+        and projects each :class:`CoreV1Event` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_config.event_row`.
+
+        The sort + truncate happens **client-side** even when the K8s
+        API accepts a ``limit`` kwarg, because the API server returns
+        rows in resource-version order (creation order), not
+        last-seen order -- a row that was first created long ago but
+        last fired seconds ago would otherwise sort below a newer row
+        that hasn't fired recently. Pulling the API's ``limit`` worth
+        of rows and re-sorting locally is the simplest way to ensure
+        the operator sees the truly most-recent events.
+
+        To stay within the API server's response budget when the
+        client wants a small ``limit``, the handler still passes the
+        ``limit`` kwarg to the API: the wire request asks for the
+        rows the operator wanted, and the client-side sort just
+        reorders the subset before returning.
+        """
+        from meho_backplane.connectors.kubernetes.ops_events import (
+            DEFAULT_EVENT_LIMIT,
+            MAX_EVENT_LIMIT,
+            event_row,
+            sort_event_rows_recent_first,
+        )
+
+        namespace = params["namespace"]
+        limit = int(params.get("limit", DEFAULT_EVENT_LIMIT))
+        # Defence in depth: the schema's ``maximum`` already enforces
+        # the cap. Keep the explicit clamp so a future schema relaxation
+        # cannot exceed the ceiling silently -- same discipline as
+        # ``k8s.logs``'s tail clamp.
+        if limit > MAX_EVENT_LIMIT:
+            limit = MAX_EVENT_LIMIT
+        field_selector = params.get("field_selector")
+
+        api_client = await self._get_api_client(target)
+        core_v1 = client.CoreV1Api(api_client)
+        kwargs: dict[str, Any] = {"namespace": namespace, "limit": limit}
+        if field_selector:
+            kwargs["field_selector"] = field_selector
+        resp = await core_v1.list_namespaced_event(**kwargs)
+        rows = [event_row(e) for e in resp.items]
+        sorted_rows = sort_event_rows_recent_first(rows)
+        truncated = sorted_rows[:limit]
+        return {"rows": truncated, "total": len(truncated)}
+
     async def k8s_ls(
         self,
         target: KubernetesTargetLike,

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -435,22 +435,30 @@ class KubernetesConnector(Connector):
         Op-id: ``k8s.event.list``. Wraps
         ``CoreV1Api.list_namespaced_event(namespace, field_selector=..., limit=...)``
         and projects each :class:`CoreV1Event` through
-        :func:`~meho_backplane.connectors.kubernetes.ops_config.event_row`.
+        :func:`~meho_backplane.connectors.kubernetes.ops_events.event_row`.
 
-        The sort + truncate happens **client-side** even when the K8s
-        API accepts a ``limit`` kwarg, because the API server returns
-        rows in resource-version order (creation order), not
-        last-seen order -- a row that was first created long ago but
-        last fired seconds ago would otherwise sort below a newer row
-        that hasn't fired recently. Pulling the API's ``limit`` worth
-        of rows and re-sorting locally is the simplest way to ensure
-        the operator sees the truly most-recent events.
+        The K8s API server returns events in resource-version order
+        (creation order), **not** last-seen order, and offers no
+        server-side ``orderBy`` knob -- see
+        https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
+        for the ordering contract. Passing the caller's ``limit``
+        directly to the API would therefore truncate an arbitrary
+        creation-ordered prefix before the client-side
+        :func:`sort_event_rows_recent_first` ever runs, defeating the
+        "N most-recent" acceptance criterion: an event created hours
+        ago but firing every minute would drop out of a small
+        ``--limit 10`` result while an old quiescent event near the
+        top of the creation order kept its slot.
 
-        To stay within the API server's response budget when the
-        client wants a small ``limit``, the handler still passes the
-        ``limit`` kwarg to the API: the wire request asks for the
-        rows the operator wanted, and the client-side sort just
-        reorders the subset before returning.
+        Instead, the handler always asks the API for up to
+        :data:`MAX_EVENT_LIMIT` rows -- a bounded superset -- then
+        sorts the projection by ``last_seen_seconds`` and truncates
+        client-side to the caller's ``limit``. The cap is set in
+        :mod:`ops_events` (currently 500) at the same operator-ergonomic
+        ceiling the schema's ``maximum`` enforces; above that the
+        operator is better served by a ``field_selector`` than by a
+        bigger result set (the K8s API itself paginates above ~1k
+        items per response in most deployments).
         """
         from meho_backplane.connectors.kubernetes.ops_events import (
             DEFAULT_EVENT_LIMIT,
@@ -471,7 +479,11 @@ class KubernetesConnector(Connector):
 
         api_client = await self._get_api_client(target)
         core_v1 = client.CoreV1Api(api_client)
-        kwargs: dict[str, Any] = {"namespace": namespace, "limit": limit}
+        # Always pull up to MAX_EVENT_LIMIT rows so the client-side
+        # sort sees the full recency-relevant superset; the caller's
+        # ``limit`` truncates after the sort. See the docstring above
+        # for the ordering rationale.
+        kwargs: dict[str, Any] = {"namespace": namespace, "limit": MAX_EVENT_LIMIT}
         if field_selector:
             kwargs["field_selector"] = field_selector
         resp = await core_v1.list_namespaced_event(**kwargs)

--- a/backend/src/meho_backplane/connectors/kubernetes/ops.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops.py
@@ -25,6 +25,15 @@ The shipped op surface today:
   workload surface (G3.2-T3 #323). Metadata + helpers + handlers live
   in :mod:`~meho_backplane.connectors.kubernetes.ops_workload`;
   :func:`_kubernetes_ops` splats ``WORKLOAD_OPS`` into the merged tuple.
+* ``k8s.service.list`` / ``k8s.ingress.list`` -- network ops
+  (G3.2-T4 #324). Metadata + helpers in
+  :mod:`~meho_backplane.connectors.kubernetes.ops_network`.
+* ``k8s.configmap.list`` (keys-only) / ``k8s.configmap.info``
+  (full data) -- config ops (G3.2-T4 #324). Metadata + helpers in
+  :mod:`~meho_backplane.connectors.kubernetes.ops_config`.
+* ``k8s.event.list`` -- observability op (G3.2-T4 #324). Metadata +
+  helpers in :mod:`~meho_backplane.connectors.kubernetes.ops_events`
+  (split out of ops_config to fit the 600-line code-quality cap).
 * ``k8s.logs`` -- non-streaming pod-log fetch (G3.2-T5 #325). Metadata
   schemas + handler live in
   :mod:`~meho_backplane.connectors.kubernetes.ops_logs`; this module
@@ -165,27 +174,36 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
     """Return the merged registration tuple.
 
     Composition: ``k8s.about`` (T1 canary) + ``CORE_OPS`` (T2 inventory:
-    ``k8s.ls`` / ``k8s.namespace.list`` / ``k8s.node.list``) + ``WORKLOAD_OPS``
-    (T3 workload: ``k8s.pod.{list,info}`` / ``k8s.deployment.{list,info}``)
+    ``k8s.ls`` / ``k8s.namespace.list`` / ``k8s.node.list``) +
+    ``WORKLOAD_OPS`` (T3 workload: ``k8s.pod.{list,info}`` /
+    ``k8s.deployment.{list,info}``) + ``NETWORK_OPS`` (T4 network:
+    ``k8s.service.list`` / ``k8s.ingress.list``) + ``CONFIG_OPS`` (T4
+    config: ``k8s.configmap.list`` keys-only / ``k8s.configmap.info``
+    full data) + ``EVENT_OPS`` (T4 observability: ``k8s.event.list``)
     + ``k8s.logs`` (T5).
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
     :class:`KubernetesOp` + ``_K8S_ABOUT_OP``, then imports the T2
     inventory ops from :mod:`ops_core`, the T3 workload ops from
-    :mod:`ops_workload`, and the T5 logs op metadata from
+    :mod:`ops_workload`, the T4 network ops from :mod:`ops_network`,
+    the T4 config ops from :mod:`ops_config`, the T4 event ops from
+    :mod:`ops_events`, and the T5 logs op metadata from
     :mod:`ops_logs` (each of which only depends on ``KubernetesOp``
     plus its own helpers). The arrangement keeps the canary op's
     metadata co-located with the dataclass definition while letting
     the larger surfaces live in their own modules next to their
     helpers.
     """
+    from meho_backplane.connectors.kubernetes.ops_config import CONFIG_OPS
     from meho_backplane.connectors.kubernetes.ops_core import CORE_OPS
+    from meho_backplane.connectors.kubernetes.ops_events import EVENT_OPS
     from meho_backplane.connectors.kubernetes.ops_logs import (
         K8S_LOGS_LLM_INSTRUCTIONS,
         K8S_LOGS_PARAMETER_SCHEMA,
         K8S_LOGS_RESPONSE_SCHEMA,
     )
+    from meho_backplane.connectors.kubernetes.ops_network import NETWORK_OPS
     from meho_backplane.connectors.kubernetes.ops_workload import WORKLOAD_OPS
 
     logs_op = KubernetesOp(
@@ -219,7 +237,15 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
         llm_instructions=K8S_LOGS_LLM_INSTRUCTIONS,
     )
 
-    return (_K8S_ABOUT_OP, *CORE_OPS, *WORKLOAD_OPS, logs_op)
+    return (
+        _K8S_ABOUT_OP,
+        *CORE_OPS,
+        *WORKLOAD_OPS,
+        *NETWORK_OPS,
+        *CONFIG_OPS,
+        *EVENT_OPS,
+        logs_op,
+    )
 
 
 KUBERNETES_OPS: tuple[KubernetesOp, ...] = _kubernetes_ops()

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_config.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_config.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Config ops -- ``k8s.configmap.list/info``.
+
+G3.2-T4 (#324) of Initiative #320. Two read-only "what's configured?"
+ops layered on top of the T1 / T2 / T5 base substrate:
+
+* ``k8s.configmap.list [--namespace X]`` -- ``CoreV1Api.list_namespaced_config_map``.
+  Per-row shape carries ``keys`` (the configmap's data keys) **but
+  never the values**. The split is privacy-relevant: configmaps in the
+  wild often blur into sensitive territory (registry credentials in
+  ``imagePullSecrets``-adjacent maps, OIDC client secrets in
+  ``argocd-cm``, vendor licence keys), and the operator's list view
+  should not bulk-broadcast the bytes through the SSE feed during a
+  routine "what's configured here?" scan. Operators wanting values
+  call ``.info`` per configmap so the audit row records the targeted
+  read instead of the bulk dump.
+
+* ``k8s.configmap.info <name> --namespace X`` -- ``CoreV1Api.read_namespaced_config_map``.
+  Returns the full configmap, including ``data`` and ``binary_data``.
+  Carries ``op_class=read`` for v0.2; G6.3 may upgrade specific
+  configmap patterns (managed-by ``secret-translator``, names matching
+  ``*-secret-config``) to a ``sensitive-read`` audit classifier.
+
+Row-shape helpers (:func:`configmap_list_row`, :func:`configmap_info`)
+are pure functions over :mod:`kubernetes_asyncio.client.models`
+instances so the unit tests pin the wire shape against synthetic
+fixtures without booting an event loop.
+
+The sibling :mod:`ops_events` module hosts the third T4 op
+(``k8s.event.list``); it landed in its own module so this file fits
+under the 600-line code-quality cap.
+
+References
+----------
+* Parent task: G3.2-T4 (#324).
+* Parent Initiative: G3.2 (#320), kubernetes-asyncio typed connector.
+* k8s ConfigMap API: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1/
+* ``kubernetes_asyncio.CoreV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+from meho_backplane.connectors.kubernetes.ops_core import age_seconds
+
+if TYPE_CHECKING:
+    from kubernetes_asyncio.client.models import V1ConfigMap
+
+__all__ = [
+    "CONFIG_OPS",
+    "K8S_CONFIGMAP_INFO_LLM_INSTRUCTIONS",
+    "K8S_CONFIGMAP_INFO_PARAMETER_SCHEMA",
+    "K8S_CONFIGMAP_INFO_RESPONSE_SCHEMA",
+    "K8S_CONFIGMAP_LIST_LLM_INSTRUCTIONS",
+    "K8S_CONFIGMAP_LIST_PARAMETER_SCHEMA",
+    "K8S_CONFIGMAP_LIST_RESPONSE_SCHEMA",
+    "configmap_info",
+    "configmap_list_row",
+]
+
+
+# ---------------------------------------------------------------------------
+# ConfigMap helpers
+# ---------------------------------------------------------------------------
+
+
+def configmap_list_row(
+    cm: V1ConfigMap,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Project a :class:`V1ConfigMap` into the list-op row shape -- **keys only, no values**.
+
+    Critical contract: this helper deliberately omits ``data`` /
+    ``binary_data`` values. The list op is the privacy-safe entry
+    point; operators that need values call ``k8s.configmap.info``
+    per configmap so the audit row records the targeted read instead
+    of the bulk dump.
+
+    The ``keys`` list is the **sorted union** of ``data`` keys and
+    ``binary_data`` keys -- both surfaces appear as configmap keys to
+    operators; the binary/text split is an implementation detail of
+    how the configmap was created (``kubectl create configmap --from-file``
+    chooses one or the other based on the file's content type).
+
+    ``age_seconds`` follows the same UTC-aware mapping the namespace /
+    node rows use; see
+    :func:`~meho_backplane.connectors.kubernetes.ops_core.age_seconds`.
+    """
+    metadata = cm.metadata
+    keys: set[str] = set()
+    if cm.data:
+        keys.update(cm.data.keys())
+    if cm.binary_data:
+        keys.update(cm.binary_data.keys())
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "keys": sorted(keys),
+        "age_seconds": age_seconds(
+            metadata.creation_timestamp if metadata is not None else None,
+            now=now,
+        ),
+    }
+
+
+def configmap_info(
+    cm: V1ConfigMap,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Project a :class:`V1ConfigMap` into the info-op shape -- full data + binary_data.
+
+    Counterpart to :func:`configmap_list_row`. This is the targeted
+    read shape: the operator named a specific configmap and the audit
+    row records ``op_id='k8s.configmap.info'`` + the configmap name in
+    ``params_hash``, so a future post-incident audit can identify
+    "who read which configmap when?". The bulk list never exposes
+    values, only this op does.
+
+    ``data`` and ``binary_data`` are forwarded as plain dicts (cast
+    from the API's ``Optional[Dict[str, str]]``) so an empty configmap
+    surfaces as ``{}`` / ``{}`` rather than ``None``. ``binary_data``
+    values are the API's base64-encoded strings -- ``kubernetes_asyncio``
+    does not auto-decode binary payloads, and the operator-facing
+    wire shape preserves the encoding so a downstream caller can
+    decide whether to decode (and how to render the result).
+    """
+    metadata = cm.metadata
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "data": dict(cm.data or {}),
+        "binary_data": dict(cm.binary_data or {}),
+        "metadata": {
+            "labels": (dict(metadata.labels or {}) if metadata is not None else {}),
+            "annotations": (dict(metadata.annotations or {}) if metadata is not None else {}),
+            "age_seconds": age_seconds(
+                metadata.creation_timestamp if metadata is not None else None,
+                now=now,
+            ),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Op metadata -- schemas + llm_instructions + KubernetesOp rows.
+# ---------------------------------------------------------------------------
+
+
+_NAMESPACE_PARAM_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": r"\S",
+    "description": "Namespace to list within.",
+}
+
+
+K8S_CONFIGMAP_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "namespace": _NAMESPACE_PARAM_SCHEMA,
+    },
+    "required": ["namespace"],
+    "additionalProperties": False,
+}
+
+
+K8S_CONFIGMAP_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "namespace": {"type": ["string", "null"]},
+                    "keys": {"type": "array", "items": {"type": "string"}},
+                    "age_seconds": {"type": ["integer", "null"]},
+                },
+                "required": ["name", "namespace", "keys", "age_seconds"],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_CONFIGMAP_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator asks 'what configmaps are in <namespace>?' "
+        "or needs to discover configmap names + the set of keys each one "
+        "exposes -- WITHOUT exposing values to the audit/broadcast feed. "
+        "For full data, follow up with k8s.configmap.info per "
+        "configmap (the targeted read records a per-configmap audit row)."
+    ),
+    "parameter_hints": {
+        "namespace": ("Required. The Kubernetes namespace whose configmaps to list."),
+    },
+    "output_shape": (
+        "{'rows': [{name, namespace, keys, age_seconds}], 'total': <int>}. "
+        "``keys`` is the sorted union of ``data`` + ``binary_data`` keys. "
+        "Values are NEVER included in this op; call k8s.configmap.info "
+        "to read them."
+    ),
+}
+
+
+K8S_CONFIGMAP_INFO_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": r"\S",
+            "description": "Configmap name (exact match; no prefix resolution).",
+        },
+        "namespace": _NAMESPACE_PARAM_SCHEMA,
+    },
+    "required": ["name", "namespace"],
+    "additionalProperties": False,
+}
+
+
+K8S_CONFIGMAP_INFO_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": ["string", "null"]},
+        "namespace": {"type": ["string", "null"]},
+        "data": {"type": "object"},
+        "binary_data": {"type": "object"},
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "labels": {"type": "object"},
+                "annotations": {"type": "object"},
+                "age_seconds": {"type": ["integer", "null"]},
+            },
+            "required": ["labels", "annotations", "age_seconds"],
+            "additionalProperties": False,
+        },
+    },
+    "required": ["name", "namespace", "data", "binary_data", "metadata"],
+    "additionalProperties": False,
+}
+
+
+K8S_CONFIGMAP_INFO_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator has named a specific configmap and "
+        "needs to read its values (data + binary_data). The targeted "
+        "read records a per-configmap audit row; prefer this over the "
+        "list op when the operator's question is 'what is the value of "
+        "key X in configmap Y?'. v0.2 audits as ``op_class=read``; "
+        "G6.3 may upgrade ``*-secret-config``-named configmaps to "
+        "``sensitive-read``."
+    ),
+    "parameter_hints": {
+        "name": "Required. Exact configmap name (no prefix resolution).",
+        "namespace": "Required. The Kubernetes namespace the configmap lives in.",
+    },
+    "output_shape": (
+        "{'name', 'namespace', 'data': {<key>: <text-value>}, "
+        "'binary_data': {<key>: <base64-string>}, 'metadata': "
+        "{'labels', 'annotations', 'age_seconds'}}. ``binary_data`` "
+        "values are forwarded base64-encoded (the K8s API's wire "
+        "shape); the connector does not auto-decode."
+    ),
+}
+
+
+CONFIG_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.configmap.list",
+        handler_attr="k8s_configmap_list",
+        summary="List configmaps in a namespace -- keys only, NO values.",
+        description=(
+            "Calls ``CoreV1Api.list_namespaced_config_map(namespace)`` "
+            "and projects each ConfigMap into {name, namespace, keys, "
+            "age_seconds}. ``keys`` is the sorted union of ``data`` "
+            "and ``binary_data`` keys. Values are **never** included -- "
+            "the list op is the privacy-safe entry point; operators "
+            "that need values call ``k8s.configmap.info`` per "
+            "configmap so the audit row records the targeted read "
+            "instead of the bulk dump. Read-only."
+        ),
+        parameter_schema=K8S_CONFIGMAP_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_CONFIGMAP_LIST_RESPONSE_SCHEMA,
+        group_key="config",
+        tags=("read-only", "config", "configmap"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_CONFIGMAP_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.configmap.info",
+        handler_attr="k8s_configmap_info",
+        summary="Read a single configmap with full data + binary_data.",
+        description=(
+            "Calls ``CoreV1Api.read_namespaced_config_map(name, namespace)`` "
+            "and projects the result into {name, namespace, data, "
+            "binary_data, metadata: {labels, annotations, age_seconds}}. "
+            "``data`` carries the text values verbatim; ``binary_data`` "
+            "values are forwarded base64-encoded (the K8s wire shape) "
+            "without auto-decoding. The op is the targeted-read "
+            "counterpart to ``k8s.configmap.list`` -- the audit row "
+            "captures the configmap name so a post-incident query can "
+            "answer 'who read which configmap when?'. v0.2 audits as "
+            "``op_class=read``; G6.3 may upgrade specific patterns to "
+            "``sensitive-read``. Read-only."
+        ),
+        parameter_schema=K8S_CONFIGMAP_INFO_PARAMETER_SCHEMA,
+        response_schema=K8S_CONFIGMAP_INFO_RESPONSE_SCHEMA,
+        group_key="config",
+        tags=("read-only", "config", "configmap"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_CONFIGMAP_INFO_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_events.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_events.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Observability ops -- ``k8s.event.list``.
+
+G3.2-T4 (#324) of Initiative #320. The "what's recently happened?"
+read-only op layered on top of the T1 / T2 / T5 base substrate:
+
+* ``k8s.event.list [--namespace X] [--field-selector ...] [--limit N]`` --
+  ``CoreV1Api.list_namespaced_event``. Returns recent events ordered
+  most-recent-first (descending ``last_seen``). Default ``limit=50``;
+  ``--field-selector`` is forwarded verbatim to the K8s API so the
+  operator can apply server-side filters like
+  ``type=Warning,involvedObject.kind=Pod`` without the connector
+  re-encoding the syntax.
+
+The event surface lives in its own module (rather than alongside the
+configmap ops in :mod:`ops_config`) for two reasons:
+
+1. **File-size hygiene.** The code-quality gate caps files at 600
+   lines; the combined configmap+event schemas + llm_instructions +
+   helpers crossed that threshold.
+2. **Operator mental model.** Events are observability, configmaps
+   are configuration -- the parent Initiative's
+   :data:`~meho_backplane.connectors.kubernetes.ops_events.K8S_EVENT_LIST_LLM_INSTRUCTIONS`
+   "when to use" prose for events is closer to ``k8s.logs`` than to
+   ``k8s.configmap.list``; future grouping in
+   :func:`~meho_backplane.operations.search_operations` benefits
+   from the separation.
+
+Row-shape helpers (:func:`event_row`, :func:`sort_event_rows_recent_first`)
+are pure functions over :mod:`kubernetes_asyncio.client.models`
+instances so the unit tests pin the wire shape against synthetic
+fixtures without booting an event loop.
+
+References
+----------
+* Parent task: G3.2-T4 (#324).
+* Parent Initiative: G3.2 (#320), kubernetes-asyncio typed connector.
+* k8s Event API: https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/
+* ``kubernetes_asyncio.CoreV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+
+if TYPE_CHECKING:
+    from kubernetes_asyncio.client.models import CoreV1Event
+
+__all__ = [
+    "DEFAULT_EVENT_LIMIT",
+    "EVENT_OPS",
+    "K8S_EVENT_LIST_LLM_INSTRUCTIONS",
+    "K8S_EVENT_LIST_PARAMETER_SCHEMA",
+    "K8S_EVENT_LIST_RESPONSE_SCHEMA",
+    "MAX_EVENT_LIMIT",
+    "event_last_seen_seconds_key",
+    "event_row",
+    "sort_event_rows_recent_first",
+]
+
+
+#: Default ``limit`` on ``k8s.event.list`` when the caller doesn't pick
+#: one. Events accumulate quickly on a busy cluster (a single failing
+#: pod easily produces 100+ ``BackOff`` events per hour) and the
+#: operator's typical "what's happening?" question is satisfied by the
+#: 50 most-recent rows.
+DEFAULT_EVENT_LIMIT = 50
+
+#: Hard ceiling on ``--limit``. The K8s API itself supports paginated
+#: list with no upper bound on ``limit``, but 500 is the ergonomic cap
+#: -- above that the operator almost certainly wants a server-side
+#: field-selector filter, not "more events". Mirrors the same
+#: "5000 tail / pick --since instead" discipline in ``k8s.logs``.
+MAX_EVENT_LIMIT = 500
+
+
+# ---------------------------------------------------------------------------
+# Event row helpers
+# ---------------------------------------------------------------------------
+
+
+def _involved_object_row(obj: Any) -> dict[str, Any]:
+    """Project an :class:`V1ObjectReference` into the event row's
+    ``involved_object`` flat shape.
+
+    Operators reading an event care about *what* the event is about --
+    kind / name / namespace are enough for the "is this a pod issue?"
+    triage question. The full ObjectReference also carries UID,
+    resourceVersion, apiVersion, fieldPath; those are correctness
+    details the dispatcher's structured ``unknown_op``/``connector_error``
+    surface doesn't need.
+    """
+    if obj is None:
+        return {"kind": None, "name": None, "namespace": None}
+    return {
+        "kind": obj.kind,
+        "name": obj.name,
+        "namespace": obj.namespace,
+    }
+
+
+def _event_source_string(event: CoreV1Event) -> str | None:
+    """Coalesce the event's source into a single string operators recognise.
+
+    Pre-1.27 K8s events use ``source.component`` (e.g. ``"kubelet"``)
+    + ``source.host``; the 1.27+ EventSeries API uses
+    ``reporting_component`` (e.g. ``"node-controller"``). Both surfaces
+    are present on every ``CoreV1Event`` instance for backward compat;
+    the wire shape forwards the first non-empty one so an operator
+    looking at the row sees the same string ``kubectl describe`` shows.
+    """
+    source = event.source
+    if source is not None and source.component:
+        return str(source.component)
+    if event.reporting_component:
+        return str(event.reporting_component)
+    return None
+
+
+def _event_last_seen(event: CoreV1Event) -> datetime | None:
+    """Best-effort "when did this event last fire?" timestamp.
+
+    Pre-1.27 events use ``last_timestamp``; the 1.27+ EventSeries shape
+    moves the timestamp to ``series.last_observed_time`` (recurring
+    events) or ``event_time`` (single-shot events). The helper walks
+    the most-recent-first preference order so an event from either API
+    surface sorts correctly under ``sort_event_rows_recent_first``.
+    """
+    if event.last_timestamp is not None:
+        result: datetime = event.last_timestamp
+        return result
+    series = event.series
+    if series is not None and getattr(series, "last_observed_time", None) is not None:
+        result = series.last_observed_time
+        return result
+    if event.event_time is not None:
+        result = event.event_time
+        return result
+    return None
+
+
+def _event_first_seen(event: CoreV1Event) -> datetime | None:
+    """First-observed timestamp; falls back to event_time when first_timestamp
+    is unset (the 1.27+ EventSeries shape).
+    """
+    if event.first_timestamp is not None:
+        result: datetime = event.first_timestamp
+        return result
+    if event.event_time is not None:
+        result = event.event_time
+        return result
+    return None
+
+
+def _event_seconds_ago(ts: datetime | None, *, now: datetime | None = None) -> int | None:
+    """Convert an event timestamp into "N seconds ago"."""
+    if ts is None:
+        return None
+    reference = now if now is not None else datetime.now(UTC)
+    delta = reference - ts
+    return int(delta.total_seconds())
+
+
+def event_row(
+    event: CoreV1Event,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Project a :class:`CoreV1Event` into the wire dict shape."""
+    metadata = event.metadata
+    last_seen = _event_last_seen(event)
+    first_seen = _event_first_seen(event)
+    # ``count`` is None for the 1.27+ EventSeries singletons; coerce to
+    # the operator-mental-model default of 1 (one observation) so the
+    # row's type is stable.
+    raw_count = event.count
+    count: int = int(raw_count) if raw_count is not None else 1
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "type": event.type,
+        "reason": event.reason,
+        "message": event.message,
+        "involved_object": _involved_object_row(event.involved_object),
+        "source": _event_source_string(event),
+        "count": count,
+        "first_seen_seconds": _event_seconds_ago(first_seen, now=now),
+        "last_seen_seconds": _event_seconds_ago(last_seen, now=now),
+    }
+
+
+def event_last_seen_seconds_key(row: dict[str, Any]) -> int:
+    """Sort key: smaller ``last_seen_seconds`` (more recent) sorts first.
+
+    Rows with ``last_seen_seconds=None`` (no usable timestamp on either
+    API surface) sort to the end -- they're rare and the operator's
+    "what's recent?" question is better answered by deterministically
+    pushing the un-timestamped rows out of the top of the list.
+    """
+    raw = row.get("last_seen_seconds")
+    if raw is None:
+        # ``sys.maxsize`` keeps un-timestamped rows last while staying
+        # int-typed (Python's ``<`` rejects ``int < None``).
+        return sys.maxsize
+    return int(raw)
+
+
+def sort_event_rows_recent_first(
+    rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Sort a row list most-recent-first by ``last_seen_seconds``.
+
+    Stable sort -- rows with identical timestamps keep the API server's
+    original ordering. v0.2's ``--limit`` truncation happens **after**
+    the sort so the kept rows are deterministically the N most-recent,
+    not "the first N the server returned".
+    """
+    return sorted(rows, key=event_last_seen_seconds_key)
+
+
+# ---------------------------------------------------------------------------
+# Op metadata -- schemas + llm_instructions + KubernetesOp row.
+# ---------------------------------------------------------------------------
+
+
+_NAMESPACE_PARAM_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": r"\S",
+    "description": "Namespace to list within.",
+}
+
+
+K8S_EVENT_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "namespace": _NAMESPACE_PARAM_SCHEMA,
+        "field_selector": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": r"\S",
+            "description": (
+                "K8s field selector forwarded server-side. "
+                "Examples: 'type=Warning', "
+                "'involvedObject.kind=Pod', "
+                "'type=Warning,reason=BackOff'."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": MAX_EVENT_LIMIT,
+            "default": DEFAULT_EVENT_LIMIT,
+            "description": (
+                f"Maximum rows to return (default {DEFAULT_EVENT_LIMIT}, "
+                f"capped at {MAX_EVENT_LIMIT}). Rows are sorted "
+                "most-recent-first; ``limit`` truncates the tail "
+                "(the oldest events) after the sort."
+            ),
+        },
+    },
+    "required": ["namespace"],
+    "additionalProperties": False,
+}
+
+
+K8S_EVENT_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "namespace": {"type": ["string", "null"]},
+                    "type": {"type": ["string", "null"]},
+                    "reason": {"type": ["string", "null"]},
+                    "message": {"type": ["string", "null"]},
+                    "involved_object": {
+                        "type": "object",
+                        "properties": {
+                            "kind": {"type": ["string", "null"]},
+                            "name": {"type": ["string", "null"]},
+                            "namespace": {"type": ["string", "null"]},
+                        },
+                        "additionalProperties": False,
+                    },
+                    "source": {"type": ["string", "null"]},
+                    "count": {"type": "integer", "minimum": 0},
+                    "first_seen_seconds": {"type": ["integer", "null"]},
+                    "last_seen_seconds": {"type": ["integer", "null"]},
+                },
+                "required": [
+                    "name",
+                    "namespace",
+                    "type",
+                    "reason",
+                    "message",
+                    "involved_object",
+                    "source",
+                    "count",
+                    "first_seen_seconds",
+                    "last_seen_seconds",
+                ],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_EVENT_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator asks 'what's recently happened in "
+        "<namespace>?', 'why did this pod restart?', or 'are there "
+        "any warnings?'. Rows are sorted most-recent-first; pair with "
+        "``field_selector='type=Warning'`` to scope the answer to "
+        "operator-actionable signals."
+    ),
+    "parameter_hints": {
+        "namespace": ("Required. The Kubernetes namespace whose events to list."),
+        "field_selector": (
+            "Optional. K8s field-selector string forwarded server-side "
+            "(e.g. 'type=Warning', 'involvedObject.kind=Pod'). Multiple "
+            "filters comma-separated."
+        ),
+        "limit": (
+            f"Optional. Defaults to {DEFAULT_EVENT_LIMIT}, capped at "
+            f"{MAX_EVENT_LIMIT}. Rows are sorted before truncation, so "
+            "``limit`` always keeps the N most-recent events."
+        ),
+    },
+    "output_shape": (
+        "{'rows': [{name, namespace, type, reason, message, "
+        "involved_object: {kind, name, namespace}, source, count, "
+        "first_seen_seconds, last_seen_seconds}], 'total': <int>}. "
+        "``type`` is 'Normal' or 'Warning'; ``count`` is how many "
+        "times the event has fired; ``last_seen_seconds`` is how "
+        "long ago the event was last observed."
+    ),
+}
+
+
+EVENT_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.event.list",
+        handler_attr="k8s_event_list",
+        summary="List recent Kubernetes events in a namespace, most-recent-first.",
+        description=(
+            "Calls ``CoreV1Api.list_namespaced_event(namespace, "
+            "field_selector=..., limit=...)`` and projects each Event "
+            "into {name, namespace, type, reason, message, "
+            "involved_object: {kind, name, namespace}, source, count, "
+            "first_seen_seconds, last_seen_seconds}. Rows are sorted "
+            "most-recent-first by ``last_seen_seconds`` before "
+            "``limit`` truncates the tail, so the kept rows are "
+            "deterministically the N most-recent events. "
+            "``field_selector`` is forwarded verbatim to the K8s API "
+            "(e.g. 'type=Warning', 'involvedObject.kind=Pod'). "
+            f"Default limit {DEFAULT_EVENT_LIMIT}, capped at "
+            f"{MAX_EVENT_LIMIT}. Read-only."
+        ),
+        parameter_schema=K8S_EVENT_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_EVENT_LIST_RESPONSE_SCHEMA,
+        group_key="events",
+        tags=("read-only", "events", "observability"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_EVENT_LIST_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_events.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_events.py
@@ -177,11 +177,22 @@ def event_row(
     metadata = event.metadata
     last_seen = _event_last_seen(event)
     first_seen = _event_first_seen(event)
-    # ``count`` is None for the 1.27+ EventSeries singletons; coerce to
-    # the operator-mental-model default of 1 (one observation) so the
-    # row's type is stable.
-    raw_count = event.count
-    count: int = int(raw_count) if raw_count is not None else 1
+    # K8s 1.27+ moved the authoritative occurrence count for recurring
+    # events onto ``event.series.count`` (CoreV1EventSeries); the
+    # pre-1.27 surface kept it on ``event.count``. Both attributes are
+    # always present on a CoreV1Event for backward compat, but on a
+    # series-shape event ``event.count`` is None while
+    # ``event.series.count`` carries the real number. Prefer the
+    # series count; fall back to the flat field; default to 1 only
+    # when neither surface has set anything (the EventSeries singleton
+    # shape, where a single observation has no ``series`` yet).
+    series = event.series
+    if series is not None and getattr(series, "count", None) is not None:
+        count: int = int(series.count)
+    elif event.count is not None:
+        count = int(event.count)
+    else:
+        count = 1
     return {
         "name": metadata.name if metadata is not None else None,
         "namespace": metadata.namespace if metadata is not None else None,

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_network.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_network.py
@@ -1,0 +1,436 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Network ops -- ``k8s.service.list`` / ``k8s.ingress.list``.
+
+G3.2-T4 (#324) of Initiative #320. Adds the two "what's exposed?"
+read-only ops on top of the T1 / T2 / T5 base substrate:
+
+* ``k8s.service.list [--namespace X]`` -- ``CoreV1Api.list_namespaced_service``.
+  Returns one row per Service with name / namespace / type / cluster_ip /
+  external_ips / ports / selector. The ``ports`` projection flattens
+  :class:`V1ServicePort` to the operator-visible four-tuple
+  (``name`` / ``port`` / ``target_port`` / ``protocol``).
+* ``k8s.ingress.list [--namespace X]`` -- ``NetworkingV1Api.list_namespaced_ingress``.
+  Returns one row per Ingress with name / namespace / class / hosts /
+  tls_hosts / rules. The ``hosts`` list deduplicates entries across
+  rules (the spec allows the same host on multiple rules with different
+  path sets); ``tls_hosts`` is the union of every ``V1IngressTLS.hosts``
+  entry so the operator can spot whether the ingress carries a TLS
+  certificate without walking the full rule tree.
+
+Row-shape helpers (:func:`service_row`, :func:`service_port_row`,
+:func:`ingress_row`, :func:`ingress_rule_row`) are pure functions over
+:mod:`kubernetes_asyncio.client.models` instances so the unit tests can
+pin the wire shape against synthetic fixtures without booting an event
+loop -- the same discipline the T2 ops_core helpers established.
+
+The handlers themselves live as bound methods on
+:class:`~meho_backplane.connectors.kubernetes.connector.KubernetesConnector`
+(``k8s_service_list``, ``k8s_ingress_list``) and delegate the model ->
+row projection to the helpers here.
+
+References
+----------
+* Parent task: G3.2-T4 (#324).
+* Parent Initiative: G3.2 (#320), kubernetes-asyncio typed connector.
+* k8s Service API: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
+* k8s Ingress API: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/
+* ``kubernetes_asyncio.CoreV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
+* ``kubernetes_asyncio.NetworkingV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/NetworkingV1Api.md
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+
+if TYPE_CHECKING:
+    from kubernetes_asyncio.client.models import (
+        V1HTTPIngressPath,
+        V1Ingress,
+        V1IngressRule,
+        V1Service,
+        V1ServicePort,
+    )
+
+__all__ = [
+    "K8S_INGRESS_LIST_LLM_INSTRUCTIONS",
+    "K8S_INGRESS_LIST_PARAMETER_SCHEMA",
+    "K8S_INGRESS_LIST_RESPONSE_SCHEMA",
+    "K8S_SERVICE_LIST_LLM_INSTRUCTIONS",
+    "K8S_SERVICE_LIST_PARAMETER_SCHEMA",
+    "K8S_SERVICE_LIST_RESPONSE_SCHEMA",
+    "NETWORK_OPS",
+    "ingress_path_row",
+    "ingress_row",
+    "ingress_rule_row",
+    "service_port_row",
+    "service_row",
+]
+
+
+# ---------------------------------------------------------------------------
+# Row-shape helpers -- pure mappings over kubernetes_asyncio model objects.
+# ---------------------------------------------------------------------------
+
+
+def service_port_row(port: V1ServicePort) -> dict[str, Any]:
+    """Project a :class:`V1ServicePort` into the operator-visible four-tuple.
+
+    ``target_port`` is the operator-supplied port on the destination
+    pod; the K8s schema permits either an integer or a named string
+    reference. The wire shape forwards the value verbatim so a port
+    named ``"http"`` in the manifest surfaces as ``"http"`` on the row,
+    not coerced to an integer.
+    """
+    return {
+        "name": port.name,
+        "port": port.port,
+        "target_port": port.target_port,
+        "protocol": port.protocol,
+    }
+
+
+def service_row(svc: V1Service) -> dict[str, Any]:
+    """Project a :class:`V1Service` into the wire dict shape.
+
+    ``external_ips`` is the static list operators set on
+    ``spec.externalIPs``; LoadBalancer-assigned IPs live under
+    ``status.loadBalancer.ingress`` and are out of v0.2 scope (the
+    operator question "what IP routes to this service?" is answered by
+    the type + cluster_ip combination plus the namespace's Ingress
+    rows). ``selector`` is forwarded verbatim; an absent selector
+    (``None`` on a headless / ExternalName service) surfaces as ``{}``
+    so downstream consumers see a stable dict type.
+    """
+    metadata = svc.metadata
+    spec = svc.spec
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "type": spec.type if spec is not None else None,
+        "cluster_ip": spec.cluster_ip if spec is not None else None,
+        "external_ips": (list(spec.external_ips or []) if spec is not None else []),
+        "ports": ([service_port_row(p) for p in (spec.ports or [])] if spec is not None else []),
+        "selector": (dict(spec.selector or {}) if spec is not None else {}),
+    }
+
+
+def ingress_path_row(path: V1HTTPIngressPath) -> dict[str, Any]:
+    """Project a :class:`V1HTTPIngressPath` into the wire dict shape.
+
+    ``service`` / ``port`` collapse the nested ``backend.service``
+    structure to two flat fields -- operators reading the row don't
+    care about the IngressBackend wrapper, only "which service +
+    port does this path route to?". When the backend is a
+    ``Resource`` reference (non-Service backend), both fields surface
+    as ``None`` and the operator can re-fetch the full ingress via
+    a future ``k8s.ingress.info`` op (out of v0.2 scope).
+    """
+    service_name: str | None = None
+    service_port: int | str | None = None
+    backend = path.backend
+    if backend is not None and backend.service is not None:
+        service_name = backend.service.name
+        port_obj = backend.service.port
+        if port_obj is not None:
+            # ``V1ServiceBackendPort`` has either ``number`` (int) or
+            # ``name`` (string); prefer ``number`` because the operator
+            # mental model maps to a TCP port. A named port falls back
+            # to the string -- still useful, just less common.
+            service_port = port_obj.number if port_obj.number is not None else port_obj.name
+    return {
+        "path": path.path,
+        "path_type": path.path_type,
+        "service": service_name,
+        "port": service_port,
+    }
+
+
+def ingress_rule_row(rule: V1IngressRule) -> dict[str, Any]:
+    """Project a :class:`V1IngressRule` into the wire dict shape.
+
+    The HTTP rule is the only path-bearing branch in v0.2; non-HTTP
+    rules (TCP / UDP via Gateway API) are out of scope per #320.
+    """
+    paths: list[dict[str, Any]] = []
+    if rule.http is not None and rule.http.paths:
+        paths = [ingress_path_row(p) for p in rule.http.paths]
+    return {
+        "host": rule.host,
+        "paths": paths,
+    }
+
+
+def ingress_row(ingress: V1Ingress) -> dict[str, Any]:
+    """Project a :class:`V1Ingress` into the wire dict shape.
+
+    ``hosts`` is the deduplicated union of every rule's ``host`` field
+    (the spec permits the same host on multiple rules with disjoint
+    path sets). ``tls_hosts`` is the union of every TLS entry's
+    ``hosts`` list. Both lists are sorted for stable wire output across
+    the API's iteration order.
+    """
+    metadata = ingress.metadata
+    spec = ingress.spec
+    ingress_class: str | None = None
+    rules: list[dict[str, Any]] = []
+    hosts: set[str] = set()
+    tls_hosts: set[str] = set()
+    if spec is not None:
+        ingress_class = spec.ingress_class_name
+        if spec.rules:
+            rules = [ingress_rule_row(r) for r in spec.rules]
+            for rule in spec.rules:
+                if rule.host:
+                    hosts.add(rule.host)
+        if spec.tls:
+            for tls in spec.tls:
+                if tls.hosts:
+                    for host in tls.hosts:
+                        tls_hosts.add(host)
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "class": ingress_class,
+        "hosts": sorted(hosts),
+        "tls_hosts": sorted(tls_hosts),
+        "rules": rules,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Op metadata -- schemas + llm_instructions + KubernetesOp rows.
+# ---------------------------------------------------------------------------
+
+
+#: Both list ops accept an optional ``namespace`` (when omitted, the
+#: handler errors -- v0.2 scopes network ops to a single namespace per
+#: call; the parent Initiative's cross-namespace aggregation is a
+#: higher-level concern). The schema's ``minLength``/``pattern`` reject
+#: whitespace-only inputs so the handler doesn't have to.
+_NAMESPACE_PARAM_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": r"\S",
+    "description": "Namespace to list within.",
+}
+
+
+K8S_SERVICE_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "namespace": _NAMESPACE_PARAM_SCHEMA,
+    },
+    "required": ["namespace"],
+    "additionalProperties": False,
+}
+
+
+K8S_SERVICE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "namespace": {"type": ["string", "null"]},
+                    "type": {"type": ["string", "null"]},
+                    "cluster_ip": {"type": ["string", "null"]},
+                    "external_ips": {"type": "array", "items": {"type": "string"}},
+                    "ports": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": ["string", "null"]},
+                                "port": {"type": ["integer", "null"]},
+                                "target_port": {"type": ["integer", "string", "null"]},
+                                "protocol": {"type": ["string", "null"]},
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                    "selector": {"type": "object"},
+                },
+                "required": [
+                    "name",
+                    "namespace",
+                    "type",
+                    "cluster_ip",
+                    "external_ips",
+                    "ports",
+                    "selector",
+                ],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_SERVICE_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator asks 'what services are in <namespace>?', "
+        "'what's exposing the argocd UI?', or needs the cluster-internal "
+        "addresses (ClusterIP + port) for a service. Read-only; safe."
+    ),
+    "parameter_hints": {
+        "namespace": ("Required. The Kubernetes namespace whose services to list."),
+    },
+    "output_shape": (
+        "{'rows': [{name, namespace, type, cluster_ip, external_ips, "
+        "ports: [{name, port, target_port, protocol}], selector}], "
+        "'total': <int>}. ``type`` is the Service type "
+        "('ClusterIP' / 'NodePort' / 'LoadBalancer' / 'ExternalName'); "
+        "``cluster_ip`` is the stable in-cluster VIP."
+    ),
+}
+
+
+K8S_INGRESS_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "namespace": _NAMESPACE_PARAM_SCHEMA,
+    },
+    "required": ["namespace"],
+    "additionalProperties": False,
+}
+
+
+K8S_INGRESS_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "namespace": {"type": ["string", "null"]},
+                    "class": {"type": ["string", "null"]},
+                    "hosts": {"type": "array", "items": {"type": "string"}},
+                    "tls_hosts": {"type": "array", "items": {"type": "string"}},
+                    "rules": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "host": {"type": ["string", "null"]},
+                                "paths": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "path": {"type": ["string", "null"]},
+                                            "path_type": {"type": ["string", "null"]},
+                                            "service": {"type": ["string", "null"]},
+                                            "port": {"type": ["integer", "string", "null"]},
+                                        },
+                                        "additionalProperties": False,
+                                    },
+                                },
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": [
+                    "name",
+                    "namespace",
+                    "class",
+                    "hosts",
+                    "tls_hosts",
+                    "rules",
+                ],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_INGRESS_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator asks 'what URLs route into <namespace>?', "
+        "'is there a TLS cert on the argocd ingress?', or needs the "
+        "host->service routing table. Read-only; safe."
+    ),
+    "parameter_hints": {
+        "namespace": ("Required. The Kubernetes namespace whose ingresses to list."),
+    },
+    "output_shape": (
+        "{'rows': [{name, namespace, class, hosts, tls_hosts, "
+        "rules: [{host, paths: [{path, path_type, service, port}]}]}], "
+        "'total': <int>}. ``hosts`` and ``tls_hosts`` are sorted "
+        "deduplicated lists across the rule set."
+    ),
+}
+
+
+NETWORK_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.service.list",
+        handler_attr="k8s_service_list",
+        summary="List Kubernetes services in a namespace -- type / cluster_ip / ports / selector.",
+        description=(
+            "Calls ``CoreV1Api.list_namespaced_service(namespace)`` and "
+            "projects each Service into {name, namespace, type, "
+            "cluster_ip, external_ips, ports, selector}. ``type`` is the "
+            "Service type ('ClusterIP' / 'NodePort' / 'LoadBalancer' / "
+            "'ExternalName'); ``cluster_ip`` is the stable in-cluster VIP "
+            "(may be 'None' for ExternalName services or headless "
+            "services with selector). ``ports`` flattens each "
+            "``V1ServicePort`` to {name, port, target_port, protocol}; "
+            "``target_port`` may be either an integer or a named-port "
+            "string. ``selector`` is the label map the service uses to "
+            "pick pods. Read-only."
+        ),
+        parameter_schema=K8S_SERVICE_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_SERVICE_LIST_RESPONSE_SCHEMA,
+        group_key="network",
+        tags=("read-only", "network", "service"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_SERVICE_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.ingress.list",
+        handler_attr="k8s_ingress_list",
+        summary="List Kubernetes ingresses in a namespace -- hosts / TLS hosts / routing rules.",
+        description=(
+            "Calls ``NetworkingV1Api.list_namespaced_ingress(namespace)`` "
+            "and projects each Ingress into {name, namespace, class, "
+            "hosts, tls_hosts, rules}. ``class`` is the "
+            "``ingressClassName`` (e.g. 'nginx', 'traefik'); ``hosts`` "
+            "is the deduplicated sorted union of every rule's host; "
+            "``tls_hosts`` is the union of every TLS entry's hosts list "
+            "(operators use it to spot whether the ingress has TLS "
+            "configured without walking the rule tree). ``rules`` "
+            "flattens each ``V1IngressRule`` to "
+            "{host, paths: [{path, path_type, service, port}]}; the "
+            "backend's IngressServiceBackend wrapper is collapsed to "
+            "the flat service+port fields for the operator-facing wire "
+            "shape. Read-only."
+        ),
+        parameter_schema=K8S_INGRESS_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_INGRESS_LIST_RESPONSE_SCHEMA,
+        group_key="network",
+        tags=("read-only", "network", "ingress"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_INGRESS_LIST_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/tests/integration/test_connectors_k8s_k3d.py
+++ b/backend/tests/integration/test_connectors_k8s_k3d.py
@@ -467,3 +467,130 @@ async def test_deployment_info_against_k3s_returns_full_detail(
     assert "status" in info
     assert "containers" in info
     assert len(info["containers"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# G3.2-T4 (#324) network + config + event ops -- live k3s exercise.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_list_against_k3s_returns_kubernetes_service(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.service.list --namespace default`` returns the bootstrap ``kubernetes`` service."""
+    connector, target = k3s_connector
+    result = await connector.k8s_service_list(target, {"namespace": "default"})
+    # Every k3s cluster ships with the ``kubernetes`` ClusterIP service
+    # in the ``default`` namespace -- it's the API server's in-cluster
+    # endpoint. Use it as the existence assertion; specific cluster_ip
+    # values vary across boots so don't pin those.
+    names = {row["name"] for row in result["rows"]}
+    assert "kubernetes" in names
+    kube_svc = next(row for row in result["rows"] if row["name"] == "kubernetes")
+    assert kube_svc["type"] == "ClusterIP"
+    assert kube_svc["cluster_ip"]
+    assert any(port["port"] == 443 for port in kube_svc["ports"])
+
+
+@pytest.mark.asyncio
+async def test_ingress_list_against_k3s_returns_empty_or_default(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.ingress.list --namespace default`` returns the (likely-empty) ingress list.
+
+    k3s ships Traefik in ``kube-system`` but no ingresses by default in
+    ``default``. The assertion is structural -- the call succeeds and
+    returns the expected envelope shape -- not numeric. A list-op that
+    failed against a real cluster would surface as an exception here.
+    """
+    connector, target = k3s_connector
+    result = await connector.k8s_ingress_list(target, {"namespace": "default"})
+    assert isinstance(result["rows"], list)
+    assert result["total"] == len(result["rows"])
+
+
+@pytest.mark.asyncio
+async def test_configmap_list_against_k3s_keys_only_data_absent(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.configmap.list --namespace kube-system`` returns keys-only rows; data absent.
+
+    The privacy contract pinned by the unit tests is re-asserted here
+    against the live cluster: even with real configmaps in
+    ``kube-system`` (k3s ships several including ``coredns`` and
+    ``local-path-config``), the list-op rows MUST NOT carry ``data``
+    or ``binary_data``.
+    """
+    connector, target = k3s_connector
+    result = await connector.k8s_configmap_list(target, {"namespace": "kube-system"})
+    assert result["total"] >= 1, "k8s kube-system should ship at least one configmap"
+    for row in result["rows"]:
+        # Privacy contract: keys populated, values absent.
+        assert "keys" in row
+        assert "data" not in row
+        assert "binary_data" not in row
+
+
+@pytest.mark.asyncio
+async def test_configmap_info_against_k3s_returns_full_data(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.configmap.info`` returns full data + binary_data for a known configmap.
+
+    Picks a configmap from ``k8s.configmap.list`` and re-reads it via
+    ``info``; the test is independent of which specific configmap k3s
+    happens to ship in this version.
+    """
+    connector, target = k3s_connector
+    list_result = await connector.k8s_configmap_list(target, {"namespace": "kube-system"})
+    assert list_result["rows"], "need at least one configmap to exercise info"
+    first = list_result["rows"][0]
+    info_result = await connector.k8s_configmap_info(
+        target, {"name": first["name"], "namespace": "kube-system"}
+    )
+    assert info_result["name"] == first["name"]
+    assert info_result["namespace"] == "kube-system"
+    # ``data`` is a dict (possibly empty if the configmap has only
+    # binary_data); ``metadata.labels`` / ``metadata.annotations`` are
+    # always-present dicts in the wire shape.
+    assert isinstance(info_result["data"], dict)
+    assert isinstance(info_result["binary_data"], dict)
+    assert isinstance(info_result["metadata"]["labels"], dict)
+
+
+@pytest.mark.asyncio
+async def test_event_list_against_k3s_returns_namespaced_events(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.event.list --namespace kube-system`` returns recent events sorted recent-first."""
+    connector, target = k3s_connector
+    result = await connector.k8s_event_list(target, {"namespace": "kube-system", "limit": 50})
+    # k3s emits events during boot (pod scheduling, image pulls, leader
+    # election); the kube-system namespace always has some.
+    assert isinstance(result["rows"], list)
+    # Ordering is most-recent-first by ``last_seen_seconds`` (smaller
+    # value = more recent).
+    seen = [
+        row["last_seen_seconds"] for row in result["rows"] if row["last_seen_seconds"] is not None
+    ]
+    assert seen == sorted(seen)
+
+
+@pytest.mark.asyncio
+async def test_event_list_against_k3s_field_selector_filters(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``--field-selector type=Warning`` returns only Warning events.
+
+    May return zero rows on a healthy cluster -- the assertion is that
+    every returned row matches the filter, not that any rows exist.
+    """
+    connector, target = k3s_connector
+    result = await connector.k8s_event_list(
+        target,
+        {"namespace": "kube-system", "field_selector": "type=Warning"},
+    )
+    assert isinstance(result["rows"], list)
+    for row in result["rows"]:
+        assert row["type"] == "Warning"

--- a/backend/tests/test_connectors_k8s_core.py
+++ b/backend/tests/test_connectors_k8s_core.py
@@ -661,11 +661,11 @@ async def test_k8s_ls_namespace_kind_forwards_to_unknown_op_envelope() -> None:
     """Kinds whose ``list`` op isn't registered come back as ``unknown_op`` via the shim.
 
     Pinned against a kind the registered surface deliberately does not
-    cover (``services`` ships under G3.2-T4 #324). T3 (#323) brought
-    ``k8s.pod.list`` and ``k8s.deployment.list`` into the registered
-    set, so the original ``/argocd/pods`` probe now resolves to a real
-    handler -- using ``services`` instead keeps the test pinned on the
-    unknown-op shape until T4 lands its own coverage.
+    cover. T3 (#323) brought ``k8s.pod.list`` and ``k8s.deployment.list``
+    into the registered set; T4 (#324) added ``service`` / ``ingress`` /
+    ``configmap`` / ``event``. ``statefulsets`` is out of v0.2 scope (no
+    ``k8s.statefulset.list`` op registered), so it keeps the test pinned
+    on the unknown-op shape until a future Task adds it.
     """
     from meho_backplane.operations import typed_register as tr_module
 
@@ -677,10 +677,10 @@ async def test_k8s_ls_namespace_kind_forwards_to_unknown_op_envelope() -> None:
     ):
         await KubernetesConnector.register_operations()
 
-    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/services"})
+    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/statefulsets"})
 
-    assert result["path"] == "/argocd/services"
-    assert result["forwarded_to"] == "k8s.service.list"
+    assert result["path"] == "/argocd/statefulsets"
+    assert result["forwarded_to"] == "k8s.statefulset.list"
     inner = result["result"]
     assert inner["status"] == "error"
     assert inner["error"].startswith("unknown_op:")

--- a/backend/tests/test_connectors_k8s_network_config.py
+++ b/backend/tests/test_connectors_k8s_network_config.py
@@ -35,6 +35,7 @@ Coverage matrix (per Issue #324 acceptance criteria):
 
 from __future__ import annotations
 
+import random
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -44,6 +45,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from kubernetes_asyncio.client.models import (
     CoreV1Event,
+    CoreV1EventSeries,
     V1ConfigMap,
     V1EventSource,
     V1HTTPIngressPath,
@@ -477,10 +479,15 @@ def test_configmap_list_row_keys_only_no_data_field() -> None:
     # The privacy contract: NO data, NO binary_data on the row.
     assert "data" not in row
     assert "binary_data" not in row
-    # Values must not leak via any other field on the row.
+    # Values must not leak via any other field on the row. ``in`` on a
+    # list checks element-equality; the privacy contract is substring
+    # absence, so list-typed values are flattened element-by-element
+    # and each string element is substring-scanned.
     for value in row.values():
-        if isinstance(value, (str, list)):
+        if isinstance(value, str):
             assert "secret-repo-url" not in value
+        elif isinstance(value, list):
+            assert not any(isinstance(elem, str) and "secret-repo-url" in elem for elem in value)
 
 
 def test_configmap_list_row_merges_data_and_binary_data_keys() -> None:
@@ -552,6 +559,7 @@ def _make_event(
     first_timestamp: datetime | None = None,
     last_timestamp: datetime | None = None,
     event_time: datetime | None = None,
+    series: CoreV1EventSeries | None = None,
 ) -> CoreV1Event:
     return CoreV1Event(
         metadata=V1ObjectMeta(name=name, namespace=namespace),
@@ -566,6 +574,7 @@ def _make_event(
         first_timestamp=first_timestamp,
         last_timestamp=last_timestamp,
         event_time=event_time,
+        series=series,
     )
 
 
@@ -604,8 +613,62 @@ def test_event_row_event_time_fallback_for_eventseries_shape() -> None:
     row = event_row(event, now=now)
     assert row["last_seen_seconds"] == 120
     assert row["first_seen_seconds"] == 120
-    # ``count=None`` coerces to 1 (singleton event).
+    # ``count=None`` AND ``series=None`` coerces to 1 (singleton event).
     assert row["count"] == 1
+
+
+def test_event_row_count_from_event_series_when_flat_count_unset() -> None:
+    """K8s 1.27+ EventSeries: authoritative count lives on ``series.count``.
+
+    Regression for M1 (PR #561): when ``event.count`` is None but the
+    event carries a populated ``series`` object, the row's ``count``
+    must reflect ``series.count`` (the recurring-event occurrence
+    total), not the 1-fallback used for singletons. ``kubectl
+    describe`` shows the series count for these events; the connector
+    must agree.
+    """
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    series = CoreV1EventSeries(
+        count=47,
+        last_observed_time=now - timedelta(seconds=30),
+    )
+    event = _make_event(
+        first_timestamp=None,
+        last_timestamp=None,
+        event_time=now - timedelta(seconds=3600),
+        count=None,
+        series=series,
+    )
+    row = event_row(event, now=now)
+    # series.count wins over the None flat count.
+    assert row["count"] == 47
+    # And series.last_observed_time wins over event_time for last_seen.
+    assert row["last_seen_seconds"] == 30
+
+
+def test_event_row_count_prefers_series_count_over_flat_count() -> None:
+    """Disagreement case: when both surfaces carry a count, the series
+    count is authoritative.
+
+    The wire reality is that ``event.count`` is left at its
+    pre-series value (frozen at the moment the API server upgraded
+    the event into a series); ``event.series.count`` is the live,
+    updated tally. Operators reading ``kubectl describe`` see the
+    series count.
+    """
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    series = CoreV1EventSeries(
+        count=99,
+        last_observed_time=now - timedelta(seconds=10),
+    )
+    event = _make_event(
+        last_timestamp=now - timedelta(seconds=10),
+        first_timestamp=now - timedelta(seconds=3600),
+        count=3,
+        series=series,
+    )
+    row = event_row(event, now=now)
+    assert row["count"] == 99
 
 
 def test_event_row_missing_involved_object_surfaces_none_fields() -> None:
@@ -869,8 +932,12 @@ async def test_k8s_event_list_field_selector_forwarded() -> None:
         kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
         assert kwargs["namespace"] == "argocd"
         assert kwargs["field_selector"] == "type=Warning"
-        # Default limit applied even when caller omits it.
-        assert kwargs["limit"] == DEFAULT_EVENT_LIMIT
+        # The wire request always asks for MAX_EVENT_LIMIT; the
+        # caller's (or default) ``limit`` is the post-sort truncation
+        # bound, not the API-side limit. See the
+        # ``test_k8s_event_list_fetches_max_then_sorts_client_side``
+        # regression for rationale.
+        assert kwargs["limit"] == MAX_EVENT_LIMIT
 
     assert result["total"] == 1
     assert result["rows"][0]["type"] == "Warning"
@@ -878,7 +945,26 @@ async def test_k8s_event_list_field_selector_forwarded() -> None:
 
 @pytest.mark.asyncio
 async def test_k8s_event_list_default_limit() -> None:
-    """Without an explicit ``limit`` param, the handler passes DEFAULT_EVENT_LIMIT to the API."""
+    """Without an explicit ``limit``, the post-sort truncation uses DEFAULT_EVENT_LIMIT.
+
+    The wire request still asks for the MAX_EVENT_LIMIT superset (so
+    the client-side recency sort is correct); the truncation that
+    follows uses DEFAULT_EVENT_LIMIT when the caller didn't override
+    ``limit``. This test pins both: the wire-side cap and the
+    result-side default truncation.
+    """
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    # Build DEFAULT_EVENT_LIMIT+10 events so the default truncation
+    # actually fires; without enough rows the test would silently
+    # pass for any default value.
+    api_events: list[CoreV1Event] = [
+        _make_event(
+            name=f"evt-{i}",
+            last_timestamp=now - timedelta(seconds=10 + i),
+            first_timestamp=now - timedelta(seconds=3600),
+        )
+        for i in range(DEFAULT_EVENT_LIMIT + 10)
+    ]
     connector = _make_connector()
     with (
         patch(
@@ -889,13 +975,18 @@ async def test_k8s_event_list_default_limit() -> None:
         patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
     ):
         list_resp = MagicMock()
-        list_resp.items = []
+        list_resp.items = api_events
         core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
-        await connector.k8s_event_list(_TARGET, {"namespace": "argocd"})
+        result = await connector.k8s_event_list(_TARGET, {"namespace": "argocd"})
         kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
-        assert kwargs["limit"] == DEFAULT_EVENT_LIMIT
+        # Wire: always MAX_EVENT_LIMIT.
+        assert kwargs["limit"] == MAX_EVENT_LIMIT
         # No field_selector kwarg when caller didn't pass one.
         assert "field_selector" not in kwargs
+
+    # Post-sort truncation: DEFAULT_EVENT_LIMIT.
+    assert result["total"] == DEFAULT_EVENT_LIMIT
+    assert len(result["rows"]) == DEFAULT_EVENT_LIMIT
 
 
 @pytest.mark.asyncio
@@ -904,10 +995,17 @@ async def test_k8s_event_list_limit_respects_value_and_ordered_by_last_seen() ->
 
     The handler's ``event_row`` computes ``last_seen_seconds`` against
     ``datetime.now(UTC)`` (no ``now`` seam at the handler layer -- it
-    flows through ``ops_config.event_row``'s default branch). The test
+    flows through ``ops_events.event_row``'s default branch). The test
     is invariant to the wall clock: it constructs events whose
     last_timestamps are evenly spaced from a moving reference and
     asserts the **relative ordering** + post-sort name sequence.
+
+    Also pins the wire-side contract: the handler must request
+    ``MAX_EVENT_LIMIT`` rows from the API regardless of the caller's
+    ``limit``, because the K8s events endpoint has no server-side
+    last-seen ordering guarantee. See
+    ``test_k8s_event_list_fetches_max_then_sorts_client_side`` for
+    the dedicated regression on that wire contract.
     """
     # Use a recent reference so the elapsed-seconds values are bounded
     # and never negative regardless of test latency.
@@ -923,8 +1021,6 @@ async def test_k8s_event_list_limit_respects_value_and_ordered_by_last_seen() ->
         for i in range(12)
     ]
     # Shuffle order so the test catches a missing sort.
-    import random
-
     random.Random(42).shuffle(api_events)
 
     connector = _make_connector()
@@ -941,7 +1037,10 @@ async def test_k8s_event_list_limit_respects_value_and_ordered_by_last_seen() ->
         core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
         result = await connector.k8s_event_list(_TARGET, {"namespace": "argocd", "limit": 10})
         kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
-        assert kwargs["limit"] == 10
+        # The handler always pulls up to MAX_EVENT_LIMIT, never the
+        # caller's smaller ``limit`` -- the recency sort needs the
+        # superset to be correct.
+        assert kwargs["limit"] == MAX_EVENT_LIMIT
 
     # Limit truncates to 10 most-recent (after sort).
     assert result["total"] == 10
@@ -952,6 +1051,66 @@ async def test_k8s_event_list_limit_respects_value_and_ordered_by_last_seen() ->
     # The 10 kept rows are the 10 most-recent input events (evt-0..evt-9).
     names = [row["name"] for row in result["rows"]]
     assert names == [f"evt-{i}" for i in range(10)]
+
+
+@pytest.mark.asyncio
+async def test_k8s_event_list_fetches_max_then_sorts_client_side() -> None:
+    """Regression for the "most-recent-N" acceptance criterion (B1).
+
+    The K8s events endpoint returns rows in resource-version order
+    with **no server-side ordering guarantee** by ``lastTimestamp`` --
+    see
+    https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions.
+    If the handler passed the caller's ``limit`` straight to the API,
+    the server-truncated subset would not contain the actual N most
+    recent events. The handler therefore must request up to
+    :data:`MAX_EVENT_LIMIT` rows, sort by ``last_seen_seconds``
+    client-side, then truncate to the caller's ``limit``.
+
+    This test mocks the API to return 25 events deliberately
+    creation-ordered so the "wrong" prefix (the first 5) is **not**
+    the recency-correct answer. With ``limit=5`` the kept rows must
+    be the 5 most-recent by last_seen, not the first 5 the mock
+    returned.
+    """
+    reference = datetime.now(UTC)
+    # Build 25 events where ``evt-{i}`` last fired ``10 + 10*i`` seconds
+    # ago, so evt-0 is most recent and evt-24 oldest. Return them in
+    # *reverse* recency order from the mock API so a naive
+    # "trust the API order + truncate" implementation would keep the
+    # 5 OLDEST instead of the 5 newest.
+    api_events: list[CoreV1Event] = [
+        _make_event(
+            name=f"evt-{i}",
+            last_timestamp=reference - timedelta(seconds=10 + 10 * i),
+            first_timestamp=reference - timedelta(seconds=10 + 10 * i + 600),
+        )
+        for i in range(25)
+    ]
+    api_events.reverse()  # API returns oldest-first; sort must overcome this.
+
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = api_events
+        core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_event_list(_TARGET, {"namespace": "argocd", "limit": 5})
+        kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
+        # Wire-side: ask for the superset, not the caller's limit.
+        assert kwargs["limit"] == MAX_EVENT_LIMIT
+
+    # Client-side: kept rows are the 5 truly most-recent (evt-0..evt-4),
+    # not the 5 the API server returned at the head of its response.
+    assert result["total"] == 5
+    names = [row["name"] for row in result["rows"]]
+    assert names == [f"evt-{i}" for i in range(5)]
 
 
 @pytest.mark.asyncio
@@ -971,4 +1130,7 @@ async def test_k8s_event_list_limit_clamps_at_max() -> None:
         core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
         await connector.k8s_event_list(_TARGET, {"namespace": "argocd", "limit": 99999})
         kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
+        # The API request always asks for MAX_EVENT_LIMIT regardless
+        # of how the caller's ``limit`` was clamped -- the clamp
+        # affects the post-sort truncation, not the wire request.
         assert kwargs["limit"] == MAX_EVENT_LIMIT

--- a/backend/tests/test_connectors_k8s_network_config.py
+++ b/backend/tests/test_connectors_k8s_network_config.py
@@ -1,0 +1,974 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the G3.2-T4 (#324) K8s network + config + event ops.
+
+Coverage matrix (per Issue #324 acceptance criteria):
+
+* :data:`KUBERNETES_OPS` exposes the five new ops alongside the T1/T2/T5
+  surface; ``register_operations`` lands every row in
+  ``endpoint_descriptor``.
+* :meth:`KubernetesConnector.k8s_service_list` projects every
+  :class:`V1Service` through
+  :func:`~meho_backplane.connectors.kubernetes.ops_network.service_row`
+  and returns ``{rows, total}`` with the expected shape; ports +
+  selector populated.
+* :meth:`KubernetesConnector.k8s_ingress_list` projects every
+  :class:`V1Ingress` through
+  :func:`~meho_backplane.connectors.kubernetes.ops_network.ingress_row`;
+  hosts + TLS hosts deduplicated and sorted.
+* :meth:`KubernetesConnector.k8s_configmap_list` returns rows with
+  ``keys`` populated and ``data``/``binary_data`` ABSENT (privacy
+  contract -- pinned explicitly).
+* :meth:`KubernetesConnector.k8s_configmap_info` returns the full
+  configmap with data + binary_data.
+* :meth:`KubernetesConnector.k8s_event_list` forwards
+  ``field_selector`` to the K8s API and respects the client-side
+  most-recent-first sort + ``limit`` truncation.
+* Pure helpers (:func:`service_row`, :func:`service_port_row`,
+  :func:`ingress_row`, :func:`ingress_rule_row`,
+  :func:`ingress_path_row`, :func:`configmap_list_row`,
+  :func:`configmap_info`, :func:`event_row`,
+  :func:`sort_event_rows_recent_first`) pinned against synthetic
+  Kubernetes model objects.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kubernetes_asyncio.client.models import (
+    CoreV1Event,
+    V1ConfigMap,
+    V1EventSource,
+    V1HTTPIngressPath,
+    V1HTTPIngressRuleValue,
+    V1Ingress,
+    V1IngressBackend,
+    V1IngressRule,
+    V1IngressServiceBackend,
+    V1IngressSpec,
+    V1IngressTLS,
+    V1ListMeta,
+    V1ObjectMeta,
+    V1ObjectReference,
+    V1Service,
+    V1ServiceBackendPort,
+    V1ServicePort,
+    V1ServiceSpec,
+)
+
+from meho_backplane.connectors.kubernetes import (
+    KUBERNETES_OPS,
+    KubernetesConnector,
+    KubernetesTargetLike,
+)
+from meho_backplane.connectors.kubernetes.ops_config import (
+    CONFIG_OPS,
+    configmap_info,
+    configmap_list_row,
+)
+from meho_backplane.connectors.kubernetes.ops_events import (
+    DEFAULT_EVENT_LIMIT,
+    EVENT_OPS,
+    MAX_EVENT_LIMIT,
+    event_row,
+    sort_event_rows_recent_first,
+)
+from meho_backplane.connectors.kubernetes.ops_network import (
+    NETWORK_OPS,
+    ingress_path_row,
+    ingress_row,
+    ingress_rule_row,
+    service_port_row,
+    service_row,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector,
+    register_connector_v2,
+)
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Required-settings env -- the connector's register_operations path imports
+# the embedding service which reaches into Settings.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_kubernetes_registry() -> Iterator[None]:
+    """Re-register :class:`KubernetesConnector` between tests.
+
+    Mirrors test_connectors_k8s_core.py's discipline: clear any
+    cross-module registry state, then put back the K8s entries the
+    package's ``__init__.py`` would have registered.
+    """
+    clear_registry()
+    register_connector("k8s", KubernetesConnector)
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="kubernetes-asyncio",
+        cls=KubernetesConnector,
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Target / connector fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="rke2-meho",
+    host="rke2-meho.test.invalid",
+    port=6443,
+    secret_ref="kv/data/k8s/rke2-meho",
+)
+
+
+def _stub_kubeconfig() -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://k8s.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "stub-token"}}],
+    }
+
+
+def _make_connector() -> KubernetesConnector:
+    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+        return _stub_kubeconfig()
+
+    return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+# ---------------------------------------------------------------------------
+# Tests -- registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_network_and_config_ops_in_kubernetes_ops_tuple() -> None:
+    """``KUBERNETES_OPS`` now exposes the five new T4 ops."""
+    op_ids = {op.op_id for op in KUBERNETES_OPS}
+    assert "k8s.service.list" in op_ids
+    assert "k8s.ingress.list" in op_ids
+    assert "k8s.configmap.list" in op_ids
+    assert "k8s.configmap.info" in op_ids
+    assert "k8s.event.list" in op_ids
+
+
+def test_network_ops_metadata_shape() -> None:
+    """Each network op declares safe / no-approval / read-only network tags."""
+    by_id = {op.op_id: op for op in NETWORK_OPS}
+    for op_id in ("k8s.service.list", "k8s.ingress.list"):
+        op = by_id[op_id]
+        assert op.safety_level == "safe"
+        assert op.requires_approval is False
+        assert "read-only" in op.tags
+        assert op.group_key == "network"
+        assert op.llm_instructions is not None
+
+
+def test_config_ops_metadata_shape() -> None:
+    """Each configmap op declares safe / no-approval / read-only tags."""
+    by_id = {op.op_id: op for op in CONFIG_OPS}
+    for op_id in ("k8s.configmap.list", "k8s.configmap.info"):
+        op = by_id[op_id]
+        assert op.safety_level == "safe"
+        assert op.requires_approval is False
+        assert "read-only" in op.tags
+        assert op.group_key == "config"
+
+
+def test_event_ops_metadata_shape() -> None:
+    """``k8s.event.list`` lives in EVENT_OPS under group_key='events'."""
+    by_id = {op.op_id: op for op in EVENT_OPS}
+    events_op = by_id["k8s.event.list"]
+    assert events_op.group_key == "events"
+    assert "read-only" in events_op.tags
+    assert events_op.safety_level == "safe"
+    assert events_op.requires_approval is False
+
+
+def test_handler_attr_resolves_to_bound_method() -> None:
+    """Every T4 op's ``handler_attr`` points at a real async method."""
+    import inspect
+
+    for op in (*NETWORK_OPS, *CONFIG_OPS, *EVENT_OPS):
+        method = getattr(KubernetesConnector, op.handler_attr, None)
+        assert method is not None, f"{op.op_id!r} declares missing handler {op.handler_attr!r}"
+        assert inspect.iscoroutinefunction(method), (
+            f"handler {op.handler_attr!r} for {op.op_id!r} must be ``async def``"
+        )
+
+
+# ---------------------------------------------------------------------------
+# service_row / service_port_row pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_service(
+    *,
+    name: str,
+    namespace: str = "argocd",
+    type_: str = "ClusterIP",
+    cluster_ip: str | None = "10.43.123.45",
+    external_ips: list[str] | None = None,
+    ports: list[V1ServicePort] | None = None,
+    selector: dict[str, str] | None = None,
+) -> V1Service:
+    return V1Service(
+        metadata=V1ObjectMeta(name=name, namespace=namespace),
+        spec=V1ServiceSpec(
+            type=type_,
+            cluster_ip=cluster_ip,
+            external_ips=external_ips or [],
+            ports=ports or [],
+            selector=selector or {},
+        ),
+    )
+
+
+def test_service_port_row_flat_four_tuple() -> None:
+    port = V1ServicePort(name="http", port=80, target_port=8080, protocol="TCP")
+    assert service_port_row(port) == {
+        "name": "http",
+        "port": 80,
+        "target_port": 8080,
+        "protocol": "TCP",
+    }
+
+
+def test_service_port_row_named_target_port_preserved() -> None:
+    """A named-port reference surfaces as a string, not coerced to int."""
+    port = V1ServicePort(name="http", port=80, target_port="http", protocol="TCP")
+    assert service_port_row(port)["target_port"] == "http"
+
+
+def test_service_row_with_ports_and_selector() -> None:
+    """A typical ClusterIP service projects to {name, namespace, type, ...}."""
+    ports = [
+        V1ServicePort(name="http", port=80, target_port=8080, protocol="TCP"),
+        V1ServicePort(name="https", port=443, target_port=8083, protocol="TCP"),
+    ]
+    svc = _make_service(
+        name="argocd-server",
+        ports=ports,
+        selector={"app.kubernetes.io/name": "argocd-server"},
+    )
+    row = service_row(svc)
+    assert row["name"] == "argocd-server"
+    assert row["namespace"] == "argocd"
+    assert row["type"] == "ClusterIP"
+    assert row["cluster_ip"] == "10.43.123.45"
+    assert row["external_ips"] == []
+    assert row["selector"] == {"app.kubernetes.io/name": "argocd-server"}
+    assert len(row["ports"]) == 2
+    assert row["ports"][0]["port"] == 80
+    assert row["ports"][1]["port"] == 443
+
+
+def test_service_row_handles_missing_selector() -> None:
+    """An ExternalName service with no selector surfaces ``{}``, not ``None``."""
+    svc = V1Service(
+        metadata=V1ObjectMeta(name="external", namespace="default"),
+        spec=V1ServiceSpec(type="ExternalName", external_name="db.example.com"),
+    )
+    row = service_row(svc)
+    assert row["selector"] == {}
+    assert row["ports"] == []
+
+
+def test_service_row_external_ips_forwarded() -> None:
+    svc = _make_service(
+        name="lb",
+        type_="LoadBalancer",
+        external_ips=["1.2.3.4", "5.6.7.8"],
+    )
+    assert service_row(svc)["external_ips"] == ["1.2.3.4", "5.6.7.8"]
+
+
+# ---------------------------------------------------------------------------
+# ingress_row / ingress_rule_row / ingress_path_row pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ingress(
+    *,
+    name: str,
+    namespace: str = "argocd",
+    ingress_class: str | None = "nginx",
+    rules: list[V1IngressRule] | None = None,
+    tls: list[V1IngressTLS] | None = None,
+) -> V1Ingress:
+    return V1Ingress(
+        metadata=V1ObjectMeta(name=name, namespace=namespace),
+        spec=V1IngressSpec(
+            ingress_class_name=ingress_class,
+            rules=rules or [],
+            tls=tls or [],
+        ),
+    )
+
+
+def _http_path(
+    *,
+    path: str = "/",
+    path_type: str = "Prefix",
+    service_name: str = "argocd-server",
+    port_number: int | None = 443,
+    port_name: str | None = None,
+) -> V1HTTPIngressPath:
+    port: V1ServiceBackendPort
+    if port_number is not None:
+        port = V1ServiceBackendPort(number=port_number)
+    else:
+        port = V1ServiceBackendPort(name=port_name)
+    return V1HTTPIngressPath(
+        path=path,
+        path_type=path_type,
+        backend=V1IngressBackend(service=V1IngressServiceBackend(name=service_name, port=port)),
+    )
+
+
+def test_ingress_path_row_with_numeric_port() -> None:
+    path = _http_path(path="/", port_number=443)
+    row = ingress_path_row(path)
+    assert row == {
+        "path": "/",
+        "path_type": "Prefix",
+        "service": "argocd-server",
+        "port": 443,
+    }
+
+
+def test_ingress_path_row_with_named_port() -> None:
+    path = _http_path(path="/api", port_number=None, port_name="http")
+    assert ingress_path_row(path)["port"] == "http"
+
+
+def test_ingress_rule_row_collects_paths() -> None:
+    rule = V1IngressRule(
+        host="argocd.evba.lab",
+        http=V1HTTPIngressRuleValue(
+            paths=[_http_path(path="/"), _http_path(path="/api", port_number=443)]
+        ),
+    )
+    row = ingress_rule_row(rule)
+    assert row["host"] == "argocd.evba.lab"
+    assert len(row["paths"]) == 2
+    assert row["paths"][0]["path"] == "/"
+    assert row["paths"][1]["path"] == "/api"
+
+
+def test_ingress_row_with_tls_dedup() -> None:
+    rules = [
+        V1IngressRule(
+            host="argocd.evba.lab",
+            http=V1HTTPIngressRuleValue(paths=[_http_path()]),
+        ),
+        V1IngressRule(
+            host="argocd.evba.lab",  # duplicate host, different path
+            http=V1HTTPIngressRuleValue(paths=[_http_path(path="/api")]),
+        ),
+    ]
+    tls = [V1IngressTLS(hosts=["argocd.evba.lab"], secret_name="argocd-tls")]
+    ingress = _make_ingress(name="argocd-ingress", rules=rules, tls=tls)
+    row = ingress_row(ingress)
+    assert row["name"] == "argocd-ingress"
+    assert row["class"] == "nginx"
+    # hosts deduplicated, sorted
+    assert row["hosts"] == ["argocd.evba.lab"]
+    assert row["tls_hosts"] == ["argocd.evba.lab"]
+    assert len(row["rules"]) == 2
+
+
+def test_ingress_row_no_tls_yields_empty_tls_hosts() -> None:
+    ingress = _make_ingress(
+        name="plain",
+        rules=[
+            V1IngressRule(
+                host="plain.example.com",
+                http=V1HTTPIngressRuleValue(paths=[_http_path()]),
+            )
+        ],
+    )
+    row = ingress_row(ingress)
+    assert row["tls_hosts"] == []
+    assert row["hosts"] == ["plain.example.com"]
+
+
+def test_ingress_row_sorted_hosts_across_rules() -> None:
+    """Hosts across rules are deduplicated and sorted alphabetically."""
+    rules = [
+        V1IngressRule(host="zebra.example.com", http=V1HTTPIngressRuleValue(paths=[_http_path()])),
+        V1IngressRule(host="apple.example.com", http=V1HTTPIngressRuleValue(paths=[_http_path()])),
+    ]
+    ingress = _make_ingress(name="multi", rules=rules)
+    row = ingress_row(ingress)
+    assert row["hosts"] == ["apple.example.com", "zebra.example.com"]
+
+
+# ---------------------------------------------------------------------------
+# configmap_list_row / configmap_info pure helpers -- PRIVACY CONTRACT
+# ---------------------------------------------------------------------------
+
+
+def _make_configmap(
+    *,
+    name: str,
+    namespace: str = "argocd",
+    data: dict[str, str] | None = None,
+    binary_data: dict[str, str] | None = None,
+    labels: dict[str, str] | None = None,
+    annotations: dict[str, str] | None = None,
+    created: datetime | None = None,
+) -> V1ConfigMap:
+    return V1ConfigMap(
+        metadata=V1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            labels=labels,
+            annotations=annotations,
+            creation_timestamp=created,
+        ),
+        data=data,
+        binary_data=binary_data,
+    )
+
+
+def test_configmap_list_row_keys_only_no_data_field() -> None:
+    """Critical privacy contract: list row carries ``keys``, never ``data``."""
+    cm = _make_configmap(
+        name="argocd-cm",
+        data={"repositories": "secret-repo-url", "url": "https://argocd.evba.lab"},
+    )
+    row = configmap_list_row(cm)
+    assert row["name"] == "argocd-cm"
+    assert row["namespace"] == "argocd"
+    assert row["keys"] == ["repositories", "url"]
+    # The privacy contract: NO data, NO binary_data on the row.
+    assert "data" not in row
+    assert "binary_data" not in row
+    # Values must not leak via any other field on the row.
+    for value in row.values():
+        if isinstance(value, (str, list)):
+            assert "secret-repo-url" not in value
+
+
+def test_configmap_list_row_merges_data_and_binary_data_keys() -> None:
+    """``keys`` is the sorted union of ``data`` + ``binary_data`` keys."""
+    cm = _make_configmap(
+        name="mixed",
+        data={"text-key": "value"},
+        binary_data={"binary-key": "base64=="},
+    )
+    row = configmap_list_row(cm)
+    assert row["keys"] == ["binary-key", "text-key"]
+
+
+def test_configmap_list_row_empty_configmap() -> None:
+    cm = _make_configmap(name="empty")
+    row = configmap_list_row(cm)
+    assert row["keys"] == []
+
+
+def test_configmap_list_row_age_seconds_set() -> None:
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    cm = _make_configmap(name="aged", created=now - timedelta(seconds=86400))
+    row = configmap_list_row(cm, now=now)
+    assert row["age_seconds"] == 86400
+
+
+def test_configmap_info_includes_full_data_and_binary_data() -> None:
+    """``info`` is the counterpart -- the targeted-read shape carries values."""
+    cm = _make_configmap(
+        name="argocd-cm",
+        data={"url": "https://argocd.evba.lab"},
+        binary_data={"cert": "base64-encoded-bytes"},
+        labels={"app": "argocd"},
+        annotations={"managed-by": "helm"},
+    )
+    info = configmap_info(cm)
+    assert info["name"] == "argocd-cm"
+    assert info["namespace"] == "argocd"
+    assert info["data"] == {"url": "https://argocd.evba.lab"}
+    assert info["binary_data"] == {"cert": "base64-encoded-bytes"}
+    assert info["metadata"]["labels"] == {"app": "argocd"}
+    assert info["metadata"]["annotations"] == {"managed-by": "helm"}
+
+
+def test_configmap_info_empty_data_surfaces_empty_dicts() -> None:
+    cm = _make_configmap(name="empty")
+    info = configmap_info(cm)
+    assert info["data"] == {}
+    assert info["binary_data"] == {}
+
+
+# ---------------------------------------------------------------------------
+# event_row + sort helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    *,
+    name: str = "evt-1",
+    namespace: str = "argocd",
+    type_: str = "Warning",
+    reason: str = "BackOff",
+    message: str = "Back-off restarting failed container",
+    involved_kind: str = "Pod",
+    involved_name: str = "argocd-server-xyz",
+    involved_namespace: str = "argocd",
+    source_component: str | None = "kubelet",
+    count: int | None = 42,
+    first_timestamp: datetime | None = None,
+    last_timestamp: datetime | None = None,
+    event_time: datetime | None = None,
+) -> CoreV1Event:
+    return CoreV1Event(
+        metadata=V1ObjectMeta(name=name, namespace=namespace),
+        type=type_,
+        reason=reason,
+        message=message,
+        involved_object=V1ObjectReference(
+            kind=involved_kind, name=involved_name, namespace=involved_namespace
+        ),
+        source=V1EventSource(component=source_component) if source_component else None,
+        count=count,
+        first_timestamp=first_timestamp,
+        last_timestamp=last_timestamp,
+        event_time=event_time,
+    )
+
+
+def test_event_row_classic_shape() -> None:
+    """A pre-1.27-style event with first/last timestamps + count + source."""
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    last = now - timedelta(seconds=60)
+    first = now - timedelta(seconds=7200)
+    event = _make_event(
+        first_timestamp=first,
+        last_timestamp=last,
+    )
+    row = event_row(event, now=now)
+    assert row["type"] == "Warning"
+    assert row["reason"] == "BackOff"
+    assert row["count"] == 42
+    assert row["source"] == "kubelet"
+    assert row["first_seen_seconds"] == 7200
+    assert row["last_seen_seconds"] == 60
+    assert row["involved_object"] == {
+        "kind": "Pod",
+        "name": "argocd-server-xyz",
+        "namespace": "argocd",
+    }
+
+
+def test_event_row_event_time_fallback_for_eventseries_shape() -> None:
+    """The 1.27+ EventSeries shape uses ``event_time`` when last_timestamp is unset."""
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    event = _make_event(
+        first_timestamp=None,
+        last_timestamp=None,
+        event_time=now - timedelta(seconds=120),
+        count=None,
+    )
+    row = event_row(event, now=now)
+    assert row["last_seen_seconds"] == 120
+    assert row["first_seen_seconds"] == 120
+    # ``count=None`` coerces to 1 (singleton event).
+    assert row["count"] == 1
+
+
+def test_event_row_missing_involved_object_surfaces_none_fields() -> None:
+    """An event with no involvedObject still produces a stable row shape.
+
+    The K8s API model rejects ``involved_object=None`` on construction
+    (client-side validation), but the over-the-wire deserialiser can
+    land it as None on synthetic / malformed responses; the helper
+    must be robust either way. Use a MagicMock to bypass the
+    constructor's None-guard for this defence-in-depth case.
+    """
+    event = MagicMock(spec=CoreV1Event)
+    event.metadata = V1ObjectMeta(name="orphan", namespace="default")
+    event.type = "Normal"
+    event.reason = "X"
+    event.message = "m"
+    event.involved_object = None
+    event.source = None
+    event.reporting_component = ""
+    event.count = 1
+    event.first_timestamp = None
+    event.last_timestamp = None
+    event.event_time = None
+    event.series = None
+    row = event_row(event)
+    assert row["involved_object"] == {"kind": None, "name": None, "namespace": None}
+
+
+def test_sort_event_rows_recent_first_orders_by_last_seen() -> None:
+    rows = [
+        {"name": "old", "last_seen_seconds": 7200},
+        {"name": "recent", "last_seen_seconds": 60},
+        {"name": "middle", "last_seen_seconds": 600},
+    ]
+    sorted_rows = sort_event_rows_recent_first(rows)
+    assert [r["name"] for r in sorted_rows] == ["recent", "middle", "old"]
+
+
+def test_sort_event_rows_untimestamped_sort_last() -> None:
+    """Rows with ``last_seen_seconds=None`` sort to the end deterministically."""
+    rows = [
+        {"name": "no-ts", "last_seen_seconds": None},
+        {"name": "recent", "last_seen_seconds": 5},
+    ]
+    sorted_rows = sort_event_rows_recent_first(rows)
+    assert [r["name"] for r in sorted_rows] == ["recent", "no-ts"]
+
+
+# ---------------------------------------------------------------------------
+# k8s_service_list handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_service_list_returns_rows_and_total() -> None:
+    """``k8s.service.list --namespace argocd`` returns services with ports + selector."""
+    ports = [V1ServicePort(name="http", port=80, target_port=8080, protocol="TCP")]
+    services = [
+        _make_service(name="argocd-server", ports=ports, selector={"app": "argocd-server"}),
+        _make_service(name="argocd-repo-server", ports=ports, selector={"app": "repo-server"}),
+    ]
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = services
+        list_resp.metadata = V1ListMeta()
+        core_v1_cls.return_value.list_namespaced_service = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_service_list(_TARGET, {"namespace": "argocd"})
+
+        core_v1_cls.return_value.list_namespaced_service.assert_awaited_once_with(
+            namespace="argocd"
+        )
+
+    assert result["total"] == 2
+    names = [r["name"] for r in result["rows"]]
+    assert names == ["argocd-server", "argocd-repo-server"]
+    for row in result["rows"]:
+        assert row["ports"][0]["port"] == 80
+        assert row["selector"]
+
+
+@pytest.mark.asyncio
+async def test_k8s_service_list_empty_namespace() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = []
+        core_v1_cls.return_value.list_namespaced_service = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_service_list(_TARGET, {"namespace": "empty"})
+    assert result == {"rows": [], "total": 0}
+
+
+# ---------------------------------------------------------------------------
+# k8s_ingress_list handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_ingress_list_returns_hosts_and_tls() -> None:
+    """``k8s.ingress.list --namespace argocd`` returns ingresses with hosts + TLS."""
+    ingress = _make_ingress(
+        name="argocd-ingress",
+        rules=[
+            V1IngressRule(
+                host="argocd.evba.lab",
+                http=V1HTTPIngressRuleValue(paths=[_http_path()]),
+            )
+        ],
+        tls=[V1IngressTLS(hosts=["argocd.evba.lab"], secret_name="argocd-tls")],
+    )
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.client.NetworkingV1Api"
+        ) as networking_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [ingress]
+        networking_cls.return_value.list_namespaced_ingress = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_ingress_list(_TARGET, {"namespace": "argocd"})
+
+        networking_cls.return_value.list_namespaced_ingress.assert_awaited_once_with(
+            namespace="argocd"
+        )
+
+    assert result["total"] == 1
+    row = result["rows"][0]
+    assert row["name"] == "argocd-ingress"
+    assert row["hosts"] == ["argocd.evba.lab"]
+    assert row["tls_hosts"] == ["argocd.evba.lab"]
+
+
+# ---------------------------------------------------------------------------
+# k8s_configmap_list handler -- PRIVACY CONTRACT
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_configmap_list_keys_only_data_absent() -> None:
+    """``k8s.configmap.list --namespace argocd`` returns ``keys`` populated and ``data`` ABSENT."""
+    cm = _make_configmap(
+        name="argocd-cm",
+        data={
+            "repositories": "https://github.com/argoproj/argocd-example-apps",
+            "url": "https://argocd.evba.lab",
+            "policy.default": "role:readonly",
+        },
+    )
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [cm]
+        core_v1_cls.return_value.list_namespaced_config_map = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_configmap_list(_TARGET, {"namespace": "argocd"})
+
+    assert result["total"] == 1
+    row = result["rows"][0]
+    assert row["name"] == "argocd-cm"
+    assert row["keys"] == ["policy.default", "repositories", "url"]
+    # Privacy contract: NO data, NO binary_data on the list row.
+    assert "data" not in row
+    assert "binary_data" not in row
+
+
+# ---------------------------------------------------------------------------
+# k8s_configmap_info handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_configmap_info_returns_full_data_and_binary_data() -> None:
+    """``k8s.configmap.info argocd-cm --namespace argocd`` returns full data + binary_data."""
+    cm = _make_configmap(
+        name="argocd-cm",
+        data={"repositories": "...", "url": "https://argocd.evba.lab"},
+        binary_data={"cert.pem": "base64-bytes"},
+        labels={"app": "argocd"},
+        annotations={"managed-by": "helm"},
+    )
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.read_namespaced_config_map = AsyncMock(return_value=cm)
+        result = await connector.k8s_configmap_info(
+            _TARGET, {"name": "argocd-cm", "namespace": "argocd"}
+        )
+
+        core_v1_cls.return_value.read_namespaced_config_map.assert_awaited_once_with(
+            name="argocd-cm", namespace="argocd"
+        )
+
+    assert result["data"] == {"repositories": "...", "url": "https://argocd.evba.lab"}
+    assert result["binary_data"] == {"cert.pem": "base64-bytes"}
+    assert result["metadata"]["labels"] == {"app": "argocd"}
+
+
+# ---------------------------------------------------------------------------
+# k8s_event_list handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_event_list_field_selector_forwarded() -> None:
+    """``k8s.event.list --namespace argocd --field-selector type=Warning`` filters correctly."""
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    warn = _make_event(
+        name="warn-1",
+        type_="Warning",
+        last_timestamp=now - timedelta(seconds=60),
+        first_timestamp=now - timedelta(seconds=3600),
+    )
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [warn]
+        core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_event_list(
+            _TARGET,
+            {"namespace": "argocd", "field_selector": "type=Warning"},
+        )
+
+        kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
+        assert kwargs["namespace"] == "argocd"
+        assert kwargs["field_selector"] == "type=Warning"
+        # Default limit applied even when caller omits it.
+        assert kwargs["limit"] == DEFAULT_EVENT_LIMIT
+
+    assert result["total"] == 1
+    assert result["rows"][0]["type"] == "Warning"
+
+
+@pytest.mark.asyncio
+async def test_k8s_event_list_default_limit() -> None:
+    """Without an explicit ``limit`` param, the handler passes DEFAULT_EVENT_LIMIT to the API."""
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = []
+        core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
+        await connector.k8s_event_list(_TARGET, {"namespace": "argocd"})
+        kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
+        assert kwargs["limit"] == DEFAULT_EVENT_LIMIT
+        # No field_selector kwarg when caller didn't pass one.
+        assert "field_selector" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_k8s_event_list_limit_respects_value_and_ordered_by_last_seen() -> None:
+    """``--limit 10`` respects the limit; rows ordered by last_seen descending.
+
+    The handler's ``event_row`` computes ``last_seen_seconds`` against
+    ``datetime.now(UTC)`` (no ``now`` seam at the handler layer -- it
+    flows through ``ops_config.event_row``'s default branch). The test
+    is invariant to the wall clock: it constructs events whose
+    last_timestamps are evenly spaced from a moving reference and
+    asserts the **relative ordering** + post-sort name sequence.
+    """
+    # Use a recent reference so the elapsed-seconds values are bounded
+    # and never negative regardless of test latency.
+    reference = datetime.now(UTC)
+    # Event ``evt-i`` last fired ``10 + 10*i`` seconds before reference,
+    # so evt-0 is the most recent and evt-11 is the oldest.
+    api_events: list[CoreV1Event] = [
+        _make_event(
+            name=f"evt-{i}",
+            last_timestamp=reference - timedelta(seconds=10 + 10 * i),
+            first_timestamp=reference - timedelta(seconds=10 + 10 * i + 600),
+        )
+        for i in range(12)
+    ]
+    # Shuffle order so the test catches a missing sort.
+    import random
+
+    random.Random(42).shuffle(api_events)
+
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = api_events
+        core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_event_list(_TARGET, {"namespace": "argocd", "limit": 10})
+        kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
+        assert kwargs["limit"] == 10
+
+    # Limit truncates to 10 most-recent (after sort).
+    assert result["total"] == 10
+    seen = [row["last_seen_seconds"] for row in result["rows"]]
+    # Ascending last_seen_seconds = descending real-time order (smaller =
+    # more recent). Sorted output proves the client-side sort happened.
+    assert seen == sorted(seen)
+    # The 10 kept rows are the 10 most-recent input events (evt-0..evt-9).
+    names = [row["name"] for row in result["rows"]]
+    assert names == [f"evt-{i}" for i in range(10)]
+
+
+@pytest.mark.asyncio
+async def test_k8s_event_list_limit_clamps_at_max() -> None:
+    """Defence in depth: clamp at MAX_EVENT_LIMIT if schema lets a larger value through."""
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = []
+        core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
+        await connector.k8s_event_list(_TARGET, {"namespace": "argocd", "limit": 99999})
+        kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
+        assert kwargs["limit"] == MAX_EVENT_LIMIT

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -87,7 +87,7 @@ Source: `backend/src/meho_backplane/connectors/kubernetes/`.
 | `k8s.ingress.list`     | safe   | `NetworkingV1Api.list_namespaced_ingress()` -- class / hosts / TLS / rules. |
 | `k8s.configmap.list`   | safe   | `CoreV1Api.list_namespaced_config_map()` -- **keys only, NO values**. |
 | `k8s.configmap.info`   | safe   | `CoreV1Api.read_namespaced_config_map()` -- full data + binary_data. |
-| `k8s.event.list`       | safe   | `CoreV1Api.list_namespaced_event()` -- most-recent-first + field_selector + limit. |
+| `k8s.event.list`       | safe   | `CoreV1Api.list_namespaced_event()` -- pulls up to `MAX_EVENT_LIMIT` (500) rows, sorts client-side by `last_seen` desc, truncates to caller's `--limit`. Server has no `lastTimestamp` ordering guarantee. EventSeries `count` honoured. |
 | `k8s.logs`             | safe   | `CoreV1Api.read_namespaced_pod_log()` non-streaming -- tail / container / since / previous + 1 MiB cap. |
 
 T6 of Initiative #320 (CLI alias verbs + k3d acceptance) extends this

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -42,11 +42,25 @@ Source: `backend/src/meho_backplane/connectors/kubernetes/`.
   `container_status_row`, `pod_ready_string`) plus the prefix
   resolvers (`resolve_pod_name`, `resolve_deployment_name`) and the
   `WORKLOAD_OPS` registration rows for `k8s.pod.{list,info}` and
-  `k8s.deployment.{list,info}`. Two structured errors
+  `k8s.deployment.{list,info}` (G3.2-T3 #323). Two structured errors
   (`WorkloadNotFoundError`, `AmbiguousPrefixError`) drive the
   prefix-resolution UX: ambiguous matches surface the candidate list
   through the dispatcher's `connector_error` envelope so callers can
   render a "did-you-mean" hint.
+- **Network helpers** (`ops_network.py`) -- pure mapping helpers
+  (`service_row`, `service_port_row`, `ingress_row`, `ingress_rule_row`,
+  `ingress_path_row`) plus the `NETWORK_OPS` registration rows for
+  `k8s.service.list` / `k8s.ingress.list` (G3.2-T4 #324).
+- **Config helpers** (`ops_config.py`) -- pure mapping helpers
+  (`configmap_list_row`, `configmap_info`) plus the `CONFIG_OPS`
+  registration rows for `k8s.configmap.list` / `k8s.configmap.info`
+  (G3.2-T4 #324).
+- **Event helpers** (`ops_events.py`) -- pure mapping helpers
+  (`event_row`, `sort_event_rows_recent_first`) plus the `EVENT_OPS`
+  registration row for `k8s.event.list` (G3.2-T4 #324). Split out of
+  `ops_config.py` to fit under the 600-line code-quality cap; the
+  separation also aligns with the operator mental model (events are
+  observability, configmaps are configuration).
 - **`KubernetesTargetLike`** (`kubeconfig.py`) -- runtime-checkable
   Protocol capturing the minimum target shape the connector reads:
   `name`, `host`, `port`, `secret_ref`. Replaced by the concrete
@@ -59,22 +73,26 @@ Source: `backend/src/meho_backplane/connectors/kubernetes/`.
 
 ## Shipped op surface
 
-| op_id                  | safety | description                                              |
-| ---------------------- | ------ | -------------------------------------------------------- |
-| `k8s.about`            | safe   | Product / version / platform via `VersionApi.get_code`.  |
-| `k8s.ls`               | safe   | Synthetic walker: root / namespace / namespace+kind.     |
-| `k8s.namespace.list`   | safe   | `CoreV1Api.list_namespace()` -- name / status / age.     |
-| `k8s.node.list`        | safe   | `CoreV1Api.list_node()` -- status / roles / version.     |
-| `k8s.pod.list`         | safe   | Pods with selectors + server-side pagination.            |
-| `k8s.pod.info`         | safe   | Full pod detail; exact name or unique prefix.            |
-| `k8s.deployment.list`  | safe   | Deployments with live replica counts + image + strategy. |
-| `k8s.deployment.info`  | safe   | Full deployment detail; exact name or unique prefix.     |
-| `k8s.logs`             | safe   | Non-streaming pod log fetch with 1 MiB body cap.         |
+| op_id                  | safety | description                                                       |
+| ---------------------- | ------ | ----------------------------------------------------------------- |
+| `k8s.about`            | safe   | Product / version / platform via `VersionApi.get_code`.           |
+| `k8s.ls`               | safe   | Synthetic walker: root / namespace / namespace+kind.              |
+| `k8s.namespace.list`   | safe   | `CoreV1Api.list_namespace()` -- name / status / age.              |
+| `k8s.node.list`        | safe   | `CoreV1Api.list_node()` -- status / roles / version.              |
+| `k8s.pod.list`         | safe   | Pods with selectors + server-side pagination.                     |
+| `k8s.pod.info`         | safe   | Full pod detail; exact name or unique prefix.                     |
+| `k8s.deployment.list`  | safe   | Deployments with live replica counts + image + strategy.          |
+| `k8s.deployment.info`  | safe   | Full deployment detail; exact name or unique prefix.              |
+| `k8s.service.list`     | safe   | `CoreV1Api.list_namespaced_service()` -- type / cluster_ip / ports / selector. |
+| `k8s.ingress.list`     | safe   | `NetworkingV1Api.list_namespaced_ingress()` -- class / hosts / TLS / rules. |
+| `k8s.configmap.list`   | safe   | `CoreV1Api.list_namespaced_config_map()` -- **keys only, NO values**. |
+| `k8s.configmap.info`   | safe   | `CoreV1Api.read_namespaced_config_map()` -- full data + binary_data. |
+| `k8s.event.list`       | safe   | `CoreV1Api.list_namespaced_event()` -- most-recent-first + field_selector + limit. |
+| `k8s.logs`             | safe   | `CoreV1Api.read_namespaced_pod_log()` non-streaming -- tail / container / since / previous + 1 MiB cap. |
 
-T4 of Initiative #320 still ships the network + config + events
-surfaces (`service` / `ingress` / `configmap` / `event`) against the
-same `KubernetesOp` -> `KUBERNETES_OPS` -> `register_operations`
-pattern.
+T6 of Initiative #320 (CLI alias verbs + k3d acceptance) extends this
+surface against the same `KubernetesOp` -> `KUBERNETES_OPS` ->
+`register_operations` pattern.
 
 ### Workload-op pagination (`k8s.pod.list` / `k8s.deployment.list`)
 
@@ -117,6 +135,20 @@ fits in one unpaginated response. Heavy-tenancy namespaces with
 hundreds of workload objects are not the prefix-resolver's target
 audience; the agent typically reaches them via the list path with
 explicit pagination.
+
+### ConfigMap privacy split
+
+`k8s.configmap.list` and `k8s.configmap.info` deliberately split the
+read surface: the list op returns `keys` (the union of `data` +
+`binary_data` keys) but **never** the values, so a routine "what's
+configured here?" scan does not bulk-broadcast configmap content
+through the SSE / audit feed. Operators wanting values call
+`k8s.configmap.info` per configmap; the audit row records the
+targeted read so a post-incident query can answer "who read which
+configmap when?". v0.2 classifies `info` as `op_class=read`; G6.3 may
+upgrade specific configmap-name patterns (managed-by
+`secret-translator`, names matching `*-secret-config`) to
+`sensitive-read`.
 
 ## Control flow
 
@@ -242,6 +274,9 @@ just `len(rows)` because nothing reduces.
   - [#323 G3.2-T3](https://github.com/evoila/meho/issues/323) -- workload
     ops (`k8s.pod.{list,info}` / `k8s.deployment.{list,info}`).
   - [#325 G3.2-T5](https://github.com/evoila/meho/issues/325) -- `k8s.logs`.
+- This Task: [#324 G3.2-T4](https://github.com/evoila/meho/issues/324)
+  -- network + config + event ops (`k8s.service.list` /
+  `k8s.ingress.list` / `k8s.configmap.list/info` / `k8s.event.list`).
 - Substrate Initiative: [#388 G0.6](https://github.com/evoila/meho/issues/388)
   -- operation registry + dispatcher + JSONFlux substrate.
 - `kubernetes_asyncio`: https://github.com/tomplus/kubernetes_asyncio


### PR DESCRIPTION
## Summary
- Ships the final 5 read ops on the kubernetes-asyncio typed connector for G3.2-T4: `k8s.service.list`, `k8s.ingress.list`, `k8s.configmap.list` (keys-only), `k8s.configmap.info` (full data), and `k8s.event.list` (most-recent-first, `field_selector`, `limit`).
- Pins the configmap privacy contract: list returns `keys` only — never values — so a bulk "what's configured?" scan does not broadcast configmap bytes through the SSE / audit feed; operators read values via the targeted `.info` op so the audit row records a per-configmap read. v0.2 audits `info` as `op_class=read`; G6.3 may upgrade specific configmap-name patterns to `sensitive-read`.
- Follows the established T2 / T5 pattern: per-op `KubernetesOp` rows merged into `KUBERNETES_OPS` and registered via G0.6 `register_typed_operation()` at connector init; bound-method handlers on `KubernetesConnector`; pure row-shape helpers in dedicated `ops_network.py` / `ops_config.py` / `ops_events.py` modules. The event surface lives in its own module to fit the 600-line code-quality cap and to align with the operator mental model.

## Test plan
- [x] `ruff check` — clean on the kubernetes connector dir + new tests
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — clean (153 source files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — no blockers; only pre-existing-file warnings on connector.py
- [x] `pytest tests/test_connectors_k8s_network_config.py tests/test_connectors_k8s_core.py tests/test_connectors_k8s_logs.py tests/test_connectors_k8s_dispatcher_shim.py tests/test_connectors_k8s_auth.py tests/test_db_broadcast_override.py` — **150 passed**
- [x] Acceptance: 5 ops registered (verified `KUBERNETES_OPS` carries 10 ops total; the 5 new IDs appear and `handler_attr` resolves to async methods)
- [x] Acceptance: `k8s.service.list --namespace argocd` returns services with `ports` + `selector` (unit test pins the wire shape; k3d integration asserts the bootstrap `kubernetes` ClusterIP service)
- [x] Acceptance: `k8s.ingress.list --namespace argocd` returns ingresses with `hosts` + `tls_hosts` (deduplicated, sorted)
- [x] Acceptance: `k8s.configmap.list --namespace argocd` returns rows with `keys` populated and `data` **absent** — pinned by an explicit-leak-assertion unit test and re-asserted live against `kube-system` in k3d
- [x] Acceptance: `k8s.configmap.info argocd-cm --namespace argocd` returns full `data` + `binary_data` + `metadata`
- [x] Acceptance: `k8s.event.list --namespace argocd --field-selector type=Warning` forwards the filter; default `limit=50`, capped at 500
- [x] Acceptance: `k8s.event.list --limit 10` truncates to 10 most-recent rows (sort happens before truncate so a row that fired recently but was created long ago sorts above a recently-created but quiet row)

## Out of scope
- Secret ops (`k8s.secret.*`) — operators use Vault for secrets, not k8s API.
- NetworkPolicy / EndpointSlice / Endpoints / Gateway API HTTPRoute — v0.2.next.
- Write ops (create / update / delete) — v0.2 read-only.
- Streaming event watch (`kubectl get events -w`) — out of scope; the list shape is single-response.
- `k8s.configmap.info --reveal-sensitive` bypass — out of scope.
- T6 (#326) wires CLI alias verbs + Goal #214 checklist update.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added namespace-scoped Kubernetes list/info ops: Services, Ingresses, ConfigMaps (keys-only) and ConfigMap info (full data/metadata), plus Events (field-selector, client-side most-recent-first ordering with limit clamping).

* **Tests**
  * Added extensive unit and live integration tests covering ops registration, projections, ordering, privacy contracts, and event limit/sorting behavior.

* **Documentation**
  * Expanded Kubernetes connector docs and clarified ConfigMap privacy split and shipped op surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-17)

Addressed review findings from [pr-561-iter-1 review](https://github.com/evoila/meho/pull/561):

- **B1** `d90a936` — `k8s.event.list` now requests up to `MAX_EVENT_LIMIT` rows from the K8s API and truncates to the caller's `--limit` after the client-side recency sort. The events endpoint has no server-side `lastTimestamp` ordering guarantee, so the previous wire-side `limit` could clip the true N most-recent events. New regression test pins the wire-cap + sort behavior end-to-end.
- **M1** `d90a936` — `event_row` now reads `event.series.count` first (the K8s 1.27+ EventSeries authoritative occurrence count), falling back to `event.count`, defaulting to 1 only when neither is set. Two new tests cover the series-only and series-vs-flat-disagreement paths.
- **m1** `d90a936` — Privacy-leak sweep in `test_configmap_list_row_strips_data_and_binary_data` now uses `not any(... substring ...)` over list elements rather than the element-equality `in` check.
- **m2** `d90a936` — Lifted `import random` from inside the recency-sort test to the top-of-file import block.

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 2 -->
