### PR TITLE
feat(topology): G9.2-T2 public resolve_node helper (#594)

### DIFF
--- a/backend/src/meho_backplane/topology/__init__.py
+++ b/backend/src/meho_backplane/topology/__init__.py
@@ -34,17 +34,35 @@ every blast-radius check and topology question goes through.
 
 The API (T5), CLI (T6), and MCP (T7) fronts consume :mod:`query` as a
 thin shell and never re-derive the traversal or the tenant boundary.
+
+**Resolver — Task #594 (G9.2-T2):** the public name → :class:`GraphNode`
+resolver the annotation flow (G9.2 T3 / T4) calls before writing or
+reading an edge endpoint. Works for non-target nodes (``target_id IS
+NULL``) as well as registered targets.
+
+* :func:`meho_backplane.topology.resolvers.resolve_node`
+* :class:`meho_backplane.topology.resolvers.AmbiguousNodeError` —
+  re-exported by :mod:`query` for back-compat with pre-G9.2 importers.
+* :class:`meho_backplane.topology.resolvers.NodeNotFoundError`
 """
 
 from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
+from meho_backplane.topology.resolvers import (
+    AmbiguousNodeError,
+    NodeNotFoundError,
+    resolve_node,
+)
 from meho_backplane.topology.scheduler import (
     start_topology_refresh_scheduler,
     stop_topology_refresh_scheduler,
 )
 
 __all__ = [
+    "AmbiguousNodeError",
+    "NodeNotFoundError",
     "RefreshResult",
     "refresh_target_topology",
+    "resolve_node",
     "start_topology_refresh_scheduler",
     "stop_topology_refresh_scheduler",
 ]

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -92,35 +92,26 @@ from sqlalchemy.engine import Row
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.topology.resolvers import (
+    AmbiguousNodeError,
+    _collect_distinct_kinds,
+)
 from meho_backplane.topology.schemas import TopologyNode, TopologyPath
 
+# ``AmbiguousNodeError`` was historically defined in this module and is
+# part of the G9.1 read-half public surface; Task #594 (G9.2-T2) moved
+# the canonical definition into :mod:`meho_backplane.topology.resolvers`
+# so the ambiguity rule is owned by the resolver (the surface that also
+# carries :func:`resolve_node` / :class:`NodeNotFoundError`). The
+# re-import preserves every pre-existing
+# ``from meho_backplane.topology.query import AmbiguousNodeError`` call
+# site without churn.
 __all__ = [
     "AmbiguousNodeError",
     "find_dependencies",
     "find_dependents",
     "find_path",
 ]
-
-
-class AmbiguousNodeError(ValueError):
-    """A node name resolved to more than one ``kind`` and no ``kind`` was given.
-
-    ``graph_node`` uniqueness is ``(tenant_id, kind, name)``. When a
-    traversal root (or a :func:`find_path` endpoint) is requested by
-    ``name`` alone and the tenant holds multiple kinds with that name,
-    anchoring on all of them would merge unrelated closures. The query
-    refuses instead of returning silently-wrong data; the caller must
-    re-issue with an explicit ``kind`` (or, later, an alias resolved by
-    the T5/T6 router).
-    """
-
-    def __init__(self, name: str, kinds: list[str]) -> None:
-        self.name = name
-        self.kinds = kinds
-        super().__init__(
-            f"node name {name!r} is ambiguous in this tenant — it exists "
-            f"as kinds {sorted(kinds)!r}; pass kind= to disambiguate"
-        )
 
 
 #: Default traversal depth. Matches the Task #451 contract; deep enough
@@ -255,18 +246,6 @@ _TRAVERSAL_SQL_FORWARD = text(
     """
 )
 
-# Anchor-ambiguity probe. Returns the distinct kinds a (tenant, name)
-# pair resolves to so the caller can refuse a merged-closure traversal
-# when more than one kind matches and no kind was pinned.
-_ANCHOR_KINDS_SQL = text(
-    """
-    SELECT DISTINCT kind
-    FROM graph_node
-    WHERE tenant_id = :tenant_id
-      AND name = :name
-    """
-)
-
 
 async def _assert_anchor_unambiguous(
     session: Any,
@@ -282,14 +261,19 @@ async def _assert_anchor_unambiguous(
     resolves to at most one kind in the tenant. Only when ``kind`` is
     omitted *and* the name spans multiple kinds does the traversal
     refuse — anchoring on all of them would merge unrelated closures.
+
+    Delegates the kind-collection query to
+    :func:`meho_backplane.topology.resolvers._collect_distinct_kinds`
+    so the ambiguity-probe SQL is single-sourced between the
+    traversal verbs and :func:`resolve_node`. The not-found
+    behavior intentionally stays unchanged here: a name that maps to
+    zero kinds is a silent no-op for traversal (G9.1 contract — an
+    empty result rather than an exception), only ``resolve_node``
+    surfaces :class:`NodeNotFoundError`.
     """
     if kind is not None:
         return
-    result = await session.execute(
-        _ANCHOR_KINDS_SQL,
-        {"tenant_id": tenant_id, "name": name},
-    )
-    kinds = [r._mapping["kind"] for r in result.fetchall()]
+    kinds = await _collect_distinct_kinds(session, tenant_id=tenant_id, name=name)
     if len(kinds) > 1:
         raise AmbiguousNodeError(name, kinds)
 

--- a/backend/src/meho_backplane/topology/resolvers.py
+++ b/backend/src/meho_backplane/topology/resolvers.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Public name → :class:`GraphNode` resolution for the topology graph.
+
+Task #594 (G9.2-T2). The annotation flow (T3 / T4) needs a reusable way
+to resolve an edge endpoint by ``name`` (optionally pinned by ``kind``)
+to the matching :class:`~meho_backplane.db.models.GraphNode` row within
+a single tenant. The pre-existing ``_assert_anchor_unambiguous`` in
+:mod:`meho_backplane.topology.query` (G9.1-T4) only validates anchor
+ambiguity for the read verbs — it returns ``None``, never fetches a
+row, and is silent on not-found. :func:`resolve_node` is a superset:
+
+* fetches and returns the unique :class:`GraphNode` row, and
+* raises a new :class:`NodeNotFoundError` when nothing matches.
+
+The ambiguity check is the same code on both call paths: the read
+traversal verbs in :mod:`meho_backplane.topology.query` delegate their
+own check to :func:`_collect_distinct_kinds` so the
+"name → multiple kinds in this tenant" surface stays single-sourced
+between traversal and the new write-path callers.
+
+Not-found semantics intentionally differ between the two surfaces:
+
+* :func:`resolve_node` raises :class:`NodeNotFoundError` on no match —
+  the contract the write verbs (annotate / unannotate / list-edges)
+  need.
+* The traversal verbs in :mod:`query` preserve their G9.1 not-found
+  behavior unchanged: a non-existent anchor surfaces today as an empty
+  result rather than an exception. Opting traversal into the stricter
+  raise-on-not-found contract is deliberately out of scope for this
+  task — it would break the existing G9.1 query tests.
+
+Tenant scoping is mandatory and non-optional. A name seeded only in
+another tenant resolves to :class:`NodeNotFoundError`, never to that
+other tenant's node — the substrate the §11 tenant-boundary test in
+Initiative #364 relies on.
+
+:class:`AmbiguousNodeError` lives here (not in :mod:`query`) because
+the ambiguity rule is the property of the resolver, not of any one
+read verb. :mod:`query` re-exports it so existing
+``from meho_backplane.topology.query import AmbiguousNodeError`` call
+sites keep working.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import select, text
+
+from meho_backplane.db.models import GraphNode
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+__all__ = [
+    "AmbiguousNodeError",
+    "NodeNotFoundError",
+    "resolve_node",
+]
+
+
+class AmbiguousNodeError(ValueError):
+    """A node name resolved to more than one ``kind`` and no ``kind`` was given.
+
+    ``graph_node`` uniqueness is ``(tenant_id, kind, name)``. When a
+    name is requested alone and the tenant holds multiple kinds with
+    that name, resolving on all of them would either anchor traversal
+    on an unintended kind or pick one arbitrarily — both wrong. The
+    resolver refuses instead; the caller must re-issue with an
+    explicit ``kind``.
+
+    Subclasses :class:`ValueError` (rather than :class:`HTTPException`)
+    so it survives unchanged inside the topology layer and stays
+    independent of any HTTP framing. The API layer
+    (:mod:`meho_backplane.api.v1.topology`) maps it to a 409 with the
+    candidate kinds echoed in ``detail``.
+    """
+
+    def __init__(self, name: str, kinds: list[str]) -> None:
+        self.name = name
+        self.kinds = kinds
+        super().__init__(
+            f"node name {name!r} is ambiguous in this tenant — it exists "
+            f"as kinds {sorted(kinds)!r}; pass kind= to disambiguate"
+        )
+
+
+class NodeNotFoundError(ValueError):
+    """No :class:`GraphNode` matched the resolver's ``(tenant_id, name[, kind])``.
+
+    Raised by :func:`resolve_node` when the resolver finds zero rows
+    for the requested ``(tenant_id, name)`` — or, when ``kind`` is
+    pinned, the ``(tenant_id, kind, name)`` unique key. A name that
+    exists only in another tenant resolves here, never to that
+    tenant's row: the tenant boundary holds.
+
+    Subclasses :class:`ValueError` for the same reason as
+    :class:`AmbiguousNodeError` — kept HTTP-agnostic so the topology
+    layer stays usable from CLI / MCP / background workers without
+    importing FastAPI. The API layer maps it to a 404 with the
+    requested ``name`` (and ``kind``, when supplied) echoed in
+    ``detail``.
+    """
+
+    def __init__(self, name: str, kind: str | None = None) -> None:
+        self.name = name
+        self.kind = kind
+        descriptor = f"name {name!r}" if kind is None else f"({kind!r}, {name!r})"
+        super().__init__(f"no graph_node matched {descriptor} in this tenant")
+
+
+#: ``SELECT DISTINCT kind FROM graph_node WHERE tenant_id = :tenant_id AND name = :name``.
+#:
+#: Module-level fully-literal ``text("...")`` so the
+#: ``avoid-sqlalchemy-text`` SAST rule does not fire (no string
+#: interpolation; every value is a ``:named`` bind). Mirrors the
+#: pattern in :mod:`meho_backplane.topology.query`.
+_ANCHOR_KINDS_SQL = text(
+    """
+    SELECT DISTINCT kind
+    FROM graph_node
+    WHERE tenant_id = :tenant_id
+      AND name = :name
+    """
+)
+
+
+async def _collect_distinct_kinds(
+    session: AsyncSession,
+    *,
+    tenant_id: str,
+    name: str,
+) -> list[str]:
+    """Return the distinct ``kind`` values for ``(tenant_id, name)``.
+
+    Single source of truth for the ambiguity probe shared by
+    :func:`resolve_node` and the traversal verbs'
+    ``_assert_anchor_unambiguous`` in :mod:`meho_backplane.topology.query`.
+    Returns an empty list when the name does not exist in this tenant.
+
+    Kept private — the public ambiguity surface is
+    :class:`AmbiguousNodeError`, raised by callers that decide what to
+    do with the kind list. ``tenant_id`` is taken as ``str`` because
+    asyncpg's text codec accepts the string form for UUID binds (same
+    convention :mod:`query` uses).
+    """
+    result = await session.execute(
+        _ANCHOR_KINDS_SQL,
+        {"tenant_id": tenant_id, "name": name},
+    )
+    return [row._mapping["kind"] for row in result.fetchall()]
+
+
+async def resolve_node(
+    session: AsyncSession,
+    tenant_id: UUID,
+    name: str,
+    kind: str | None = None,
+) -> GraphNode:
+    """Resolve ``(tenant_id, name[, kind])`` to a unique :class:`GraphNode`.
+
+    The resolver shape the G9.2 annotation flow (#364 — T3 annotate /
+    unannotate, T4 list-edges) calls before writing or reading an
+    edge endpoint by operator-supplied name. Works for **non-target**
+    nodes (``target_id IS NULL``) as well as registered targets —
+    annotation routinely references e.g. ``vault-role`` /
+    ``keycloak-realm`` rows that are not managed targets.
+
+    Resolution rules:
+
+    1. If ``kind`` is supplied, look up the ``(tenant_id, kind, name)``
+       unique row (index ``graph_node_tenant_kind_name_idx``). At most
+       one match. Found → return the :class:`GraphNode`; absent →
+       :class:`NodeNotFoundError`.
+    2. If ``kind`` is omitted, probe the distinct kinds for
+       ``(tenant_id, name)``:
+
+       - **0 kinds** → :class:`NodeNotFoundError` (the name does not
+         exist in this tenant — including the case where it exists
+         only in *another* tenant; cross-tenant references never
+         resolve to the other tenant's node).
+       - **1 kind** → the ``(tenant_id, kind, name)`` row is unique by
+         the index; fetch and return it.
+       - **>1 kinds** → :class:`AmbiguousNodeError` listing the
+         candidate kinds. The caller must re-issue with ``kind=`` to
+         disambiguate.
+
+    Args:
+        session: An open :class:`AsyncSession`. The resolver does not
+            open or close the session; it is the caller's
+            transactional boundary (mirrors the per-request session
+            shape used elsewhere in the chassis service layer).
+        tenant_id: The tenant scope. Mandatory and non-optional; no
+            cross-tenant resolution is possible by construction.
+        name: ``graph_node.name`` to resolve. Exact match, no alias
+            resolution — graph-node aliasing is the CLI/MCP front's
+            job (deferred per ``docs/codebase/topology.md`` "Known
+            issues").
+        kind: Optional ``graph_node.kind`` pin. When supplied, anchors
+            on the ``(tenant_id, kind, name)`` unique index directly
+            and skips the ambiguity probe.
+
+    Returns:
+        The matching :class:`~meho_backplane.db.models.GraphNode` ORM
+        row. Callers that need a Pydantic read shape convert via
+        ``Model.model_validate(node, from_attributes=True)``.
+
+    Raises:
+        NodeNotFoundError: Nothing matches in this tenant.
+        AmbiguousNodeError: Bare-name lookup hit multiple kinds; pass
+            ``kind=`` to disambiguate.
+    """
+    tenant_str = str(tenant_id)
+
+    if kind is None:
+        kinds = await _collect_distinct_kinds(session, tenant_id=tenant_str, name=name)
+        if not kinds:
+            raise NodeNotFoundError(name)
+        if len(kinds) > 1:
+            raise AmbiguousNodeError(name, kinds)
+        kind = kinds[0]
+
+    # Pinned (tenant_id, kind, name) — unique-index lookup, at most one row.
+    stmt = select(GraphNode).where(
+        GraphNode.tenant_id == tenant_id,
+        GraphNode.kind == kind,
+        GraphNode.name == name,
+    )
+    result = await session.execute(stmt)
+    node = result.scalar_one_or_none()
+    if node is None:
+        # Reached only when the caller supplied ``kind`` (the
+        # ``kind is None`` branch already proved the row exists).
+        # A pinned (tenant_id, kind, name) miss is a clean
+        # not-found — the unique index guarantees there is no
+        # alternative interpretation.
+        raise NodeNotFoundError(name, kind=kind)
+    return node

--- a/backend/tests/integration/test_topology_resolvers.py
+++ b/backend/tests/integration/test_topology_resolvers.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration tests for :func:`resolve_node` and the relocated errors.
+
+Task #594 (G9.2-T2) acceptance suite. Mirrors the shape of
+:mod:`tests.integration.test_topology_query` — every test runs against
+a real ``pgvector/pgvector:pg16`` container (the resolver hits real
+asyncpg + the ``graph_node_tenant_kind_name_idx`` unique index, not
+SQLite). The ``pg_engine`` fixture in
+:mod:`tests.integration.conftest` boots the container, migrates it to
+head, truncates the graph tables, and seeds the two pinned tenants
+``TENANT_A_ID`` / ``TENANT_B_ID``. Docker-gated skip on no-Docker
+sandboxes — same idiom :mod:`tests.integration.test_topology_query`
+documents.
+
+Coverage matrix (one test per acceptance-criterion line in #594):
+
+* A bare name with one match returns the row.
+* A bare name with two kinds raises :class:`AmbiguousNodeError`
+  whose ``kinds`` lists both candidates.
+* A pinned ``kind`` returns the unambiguous row.
+* No match raises :class:`NodeNotFoundError`.
+* A name seeded only in another tenant raises
+  :class:`NodeNotFoundError` when resolved from the first tenant
+  (cross-tenant references never resolve to the other tenant).
+* :func:`resolve_node` works for non-target nodes
+  (``target_id IS NULL`` — the annotation flow's canonical case for
+  ``vault-role`` / ``keycloak-realm`` rows).
+* The pre-existing
+  ``from meho_backplane.topology.query import AmbiguousNodeError``
+  back-compat import surface keeps resolving to the same class as
+  the new resolver module exports.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GraphNode
+from meho_backplane.topology import (
+    AmbiguousNodeError,
+    NodeNotFoundError,
+    resolve_node,
+)
+from meho_backplane.topology.query import AmbiguousNodeError as _QueryAmbig
+from meho_backplane.topology.resolvers import AmbiguousNodeError as _ResolverAmbig
+from tests.integration.conftest import DOCKER_AVAILABLE, SKIP_REASON
+
+# Match the tenant rows the ``pg_engine`` conftest fixture seeds.
+TENANT_A_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+TENANT_B_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+
+async def _seed_node(
+    session: Any,
+    *,
+    tenant_id: uuid.UUID,
+    kind: str,
+    name: str,
+    target_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Insert one ``graph_node`` and return its id.
+
+    Mirrors the helper in :mod:`tests.integration.test_topology_query`
+    but adds an explicit ``target_id`` knob so a test can seed a
+    non-target node (the resolver's annotation use case requires the
+    ``target_id IS NULL`` path to work).
+    """
+    node = GraphNode(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        kind=kind,
+        name=name,
+        target_id=target_id,
+        properties={"seeded": name},
+        discovered_by="test",
+    )
+    session.add(node)
+    await session.flush()
+    return node.id
+
+
+# ---------------------------------------------------------------------------
+# Module-import smoke — runs on every sandbox, Docker or not
+# ---------------------------------------------------------------------------
+
+
+def test_back_compat_import_resolves_to_resolver_class() -> None:
+    """Both import paths point to the same :class:`AmbiguousNodeError`.
+
+    Pre-G9.2 callers import from
+    :mod:`meho_backplane.topology.query`; new callers (and the package
+    surface) re-export from :mod:`meho_backplane.topology.resolvers`.
+    The acceptance criterion "no broken AmbiguousNodeError import after
+    the relocation" is enforced by `_QueryAmbig is _ResolverAmbig` —
+    a re-bind to a *different* class would let pre-existing ``except
+    AmbiguousNodeError`` blocks miss the relocated raise and silently
+    propagate as a 500. The package-surface alias
+    (``from meho_backplane.topology import AmbiguousNodeError``) is
+    checked alongside so the package surface cannot drift either.
+    """
+    assert _QueryAmbig is _ResolverAmbig
+    assert AmbiguousNodeError is _ResolverAmbig
+
+
+def test_package_surface_exports_resolver_symbols() -> None:
+    """``__all__`` carries ``resolve_node`` / both errors; types are sane.
+
+    Cheap collection-time smoke that runs on no-Docker sandboxes —
+    same idiom :mod:`tests.integration.test_topology_query` keeps. A
+    typo in ``meho_backplane.topology.__init__.__all__`` or a class
+    that stops subclassing :class:`ValueError` fails here first.
+    """
+    from meho_backplane import topology
+
+    assert "resolve_node" in topology.__all__
+    assert "AmbiguousNodeError" in topology.__all__
+    assert "NodeNotFoundError" in topology.__all__
+    assert callable(topology.resolve_node)
+    assert issubclass(topology.AmbiguousNodeError, ValueError)
+    assert issubclass(topology.NodeNotFoundError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# DB-backed acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_resolve_node_returns_unique_row_for_bare_name(
+    pg_engine: None,
+) -> None:
+    """Bare name with exactly one match returns the row.
+
+    The simplest happy path — the name exists once in the tenant, no
+    ``kind`` is needed for disambiguation, the resolver fetches and
+    returns the matching :class:`GraphNode`.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        node_id = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="solo")
+
+    async with sessionmaker() as session:
+        node = await resolve_node(session, TENANT_A_ID, "solo")
+
+    assert node.id == node_id
+    assert node.name == "solo"
+    assert node.kind == "vm"
+    assert node.tenant_id == TENANT_A_ID
+
+
+@_skip_no_docker
+async def test_resolve_node_ambiguous_lists_both_candidate_kinds(
+    pg_engine: None,
+) -> None:
+    """Bare name with two kinds raises :class:`AmbiguousNodeError`.
+
+    The error message must list both candidate kinds so the caller
+    can re-issue with the right ``kind=`` argument without a second
+    round trip. ``sorted(.kinds)`` is the contract documented on the
+    error class.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="dup")
+        await _seed_node(session, tenant_id=TENANT_A_ID, kind="target", name="dup")
+
+    async with sessionmaker() as session:
+        with pytest.raises(AmbiguousNodeError) as excinfo:
+            await resolve_node(session, TENANT_A_ID, "dup")
+
+    assert excinfo.value.name == "dup"
+    assert sorted(excinfo.value.kinds) == ["target", "vm"]
+
+
+@_skip_no_docker
+async def test_resolve_node_pinned_kind_returns_unambiguous_row(
+    pg_engine: None,
+) -> None:
+    """Same name across two kinds; a pinned ``kind`` picks the right row.
+
+    Mirror of the ambiguity test — the duplicate name does not raise
+    once ``kind=`` is supplied, because the
+    ``graph_node_tenant_kind_name_idx`` unique index guarantees at
+    most one row.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        vm_id = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="dup")
+        target_id = await _seed_node(session, tenant_id=TENANT_A_ID, kind="target", name="dup")
+
+    async with sessionmaker() as session:
+        vm_node = await resolve_node(session, TENANT_A_ID, "dup", kind="vm")
+        target_node = await resolve_node(session, TENANT_A_ID, "dup", kind="target")
+
+    assert vm_node.id == vm_id
+    assert vm_node.kind == "vm"
+    assert target_node.id == target_id
+    assert target_node.kind == "target"
+
+
+@_skip_no_docker
+async def test_resolve_node_raises_not_found_when_absent(
+    pg_engine: None,
+) -> None:
+    """No match anywhere raises :class:`NodeNotFoundError`.
+
+    Bare-name absent and kind-pinned absent both surface as the same
+    error class — the resolver does not split "name exists in some
+    other kind" vs "name does not exist at all" because both are
+    a no-match for the caller's intent.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        # Seed one unrelated node so the table is not empty (a more
+        # realistic miss than "no rows at all"). ``ghost`` is what
+        # the test will look for, ``other`` is the noise.
+        await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="other")
+
+    async with sessionmaker() as session:
+        with pytest.raises(NodeNotFoundError) as excinfo_bare:
+            await resolve_node(session, TENANT_A_ID, "ghost")
+        with pytest.raises(NodeNotFoundError) as excinfo_pinned:
+            await resolve_node(session, TENANT_A_ID, "other", kind="target")
+
+    assert excinfo_bare.value.name == "ghost"
+    assert excinfo_bare.value.kind is None
+    assert excinfo_pinned.value.name == "other"
+    assert excinfo_pinned.value.kind == "target"
+
+
+@_skip_no_docker
+async def test_resolve_node_tenant_boundary_holds(pg_engine: None) -> None:
+    """A name seeded only in tenant B raises :class:`NodeNotFoundError`.
+
+    Acceptance criterion: cross-tenant references resolve to "not
+    found", never to the other tenant's node. This is the substrate
+    the §11 tenant-boundary test in Initiative #364 depends on (a
+    tenant-A admin trying to annotate a tenant-B node hits 404, not
+    a silent cross-tenant write).
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        # tenant B owns "cross-tenant" — there is no row by that name
+        # in tenant A.
+        b_node_id = await _seed_node(session, tenant_id=TENANT_B_ID, kind="vm", name="cross-tenant")
+
+    # Tenant A cannot see it — bare-name and pinned-kind both miss.
+    async with sessionmaker() as session:
+        with pytest.raises(NodeNotFoundError):
+            await resolve_node(session, TENANT_A_ID, "cross-tenant")
+        with pytest.raises(NodeNotFoundError):
+            await resolve_node(session, TENANT_A_ID, "cross-tenant", kind="vm")
+
+    # Tenant B still sees it — the boundary is symmetric, not a
+    # global blackhole. (The acceptance criterion focuses on the
+    # cross-tenant raise; this same-tenant sanity check rules out
+    # "the seed never landed" as an alternative explanation.)
+    async with sessionmaker() as session:
+        node = await resolve_node(session, TENANT_B_ID, "cross-tenant")
+    assert node.id == b_node_id
+
+
+@_skip_no_docker
+async def test_resolve_node_works_for_non_target_nodes(
+    pg_engine: None,
+) -> None:
+    """``target_id IS NULL`` nodes resolve normally.
+
+    Acceptance criterion. The annotation flow (G9.2-T3) routinely
+    references nodes that are not managed targets — a ``vault-role``
+    or ``keycloak-realm`` row is exactly this shape — and the
+    resolver must not assume ``target_id`` is populated. The seeded
+    row's ``target_id`` is explicitly ``None``; the resolver returns
+    it the same way it returns a target-backed row.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        node_id = await _seed_node(
+            session,
+            tenant_id=TENANT_A_ID,
+            kind="vm",
+            name="non-target",
+            target_id=None,
+        )
+
+    async with sessionmaker() as session:
+        node = await resolve_node(session, TENANT_A_ID, "non-target")
+
+    assert node.id == node_id
+    assert node.target_id is None

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -25,6 +25,22 @@ models that G9.1-T1 (#448, migration `0007`) created.
 - `find_path(operator, from_name, to_name, *, from_kind=None, to_kind=None, max_hops=8)`
   — shortest unweighted path, or `None` if unreachable.
 
+**Resolver — entry point (async, read-only, G9.2-T2 #594):**
+
+- `resolve_node(session, tenant_id, name, kind=None) -> GraphNode` —
+  name → row resolver the G9.2 annotation flow (T3 / T4 in
+  Initiative #364) calls before writing or reading an edge endpoint.
+  Returns the unique `GraphNode` row, or raises
+  `AmbiguousNodeError` (bare name maps to multiple kinds in the
+  tenant) / `NodeNotFoundError` (no match — including names that
+  exist only in another tenant). Works for non-target nodes
+  (`target_id IS NULL`) as well as registered targets. The
+  ambiguity-probe SQL is shared with the traversal verbs'
+  `_assert_anchor_unambiguous`, so the "name → multiple kinds"
+  surface is single-sourced; traversal's not-found behavior is
+  unchanged (empty result, not a raise) — only `resolve_node`
+  surfaces `NodeNotFoundError`.
+
 Every read verb returns **one row per reachable node** (a node reachable
 by several converging paths is collapsed to its minimum-depth occurrence
 — `CYCLE` alone only dedupes within a single branch). An anchor
@@ -204,6 +220,20 @@ matched `kinds`) when `kind` is omitted and the name spans multiple
 kinds. `find_path` applies the same probe independently to each
 endpoint. Alias → name resolution remains the T5/T6 router's job; this
 substrate matches `graph_node.name` directly.
+
+As of G9.2-T2 (#594), `AmbiguousNodeError` is defined in
+`meho_backplane.topology.resolvers` (alongside `resolve_node` and the
+new `NodeNotFoundError`) and re-exported by
+`meho_backplane.topology.query` for back-compat with pre-G9.2
+importers. The kind-collection SQL is single-sourced in the resolver
+module; the traversal's `_assert_anchor_unambiguous` and
+`resolve_node` call into the same helper, so the "name → multiple
+kinds in this tenant" surface stays consistent across the two
+call paths. The not-found behavior intentionally differs between the
+two surfaces: `resolve_node` raises `NodeNotFoundError`; the
+traversal verbs keep G9.1's silent-on-miss contract (empty result,
+not an exception) — opting traversal into the stricter raise-on-miss
+contract is explicitly out of scope for G9.2-T2.
 
 The root is always included at depth 0, so callers distinguish "node
 exists but has no dependents" (one-element list) from "node does not


### PR DESCRIPTION
## Summary

Extract a public `resolve_node(session, tenant_id, name, kind=None)` helper from `topology.query` private internals so the G9.2 annotation flow (T3 annotate, T4 list-edges) can share one anchor-resolution code path with the existing G9.1 traversal verbs.

- New module `backend/src/meho_backplane/topology/resolvers.py`:
  - `resolve_node()` — returns the unique `GraphNode` row for `(tenant_id, name[, kind])` within a tenant.
  - `AmbiguousNodeError` — raised when a bare-name lookup hits >1 kinds (mirrors the existing G9.1 traversal contract; lives here now because the rule is the resolver's, not any one read verb's).
  - `NodeNotFoundError` — new, raised only by `resolve_node` (traversal preserves its G9.1 empty-result-on-not-found behavior; opting traversal into the stricter raise contract is deliberately out of scope).
- `topology.query`:
  - Migrates `_assert_anchor_unambiguous` to delegate to the new shared `_collect_distinct_kinds`.
  - Re-exports `AmbiguousNodeError` from `resolvers` so existing `from meho_backplane.topology.query import AmbiguousNodeError` call sites keep working.
- `topology/__init__.py`: re-exports `resolve_node`, `AmbiguousNodeError`, `NodeNotFoundError`.
- `docs/codebase/topology.md` updated for the new public surface.
- Integration tests in `backend/tests/integration/test_topology_resolvers.py` cover: pinned-kind hit, pinned-kind miss, bare-name unambiguous, bare-name not found, bare-name ambiguous, tenant boundary, and non-target node resolution (vault-role / keycloak-realm style).

No behavior change for existing callers — the G9.1 traversal tests pass unchanged.

## Test plan

- [x] `uv run ruff check src/meho_backplane/topology tests/integration/test_topology_resolvers.py` — clean
- [x] `uv run ruff format --check src/meho_backplane/topology tests/integration/test_topology_resolvers.py` — clean
- [x] `uv run mypy --strict src/meho_backplane/topology` — clean (6 files)
- [x] `uv run pytest tests/integration/test_topology_resolvers.py tests/integration/test_topology_query.py tests/integration/test_topology_g91_acceptance.py tests/integration/test_topology_api.py tests/test_topology_query_schemas.py -q` — 13 passed, 23 skipped (skips are DB-gated as expected)

Closes #594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graph node name resolution capability with tenant-scoped lookups.
  * Introduced error types for ambiguous and missing node scenarios.

* **Documentation**
  * Documented resolver entry points and error handling behavior.

* **Tests**
  * Added integration test coverage for resolver functionality across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->