### PR TITLE
feat(cli): G3.3-T6 meho vault kv/sys/auth alias verb tree

### DIFF
--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
 	"github.com/evoila/meho/cli/internal/cmd/targets"
+	"github.com/evoila/meho/cli/internal/cmd/vault"
 	"github.com/evoila/meho/cli/internal/cmd/vmware"
 	"github.com/evoila/meho/cli/internal/discovery"
 )
@@ -138,6 +139,19 @@ func newRootCmd() *cobra.Command {
 	// the backplane manifest cannot shadow the built-in `vmware`
 	// parent.
 	root.AddCommand(vmware.NewRootCmd())
+
+	// G3.3-T6 (#550) -- vault-1.x operator alias verbs for Initiative
+	// #366. The verb tree pre-bakes connector_id="vault-1.x" on top of
+	// the existing /api/v1/operations/call dispatcher route so operators
+	// don't type the connector ID on every invocation. Ships the KV-v2
+	// (read/list/put/versions/delete), sys (health/seal-status/mounts-
+	// list/auth-list), and auth (userpass/approle list+read) verbs over
+	// the typed ops registered by G3.3-T1/T2/T3 (#545/#546/#547).
+	// `meho vault kv read --target rdc-vault secret <path>` replaces the
+	// consumer's `_secret-read.sh` wrapper. Registered before
+	// registerDynamicSubcommands so the backplane manifest cannot shadow
+	// the built-in `vault` parent.
+	root.AddCommand(vault.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/cli/internal/cmd/vault/auth.go
+++ b/cli/internal/cmd/vault/auth.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vault
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// Identity op IDs registered by G3.3-T3 (#547). All read-only. The
+// list verbs take no params; the read verbs take a single identifier
+// param (`username` for userpass, `role_name` for approle) per the
+// G3.3-T3 schemas.
+const (
+	opAuthUserpassList = "vault.auth.userpass.list"
+	opAuthUserpassRead = "vault.auth.userpass.read"
+	opAuthApproleList  = "vault.auth.approle.list"
+	opAuthApproleRead  = "vault.auth.approle.read"
+)
+
+// newAuthCmd returns the `meho vault auth` parent command and
+// assembles its four read-only identity verbs.
+func newAuthCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "auth",
+		Short:        "Vault identity verbs (userpass / approle, read-only)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAuthListVerbCmd(
+		"userpass-list", opAuthUserpassList,
+		"List configured userpass users",
+		"userpass-list dispatches op_id=\"vault.auth.userpass.list\" against\n"+
+			"connector_id=\"vault-1.x\". Read-only; result carries the\n"+
+			"userpass roster (set-shaped — large rosters return a JSONFlux\n"+
+			"handle + sample, drill in with the result verbs).",
+		"  meho vault auth userpass-list --target rdc-vault",
+	))
+	cmd.AddCommand(newAuthReadVerbCmd(
+		"userpass-read", "<user>", "username", opAuthUserpassRead,
+		"Read one userpass user (policies, ttl)",
+		"userpass-read dispatches op_id=\"vault.auth.userpass.read\" against\n"+
+			"connector_id=\"vault-1.x\". <user> is the userpass username (no\n"+
+			"mount prefix). Read-only; result carries the user's policies +\n"+
+			"token ttls.",
+		"  meho vault auth userpass-read --target rdc-vault svc-deploy",
+	))
+	cmd.AddCommand(newAuthListVerbCmd(
+		"approle-list", opAuthApproleList,
+		"List configured approle role names",
+		"approle-list dispatches op_id=\"vault.auth.approle.list\" against\n"+
+			"connector_id=\"vault-1.x\". Read-only; result carries the\n"+
+			"approle role-name roster.",
+		"  meho vault auth approle-list --target rdc-vault",
+	))
+	cmd.AddCommand(newAuthReadVerbCmd(
+		"approle-read", "<role>", "role_name", opAuthApproleRead,
+		"Read one approle role (policies, ttls)",
+		"approle-read dispatches op_id=\"vault.auth.approle.read\" against\n"+
+			"connector_id=\"vault-1.x\". <role> is the AppRole role name (no\n"+
+			"mount prefix). Read-only; result carries the role's policies +\n"+
+			"token/secret-id ttls.",
+		"  meho vault auth approle-read --target rdc-vault ci-runner",
+	))
+	return cmd
+}
+
+// authAddrFlags binds the shared address flags onto a command. Split
+// out so the list-verb and read-verb factories share one flag-wiring
+// implementation.
+type authAddrFlags struct {
+	targetName        string
+	jsonOut           bool
+	backplaneOverride string
+}
+
+func bindAuthAddrFlags(cmd *cobra.Command) *authAddrFlags {
+	f := &authAddrFlags{}
+	cmd.Flags().StringVar(&f.targetName, "target", "",
+		"Vault target slug to dispatch against (resolved server-side)")
+	cmd.Flags().BoolVar(&f.jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&f.backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return f
+}
+
+// dispatchAuth runs the resolve → dispatch → render pipeline shared by
+// every auth verb. params is nil for the list verbs.
+func dispatchAuth(cmd *cobra.Command, f *authAddrFlags, opID string, params map[string]any) error {
+	backplaneURL, err := resolveBackplane(f.backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), f.jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, f.targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, f.jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, f.jsonOut, nil)
+}
+
+// newAuthListVerbCmd builds one no-arg, no-param list verb (userpass-
+// list / approle-list). They share the exact same shape, differing
+// only in op_id + help text.
+func newAuthListVerbCmd(use, opID, short, long, example string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           use,
+		Short:         short,
+		Long:          long + "\n\nExit codes mirror meho operation call.",
+		Example:       example,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	f := bindAuthAddrFlags(cmd)
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		return dispatchAuth(cmd, f, opID, nil)
+	}
+	return cmd
+}
+
+// newAuthReadVerbCmd builds one single-identifier read verb (userpass-
+// read <user> / approle-read <role>). paramKey is the op's schema key
+// for the identifier (`username` or `role_name`); useArg is the
+// help-text placeholder (`<user>` / `<role>`).
+func newAuthReadVerbCmd(verb, useArg, paramKey, opID, short, long, example string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           verb + " " + useArg,
+		Short:         short,
+		Long:          long + "\n\nExit codes mirror meho operation call.",
+		Example:       example,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	f := bindAuthAddrFlags(cmd)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return dispatchAuth(cmd, f, opID, map[string]any{paramKey: args[0]})
+	}
+	return cmd
+}

--- a/cli/internal/cmd/vault/dispatch.go
+++ b/cli/internal/cmd/vault/dispatch.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model. Same
+// shape as cmd/vmware/CallResult; duplicated here because cmd/vault
+// can't import cmd/vmware without an import cycle (cmd/root.go grafts
+// both onto the tree).
+//
+// Result is left as json.RawMessage because the backend types it as a
+// oneOf(dict, list) union — pretty-printing the raw bytes is the
+// cleanest renderer. Set-shaped Vault ops (kv.list, sys.mounts.list,
+// auth.userpass.list, …) return whatever the dispatcher's JSONFlux
+// layer reduced them to (a handle envelope + sample when the row count
+// crosses the threshold); the CLI renders that verbatim, consistent
+// with the vmware sibling.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic
+// model. Target uses a map[string]any so the empty case serialises as
+// `null` rather than an empty struct; the route layer's resolver
+// short-circuits on the missing-name case for the ops that need a
+// target. Vault ops resolve a Vault target server-side, so every verb
+// passes the --target slug through here.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+// errOpError is the sentinel returned when the dispatcher reported a
+// structured-failure result (status == "error" or status == "denied").
+// main translates non-nil RunE errors into a non-zero exit;
+// SilenceErrors=true on each command keeps cobra from double-printing
+// the error string. Same shape as the vmware sibling's errOpError.
+var errOpError = errors.New("operation status not ok")
+
+// dispatchOp POSTs an OperationCall to the backplane and returns the
+// decoded CallResult. The pre-baked connector_id ("vault-1.x") is
+// baked in; callers pass op_id, an optional target slug (empty string
+// → no target field on the wire), and an optional params map.
+//
+// Centralised here so every verb in the package shares one dispatcher
+// implementation. A grep for `dispatchOp` finds every alias-verb
+// dispatch in the vault package.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: ConnectorID,
+		OpID:        opID,
+		Target:      nil,
+	}
+	if targetSlug != "" {
+		body.Target = map[string]any{"name": targetSlug}
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderCallResult handles the unified post-dispatch path every verb
+// uses: validate status enum, render the envelope (JSON or human),
+// then translate "error" / "denied" into the errOpError sentinel so
+// main propagates the right non-zero exit. Returns nil on success or
+// one of:
+//   - errOpError (status == "error" / "denied" → exit 1)
+//   - a structured renderer error (unexpected status → exit 4)
+//
+// Pretty-printing is delegated to a per-verb closure so verb files can
+// lay out their domain-specific render. When prettyPrinter is nil, the
+// fallback renders the generic envelope shape the vmware sibling uses.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+		// fall through.
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		printGenericResult(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+// printGenericResult renders a CallResult in the same shape the vmware
+// sibling's printGenericResult uses. Used as the default pretty-
+// printer for every vault verb: the Vault op results (secret data,
+// metadata, mount maps, key lists, JSONFlux handle envelopes) are
+// nested JSON the operator reads as a tree, and a per-shape table buys
+// little over the indented dump while risking contract-drift panics.
+// Set-shaped responses arrive already reduced to the JSONFlux
+// sample + handle envelope by the dispatcher, so they print here with
+// the handle hint intact, consistent with the vmware sibling.
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+// prettyJSON pretty-prints a json.RawMessage with 2-space indent. Same
+// implementation as the vmware sibling.
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cli/internal/cmd/vault/kv.go
+++ b/cli/internal/cmd/vault/kv.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// KV-v2 op IDs registered by G3.3-T1 (#545). The CLI references the
+// canonical op_id strings verbatim — a drift here would dispatch a
+// non-existent op (the dispatcher would return status=error
+// "operation not found", which surfaces in the standard trailer).
+const (
+	opKVRead     = "vault.kv.read"
+	opKVList     = "vault.kv.list"
+	opKVPut      = "vault.kv.put"
+	opKVVersions = "vault.kv.versions"
+	opKVDelete   = "vault.kv.delete"
+)
+
+// newKVCmd returns the `meho vault kv` parent command and assembles
+// its five verbs. The parent itself takes no args and prints its own
+// help.
+func newKVCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "kv",
+		Short:        "KV-v2 secret verbs (read / list / put / versions / delete)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newKVReadCmd())
+	cmd.AddCommand(newKVListCmd())
+	cmd.AddCommand(newKVPutCmd())
+	cmd.AddCommand(newKVVersionsCmd())
+	cmd.AddCommand(newKVDeleteCmd())
+	return cmd
+}
+
+// kvAddrFlags holds the flags every KV verb shares (target slug,
+// --json, --backplane). Each verb embeds it so the flag wiring + the
+// resolve-and-dispatch boilerplate stays in one place.
+type kvAddrFlags struct {
+	targetName        string
+	jsonOut           bool
+	backplaneOverride string
+}
+
+// bindKVAddrFlags registers the shared address flags on a command and
+// returns a pointer to the populated struct. Verbs add their own
+// op-specific flags (--data, --cas, --versions) on top.
+func bindKVAddrFlags(cmd *cobra.Command) *kvAddrFlags {
+	f := &kvAddrFlags{}
+	cmd.Flags().StringVar(&f.targetName, "target", "",
+		"Vault target slug to dispatch against (resolved server-side)")
+	cmd.Flags().BoolVar(&f.jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&f.backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return f
+}
+
+// dispatchKV is the resolve-backplane → dispatch → render pipeline
+// every KV verb runs. opID + params come from the verb; the shared
+// address flags carry target / json / backplane. The generic renderer
+// is used: Vault payloads (secret data, metadata, version maps) are
+// nested JSON the operator reads as a tree, and set-shaped responses
+// (kv list) arrive already reduced to the JSONFlux sample + handle by
+// the dispatcher.
+func dispatchKV(cmd *cobra.Command, f *kvAddrFlags, opID string, params map[string]any) error {
+	backplaneURL, err := resolveBackplane(f.backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), f.jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, f.targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, f.jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, f.jsonOut, nil)
+}
+
+// kvPathParams folds the `<mount> <path>` positional pair into the op
+// params map. The G3.3-T1 KV-v2 handlers take `path` (required) and an
+// optional `mount` (defaulting to "secret" server-side). The CLI
+// always sends `mount` explicitly so the operator's positional choice
+// is authoritative — there is no client-side mount default that could
+// drift from the handler's.
+func kvPathParams(mount, path string) map[string]any {
+	return map[string]any{"mount": mount, "path": path}
+}
+
+// newKVReadCmd returns `meho vault kv read <mount> <path>`.
+func newKVReadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "read <mount> <path>",
+		Short: "Read the latest version of a KV-v2 secret",
+		Long: "read dispatches op_id=\"vault.kv.read\" against connector_id=\n" +
+			"\"vault-1.x\". <mount> is the KV-v2 engine mount (e.g. secret);\n" +
+			"<path> is the secret path relative to the mount root (no leading\n" +
+			"slash, no mount prefix). The result envelope carries\n" +
+			"{data: {...}, version: <int>}.\n\n" +
+			"This replaces the consumer's `_secret-read.sh secret/<mount>/<path>`\n" +
+			"wrapper. The dispatch path is the same /api/v1/operations/call route\n" +
+			"the agent surface uses — auth, audit, broadcast, and policy gates\n" +
+			"all run as documented in CLAUDE.md §6.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vault kv read --target rdc-vault secret meho/test/federation\n" +
+			"  meho vault kv read --target rdc-vault secret app/db --json | jq .result.data",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	f := bindKVAddrFlags(cmd)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return dispatchKV(cmd, f, opKVRead, kvPathParams(args[0], args[1]))
+	}
+	return cmd
+}
+
+// newKVListCmd returns `meho vault kv list <mount> <path>`.
+func newKVListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <mount> <path>",
+		Short: "List keys at a KV-v2 path",
+		Long: "list dispatches op_id=\"vault.kv.list\" against connector_id=\n" +
+			"\"vault-1.x\". Lists the child keys at <mount>/<path> via the\n" +
+			"KV-v2 metadata endpoint. The result is set-shaped: when the key\n" +
+			"count crosses the backplane's JSONFlux threshold the envelope\n" +
+			"carries a result handle + sample instead of the full list — drill\n" +
+			"in with `meho operation` result verbs (result_query / result_export)\n" +
+			"exactly as for any other connector's set-shaped op.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vault kv list --target rdc-vault secret meho\n" +
+			"  meho vault kv list --target rdc-vault secret meho/test --json",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	f := bindKVAddrFlags(cmd)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return dispatchKV(cmd, f, opKVList, kvPathParams(args[0], args[1]))
+	}
+	return cmd
+}
+
+// newKVPutCmd returns `meho vault kv put <mount> <path> --data ...`.
+func newKVPutCmd() *cobra.Command {
+	var (
+		dataFlag string
+		casFlag  int
+		casSet   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "put <mount> <path>",
+		Short: "Write a new version of a KV-v2 secret",
+		Long: "put dispatches op_id=\"vault.kv.put\" against connector_id=\n" +
+			"\"vault-1.x\". --data accepts the secret body as inline JSON or\n" +
+			"@<file> (a JSON object of key/value pairs). --cas N enables a\n" +
+			"check-and-set write: the put only succeeds if the secret's current\n" +
+			"version equals N (use --cas 0 to assert the secret does not yet\n" +
+			"exist). This is a write op — the dispatcher emits an audit row at\n" +
+			"op_class=write.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vault kv put --target rdc-vault secret app/db --data '{\"password\":\"s3cr3t\"}'\n" +
+			"  meho vault kv put --target rdc-vault secret app/db --data @secret.json --cas 3",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	f := bindKVAddrFlags(cmd)
+	cmd.Flags().StringVar(&dataFlag, "data", "",
+		"secret body as inline JSON object or @<file>; required")
+	cmd.Flags().IntVar(&casFlag, "cas", 0,
+		"check-and-set: only write if the current version equals this value")
+	_ = cmd.MarkFlagRequired("data")
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// cobra populates casFlag even when the operator didn't pass
+		// --cas; Changed() distinguishes "explicitly --cas 0" (a real
+		// "must-not-exist" assertion) from "flag absent".
+		casSet = cmd.Flags().Changed("cas")
+		secret, err := loadJSONFlag(dataFlag)
+		if err != nil {
+			return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), f.jsonOut)
+		}
+		params := kvPathParams(args[0], args[1])
+		params["data"] = secret
+		if casSet {
+			params["cas"] = casFlag
+		}
+		return dispatchKV(cmd, f, opKVPut, params)
+	}
+	return cmd
+}
+
+// newKVVersionsCmd returns `meho vault kv versions <mount> <path>`.
+func newKVVersionsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "versions <mount> <path>",
+		Short: "List the version history of a KV-v2 secret",
+		Long: "versions dispatches op_id=\"vault.kv.versions\" against\n" +
+			"connector_id=\"vault-1.x\". Read-only browse of the secret's\n" +
+			"version map (version number → created/deleted/destroyed\n" +
+			"timestamps) from the KV-v2 metadata endpoint.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vault kv versions --target rdc-vault secret app/db\n" +
+			"  meho vault kv versions --target rdc-vault secret app/db --json",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	f := bindKVAddrFlags(cmd)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return dispatchKV(cmd, f, opKVVersions, kvPathParams(args[0], args[1]))
+	}
+	return cmd
+}
+
+// newKVDeleteCmd returns `meho vault kv delete <mount> <path> --versions`.
+func newKVDeleteCmd() *cobra.Command {
+	var versionsFlag string
+	cmd := &cobra.Command{
+		Use:   "delete <mount> <path>",
+		Short: "Soft-delete specific versions of a KV-v2 secret",
+		Long: "delete dispatches op_id=\"vault.kv.delete\" against connector_id=\n" +
+			"\"vault-1.x\". --versions is a comma-separated list of version\n" +
+			"numbers to soft-delete (Vault KV-v2 reversible delete — the\n" +
+			"versions can be undeleted). This is a write op — the dispatcher\n" +
+			"emits an audit row at op_class=write.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vault kv delete --target rdc-vault secret app/db --versions 3\n" +
+			"  meho vault kv delete --target rdc-vault secret app/db --versions 3,4,5",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	f := bindKVAddrFlags(cmd)
+	cmd.Flags().StringVar(&versionsFlag, "versions", "",
+		"comma-separated version numbers to soft-delete (e.g. 3,4,5); required")
+	_ = cmd.MarkFlagRequired("versions")
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		versions, err := parseVersionList(versionsFlag)
+		if err != nil {
+			return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), f.jsonOut)
+		}
+		params := kvPathParams(args[0], args[1])
+		params["versions"] = versions
+		return dispatchKV(cmd, f, opKVDelete, params)
+	}
+	return cmd
+}
+
+// parseVersionList turns "3,4,5" into []int{3,4,5}. The G3.3-T1
+// vault.kv.delete handler's schema requires `versions` to be a
+// non-empty array of integers; parsing client-side gives the operator
+// an argv-level error ("--versions \"x\": …") instead of a backend
+// schema-validation rejection round-trip. Whitespace around each
+// element is tolerated (`3, 4`); an empty / non-integer element is an
+// error.
+func parseVersionList(s string) ([]int, error) {
+	parts := strings.Split(s, ",")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		if t == "" {
+			return nil, fmt.Errorf("--versions %q: empty version element", s)
+		}
+		n, err := strconv.Atoi(t)
+		if err != nil {
+			return nil, fmt.Errorf("--versions %q: %q is not an integer", s, t)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}

--- a/cli/internal/cmd/vault/sys.go
+++ b/cli/internal/cmd/vault/sys.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vault
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// System op IDs registered by G3.3-T2 (#546). Read-only diagnostics;
+// none take params.
+const (
+	opSysHealth     = "vault.sys.health"
+	opSysSealStatus = "vault.sys.seal_status"
+	opSysMountsList = "vault.sys.mounts.list"
+	opSysAuthList   = "vault.sys.auth.list"
+)
+
+// newSysCmd returns the `meho vault sys` parent command and assembles
+// its four read-only diagnostic verbs.
+func newSysCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "sys",
+		Short:        "Vault system diagnostics (health / seal-status / mounts-list / auth-list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSysVerbCmd(
+		"health", opSysHealth,
+		"Report Vault health (initialized / sealed / standby)",
+		"health dispatches op_id=\"vault.sys.health\" against connector_id=\n"+
+			"\"vault-1.x\". Read-only; the result envelope carries\n"+
+			"{ok: <bool>, detail: <str>} plus the raw sys/health fields.",
+		"  meho vault sys health --target rdc-vault",
+	))
+	cmd.AddCommand(newSysVerbCmd(
+		"seal-status", opSysSealStatus,
+		"Read the Vault seal state",
+		"seal-status dispatches op_id=\"vault.sys.seal_status\" against\n"+
+			"connector_id=\"vault-1.x\". Read-only; result carries\n"+
+			"{sealed: <bool>, initialized: <bool>, ...}.",
+		"  meho vault sys seal-status --target rdc-vault",
+	))
+	cmd.AddCommand(newSysVerbCmd(
+		"mounts-list", opSysMountsList,
+		"List enabled secret backends",
+		"mounts-list dispatches op_id=\"vault.sys.mounts.list\" against\n"+
+			"connector_id=\"vault-1.x\". Read-only; result carries the\n"+
+			"enabled secret-engine mount map.",
+		"  meho vault sys mounts-list --target rdc-vault",
+	))
+	cmd.AddCommand(newSysVerbCmd(
+		"auth-list", opSysAuthList,
+		"List enabled auth backends",
+		"auth-list dispatches op_id=\"vault.sys.auth.list\" against\n"+
+			"connector_id=\"vault-1.x\". Read-only; result carries the\n"+
+			"enabled auth-method map.",
+		"  meho vault sys auth-list --target rdc-vault",
+	))
+	return cmd
+}
+
+// newSysVerbCmd builds one no-arg, no-param sys verb. The four sys ops
+// share the exact same shape (resolve target → dispatch → generic
+// render) and differ only in op_id + help text, so a single factory
+// avoids four near-identical command bodies. The trailing "Exit codes
+// mirror meho operation call." sentence is appended here so every
+// verb's help is consistent without repeating it in each caller.
+func newSysVerbCmd(use, opID, short, long, example string) *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           use,
+		Short:         short,
+		Long:          long + "\n\nExit codes mirror meho operation call.",
+		Example:       example,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			backplaneURL, err := resolveBackplane(backplaneOverride)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+			}
+			r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+			if err != nil {
+				return renderRequestError(cmd, backplaneURL, err, jsonOut)
+			}
+			return renderCallResult(cmd, opID, r, jsonOut, nil)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"Vault target slug to dispatch against (resolved server-side)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}

--- a/cli/internal/cmd/vault/vault.go
+++ b/cli/internal/cmd/vault/vault.go
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package vault hosts the cobra commands under `meho vault ...` for
+// G3.3-T6 (#550) of Initiative #366. v0.2 ships the operator-facing
+// alias verbs the Initiative #366 work-item table names, each pre-
+// baking the `connector_id="vault-1.x"` argument so operators don't
+// type the connector ID on every dispatch:
+//
+//   - `meho vault kv read <mount> <path>`        — vault.kv.read
+//   - `meho vault kv list <mount> <path>`        — vault.kv.list
+//   - `meho vault kv put <mount> <path> --data`  — vault.kv.put
+//   - `meho vault kv versions <mount> <path>`    — vault.kv.versions
+//   - `meho vault kv delete <mount> <path>`      — vault.kv.delete
+//   - `meho vault sys health`                    — vault.sys.health
+//   - `meho vault sys seal-status`               — vault.sys.seal_status
+//   - `meho vault sys mounts-list`               — vault.sys.mounts.list
+//   - `meho vault sys auth-list`                 — vault.sys.auth.list
+//   - `meho vault auth userpass-list`            — vault.auth.userpass.list
+//   - `meho vault auth userpass-read <user>`     — vault.auth.userpass.read
+//   - `meho vault auth approle-list`             — vault.auth.approle.list
+//   - `meho vault auth approle-read <role>`      — vault.auth.approle.read
+//
+// Every verb is a thin Cobra command that POSTs to
+// `/api/v1/operations/call` with a pre-baked connector_id. No new
+// backend code; no new HTTP routes — CLI alias verbs are pure operator
+// ergonomics over the existing dispatcher surface (per CLAUDE.md
+// postulate 5: agent surface stays narrow-waist meta-tools; vendor-
+// specific tooling lives only in the CLI). The underlying typed ops
+// register via G3.3-T1/T2/T3 (#545/#546/#547); this verb tree is the
+// operator front-end over the same auth/policy/audit/JSONFlux path the
+// agent surface uses.
+//
+// `meho vault kv read --target rdc-vault secret <path>` replaces the
+// consumer's `_secret-read.sh secret/<mount>/<path>` wrapper.
+package vault
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under
+// `meho vault ...` dispatches against. Exported so the per-verb files
+// and tests reference the same constant; a future re-versioning
+// (vault-2.x) lands as a single line edit here. The string form is the
+// dispatcher's natural-key encoding (product="vault", version="1.x",
+// impl_id="vault" → "vault-1.x"), pinned by the backend's
+// connector-id-parse contract test.
+const ConnectorID = "vault-1.x"
+
+// NewRootCmd returns the `meho vault` parent command. cmd/root.go
+// grafts this onto the top-level command tree alongside the other
+// built-in verb trees (operation / connector / targets / kb /
+// retrieval / audit / vmware). The parent itself takes no args and
+// prints its own help; every piece of behaviour lives in the per-
+// subcommand RunE closures.
+//
+// Sub-tree layout follows Initiative #366's work-item grouping:
+//   - `vault kv <read|list|put|versions|delete>`  — KV-v2 sub-tree
+//   - `vault sys <health|seal-status|mounts-list|auth-list>` — sys sub-tree
+//   - `vault auth <userpass-list|userpass-read|approle-list|approle-read>`
+//
+// Sub-tree roots delegate to their own factories in this package so
+// each noun's verbs live next to their tests.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vault",
+		Short: "Pre-scoped CLI verbs for the vault-1.x connector",
+		Long: "vault is the operator-facing verb tree for the vault-1.x\n" +
+			"connector. Each verb dispatches through POST /api/v1/operations/call\n" +
+			"with connector_id=\"vault-1.x\" pre-baked so operators don't type\n" +
+			"the connector ID on every command. The KV-v2 verbs address secrets\n" +
+			"as <mount> <path> (mirroring the consumer's _secret-read.sh /\n" +
+			"vault.sh wrappers); sys and auth verbs are read-only diagnostics.\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
+			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
+			"continue to use search_operations / call_operation against the\n" +
+			"narrow-waist meta-tool contract.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newKVCmd())
+	cmd.AddCommand(newSysCmd())
+	cmd.AddCommand(newAuthCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers can
+// distinguish "operator never logged in" (→ auth_expired exit code 2 —
+// the right fix is `meho login`) from URL-parse failures (→ unexpected
+// exit code 4 — the right fix is correcting argv). Same shape as the
+// operation / connector / vmware siblings; kept independent because
+// cmd/{operation,connector,kb,vmware,vault} can't import each other
+// without an import cycle (cmd/root.go grafts each onto the tree).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane mirrors the vmware sibling helper: --backplane
+// override flag wins; otherwise read the URL the most recent
+// `meho login` wrote to config.json. Missing config surfaces as
+// errNoBackplaneConfigured so classifyBackplaneError can route it to
+// auth_expired.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical routing to the vmware
+// sibling: missing-config → auth_expired; everything else (parse
+// errors, fs errors) → unexpected.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail fast
+// on garbage input. Mirrors the vmware sibling.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from doAuthedRequest into the
+// right output.RenderError category. Same classification ladder as the
+// vmware sibling: token-not-found / no-refresh-token → auth_expired
+// with `meho login` hints; HTTP-error → unexpected; everything else
+// (transport) → unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// httpError carries a non-2xx response so renderRequestError can pick
+// the right StructuredError category. Same shape as the vmware sibling.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection + one-shot 401-refresh-retry. Mirrors the
+// vmware sibling verbatim (duplicated to avoid an import cycle —
+// cmd/root.go grafts each onto the tree). Centralised per-package so
+// the per-verb runners stay small.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	// 1 MiB cap matches the vmware sibling. Vault secret payloads are
+	// small; the cap leaves headroom while still bounding pathological
+	// payloads.
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// sendRequest builds + fires the HTTP request. Mirrors the vmware
+// sibling; split out so the 401-refresh-retry path can reuse the same
+// body bytes without re-marshalling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// loadJSONFlag parses a flag value that is either inline JSON or an
+// `@<file>` reference. Returns nil for an empty value so the caller
+// can omit the key. Same shape as the vmware sibling's
+// loadParamsFlag, kept local to avoid the cross-package import cycle.
+func loadJSONFlag(val string) (map[string]any, error) {
+	if val == "" {
+		return nil, nil
+	}
+	var raw []byte
+	if strings.HasPrefix(val, "@") {
+		path := strings.TrimPrefix(val, "@")
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read JSON file %q: %w", path, err)
+		}
+	} else {
+		raw = []byte(val)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parse JSON: %w", err)
+	}
+	return m, nil
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Operates on runes (not bytes) so multi-byte
+// UTF-8 in Vault-side names survives without producing an invalid
+// UTF-8 cut. Same implementation as the vmware sibling — duplicated to
+// avoid the import cycle.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/vault/vault_test.go
+++ b/cli/internal/cmd/vault/vault_test.go
@@ -1,0 +1,751 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vault
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- pure-function helpers ----------
+
+// TestTruncatePassthroughAndCut covers the rune-aware truncate helper.
+// Same shape as the vmware sibling — duplicated because cmd/vault
+// can't import it without an import cycle.
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+// TestNormaliseURLBasic — trailing-slash trimming + reject-empty are
+// the load-bearing properties.
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or any
+// wrapping error) maps to AuthExpired; everything else to Unexpected.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+// TestConnectorIDIsFrozen pins the pre-baked connector_id. Every verb
+// dispatches against this value; a regression would silently rebind
+// the entire vault verb tree to a different connector. The string form
+// is the backend's natural-key encoding for
+// (product="vault", version="1.x", impl_id="vault").
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "vault-1.x" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "vault-1.x")
+	}
+}
+
+// ---------- loadJSONFlag ----------
+
+func TestLoadJSONFlagEmpty(t *testing.T) {
+	got, err := loadJSONFlag("")
+	if err != nil {
+		t.Fatalf("loadJSONFlag(\"\"): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("loadJSONFlag(\"\") should be nil; got %v", got)
+	}
+}
+
+func TestLoadJSONFlagInline(t *testing.T) {
+	got, err := loadJSONFlag(`{"password":"s3cr3t","user":"svc"}`)
+	if err != nil {
+		t.Fatalf("loadJSONFlag: %v", err)
+	}
+	if got["password"] != "s3cr3t" || got["user"] != "svc" {
+		t.Fatalf("inline JSON not parsed; got %v", got)
+	}
+}
+
+func TestLoadJSONFlagFileReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.json")
+	if err := os.WriteFile(path, []byte(`{"k":"v"}`), 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	got, err := loadJSONFlag("@" + path)
+	if err != nil {
+		t.Fatalf("loadJSONFlag @file: %v", err)
+	}
+	if got["k"] != "v" {
+		t.Fatalf("file JSON not parsed; got %v", got)
+	}
+}
+
+func TestLoadJSONFlagInvalidJSON(t *testing.T) {
+	if _, err := loadJSONFlag(`{not-json`); err == nil {
+		t.Fatalf("invalid JSON should error")
+	}
+}
+
+// ---------- parseVersionList ----------
+
+func TestParseVersionList(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []int
+		wantErr bool
+	}{
+		{"single", "3", []int{3}, false},
+		{"multi", "3,4,5", []int{3, 4, 5}, false},
+		{"whitespace tolerated", " 3 , 4 ", []int{3, 4}, false},
+		{"empty element", "3,,4", nil, true},
+		{"non-integer", "3,x", nil, true},
+		{"empty string", "", nil, true},
+	}
+	for _, tt := range tests {
+		got, err := parseVersionList(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error for %q", tt.name, tt.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tt.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%s: got %v want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+// TestKVPathParamsAlwaysSendsMount — the CLI must send mount
+// explicitly so the operator's positional choice is authoritative and
+// never silently falls back to the handler's "secret" default.
+func TestKVPathParamsAlwaysSendsMount(t *testing.T) {
+	p := kvPathParams("kv2", "app/db")
+	if p["mount"] != "kv2" || p["path"] != "app/db" {
+		t.Fatalf("kvPathParams: got %v", p)
+	}
+}
+
+// ---------- errOpError sentinel ----------
+
+func TestErrOpErrorIsSentinel(t *testing.T) {
+	if errOpError == nil {
+		t.Fatalf("errOpError should be non-nil")
+	}
+	if errors.Is(errOpError, errors.New("other")) {
+		t.Fatalf("errOpError should not match arbitrary errors")
+	}
+}
+
+// ---------- HTTP wire shape (mocked) ----------
+
+type mockHandler = http.HandlerFunc
+
+// mockBackplane stands up an httptest.Server that routes by
+// `<METHOD> <path>` keys. Same shape as the vmware sibling's helper.
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+// primeToken installs an in-memory token store with a usable bearer
+// for the mocked backplane URL. Mirrors the vmware sibling.
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID — every verb dispatches with
+// connector_id="vault-1.x" pre-baked.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "vault-1.x" {
+				t.Errorf("connector_id: got %q want vault-1.x", body.ConnectorID)
+			}
+			if body.OpID != opKVRead {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok", OpID: opKVRead,
+				Result: json.RawMessage(`{"data":{"k":"v"},"version":1}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, opKVRead, "rdc-vault", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestDispatchOpEmptyTargetSendsNullTarget — empty target slug must
+// surface as `null` so the dispatcher's resolver can fall through.
+func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if raw["target"] != nil {
+				t.Errorf("target should be null when slug empty; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "x"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "x", "", nil); err != nil {
+		t.Fatalf("dispatchOp empty-target: %v", err)
+	}
+}
+
+// TestDispatchOpTargetSlugWrappedAsName — a non-empty target slug must
+// surface as `{"name": "<slug>"}` so the dispatcher's resolver pulls
+// it under the canonical TargetRef shape.
+func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			tgt, _ := raw["target"].(map[string]any)
+			if tgt == nil || tgt["name"] != "rdc-vault" {
+				t.Errorf("target should wrap slug as {name: ...}; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "x"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "x", "rdc-vault", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// ---------- verb-tree wiring ----------
+
+// subnames returns the set of child command names of the named
+// top-level verb under the vault root.
+func subnames(t *testing.T, parent string) map[string]bool {
+	t.Helper()
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() == parent {
+			s := map[string]bool{}
+			for _, sub := range c.Commands() {
+				s[sub.Name()] = true
+			}
+			return s
+		}
+	}
+	t.Fatalf("%q sub-tree not found under vault root", parent)
+	return nil
+}
+
+// TestNewRootCmdAssemblesTopLevelVerbs pins the kv/sys/auth groups.
+func TestNewRootCmdAssemblesTopLevelVerbs(t *testing.T) {
+	root := NewRootCmd()
+	if root.Name() != "vault" {
+		t.Fatalf("root command name: got %q want vault", root.Name())
+	}
+	want := map[string]bool{"kv": true, "sys": true, "auth": true}
+	for _, c := range root.Commands() {
+		delete(want, c.Name())
+	}
+	if len(want) > 0 {
+		t.Errorf("vault tree missing top-level groups: %v", want)
+	}
+}
+
+func TestKVSubtreeAssemblesAllVerbs(t *testing.T) {
+	got := subnames(t, "kv")
+	for _, want := range []string{"read", "list", "put", "versions", "delete"} {
+		if !got[want] {
+			t.Errorf("vault kv sub-tree missing %q; got %v", want, got)
+		}
+	}
+}
+
+func TestSysSubtreeAssemblesAllVerbs(t *testing.T) {
+	got := subnames(t, "sys")
+	for _, want := range []string{"health", "seal-status", "mounts-list", "auth-list"} {
+		if !got[want] {
+			t.Errorf("vault sys sub-tree missing %q; got %v", want, got)
+		}
+	}
+}
+
+func TestAuthSubtreeAssemblesAllVerbs(t *testing.T) {
+	got := subnames(t, "auth")
+	for _, want := range []string{"userpass-list", "userpass-read", "approle-list", "approle-read"} {
+		if !got[want] {
+			t.Errorf("vault auth sub-tree missing %q; got %v", want, got)
+		}
+	}
+}
+
+// ---------- flag parsing / arg arity ----------
+
+// TestKVReadRequiresTwoArgs — `kv read` takes exactly <mount> <path>.
+func TestKVReadRequiresTwoArgs(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"kv", "read", "only-one"})
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err == nil {
+		t.Fatalf("kv read with one arg should error on arity")
+	}
+}
+
+// TestKVPutRequiresDataFlag — --data is MarkFlagRequired.
+func TestKVPutRequiresDataFlag(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"kv", "put", "secret", "app/db"})
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err == nil {
+		t.Fatalf("kv put without --data should error on required flag")
+	}
+}
+
+// TestKVDeleteRequiresVersionsFlag — --versions is MarkFlagRequired.
+func TestKVDeleteRequiresVersionsFlag(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"kv", "delete", "secret", "app/db"})
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err == nil {
+		t.Fatalf("kv delete without --versions should error on required flag")
+	}
+}
+
+// ---------- end-to-end: flag → params wire shape ----------
+
+// TestKVReadE2E pins the full `meho vault kv read` path: positional
+// <mount> <path> map to params.mount/params.path, op_id is
+// vault.kv.read, connector_id pre-baked, target wrapped.
+func TestKVReadE2E(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != opKVRead {
+				t.Errorf("op_id: got %q want %q", body.OpID, opKVRead)
+			}
+			if body.Params["mount"] != "secret" || body.Params["path"] != "meho/test/fed" {
+				t.Errorf("params: got %v", body.Params)
+			}
+			if body.Target["name"] != "rdc-vault" {
+				t.Errorf("target: got %v", body.Target)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok", OpID: opKVRead,
+				Result: json.RawMessage(`{"data":{"token":"abc"},"version":2}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{
+		"kv", "read", "secret", "meho/test/fed",
+		"--target", "rdc-vault", "--backplane", srv.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("kv read e2e: %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "vault-1.x") || !strings.Contains(out.String(), "token") {
+		t.Errorf("kv read render missing connector id / payload; got:\n%s", out.String())
+	}
+}
+
+// TestKVPutE2E pins --data parsing + --cas binding into params.
+func TestKVPutE2E(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != opKVPut {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			data, _ := body.Params["data"].(map[string]any)
+			if data == nil || data["password"] != "s3cr3t" {
+				t.Errorf("params.data: got %v", body.Params["data"])
+			}
+			// JSON numbers decode as float64 into map[string]any.
+			if body.Params["cas"] != float64(3) {
+				t.Errorf("params.cas: got %v (%T)", body.Params["cas"], body.Params["cas"])
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok", OpID: opKVPut,
+				Result: json.RawMessage(`{"version":4}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{
+		"kv", "put", "secret", "app/db",
+		"--data", `{"password":"s3cr3t"}`, "--cas", "3",
+		"--target", "rdc-vault", "--backplane", srv.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("kv put e2e: %v\noutput:\n%s", err, out.String())
+	}
+}
+
+// TestKVPutOmitsCasWhenNotPassed — without --cas the params map must
+// not carry a "cas" key (so the handler's must-not-exist / no-cas
+// path isn't accidentally triggered by a zero default).
+func TestKVPutOmitsCasWhenNotPassed(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if _, present := body.Params["cas"]; present {
+				t.Errorf("cas must be absent when --cas not passed; got %v", body.Params["cas"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: opKVPut})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{
+		"kv", "put", "secret", "app/db",
+		"--data", `{"k":"v"}`,
+		"--target", "rdc-vault", "--backplane", srv.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("kv put (no cas) e2e: %v\noutput:\n%s", err, out.String())
+	}
+}
+
+// TestKVDeleteE2E pins --versions "3,4,5" → params.versions []int.
+func TestKVDeleteE2E(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != opKVDelete {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			vs, _ := body.Params["versions"].([]any)
+			if len(vs) != 3 || vs[0] != float64(3) || vs[2] != float64(5) {
+				t.Errorf("params.versions: got %v", body.Params["versions"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: opKVDelete})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{
+		"kv", "delete", "secret", "app/db",
+		"--versions", "3,4,5",
+		"--target", "rdc-vault", "--backplane", srv.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("kv delete e2e: %v\noutput:\n%s", err, out.String())
+	}
+}
+
+// TestSysHealthE2E pins a no-param sys verb dispatches the right
+// op_id with no params field.
+func TestSysHealthE2E(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != opSysHealth {
+				t.Errorf("op_id: got %q want %q", body.OpID, opSysHealth)
+			}
+			if body.Params != nil {
+				t.Errorf("sys health should send no params; got %v", body.Params)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok", OpID: opSysHealth,
+				Result: json.RawMessage(`{"ok":true,"detail":"healthy"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"sys", "health", "--target", "rdc-vault", "--backplane", srv.URL})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("sys health e2e: %v\noutput:\n%s", err, out.String())
+	}
+}
+
+// TestAuthUserpassReadE2E pins <user> → params.username and the
+// vault.auth.userpass.read op_id.
+func TestAuthUserpassReadE2E(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != opAuthUserpassRead {
+				t.Errorf("op_id: got %q want %q", body.OpID, opAuthUserpassRead)
+			}
+			if body.Params["username"] != "svc-deploy" {
+				t.Errorf("params.username: got %v", body.Params["username"])
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok", OpID: opAuthUserpassRead,
+				Result: json.RawMessage(`{"policies":["default"]}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{
+		"auth", "userpass-read", "svc-deploy",
+		"--target", "rdc-vault", "--backplane", srv.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("auth userpass-read e2e: %v\noutput:\n%s", err, out.String())
+	}
+}
+
+// TestAuthApproleReadMapsRoleNameParam — approle-read uses the
+// `role_name` schema key (not `username`).
+func TestAuthApproleReadMapsRoleNameParam(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != opAuthApproleRead {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			if body.Params["role_name"] != "ci-runner" {
+				t.Errorf("params.role_name: got %v", body.Params)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: opAuthApproleRead})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{
+		"auth", "approle-read", "ci-runner",
+		"--target", "rdc-vault", "--backplane", srv.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("auth approle-read e2e: %v\noutput:\n%s", err, out.String())
+	}
+}
+
+// TestErrorStatusExitsNonZero — a dispatcher status=error envelope
+// surfaces as errOpError so main exits non-zero.
+func TestErrorStatusExitsNonZero(t *testing.T) {
+	errStr := "permission denied"
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, CallResult{
+				Status: "error", OpID: opKVRead, Error: &errStr,
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{
+		"kv", "read", "secret", "x",
+		"--target", "rdc-vault", "--backplane", srv.URL,
+	})
+	if err := root.Execute(); err == nil {
+		t.Fatalf("status=error should propagate a non-nil RunE error")
+	}
+}
+
+// TestHelpListsTree — `meho vault --help` documents every group, an
+// explicit acceptance criterion.
+func TestHelpListsTree(t *testing.T) {
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("vault --help: %v", err)
+	}
+	for _, want := range []string{"kv", "sys", "auth", "vault-1.x"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("vault --help missing %q; got:\n%s", want, out.String())
+		}
+	}
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -127,14 +127,22 @@ cli/
     │   │   ├── search.go         # `meho operation search` (GET /api/v1/operations/search).
     │   │   ├── call.go           # `meho operation call`   (POST /api/v1/operations/call).
     │   │   └── operation_test.go # render + helper + sentinel tests.
-    │   └── retrieval/         # G4.3-T2 #441 — retrieval-quality tooling.
-    │       ├── retrieval.go            # NewRootCmd.
-    │       ├── eval.go                 # `meho retrieval eval` (POST /api/v1/retrieve/eval).
-    │       ├── eval_test.go            # output-contract + URL-resolution tests.
-    │       ├── usage.go                # `meho retrieval usage` (GET /api/v1/retrieve/usage) — G4.3-T5b #464.
-    │       ├── usage_test.go           # query-param + wire-shape + 403/400 routing tests.
-    │       ├── retire_checklist.go     # `meho retrieval retire-checklist` (POST /api/v1/retrieve/retire-checklist) — G4.3-T6 #445.
-    │       └── retire_checklist_test.go # surface-bucket + table-render + marshal tests.
+    │   ├── retrieval/         # G4.3-T2 #441 — retrieval-quality tooling.
+    │   │   ├── retrieval.go            # NewRootCmd.
+    │   │   ├── eval.go                 # `meho retrieval eval` (POST /api/v1/retrieve/eval).
+    │   │   ├── eval_test.go            # output-contract + URL-resolution tests.
+    │   │   ├── usage.go                # `meho retrieval usage` (GET /api/v1/retrieve/usage) — G4.3-T5b #464.
+    │   │   ├── usage_test.go           # query-param + wire-shape + 403/400 routing tests.
+    │   │   ├── retire_checklist.go     # `meho retrieval retire-checklist` (POST /api/v1/retrieve/retire-checklist) — G4.3-T6 #445.
+    │   │   └── retire_checklist_test.go # surface-bucket + table-render + marshal tests.
+    │   ├── vmware/            # G3.1-T7 #511 — `meho vmware …` alias verb tree (connector_id="vmware-rest-9.0" pre-baked).
+    │   └── vault/             # G3.3-T6 #550 — `meho vault …` alias verb tree (connector_id="vault-1.x" pre-baked).
+    │       ├── vault.go          # NewRootCmd + shared HTTP/auth/render helpers + ConnectorID const.
+    │       ├── dispatch.go       # CallResult/callRequestBody + dispatchOp + renderCallResult + generic renderer.
+    │       ├── kv.go             # `meho vault kv read|list|put|versions|delete` (vault.kv.* ops, #545).
+    │       ├── sys.go            # `meho vault sys health|seal-status|mounts-list|auth-list` (vault.sys.* ops, #546).
+    │       ├── auth.go           # `meho vault auth userpass/approle list+read` (vault.auth.* ops, #547).
+    │       └── vault_test.go     # helpers + verb-tree wiring + flag→params wire-shape + e2e mocked-backplane tests.
     ├── discovery/
     │   ├── discovery.go       # /api/v1/commands manifest fetch + cobra graft.
     │   └── discovery_test.go  # 200/404/transport/decode + collision tests.
@@ -785,6 +793,79 @@ envelope, 409 carries `ambiguous_target` with colliding names, and
   would need a separate `cobra-complete`-style design pass.
 - Client-side caching. Every CLI invocation hits the API fresh — the
   source of truth is the backplane, not a stale local copy.
+
+## Vault alias verbs (`meho vault`, G3.3-T6 #550)
+
+`cli/internal/cmd/vault/` registers the operator-facing alias verb
+tree for the `vault-1.x` typed connector (Initiative #366). It is the
+same pattern as the `vmware` tree (G3.1-T7 #511): a thin cobra layer
+that pre-bakes one `connector_id` so operators don't type it on every
+dispatch. Every verb POSTs to `POST /api/v1/operations/call` — the
+same G0.6 dispatcher route the agent surface uses — so auth, policy,
+audit, JSONFlux, and broadcast all run identically whether an agent
+calls `call_operation` or an operator runs `meho vault …`. Per
+[CLAUDE.md](../../CLAUDE.md) postulate 5 these alias verbs are
+operator-only ergonomics and are **not** mirrored on the MCP surface.
+
+`ConnectorID = "vault-1.x"` is the dispatcher's natural-key encoding
+of `(product="vault", version="1.x", impl_id="vault")`, pinned by the
+backend connector-id-parse contract test. A future re-versioning is a
+single-line edit.
+
+### Subcommands
+
+- `meho vault kv read|list|put|versions|delete <mount> <path>` —
+  the KV-v2 group (`vault.kv.*`, ops registered by G3.3-T1 #545). The
+  `<mount> <path>` positional pair maps to `params.mount` /
+  `params.path`; the CLI always sends `mount` explicitly so the
+  operator's choice is authoritative (no client-side default that
+  could drift from the handler's `"secret"`). `put` takes
+  `--data '<json>'|@<file>` and an optional `--cas N`
+  (check-and-set; only sent when explicitly passed). `delete` takes
+  `--versions 3,4,5` (parsed client-side to `[]int` so a bad value is
+  an argv error, not a backend schema-rejection round-trip). `read`
+  replaces the consumer's `_secret-read.sh secret/<mount>/<path>`
+  wrapper.
+- `meho vault sys health|seal-status|mounts-list|auth-list` — read-
+  only diagnostics (`vault.sys.*`, G3.3-T2 #546). No args, no params.
+- `meho vault auth userpass-list|userpass-read <user>|approle-list|approle-read <role>`
+  — read-only identity browse (`vault.auth.*`, G3.3-T3 #547). The
+  `read` verbs map their single positional to the op's schema key
+  (`username` for userpass, `role_name` for approle).
+
+### Reserved flags (same shape across every verb)
+
+- `--target <slug>` — the Vault target the dispatcher resolves
+  server-side (sent as `{"name": "<slug>"}`; absent → `null` on the
+  wire).
+- `--json` — emit the raw `OperationResult` envelope instead of the
+  human render.
+- `--backplane <url>` — override the backplane URL (defaults to the
+  URL recorded by `meho login`).
+
+### Output discipline
+
+Vault payloads (secret data, metadata, version maps, mount maps) are
+nested JSON the operator reads as a tree, so every verb uses the
+generic indented-JSON renderer rather than a per-shape table — a
+per-op table buys little over the dump while risking contract-drift
+panics. Set-shaped responses (`vault kv list`,
+`vault auth userpass-list`, …) arrive **already reduced** to the
+JSONFlux sample + result-handle envelope by the dispatcher; the CLI
+prints that verbatim with the handle hint intact, consistent with the
+`vmware` sibling. Operators drill into a handle with the
+`meho operation` result verbs.
+
+### HTTP shape + exit codes
+
+Identical to the `meho operation` surface (the verbs are pre-scoped
+wrappers over the same route): bearer injection + one-shot
+401-refresh-retry via `api.NewAuthedClient`, hand-written
+`CallResult` / `callRequestBody` structs mirroring the backend
+Pydantic models (duplicated per package to avoid the cmd/* import
+cycle cmd/root.go's graft would otherwise create). Exit codes: `0`
+status=ok, `1` status=error/denied (via the `errOpError` sentinel),
+`2` auth_expired, `3` unreachable, `4` unexpected_response.
 
 ## Server-driven discovery (`internal/discovery/`)
 


### PR DESCRIPTION
## Summary

- Adds `cli/internal/cmd/vault/` — the operator-facing alias verb tree for the `vault-1.x` typed connector (Initiative #366), modeled on the existing `cmd/vmware/` tree. Every verb is a thin cobra wrapper that POSTs to `/api/v1/operations/call` with `connector_id="vault-1.x"` pre-baked, so it travels the **same G0.6 dispatcher path** (auth, policy, audit, JSONFlux, broadcast) the agent surface uses — not a vendor bypass. Per CLAUDE.md postulate 5 these verbs are operator-only ergonomics and are **not** mirrored on the MCP surface.
- Ships `vault kv read|list|put|versions|delete` (over `vault.kv.*` #545), `vault sys health|seal-status|mounts-list|auth-list` (over `vault.sys.*` #546), and `vault auth userpass/approle list+read` (over `vault.auth.*` #547). `vault kv read` replaces the consumer's `_secret-read.sh secret/<mount>/<path>` wrapper.
- Design choices: `<mount> <path>` always sends `mount` explicitly so the operator's choice is authoritative (no client-side default that could drift from the handler's `"secret"`); `--cas` is only sent when explicitly passed; `--versions` is parsed client-side to `[]int` so a bad value is an argv error, not a backend schema-rejection round-trip.
- Registered in `root.go` before dynamic discovery so the backplane manifest cannot shadow the built-in `vault` parent. `docs/codebase/cli.md` gains the module-layout entries (including the previously-undocumented `vmware` tree) and a `meho vault` section.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — no files need formatting
- [x] `go test ./internal/cmd/...` — all packages pass (new `vault` package: helpers, verb-tree wiring, flag→params wire-shape, arg arity, e2e mocked-backplane dispatch for kv/sys/auth, error-status non-zero exit, `--help` tree)
- [x] `meho vault --help` renders the kv/sys/auth tree; per-verb help documents op intent
- [x] `--target` resolves the Vault target (sent as `{"name": slug}`); `--data`/`--cas`/`--versions` map to op params; set-shaped output prints the dispatcher-reduced JSONFlux sample + handle verbatim (consistent with the vmware sibling)
- [x] `.claude/hooks/code-quality.py --diff` — exit 0

## Out of scope

- Op handler logic (Python; #545/#546/#547, already merged).
- Dev-mode integration harness / e2e suite against a real Vault (G3.3-T7).
- Operator onboarding doc (G3.3-T8).
- A dedicated `meho vmware` section in `docs/codebase/cli.md` — that tree (#511) shipped without its own doc section; this PR only adds its module-layout line for adjacency. Recorded as an adjacent finding for #511's doc debt.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #550


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `meho vault` command suite with support for KV-v2 operations (read, list, put, delete, versions)
  * Added vault system diagnostic commands (health, seal-status, mounts-list, auth-list)
  * Added vault authentication operations (userpass and approle read/list)
  * Introduced `--target`, `--json`, and `--backplane` flags for vault commands
  * JSON output support available across all vault operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->