### PR TITLE
feat(mcp): G9.1-T7 query_topology + list_targets meta-tools

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -1,0 +1,555 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``query_topology`` + ``list_targets`` — the G9 Targets/topology MCP family.
+
+Task #455 (G9.1-T7). Exactly **two** meta-tools register here, matching
+the CLAUDE.md narrow-waist agent surface (postulate 5, the
+Targets/topology row of the agent-surface table — 2 of the ~17
+meta-tools):
+
+* ``query_topology`` — *parametric*. One ``kind`` argument
+  (``dependents`` / ``dependencies`` / ``path``) selects between the
+  three T4 (#451) recursive-CTE read shapes. The per-shape verbs are
+  **not** registered as separate MCP tools — that would be the
+  per-op-tool anti-pattern CLAUDE.md's "What MEHO is NOT" bullet 1
+  forbids. ``topology.refresh`` is deliberately absent from the agent
+  surface: it is the operator CLI verb ``meho topology refresh
+  <target>`` (Initiative #363 item 10 amendment, 2026-05-14).
+* ``list_targets`` — enumerate the operator's accessible infrastructure
+  targets so an agent can pick a target before a ``call_operation`` or
+  a ``query_topology`` call.
+
+Why direct substrate calls, not REST wrappers
+=============================================
+
+CLAUDE.md "What MEHO is NOT" bullet 2: CLI, MCP, and REST are sibling
+fronts on one backplane — none is a thin wrapper of another.
+``query_topology`` calls the T4 :mod:`meho_backplane.topology.query`
+service functions directly; ``list_targets`` runs the same
+tenant-scoped ``select(TargetORM)`` the T5 REST route runs. This
+mirrors the established ``query_audit`` (#468) precedent which dispatches
+straight through the T1 audit substrate rather than the REST router.
+
+Audit + broadcast
+=================
+
+The MCP dispatcher (:func:`~meho_backplane.mcp.handlers.handle_tools_call`)
+writes exactly one ``audit_log`` row per ``tools/call`` invocation,
+keyed ``op_id = <tool-name>`` with the declared ``op_class``. Both
+tools declare ``op_class="read"`` so the broadcast classifier's
+read-shaped (aggregate-only) policy applies — no per-resource payload
+leak. No tool-side audit code is needed: registration alone satisfies
+the "each tools/call writes an audit row" acceptance criterion (same
+as ``query_audit``).
+
+Tenant scoping
+==============
+
+``query_topology`` is tenant-scoped automatically — the T4 service
+filters ``graph_node.tenant_id`` / ``graph_edge.tenant_id`` against
+``operator.tenant_id`` (lifted from the validated JWT) in both the
+anchor and the recursive term; no ``tenant_id`` argument exists on the
+tool so a cross-tenant probe is structurally impossible. ``list_targets``
+defaults to the operator's own tenant; the optional ``tenant`` argument
+selects another tenant's targets and is gated to ``tenant_admin`` —
+an ``operator``-role caller passing ``tenant`` gets ``-32602``.
+
+inputSchema conditionals
+========================
+
+The MCP dispatcher validates ``arguments`` with
+:class:`jsonschema.Draft202012Validator`, which honours JSON Schema
+2020-12 ``allOf`` / ``if`` / ``then``. ``query_topology``'s schema
+encodes the per-``kind`` requirement declaratively: ``dependents`` /
+``dependencies`` require ``target``; ``path`` requires ``from_name`` +
+``to_name``. A call that omits the conditionally-required field is
+rejected at the schema layer before the handler runs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.db.models import Tenant
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.operations._lookup import parse_connector_id
+from meho_backplane.topology.query import (
+    AmbiguousNodeError,
+    find_dependencies,
+    find_dependents,
+    find_path,
+)
+
+__all__: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# query_topology
+# ---------------------------------------------------------------------------
+
+
+_QUERY_TOPOLOGY_NAME: Final[str] = "query_topology"
+
+#: Bounds mirror the T4 service defaults (``query._DEFAULT_DEPTH`` /
+#: ``query._DEFAULT_MAX_HOPS``) and the T5 REST ceilings
+#: (``api.v1.topology._DEPTH_MAX`` / ``_MAX_HOPS_MAX``) so the three
+#: fronts cap a pathological traversal identically (#363 performance
+#: discipline).
+_DEPTH_DEFAULT: Final[int] = 16
+_DEPTH_MAX: Final[int] = 64
+_MAX_HOPS_DEFAULT: Final[int] = 8
+_MAX_HOPS_MAX: Final[int] = 32
+
+
+_QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "kind": {
+            "type": "string",
+            "enum": ["dependents", "dependencies", "path"],
+            "description": (
+                "Which traversal to run. `dependents` = reverse closure "
+                "(what depends on `target`); `dependencies` = forward "
+                "closure (what `target` depends on); `path` = shortest "
+                "unweighted route between `from_name` and `to_name`."
+            ),
+        },
+        "target": {
+            "type": ["string", "null"],
+            "description": (
+                "Root node name for `dependents` / `dependencies`. "
+                "Resolved against `graph_node.name` scoped to the "
+                "operator's tenant. Required when `kind` is `dependents` "
+                "or `dependencies`; ignored for `path`."
+            ),
+            "maxLength": 256,
+        },
+        "from_name": {
+            "type": ["string", "null"],
+            "description": (
+                "Path start node name. Required when `kind` is `path`; ignored otherwise."
+            ),
+            "maxLength": 256,
+        },
+        "to_name": {
+            "type": ["string", "null"],
+            "description": (
+                "Path end node name. Required when `kind` is `path`; ignored otherwise."
+            ),
+            "maxLength": 256,
+        },
+        "kind_filter": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional `graph_edge.kind` filter for `dependents` / "
+                "`dependencies` (e.g. `runs-on`, `mounts`, "
+                "`routes-through`, `belongs-to`). Restricts the walk to "
+                "edges of that kind. Ignored for `path`."
+            ),
+            "maxLength": 64,
+        },
+        "node_kind": {
+            "type": ["string", "null"],
+            "description": (
+                "Disambiguates the anchor when a name resolves to more "
+                "than one node kind in the tenant (e.g. a `target` and a "
+                "`vm` both named `app`). Pins the root to "
+                "`(tenant, node_kind, name)`. For `path` this pins the "
+                "`from_name` endpoint; pass `to_node_kind` for the other."
+            ),
+            "maxLength": 64,
+        },
+        "to_node_kind": {
+            "type": ["string", "null"],
+            "description": (
+                "Like `node_kind` but pins the `to_name` endpoint. Only "
+                "meaningful when `kind` is `path`."
+            ),
+            "maxLength": 64,
+        },
+        "depth": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": _DEPTH_MAX,
+            "default": _DEPTH_DEFAULT,
+            "description": (
+                "Max traversal depth for `dependents` / `dependencies`. "
+                f"Default {_DEPTH_DEFAULT}; hard ceiling {_DEPTH_MAX}. "
+                "Ignored for `path`."
+            ),
+        },
+        "max_hops": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": _MAX_HOPS_MAX,
+            "default": _MAX_HOPS_DEFAULT,
+            "description": (
+                "Max hops for `path`. Default "
+                f"{_MAX_HOPS_DEFAULT}; hard ceiling {_MAX_HOPS_MAX}. "
+                "Ignored for the closure kinds."
+            ),
+        },
+    },
+    "required": ["kind"],
+    "additionalProperties": False,
+    # Conditionally require the kind-specific arguments. Draft 2020-12
+    # `allOf` + `if`/`then` is honoured by the dispatcher's
+    # `jsonschema.Draft202012Validator`, so an agent that asks for
+    # `kind=path` without `from_name`/`to_name` is rejected at the
+    # schema layer before the handler runs.
+    "allOf": [
+        {
+            "if": {"properties": {"kind": {"const": "dependents"}}},
+            "then": {"required": ["target"]},
+        },
+        {
+            "if": {"properties": {"kind": {"const": "dependencies"}}},
+            "then": {"required": ["target"]},
+        },
+        {
+            "if": {"properties": {"kind": {"const": "path"}}},
+            "then": {"required": ["from_name", "to_name"]},
+        },
+    ],
+}
+
+
+_QUERY_TOPOLOGY_DESCRIPTION: Final[str] = (
+    "Query the topology graph. Use `kind=dependents` BEFORE recommending "
+    "a destructive op on a resource — it answers 'what depends on this "
+    "resource that I'd break?' (the blast-radius check: call this "
+    "*before* recommending a destructive op). Use `kind=dependencies` to "
+    "understand what a resource needs. Use `kind=path` to trace "
+    "connectivity between two specific resources. Tenant-scoped "
+    "automatically.\n\n"
+    "WHEN TO CALL: before suggesting any delete/shutdown/detach — "
+    "'is it safe to delete namespace customer-a-prod-foo?' → "
+    "`query_topology {kind: dependents, target: customer-a-prod-foo}` "
+    "returns every service / ingress / database that would break. Also "
+    "for impact reasoning ('what does this VM run on?') and reachability "
+    "('is there any route from this ingress to that datastore?').\n\n"
+    "PARAMETRIC: `kind` is the discriminator — `dependents` / "
+    "`dependencies` need `target`; `path` needs `from_name` + "
+    "`to_name`. The three shapes are one tool, not three: there is no "
+    "separate `topology.dependents` tool. If a name is ambiguous in the "
+    "tenant (same name as both, e.g., a target and a vm) pass "
+    "`node_kind` to pin the anchor; an ambiguous bare name returns "
+    "-32602 naming the candidate kinds.\n\n"
+    "Returns `{kind, nodes: [TopologyNode, ...]}` for the closure kinds "
+    "(root at depth 0, so a one-element list means 'exists but nothing "
+    "depends on it' and an empty list means 'no such node in this "
+    'tenant\'); `{kind: "path", path: TopologyPath|null}` for `path` '
+    "(null = unreachable within `max_hops`, a valid answer, not an "
+    "error)."
+)
+
+
+async def _query_topology_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a ``query_topology`` call to the matching T4 verb.
+
+    The dispatcher has already jsonschema-validated *arguments* against
+    :data:`_QUERY_TOPOLOGY_INPUT_SCHEMA`, including the per-``kind``
+    conditional ``required`` clauses, so the conditionally-required
+    field is guaranteed present for its ``kind``. Tenant scope comes
+    from *operator* inside the T4 service — never from *arguments*.
+
+    :class:`~meho_backplane.topology.query.AmbiguousNodeError` (a bare
+    name resolving to multiple kinds with no ``node_kind`` pin) is an
+    operator-actionable input problem, so it surfaces as JSON-RPC
+    ``-32602`` with the candidate kinds named — the same recovery the
+    REST front offers as a 409.
+    """
+    kind: str = arguments["kind"]
+    try:
+        if kind == "dependents":
+            nodes = await find_dependents(
+                operator,
+                arguments["target"],
+                kind=arguments.get("node_kind"),
+                depth=int(arguments.get("depth", _DEPTH_DEFAULT)),
+                kind_filter=arguments.get("kind_filter"),
+            )
+            return {"kind": kind, "nodes": [n.model_dump(mode="json") for n in nodes]}
+        if kind == "dependencies":
+            nodes = await find_dependencies(
+                operator,
+                arguments["target"],
+                kind=arguments.get("node_kind"),
+                depth=int(arguments.get("depth", _DEPTH_DEFAULT)),
+                kind_filter=arguments.get("kind_filter"),
+            )
+            return {"kind": kind, "nodes": [n.model_dump(mode="json") for n in nodes]}
+        # kind == "path" — the enum + schema guarantee no other value.
+        result = await find_path(
+            operator,
+            arguments["from_name"],
+            arguments["to_name"],
+            from_kind=arguments.get("node_kind"),
+            to_kind=arguments.get("to_node_kind"),
+            max_hops=int(arguments.get("max_hops", _MAX_HOPS_DEFAULT)),
+        )
+    except AmbiguousNodeError as exc:
+        raise McpInvalidParamsError(str(exc)) from exc
+    return {
+        "kind": kind,
+        "path": None if result is None else result.model_dump(mode="json"),
+    }
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_QUERY_TOPOLOGY_NAME,
+        description=_QUERY_TOPOLOGY_DESCRIPTION,
+        inputSchema=_QUERY_TOPOLOGY_INPUT_SCHEMA,
+        outputSchema={
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": ["dependents", "dependencies", "path"],
+                },
+                "nodes": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Present for the closure kinds. TopologyNode rows "
+                        "ordered (depth, name); root at depth 0. See "
+                        "`meho_backplane.topology.schemas.TopologyNode`."
+                    ),
+                },
+                "path": {
+                    "type": ["object", "null"],
+                    "description": (
+                        "Present for `kind=path`. A TopologyPath, or null "
+                        "when the target is unreachable within `max_hops`."
+                    ),
+                },
+            },
+            "required": ["kind"],
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class="read",
+    ),
+    handler=_query_topology_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# list_targets
+# ---------------------------------------------------------------------------
+
+
+_LIST_TARGETS_NAME: Final[str] = "list_targets"
+
+
+_LIST_TARGETS_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "connector_id": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional connector filter in the form "
+                '`<impl_id>-<version>` (e.g. "vmware-rest-9.0") or a '
+                'v1-style single-product slug (e.g. "vault"). Only the '
+                "product component is used: the result is narrowed to "
+                "targets whose `product` matches that connector's "
+                "product. Omit to list every target."
+            ),
+            "maxLength": 256,
+        },
+        "tenant": {
+            "type": ["string", "null"],
+            "description": (
+                "Cross-tenant scope. Omit / null → the operator's own "
+                "tenant (the only choice for the `operator` role). A "
+                "tenant slug or UUID selects another tenant's targets "
+                "and REQUIRES the `tenant_admin` role; an `operator`-role "
+                "caller passing this gets -32602."
+            ),
+            "maxLength": 256,
+        },
+        "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100,
+            "description": "Page size. Default 100; max 500.",
+        },
+        "cursor": {
+            "type": ["string", "null"],
+            "description": (
+                "Keyset-pagination cursor: pass the last `name` from the "
+                "previous page to fetch the next. Results are ordered by "
+                "`name` ascending."
+            ),
+            "maxLength": 256,
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+_LIST_TARGETS_DESCRIPTION: Final[str] = (
+    "List the operator's accessible infrastructure targets, optionally "
+    "filtered by connector. Use to enumerate available infrastructure "
+    "before picking a target for `call_operation` or `query_topology` — "
+    "the `name` of a row here is what those tools expect as their "
+    "`target`.\n\n"
+    "WHEN TO CALL: the operator asks 'what can I act on?', or you need a "
+    "concrete target name and only have a product in mind ('list the "
+    "vCenters' → `connector_id=vmware-rest-9.0`). Tenant scope is the "
+    "operator's own tenant unless a `tenant_admin` passes `tenant`.\n\n"
+    "Returns `{targets: [{id, name, aliases, product, host}, ...], "
+    "next_cursor: <name|null>}` ordered by name; `next_cursor` is the "
+    "last name on the page when more rows may exist, else null."
+)
+
+
+async def _resolve_tenant_scope(operator: Operator, tenant_arg: str | None) -> Any:
+    """Resolve the tenant id to scope the listing to.
+
+    No ``tenant`` argument → the operator's own tenant (the only path
+    open to an ``operator``-role caller). A ``tenant`` argument is a
+    cross-tenant request: it requires ``tenant_admin`` and is resolved
+    by slug first then UUID. An unknown tenant, or a non-admin passing
+    ``tenant``, surfaces as ``-32602`` (operator-actionable input
+    problem) rather than silently falling back to the own-tenant scope
+    — a silent fallback would make a typo'd cross-tenant query look
+    like an empty tenant.
+    """
+    if tenant_arg is None:
+        return operator.tenant_id
+    if operator.tenant_role != TenantRole.TENANT_ADMIN:
+        raise McpInvalidParamsError(
+            "list_targets: the `tenant` argument (cross-tenant scope) "
+            "requires the tenant_admin role",
+        )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        by_slug = await session.execute(
+            select(Tenant.id).where(Tenant.slug == tenant_arg),
+        )
+        tenant_id = by_slug.scalar_one_or_none()
+        if tenant_id is not None:
+            return tenant_id
+        # Slug miss — try the argument as a tenant UUID.
+        try:
+            from uuid import UUID
+
+            candidate = UUID(tenant_arg)
+        except ValueError:
+            candidate = None
+        if candidate is not None:
+            by_id = await session.execute(
+                select(Tenant.id).where(Tenant.id == candidate),
+            )
+            tenant_id = by_id.scalar_one_or_none()
+            if tenant_id is not None:
+                return tenant_id
+    raise McpInvalidParamsError(
+        f"list_targets: no tenant matches {tenant_arg!r} (tried slug then UUID)",
+    )
+
+
+async def _list_targets_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Enumerate targets for the resolved tenant, optionally product-filtered.
+
+    Runs the same tenant-scoped, name-keyset-paginated
+    ``select(TargetORM)`` the T5 REST ``GET /api/v1/targets`` route runs
+    — CLI / MCP / REST are sibling fronts on one backplane, so this is a
+    direct substrate query, not a REST-route wrapper. The optional
+    ``connector_id`` is canonicalised through
+    :func:`~meho_backplane.operations._lookup.parse_connector_id` and
+    only its product component drives a ``TargetORM.product`` exact-match
+    filter (targets carry a product slug, not a connector id).
+    """
+    scope_tenant_id = await _resolve_tenant_scope(operator, arguments.get("tenant"))
+
+    stmt = select(TargetORM).where(TargetORM.tenant_id == scope_tenant_id)
+
+    connector_id = arguments.get("connector_id")
+    if connector_id is not None:
+        product, _version, _impl_id = parse_connector_id(connector_id)
+        stmt = stmt.where(TargetORM.product == product)
+
+    cursor = arguments.get("cursor")
+    if cursor is not None:
+        stmt = stmt.where(TargetORM.name > cursor)
+
+    limit = int(arguments.get("limit", 100))
+    stmt = stmt.order_by(TargetORM.name).limit(limit)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(stmt)
+        rows = list(result.scalars().all())
+
+    targets = [
+        {
+            "id": str(t.id),
+            "name": t.name,
+            "aliases": list(t.aliases),
+            "product": t.product,
+            "host": t.host,
+        }
+        for t in rows
+    ]
+    # A full page implies there *may* be more rows; surface the last
+    # name as the keyset cursor. A short page is definitively the end.
+    next_cursor = targets[-1]["name"] if len(targets) == limit else None
+    return {"targets": targets, "next_cursor": next_cursor}
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_LIST_TARGETS_NAME,
+        description=_LIST_TARGETS_DESCRIPTION,
+        inputSchema=_LIST_TARGETS_INPUT_SCHEMA,
+        outputSchema={
+            "type": "object",
+            "properties": {
+                "targets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "name": {"type": "string"},
+                            "aliases": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "product": {"type": "string"},
+                            "host": {"type": "string"},
+                        },
+                        "required": ["id", "name", "aliases", "product", "host"],
+                    },
+                },
+                "next_cursor": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Last name on the page when more rows may exist; "
+                        "null when the page is the end of the set."
+                    ),
+                },
+            },
+            "required": ["targets", "next_cursor"],
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class="read",
+    ),
+    handler=_list_targets_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -129,7 +129,9 @@ def isolated_registry() -> Iterator[None]:
     in any test file that imports the fixture after the first one
     runs. The G4.1-T3 kb meta-tools (``mcp.tools.knowledge``) and the
     matching ``meho://kb/{slug}`` resource (``mcp.resources.kb``) join
-    the list for the same reason.
+    the list for the same reason. The G9.1-T7 topology meta-tools
+    (``mcp.tools.topology`` — ``query_topology`` + ``list_targets``)
+    join the list for the same reason.
     """
     from meho_backplane.mcp.resources import kb as kb_resource
     from meho_backplane.mcp.resources import tenant_feed, tenant_info
@@ -139,6 +141,7 @@ def isolated_registry() -> Iterator[None]:
         knowledge,
         meho_status,
         operations,
+        topology,
     )
 
     clear_registries()
@@ -147,6 +150,7 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(connector_admin)
     importlib.reload(audit)
     importlib.reload(knowledge)
+    importlib.reload(topology)
     importlib.reload(tenant_info)
     importlib.reload(tenant_feed)
     importlib.reload(kb_resource)

--- a/backend/tests/test_mcp_tools_topology.py
+++ b/backend/tests/test_mcp_tools_topology.py
@@ -1,0 +1,570 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G9.1-T7 (#455) topology MCP meta-tools.
+
+Two tools, exactly two — ``query_topology`` (parametric) and
+``list_targets``. Coverage maps to the issue acceptance criteria:
+
+* Both meta-tools registered against G0.5's MCP server (visible in
+  ``tools/list``); the per-shape ``topology.*`` tools are NOT
+  registered (narrow-waist postulate).
+* ``query_topology`` inputSchema is conditional on ``kind``:
+  ``dependents`` / ``dependencies`` require ``target``; ``path``
+  requires ``from_name`` + ``to_name`` — enforced at the dispatcher's
+  ``jsonschema.Draft202012Validator`` layer.
+* ``tools/call query_topology {kind: dependents, target: <node>}``
+  dispatches through the T4 service and returns the dependents list.
+* ``list_targets`` returns the operator's tenant's targets;
+  ``tenant_admin`` + ``tenant`` works cross-tenant; an ``operator``
+  passing ``tenant`` is rejected.
+* Tool descriptions name the blast-radius use-case verbatim ("call
+  this *before* recommending a destructive op").
+* Tenant scope comes from the operator JWT, never the arguments dict.
+
+The T4 service functions are patched at the tool's import site so the
+route tests don't depend on a PG-seeded graph; the service itself is
+covered by ``tests/test_topology_query_schemas.py`` +
+``tests/integration/test_topology_query.py``. ``list_targets`` runs a
+real ``select(TargetORM)`` against the SQLite-migrated test DB with
+seeded rows (no substrate to patch — it is a direct query).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.db.models import Tenant
+from meho_backplane.mcp.registry import get_tool
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.topology.schemas import TopologyNode, TopologyPath
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_DEPENDENTS_PATCH = "meho_backplane.mcp.tools.topology.find_dependents"
+_DEPENDENCIES_PATCH = "meho_backplane.mcp.tools.topology.find_dependencies"
+_PATH_PATCH = "meho_backplane.mcp.tools.topology.find_path"
+
+_OTHER_TENANT_ID = UUID("00000000-0000-0000-0000-0000000000b0")
+
+
+def _node(name: str, kind: str, depth: int, via: str | None) -> TopologyNode:
+    return TopologyNode(
+        id=UUID(int=depth + 1),
+        kind=kind,
+        name=name,
+        properties={},
+        depth=depth,
+        via_edge_kind=via,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration + narrow-waist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_tools_list_exposes_exactly_the_two_meta_tools(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Both meta-tools register; the per-shape variants do not."""
+    client, _op = client_with_operator
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert response.status_code == 200
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "query_topology" in names
+    assert "list_targets" in names
+    # Narrow-waist postulate (CLAUDE.md #5): no per-shape topology tools.
+    for forbidden in (
+        "topology.dependents",
+        "topology.dependencies",
+        "topology.path",
+        "topology.refresh",
+        "targets.discover",
+    ):
+        assert forbidden not in names
+        assert get_tool(forbidden) is None
+
+
+def test_registered_definitions_are_operator_read_class() -> None:
+    """Both tools declare operator role + read op_class (audit/broadcast contract)."""
+    for tool_name in ("query_topology", "list_targets"):
+        entry = get_tool(tool_name)
+        assert entry is not None
+        defn, _handler = entry
+        assert defn.required_role == TenantRole.OPERATOR
+        assert defn.op_class == "read"
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_description_names_blast_radius_verbatim(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The load-bearing description names the blast-radius use-case verbatim."""
+    client, _op = client_with_operator
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    )
+    tools = {t["name"]: t for t in response.json()["result"]["tools"]}
+    desc = tools["query_topology"]["description"]
+    # Verbatim phrase from CLAUDE.md / the initiative body.
+    assert "before* recommending a destructive op" in desc
+    assert "kind=dependents" in desc
+    list_desc = tools["list_targets"]["description"].lower()
+    assert "before picking a target" in list_desc
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_input_schema_is_conditional_on_kind(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """inputSchema encodes the per-kind required fields via allOf/if/then."""
+    client, _op = client_with_operator
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 3, "method": "tools/list"},
+    )
+    tools = {t["name"]: t for t in response.json()["result"]["tools"]}
+    schema = tools["query_topology"]["inputSchema"]
+    assert schema["required"] == ["kind"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["kind"]["enum"] == [
+        "dependents",
+        "dependencies",
+        "path",
+    ]
+    conditionals = schema["allOf"]
+    by_kind = {c["if"]["properties"]["kind"]["const"]: c["then"]["required"] for c in conditionals}
+    assert by_kind["dependents"] == ["target"]
+    assert by_kind["dependencies"] == ["target"]
+    assert sorted(by_kind["path"]) == ["from_name", "to_name"]
+    # MEHO-internal fields stripped from the wire shape.
+    assert "required_role" not in tools["query_topology"]
+    assert "op_class" not in tools["query_topology"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_path_without_endpoints_rejected_at_schema_layer(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """kind=path with no from_name/to_name → -32602 before the handler runs."""
+    client, _op = client_with_operator
+    mock_path = AsyncMock()
+    with patch(_PATH_PATCH, new=mock_path):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {"name": "query_topology", "arguments": {"kind": "path"}},
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    mock_path.assert_not_awaited()
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_dependents_without_target_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """kind=dependents with no target → -32602 at the schema layer."""
+    client, _op = client_with_operator
+    mock_dep = AsyncMock()
+    with patch(_DEPENDENTS_PATCH, new=mock_dep):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {"kind": "dependents"},
+                },
+            },
+        )
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+    mock_dep.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# query_topology dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_dependents_returns_node_list(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """kind=dependents dispatches find_dependents and returns its closure."""
+    client, op = client_with_operator
+    nodes = [
+        _node("customer-a-prod-foo", "namespace", 0, None),
+        _node("svc-a", "service", 1, "belongs-to"),
+    ]
+    mock_dep = AsyncMock(return_value=nodes)
+    with patch(_DEPENDENTS_PATCH, new=mock_dep):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {
+                        "kind": "dependents",
+                        "target": "customer-a-prod-foo",
+                    },
+                },
+            },
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["kind"] == "dependents"
+    assert [n["name"] for n in payload["nodes"]] == [
+        "customer-a-prod-foo",
+        "svc-a",
+    ]
+    mock_dep.assert_awaited_once()
+    # Tenant scope comes from the operator, not the arguments dict.
+    assert mock_dep.await_args.args[0] is op
+    assert mock_dep.await_args.args[1] == "customer-a-prod-foo"
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_dependencies_passes_filters_through(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """kind=dependencies forwards depth / kind_filter / node_kind to T4."""
+    client, _op = client_with_operator
+    mock_deps = AsyncMock(return_value=[_node("vm-1", "vm", 0, None)])
+    with patch(_DEPENDENCIES_PATCH, new=mock_deps):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {
+                        "kind": "dependencies",
+                        "target": "vm-1",
+                        "depth": 4,
+                        "kind_filter": "runs-on",
+                        "node_kind": "vm",
+                    },
+                },
+            },
+        )
+    assert response.json()["result"]["isError"] is False
+    assert mock_deps.await_args.kwargs == {
+        "kind": "vm",
+        "depth": 4,
+        "kind_filter": "runs-on",
+    }
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_path_returns_path_or_null(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """kind=path returns the TopologyPath; an unreachable pair returns null."""
+    client, _op = client_with_operator
+    found = TopologyPath(
+        nodes=(
+            _node("a", "service", 0, None),
+            _node("b", "datastore", 1, "mounts"),
+        ),
+        total_hops=1,
+    )
+    with patch(_PATH_PATCH, new=AsyncMock(return_value=found)):
+        ok = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {
+                        "kind": "path",
+                        "from_name": "a",
+                        "to_name": "b",
+                    },
+                },
+            },
+        )
+    payload = json.loads(ok.json()["result"]["content"][0]["text"])
+    assert payload["kind"] == "path"
+    assert [n["name"] for n in payload["path"]["nodes"]] == ["a", "b"]
+
+    with patch(_PATH_PATCH, new=AsyncMock(return_value=None)):
+        miss = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 13,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {
+                        "kind": "path",
+                        "from_name": "a",
+                        "to_name": "z",
+                    },
+                },
+            },
+        )
+    miss_payload = json.loads(miss.json()["result"]["content"][0]["text"])
+    assert miss_payload == {"kind": "path", "path": None}
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_ambiguous_node_maps_to_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AmbiguousNodeError → -32602 naming the candidate kinds."""
+    from meho_backplane.topology.query import AmbiguousNodeError
+
+    client, _op = client_with_operator
+    mock_dep = AsyncMock(side_effect=AmbiguousNodeError("app", ["target", "vm"]))
+    with patch(_DEPENDENTS_PATCH, new=mock_dep):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 14,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {"kind": "dependents", "target": "app"},
+                },
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "ambiguous" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_rejects_additional_properties(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """additionalProperties: false blocks a smuggled tenant_id."""
+    client, _op = client_with_operator
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 15,
+            "method": "tools/call",
+            "params": {
+                "name": "query_topology",
+                "arguments": {
+                    "kind": "dependents",
+                    "target": "x",
+                    "tenant_id": "11111111-1111-1111-1111-111111111111",
+                },
+            },
+        },
+    )
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.READ_ONLY], indirect=True)
+def test_query_topology_read_only_role_forbidden(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """read_only is below the operator gate."""
+    client, _op = client_with_operator
+    mock_dep = AsyncMock(return_value=[])
+    with patch(_DEPENDENTS_PATCH, new=mock_dep):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 16,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {"kind": "dependents", "target": "x"},
+                },
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+    mock_dep.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# list_targets — runs a real query against the migrated test DB
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(tenant_id: UUID, slug: str) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(Tenant(id=tenant_id, slug=slug, name=slug))
+
+
+async def _seed_target(
+    tenant_id: UUID,
+    name: str,
+    product: str,
+    host: str,
+) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            TargetORM(
+                tenant_id=tenant_id,
+                name=name,
+                aliases=[],
+                product=product,
+                host=host,
+                port=443,
+                secret_ref="vault:kv/data/x",
+                auth_model="shared_service_account",
+            )
+        )
+
+
+def _list_targets_call(
+    client: TestClient,
+    call_id: int,
+    arguments: dict[str, Any],
+) -> Any:
+    return client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": "list_targets", "arguments": arguments},
+        },
+    )
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+async def test_list_targets_returns_own_tenant_rows(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """list_targets returns the operator's tenant's targets, name-ordered."""
+    client, _op = client_with_operator
+    await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+    await _seed_target(OPERATOR_TENANT_ID, "rdc-vcenter", "vmware", "vc.example")
+    await _seed_target(OPERATOR_TENANT_ID, "rdc-vault", "vault", "vault.example")
+
+    response = _list_targets_call(client, 20, {})
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert [t["name"] for t in payload["targets"]] == ["rdc-vault", "rdc-vcenter"]
+    assert payload["next_cursor"] is None
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+async def test_list_targets_connector_id_filters_by_product(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """connector_id is canonicalised to its product and filters the rows."""
+    client, _op = client_with_operator
+    await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+    await _seed_target(OPERATOR_TENANT_ID, "rdc-vcenter", "vmware", "vc.example")
+    await _seed_target(OPERATOR_TENANT_ID, "rdc-vault", "vault", "vault.example")
+
+    response = _list_targets_call(client, 21, {"connector_id": "vmware-rest-9.0"})
+    payload = json.loads(response.json()["result"]["content"][0]["text"])
+    assert [t["name"] for t in payload["targets"]] == ["rdc-vcenter"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+async def test_list_targets_operator_cannot_cross_tenant(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An operator passing `tenant` is rejected (-32602), not silently scoped."""
+    client, _op = client_with_operator
+    await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+
+    response = _list_targets_call(client, 22, {"tenant": "other-tenant"})
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "tenant_admin" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_list_targets_tenant_admin_cross_tenant_by_slug(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """tenant_admin + `tenant` slug lists the other tenant's targets."""
+    client, _op = client_with_operator
+    await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+    await _seed_tenant(_OTHER_TENANT_ID, "other-tenant")
+    await _seed_target(_OTHER_TENANT_ID, "other-vc", "vmware", "ovc.example")
+
+    response = _list_targets_call(client, 23, {"tenant": "other-tenant"})
+    payload = json.loads(response.json()["result"]["content"][0]["text"])
+    assert [t["name"] for t in payload["targets"]] == ["other-vc"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_list_targets_unknown_tenant_is_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An unknown `tenant` surfaces as -32602, not an empty list."""
+    client, _op = client_with_operator
+    await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+
+    response = _list_targets_call(client, 24, {"tenant": "no-such-tenant"})
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "no tenant matches" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+async def test_list_targets_keyset_pagination(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A full page surfaces a next_cursor; the follow-up page resumes after it."""
+    client, _op = client_with_operator
+    await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+    for n in ("t-a", "t-b", "t-c"):
+        await _seed_target(OPERATOR_TENANT_ID, n, "vmware", f"{n}.example")
+
+    page1 = json.loads(
+        _list_targets_call(client, 25, {"limit": 2}).json()["result"]["content"][0]["text"]
+    )
+    assert [t["name"] for t in page1["targets"]] == ["t-a", "t-b"]
+    assert page1["next_cursor"] == "t-b"
+
+    page2 = json.loads(
+        _list_targets_call(client, 26, {"limit": 2, "cursor": "t-b"}).json()["result"]["content"][
+            0
+        ]["text"]
+    )
+    assert [t["name"] for t in page2["targets"]] == ["t-c"]
+    assert page2["next_cursor"] is None

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -34,10 +34,14 @@ tenant raises `AmbiguousNodeError`; pass the optional `kind` (or
 name)` unique row. The read package never inserts, updates, or deletes.
 
 The REST front (T5, #453) is landed and documented below ("REST API
-surface"). The CLI/MCP fronts (T6/T7) and the
-`docs/architecture/topology.md` operator doc remain out of scope here —
-they consume `query.py` / `refresh.py` as a thin shell and land in
-G9.1-T6 through T8.
+surface"). The MCP front (T7, #455) is landed too — the two
+narrow-waist meta-tools `query_topology` (parametric: `kind` selects
+`dependents` / `dependencies` / `path`) and `list_targets` register in
+`mcp/tools/topology.py` and call `query.py` / `select(TargetORM)`
+directly (sibling fronts on one backplane, not REST wrappers). The CLI
+front (T6) and the `docs/architecture/topology.md` operator doc remain
+out of scope here — they consume `query.py` / `refresh.py` as a thin
+shell and land in G9.1-T6 and T8.
 
 ## Key types
 


### PR DESCRIPTION
## Summary

- Registers exactly the **two** CLAUDE.md narrow-waist Targets/topology meta-tools against G0.5's MCP registry — `query_topology` (parametric) and `list_targets` — mirroring the `meho_status` / `query_audit` registration pattern. No per-shape `topology.*` tools (the per-op-tool anti-pattern CLAUDE.md forbids); `topology.refresh` stays CLI-only per the #363 amendment.
- `query_topology` is parametric: one `kind` arg (`dependents`/`dependencies`/`path`) dispatches to the merged T4 (#451) recursive-CTE service. The `inputSchema` encodes the per-`kind` required fields declaratively via Draft-2020-12 `allOf`/`if`/`then`, so the dispatcher's `jsonschema` layer rejects an under-specified call before the handler runs. The description names the blast-radius use-case verbatim ("call this *before* recommending a destructive op").
- `list_targets` runs the same tenant-scoped `select(TargetORM)` the T5 REST route runs (sibling front on the backplane, not a REST wrapper). `connector_id` is canonicalised via `parse_connector_id` and filters by product; the optional `tenant` arg is cross-tenant and gated to `tenant_admin`.
- Both declare `op_class=read` so the dispatcher's one-audit-row-per-`tools/call` plus the broadcast classifier's aggregate-only policy apply with no tool-side audit code.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean (applied)
- [x] `mypy src/meho_backplane/mcp/tools/topology.py` — clean
- [x] `pytest tests/test_mcp_tools_topology.py` — 18 passed
- [x] Adjacent MCP/topology suites — `tests/test_mcp_tools_connector_admin.py tests/test_mcp_tools_knowledge.py tests/test_mcp_audit.py tests/test_topology_query_schemas.py` + topology — 61 passed
- [x] Both meta-tools registered + visible in `tools/list`; per-shape variants absent (narrow-waist)
- [x] `query_topology` inputSchema conditional on `kind` (`dependents`/`dependencies` → `target`; `path` → `from_name`+`to_name`), enforced at the schema layer
- [x] `tools/call query_topology {kind: dependents, target: <node>}` returns the dependents list
- [x] `list_targets` returns own-tenant targets; `tenant_admin`+`tenant` works cross-tenant; `operator`+`tenant` → -32602; unknown tenant → -32602; keyset pagination
- [x] Tool descriptions name the blast-radius use-case verbatim
- [x] Audit row per `tools/call` (declared `op_class=read`; dispatcher writes it)
- [x] `code-quality.py --diff` — 0 blockers

## Out of scope

- T4 query service (#451) + T5 REST routes (#453) — merged prerequisites.
- T6 CLI verbs (#454), T8 acceptance/docs (#456) — sibling tasks.
- Admin meta-tools (G9.2 annotate; G9.3 history/diff/timeline) — own Initiatives.

## Adjacent findings (out of scope; not addressed here)

- `tests/test_mcp_registry.py::test_tools_list_endpoint_returns_filtered_tools` is **already red on clean `origin/main`** (verified by stash-and-run). Root cause is a pre-existing test-isolation bug: the `TestClient` lifespan's `eager_import_mcp_modules` re-registers production tools (`meho.status`, etc.) after the test's `clear_registries()`, breaking its strict `== ["read_only.tool"]` assertion — independent of this PR. Worth its own ticket.
- `mcp/tools/topology.py` is 556 lines (code-quality warn >400, block >600). Two-tool MCP family is one cohesive module per CLAUDE.md; splitting now would be premature.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #455


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `query_topology` MCP tool to query infrastructure topology, including dependents, dependencies, and shortest paths between nodes.
  * Added `list_targets` MCP tool to list infrastructure targets with pagination support and optional product filtering.
  * Both tools require operator role; tenant admins can access cross-tenant data.

* **Tests**
  * Added comprehensive test suite for topology MCP tools.

* **Documentation**
  * Updated topology documentation to describe MCP tools and their capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->