### PR TITLE
test(connectors): G3.2 fix k3d cache-key assertion (KeyError: 'k3s-test') (#578)

### DIFF
--- a/backend/tests/integration/test_connectors_k8s_k3d.py
+++ b/backend/tests/integration/test_connectors_k8s_k3d.py
@@ -214,10 +214,16 @@ async def test_api_client_cached_across_calls_against_live_k3s(
 ) -> None:
     """Second fingerprint against the same target reuses the cached client."""
     connector, target = k3s_connector
+    # Derive the cache key from the SUT itself so the test tracks the
+    # connector's keying contract (currently ``target.secret_ref``;
+    # see ``KubernetesConnector._cache_key``). Indexing by
+    # ``target.name`` instead raised ``KeyError`` whenever the k3s
+    # testcontainer actually provisioned.
+    cache_key = connector._cache_key(target)
     await connector.fingerprint(target)
-    cached_client_id_after_first = id(connector._api_clients[target.name])
+    cached_client_id_after_first = id(connector._api_clients[cache_key])
     await connector.fingerprint(target)
-    cached_client_id_after_second = id(connector._api_clients[target.name])
+    cached_client_id_after_second = id(connector._api_clients[cache_key])
     assert cached_client_id_after_first == cached_client_id_after_second
 
 


### PR DESCRIPTION
## Summary
- Fix the k3d integration test `test_api_client_cached_across_calls_against_live_k3s` so it indexes `connector._api_clients` via `connector._cache_key(target)` (returns `target.secret_ref`) instead of `target.name`. The old assertion deterministically raised `KeyError: 'k3s-test'` whenever the k3s testcontainer actually provisioned; it stayed invisible in CI because the test skips cleanly when the runner cannot bring up k3s.
- Test-only correction; production code under `backend/src/meho_backplane/connectors/kubernetes/` is untouched — the connector's `secret_ref`-keyed cache is correct as-is.
- Deriving the cache key from the SUT itself keeps the test tracking the connector's keying contract rather than re-encoding it, so the invariant ("second `fingerprint()` reuses the cached `ApiClient`") remains genuinely under test.

## Test plan
- [x] `uv run ruff check backend/tests/integration/test_connectors_k8s_k3d.py` — clean
- [x] `uv run ruff format --check backend/tests/integration/test_connectors_k8s_k3d.py` — formatted
- [x] `uv run mypy backend/tests/integration/test_connectors_k8s_k3d.py --ignore-missing-imports` — Success: no issues found in 1 source file
- [x] `uv run pytest backend/tests/integration/test_connectors_k8s_k3d.py --collect-only` — 22 tests collected
- [x] `uv run pytest backend/tests/test_connectors_k8s_*.py -q` — 175 passed (full K8s connector unit-test suite)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0 (no new violations)
- [x] AC: assertion now indexes `connector._api_clients[connector._cache_key(target)]` (test-only edit confirmed by `git diff`)
- [ ] AC: live-k3s run (`uv run pytest ...::test_api_client_cached_across_calls_against_live_k3s`) — `skipped-in-sandbox` here (no Docker socket); CI runs the integration job with provisioned containers.
- [ ] AC: teeth check (force `_get_api_client` to rebuild → test goes red) — also requires a live k3s; logically: with the cache key now correct, both `_api_clients[cache_key]` reads resolve to whatever `_get_api_client` returned at that moment, so forcing a rebuild produces two distinct `ApiClient` ids and the `==` assertion fails. Both kept-but-not-pinned checks land in CI on the integration runner.

## Out of scope
- The k3s-skips-in-CI behavior itself (intentional infra resilience).
- Any change to `_cache_key` semantics or the `secret_ref` keying decision.
- The unrelated CLI Go flaky test (`TestRunWatch_AuthHeaderSent`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #578


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed internal test to properly verify Kubernetes connector cache key computation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->