### PR TITLE
fix(test): process-wide registry isolation — unblock pytest-xdist (#585)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,12 @@ jobs:
     # testcontainer variance) with headroom for unit-suite growth.
     # Job name is intentionally unchanged so the existing
     # branch-protection required check stays satisfied. The durable
-    # fix that brings this back under ~10 min — pytest-xdist
-    # `-n auto` parallelization of the serial unit suite — is
-    # tracked in #564.
+    # fix — pytest-xdist `-n auto` parallelization of the unit suite —
+    # LANDED via #585 (which removed the global-registry isolation
+    # leaks that blocked it; see the Pytest step below). The 50-min
+    # cap is now generous headroom kept deliberately for the first
+    # parallel CI runs; retune downward once real multi-core CI
+    # wall-clock is observed (local: 10:18 → 6:14).
     timeout-minutes: 50
     env:
       # Route testcontainers pulls through the in-cluster Harbor proxy
@@ -231,24 +234,26 @@ jobs:
         run: uv run python -m meho_backplane.retrieval.warm
 
       - name: Pytest (unit + coverage)
-        # NOT YET PARALLELIZED — deliberately serial. pytest-xdist `-n
-        # auto` (the job header's long-standing target) was implemented
-        # and measured (serial 4:43 → xdist 1:29 locally) but a
-        # controlled same-commit diff (serial 2007/0/0 vs `-n auto
-        # --dist loadscope` 2006/1/2) proved the suite has PRE-EXISTING
-        # cross-module global-registry isolation leaks: tests/
-        # test_mcp_registry.py + tests/test_audit_middleware.py pass
-        # ONLY in the full-suite serial collection order — they fail in
-        # ANY repartition, including a dedicated serial 2-file pass
-        # (locally verified red), so no split-pass workaround is
-        # viable. Parallelizing the unit job is therefore HARD-BLOCKED
-        # on the registry snapshot/restore fix in #585; flip this to
-        # `-n auto --dist loadscope --maxfail=1` there. The fastembed
-        # model cache + HF_TOKEN above are the safe wins shipped now.
-        # -x fast-fail. --ignore=tests/integration → the container-
-        # heavy subtree runs in the sibling `python-integration` job.
-        # Coverage is the unit sweep only; combined cov is #564.
-        run: uv run pytest -x --ignore=tests/integration --cov=meho_backplane --cov-report=xml --cov-report=term tests/
+        # PARALLELIZED via pytest-xdist (#585 unblocked this). The
+        # serial sweep was the job's dominant cost (~49 min in CI vs
+        # ~5 min local). #585 added process-wide global-registry
+        # snapshot/restore + deterministic MCP-module import in
+        # tests/conftest.py, eliminating the cross-module isolation
+        # leaks that previously made `-n auto` red on
+        # test_mcp_registry / test_audit_middleware. Controlled
+        # same-commit proof (acceptance of #585): serial 2007/0/0 and
+        # `-n auto --dist loadscope` 2007/0/0 — identical, empty
+        # failure set; local wall-clock serial 10:18 → xdist 6:14
+        # (limited by core count; CI multi-core gets the ~49→~10 min).
+        # -n auto: one worker per core. --dist loadscope: a module's
+        # tests stay on one worker so module-/session-scoped fixtures
+        # (testcontainers PG, embedding service) instantiate per
+        # worker, not per test. --maxfail=1 preserves the old `-x`
+        # fast-fail (xdist ignores `-x`). --ignore=tests/integration →
+        # the container-heavy subtree runs in the sibling
+        # `python-integration` job. Coverage is the unit sweep only;
+        # combined cov is #564.
+        run: uv run pytest -n auto --dist loadscope --maxfail=1 --ignore=tests/integration --cov=meho_backplane --cov-report=xml --cov-report=term tests/
 
       - name: Upload Python coverage artifact
         # Consumed by quality-gate.yml (`workflow_run` -> SonarCloud).

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -336,6 +336,83 @@ def _no_secret_leak_sweep(
 
 
 # ---------------------------------------------------------------------------
+# Global-registry test isolation (#585 — unblocks pytest-xdist)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _force_import_mcp_modules() -> None:
+    """Import every MCP tool/resource module ONCE per worker, up front.
+
+    ``register_mcp_tool`` / ``register_mcp_resource`` fire as *module-
+    import side effects*; :func:`eager_import_mcp_modules` only triggers
+    them on a module's first import (Python caches imports).
+    ``clear_registries()`` (the per-test reset in
+    ``tests/test_mcp_registry.py``) empties ``_TOOLS`` but cannot
+    un-import modules, so whether a later lifespan-driven
+    ``eager_import_mcp_modules()`` re-populates real tools depends purely
+    on import history — deterministic only in full-suite *serial*
+    collection order. That coupling is exactly what made
+    ``test_mcp_registry`` / ``test_audit_middleware`` pass serially but
+    fail under ``pytest-xdist`` (#585; the #540 class generalised).
+
+    Forcing the imports once at session start makes the registration
+    side effects fire before any test, so every subsequent
+    ``eager_import_mcp_modules()`` (lifespan startup, any worker, any
+    order) is a cached no-op. Combined with the per-test
+    snapshot/restore below, registry state becomes a pure function of
+    what each test explicitly registers — order- and worker-independent.
+    """
+    from meho_backplane.mcp.registry import eager_import_mcp_modules
+
+    eager_import_mcp_modules()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_registries() -> Iterator[None]:
+    """Snapshot/restore every process-global registry around each test.
+
+    The backplane keeps mutable module-level registries that the app
+    lifespan and ``@register_*`` decorators populate:
+    ``mcp.registry._TOOLS`` / ``_RESOURCES``,
+    ``connectors.registry._REGISTRY`` / ``_REGISTRY_V2``, and
+    ``operations.typed_register._TYPED_OP_REGISTRARS``. None had a
+    process-wide per-test reset, so a test that triggered the lifespan
+    leaked real registrations into whatever test the (xdist) scheduler
+    ran next on the same worker. #540 fixed exactly one of these with a
+    local fixture; this generalises the snapshot/restore to all of
+    them, process-wide.
+
+    Snapshot the *contents* (not the binding — other modules hold the
+    same dict/list objects, so rebinding would not propagate) at setup,
+    restore them verbatim at teardown. Restore-not-clear: registrations
+    a test legitimately makes survive *within* that test; only the
+    cross-test bleed is removed.
+    """
+    from meho_backplane.connectors import registry as conn_reg
+    from meho_backplane.mcp import registry as mcp_reg
+    from meho_backplane.operations import typed_register as typed_reg
+
+    tools = dict(mcp_reg._TOOLS)
+    resources = dict(mcp_reg._RESOURCES)
+    connectors_v1 = dict(conn_reg._REGISTRY)
+    connectors_v2 = dict(conn_reg._REGISTRY_V2)
+    registrars = list(typed_reg._TYPED_OP_REGISTRARS)
+    try:
+        yield
+    finally:
+        mcp_reg._TOOLS.clear()
+        mcp_reg._TOOLS.update(tools)
+        mcp_reg._RESOURCES.clear()
+        mcp_reg._RESOURCES.update(resources)
+        conn_reg._REGISTRY.clear()
+        conn_reg._REGISTRY.update(connectors_v1)
+        conn_reg._REGISTRY_V2.clear()
+        conn_reg._REGISTRY_V2.update(connectors_v2)
+        typed_reg._TYPED_OP_REGISTRARS[:] = registrars
+
+
+# ---------------------------------------------------------------------------
 # Shared JWT / JWKS helpers (lifted from tests/test_auth_jwt.py)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #585. This is the unlock for the CI speedup: the `Python (ruff + mypy + pytest)` job (~49 min in CI vs ~5 min local) is the long-standing bottleneck; #592 shipped the safe cache wins and pointed here for the real lever.

## Root cause

`register_mcp_tool` / `register_mcp_resource` run as **module-import side effects**. `eager_import_mcp_modules()` (FastAPI lifespan) only triggers them on a module's *first* import — Python caches modules — and `clear_registries()` (the per-test reset in `test_mcp_registry.py`) empties `_TOOLS` but cannot un-import. So whether a lifespan-driven re-import re-populates real tools (`meho.status`, …) depended purely on **import history** → deterministic only in full-suite **serial** collection order. That coupling (plus unreset `_REGISTRY` / `_TYPED_OP_REGISTRARS`) is exactly what made `test_mcp_registry` + `test_audit_middleware` pass serially but fail under `pytest-xdist`.

## Fix — `tests/conftest.py` only (zero production-code change)

- **`_force_import_mcp_modules`** (session-autouse): run `eager_import_mcp_modules()` once per worker at session start, so the registration side effects fire before any test and every later lifespan call is a cached no-op — the "serial-lucky" state made unconditional.
- **`_isolate_global_registries`** (function-autouse): snapshot/restore the *contents* of `mcp.registry._TOOLS`/`_RESOURCES`, `connectors.registry._REGISTRY`/`_REGISTRY_V2`, `operations.typed_register._TYPED_OP_REGISTRARS` around every test — the #540 local pattern, generalized process-wide. Restore-not-clear: within-test registrations survive; only cross-test bleed is removed.
- **`ci.yml`**: unit job flipped to `pytest -n auto --dist loadscope --maxfail=1` (the exact flip the #592 comment pointed here for); stale job-header note (xdist "pending #564") corrected. Integration job left serial (out of #585 scope, xdist-unverified).

## Acceptance — controlled diff, same machine/commit, identical flags

| | passed | failed | errors | wall |
|---|---|---|---|---|
| serial | 2007 | 0 | 0 | 10:18 |
| `-n auto --dist loadscope` | **2007** | **0** | **0** | **6:14** |

Identical, **empty** failure set (was serial 2007/0/0 vs xdist 2006/**1**/**2** before the fix). `test_mcp_registry.py` + `test_audit_middleware.py` each green run **alone** under `-n auto` (26 / 10 passed). CI multi-core should land the job's ~49 → ~10 min target.

ruff / ruff-format / mypy clean. DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with parallel execution support and improved test isolation to ensure reliability.

* **Chores**
  * Updated CI workflow configuration for optimized test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->