### PR TITLE
fix(chart): G0.8-T2 align Valkey env var (BROADCAST_REDIS_URL) — restore /ready broadcast leg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ cli/*.out
 *.bak
 *.orig
 .idea/
+*.code-workspace
 
 # =============================================================================
 # Docker / runtime data

--- a/deploy/charts/meho/charts/broadcast/Chart.yaml
+++ b/deploy/charts/meho/charts/broadcast/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   — as a single-replica Deployment with ephemeral streams. Subchart slug is
   `broadcast` rather than `redis` because the protocol contract matters more
   than the brand (ADR 0005). The Service name (`<release>-broadcast`) is the
-  endpoint the backplane connects to via `REDIS_URL`.
+  endpoint the backplane connects to via `BROADCAST_REDIS_URL`.
 
 # Subchart version is independent of the parent chart's calver. Bump on
 # breaking subchart-values changes; rev the patch level on image-tag bumps.

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -51,15 +51,17 @@ spec:
                   name: {{ .Values.postgres.credentialsSecret }}
                   key: url
             {{- if .Values.broadcast.enabled }}
-            # REDIS_URL points the backplane at the in-cluster broadcast
-            # store. The activity-broadcast pillar's full implementation
-            # lands in v0.2 (Goal #11 scope: chassis-only in v0.1) but the
-            # env var is forward-prepared here so the backplane chassis
-            # discovers the endpoint as soon as the broadcast code uses
-            # it. ADR 0005 locks the wire-protocol-compatible store as
-            # Valkey 9.x; `redis-py` (locked driver) parses the
-            # `redis://` scheme unchanged.
-            - name: REDIS_URL
+            # BROADCAST_REDIS_URL points the backplane at the in-cluster
+            # broadcast store. The name must match the env var the
+            # backplane actually reads (`Settings.broadcast_redis_url`
+            # resolves from `BROADCAST_REDIS_URL` in
+            # backend/src/meho_backplane/settings.py); an unset var falls
+            # back to `redis://localhost:6379`, so the readiness probe's
+            # broadcast leg dials localhost inside the Pod and the healthy
+            # Service is never contacted. ADR 0005 locks the
+            # wire-protocol-compatible store as Valkey 9.x; `redis-py`
+            # (locked driver) parses the `redis://` scheme unchanged.
+            - name: BROADCAST_REDIS_URL
               value: "redis://{{ .Release.Name }}-broadcast:{{ .Values.broadcast.service.port }}/0"
             {{- end }}
             # Other operator-supplied secrets (Keycloak client secret, Vault

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -566,7 +566,7 @@
     },
     "extraEnv": {
       "type": "array",
-      "description": "Extra Kubernetes EnvVar objects (value or valueFrom) appended to the backplane container env AND the migration Job container env. Most common use: pointing `SSL_CERT_FILE` at a mounted trust-bundle path so Python's default ssl context trusts internal-CA-signed Vault / Keycloak / Postgres endpoints (Issue #209). Don't collide with the chart's own keys (DATABASE_URL, REDIS_URL).",
+      "description": "Extra Kubernetes EnvVar objects (value or valueFrom) appended to the backplane container env AND the migration Job container env. Most common use: pointing `SSL_CERT_FILE` at a mounted trust-bundle path so Python's default ssl context trusts internal-CA-signed Vault / Keycloak / Postgres endpoints (Issue #209). Don't collide with the chart's own keys (DATABASE_URL, BROADCAST_REDIS_URL).",
       "items": { "type": "object" }
     },
     "retrieval": {

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -240,8 +240,8 @@ audit:
 # running Valkey OSS as a single-replica Deployment with ephemeral streams.
 # Subchart slug is `broadcast` rather than `redis` because the protocol
 # contract matters more than the brand. The backplane connects via the
-# `REDIS_URL` env var (operator-facing) rendered against the Service name
-# `<release>-broadcast`.
+# `BROADCAST_REDIS_URL` env var (operator-facing) rendered against the
+# Service name `<release>-broadcast`.
 #
 # Operators on clusters running an external Valkey/Redis can flip
 # `broadcast.enabled: false` and (in v0.2+) point the backplane at the
@@ -444,7 +444,7 @@ extraVolumeMounts: []
 # (accepts `value` OR `valueFrom`). Most common use: `SSL_CERT_FILE`
 # pointing at a mounted trust bundle's path, so Python's default ssl
 # context honours internal CAs. The list is appended after the chart's
-# own env (DATABASE_URL, REDIS_URL); operator values win on collisions
+# own env (DATABASE_URL, BROADCAST_REDIS_URL); operator values win on collisions
 # only if Kubernetes' duplicate-EnvVar resolution rule (last-write-wins)
 # applies to your runtime. Don't rely on overrides — pick a name that
 # doesn't clash.

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -243,7 +243,7 @@ implementation of that decision.
 | Auth | None (no `requirepass`) | v0.1 single-tenant; gated at the network layer by the umbrella chart's NetworkPolicy |
 | Update strategy | `Recreate` | Single-replica + port-bind constraint makes RollingUpdate worse |
 | Probes | TCP `connect` on 6379 | Minimal — avoids coupling to `redis-cli` / `valkey-cli` binary naming variance |
-| Service | ClusterIP `<release>-broadcast:6379` (port name `redis`) | In-cluster only; backplane consumes via the operator-facing `REDIS_URL` env |
+| Service | ClusterIP `<release>-broadcast:6379` (port name `redis`) | In-cluster only; backplane consumes via the operator-facing `BROADCAST_REDIS_URL` env |
 
 The subchart lives unpacked at `deploy/charts/meho/charts/broadcast/`.
 The parent `Chart.yaml` declares it as a dependency with
@@ -267,13 +267,17 @@ subchart's own values.yaml shape is also enforced by Helm independently —
 this parent block is the surface visible to the umbrella's `--set` flags.
 
 **Backplane wiring.** When `broadcast.enabled: true` (the default), the
-backplane Deployment renders a `REDIS_URL` env var pointing at
+backplane Deployment renders a `BROADCAST_REDIS_URL` env var pointing at
 `redis://{{ .Release.Name }}-broadcast:{{ .Values.broadcast.service.port }}/0`.
-The full broadcast feature is v0.2 work; the env var is forward-prepared
-in v0.1 so the chassis discovers the endpoint as soon as the broadcast
-code uses it. ADR 0005 locked `redis-py` as the driver — it parses
-`redis://` schemes against a Valkey endpoint unchanged (wire-protocol
-compatibility carries from Redis 7.2.4).
+The env-var name is load-bearing: `Settings.broadcast_redis_url`
+(`backend/src/meho_backplane/settings.py`) resolves from
+`BROADCAST_REDIS_URL` and falls back to `redis://localhost:6379` when it
+is unset, so a chart that injects any other name (the v0.2 `REDIS_URL`
+mismatch fixed in #583) leaves the readiness probe's broadcast leg
+dialing localhost while the healthy Service is never contacted. ADR 0005
+locked `redis-py` as the driver — it parses `redis://` schemes against a
+Valkey endpoint unchanged (wire-protocol compatibility carries from
+Redis 7.2.4).
 
 **Operator-supplied secrets.** The Job + the backplane both consume
 `DATABASE_URL` from a Kubernetes Secret named by


### PR DESCRIPTION
## Summary

- The backplane reads `Settings.broadcast_redis_url` from the **`BROADCAST_REDIS_URL`** env var (`backend/src/meho_backplane/settings.py`), defaulting to `redis://localhost:6379` when unset. The umbrella chart injected the value under **`REDIS_URL`**, a name the code never reads — so on a real deploy the `/ready` broadcast probe dialed localhost inside the Pod and reported `unreachable: ConnectionError` against a healthy Valkey, forcing a `helm upgrade` rollback.
- Renamed the injected env key to the name the code actually reads (consumer-supplied **option 1**: one-key rename; env-var name identical to the settings field — no ambiguous `REDIS_URL` alias). No backend change — the name the code reads was already correct; the bug was purely the chart template.
- Propagated the corrected name through `values.yaml` / `values.schema.json` / the broadcast subchart `Chart.yaml` comments and the `docs/codebase/devops.md` codebase doc, so the chart↔backplane env contract is a single source of truth.

## Test plan

- [x] `helm lint deploy/charts/meho/` (CI override set) — `0 chart(s) failed`
- [x] `helm template` renders the Deployment with `- name: BROADCAST_REDIS_URL` → `redis://<release>-broadcast:6379/0` (the broadcast Service) — **AC1**
- [x] No bare `name: REDIS_URL` env remains in the rendered manifest — **AC3** (single source of truth)
- [x] `kubeconform -strict -kubernetes-version 1.28.0` — 11 resources, 0 invalid
- [x] `values.yaml` / `values.schema.json` / subchart `Chart.yaml` use the `BROADCAST_REDIS_URL` name; chart-lint clean — **AC4**
- [ ] **AC2** (deploy-against-healthy-Valkey `/ready` broadcast `ok` + `helm upgrade` no rollback): requires a live cluster — not runnable in the sandbox. Verified by correctness (code reads `BROADCAST_REDIS_URL`; chart now injects exactly that name pointing at the healthy Service). Exercised by the #634 clean-room re-verification.

## Out of scope

- Adding a `REDIS_URL` settings alias/fallback (option 2 — deliberately rejected: an alias makes "which var wins" deploy-time state and invites the next mismatch).
- Any backend code change — the env name the code reads is correct.
- Broadcast retry/backoff tuning — separate concern.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the backplane broadcast Redis environment variable from `REDIS_URL` to `BROADCAST_REDIS_URL`.

* **Documentation**
  * Updated Helm chart descriptions, inline comments, and operator documentation to reflect the corrected environment variable naming and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->