### PR TITLE
fix(connectors): repair vault/__init__.py — main unparseable since #556 (HOTFIX)

### DIFF
--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -50,11 +50,12 @@ from meho_backplane.connectors.vault.ops import (
     register_vault_typed_operations,
     vault_kv_read,
 )
-from meho_backplane.connectors.vault.ops_sys import (
-    register_vault_sys_typed_operations,
 from meho_backplane.connectors.vault.ops_auth import (
     VaultAuthBackendNotMountedError,
     register_vault_auth_operations,
+)
+from meho_backplane.connectors.vault.ops_sys import (
+    register_vault_sys_typed_operations,
 )
 from meho_backplane.operations.typed_register import register_typed_op_registrar
 
@@ -81,6 +82,7 @@ __all__ = [
     "VaultAuthBackendNotMountedError",
     "VaultConnector",
     "VaultTarget",
+    "register_vault_auth_operations",
     "register_vault_sys_typed_operations",
     "register_vault_typed_operations",
     "vault_kv_read",


### PR DESCRIPTION
## 🔴 main is hard-down

`backend/src/meho_backplane/connectors/vault/__init__.py` does not parse on `main` (since #556 / `2dc7283`). Every PR in the repo fails the `Python (ruff + mypy + pytest)` required check at the `ruff check` step — `invalid-syntax: Expected ')'`.

## Root cause

PR #556 (G3.3-T2 Vault sys op group) squash-merged on top of #555 (G3.3-T3 Vault auth op group, `28b32ae`, which was fine). The squash regenerated `vault/__init__.py` with a **semantic merge collision** git did not flag as a textual conflict:

```python
from meho_backplane.connectors.vault.ops_sys import (
    register_vault_sys_typed_operations,
from meho_backplane.connectors.vault.ops_auth import (   # ← ops_sys '(' never closed
```

Two consequences:
1. **SyntaxError** (`'(' was never closed`) — the module is unimportable; ruff/mypy/pytest all fail at parse.
2. **Regression of #555**: `register_vault_auth_operations` was left imported (F401) but dropped from `__all__`, silently removing the Vault auth op group's public export.

## Fix (minimal, intent-restoring)

- Close the `ops_sys` import block (`)`).
- Restore `register_vault_auth_operations` to `__all__` — the #555 ∪ #556 union (7 names).
- ruff re-sorted the import block (ops → ops_auth → ops_sys).
- **No registrar call added** — #555 itself never called `register_typed_op_registrar(register_vault_auth_operations)`; this restores #555's intent, not new behavior.

## Verification

`python -m ast.parse` OK · `ruff check` clean · `ruff format --check` clean · `import meho_backplane.connectors.vault` succeeds with the full 7-name `__all__`.

## Priority

**Merge ahead of everything.** main does not parse; this blocks the entire repo, not just Initiative #363 (whose #560 first surfaced it after the CI 40-min cap let ruff's error become visible instead of the pytest timeout masking it). cc the #555/#556 authors for awareness of the squash-merge semantic-collision failure mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal reorganization of vault authentication operations module exports for improved API accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->