### PR TITLE
feat(connectors): G3.2-T3 K8s workload ops — k8s.pod.{list,info} + k8s.deployment.{list,info}

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -535,6 +535,60 @@ class KubernetesConnector(Connector):
 
         return await k8s_logs(self, target, params)
 
+    async def k8s_pod_list(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``k8s.pod.list`` op (G3.2-T3 #323).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.kubernetes.ops_workload.k8s_pod_list`.
+        Same module-level-function shape :meth:`logs` uses so a future
+        per-op-handler-file split keeps the registration API stable.
+        """
+        from meho_backplane.connectors.kubernetes.ops_workload import (
+            k8s_pod_list as _k8s_pod_list,
+        )
+
+        return await _k8s_pod_list(self, target, params)
+
+    async def k8s_pod_info(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``k8s.pod.info`` op (G3.2-T3 #323)."""
+        from meho_backplane.connectors.kubernetes.ops_workload import (
+            k8s_pod_info as _k8s_pod_info,
+        )
+
+        return await _k8s_pod_info(self, target, params)
+
+    async def k8s_deployment_list(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``k8s.deployment.list`` op (G3.2-T3 #323)."""
+        from meho_backplane.connectors.kubernetes.ops_workload import (
+            k8s_deployment_list as _k8s_deployment_list,
+        )
+
+        return await _k8s_deployment_list(self, target, params)
+
+    async def k8s_deployment_info(
+        self,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``k8s.deployment.info`` op (G3.2-T3 #323)."""
+        from meho_backplane.connectors.kubernetes.ops_workload import (
+            k8s_deployment_info as _k8s_deployment_info,
+        )
+
+        return await _k8s_deployment_info(self, target, params)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`KUBERNETES_OPS` into ``endpoint_descriptor``.

--- a/backend/src/meho_backplane/connectors/kubernetes/ops.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops.py
@@ -21,6 +21,10 @@ The shipped op surface today:
   inventory surface (G3.2-T2 #322). Metadata + helper functions live in
   :mod:`~meho_backplane.connectors.kubernetes.ops_core`; this module
   re-exports the merged tuple so registration walks a single list.
+* ``k8s.pod.{list,info}`` / ``k8s.deployment.{list,info}`` -- the
+  workload surface (G3.2-T3 #323). Metadata + helpers + handlers live
+  in :mod:`~meho_backplane.connectors.kubernetes.ops_workload`;
+  :func:`_kubernetes_ops` splats ``WORKLOAD_OPS`` into the merged tuple.
 * ``k8s.logs`` -- non-streaming pod-log fetch (G3.2-T5 #325). Metadata
   schemas + handler live in
   :mod:`~meho_backplane.connectors.kubernetes.ops_logs`; this module
@@ -158,17 +162,23 @@ _K8S_ABOUT_OP = KubernetesOp(
 
 
 def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
-    """Return the merged registration tuple (``k8s.about`` + core inventory ops + ``k8s.logs``).
+    """Return the merged registration tuple.
+
+    Composition: ``k8s.about`` (T1 canary) + ``CORE_OPS`` (T2 inventory:
+    ``k8s.ls`` / ``k8s.namespace.list`` / ``k8s.node.list``) + ``WORKLOAD_OPS``
+    (T3 workload: ``k8s.pod.{list,info}`` / ``k8s.deployment.{list,info}``)
+    + ``k8s.logs`` (T5).
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
     :class:`KubernetesOp` + ``_K8S_ABOUT_OP``, then imports the T2
-    inventory ops from :mod:`ops_core` and the T5 logs op metadata
-    from :mod:`ops_logs` (each of which only depends on
-    ``KubernetesOp`` plus its own helpers). The arrangement keeps the
-    canary op's metadata co-located with the dataclass definition
-    while letting the larger surfaces live in their own modules next
-    to their helpers.
+    inventory ops from :mod:`ops_core`, the T3 workload ops from
+    :mod:`ops_workload`, and the T5 logs op metadata from
+    :mod:`ops_logs` (each of which only depends on ``KubernetesOp``
+    plus its own helpers). The arrangement keeps the canary op's
+    metadata co-located with the dataclass definition while letting
+    the larger surfaces live in their own modules next to their
+    helpers.
     """
     from meho_backplane.connectors.kubernetes.ops_core import CORE_OPS
     from meho_backplane.connectors.kubernetes.ops_logs import (
@@ -176,6 +186,7 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
         K8S_LOGS_PARAMETER_SCHEMA,
         K8S_LOGS_RESPONSE_SCHEMA,
     )
+    from meho_backplane.connectors.kubernetes.ops_workload import WORKLOAD_OPS
 
     logs_op = KubernetesOp(
         op_id="k8s.logs",
@@ -208,7 +219,7 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
         llm_instructions=K8S_LOGS_LLM_INSTRUCTIONS,
     )
 
-    return (_K8S_ABOUT_OP, *CORE_OPS, logs_op)
+    return (_K8S_ABOUT_OP, *CORE_OPS, *WORKLOAD_OPS, logs_op)
 
 
 KUBERNETES_OPS: tuple[KubernetesOp, ...] = _kubernetes_ops()

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
@@ -1,0 +1,1178 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Workload K8s ops -- ``k8s.pod.{list,info}`` + ``k8s.deployment.{list,info}``.
+
+G3.2-T3 (#323) of Initiative #320. T1 + T2 + T5 landed the connector
+skeleton, the core inventory ops, and the logs op against the G0.6
+substrate; this module adds the four highest-volume workload ops the
+operator's daily ``kubectl-vcf.sh`` usage covers:
+
+* ``k8s.pod.list [--namespace X | --all-namespaces]
+  [--label-selector ...] [--field-selector ...] [--limit N]
+  [--continue-token ...]`` -- one row per pod with name / namespace /
+  status / ready / restarts / age / node / IP. Forwards the standard
+  k8s ``label_selector`` / ``field_selector`` / ``limit`` /
+  ``_continue`` query knobs to the API server so heavy-tenancy
+  clusters can paginate server-side without pulling every row through
+  the connector.
+* ``k8s.pod.info <name> --namespace X`` -- full pod detail (spec
+  containers / volumes / status conditions / container statuses / node
+  assignment / QoS / init containers). Pod-name resolution accepts an
+  exact match or a unique prefix; ambiguous prefixes return a
+  structured error listing the candidates so the agent can disambiguate
+  without a second namespace list.
+* ``k8s.deployment.list [--namespace X | --all-namespaces]
+  [--label-selector ...] [--limit N] [--continue-token ...]`` -- one
+  row per deployment with name / namespace / replica counts / image /
+  age / strategy. Same pagination shape as ``k8s.pod.list``.
+* ``k8s.deployment.info <name> --namespace X`` -- full deployment
+  detail (spec template / strategy / status replicas / conditions).
+  Prefix resolution mirrors ``k8s.pod.info``.
+
+Wire shape conventions
+----------------------
+
+The list handlers emit ``{"rows": [...], "total": N}`` plus an optional
+``next_continue`` key when the server signals more pages via
+``V1ListMeta._continue``. T2's module docstring spells out the
+rationale: connector handlers stay reducer-agnostic (raw rows + total),
+and the v0.2 substrate's :class:`PassThroughReducer` lands the dict
+verbatim into :attr:`OperationResult.result`. A future JSONFlux reducer
+owns set-shaped truncation + handle creation; the ``next_continue``
+token is the same server-side cursor the operator can pass back as
+``continue_token`` for the next page.
+
+The ``info`` handlers emit a flat dict structured around the API
+object's spec + status. Pod info includes container statuses (with
+ready / restartCount / lastState) because the operator's "is this pod
+healthy?" question is the dominant ``kubectl describe pod`` use case.
+Deployment info includes the rollout status (replicas / available /
+ready / updated) because that's what ``kubectl rollout status`` reads.
+
+Prefix resolution
+-----------------
+
+:func:`resolve_pod_name` and :func:`resolve_deployment_name` accept an
+exact name first; a unique prefix second; otherwise raise
+:class:`WorkloadNotFoundError` with the candidate list. The handler
+maps the error to a structured ``OperationResult(status="error",
+error="...")`` shape via the dispatcher's ``connector_error`` branch
+(the exception class lands in ``extras.exception_class`` so callers
+can render a "did-you-mean" hint without parsing the error string).
+
+The resolution shape mirrors :mod:`ops_logs` -- both modules end up
+listing the namespace's pods / deployments to resolve a prefix.
+``k8s.pod.list`` itself uses the server-side ``limit`` /
+``_continue`` knobs because the operator-typed query is unconstrained;
+the prefix resolver bounds itself to the same namespace's pod set
+which is typically O(10) in operator daily use.
+
+References
+----------
+* Parent task: G3.2-T3 (#323).
+* Parent Initiative: G3.2 (#320).
+* Substrate: G0.6 (#388) typed-op registry + dispatcher.
+* k8s Pod API:
+  https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/
+* k8s Deployment API:
+  https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/
+* ``kubernetes_asyncio.CoreV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
+* ``kubernetes_asyncio.AppsV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/AppsV1Api.md
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from kubernetes_asyncio import client
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+from meho_backplane.connectors.kubernetes.ops_core import age_seconds
+
+if TYPE_CHECKING:
+    from kubernetes_asyncio.client.models import (
+        V1Container,
+        V1ContainerStatus,
+        V1Deployment,
+        V1Pod,
+    )
+
+    from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
+    from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
+
+__all__ = [
+    "K8S_DEPLOYMENT_INFO_LLM_INSTRUCTIONS",
+    "K8S_DEPLOYMENT_INFO_PARAMETER_SCHEMA",
+    "K8S_DEPLOYMENT_LIST_LLM_INSTRUCTIONS",
+    "K8S_DEPLOYMENT_LIST_PARAMETER_SCHEMA",
+    "K8S_POD_INFO_LLM_INSTRUCTIONS",
+    "K8S_POD_INFO_PARAMETER_SCHEMA",
+    "K8S_POD_LIST_LLM_INSTRUCTIONS",
+    "K8S_POD_LIST_PARAMETER_SCHEMA",
+    "WORKLOAD_OPS",
+    "AmbiguousPrefixError",
+    "WorkloadNotFoundError",
+    "container_status_row",
+    "deployment_info",
+    "deployment_row",
+    "k8s_deployment_info",
+    "k8s_deployment_list",
+    "k8s_pod_info",
+    "k8s_pod_list",
+    "pod_info",
+    "pod_ready_string",
+    "pod_row",
+    "resolve_deployment_name",
+    "resolve_pod_name",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class WorkloadNotFoundError(LookupError):
+    """Workload object not found by exact name or unique prefix.
+
+    Distinct from a generic :class:`LookupError` so the dispatcher's
+    ``connector_error`` envelope carries
+    ``extras.exception_class="WorkloadNotFoundError"`` and callers can
+    render a not-found hint. ``candidates`` is always empty for this
+    error (the prefix matched zero objects); the ambiguous case lives
+    on :class:`AmbiguousPrefixError`.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class AmbiguousPrefixError(LookupError):
+    """Workload prefix matched multiple objects.
+
+    The candidate list is on :attr:`candidates` so the dispatcher's
+    ``connector_error`` envelope can surface them without forcing the
+    caller to parse the error string. Subclassing
+    :class:`LookupError` (not :class:`ValueError`) keeps the
+    name-resolution shape uniform with :class:`WorkloadNotFoundError`
+    so dispatch-error renderers can branch once on
+    ``isinstance(exc, LookupError)``.
+    """
+
+    def __init__(self, message: str, candidates: list[str]) -> None:
+        super().__init__(message, candidates)
+
+    @property
+    def candidates(self) -> list[str]:
+        return list(self.args[1])
+
+
+# ---------------------------------------------------------------------------
+# Pure row-shape helpers
+# ---------------------------------------------------------------------------
+
+
+def container_status_row(status: V1ContainerStatus) -> dict[str, Any]:
+    """Project a :class:`V1ContainerStatus` into a flat dict.
+
+    ``state`` and ``last_state`` are :class:`V1ContainerState` unions
+    -- exactly one of ``running``, ``waiting``, ``terminated`` is
+    non-null. The handler picks the populated branch's keyword (e.g.
+    ``"running"`` / ``"waiting"`` / ``"terminated"``) so the caller
+    sees the operator-visible string ``kubectl get pods`` prints,
+    not the union nesting.
+    """
+    return {
+        "name": status.name,
+        "image": status.image,
+        "ready": bool(status.ready),
+        "restart_count": int(status.restart_count or 0),
+        "state": _container_state_label(status.state),
+        "last_state": _container_state_label(status.last_state),
+    }
+
+
+def _container_state_label(state: Any) -> str | None:
+    """Pick the populated branch of a :class:`V1ContainerState` union.
+
+    Returns ``"running"`` / ``"waiting"`` / ``"terminated"`` or
+    ``None`` when the state is absent (e.g. ``last_state`` on a pod
+    that has never restarted). Mirrors what ``kubectl get pods -o
+    wide`` shows in its STATUS column.
+    """
+    if state is None:
+        return None
+    if state.running is not None:
+        return "running"
+    if state.waiting is not None:
+        return "waiting"
+    if state.terminated is not None:
+        return "terminated"
+    return None
+
+
+def pod_ready_string(pod: V1Pod) -> str:
+    """Format the ``READY`` column the way ``kubectl get pods`` prints it.
+
+    The column is ``<ready>/<total>`` over containers (excluding init
+    containers, per kubectl's convention). Init-container readiness is
+    surfaced in the per-container statuses on the info path; the list
+    column intentionally summarises only the main containers because
+    that's what operators are looking at.
+    """
+    spec = pod.spec
+    status = pod.status
+    total = len(spec.containers) if spec is not None and spec.containers else 0
+    ready = 0
+    if status is not None and status.container_statuses:
+        ready = sum(1 for cs in status.container_statuses if cs.ready)
+    return f"{ready}/{total}"
+
+
+def _pod_total_restarts(pod: V1Pod) -> int:
+    """Sum the restart_count across all main containers.
+
+    ``kubectl get pods`` shows the sum across containers; init-container
+    restarts are tracked separately on the info path and would inflate
+    the list column for sidecar-heavy pods.
+    """
+    status = pod.status
+    if status is None or not status.container_statuses:
+        return 0
+    return sum(int(cs.restart_count or 0) for cs in status.container_statuses)
+
+
+def pod_row(pod: V1Pod, *, now: datetime | None = None) -> dict[str, Any]:
+    """Project a :class:`V1Pod` into the ``k8s.pod.list`` row shape.
+
+    Pure mapping; the test suite pins it against synthetic
+    :class:`V1Pod` instances without an event loop. ``status`` is the
+    phase string (``Running`` / ``Pending`` / ``Succeeded`` /
+    ``Failed`` / ``Unknown``); ``ready`` is the ``X/Y`` column ``kubectl
+    get pods`` prints; ``restarts`` is the sum across main containers;
+    ``node`` is the assigned node name (``None`` if the pod is
+    pending-schedule); ``ip`` is the pod IP (``None`` until the
+    network plugin assigns one).
+    """
+    metadata = pod.metadata
+    status = pod.status
+    spec = pod.spec
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "status": status.phase if status is not None else None,
+        "ready": pod_ready_string(pod),
+        "restarts": _pod_total_restarts(pod),
+        "age_seconds": age_seconds(
+            metadata.creation_timestamp if metadata is not None else None,
+            now=now,
+        ),
+        "node": spec.node_name if spec is not None else None,
+        "ip": status.pod_ip if status is not None else None,
+    }
+
+
+def _container_row(container: V1Container) -> dict[str, Any]:
+    """Project a :class:`V1Container` into the info-path container dict.
+
+    Ports / env / resources are surfaced as lightweight nested dicts so
+    the operator sees what they need without the full openapi model
+    shape. Volume mounts are projected by name + mount path; the full
+    volume definition lives on the pod-level ``volumes`` key.
+    """
+    ports = [
+        {
+            "name": p.name,
+            "container_port": p.container_port,
+            "protocol": p.protocol,
+            "host_port": p.host_port,
+        }
+        for p in (container.ports or [])
+    ]
+    env = [{"name": e.name, "value": e.value} for e in (container.env or [])]
+    resources_block: dict[str, Any] = {}
+    resources = container.resources
+    if resources is not None:
+        if resources.requests:
+            resources_block["requests"] = dict(resources.requests)
+        if resources.limits:
+            resources_block["limits"] = dict(resources.limits)
+    volume_mounts = [
+        {
+            "name": vm.name,
+            "mount_path": vm.mount_path,
+            "read_only": bool(vm.read_only) if vm.read_only is not None else False,
+        }
+        for vm in (container.volume_mounts or [])
+    ]
+    return {
+        "name": container.name,
+        "image": container.image,
+        "ports": ports,
+        "env": env,
+        "resources": resources_block,
+        "volume_mounts": volume_mounts,
+    }
+
+
+def _pod_volume_row(volume: Any) -> dict[str, Any]:
+    """Project a :class:`V1Volume` into a flat dict.
+
+    Surfaces the volume's name and the populated source-type label
+    (``configMap``, ``secret``, ``persistentVolumeClaim``, ``emptyDir``,
+    etc.). The full source spec stays out of the response -- operators
+    almost always want "what kind of volume is mounted?" rather than the
+    full source detail.
+    """
+    sources = (
+        "config_map",
+        "secret",
+        "persistent_volume_claim",
+        "empty_dir",
+        "host_path",
+        "projected",
+        "downward_api",
+        "csi",
+        "ephemeral",
+    )
+    source_label: str | None = None
+    for attr in sources:
+        if getattr(volume, attr, None) is not None:
+            source_label = attr.replace("_", "-")
+            break
+    return {"name": volume.name, "source": source_label}
+
+
+def pod_info(pod: V1Pod, *, now: datetime | None = None) -> dict[str, Any]:
+    """Project a :class:`V1Pod` into the ``k8s.pod.info`` full-detail shape.
+
+    Flat top-level dict; nested dicts for spec/status sub-objects.
+    Container statuses include the per-container readiness +
+    restartCount + state so the operator can identify which container
+    is unhealthy on a multi-container pod without a second round-trip.
+    Init containers are surfaced separately because their state
+    interpretation differs (an init container in ``terminated``/
+    ``Completed`` is healthy; a main container in that state is not).
+    """
+    metadata = pod.metadata
+    spec = pod.spec
+    status = pod.status
+
+    containers: list[dict[str, Any]] = []
+    init_containers: list[dict[str, Any]] = []
+    volumes: list[dict[str, Any]] = []
+    if spec is not None:
+        containers = [_container_row(c) for c in (spec.containers or [])]
+        init_containers = [_container_row(c) for c in (spec.init_containers or [])]
+        volumes = [_pod_volume_row(v) for v in (spec.volumes or [])]
+
+    container_statuses: list[dict[str, Any]] = []
+    init_container_statuses: list[dict[str, Any]] = []
+    conditions: list[dict[str, Any]] = []
+    if status is not None:
+        container_statuses = [container_status_row(cs) for cs in (status.container_statuses or [])]
+        init_container_statuses = [
+            container_status_row(cs) for cs in (status.init_container_statuses or [])
+        ]
+        conditions = [
+            {
+                "type": cond.type,
+                "status": cond.status,
+                "reason": cond.reason,
+                "message": cond.message,
+            }
+            for cond in (status.conditions or [])
+        ]
+
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "status": status.phase if status is not None else None,
+        "node": spec.node_name if spec is not None else None,
+        "ip": status.pod_ip if status is not None else None,
+        "host_ip": status.host_ip if status is not None else None,
+        "qos_class": status.qos_class if status is not None else None,
+        "age_seconds": age_seconds(
+            metadata.creation_timestamp if metadata is not None else None,
+            now=now,
+        ),
+        "labels": (metadata.labels or {}) if metadata is not None else {},
+        "containers": containers,
+        "init_containers": init_containers,
+        "volumes": volumes,
+        "container_statuses": container_statuses,
+        "init_container_statuses": init_container_statuses,
+        "conditions": conditions,
+    }
+
+
+def _deployment_strategy_label(deployment: V1Deployment) -> str | None:
+    """Pick the operator-facing strategy label (``RollingUpdate`` / ``Recreate``)."""
+    spec = deployment.spec
+    if spec is None or spec.strategy is None:
+        return None
+    label: str | None = spec.strategy.type
+    return label
+
+
+def _deployment_first_image(deployment: V1Deployment) -> str | None:
+    """Return the first container image from the deployment's pod template.
+
+    The list path's ``image`` column shows one image (kubectl's
+    convention is the first container in the template). Multi-container
+    deployments surface the full template on the info path.
+    """
+    spec = deployment.spec
+    if spec is None or spec.template is None or spec.template.spec is None:
+        return None
+    containers = spec.template.spec.containers or []
+    if not containers:
+        return None
+    image: str | None = containers[0].image
+    return image
+
+
+def deployment_row(deployment: V1Deployment, *, now: datetime | None = None) -> dict[str, Any]:
+    """Project a :class:`V1Deployment` into the list row shape.
+
+    Replica counts come from ``status`` (the controller's observed
+    state) rather than ``spec.replicas`` (the desired count) because
+    operators want the live-state breakdown. ``replicas_desired``
+    surfaces the spec value so the operator sees both targets in one
+    row.
+    """
+    metadata = deployment.metadata
+    spec = deployment.spec
+    status = deployment.status
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "replicas_desired": int(spec.replicas)
+        if spec is not None and spec.replicas is not None
+        else 0,
+        "replicas_ready": int(status.ready_replicas)
+        if status is not None and status.ready_replicas is not None
+        else 0,
+        "replicas_available": int(status.available_replicas)
+        if status is not None and status.available_replicas is not None
+        else 0,
+        "image": _deployment_first_image(deployment),
+        "age_seconds": age_seconds(
+            metadata.creation_timestamp if metadata is not None else None,
+            now=now,
+        ),
+        "strategy": _deployment_strategy_label(deployment),
+    }
+
+
+def deployment_info(deployment: V1Deployment, *, now: datetime | None = None) -> dict[str, Any]:
+    """Project a :class:`V1Deployment` into the ``k8s.deployment.info`` full-detail shape.
+
+    Includes the pod template's container list (image / ports / env /
+    resources / volume mounts), the rollout strategy block, the full
+    status block (replica counts + observed generation), and the
+    deployment conditions (``Available`` / ``Progressing`` /
+    ``ReplicaFailure``). The conditions list is the operator's hook
+    for "why is this deployment unhealthy?" -- ``status=False`` on
+    ``Available`` carries a ``message`` the API server wrote.
+    """
+    metadata = deployment.metadata
+    spec = deployment.spec
+    status = deployment.status
+
+    containers: list[dict[str, Any]] = []
+    if spec is not None and spec.template is not None and spec.template.spec is not None:
+        containers = [_container_row(c) for c in (spec.template.spec.containers or [])]
+
+    strategy_block: dict[str, Any] = {}
+    if spec is not None and spec.strategy is not None:
+        strategy_block["type"] = spec.strategy.type
+        if spec.strategy.rolling_update is not None:
+            rolling = spec.strategy.rolling_update
+            strategy_block["rolling_update"] = {
+                "max_surge": str(rolling.max_surge) if rolling.max_surge is not None else None,
+                "max_unavailable": str(rolling.max_unavailable)
+                if rolling.max_unavailable is not None
+                else None,
+            }
+
+    status_block: dict[str, Any] = {}
+    conditions: list[dict[str, Any]] = []
+    if status is not None:
+        status_block = {
+            "replicas": int(status.replicas) if status.replicas is not None else 0,
+            "ready_replicas": int(status.ready_replicas)
+            if status.ready_replicas is not None
+            else 0,
+            "available_replicas": int(status.available_replicas)
+            if status.available_replicas is not None
+            else 0,
+            "updated_replicas": int(status.updated_replicas)
+            if status.updated_replicas is not None
+            else 0,
+            "unavailable_replicas": int(status.unavailable_replicas)
+            if status.unavailable_replicas is not None
+            else 0,
+            "observed_generation": int(status.observed_generation)
+            if status.observed_generation is not None
+            else 0,
+        }
+        conditions = [
+            {
+                "type": cond.type,
+                "status": cond.status,
+                "reason": cond.reason,
+                "message": cond.message,
+            }
+            for cond in (status.conditions or [])
+        ]
+
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "replicas_desired": int(spec.replicas)
+        if spec is not None and spec.replicas is not None
+        else 0,
+        "age_seconds": age_seconds(
+            metadata.creation_timestamp if metadata is not None else None,
+            now=now,
+        ),
+        "labels": (metadata.labels or {}) if metadata is not None else {},
+        "strategy": strategy_block,
+        "containers": containers,
+        "status": status_block,
+        "conditions": conditions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prefix resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_from_items(items: list[Any], target_name: str, kind: str) -> Any:
+    """Pick the exact-match or unique-prefix match from *items*.
+
+    Common logic shared between :func:`resolve_pod_name` and
+    :func:`resolve_deployment_name`. Two-pass: exact match wins (so
+    ``foo-bar`` matches ``foo-bar`` even when ``foo-bar-x`` also
+    exists); otherwise the prefix matches collect into a candidate
+    list. Zero candidates raises :class:`WorkloadNotFoundError`;
+    multiple raise :class:`AmbiguousPrefixError` with the candidate
+    list. *kind* parameterises the error string ("pod", "deployment").
+    """
+    exact_matches = [obj for obj in items if obj.metadata.name == target_name]
+    if exact_matches:
+        return exact_matches[0]
+
+    prefix_matches = [obj for obj in items if obj.metadata.name.startswith(target_name)]
+    if not prefix_matches:
+        raise WorkloadNotFoundError(f"{kind} {target_name!r} not found")
+    if len(prefix_matches) > 1:
+        candidates = sorted(obj.metadata.name for obj in prefix_matches)
+        raise AmbiguousPrefixError(
+            f"{kind} prefix {target_name!r} matched {len(candidates)} objects",
+            candidates,
+        )
+    return prefix_matches[0]
+
+
+async def resolve_pod_name(v1: client.CoreV1Api, namespace: str, pod_name: str) -> V1Pod:
+    """Resolve a pod name + namespace pair to a :class:`V1Pod`.
+
+    Exact-match wins; otherwise tries ``pod_name`` as a prefix within
+    the namespace. Raises :class:`WorkloadNotFoundError` /
+    :class:`AmbiguousPrefixError`. The single ``list_namespaced_pod``
+    call is unbounded server-side -- operator-facing namespaces are
+    typically O(10..100) pods which is well within an unpaginated list
+    -- but a heavy-tenancy namespace would benefit from a future
+    field-selector + pagination shape (recorded in the module
+    docstring's prefix-resolution note).
+    """
+    pod_list = await v1.list_namespaced_pod(namespace=namespace)
+    return _resolve_from_items(list(pod_list.items or []), pod_name, "pod")
+
+
+async def resolve_deployment_name(
+    apps_v1: client.AppsV1Api, namespace: str, deployment_name: str
+) -> V1Deployment:
+    """Resolve a deployment name + namespace pair to a :class:`V1Deployment`."""
+    deployment_list = await apps_v1.list_namespaced_deployment(namespace=namespace)
+    return _resolve_from_items(list(deployment_list.items or []), deployment_name, "deployment")
+
+
+# ---------------------------------------------------------------------------
+# Handlers -- module-level free functions
+#
+# The :class:`KubernetesConnector` bound-method shims forward into these so a
+# future per-op-handler-file split (one ``ops_<verb>.py`` per op, without a
+# class) keeps the API stable. Same shape :mod:`ops_logs` uses for its
+# ``k8s.logs`` handler.
+# ---------------------------------------------------------------------------
+
+
+def _list_kwargs(params: dict[str, Any]) -> dict[str, Any]:
+    """Translate the operator-facing list params into kubernetes_asyncio kwargs.
+
+    The operator's ``--label-selector`` / ``--field-selector`` /
+    ``--limit`` / ``--continue-token`` map to ``label_selector`` /
+    ``field_selector`` / ``limit`` / ``_continue`` on the API. ``None``
+    values are stripped so ``kubernetes_asyncio`` doesn't send empty
+    filter strings to the API server (which would change query
+    semantics on some k8s versions).
+    """
+    kwargs: dict[str, Any] = {
+        "label_selector": params.get("label_selector"),
+        "field_selector": params.get("field_selector"),
+        "limit": params.get("limit"),
+        "_continue": params.get("continue_token"),
+    }
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
+def _next_continue_token(resp: Any) -> str | None:
+    """Extract the server's continuation token from a list response.
+
+    The token lives at ``resp.metadata._continue`` -- non-empty means
+    "more pages exist; pass this back as ``continue_token`` to fetch
+    them". The connector surfaces it under ``next_continue`` in the
+    response dict so the operator-facing renderer can decide whether
+    to fetch + concatenate or to expose a "fetch more" affordance.
+    """
+    metadata = getattr(resp, "metadata", None)
+    if metadata is None:
+        return None
+    token: str | None = getattr(metadata, "_continue", None)
+    if not token:
+        return None
+    return token
+
+
+async def k8s_pod_list(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.pod.list``.
+
+    Routes by ``all_namespaces`` (``list_pod_for_all_namespaces``) vs
+    ``namespace`` (``list_namespaced_pod``). Returns
+    ``{rows, total, next_continue?}``; the ``next_continue`` key is
+    only present when the server signalled more pages exist. Schema
+    validation runs in the dispatcher before this handler is called.
+    """
+    namespace: str | None = params.get("namespace")
+    all_namespaces = bool(params.get("all_namespaces", False))
+    api_client = await connector._get_api_client(target)
+    v1 = client.CoreV1Api(api_client)
+    kwargs = _list_kwargs(params)
+    if all_namespaces:
+        resp = await v1.list_pod_for_all_namespaces(**kwargs)
+    else:
+        # Schema enforces exactly-one-of (namespace, all_namespaces); the
+        # ``or ""`` cast is defensive against a schema relaxation that
+        # would otherwise crash with a TypeError from kubernetes_asyncio.
+        resp = await v1.list_namespaced_pod(namespace=namespace or "", **kwargs)
+    rows = [pod_row(p) for p in (resp.items or [])]
+    result: dict[str, Any] = {"rows": rows, "total": len(rows)}
+    token = _next_continue_token(resp)
+    if token is not None:
+        result["next_continue"] = token
+    return result
+
+
+async def k8s_pod_info(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.pod.info``.
+
+    Resolves the pod name (exact-match or unique-prefix) within the
+    namespace and returns the full info dict. Reads the pod via
+    :meth:`CoreV1Api.read_namespaced_pod` only when the resolved name
+    differs from the input -- the prefix-resolution list response
+    already contains the full :class:`V1Pod`, so the extra round-trip
+    is skipped for the exact-name path.
+    """
+    pod_name: str = params["pod_name"]
+    namespace: str = params["namespace"]
+    api_client = await connector._get_api_client(target)
+    v1 = client.CoreV1Api(api_client)
+    pod = await resolve_pod_name(v1, namespace, pod_name)
+    # The list-derived V1Pod carries the full spec + status by default,
+    # so we don't need a second ``read_namespaced_pod`` round-trip --
+    # ``list_namespaced_pod`` returns the same object kubectl get
+    # serves.
+    return pod_info(pod)
+
+
+async def k8s_deployment_list(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.deployment.list``.
+
+    Same pagination + filter shape as ``k8s.pod.list``. The
+    ``field_selector`` knob is less commonly used against deployments
+    (no ``status.phase`` filter equivalent), but the API accepts it so
+    we forward it for parity with the pod path.
+    """
+    namespace: str | None = params.get("namespace")
+    all_namespaces = bool(params.get("all_namespaces", False))
+    api_client = await connector._get_api_client(target)
+    apps_v1 = client.AppsV1Api(api_client)
+    kwargs = _list_kwargs(params)
+    if all_namespaces:
+        resp = await apps_v1.list_deployment_for_all_namespaces(**kwargs)
+    else:
+        resp = await apps_v1.list_namespaced_deployment(namespace=namespace or "", **kwargs)
+    rows = [deployment_row(d) for d in (resp.items or [])]
+    result: dict[str, Any] = {"rows": rows, "total": len(rows)}
+    token = _next_continue_token(resp)
+    if token is not None:
+        result["next_continue"] = token
+    return result
+
+
+async def k8s_deployment_info(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.deployment.info``. Mirrors :func:`k8s_pod_info`."""
+    deployment_name: str = params["deployment_name"]
+    namespace: str = params["namespace"]
+    api_client = await connector._get_api_client(target)
+    apps_v1 = client.AppsV1Api(api_client)
+    deployment = await resolve_deployment_name(apps_v1, namespace, deployment_name)
+    return deployment_info(deployment)
+
+
+# ---------------------------------------------------------------------------
+# Parameter schemas + LLM instructions
+# ---------------------------------------------------------------------------
+
+
+#: Shared by both list ops: namespace XOR all_namespaces, plus the
+#: standard k8s ``label_selector`` / ``field_selector`` / ``limit`` /
+#: ``continue_token`` filter knobs. The ``oneOf`` clause enforces
+#: exactly-one of the namespace selectors so the operator can't
+#: accidentally pass both (which would be ambiguous about whether
+#: ``all_namespaces`` overrides ``namespace`` or vice-versa).
+_LIST_BASE_PROPERTIES: dict[str, Any] = {
+    "namespace": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Namespace to list in. Required unless ``all_namespaces`` is true.",
+    },
+    "all_namespaces": {
+        "type": "boolean",
+        "default": False,
+        "description": (
+            "List across every namespace the kubeconfig's service "
+            "account can read. Mutually exclusive with ``namespace``."
+        ),
+    },
+    "label_selector": {
+        "type": "string",
+        "minLength": 1,
+        "description": (
+            "Standard k8s label selector (e.g. ``app=argocd-server``, "
+            "``app in (frontend,backend)``). Forwarded server-side."
+        ),
+    },
+    "field_selector": {
+        "type": "string",
+        "minLength": 1,
+        "description": (
+            "Standard k8s field selector (e.g. ``status.phase=Running``, "
+            "``spec.nodeName=node-1``). Forwarded server-side."
+        ),
+    },
+    "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 1000,
+        "description": (
+            "Server-side ``?limit=`` for paginated reads. Combine with "
+            "``continue_token`` from a prior response's ``next_continue`` "
+            "field to walk pages. Capped at 1000 to bound per-call "
+            "payload."
+        ),
+    },
+    "continue_token": {
+        "type": "string",
+        "minLength": 1,
+        "description": (
+            "Server-emitted pagination cursor from a prior list call's "
+            "``next_continue`` field. Pass it back unchanged to fetch the "
+            "next page; passing a stale token (>5..15 min old) returns a "
+            "410 ResourceExpired -- restart the list without it."
+        ),
+    },
+}
+
+
+#: ``oneOf`` clause: exactly one of {namespace, all_namespaces=true}.
+#:
+#: The ``not`` branches encode "the other selector is absent" for the
+#: namespace branch and "all_namespaces is false-or-absent" for the
+#: missing-both branch. Draft 2020-12 evaluates each branch
+#: independently; the combined effect is the operator must supply
+#: exactly one selector.
+_NAMESPACE_XOR_ALL_NAMESPACES: list[dict[str, Any]] = [
+    {
+        "required": ["namespace"],
+        "not": {"required": ["all_namespaces"]},
+    },
+    {
+        "required": ["namespace", "all_namespaces"],
+        "properties": {"all_namespaces": {"const": False}},
+    },
+    {
+        "required": ["all_namespaces"],
+        "properties": {"all_namespaces": {"const": True}},
+        "not": {"required": ["namespace"]},
+    },
+]
+
+
+K8S_POD_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": _LIST_BASE_PROPERTIES,
+    "oneOf": _NAMESPACE_XOR_ALL_NAMESPACES,
+    "additionalProperties": False,
+}
+
+
+K8S_POD_INFO_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "pod_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Pod name. Exact match wins; otherwise treated as a "
+                "prefix within the namespace. Ambiguous prefixes return "
+                "a structured error listing the candidates."
+            ),
+        },
+        "namespace": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Namespace the pod lives in.",
+        },
+    },
+    "required": ["pod_name", "namespace"],
+    "additionalProperties": False,
+}
+
+
+K8S_DEPLOYMENT_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": _LIST_BASE_PROPERTIES,
+    "oneOf": _NAMESPACE_XOR_ALL_NAMESPACES,
+    "additionalProperties": False,
+}
+
+
+K8S_DEPLOYMENT_INFO_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "deployment_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": ("Deployment name. Exact match or unique prefix within the namespace."),
+        },
+        "namespace": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Namespace the deployment lives in.",
+        },
+    },
+    "required": ["deployment_name", "namespace"],
+    "additionalProperties": False,
+}
+
+
+K8S_POD_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator asks 'what pods are running?' or wants "
+        "the kubectl-equivalent of 'kubectl get pods -n <ns>'. Pass "
+        "label_selector / field_selector to narrow (e.g. "
+        "field_selector='status.phase=Running'). Use all_namespaces=true "
+        "for cluster-wide questions. Combine limit + continue_token for "
+        "explicit pagination on heavy-tenancy clusters."
+    ),
+    "parameter_hints": {
+        "namespace": "Required unless all_namespaces is true.",
+        "all_namespaces": "Pass true for cluster-wide listings.",
+        "label_selector": ("k8s selector syntax (e.g. 'app=argocd-server', 'role in (cp, etcd)')."),
+        "field_selector": (
+            "Server-side filter. Common: 'status.phase=Running', 'spec.nodeName=node-1'."
+        ),
+        "limit": "Cap rows per response. Combine with continue_token.",
+        "continue_token": "Pass the prior response's next_continue verbatim.",
+    },
+    "output_shape": (
+        "{'rows': [{name, namespace, status, ready, restarts, "
+        "age_seconds, node, ip}], 'total': <int>, 'next_continue': "
+        "<str | absent>}. ``ready`` is the kubectl 'X/Y' string; "
+        "``restarts`` is the sum across main containers. "
+        "``next_continue`` is present iff the server has more pages."
+    ),
+}
+
+
+K8S_POD_INFO_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator names a specific pod and wants the "
+        "kubectl-describe equivalent: spec containers, volumes, status "
+        "conditions, per-container statuses, node assignment, QoS, "
+        "init-container detail. Accepts a prefix (e.g. 'argocd-server') "
+        "as long as it matches one pod in the namespace; "
+        "ambiguous prefixes return a candidates list."
+    ),
+    "parameter_hints": {
+        "pod_name": "Exact name or unique prefix within the namespace.",
+        "namespace": "Required.",
+    },
+    "output_shape": (
+        "Flat dict: {name, namespace, status, node, ip, host_ip, "
+        "qos_class, age_seconds, labels, containers, init_containers, "
+        "volumes, container_statuses, init_container_statuses, "
+        "conditions}. ``container_statuses`` carries per-container "
+        "ready/restart_count/state for unhealthy-container diagnosis."
+    ),
+}
+
+
+K8S_DEPLOYMENT_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator asks 'what's deployed in <ns>?' or "
+        "wants 'kubectl get deployments'. Same pagination + selector "
+        "shape as k8s.pod.list. Use to read rollout state across the "
+        "namespace; for a single deployment's full detail call "
+        "k8s.deployment.info."
+    ),
+    "parameter_hints": {
+        "namespace": "Required unless all_namespaces is true.",
+        "all_namespaces": "Pass true for cluster-wide listings.",
+        "label_selector": "k8s selector syntax.",
+        "limit": "Cap rows per response. Combine with continue_token.",
+        "continue_token": "Pass the prior response's next_continue verbatim.",
+    },
+    "output_shape": (
+        "{'rows': [{name, namespace, replicas_desired, replicas_ready, "
+        "replicas_available, image, age_seconds, strategy}], 'total', "
+        "'next_continue'?}. ``image`` is the first container's image "
+        "(kubectl convention); full template is on the info path."
+    ),
+}
+
+
+K8S_DEPLOYMENT_INFO_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call when the operator names a specific deployment and wants "
+        "the full template + rollout status: pod-template containers, "
+        "strategy (RollingUpdate maxSurge/maxUnavailable), live replica "
+        "counts, conditions (Available / Progressing / ReplicaFailure). "
+        "Prefix resolution mirrors k8s.pod.info."
+    ),
+    "parameter_hints": {
+        "deployment_name": "Exact name or unique prefix within the namespace.",
+        "namespace": "Required.",
+    },
+    "output_shape": (
+        "Flat dict: {name, namespace, replicas_desired, age_seconds, "
+        "labels, strategy, containers, status, conditions}. ``status`` "
+        "is the live replica breakdown (replicas / ready / available / "
+        "updated / unavailable / observed_generation)."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Response schemas -- informational; the dispatcher's pass-through reducer
+# does not validate outbound payloads in v0.2.
+# ---------------------------------------------------------------------------
+
+
+_POD_ROW_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": ["string", "null"]},
+        "namespace": {"type": ["string", "null"]},
+        "status": {"type": ["string", "null"]},
+        "ready": {"type": "string"},
+        "restarts": {"type": "integer"},
+        "age_seconds": {"type": ["integer", "null"]},
+        "node": {"type": ["string", "null"]},
+        "ip": {"type": ["string", "null"]},
+    },
+    "required": ["name", "namespace", "status", "ready", "restarts", "age_seconds", "node", "ip"],
+    "additionalProperties": False,
+}
+
+
+_K8S_POD_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": _POD_ROW_SCHEMA},
+        "total": {"type": "integer"},
+        "next_continue": {"type": "string"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+_K8S_POD_INFO_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Flat pod detail; see llm_instructions.output_shape.",
+    "additionalProperties": True,
+}
+
+
+_DEPLOYMENT_ROW_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": ["string", "null"]},
+        "namespace": {"type": ["string", "null"]},
+        "replicas_desired": {"type": "integer"},
+        "replicas_ready": {"type": "integer"},
+        "replicas_available": {"type": "integer"},
+        "image": {"type": ["string", "null"]},
+        "age_seconds": {"type": ["integer", "null"]},
+        "strategy": {"type": ["string", "null"]},
+    },
+    "required": [
+        "name",
+        "namespace",
+        "replicas_desired",
+        "replicas_ready",
+        "replicas_available",
+        "image",
+        "age_seconds",
+        "strategy",
+    ],
+    "additionalProperties": False,
+}
+
+
+_K8S_DEPLOYMENT_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": _DEPLOYMENT_ROW_SCHEMA},
+        "total": {"type": "integer"},
+        "next_continue": {"type": "string"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+_K8S_DEPLOYMENT_INFO_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Flat deployment detail; see llm_instructions.output_shape.",
+    "additionalProperties": True,
+}
+
+
+WORKLOAD_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.pod.list",
+        handler_attr="k8s_pod_list",
+        summary="List pods in a namespace (or cluster-wide) with selectors + pagination.",
+        description=(
+            "Calls ``CoreV1Api.list_namespaced_pod`` (or "
+            "``list_pod_for_all_namespaces`` when ``all_namespaces=true``) "
+            "and projects each pod into a flat row {name, namespace, "
+            "status, ready, restarts, age_seconds, node, ip}. Forwards "
+            "the standard k8s ``label_selector`` / ``field_selector`` / "
+            "``limit`` / ``_continue`` query knobs to the API server "
+            "so heavy-tenancy clusters can paginate server-side. The "
+            "response includes ``next_continue`` when the server signals "
+            "more pages; pass it back as ``continue_token`` to walk."
+        ),
+        parameter_schema=K8S_POD_LIST_PARAMETER_SCHEMA,
+        response_schema=_K8S_POD_LIST_RESPONSE_SCHEMA,
+        group_key="workload",
+        tags=("read-only", "pod", "workload"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_POD_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.pod.info",
+        handler_attr="k8s_pod_info",
+        summary="Full pod detail by exact name or unique prefix.",
+        description=(
+            "Resolves ``pod_name`` against the namespace (exact match "
+            "wins; otherwise unique prefix) and returns the full spec + "
+            "status snapshot the operator's ``kubectl describe pod`` "
+            "habit reads: containers (image / ports / env / resources / "
+            "volume mounts), init containers, volumes (name + source "
+            "type), per-container statuses (ready / restart_count / "
+            "state), conditions, node assignment, QoS class. Ambiguous "
+            "prefixes return a structured error listing the candidates."
+        ),
+        parameter_schema=K8S_POD_INFO_PARAMETER_SCHEMA,
+        response_schema=_K8S_POD_INFO_RESPONSE_SCHEMA,
+        group_key="workload",
+        tags=("read-only", "pod", "workload"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_POD_INFO_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.deployment.list",
+        handler_attr="k8s_deployment_list",
+        summary="List deployments with live replica counts + image + strategy.",
+        description=(
+            "Calls ``AppsV1Api.list_namespaced_deployment`` (or "
+            "``list_deployment_for_all_namespaces``) and projects each "
+            "row down to {name, namespace, replicas_desired, "
+            "replicas_ready, replicas_available, image, age_seconds, "
+            "strategy}. ``image`` is the first container's image "
+            "(kubectl convention; full template lives on the info path). "
+            "Same server-side pagination shape as ``k8s.pod.list``."
+        ),
+        parameter_schema=K8S_DEPLOYMENT_LIST_PARAMETER_SCHEMA,
+        response_schema=_K8S_DEPLOYMENT_LIST_RESPONSE_SCHEMA,
+        group_key="workload",
+        tags=("read-only", "deployment", "workload"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_DEPLOYMENT_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.deployment.info",
+        handler_attr="k8s_deployment_info",
+        summary="Full deployment detail by exact name or unique prefix.",
+        description=(
+            "Resolves ``deployment_name`` against the namespace and "
+            "returns the full template + rollout status: pod-template "
+            "containers, strategy block (RollingUpdate's maxSurge / "
+            "maxUnavailable when present), live replica breakdown "
+            "(replicas / ready / available / updated / unavailable / "
+            "observed_generation), and deployment conditions "
+            "(``Available`` / ``Progressing`` / ``ReplicaFailure``) "
+            "with reason + message. Prefix resolution mirrors "
+            "``k8s.pod.info``."
+        ),
+        parameter_schema=K8S_DEPLOYMENT_INFO_PARAMETER_SCHEMA,
+        response_schema=_K8S_DEPLOYMENT_INFO_RESPONSE_SCHEMA,
+        group_key="workload",
+        tags=("read-only", "deployment", "workload"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_DEPLOYMENT_INFO_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/tests/integration/test_connectors_k8s_k3d.py
+++ b/backend/tests/integration/test_connectors_k8s_k3d.py
@@ -301,13 +301,169 @@ async def test_ls_namespace_against_k3s_returns_kind_counts(
 async def test_ls_namespace_kind_against_k3s_forwards_to_unknown_op(
     k3s_connector: tuple[KubernetesConnector, _K3sTarget],
 ) -> None:
-    """``k8s.ls /default/pods`` forwards to ``k8s.pod.list`` -- unknown_op until T3."""
+    """``k8s.ls /default/pods`` forwards to ``k8s.pod.list``.
+
+    Pre-T3, this exercised the dispatcher's ``unknown_op`` shape.
+    T3 (#323) registers ``k8s.pod.list``, but registration only runs
+    inside the lifespan-driven
+    :meth:`KubernetesConnector.register_operations`; this test
+    constructs the connector directly, so no descriptor row is written
+    to ``endpoint_descriptor`` and the dispatcher shim still surfaces
+    ``unknown_op`` on the forwarded sub-call. Live registration +
+    end-to-end dispatch is covered by the chassis lifespan tests, not
+    by this module.
+    """
     connector, target = k3s_connector
     result = await connector.k8s_ls(target, {"path": "/default/pods"})
     assert result["forwarded_to"] == "k8s.pod.list"
     inner = result["result"]
-    # T3 hasn't shipped k8s.pod.list yet, so the dispatcher shim emits
-    # the structured unknown_op envelope. When T3 lands, this test
-    # gains a real-pod-row assertion in the inner result.
     assert inner["status"] == "error"
     assert inner["error"].startswith("unknown_op:")
+
+
+# ---------------------------------------------------------------------------
+# G3.2-T3 (#323) workload ops -- live k3s exercise.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pod_list_against_k3s_returns_kube_system_pods(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.pod.list -n kube-system`` returns the bootstrap pods.
+
+    k3s ships coredns + traefik + local-path-provisioner + metrics-server
+    pods in ``kube-system`` post-boot; the assertion is existential
+    (at least one pod) rather than exact-list because the k3s minor
+    drift adds/removes shipped components.
+    """
+    connector, target = k3s_connector
+    result = await connector.k8s_pod_list(target, {"namespace": "kube-system"})
+    assert result["total"] >= 1
+    sample = result["rows"][0]
+    for key in ("name", "namespace", "status", "ready", "restarts", "age_seconds", "node", "ip"):
+        assert key in sample
+    assert sample["namespace"] == "kube-system"
+
+
+@pytest.mark.asyncio
+async def test_pod_list_all_namespaces_against_k3s(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.pod.list --all-namespaces`` returns pods spanning multiple namespaces."""
+    connector, target = k3s_connector
+    result = await connector.k8s_pod_list(target, {"all_namespaces": True})
+    assert result["total"] >= 1
+    namespaces = {row["namespace"] for row in result["rows"]}
+    # k3s' bootstrap pods live in kube-system.
+    assert "kube-system" in namespaces
+
+
+@pytest.mark.asyncio
+async def test_pod_list_server_side_limit_caps_rows(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``limit=1`` enforces a one-row page; further pages reachable via continue_token."""
+    connector, target = k3s_connector
+    result = await connector.k8s_pod_list(target, {"namespace": "kube-system", "limit": 1})
+    assert result["total"] == 1
+    # next_continue presence depends on whether kube-system has >1 pod
+    # (it normally does on k3s); single-pod namespaces omit the token.
+    # Both shapes are valid; when present, the cursor round-trips
+    # cleanly back through a second list call.
+    if "next_continue" in result:
+        page_2 = await connector.k8s_pod_list(
+            target,
+            {
+                "namespace": "kube-system",
+                "limit": 1,
+                "continue_token": result["next_continue"],
+            },
+        )
+        assert page_2["total"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_pod_info_against_k3s_resolves_prefix(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.pod.info`` resolves a unique prefix and returns full container detail."""
+    connector, target = k3s_connector
+    listing = await connector.k8s_pod_list(target, {"namespace": "kube-system"})
+    assert listing["total"] >= 1
+    pod_name = listing["rows"][0]["name"]
+    # k3s pod names follow ``<deployment>-<hash>-<id>``; the first
+    # segment is unique when only one pod from a given deployment
+    # exists. Fall back to the full name when the prefix would clash.
+    prefix = pod_name.split("-", 1)[0]
+    prefix_matches = [r for r in listing["rows"] if r["name"].startswith(prefix)]
+    target_name = prefix if len(prefix_matches) == 1 else pod_name
+    info = await connector.k8s_pod_info(
+        target, {"pod_name": target_name, "namespace": "kube-system"}
+    )
+    assert info["name"] == pod_name
+    assert info["namespace"] == "kube-system"
+    assert isinstance(info["containers"], list)
+    assert len(info["containers"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_pod_info_not_found_raises_against_k3s(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """A non-existent pod name surfaces :class:`WorkloadNotFoundError`."""
+    from meho_backplane.connectors.kubernetes.ops_workload import WorkloadNotFoundError
+
+    connector, target = k3s_connector
+    with pytest.raises(WorkloadNotFoundError):
+        await connector.k8s_pod_info(
+            target,
+            {"pod_name": "definitely-not-a-real-pod-zzz", "namespace": "kube-system"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_deployment_list_against_k3s_kube_system(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.deployment.list -n kube-system`` returns the bootstrap deployments.
+
+    k3s ships coredns + metrics-server + local-path-provisioner +
+    traefik as deployments in ``kube-system``; this assertion is
+    existential (at least one) for k3s-minor drift tolerance.
+    """
+    connector, target = k3s_connector
+    result = await connector.k8s_deployment_list(target, {"namespace": "kube-system"})
+    assert result["total"] >= 1
+    sample = result["rows"][0]
+    for key in (
+        "name",
+        "namespace",
+        "replicas_desired",
+        "replicas_ready",
+        "replicas_available",
+        "image",
+        "age_seconds",
+        "strategy",
+    ):
+        assert key in sample
+    assert sample["namespace"] == "kube-system"
+
+
+@pytest.mark.asyncio
+async def test_deployment_info_against_k3s_returns_full_detail(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``k8s.deployment.info`` returns the full template + status block."""
+    connector, target = k3s_connector
+    listing = await connector.k8s_deployment_list(target, {"namespace": "kube-system"})
+    assert listing["total"] >= 1
+    dep_name = listing["rows"][0]["name"]
+    info = await connector.k8s_deployment_info(
+        target, {"deployment_name": dep_name, "namespace": "kube-system"}
+    )
+    assert info["name"] == dep_name
+    assert info["namespace"] == "kube-system"
+    assert "status" in info
+    assert "containers" in info
+    assert len(info["containers"]) >= 1

--- a/backend/tests/test_connectors_k8s_auth.py
+++ b/backend/tests/test_connectors_k8s_auth.py
@@ -373,11 +373,13 @@ async def test_execute_returns_unknown_op_for_every_op_id() -> None:
     """Unknown op_ids surface the dispatcher's structured ``unknown_op`` shape.
 
     Post-G0.6 (#391) the connector's ``execute`` is a thin shim that
-    delegates to a global ``endpoint_descriptor`` lookup; an op_id that
-    nothing registered (here ``k8s.pod.list``, which T2-T5 of #320 will
-    land) hits :func:`~meho_backplane.operations._errors.result_unknown_op`
-    and returns the dispatcher's canonical error envelope rather than
-    the pre-refactor hard-coded ``{"known_ops": []}`` shape.
+    delegates to a global ``endpoint_descriptor`` lookup; this test
+    never calls ``register_operations()``, so the DB row set is empty
+    and any op_id -- including ones T3+ have since registered
+    elsewhere -- hits
+    :func:`~meho_backplane.operations._errors.result_unknown_op` and
+    returns the dispatcher's canonical error envelope rather than the
+    pre-refactor hard-coded ``{"known_ops": []}`` shape.
     """
     connector = _make_connector_with_stub_kubeconfig()
     result = await connector.execute(_TARGET_A, "k8s.pod.list", {"namespace": "argocd"})

--- a/backend/tests/test_connectors_k8s_core.py
+++ b/backend/tests/test_connectors_k8s_core.py
@@ -658,14 +658,18 @@ async def test_k8s_ls_namespace_kind_with_rbac_403_records_error() -> None:
 
 @pytest.mark.asyncio
 async def test_k8s_ls_namespace_kind_forwards_to_unknown_op_envelope() -> None:
-    """Kinds whose ``list`` op isn't registered come back as ``unknown_op`` via the shim."""
-    # ``k8s.pod.list`` isn't registered (T3 ships it). The shim returns the
-    # dispatcher's structured ``unknown_op`` envelope; the forwarder
-    # surfaces it verbatim under ``result``.
+    """Kinds whose ``list`` op isn't registered come back as ``unknown_op`` via the shim.
+
+    Pinned against a kind the registered surface deliberately does not
+    cover (``services`` ships under G3.2-T4 #324). T3 (#323) brought
+    ``k8s.pod.list`` and ``k8s.deployment.list`` into the registered
+    set, so the original ``/argocd/pods`` probe now resolves to a real
+    handler -- using ``services`` instead keeps the test pinned on the
+    unknown-op shape until T4 lands its own coverage.
+    """
     from meho_backplane.operations import typed_register as tr_module
 
     connector = _make_connector()
-    # Register only the T2 surface so the descriptor lookup is deterministic.
     with patch.object(
         tr_module,
         "encode_endpoint_text",
@@ -673,11 +677,10 @@ async def test_k8s_ls_namespace_kind_forwards_to_unknown_op_envelope() -> None:
     ):
         await KubernetesConnector.register_operations()
 
-    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/pods"})
+    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/services"})
 
-    assert result["path"] == "/argocd/pods"
-    assert result["forwarded_to"] == "k8s.pod.list"
-    # The shim's ``unknown_op`` envelope -- serialised via ``model_dump(mode='json')``.
+    assert result["path"] == "/argocd/services"
+    assert result["forwarded_to"] == "k8s.service.list"
     inner = result["result"]
     assert inner["status"] == "error"
     assert inner["error"].startswith("unknown_op:")
@@ -686,7 +689,12 @@ async def test_k8s_ls_namespace_kind_forwards_to_unknown_op_envelope() -> None:
 
 @pytest.mark.asyncio
 async def test_k8s_ls_path_with_extra_segments_collapses_to_two_arg_forward() -> None:
-    """``k8s.ls /ns/kind/extra`` collapses to the ``/ns/kind`` forwarder shape."""
+    """``k8s.ls /ns/kind/extra`` collapses to the ``/ns/kind`` forwarder shape.
+
+    Uses ``services`` (still unshipped post-T3) so the inner result is
+    the deterministic ``unknown_op`` envelope; the assertion target is
+    the canonical 2-segment collapse, not the sub-op's success.
+    """
     from meho_backplane.operations import typed_register as tr_module
 
     connector = _make_connector()
@@ -697,10 +705,10 @@ async def test_k8s_ls_path_with_extra_segments_collapses_to_two_arg_forward() ->
     ):
         await KubernetesConnector.register_operations()
 
-    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/pods/extra/segments"})
-    assert result["forwarded_to"] == "k8s.pod.list"
+    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/services/extra/segments"})
+    assert result["forwarded_to"] == "k8s.service.list"
     # The path retained is the canonical 2-segment shape.
-    assert result["path"] == "/argocd/pods"
+    assert result["path"] == "/argocd/services"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_k8s_workload.py
+++ b/backend/tests/test_connectors_k8s_workload.py
@@ -1,0 +1,985 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the G3.2-T3 (#323) K8s workload ops.
+
+Coverage matrix (per Issue #323 acceptance criteria):
+
+* :data:`KUBERNETES_OPS` exposes the four new workload ops alongside
+  the existing T1 / T2 / T5 surface; ``register_operations`` would land
+  all rows in ``endpoint_descriptor``.
+* :meth:`KubernetesConnector.k8s_pod_list` happy-path + cluster-wide
+  + label-selector + field-selector + server-side pagination
+  (``limit`` + ``continue_token`` + ``next_continue`` round-trip).
+* :meth:`KubernetesConnector.k8s_pod_info` exact-match resolution +
+  unique-prefix resolution + ambiguous-prefix error + not-found error.
+* :meth:`KubernetesConnector.k8s_deployment_list` mirrors pod-list
+  pagination shape against ``AppsV1Api``.
+* :meth:`KubernetesConnector.k8s_deployment_info` prefix-resolution
+  + status block + conditions list.
+* Pure helpers (:func:`pod_row`, :func:`pod_info`, :func:`deployment_row`,
+  :func:`deployment_info`, :func:`pod_ready_string`,
+  :func:`container_status_row`) pinned against synthetic Kubernetes
+  model objects.
+
+The k3d integration shape lives in
+:mod:`tests.integration.test_connectors_k8s_k3d`; this module
+exercises the same contract with mocked
+``kubernetes_asyncio.client.CoreV1Api`` / ``AppsV1Api`` so the gate
+runs in every CI lane regardless of Docker availability.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kubernetes_asyncio.client.models import (
+    V1Container,
+    V1ContainerPort,
+    V1ContainerState,
+    V1ContainerStateRunning,
+    V1ContainerStateTerminated,
+    V1ContainerStateWaiting,
+    V1ContainerStatus,
+    V1Deployment,
+    V1DeploymentCondition,
+    V1DeploymentList,
+    V1DeploymentSpec,
+    V1DeploymentStatus,
+    V1DeploymentStrategy,
+    V1EnvVar,
+    V1LabelSelector,
+    V1ListMeta,
+    V1ObjectMeta,
+    V1Pod,
+    V1PodCondition,
+    V1PodList,
+    V1PodSpec,
+    V1PodStatus,
+    V1PodTemplateSpec,
+    V1ResourceRequirements,
+    V1RollingUpdateDeployment,
+    V1Volume,
+    V1VolumeMount,
+)
+
+from meho_backplane.connectors.kubernetes import (
+    KUBERNETES_OPS,
+    KubernetesConnector,
+    KubernetesTargetLike,
+)
+from meho_backplane.connectors.kubernetes.ops_workload import (
+    WORKLOAD_OPS,
+    AmbiguousPrefixError,
+    WorkloadNotFoundError,
+    container_status_row,
+    deployment_info,
+    deployment_row,
+    pod_info,
+    pod_ready_string,
+    pod_row,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector,
+    register_connector_v2,
+)
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Settings + registry fixtures (mirror test_connectors_k8s_core.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for the DB-touching path."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_kubernetes_registry() -> Iterator[None]:
+    """Re-register :class:`KubernetesConnector` between tests.
+
+    A prior test's autouse ``clear_registry()`` strips the K8s entries
+    that ``connectors/kubernetes/__init__.py`` set; restore them so the
+    dispatcher can resolve the connector during any forwarding tests.
+    """
+    clear_registry()
+    register_connector("k8s", KubernetesConnector)
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="kubernetes-asyncio",
+        cls=KubernetesConnector,
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Target + connector stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="rke2-meho",
+    host="rke2-meho.test.invalid",
+    port=6443,
+    secret_ref="kv/data/k8s/rke2-meho",
+)
+
+
+def _stub_kubeconfig() -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://k8s.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "stub-token"}}],
+    }
+
+
+def _make_connector() -> KubernetesConnector:
+    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+        return _stub_kubeconfig()
+
+    return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic K8s model builders
+# ---------------------------------------------------------------------------
+
+
+def _make_container_status(
+    *,
+    name: str,
+    ready: bool = True,
+    restart_count: int = 0,
+    state_label: str = "running",
+) -> V1ContainerStatus:
+    state_map = {
+        "running": V1ContainerState(running=V1ContainerStateRunning(started_at=None)),
+        "waiting": V1ContainerState(waiting=V1ContainerStateWaiting(reason="ContainerCreating")),
+        "terminated": V1ContainerState(
+            terminated=V1ContainerStateTerminated(exit_code=0, reason="Completed")
+        ),
+    }
+    return V1ContainerStatus(
+        name=name,
+        image=f"{name}:1.0",
+        image_id="sha256:abcdef",
+        ready=ready,
+        restart_count=restart_count,
+        state=state_map[state_label],
+    )
+
+
+def _make_pod(
+    *,
+    name: str,
+    namespace: str = "default",
+    phase: str = "Running",
+    containers: list[str] | None = None,
+    container_statuses: list[V1ContainerStatus] | None = None,
+    pod_ip: str | None = "10.0.0.1",
+    host_ip: str | None = "192.168.1.1",
+    node_name: str | None = "node-1",
+    qos_class: str = "Guaranteed",
+    created: datetime | None = None,
+    labels: dict[str, str] | None = None,
+    init_containers: list[str] | None = None,
+    volumes: list[str] | None = None,
+) -> V1Pod:
+    container_names = containers if containers is not None else [name]
+    container_objs = [V1Container(name=c, image=f"{c}:1.0") for c in container_names]
+    init_objs = [V1Container(name=c, image=f"{c}:init") for c in (init_containers or [])]
+    volume_objs = [V1Volume(name=v) for v in (volumes or [])]
+    statuses = container_statuses
+    if statuses is None:
+        statuses = [_make_container_status(name=c) for c in container_names]
+    return V1Pod(
+        metadata=V1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            creation_timestamp=created,
+            labels=labels,
+        ),
+        spec=V1PodSpec(
+            containers=container_objs,
+            init_containers=init_objs,
+            volumes=volume_objs,
+            node_name=node_name,
+        ),
+        status=V1PodStatus(
+            phase=phase,
+            container_statuses=statuses,
+            init_container_statuses=[],
+            conditions=[V1PodCondition(type="Ready", status="True")],
+            pod_ip=pod_ip,
+            host_ip=host_ip,
+            qos_class=qos_class,
+        ),
+    )
+
+
+def _make_deployment(
+    *,
+    name: str,
+    namespace: str = "default",
+    replicas_desired: int = 3,
+    replicas_ready: int = 3,
+    replicas_available: int = 3,
+    image: str = "nginx:1.25",
+    strategy_type: str = "RollingUpdate",
+    rolling_max_surge: str | None = "25%",
+    rolling_max_unavailable: str | None = "25%",
+    created: datetime | None = None,
+    labels: dict[str, str] | None = None,
+    conditions: list[V1DeploymentCondition] | None = None,
+) -> V1Deployment:
+    template = V1PodTemplateSpec(
+        metadata=V1ObjectMeta(labels={"app": name}),
+        spec=V1PodSpec(containers=[V1Container(name="app", image=image)]),
+    )
+    rolling = None
+    if strategy_type == "RollingUpdate":
+        rolling = V1RollingUpdateDeployment(
+            max_surge=rolling_max_surge,
+            max_unavailable=rolling_max_unavailable,
+        )
+    strategy = V1DeploymentStrategy(type=strategy_type, rolling_update=rolling)
+    return V1Deployment(
+        metadata=V1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            creation_timestamp=created,
+            labels=labels,
+        ),
+        spec=V1DeploymentSpec(
+            replicas=replicas_desired,
+            strategy=strategy,
+            selector=V1LabelSelector(match_labels={"app": name}),
+            template=template,
+        ),
+        status=V1DeploymentStatus(
+            replicas=replicas_desired,
+            ready_replicas=replicas_ready,
+            available_replicas=replicas_available,
+            updated_replicas=replicas_desired,
+            unavailable_replicas=max(replicas_desired - replicas_available, 0),
+            observed_generation=1,
+            conditions=conditions or [],
+        ),
+    )
+
+
+def _pod_list(pods: list[V1Pod], continue_token: str | None = None) -> V1PodList:
+    return V1PodList(items=pods, metadata=V1ListMeta(_continue=continue_token))
+
+
+def _deployment_list(
+    deps: list[V1Deployment], continue_token: str | None = None
+) -> V1DeploymentList:
+    return V1DeploymentList(items=deps, metadata=V1ListMeta(_continue=continue_token))
+
+
+def _patch_kubeconfig() -> Any:
+    """Patch the kubeconfig client builder so the connector's cache wires up."""
+    return patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new_callable=AsyncMock,
+        return_value=MagicMock(close=AsyncMock()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_workload_ops_in_kubernetes_ops_tuple() -> None:
+    """``KUBERNETES_OPS`` exposes the four T3 workload ops alongside the rest."""
+    op_ids = {op.op_id for op in KUBERNETES_OPS}
+    assert "k8s.pod.list" in op_ids
+    assert "k8s.pod.info" in op_ids
+    assert "k8s.deployment.list" in op_ids
+    assert "k8s.deployment.info" in op_ids
+
+
+def test_workload_ops_metadata_shape() -> None:
+    """Every workload op is safe / no-approval / read-only / group=workload."""
+    by_id = {op.op_id: op for op in WORKLOAD_OPS}
+    for op_id in (
+        "k8s.pod.list",
+        "k8s.pod.info",
+        "k8s.deployment.list",
+        "k8s.deployment.info",
+    ):
+        op = by_id[op_id]
+        assert op.safety_level == "safe"
+        assert op.requires_approval is False
+        assert "read-only" in op.tags
+        assert op.group_key == "workload"
+        assert op.llm_instructions is not None
+
+
+def test_workload_handler_attrs_resolve_to_async_methods() -> None:
+    """Every workload op's ``handler_attr`` points at an async method on the connector."""
+    import inspect
+
+    for op in WORKLOAD_OPS:
+        method = getattr(KubernetesConnector, op.handler_attr, None)
+        assert method is not None, f"{op.op_id!r} declares missing handler {op.handler_attr!r}"
+        assert inspect.iscoroutinefunction(method), (
+            f"handler {op.handler_attr!r} for {op.op_id!r} must be ``async def``"
+        )
+
+
+def test_list_schemas_enforce_namespace_xor_all_namespaces() -> None:
+    """Schema requires exactly one of {namespace, all_namespaces=true}."""
+    from jsonschema import Draft202012Validator
+
+    for op in WORKLOAD_OPS:
+        if op.op_id not in {"k8s.pod.list", "k8s.deployment.list"}:
+            continue
+        validator = Draft202012Validator(op.parameter_schema)
+        # Valid: namespace alone.
+        assert validator.is_valid({"namespace": "argocd"})
+        # Valid: all_namespaces=true alone.
+        assert validator.is_valid({"all_namespaces": True})
+        # Invalid: neither.
+        assert not validator.is_valid({})
+        # Invalid: both, with all_namespaces=true (conflict).
+        assert not validator.is_valid({"namespace": "argocd", "all_namespaces": True})
+        # Valid: both, with all_namespaces=false (effectively just namespace).
+        assert validator.is_valid({"namespace": "argocd", "all_namespaces": False})
+
+
+def test_info_schemas_require_name_and_namespace() -> None:
+    """Schema rejects empty name / namespace inputs."""
+    from jsonschema import Draft202012Validator
+
+    pod_info_op = next(op for op in WORKLOAD_OPS if op.op_id == "k8s.pod.info")
+    validator = Draft202012Validator(pod_info_op.parameter_schema)
+    assert validator.is_valid({"pod_name": "argocd-server", "namespace": "argocd"})
+    assert not validator.is_valid({"pod_name": "argocd-server"})  # missing namespace
+    assert not validator.is_valid({"namespace": "argocd"})  # missing pod_name
+    assert not validator.is_valid({"pod_name": "", "namespace": "argocd"})  # empty pod_name
+
+
+# ---------------------------------------------------------------------------
+# Pure row-shape helpers -- pod
+# ---------------------------------------------------------------------------
+
+
+def test_pod_ready_string_x_over_y_excluding_init() -> None:
+    """``ready`` column counts main containers only, like kubectl."""
+    pod = _make_pod(
+        name="multi",
+        containers=["app", "sidecar"],
+        container_statuses=[
+            _make_container_status(name="app", ready=True),
+            _make_container_status(name="sidecar", ready=False),
+        ],
+        init_containers=["init-1"],
+    )
+    assert pod_ready_string(pod) == "1/2"
+
+
+def test_pod_row_projects_full_shape() -> None:
+    """The row dict carries every operator-facing list column."""
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    pod = _make_pod(
+        name="argocd-server-x7r2k",
+        namespace="argocd",
+        phase="Running",
+        containers=["argocd-server"],
+        container_statuses=[
+            _make_container_status(name="argocd-server", ready=True, restart_count=2)
+        ],
+        pod_ip="10.42.1.23",
+        node_name="rke2-meho-01",
+        created=now - timedelta(seconds=86400),
+    )
+    row = pod_row(pod, now=now)
+    assert row == {
+        "name": "argocd-server-x7r2k",
+        "namespace": "argocd",
+        "status": "Running",
+        "ready": "1/1",
+        "restarts": 2,
+        "age_seconds": 86400,
+        "node": "rke2-meho-01",
+        "ip": "10.42.1.23",
+    }
+
+
+def test_pod_row_pending_pod_with_nil_node_and_ip() -> None:
+    """A Pending pod with no scheduled node / IP surfaces ``None`` not crashes."""
+    pod = _make_pod(
+        name="pending",
+        phase="Pending",
+        node_name=None,
+        pod_ip=None,
+        container_statuses=[],
+    )
+    row = pod_row(pod)
+    assert row["status"] == "Pending"
+    assert row["node"] is None
+    assert row["ip"] is None
+    assert row["ready"] == "0/1"
+    assert row["restarts"] == 0
+
+
+def test_container_status_row_picks_state_branch() -> None:
+    """The state label is the populated union branch's key."""
+    cs_running = _make_container_status(name="app", state_label="running")
+    cs_waiting = _make_container_status(name="app", state_label="waiting")
+    cs_terminated = _make_container_status(name="app", state_label="terminated")
+    assert container_status_row(cs_running)["state"] == "running"
+    assert container_status_row(cs_waiting)["state"] == "waiting"
+    assert container_status_row(cs_terminated)["state"] == "terminated"
+
+
+def test_pod_info_carries_per_container_statuses_and_volumes() -> None:
+    """``pod_info`` projects spec + status + container statuses + volumes."""
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    pod = V1Pod(
+        metadata=V1ObjectMeta(
+            name="argocd-server-x",
+            namespace="argocd",
+            creation_timestamp=now - timedelta(seconds=60),
+            labels={"app": "argocd-server"},
+        ),
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="argocd-server",
+                    image="argocd:1.0",
+                    ports=[V1ContainerPort(name="http", container_port=8080, protocol="TCP")],
+                    env=[V1EnvVar(name="LOG_LEVEL", value="info")],
+                    resources=V1ResourceRequirements(
+                        requests={"cpu": "100m"}, limits={"cpu": "500m"}
+                    ),
+                    volume_mounts=[V1VolumeMount(name="cfg", mount_path="/etc/argocd")],
+                )
+            ],
+            init_containers=[V1Container(name="init-cfg", image="busybox")],
+            volumes=[V1Volume(name="cfg")],
+            node_name="rke2-meho-01",
+        ),
+        status=V1PodStatus(
+            phase="Running",
+            pod_ip="10.0.0.5",
+            host_ip="192.168.1.1",
+            qos_class="Burstable",
+            container_statuses=[
+                _make_container_status(name="argocd-server", ready=True, restart_count=1)
+            ],
+            init_container_statuses=[
+                _make_container_status(name="init-cfg", state_label="terminated")
+            ],
+            conditions=[V1PodCondition(type="Ready", status="True")],
+        ),
+    )
+
+    info = pod_info(pod, now=now)
+    assert info["name"] == "argocd-server-x"
+    assert info["namespace"] == "argocd"
+    assert info["status"] == "Running"
+    assert info["node"] == "rke2-meho-01"
+    assert info["ip"] == "10.0.0.5"
+    assert info["qos_class"] == "Burstable"
+    assert info["age_seconds"] == 60
+    assert len(info["containers"]) == 1
+    container = info["containers"][0]
+    assert container["name"] == "argocd-server"
+    assert container["ports"][0]["container_port"] == 8080
+    assert container["env"][0] == {"name": "LOG_LEVEL", "value": "info"}
+    assert container["resources"]["limits"]["cpu"] == "500m"
+    assert container["volume_mounts"][0]["mount_path"] == "/etc/argocd"
+    assert len(info["init_containers"]) == 1
+    assert info["init_containers"][0]["name"] == "init-cfg"
+    assert info["volumes"][0]["name"] == "cfg"
+    assert info["container_statuses"][0]["ready"] is True
+    assert info["container_statuses"][0]["restart_count"] == 1
+    assert info["init_container_statuses"][0]["state"] == "terminated"
+    assert info["conditions"][0]["type"] == "Ready"
+
+
+# ---------------------------------------------------------------------------
+# Pure row-shape helpers -- deployment
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_row_projects_full_shape() -> None:
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    dep = _make_deployment(
+        name="argocd-server",
+        namespace="argocd",
+        replicas_desired=3,
+        replicas_ready=2,
+        replicas_available=2,
+        image="argocd:1.2",
+        created=now - timedelta(seconds=3600),
+    )
+    row = deployment_row(dep, now=now)
+    assert row == {
+        "name": "argocd-server",
+        "namespace": "argocd",
+        "replicas_desired": 3,
+        "replicas_ready": 2,
+        "replicas_available": 2,
+        "image": "argocd:1.2",
+        "age_seconds": 3600,
+        "strategy": "RollingUpdate",
+    }
+
+
+def test_deployment_row_zero_replica_fields_default_to_int_zero() -> None:
+    """A brand-new deployment with no observed replicas yet reports 0, not None."""
+    dep = V1Deployment(
+        metadata=V1ObjectMeta(name="fresh", namespace="default"),
+        spec=V1DeploymentSpec(
+            replicas=3,
+            selector=V1LabelSelector(match_labels={"app": "fresh"}),
+            template=V1PodTemplateSpec(
+                metadata=V1ObjectMeta(labels={"app": "fresh"}),
+                spec=V1PodSpec(containers=[V1Container(name="app", image="img:1")]),
+            ),
+        ),
+        status=V1DeploymentStatus(),  # all None
+    )
+    row = deployment_row(dep)
+    assert row["replicas_desired"] == 3
+    assert row["replicas_ready"] == 0
+    assert row["replicas_available"] == 0
+    assert row["strategy"] is None
+
+
+def test_deployment_info_carries_status_block_and_conditions() -> None:
+    now = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    cond = V1DeploymentCondition(
+        type="Available",
+        status="True",
+        reason="MinimumReplicasAvailable",
+        message="Deployment has minimum availability.",
+    )
+    dep = _make_deployment(
+        name="argocd-server",
+        namespace="argocd",
+        replicas_desired=3,
+        replicas_ready=3,
+        replicas_available=3,
+        image="argocd:1.2",
+        created=now - timedelta(seconds=120),
+        labels={"app": "argocd-server"},
+        conditions=[cond],
+    )
+    info = deployment_info(dep, now=now)
+    assert info["name"] == "argocd-server"
+    assert info["namespace"] == "argocd"
+    assert info["replicas_desired"] == 3
+    assert info["age_seconds"] == 120
+    assert info["labels"] == {"app": "argocd-server"}
+    assert info["strategy"]["type"] == "RollingUpdate"
+    assert info["strategy"]["rolling_update"]["max_surge"] == "25%"
+    assert info["containers"][0]["image"] == "argocd:1.2"
+    assert info["status"]["replicas"] == 3
+    assert info["status"]["ready_replicas"] == 3
+    assert info["status"]["available_replicas"] == 3
+    assert info["status"]["updated_replicas"] == 3
+    assert info["status"]["observed_generation"] == 1
+    assert info["conditions"][0]["type"] == "Available"
+    assert info["conditions"][0]["reason"] == "MinimumReplicasAvailable"
+
+
+# ---------------------------------------------------------------------------
+# k8s.pod.list handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_list_returns_rows_and_total() -> None:
+    """Handler wraps ``list_namespaced_pod`` and projects each row through ``pod_row``."""
+    pods = [
+        _make_pod(name="argocd-server-x", namespace="argocd"),
+        _make_pod(name="argocd-repo-y", namespace="argocd"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list(pods))
+        result = await connector.k8s_pod_list(_TARGET, {"namespace": "argocd"})
+
+    assert result["total"] == 2
+    assert {row["name"] for row in result["rows"]} == {"argocd-server-x", "argocd-repo-y"}
+    assert "next_continue" not in result
+    core_v1_cls.return_value.list_namespaced_pod.assert_awaited_once()
+    kwargs = core_v1_cls.return_value.list_namespaced_pod.call_args.kwargs
+    assert kwargs["namespace"] == "argocd"
+    assert "label_selector" not in kwargs
+    assert "limit" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_list_all_namespaces_uses_for_all_namespaces() -> None:
+    """``all_namespaces=true`` routes through ``list_pod_for_all_namespaces``."""
+    pods = [
+        _make_pod(name="p1", namespace="argocd"),
+        _make_pod(name="p2", namespace="kube-system"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_pod_for_all_namespaces = AsyncMock(
+            return_value=_pod_list(pods)
+        )
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock()
+        result = await connector.k8s_pod_list(_TARGET, {"all_namespaces": True})
+
+    assert result["total"] == 2
+    core_v1_cls.return_value.list_pod_for_all_namespaces.assert_awaited_once()
+    core_v1_cls.return_value.list_namespaced_pod.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_list_label_selector_flows_through() -> None:
+    """``label_selector`` forwards to the API as ``label_selector=...``."""
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([]))
+        await connector.k8s_pod_list(
+            _TARGET, {"namespace": "argocd", "label_selector": "app=argocd-server"}
+        )
+    kwargs = core_v1_cls.return_value.list_namespaced_pod.call_args.kwargs
+    assert kwargs["label_selector"] == "app=argocd-server"
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_list_field_selector_flows_through() -> None:
+    """``field_selector`` forwards verbatim to the API."""
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([]))
+        await connector.k8s_pod_list(
+            _TARGET, {"namespace": "argocd", "field_selector": "status.phase=Running"}
+        )
+    kwargs = core_v1_cls.return_value.list_namespaced_pod.call_args.kwargs
+    assert kwargs["field_selector"] == "status.phase=Running"
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_list_server_side_pagination_returns_next_continue() -> None:
+    """``limit=N`` + server continuation produces ``next_continue`` in the result."""
+    pods = [_make_pod(name=f"p{i}", namespace="argocd") for i in range(5)]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(
+            return_value=_pod_list(pods, continue_token="page-2")
+        )
+        result = await connector.k8s_pod_list(_TARGET, {"namespace": "argocd", "limit": 5})
+
+    assert result["total"] == 5
+    assert result["next_continue"] == "page-2"
+    kwargs = core_v1_cls.return_value.list_namespaced_pod.call_args.kwargs
+    assert kwargs["limit"] == 5
+    assert "_continue" not in kwargs  # no token passed in the request
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_list_continue_token_passed_to_api_as_underscore_continue() -> None:
+    """Operator's ``continue_token`` maps to ``_continue=`` on the API call."""
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([]))
+        await connector.k8s_pod_list(_TARGET, {"namespace": "argocd", "continue_token": "abc123"})
+    kwargs = core_v1_cls.return_value.list_namespaced_pod.call_args.kwargs
+    assert kwargs["_continue"] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_list_omits_next_continue_when_no_more_pages() -> None:
+    """When the server returns no continuation token, the key is omitted."""
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(
+            return_value=_pod_list([_make_pod(name="solo", namespace="argocd")])
+        )
+        result = await connector.k8s_pod_list(_TARGET, {"namespace": "argocd"})
+    assert "next_continue" not in result
+
+
+# ---------------------------------------------------------------------------
+# k8s.pod.info handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_info_exact_match_returns_full_detail() -> None:
+    """An exact name match returns the full info dict without a second round-trip."""
+    pod = _make_pod(name="argocd-server", namespace="argocd")
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([pod]))
+        result = await connector.k8s_pod_info(
+            _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
+        )
+    assert result["name"] == "argocd-server"
+    assert result["namespace"] == "argocd"
+    assert "containers" in result
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_info_unique_prefix_resolves_to_one_pod() -> None:
+    """A prefix that matches exactly one pod resolves to it."""
+    pods = [
+        _make_pod(name="argocd-server-7c4b8d-x7r2k", namespace="argocd"),
+        _make_pod(name="argocd-repo-abc", namespace="argocd"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list(pods))
+        result = await connector.k8s_pod_info(
+            _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
+        )
+    assert result["name"] == "argocd-server-7c4b8d-x7r2k"
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_info_ambiguous_prefix_raises() -> None:
+    """A prefix matching multiple pods raises with the candidate list."""
+    pods = [
+        _make_pod(name="api-1", namespace="argocd"),
+        _make_pod(name="api-2", namespace="argocd"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list(pods))
+        with pytest.raises(AmbiguousPrefixError) as exc:
+            await connector.k8s_pod_info(_TARGET, {"pod_name": "api", "namespace": "argocd"})
+    assert exc.value.candidates == ["api-1", "api-2"]
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_info_not_found_raises() -> None:
+    """A name matching nothing raises :class:`WorkloadNotFoundError`."""
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([]))
+        with pytest.raises(WorkloadNotFoundError):
+            await connector.k8s_pod_info(_TARGET, {"pod_name": "ghost", "namespace": "argocd"})
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_info_exact_match_wins_over_prefix() -> None:
+    """``foo-bar`` resolves to the exact-named pod even when ``foo-bar-x`` also exists."""
+    pods = [
+        _make_pod(name="api-1", namespace="argocd"),
+        _make_pod(name="api-1-replica", namespace="argocd"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
+    ):
+        core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list(pods))
+        result = await connector.k8s_pod_info(_TARGET, {"pod_name": "api-1", "namespace": "argocd"})
+    assert result["name"] == "api-1"
+
+
+# ---------------------------------------------------------------------------
+# k8s.deployment.list handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_list_returns_rows_and_total() -> None:
+    deps = [
+        _make_deployment(name="argocd-server", namespace="argocd"),
+        _make_deployment(name="argocd-repo-server", namespace="argocd"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.AppsV1Api") as apps_v1_cls,
+    ):
+        apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock(
+            return_value=_deployment_list(deps)
+        )
+        result = await connector.k8s_deployment_list(_TARGET, {"namespace": "argocd"})
+
+    assert result["total"] == 2
+    names = {row["name"] for row in result["rows"]}
+    assert names == {"argocd-server", "argocd-repo-server"}
+    assert "next_continue" not in result
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_list_all_namespaces_routes_to_all_namespaces_api() -> None:
+    deps = [
+        _make_deployment(name="d1", namespace="argocd"),
+        _make_deployment(name="d2", namespace="kube-system"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.AppsV1Api") as apps_v1_cls,
+    ):
+        apps_v1_cls.return_value.list_deployment_for_all_namespaces = AsyncMock(
+            return_value=_deployment_list(deps)
+        )
+        apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock()
+        result = await connector.k8s_deployment_list(_TARGET, {"all_namespaces": True})
+    assert result["total"] == 2
+    apps_v1_cls.return_value.list_deployment_for_all_namespaces.assert_awaited_once()
+    apps_v1_cls.return_value.list_namespaced_deployment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_list_pagination_returns_next_continue() -> None:
+    deps = [_make_deployment(name=f"d{i}", namespace="argocd") for i in range(3)]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.AppsV1Api") as apps_v1_cls,
+    ):
+        apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock(
+            return_value=_deployment_list(deps, continue_token="page-2")
+        )
+        result = await connector.k8s_deployment_list(_TARGET, {"namespace": "argocd", "limit": 3})
+    assert result["next_continue"] == "page-2"
+    kwargs = apps_v1_cls.return_value.list_namespaced_deployment.call_args.kwargs
+    assert kwargs["limit"] == 3
+
+
+# ---------------------------------------------------------------------------
+# k8s.deployment.info handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_info_exact_match_returns_full_detail() -> None:
+    dep = _make_deployment(name="argocd-server", namespace="argocd")
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.AppsV1Api") as apps_v1_cls,
+    ):
+        apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock(
+            return_value=_deployment_list([dep])
+        )
+        result = await connector.k8s_deployment_info(
+            _TARGET, {"deployment_name": "argocd-server", "namespace": "argocd"}
+        )
+    assert result["name"] == "argocd-server"
+    assert result["status"]["replicas"] == 3
+    assert result["strategy"]["type"] == "RollingUpdate"
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_info_prefix_resolves_to_one_deployment() -> None:
+    deps = [
+        _make_deployment(name="argocd-server", namespace="argocd"),
+        _make_deployment(name="argocd-redis", namespace="argocd"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.AppsV1Api") as apps_v1_cls,
+    ):
+        apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock(
+            return_value=_deployment_list(deps)
+        )
+        result = await connector.k8s_deployment_info(
+            _TARGET, {"deployment_name": "argocd-serv", "namespace": "argocd"}
+        )
+    assert result["name"] == "argocd-server"
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_info_ambiguous_prefix_raises() -> None:
+    deps = [
+        _make_deployment(name="api-1", namespace="argocd"),
+        _make_deployment(name="api-2", namespace="argocd"),
+    ]
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.AppsV1Api") as apps_v1_cls,
+    ):
+        apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock(
+            return_value=_deployment_list(deps)
+        )
+        with pytest.raises(AmbiguousPrefixError) as exc:
+            await connector.k8s_deployment_info(
+                _TARGET, {"deployment_name": "api", "namespace": "argocd"}
+            )
+    assert exc.value.candidates == ["api-1", "api-2"]
+
+
+@pytest.mark.asyncio
+async def test_k8s_deployment_info_not_found_raises() -> None:
+    connector = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_workload.client.AppsV1Api") as apps_v1_cls,
+    ):
+        apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock(
+            return_value=_deployment_list([])
+        )
+        with pytest.raises(WorkloadNotFoundError):
+            await connector.k8s_deployment_info(
+                _TARGET, {"deployment_name": "ghost", "namespace": "argocd"}
+            )

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -28,13 +28,25 @@ Source: `backend/src/meho_backplane/connectors/kubernetes/`.
 - **Op metadata** (`ops.py`) -- the `KubernetesOp` dataclass plus the
   `KUBERNETES_OPS` tuple the connector's `register_operations` walks
   at startup. The tuple merges `k8s.about` (T1's canary, refactored
-  through G0.6) with the T2 inventory ops imported from `ops_core.py`.
+  through G0.6), the T2 inventory ops (from `ops_core.py`), the T3
+  workload ops (from `ops_workload.py`), and the T5 logs op (from
+  `ops_logs.py`).
 - **Core inventory helpers** (`ops_core.py`) -- pure mapping helpers
   (`namespace_row`, `node_row`, `taint_row`, `age_seconds`) plus the
   `CORE_OPS` registration rows for `k8s.ls` / `k8s.namespace.list` /
   `k8s.node.list`. Helpers stay pure-function so the unit suite can pin
   the wire shape against synthetic `V1Namespace` / `V1Node` model
   instances without booting an event loop.
+- **Workload helpers** (`ops_workload.py`) -- pure row mappers
+  (`pod_row`, `pod_info`, `deployment_row`, `deployment_info`,
+  `container_status_row`, `pod_ready_string`) plus the prefix
+  resolvers (`resolve_pod_name`, `resolve_deployment_name`) and the
+  `WORKLOAD_OPS` registration rows for `k8s.pod.{list,info}` and
+  `k8s.deployment.{list,info}`. Two structured errors
+  (`WorkloadNotFoundError`, `AmbiguousPrefixError`) drive the
+  prefix-resolution UX: ambiguous matches surface the candidate list
+  through the dispatcher's `connector_error` envelope so callers can
+  render a "did-you-mean" hint.
 - **`KubernetesTargetLike`** (`kubeconfig.py`) -- runtime-checkable
   Protocol capturing the minimum target shape the connector reads:
   `name`, `host`, `port`, `secret_ref`. Replaced by the concrete
@@ -47,16 +59,64 @@ Source: `backend/src/meho_backplane/connectors/kubernetes/`.
 
 ## Shipped op surface
 
-| op_id                | safety | description                                              |
-| -------------------- | ------ | -------------------------------------------------------- |
-| `k8s.about`          | safe   | Product / version / platform via `VersionApi.get_code`.  |
-| `k8s.ls`             | safe   | Synthetic walker: root / namespace / namespace+kind.     |
-| `k8s.namespace.list` | safe   | `CoreV1Api.list_namespace()` -- name / status / age.    |
-| `k8s.node.list`      | safe   | `CoreV1Api.list_node()` -- status / roles / version.    |
+| op_id                  | safety | description                                              |
+| ---------------------- | ------ | -------------------------------------------------------- |
+| `k8s.about`            | safe   | Product / version / platform via `VersionApi.get_code`.  |
+| `k8s.ls`               | safe   | Synthetic walker: root / namespace / namespace+kind.     |
+| `k8s.namespace.list`   | safe   | `CoreV1Api.list_namespace()` -- name / status / age.     |
+| `k8s.node.list`        | safe   | `CoreV1Api.list_node()` -- status / roles / version.     |
+| `k8s.pod.list`         | safe   | Pods with selectors + server-side pagination.            |
+| `k8s.pod.info`         | safe   | Full pod detail; exact name or unique prefix.            |
+| `k8s.deployment.list`  | safe   | Deployments with live replica counts + image + strategy. |
+| `k8s.deployment.info`  | safe   | Full deployment detail; exact name or unique prefix.     |
+| `k8s.logs`             | safe   | Non-streaming pod log fetch with 1 MiB body cap.         |
 
-T3 / T4 / T5 of Initiative #320 add the workload / network+config /
-logs surfaces against the same `KubernetesOp` -> `KUBERNETES_OPS` ->
-`register_operations` pattern.
+T4 of Initiative #320 still ships the network + config + events
+surfaces (`service` / `ingress` / `configmap` / `event`) against the
+same `KubernetesOp` -> `KUBERNETES_OPS` -> `register_operations`
+pattern.
+
+### Workload-op pagination (`k8s.pod.list` / `k8s.deployment.list`)
+
+The list handlers forward the standard k8s `label_selector` /
+`field_selector` / `limit` / `_continue` filter knobs to the API
+server so heavy-tenancy clusters can paginate server-side without
+streaming every row through the connector. The operator passes
+`limit=N` plus optional `continue_token=<cursor>` on each call; the
+response carries `next_continue` whenever the server signals more
+pages. Tokens are server-defined and expire after ~5-15 minutes; a
+stale token returns 410 ResourceExpired, and the handler propagates
+the API exception verbatim so the caller can restart without the
+token.
+
+`namespace` and `all_namespaces` are mutually exclusive in the
+schema's `oneOf` clause -- exactly one must be supplied. The
+`all_namespaces=true` path routes through
+`list_pod_for_all_namespaces` / `list_deployment_for_all_namespaces`;
+the per-namespace path uses the `_namespaced_` variants.
+
+### Workload-op prefix resolution (`k8s.pod.info` / `k8s.deployment.info`)
+
+Both `info` ops accept an exact name or a unique prefix within the
+namespace. Resolution shape (`_resolve_from_items` in `ops_workload.py`):
+
+1. Exact match wins -- `foo-bar` resolves to the literal `foo-bar`
+   pod even when `foo-bar-x` also exists.
+2. Otherwise the prefix matches collect into a candidate list.
+3. Zero candidates -> `WorkloadNotFoundError`.
+4. Multiple candidates -> `AmbiguousPrefixError` with the sorted
+   candidate list on `.candidates`. The dispatcher's
+   `connector_error` envelope carries the exception class name and
+   the args list, so the agent / CLI can render a "did-you-mean"
+   hint without parsing the error string.
+
+The resolver pages via `list_namespaced_pod` /
+`list_namespaced_deployment` without server-side pagination -- the
+operator-facing namespaces are typically O(10..100) objects which
+fits in one unpaginated response. Heavy-tenancy namespaces with
+hundreds of workload objects are not the prefix-resolver's target
+audience; the agent typically reaches them via the list path with
+explicit pagination.
 
 ## Control flow
 
@@ -175,12 +235,18 @@ just `len(rows)` because nothing reduces.
 
 - Parent Initiative: [#320 G3.2](https://github.com/evoila/meho/issues/320)
   -- `k8s-1.x kubernetes-asyncio` typed connector.
-- Predecessor Task: [#321 G3.2-T1](https://github.com/evoila/meho/issues/321)
-  -- `KubernetesConnector` skeleton (kubeconfig + fingerprint + probe).
-- This Task: [#322 G3.2-T2](https://github.com/evoila/meho/issues/322)
-  -- core inventory ops (`k8s.about` / `k8s.ls` /
-  `k8s.namespace.list` / `k8s.node.list`).
+- Predecessor Tasks:
+  - [#321 G3.2-T1](https://github.com/evoila/meho/issues/321) -- skeleton.
+  - [#322 G3.2-T2](https://github.com/evoila/meho/issues/322) -- core
+    inventory ops.
+  - [#323 G3.2-T3](https://github.com/evoila/meho/issues/323) -- workload
+    ops (`k8s.pod.{list,info}` / `k8s.deployment.{list,info}`).
+  - [#325 G3.2-T5](https://github.com/evoila/meho/issues/325) -- `k8s.logs`.
 - Substrate Initiative: [#388 G0.6](https://github.com/evoila/meho/issues/388)
   -- operation registry + dispatcher + JSONFlux substrate.
 - `kubernetes_asyncio`: https://github.com/tomplus/kubernetes_asyncio
 - Kubernetes API spec: https://kubernetes.io/docs/reference/kubernetes-api/
+- Kubernetes Pod API:
+  <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/>
+- Kubernetes Deployment API:
+  <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/>


### PR DESCRIPTION
## Summary

- Add `k8s.pod.{list,info}` and `k8s.deployment.{list,info}` ops to the
  `(k8s, 1.x, kubernetes-asyncio)` typed connector — the four highest-volume
  workload reads the consumer's daily `kubectl-vcf.sh` usage covers.
- List ops forward the standard `label_selector` / `field_selector` /
  `limit` / `_continue` knobs to the API server (server-side pagination)
  and surface the server's continuation cursor as `next_continue`.
- Info ops resolve exact name first, unique prefix second; ambiguous
  prefixes raise `AmbiguousPrefixError` with the candidate list so the
  dispatcher's `connector_error` envelope can render a "did-you-mean"
  hint. Not-found raises `WorkloadNotFoundError`.
- Schemas use `oneOf` to enforce `namespace` XOR `all_namespaces=true`
  on the list ops, mirroring the kubectl mental model.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 300 files already formatted
- [x] `uv run mypy src/` — Success: no issues found in 152 source files
- [x] `uv run pytest tests/test_connectors_k8s_workload.py` — 32 passed
- [x] `uv run pytest tests/test_connectors_k8s_{core,logs,auth,dispatcher_shim,workload}.py`
      — 136 passed
- [x] Full backend `uv run pytest tests/ --ignore=tests/integration` (see verification)
- [x] Acceptance criteria coverage:
  - All 4 ops registered into `KUBERNETES_OPS`; `execute()` dispatches
    correctly (test_workload_ops_in_kubernetes_ops_tuple,
    test_workload_handler_attrs_resolve_to_async_methods,
    test_workload_ops_metadata_shape).
  - `--namespace` path (test_k8s_pod_list_returns_rows_and_total).
  - `--all-namespaces` path (test_k8s_pod_list_all_namespaces_uses_for_all_namespaces).
  - `--label-selector` (test_k8s_pod_list_label_selector_flows_through).
  - `--field-selector` (test_k8s_pod_list_field_selector_flows_through).
  - Server-side pagination — `limit` + `next_continue` round-trip
    (test_k8s_pod_list_server_side_pagination_returns_next_continue,
    test_k8s_pod_list_continue_token_passed_to_api_as_underscore_continue).
  - `k8s.pod.info` exact match, unique prefix, ambiguous prefix,
    not-found (four dedicated tests).
  - `k8s.deployment.{list,info}` parity tests against `AppsV1Api`.
  - k3d integration: pod.list / pod.info / deployment.list /
    deployment.info exercised against the live k3s container in
    `tests/integration/test_connectors_k8s_k3d.py` (runs in CI with
    Docker; skips in this sandbox without socket access).

## Out of scope

- Pod write ops (delete, eviction, exec, port-forward) — v0.2.next.
- StatefulSet / DaemonSet / Job / CronJob / HPA / VPA / PDB — out of
  the v0.2 read surface per Issue body.
- `k8s.service.list` / `ingress.list` / `configmap.list` / `event.list`
  — separately scoped under G3.2-T4 #324.
- CLI alias verbs + `register_typed_operation()` lifespan wiring on
  the operator side — already in place from T1 #321 + T5 #325; this
  task only adds rows to the existing `KUBERNETES_OPS` walk.

Closes #323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pod and deployment list/info operations for Kubernetes with server-side pagination, next-token support, and prefix-based name resolution; includes structured not-found and ambiguous-prefix errors.

* **Tests**
  * Added comprehensive unit and integration tests covering listing, pagination, prefix resolution, and error cases.

* **Documentation**
  * Expanded Kubernetes connector docs with operation table, pagination semantics, and prefix-resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->