### PR TITLE
ci: raise Python job timeout-minutes 20 → 40 (unblock G9.1 #363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,15 +88,18 @@ jobs:
     # so no step ever starts on a fork PR.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: meho-runners
-    # 20-min cap: the pytest suite now actually completes (the
-    # integration TRUNCATE fix one commit earlier unblocked the
-    # tests/integration/* subtree that previously failed fast at
-    # setup), so the budget is wall-clock for the full unit-plus-
-    # integration sweep + uv sync + coverage emit, not for a
-    # short-circuit-on-first-failure run. Run 25910787068 cancelled
-    # at 49% through unit tests under the old 10-min cap; doubling
-    # gives headroom for moderate suite growth.
-    timeout-minutes: 20
+    # 40-min cap: the budget is wall-clock for the full unit-plus-
+    # integration sweep + uv sync + coverage emit (serial pytest, no
+    # xdist), not for a short-circuit-on-first-failure run. History:
+    # run 25910787068 cancelled at 49% under the old 10-min cap →
+    # bumped to 20; the G9.1 topology suite (graph_node/edge schema,
+    # refresh service, recursive-CTE query verbs, REST surface) plus
+    # its slow tests/integration/* pgvector:pg16 testcontainer cases
+    # then pushed the serial sweep past 20 min too (runs 25970564527,
+    # 25972807988 cancelled with the Pytest step at ~18m45s). Doubling
+    # to 40 restores headroom for continued suite growth. Durable fix
+    # (pytest-xdist `-n auto` parallelization) tracked as a follow-up.
+    timeout-minutes: 40
     env:
       # Route testcontainers pulls through the in-cluster Harbor proxy
       # cache (claude-rdc-hetzner-dc#463; project `dockerhub-proxy` public,


### PR DESCRIPTION
## What

Raise the `Python (ruff + mypy + pytest)` job `timeout-minutes` from 20 to 40 in `.github/workflows/ci.yml`.

## Why

The Python job runs pytest **serially** (`uv run pytest -x --cov ... tests/`, no `pytest-xdist`). The G9.1 topology work (Initiative #363) added the graph schema, refresh service, recursive-CTE query verbs, and REST surface — plus slow `tests/integration/*` cases that spin up a real `pgvector/pgvector:pg16` testcontainer. The serial sweep now exceeds the 20-min job cap.

Observed: CI runs `25970564527` (PR #542) and `25972807988` (PR #560) were both **cancelled** with the *Pytest* step killed at ~18m45s, while ruff / ruff-format / mypy passed in the first ~90s. The job-timeout signature (other jobs in the same workflow run succeeded; only the long pytest step was terminated) confirms a timeout, not a concurrency cancel or test failure — the sub-agents run the same suite green locally on each head SHA.

Doubling the cap to 40 restores headroom for continued suite growth (T6/T7/T8 add more tests). The durable fix — `pytest-xdist -n auto` parallelization — is tracked as a follow-up; it needs an xdist-safety pass over the integration testcontainer fixtures and is out of scope for this one-line unblock.

## Risk

Minimal — a single config value. No code, no test, no behavior change. Worst case a genuinely hung suite takes up to 40 min to fail instead of 20.

## Scope

Prep for Initiative #363 (G9.1) so its remaining PRs (#560, #454, #455, #456) land on a green Python required check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted CI timeout configuration to improve build reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->