### PR TITLE
feat(connectors): G3.5-T1 NsxConnector skeleton + session/XSRF auth (#613)

### DIFF
--- a/backend/src/meho_backplane/connectors/nsx/__init__.py
+++ b/backend/src/meho_backplane/connectors/nsx/__init__.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.nsx -- NsxConnector package.
+
+Importing this package registers :class:`NsxConnector` against the v2
+connector registry under
+``(product="nsx", version="4.2", impl_id="nsx-rest")``. The chassis
+lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+which walks every ``connectors/<product>/`` subpackage at startup, so
+the registration lands before any dispatch can occur.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector`
+entry point is deliberately **not** called. The connector advertises
+an explicit ``(version="4.2", impl_id="nsx-rest")`` key; the v1 entry
+would land as ``("nsx", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s
+tie-break ladder. Same pattern :mod:`meho_backplane.connectors.vmware_rest`
+established.
+
+Once G0.7-T8 (#408) lands its
+:func:`ensure_connector_class_registered` auto-shim in main, the
+idempotency check there will no-op on the
+``(product="nsx", version="4.2", impl_id="nsx-rest")`` triple because
+this module has already registered the hand-rolled class. Until then,
+this module is the only registration path; no behavioural drift
+results from the absence of the auto-shim infrastructure.
+
+Operations for this connector arrive in #614 via G0.7 spec ingestion
+of ``nsx-4.2/policy.yaml`` + ``nsx-4.2/manager.yaml`` against the
+``endpoint_descriptor`` table. This Task ships only the skeleton.
+"""
+
+from meho_backplane.connectors.nsx.connector import NsxConnector
+from meho_backplane.connectors.nsx.session import (
+    NsxSessionLoader,
+    NsxTargetLike,
+    SessionCredentials,
+    load_session_credentials_from_vault,
+)
+from meho_backplane.connectors.registry import register_connector_v2
+
+register_connector_v2(
+    product="nsx",
+    version="4.2",
+    impl_id="nsx-rest",
+    cls=NsxConnector,
+)
+
+__all__ = [
+    "NsxConnector",
+    "NsxSessionLoader",
+    "NsxTargetLike",
+    "SessionCredentials",
+    "load_session_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -120,9 +120,10 @@ _SESSION_CREATE_PATH = "/api/session/create"
 # either one alone is rejected.
 _XSRF_HEADER = "X-XSRF-TOKEN"
 
-# Form-body keys. Lifted to module constants so the assertion in
-# :meth:`_session_token` and the respx body-shape test in
-# ``tests/test_connectors_nsx_auth.py`` can't drift.
+# Form-body keys NSX's session-create endpoint expects. Lifted to
+# module constants so the call site in :meth:`_session_token` reads
+# as ``data={_FORM_USERNAME_KEY: username, _FORM_PASSWORD_KEY: password}``
+# rather than carrying the magic strings inline.
 _FORM_USERNAME_KEY = "j_username"
 _FORM_PASSWORD_KEY = "j_password"
 

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -1,0 +1,462 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""NsxConnector -- hand-rolled HttpConnector subclass for NSX 4.x.
+
+Skeleton-only -- auth + fingerprint + probe + the G0.6 dispatch shim.
+Operations arrive in #614 via G0.7 spec ingestion against
+``nsx-4.2/policy.yaml`` + ``nsx-4.2/manager.yaml``.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.nsx.__init__`. The G0.7 auto-shim's
+idempotency check (in
+:func:`~meho_backplane.operations.ingest.connector_registration.ensure_connector_class_registered`
+once #408's pipeline lands in main) no-ops on subsequent ingests
+against the same ``(product="nsx", version="4.2", impl_id="nsx-rest")``
+triple.
+
+Auth divergence from the vSphere precedent
+------------------------------------------
+
+NSX rejects HTTP Basic on the canonical FQDN behind the VCF 9 envoy
+proxy; session-cookie + X-XSRF-TOKEN is the only mode that works across
+both VCF 9 and standalone NSX-T (per ``scripts/nsx.sh`` in the
+consumer wrapper repo). The flow:
+
+1. ``POST /api/session/create`` with **form-encoded** body
+   ``j_username`` / ``j_password`` (``httpx.AsyncClient.post(url,
+   data=<dict>)`` = ``application/x-www-form-urlencoded``; NOT JSON,
+   NOT HTTP Basic).
+2. The response's ``Set-Cookie`` header (``JSESSIONID=...``) lands in
+   :attr:`httpx.AsyncClient.cookies` automatically -- httpx calls
+   ``self.cookies.extract_cookies(response)`` on every response, so
+   subsequent requests through the same per-target client carry the
+   cookie without manual plumbing.
+3. The response's ``X-XSRF-TOKEN`` header is captured into
+   :attr:`_session_tokens` keyed on ``target.name`` (mirrors
+   :class:`VmwareRestConnector._session_tokens` per-target isolation).
+4. :meth:`auth_headers` returns ``{"X-XSRF-TOKEN": <cached>}`` on
+   subsequent calls; the cookie travels via the client jar.
+5. On HTTP 401 from a downstream call, :meth:`_get_json_with_session_retry`
+   clears the cached token + the client cookies, re-establishes the
+   session via ``_session_token``, and retries once. A second 401
+   surfaces as :exc:`RuntimeError` naming the target -- the consumer
+   wrapper's posture (re-login + retry once, not a loop) so a
+   misconfigured credential pair fails fast instead of hammering
+   NSX's audit log.
+
+Auth model gating
+-----------------
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT`
+(or ``None`` for pre-G0.3 targets where the column hasn't been
+populated yet). :meth:`auth_headers` rejects any other value with a
+clear :exc:`NotImplementedError` naming the target + the requested
+mode. Per-user and impersonation modes are deferred to v0.2.next,
+same posture the vSphere precedent established.
+
+Session lifecycle
+-----------------
+
+NSX session has a documented idle timeout (default ~30 minutes for NSX
+Manager); the connector does not proactively refresh tokens. The
+401-retry layer above re-establishes on demand. :meth:`aclose` clears
+the in-memory caches and tears down the httpx pool but does NOT
+issue a DELETE-revoke -- NSX has a ``POST /api/session/destroy``
+endpoint, but graceful shutdown is bounded by Kubernetes'
+``terminationGracePeriod`` and a network-call-per-target during
+lifespan exit is more risk than benefit. Same posture vSphere takes
+for proactive refresh: revoke-on-close is v0.2.next.
+
+Operations
+----------
+
+This module ships zero operations -- the G0.6 dispatch shim
+:meth:`execute` exists for ABC compatibility but operations land in
+the ``endpoint_descriptor`` table via #614's spec ingestion. Until
+then, the connector is registered and discoverable but
+``execute(target, op_id, ...)`` against any ``op_id`` will resolve to
+"unknown operation" at the dispatcher layer -- which is the correct
+behaviour for a registered-but-empty connector at this Task's stage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.nsx.session import (
+    NsxSessionLoader,
+    NsxTargetLike,
+    load_session_credentials_from_vault,
+)
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["NsxConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# NSX session-establish endpoint. POST with form-encoded
+# ``j_username`` / ``j_password``; success returns 200 with the
+# ``Set-Cookie: JSESSIONID=...`` and ``X-XSRF-TOKEN: ...`` response
+# headers. Per the consumer wrapper at
+# https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/nsx.sh
+# and the NSX REST API guide.
+_SESSION_CREATE_PATH = "/api/session/create"
+
+# Header NSX expects on every authenticated request (except session
+# create itself). The XSRF token is paired with the JSESSIONID cookie;
+# either one alone is rejected.
+_XSRF_HEADER = "X-XSRF-TOKEN"
+
+# Form-body keys. Lifted to module constants so the assertion in
+# :meth:`_session_token` and the respx body-shape test in
+# ``tests/test_connectors_nsx_auth.py`` can't drift.
+_FORM_USERNAME_KEY = "j_username"
+_FORM_PASSWORD_KEY = "j_password"
+
+
+def _is_acceptable_auth_model(value: Any) -> bool:
+    """Return ``True`` iff *value* is the SHARED_SERVICE_ACCOUNT mode or unset.
+
+    Accepts the enum member, the equivalent string, and ``None`` (the
+    "auth_model column not yet populated" sentinel for pre-G0.3
+    targets). Any other value (``"per_user"``, ``"impersonation"``, a
+    typo, an int) is rejected by the caller. Same predicate the
+    vSphere precedent uses; lifted into this module rather than
+    imported to keep the two connectors decoupled.
+    """
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+class NsxConnector(HttpConnector):
+    """NSX 4.x REST connector with session-cookie + XSRF auth.
+
+    Per-target XSRF token cached in :attr:`_session_tokens`; the
+    accompanying ``JSESSIONID`` cookie is held by the per-target
+    ``httpx.AsyncClient`` instance's cookie jar (httpx auto-extracts
+    Set-Cookie response headers, so the cookie is reused on subsequent
+    requests through the same client without manual plumbing).
+
+    The :attr:`priority` is set to ``1`` so a future
+    ``GenericRestConnector`` auto-shim that somehow registers for the
+    same triple (e.g. a stale ingest before this class's module
+    imports) loses the registry's tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"nsx-rest-4.2"`` -> (``"nsx"``, ``"4.2"``, ``"nsx-rest"``).
+    product = "nsx"
+    version = "4.2"
+    impl_id = "nsx-rest"
+    supported_version_range = ">=4.0,<5.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        session_loader: NsxSessionLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._session_tokens: dict[str, str] = {}
+        self._session_lock = asyncio.Lock()
+        self._session_loader: NsxSessionLoader = (
+            session_loader if session_loader is not None else load_session_credentials_from_vault
+        )
+
+    async def auth_headers(self, target: NsxTargetLike, raw_jwt: str) -> dict[str, str]:
+        """Return ``{"X-XSRF-TOKEN": <token>}`` for the request.
+
+        Lazily establishes the session on first call against *target*;
+        subsequent calls reuse the cached token. ``raw_jwt`` is accepted
+        for ABC-signature compatibility but unused --
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
+        Vault-sourced service account, not the operator's OIDC token.
+
+        The JSESSIONID cookie that pairs with this XSRF token lives in
+        the per-target client's cookie jar
+        (:attr:`httpx.AsyncClient.cookies`); httpx attaches it
+        automatically on subsequent requests through the same client.
+
+        Raises :exc:`NotImplementedError` (with ``target.name`` and the
+        requested mode in the message) if ``target.auth_model`` is
+        anything other than ``shared_service_account`` or ``None``.
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT does not forward operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not _is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"NsxConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        token = await self._session_token(target)
+        return {_XSRF_HEADER: token}
+
+    async def _session_token(self, target: NsxTargetLike) -> str:
+        """Return the cached XSRF token for *target*, establishing one on first use.
+
+        The lock serialises concurrent first-use for one target; the
+        cache fast-path means subsequent callers are bounded only by
+        the lock acquisition itself. The slow
+        ``POST /api/session/create`` call runs under the lock so two
+        concurrent first-use callers against the same target don't both
+        pay the round-trip cost.
+
+        The response carries ``X-XSRF-TOKEN`` as a header (cached here)
+        and ``Set-Cookie: JSESSIONID=...`` which the per-target httpx
+        client jar captures automatically. The response body is not
+        used.
+        """
+        async with self._session_lock:
+            cached = self._session_tokens.get(target.name)
+            if cached is not None:
+                return cached
+            creds = await self._session_loader(target)
+            try:
+                username = creds["username"]
+                password = creds["password"]
+            except KeyError as exc:
+                # Surface a clear error if the loader returned a dict
+                # missing one of the two required keys -- a typo in a
+                # production loader implementation otherwise surfaces
+                # as a confusing KeyError deep inside the form encoder.
+                raise RuntimeError(
+                    f"nsx session loader for target {target.name!r} returned "
+                    f"a dict missing required key {exc.args[0]!r}; need "
+                    "{'username': str, 'password': str}"
+                ) from exc
+            client = await self._http_client(target)
+            try:
+                resp = await client.post(
+                    _SESSION_CREATE_PATH,
+                    data={_FORM_USERNAME_KEY: username, _FORM_PASSWORD_KEY: password},
+                )
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                # Wrap so the operator-facing message names the target;
+                # httpx's default str() shows only the URL/status, which
+                # loses the per-target identification the dispatcher's
+                # audit row needs.
+                raise RuntimeError(
+                    f"nsx session establish failed for target {target.name!r}: "
+                    f"POST {_SESSION_CREATE_PATH} returned HTTP {exc.response.status_code}"
+                ) from exc
+            xsrf: str | None = resp.headers.get(_XSRF_HEADER)
+            if not xsrf:
+                # NSX guarantees the XSRF header on success; absence
+                # signals a misbehaving proxy or a wrong endpoint
+                # (probably HTTP Basic against /api/session/create
+                # silently 200-ing on a stale appliance). Fail loudly.
+                raise RuntimeError(
+                    f"nsx session establish for target {target.name!r}: "
+                    f"POST {_SESSION_CREATE_PATH} returned 2xx with no "
+                    f"{_XSRF_HEADER} response header"
+                )
+            self._session_tokens[target.name] = xsrf
+            _log.info(
+                "nsx_session_established",
+                target=target.name,
+                host=target.host,
+            )
+            return xsrf
+
+    async def _invalidate_session(self, target: NsxTargetLike) -> None:
+        """Drop the cached XSRF token + clear the client cookie jar for *target*.
+
+        Called by :meth:`_get_json_with_session_retry` on 401 from a
+        downstream call so the subsequent :meth:`_session_token`
+        re-issues ``POST /api/session/create`` from a clean state.
+        Holds the lock so a concurrent re-establish doesn't race with
+        the invalidation.
+        """
+        async with self._session_lock:
+            self._session_tokens.pop(target.name, None)
+            client = self._clients.get(target.name)
+            if client is not None:
+                client.cookies.clear()
+
+    async def _get_json_with_session_retry(
+        self,
+        target: NsxTargetLike,
+        path: str,
+        *,
+        raw_jwt: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """GET *path* with single 401 -> re-login -> retry-once recovery.
+
+        Wraps the inherited :meth:`HttpConnector._get_json` (which
+        carries tenacity's connection-error + 5xx retry decorator);
+        invokes it via ``super()._get_json`` so the ``.retry`` attribute
+        on the base method is preserved for retry-aware
+        introspection.
+
+        On 401 from the inherited call, invalidates the cached XSRF
+        token + the client cookie jar and re-tries once. A second 401
+        raises :exc:`RuntimeError` naming the target -- the consumer
+        wrapper's posture: re-login once on session-expiry, not a
+        retry loop.
+        """
+        try:
+            return await self._get_json(target, path, raw_jwt=raw_jwt, params=params)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 401:
+                raise
+            await self._invalidate_session(target)
+        try:
+            return await self._get_json(target, path, raw_jwt=raw_jwt, params=params)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 401:
+                raise RuntimeError(
+                    f"nsx session re-login failed for target {target.name!r}: "
+                    f"GET {path} returned HTTP 401 after refresh"
+                ) from exc
+            raise
+
+    async def fingerprint(self, target: NsxTargetLike) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /api/v1/node``.
+
+        The session is fetched lazily by :meth:`auth_headers` (called
+        transitively through
+        :meth:`HttpConnector._request_json`). The GET goes through
+        :meth:`_get_json_with_session_retry` so an expired session
+        (401) triggers one re-login before the result is reported.
+
+        On transport, status, or session-establish failure, returns a
+        non-reachable :class:`FingerprintResult` whose
+        ``extras["error"]`` carries the exception class + message --
+        same pattern :class:`VmwareRestConnector` established so the
+        operator's first ``meho connector fingerprint`` against an
+        unreachable NSX gets a structured response rather than a
+        stack trace.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            payload = await self._get_json_with_session_retry(target, "/api/v1/node", raw_jwt="")
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="nsx",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="GET /api/v1/node",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        return FingerprintResult(
+            vendor="vmware",
+            product="nsx",
+            version=payload.get("node_version"),
+            build=payload.get("kernel_version"),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="GET /api/v1/node",
+            extras={
+                "node_uuid": payload.get("node_uuid"),
+                "hostname": payload.get("hostname"),
+                "external_id": payload.get("external_id"),
+            },
+        )
+
+    async def probe(self, target: NsxTargetLike) -> ProbeResult:
+        """Lightweight reachability + auth-challenge check.
+
+        Delegates to :meth:`fingerprint` rather than running a
+        separate probe path. The issue body permits the implementer
+        to pick between (a) the heavier fingerprint delegation or (b)
+        a lighter ``GET /api/v1/cluster/status`` call; the delegation
+        path is chosen here for parity with the vSphere precedent
+        (one auth round-trip already covers both reachability and
+        auth-challenge, so a separate cluster-status call would add
+        round-trip cost without changing the boolean ``ok``).
+        ``probe()`` therefore inherits :meth:`fingerprint`'s 401-retry
+        layer transparently.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: NsxTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim -- delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`VmwareRestConnector.execute`'s shape: the
+        connector's ABC :meth:`Connector.execute` predates the G0.6
+        operator-aware dispatch path, so this shim exists for
+        pre-G0.6 callers. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI
+        verbs once #615 lands) construct a real :class:`Operator` and
+        call :func:`meho_backplane.operations.dispatch` directly.
+
+        The shim synthesises a minimal :class:`Operator` carrying a
+        nil-UUID tenant_id + a fixed system sentinel ``sub``; the
+        connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``'s contract:
+        ``"nsx-rest-4.2"`` -> (product=``"nsx"``, version=``"4.2"``,
+        impl_id=``"nsx-rest"``).
+        """
+        # Lazy import -- meho_backplane.operations.dispatch transitively
+        # imports the connector registry which imports this module at
+        # package import time; deferring keeps that initialisation
+        # order stable.
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:nsx-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached XSRF tokens, then tear down the httpx pool.
+
+        No DELETE-revoke is issued -- NSX's session has a documented
+        idle timeout, and a per-target network call during lifespan
+        shutdown is more risk than benefit (a hung DELETE on an
+        unreachable target would trip Kubernetes' 30-second
+        terminationGracePeriod). The token cache is cleared so a
+        post-aclose reuse of the same connector instance (e.g. a test
+        that builds one connector across two contexts) starts clean.
+        """
+        async with self._session_lock:
+            self._session_tokens.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/nsx/session.py
+++ b/backend/src/meho_backplane/connectors/nsx/session.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Session-credential loading for the nsx connector.
+
+The hand-rolled :class:`~meho_backplane.connectors.nsx.connector.NsxConnector`
+trades operator-context Vault reads to a session cookie + XSRF token via
+NSX's ``POST /api/session/create`` endpoint (form-encoded
+``j_username`` / ``j_password``). The credential fetch (Vault path ->
+service-account ``{"username": ..., "password": ...}`` dict) is split out
+behind a narrow :class:`NsxSessionLoader` callable so:
+
+* Production deploys override the default loader at construction time
+  once G0.3 (#224) lands the operator-context Vault read path.
+* Unit tests inject their own (mock) loader returning a pre-built dict.
+* Integration tests against a recorded-fixture or live NSX target pass a
+  loader that yields the appropriate service-account credentials.
+
+The default loader, :func:`load_session_credentials_from_vault`, raises
+:exc:`NotImplementedError` until G0.3 (#224) merges. Mirrors the shape
+:func:`~meho_backplane.connectors.vmware_rest.session.load_session_credentials_from_vault`
+established for :class:`VmwareRestConnector` -- once the Target model +
+operator-context Vault reads land, both loaders pick up the concrete
+implementation in a single follow-up commit.
+
+The :class:`NsxTargetLike` Protocol captures the minimum target shape
+the connector reads: ``name`` (for the per-target session-token cache
+key), ``host``, ``port`` (forwarded to :meth:`HttpConnector._base_url`),
+``secret_ref`` (the Vault path the loader resolves), and ``auth_model``
+(checked by :meth:`NsxConnector.auth_headers` to reject ``per_user`` /
+``impersonation`` targets at the boundary). Once G0.3 ships its
+concrete ``Target`` model in :mod:`meho_backplane.targets`, the model
+satisfies this Protocol structurally -- no edits here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "NsxSessionLoader",
+    "NsxTargetLike",
+    "SessionCredentials",
+    "load_session_credentials_from_vault",
+]
+
+
+class SessionCredentials(Protocol):
+    """The dict shape :class:`NsxSessionLoader` returns.
+
+    Captured as a Protocol so the type checker can flag a loader that
+    forgets a key. The two values map to the form-encoded body
+    ``j_username`` / ``j_password`` NSX's ``POST /api/session/create``
+    expects; nothing else is read.
+    """
+
+    username: str
+    password: str
+
+
+@runtime_checkable
+class NsxTargetLike(Protocol):
+    """Minimum target shape :class:`NsxConnector` reads.
+
+    Structural Protocol -- once G0.3 (#224) lands the concrete
+    ``Target`` model in :mod:`meho_backplane.targets`, that model
+    satisfies this Protocol unchanged. ``auth_model`` is checked at the
+    boundary so a target tagged ``per_user`` or ``impersonation`` raises
+    a clear error rather than silently authenticating as the shared
+    service account.
+
+    ``secret_ref`` is the Vault path the loader resolves to a
+    :class:`SessionCredentials`-shaped dict. ``port`` is optional --
+    NSX manager defaults to 443 and
+    :meth:`HttpConnector._base_url` already handles the
+    ``port is None or 443`` case correctly.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+
+
+NsxSessionLoader = Callable[[NsxTargetLike], Awaitable[dict[str, str]]]
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+The connector's :meth:`NsxConnector._session_token` invokes the loader
+on every session-establish (first use against a target, and again after
+a 401-driven invalidation). The return type is the looser
+``dict[str, str]`` (not :class:`SessionCredentials`) because Python
+:class:`Protocol` instances aren't runtime-constructible without a
+matching class -- production code returns a plain dict and the
+connector reads ``creds["username"]`` / ``creds["password"]`` by key.
+"""
+
+
+async def load_session_credentials_from_vault(
+    target: NsxTargetLike,
+) -> dict[str, str]:
+    """Default credential loader -- Vault read by ``target.secret_ref``.
+
+    Stubbed until G0.3 (#224) lands the ``Target`` model and the
+    operator-context Vault read path. Mirrors
+    :func:`~meho_backplane.connectors.vmware_rest.session.load_session_credentials_from_vault`'s
+    ``NotImplementedError`` stub so the wiring shape is stable: a
+    production caller without an explicit loader override receives a
+    clear error rather than a silent fallback or a hallucinated
+    credential pair.
+
+    Once G0.3 lands, this function becomes the live implementation that
+    reads the ``nsx/<target.name>`` Vault path and returns the parsed
+    ``{"username": ..., "password": ...}`` dict. Until then, tests and
+    any acceptance harness inject a custom :class:`NsxSessionLoader` on
+    connector construction.
+    """
+    raise NotImplementedError(
+        "load_session_credentials_from_vault requires G0.3 Target model + "
+        f"operator-context Vault read; target={target.name!r} "
+        f"secret_ref={target.secret_ref!r}. Inject a custom session_loader "
+        "on NsxConnector until G0.3 lands."
+    )

--- a/backend/tests/test_connectors_nsx_auth.py
+++ b/backend/tests/test_connectors_nsx_auth.py
@@ -1,0 +1,603 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`NsxConnector` session-auth + fingerprint/probe (G3.5-T1 #613).
+
+Exercises the form-encoded session-create flow, the X-XSRF-TOKEN +
+JSESSIONID-cookie pairing, the 401 -> re-login + retry-once recovery,
+per-target isolation, and the auth_model boundary gate. The
+contract mirrors :mod:`tests.test_connectors_vmware_rest_auth` with NSX
+auth divergence: form body (not HTTP Basic), Set-Cookie + X-XSRF-TOKEN
+response (not JSON-string token), and the connector-level 401 retry
+(vSphere defers 401 recovery; NSX does it once per call).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from urllib.parse import parse_qsl
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.nsx import (
+    NsxConnector,
+    NsxTargetLike,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+
+
+@pytest.fixture(autouse=True)
+def _clean_nsx_registry() -> Iterator[None]:
+    """Re-register NsxConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that
+    calls :func:`clear_registry` between tests. The connector class
+    self-registered at import time, but the post-clear empty state
+    breaks the registration-acceptance test below. Re-register before
+    every test in this module and clear after -- same pattern
+    :mod:`tests.test_connectors_vmware_rest_auth` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=NsxConnector.product,
+        version=NsxConnector.version,
+        impl_id=NsxConnector.impl_id,
+        cls=NsxConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub -- satisfies NsxTargetLike Protocol structurally.
+# Replaced by the real Target model when G0.3 (#224) lands.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET_A = _StubTarget(
+    name="nsx-a",
+    host="nsx-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/nsx/nsx-a",
+)
+_TARGET_B = _StubTarget(
+    name="nsx-b",
+    host="nsx-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/nsx/nsx-b",
+)
+
+
+async def _stub_loader(_target: NsxTargetLike) -> dict[str, str]:
+    """Return canned credentials regardless of the target."""
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> NsxConnector:
+    """Build a connector wired with the stub loader."""
+    return NsxConnector(session_loader=_stub_loader)
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_nsx_connector_subclasses_http_connector() -> None:
+    """Sanity check: the connector inherits from HttpConnector with the right metadata."""
+    assert issubclass(NsxConnector, HttpConnector)
+    assert NsxConnector.product == "nsx"
+    assert NsxConnector.version == "4.2"
+    assert NsxConnector.impl_id == "nsx-rest"
+    assert NsxConnector.supported_version_range == ">=4.0,<5.0"
+    # Outranks a future GenericRestConnector auto-shim defensively.
+    assert NsxConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    """The package's __init__ calls register_connector_v2 at import time."""
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("nsx", "4.2", "nsx-rest")
+    assert key in registry
+    assert registry[key] is NsxConnector
+
+
+def test_default_session_loader_raises_until_g03_lands() -> None:
+    """The default Vault loader stays unimplemented until G0.3."""
+    import asyncio
+
+    from meho_backplane.connectors.nsx.session import (
+        load_session_credentials_from_vault,
+    )
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"G0\.3"):
+            await load_session_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Session establishment -- happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_establishes_session_with_form_encoded_body() -> None:
+    """First auth_headers call POSTs form-encoded creds to /api/session/create.
+
+    Asserts the load-bearing auth divergence from vSphere:
+    ``Content-Type: application/x-www-form-urlencoded`` body with
+    ``j_username`` + ``j_password`` keys (NOT JSON, NOT HTTP Basic).
+    """
+    connector = _make_connector()
+    xsrf_token = "xsrf-abc-123"
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        session_route = mock.post("/api/session/create").respond(
+            200,
+            headers={"X-XSRF-TOKEN": xsrf_token, "Set-Cookie": "JSESSIONID=jsess-1; Path=/"},
+        )
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert session_route.called and session_route.call_count == 1
+    assert headers == {"X-XSRF-TOKEN": xsrf_token}
+
+    # Form-encoded body assertion -- decode the URL-encoded bytes back
+    # to a dict so a key-order swap in form encoding doesn't flake the
+    # test. The connector must send j_username + j_password verbatim.
+    request = session_route.calls[0].request
+    assert request.headers.get("content-type", "").startswith("application/x-www-form-urlencoded")
+    sent = dict(parse_qsl(request.content.decode()))
+    assert sent == {"j_username": "svc-meho", "j_password": "stub-password"}
+    # NSX rejects HTTP Basic on the canonical FQDN -- the form-encoded
+    # flow must NOT smuggle an Authorization: Basic header alongside.
+    assert "authorization" not in {k.lower() for k in request.headers}
+
+    # The JSESSIONID cookie landed in the per-target client jar
+    # automatically (httpx.AsyncClient.cookies.extract_cookies).
+    client = await connector._http_client(_TARGET_A)
+    assert client.cookies.get("JSESSIONID") == "jsess-1"
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_session_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-POST /api/session/create."""
+    connector = _make_connector()
+    xsrf_token = "xsrf-cached-456"
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        session_route = mock.post("/api/session/create").respond(
+            200,
+            headers={"X-XSRF-TOKEN": xsrf_token, "Set-Cookie": "JSESSIONID=jsess-1; Path=/"},
+        )
+        h1 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+        h2 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert h1 == h2 == {"X-XSRF-TOKEN": xsrf_token}
+    # The load-bearing assertion -- exactly one POST /api/session/create
+    # for two auth header calls.
+    assert session_route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_session_tokens_separate() -> None:
+    """Two targets get two distinct cached tokens; no cross-target leakage."""
+    connector = _make_connector()
+
+    async with respx.mock() as mock:
+        route_a = mock.post("https://nsx-a.test.invalid/api/session/create").respond(
+            200,
+            headers={"X-XSRF-TOKEN": "xsrf-a", "Set-Cookie": "JSESSIONID=jsess-a"},
+        )
+        route_b = mock.post("https://nsx-b.test.invalid/api/session/create").respond(
+            200,
+            headers={"X-XSRF-TOKEN": "xsrf-b", "Set-Cookie": "JSESSIONID=jsess-b"},
+        )
+
+        h_a = await connector.auth_headers(_TARGET_A, raw_jwt="")
+        h_b = await connector.auth_headers(_TARGET_B, raw_jwt="")
+
+    assert route_a.called and route_b.called
+    assert h_a == {"X-XSRF-TOKEN": "xsrf-a"}
+    assert h_b == {"X-XSRF-TOKEN": "xsrf-b"}
+    assert connector._session_tokens == {
+        "nsx-a": "xsrf-a",
+        "nsx-b": "xsrf-b",
+    }
+    # Cookie jars are also isolated -- one client per target.
+    client_a = await connector._http_client(_TARGET_A)
+    client_b = await connector._http_client(_TARGET_B)
+    assert client_a.cookies.get("JSESSIONID") == "jsess-a"
+    assert client_b.cookies.get("JSESSIONID") == "jsess-b"
+
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Session establishment -- failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_create_401_surfaces_runtime_error_naming_target() -> None:
+    """401 from POST /api/session/create raises RuntimeError naming the target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        mock.post("/api/session/create").respond(401, json={"error": "invalid_credentials"})
+        with pytest.raises(RuntimeError, match=r"nsx-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "401" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_create_missing_xsrf_header_raises() -> None:
+    """A 2xx response without X-XSRF-TOKEN raises naming the target.
+
+    A misbehaving proxy or a wrong endpoint can 200 with no XSRF header;
+    the connector fails loudly rather than caching an empty token that
+    would silently 401 every subsequent call.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        # Set-Cookie present but no X-XSRF-TOKEN -- failure case.
+        mock.post("/api/session/create").respond(200, headers={"Set-Cookie": "JSESSIONID=jsess-1"})
+        with pytest.raises(RuntimeError, match=r"nsx-a"):
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_clear_error() -> None:
+    """A loader returning a dict without 'password' surfaces a clear message."""
+
+    async def _bad_loader(_target: NsxTargetLike) -> dict[str, str]:
+        return {"username": "svc-meho"}  # type: ignore[return-value]
+
+    connector = NsxConnector(session_loader=_bad_loader)
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid"):
+        with pytest.raises(RuntimeError, match=r"password"):
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="nsx-per-user",
+        host="nsx.test.invalid",
+        port=443,
+        secret_ref="kv/data/nsx/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="")
+
+    assert "nsx-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="nsx-pre-g03",
+        host="nsx.test.invalid",
+        port=443,
+        secret_ref="kv/data/nsx/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx.test.invalid") as mock:
+        mock.post("/api/session/create").respond(200, headers={"X-XSRF-TOKEN": "pre-g03-token"})
+        headers = await connector.auth_headers(target, raw_jwt="")
+
+    assert headers == {"X-XSRF-TOKEN": "pre-g03-token"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_value_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="nsx-enum",
+        host="nsx.test.invalid",
+        port=443,
+        secret_ref="kv/data/nsx/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx.test.invalid") as mock:
+        mock.post("/api/session/create").respond(200, headers={"X-XSRF-TOKEN": "enum-token"})
+        headers = await connector.auth_headers(target, raw_jwt="")
+
+    assert headers == {"X-XSRF-TOKEN": "enum-token"}
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# 401 -> re-login -> retry-once recovery (downstream call)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_downstream_401_triggers_relogin_and_retry_once() -> None:
+    """A 401 on a downstream GET triggers session invalidation + re-login + a single retry.
+
+    Exercises the issue's "on HTTP 401 from a downstream call, re-login
+    once then retry once" contract. The session-create route is called
+    twice (initial + post-401 re-login); the downstream route is
+    called twice (401 then 200).
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        session_route = mock.post("/api/session/create")
+        session_route.side_effect = [
+            httpx.Response(
+                200, headers={"X-XSRF-TOKEN": "xsrf-first", "Set-Cookie": "JSESSIONID=js1"}
+            ),
+            httpx.Response(
+                200,
+                headers={"X-XSRF-TOKEN": "xsrf-second", "Set-Cookie": "JSESSIONID=js2"},
+            ),
+        ]
+        node_route = mock.get("/api/v1/node")
+        node_route.side_effect = [
+            httpx.Response(401),
+            httpx.Response(
+                200,
+                json={
+                    "node_version": "4.2.0.0.0",
+                    "kernel_version": "5.10.0-nsx",
+                    "node_uuid": "uuid-1",
+                    "hostname": "nsx-a.test.invalid",
+                },
+            ),
+        ]
+
+        result = await connector._get_json_with_session_retry(_TARGET_A, "/api/v1/node", raw_jwt="")
+
+    assert result["node_version"] == "4.2.0.0.0"
+    # Re-login fired exactly once -- two POSTs total.
+    assert session_route.call_count == 2
+    # Downstream GET fired twice -- the original 401 + the post-relogin retry.
+    assert node_route.call_count == 2
+    # The post-relogin XSRF replaced the stale one.
+    assert connector._session_tokens == {"nsx-a": "xsrf-second"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_downstream_401_then_still_401_after_relogin_raises_runtime_error() -> None:
+    """If the post-relogin retry also 401s, RuntimeError naming the target is raised.
+
+    Single retry, not a loop -- a configured credential pair that
+    consistently 401s should fail fast rather than hammering NSX's
+    audit log.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        session_route = mock.post("/api/session/create").respond(
+            200,
+            headers={"X-XSRF-TOKEN": "xsrf-any", "Set-Cookie": "JSESSIONID=js"},
+        )
+        node_route = mock.get("/api/v1/node").respond(401)
+
+        with pytest.raises(RuntimeError, match=r"nsx-a") as exc_info:
+            await connector._get_json_with_session_retry(_TARGET_A, "/api/v1/node", raw_jwt="")
+
+    assert "401" in str(exc_info.value)
+    assert "after refresh" in str(exc_info.value)
+    # Exactly one re-login attempt + two GETs (no further retries).
+    assert session_route.call_count == 2
+    assert node_route.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_downstream_non_401_status_error_propagates_untouched() -> None:
+    """A 500 (or any non-401 status) on a downstream call does NOT trigger relogin.
+
+    Re-establishing the session on a 5xx would mask transient backend
+    failures behind a credential-rotation that solves nothing; the
+    relogin branch is keyed strictly on 401.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        session_route = mock.post("/api/session/create").respond(
+            200,
+            headers={"X-XSRF-TOKEN": "xsrf-any", "Set-Cookie": "JSESSIONID=js"},
+        )
+        # 502 is the gateway-error shape behind the VCF 9 envoy proxy;
+        # tenacity's @retry on _request_json will retry it up to its
+        # budget before raising. Asserting "exactly one POST" guarantees
+        # we never triggered a relogin.
+        mock.get("/api/v1/node").respond(502)
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await connector._get_json_with_session_retry(_TARGET_A, "/api/v1/node", raw_jwt="")
+
+    assert exc_info.value.response.status_code == 502
+    # One session-create call (initial); no re-login fired.
+    assert session_route.call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() + probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against a respx-mocked GET /api/v1/node returns the canonical shape."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        mock.post("/api/session/create").respond(
+            200,
+            headers={"X-XSRF-TOKEN": "xsrf-1", "Set-Cookie": "JSESSIONID=js"},
+        )
+        mock.get("/api/v1/node").respond(
+            200,
+            json={
+                "node_version": "4.2.0.0.0.21761695",
+                "kernel_version": "5.10.0-nsx",
+                "node_uuid": "abc-uuid-1",
+                "hostname": "nsx-a.test.invalid",
+                "external_id": "ext-1",
+            },
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "nsx"
+    assert fp.version == "4.2.0.0.0.21761695"
+    assert fp.build == "5.10.0-nsx"
+    assert fp.reachable is True
+    assert fp.probe_method == "GET /api/v1/node"
+    assert fp.extras["node_uuid"] == "abc-uuid-1"
+    assert fp.extras["hostname"] == "nsx-a.test.invalid"
+    assert fp.extras["external_id"] == "ext-1"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_returns_reachable_false_with_error() -> None:
+    """Transport/status/session failure returns reachable=False with structured extras."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        # Session-create itself fails 401 -- the RuntimeError from
+        # ``_session_token`` must surface as a clean reachable=False
+        # rather than propagating up.
+        mock.post("/api/session/create").respond(401, json={"error": "invalid_credentials"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "nsx"
+    assert fp.reachable is False
+    assert fp.probe_method == "GET /api/v1/node"
+    # Structured error: ``"<ExcType>: <message>"``.
+    error = fp.extras["error"]
+    assert "RuntimeError" in error
+    assert "nsx-a" in error
+    assert "401" in error
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_when_reachable() -> None:
+    """probe() returns ok=True on a reachable target (delegates to fingerprint)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        mock.post("/api/session/create").respond(
+            200, headers={"X-XSRF-TOKEN": "xsrf", "Set-Cookie": "JSESSIONID=js"}
+        )
+        mock.get("/api/v1/node").respond(
+            200,
+            json={
+                "node_version": "4.2.0",
+                "kernel_version": "5.10.0",
+                "node_uuid": "u",
+                "hostname": "nsx-a.test.invalid",
+            },
+        )
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_with_reason_when_unreachable() -> None:
+    """probe() returns ok=False + reason on an unreachable target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        mock.post("/api/session/create").respond(401, json={"error": "bad_creds"})
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    assert "401" in result.reason
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose -- token cache clear + pool tear-down
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_session_token_cache_and_pool() -> None:
+    """aclose() clears in-memory session caches and tears down the httpx pool."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://nsx-a.test.invalid") as mock:
+        mock.post("/api/session/create").respond(
+            200, headers={"X-XSRF-TOKEN": "xsrf", "Set-Cookie": "JSESSIONID=js"}
+        )
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert connector._session_tokens == {"nsx-a": "xsrf"}
+    await connector.aclose()
+    assert connector._session_tokens == {}
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_with_no_cached_sessions_is_a_noop() -> None:
+    """A fresh connector with no sessions established closes cleanly."""
+    connector = _make_connector()
+    await connector.aclose()
+    assert connector._clients == {}
+    assert connector._session_tokens == {}

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -72,7 +72,9 @@ endpoint accepts only form-encoded credentials. The flow:
    `application/x-www-form-urlencoded`.
 4. The response's `Set-Cookie: JSESSIONID=...` header is captured
    into the per-target `httpx.AsyncClient.cookies` jar automatically
-   (`httpx/_client.py:1737` -- `self.cookies.extract_cookies(response)`).
+   -- httpx calls `self.cookies.extract_cookies(response)` on every
+   response, so subsequent requests through the same client carry
+   the cookie without manual plumbing.
 5. The response's `X-XSRF-TOKEN` header is captured into
    `self._session_tokens[target.name]`.
 6. `auth_headers()` returns `{"X-XSRF-TOKEN": <cached>}`. The
@@ -137,9 +139,10 @@ real `Operator` and call `dispatch` themselves.
 client. No `DELETE /api/session/destroy` is issued -- NSX's session
 has a documented idle timeout, and a per-target network call during
 lifespan shutdown is more risk than benefit (a hung DELETE on an
-unreachable target trips Kubernetes' 30-second
-`terminationGracePeriod`). Revoke-on-close is a v0.2.next concern,
-same posture vSphere takes for proactive refresh.
+unreachable target can exceed Kubernetes' default 30 s
+`terminationGracePeriod`, which is configurable per Pod spec but
+typically left at the default). Revoke-on-close is a v0.2.next
+concern, same posture vSphere takes for proactive refresh.
 
 ## Dependencies
 
@@ -190,7 +193,12 @@ same posture vSphere takes for proactive refresh.
   `connectors/adapters/http.py` (`HttpConnector`);
   `connectors/base.py` (`Connector` ABC);
   `connectors/registry.py:108` (`register_connector_v2`).
-- Consumer wrapper this contract mirrors:
-  https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/nsx.sh
-- NSX REST API guide:
-  https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/
+- Consumer wrapper this contract mirrors: `scripts/nsx.sh` in the
+  consumer's `claude-rdc-hetzner-dc` repository (private to the
+  `evoila-bosnia` org; the wrapper is the source of truth for the
+  form-encoded `j_username`/`j_password` + `X-XSRF-TOKEN` flow).
+- NSX REST API reference -- official documentation is hosted under
+  Broadcom's developer portal at `developer.broadcom.com` (the
+  exact version-pinned URL has shifted since the VMware-by-Broadcom
+  domain consolidation; search "NSX REST API guide" from the portal
+  root rather than hard-coding a path here).

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -1,0 +1,196 @@
+# Connector: nsx (NSX 4.x)
+
+## Overview
+
+The `nsx` connector is the hand-rolled `HttpConnector` subclass that
+will dispatch ingested NSX REST operations under the
+`(product="nsx", version="4.2", impl_id="nsx-rest")` registry triple.
+G3.5-T1 (#613) ships only the skeleton -- session-cookie / XSRF auth,
+fingerprint, probe, and the G0.6 dispatch shim. Operations arrive in
+G3.5-T2 (#614) via G0.7 spec ingestion against `nsx-4.2/policy.yaml`
++ `nsx-4.2/manager.yaml`; CLI verbs + MCP review + recorded-fixture
+E2E arrive in G3.5-T3 (#615).
+
+Source: `backend/src/meho_backplane/connectors/nsx/`.
+
+## Key types
+
+- **`NsxConnector`** (`connector.py`) -- `HttpConnector` subclass.
+  Class attributes: `product="nsx"`, `version="4.2"`,
+  `impl_id="nsx-rest"`, `supported_version_range=">=4.0,<5.0"`,
+  `priority=1`. The priority outranks a future
+  `GenericRestConnector` auto-shim (priority=0) defensively if both
+  somehow register for the same triple.
+- **`NsxTargetLike`** (`session.py`) -- runtime-checkable Protocol
+  capturing the minimum target shape the connector reads: `name`,
+  `host`, `port`, `secret_ref`, `auth_model`. Replaced by the
+  concrete `Target` model once G0.3 (#224) lands; the model
+  satisfies the Protocol structurally without code edits here.
+- **`NsxSessionLoader`** (`session.py`) -- async callable type
+  resolving a target to `{"username": ..., "password": ...}`.
+  Injectable on connector construction
+  (`NsxConnector(session_loader=...)`) so unit tests, integration
+  tests, and pre-G0.3 production deploys override the default Vault
+  loader.
+- **`load_session_credentials_from_vault`** (`session.py`) -- default
+  loader, stubbed `NotImplementedError` until G0.3 lands the
+  operator-context Vault read path. Mirrors the
+  `load_session_credentials_from_vault` shape in
+  `connectors/vmware_rest/`.
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()` in
+   `meho_backplane/connectors/registry.py`, which walks every
+   `connectors/<product>/` subpackage in name-sorted order.
+2. Importing `meho_backplane.connectors.nsx` triggers the
+   module-level
+   `register_connector_v2(product="nsx", version="4.2", impl_id="nsx-rest", cls=NsxConnector)`
+   call.
+3. The registry's v2 table now resolves `("nsx", "4.2", "nsx-rest")`
+   to `NsxConnector`. The G0.7 auto-shim's idempotency check (in
+   `ensure_connector_class_registered`, once #408's pipeline lands
+   in main) no-ops on subsequent ingests against the same triple.
+
+### Per-target session
+
+NSX auth diverges from the vSphere precedent: the canonical FQDN
+behind the VCF 9 envoy proxy rejects HTTP Basic, and the session
+endpoint accepts only form-encoded credentials. The flow:
+
+1. `NsxConnector.auth_headers(target)` is called for the first time
+   against `target`.
+2. `_session_token(target)` acquires the per-instance `asyncio.Lock`,
+   checks the `self._session_tokens` cache (keyed on `target.name`),
+   misses, calls the injected `session_loader(target)` -> resolves
+   to `{"username": ..., "password": ...}`.
+3. `_session_token` POSTs to `/api/session/create` with
+   `data={"j_username": ..., "j_password": ...}` -- `httpx 0.28.x`'s
+   `client.post(url, data=<dict>)` sends
+   `application/x-www-form-urlencoded`.
+4. The response's `Set-Cookie: JSESSIONID=...` header is captured
+   into the per-target `httpx.AsyncClient.cookies` jar automatically
+   (`httpx/_client.py:1737` -- `self.cookies.extract_cookies(response)`).
+5. The response's `X-XSRF-TOKEN` header is captured into
+   `self._session_tokens[target.name]`.
+6. `auth_headers()` returns `{"X-XSRF-TOKEN": <cached>}`. The
+   `JSESSIONID` cookie travels via the client jar; subsequent
+   requests through the same per-target client get both
+   transparently.
+
+### 401 -> re-login -> retry-once
+
+`_get_json_with_session_retry(target, path)` wraps the inherited
+`HttpConnector._get_json`. The inherited method carries tenacity's
+`@retry(retry_if_exception(_retryable))` decorator that excludes 4xx
+responses, so a 401 propagates cleanly to the wrapper.
+
+1. First call to `_get_json` succeeds -> return.
+2. First call raises `httpx.HTTPStatusError(401)` ->
+   `_invalidate_session(target)` acquires the lock, drops the cached
+   XSRF token, and clears the per-target client cookie jar.
+3. Second call to `_get_json` re-establishes the session via
+   `auth_headers -> _session_token` (cache-miss path) and re-tries
+   the GET.
+4. Second call succeeds -> return; second call raises 401 ->
+   wrapper raises
+   `RuntimeError("nsx session re-login failed for target ...")`.
+5. Any non-401 status error propagates untouched -- relogin would
+   mask transient backend failures.
+
+The single retry posture (not a loop) matches the consumer wrapper
+in `scripts/nsx.sh` so a misconfigured credential pair fails fast
+instead of hammering NSX's audit log.
+
+### Fingerprint + probe
+
+- `fingerprint(target)` issues `GET /api/v1/node` through
+  `_get_json_with_session_retry`. On success: returns
+  `FingerprintResult(vendor="vmware", product="nsx",
+  version=<node_version>, build=<kernel_version>, reachable=True,
+  extras={"node_uuid", "hostname", "external_id"})`. On transport,
+  HTTP-status, or session-establish failure: returns
+  `reachable=False` with `extras["error"] = "<ExcType>: <message>"`.
+- `probe(target)` delegates to `fingerprint`. The issue body
+  permits an alternative `GET /api/v1/cluster/status` call; the
+  delegation path is chosen for parity with `VmwareRestConnector`
+  -- one auth round-trip already covers both reachability and
+  auth-challenge.
+
+### Dispatch shim
+
+`execute(target, op_id, params)` synthesises a minimal `Operator`
+(nil-UUID tenant_id + `sub="system:nsx-rest-connector-shim"`) and
+delegates to `meho_backplane.operations.dispatch` with
+`connector_id="nsx-rest-4.2"`. Pre-G0.6 chassis routes that still
+invoke `Connector.execute` directly reach the dispatcher through
+this shim; post-G0.6 callers (the `/api/v1/operations/call` route,
+MCP `call_operation`, the CLI verbs once #615 lands) construct a
+real `Operator` and call `dispatch` themselves.
+
+### Shutdown
+
+`aclose()` clears `self._session_tokens` and delegates to
+`HttpConnector.aclose()` which closes every per-target httpx
+client. No `DELETE /api/session/destroy` is issued -- NSX's session
+has a documented idle timeout, and a per-target network call during
+lifespan shutdown is more risk than benefit (a hung DELETE on an
+unreachable target trips Kubernetes' 30-second
+`terminationGracePeriod`). Revoke-on-close is a v0.2.next concern,
+same posture vSphere takes for proactive refresh.
+
+## Dependencies
+
+- **httpx 0.28.x** -- per-target `AsyncClient` pool (inherited from
+  `HttpConnector`); `client.post(url, data=<dict>)` for the
+  form-encoded session create; automatic cookie-jar management for
+  `JSESSIONID`.
+- **tenacity 9.x** -- the inherited `@retry` decorator on
+  `HttpConnector._request_json` retries connection errors and 5xx
+  responses up to four attempts with exponential backoff; 4xx
+  (including 401) propagates cleanly to the connector-level retry
+  layer.
+- **pydantic 2.13.x** -- `FingerprintResult` / `ProbeResult` /
+  `OperationResult` are frozen models with `MappingProxyType` -wrapped
+  `extras`; the connector constructs them by keyword.
+- **respx 0.23.x (test-only)** -- the unit-test module mocks every
+  request shape (form-encoded body, Set-Cookie response, X-XSRF-TOKEN
+  response, 401 / 502 status sequences) without a network call.
+- **structlog** -- a single `nsx_session_established` info event per
+  successful session create; no other emit points in this skeleton.
+
+## Known issues
+
+- The connector cannot exercise any operation yet -- `endpoint_descriptor`
+  rows for NSX REST land in #614 via G0.7 spec ingestion. The
+  dispatch shim resolves `connector_id="nsx-rest-4.2"` but
+  `op_id=<anything>` returns the dispatcher's "unknown operation"
+  shape until the rows exist.
+- Default session loader raises `NotImplementedError`. Production
+  callers must inject `session_loader=...` on construction until
+  G0.3 (#224) lands the operator-context Vault read path. Mirrors
+  the `vmware_rest` precedent; both connectors pick up the live
+  implementation in a single follow-up commit once G0.3 merges.
+- Session-revoke on `aclose()` is deliberately omitted. NSX's idle
+  timeout (~30 min for NSX Manager) reclaims abandoned sessions
+  naturally; the cost of a hung DELETE during lifespan shutdown
+  outweighs the audit-log neatness of an explicit revoke.
+
+## References
+
+- Issue: [G3.5-T1 #613](https://github.com/evoila/meho/issues/613).
+- Parent Initiative: [G3.5 #368](https://github.com/evoila/meho/issues/368).
+- Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
+- Sibling tasks: #614 (spec ingestion), #615 (CLI + MCP review + E2E).
+- Precedent: `connectors/vmware_rest/connector.py` (session auth +
+  fingerprint + probe + dispatch shim);
+  `connectors/vmware_rest/__init__.py` (registration);
+  `connectors/adapters/http.py` (`HttpConnector`);
+  `connectors/base.py` (`Connector` ABC);
+  `connectors/registry.py:108` (`register_connector_v2`).
+- Consumer wrapper this contract mirrors:
+  https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/nsx.sh
+- NSX REST API guide:
+  https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/


### PR DESCRIPTION
## Summary

- Ship the `NsxConnector` skeleton: `HttpConnector` subclass under registry triple `("nsx", "4.2", "nsx-rest")` with form-encoded `POST /api/session/create` auth, JSESSIONID-cookie + X-XSRF-TOKEN pairing, `fingerprint()` → `GET /api/v1/node`, `probe()` delegating to fingerprint, and the G0.6 dispatch shim (`connector_id="nsx-rest-4.2"`).
- Auth divergence from `VmwareRestConnector` is load-bearing: NSX rejects HTTP Basic on the canonical FQDN behind the VCF 9 envoy proxy, so the connector uses form-encoded `j_username`/`j_password` + Set-Cookie + X-XSRF-TOKEN (mirrors the consumer wrapper at `scripts/nsx.sh`). On HTTP 401 from a downstream call, the connector invalidates the cached XSRF + clears the per-target client cookie jar, re-establishes the session, and retries once; a second 401 surfaces as `RuntimeError` naming the target.
- Operations arrive separately in #614 via G0.7 spec ingestion of `nsx-4.2/policy.yaml` + `nsx-4.2/manager.yaml`.

## Test plan

- [x] `ruff check backend/src/meho_backplane/connectors/nsx/ backend/tests/test_connectors_nsx_auth.py` — clean
- [x] `ruff format --check ...` — clean
- [x] `mypy backend/src/meho_backplane/connectors/nsx/ --ignore-missing-imports` — clean
- [x] `pytest backend/tests/test_connectors_nsx_auth.py backend/tests/test_connectors_registry_v2.py` — **36 passed**
- [x] Sibling connector regression sweep (`test_connectors_resolver`, `test_connectors_registry`, `test_connectors_base`, `test_connectors_http_adapter`, `test_connectors_vmware_rest_auth`, `test_operations_ingest_review`) — **138 passed**, no regressions
- [x] Form-encoded body assertion: `POST /api/session/create` carries `application/x-www-form-urlencoded` with `j_username` + `j_password` keys and NO `Authorization: Basic` header (`test_auth_headers_establishes_session_with_form_encoded_body`)
- [x] JSESSIONID cookie auto-captured into `httpx.AsyncClient.cookies` and reused on subsequent requests (same test)
- [x] Session reuse: one `POST /api/session/create` for two `auth_headers` calls (`test_auth_headers_reuses_cached_session_across_calls`)
- [x] Per-target token isolation (`test_per_target_isolation_keeps_session_tokens_separate`)
- [x] 401 → re-login + retry-once → success (`test_downstream_401_triggers_relogin_and_retry_once`)
- [x] 401 → re-login → still 401 → `RuntimeError` naming target + "after refresh" (`test_downstream_401_then_still_401_after_relogin_raises_runtime_error`)
- [x] Non-401 status errors propagate untouched, no relogin (`test_downstream_non_401_status_error_propagates_untouched`)
- [x] `auth_model` gating: `per_user` / `impersonation` / unknown → `NotImplementedError` naming target + mode; `None` and `SHARED_SERVICE_ACCOUNT` enum/value accepted (4 parametrised + 2 individual tests)
- [x] `fingerprint()` canonical shape on reachable target; unreachable returns `reachable=False` with structured `extras["error"]`
- [x] `probe()` returns `ok=True` reachable / `ok=False` + reason unreachable
- [x] `aclose()` clears caches + tears down pool; idempotent on fresh connector

## Out of scope

- NSX operations (segment/tier0/firewall/policy list ops) — spec-ingested in #614.
- CLI verbs / MCP review / recorded-fixture E2E / `nsx-onboarding.md` — #615.
- NSX write ops, policy-as-code, LB/IDS/IPS — deferred per #368 *Out of scope*.
- Proactive 401 session refresh beyond the single retry — v0.2.next, same posture as the vSphere precedent.
- Default `load_session_credentials_from_vault` loader — stubbed `NotImplementedError` until G0.3 (#224) lands the operator-context Vault read path; production callers inject `session_loader=...` until then.
- `DELETE /api/session/destroy` on `aclose()` — NSX session has a documented idle timeout; per-target network calls during lifespan shutdown are more risk than benefit (same posture vSphere takes for proactive refresh).

Closes #613


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NSX 4.x connector for VMware NSX 4.0–4.x with session-based auth, token caching, fingerprinting, and probe support; automatic re-login + single retry on auth failures.
* **Documentation**
  * New connector design and behavior docs covering auth flow, session semantics, retry and shutdown behavior.
* **Tests**
  * Comprehensive unit tests for session establishment, token/cookie caching and isolation, retry/failure modes, fingerprint/probe, and shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->