### PR TITLE
fix(connectors): G0.8-T3 vault reads operator JWT from request context (#629)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ cli/*.out
 *.bak
 *.orig
 .idea/
+*.code-workspace
 
 # =============================================================================
 # Docker / runtime data

--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -49,7 +49,6 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors.vault.connector import VaultTarget
 from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.middleware import verify_jwt_and_bind
 from meho_backplane.operations import dispatch
@@ -181,12 +180,14 @@ async def _probe_vault_federation(
     controllable URL substrings never leak into a 200 response body
     or into a structlog payload.
     """
-    target = VaultTarget(raw_jwt=operator.raw_jwt)
+    # The vault.kv.read handler reads the operator JWT from the
+    # request-scoped Operator (G0.8-T3 #629), not a target row; the
+    # connector is resolved by connector_id, so target is None.
     result = await dispatch(
         operator=operator,
         connector_id="vault-1.x",
         op_id="vault.kv.read",
-        target=target,
+        target=None,
         params={"path": _FEDERATION_PROOF_PATH},
     )
 

--- a/backend/src/meho_backplane/auth/vault.py
+++ b/backend/src/meho_backplane/auth/vault.py
@@ -324,9 +324,11 @@ async def vault_readiness_probe() -> ProbeResult:
 
     # Lazy import: connectors.vault.connector imports auth.vault at module
     # level, so a top-level import here would create a cycle.
-    from meho_backplane.connectors.vault.connector import VaultConnector, VaultTarget
+    from meho_backplane.connectors.vault.connector import VaultConnector
 
-    connector_probe = await VaultConnector().probe(VaultTarget())
+    # probe() reads Vault connection params from settings, not the
+    # target — the readiness probe has no target row, so pass None.
+    connector_probe = await VaultConnector().probe(None)
     return ProbeResult(
         name="vault",
         ok=connector_probe.ok,

--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -45,7 +45,7 @@ refactor.
 """
 
 from meho_backplane.connectors.registry import register_connector_v2
-from meho_backplane.connectors.vault.connector import VaultConnector, VaultTarget
+from meho_backplane.connectors.vault.connector import VaultConnector
 from meho_backplane.connectors.vault.ops import (
     register_vault_typed_operations,
     vault_kv_delete,
@@ -85,7 +85,6 @@ register_typed_op_registrar(register_vault_sys_typed_operations)
 __all__ = [
     "VaultAuthBackendNotMountedError",
     "VaultConnector",
-    "VaultTarget",
     "register_vault_auth_operations",
     "register_vault_sys_typed_operations",
     "register_vault_typed_operations",

--- a/backend/src/meho_backplane/connectors/vault/connector.py
+++ b/backend/src/meho_backplane/connectors/vault/connector.py
@@ -17,15 +17,20 @@ role. The resulting Vault token is per-request and revoked on context
 exit (behaviour inherited from
 :func:`~meho_backplane.auth.vault.vault_client_for_operator`).
 
-Target contract (pre-G0.3 placeholder):
+Target contract (G0.3 #224, operator-aware dispatch G0.8-T3 #629):
 
-:class:`VaultTarget` is a minimal stand-in for the ``Target`` model
-that G0.3 (#224) will land. Once G0.3 merges, replace ``VaultTarget``
-usages with proper ``Target`` instances. The connector reads Vault
+The connector is typed against the real
+:class:`~meho_backplane.targets.schemas.Target`. It reads Vault
 connection parameters (address, role, mount path, namespace, timeout)
-from :func:`~meho_backplane.settings.get_settings` rather than from
-the target because those are deployment-level settings, not per-
-operator overrides.
+from :func:`~meho_backplane.settings.get_settings`, not from the
+target, because those are deployment-level settings, not per-operator
+overrides — so ``probe``/``fingerprint`` accept ``Target | None`` and
+ignore the value entirely. The operator's bearer token is **not** on
+the persisted ``Target`` row (a per-request token must not be
+persisted on a shared target); typed KV/auth/sys handlers read it from
+the request-scoped :class:`~meho_backplane.auth.operator.Operator` the
+dispatcher threads (see
+:func:`~meho_backplane.operations._branches.dispatch_typed`).
 
 Operation dispatch (post-G0.6-T-Refactor-Vault):
 
@@ -51,7 +56,6 @@ construct the :class:`~meho_backplane.auth.operator.Operator` and call
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
@@ -65,8 +69,9 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
 from meho_backplane.settings import get_settings
+from meho_backplane.targets.schemas import Target
 
-__all__ = ["VaultConnector", "VaultTarget"]
+__all__ = ["VaultConnector"]
 
 _log = structlog.get_logger(__name__)
 
@@ -83,19 +88,6 @@ _log = structlog.get_logger(__name__)
 # deploys.
 _SYSTEM_TENANT_ID: UUID = UUID(int=0)
 _SYSTEM_OPERATOR_SUB: str = "system:vault-connector-shim"
-
-
-@dataclass(frozen=True)
-class VaultTarget:
-    """Pre-G0.3 stand-in for the G0.3 Target model (VaultConnector only).
-
-    Replace with ``meho_backplane.targets.Target`` once G0.3 (#224)
-    lands. Only ``raw_jwt`` is needed today; connection parameters are
-    read from :func:`~meho_backplane.settings.get_settings` so the same
-    single-source of truth governs probe, fingerprint, and execute.
-    """
-
-    raw_jwt: str | None = None
 
 
 class VaultConnector(Connector):
@@ -119,13 +111,15 @@ class VaultConnector(Connector):
     version = "1.x"
     impl_id = "vault"
 
-    async def fingerprint(self, target: VaultTarget) -> FingerprintResult:
+    async def fingerprint(self, target: Target | None) -> FingerprintResult:
         """Canonical fingerprint from ``GET /v1/sys/health``.
 
         Reuses :func:`~meho_backplane.auth.vault._build_client` so the
         existing test seam applies and the vault_timeout / namespace
         settings are respected without duplicating the client-
-        construction logic.
+        construction logic. ``target`` is part of the
+        :class:`~meho_backplane.connectors.base.Connector` ABC contract
+        but unused — Vault connection params come from settings.
         """
         settings = get_settings()
         client = _auth_vault._build_client(settings)
@@ -158,7 +152,7 @@ class VaultConnector(Connector):
             extras=extras,
         )
 
-    async def probe(self, target: VaultTarget) -> ProbeResult:
+    async def probe(self, target: Target | None) -> ProbeResult:
         """Lightweight reachability check via unauthenticated ``/v1/sys/health``.
 
         Reuses :func:`~meho_backplane.auth.vault._build_client` so the
@@ -198,7 +192,7 @@ class VaultConnector(Connector):
 
     async def execute(
         self,
-        target: VaultTarget,
+        target: Target | None,
         op_id: str,
         params: dict[str, Any],
     ) -> OperationResult:
@@ -219,12 +213,18 @@ class VaultConnector(Connector):
 
         Operator identity is synthesised from a fixed system-tenant
         sentinel because :class:`Connector.execute`'s ABC signature
-        predates the G0.6 introduction of operator-aware dispatch.
-        The synthesised operator's ``raw_jwt`` is read from
-        ``target.raw_jwt`` so the dispatched handler still has the
-        token it needs for OIDC forwarding; the synthesised ``sub``
-        and ``tenant_id`` only surface on the dispatcher's own audit
-        row. Routed call sites already write a richer audit row via
+        carries no operator. The synthesised operator's ``raw_jwt`` is
+        the empty string — the shim's only callers are operator-less
+        (``vault_readiness_probe`` exercises ``vault.sys.health``, an
+        *unauthenticated* Vault endpoint that forwards no token),
+        mirroring the
+        :func:`~meho_backplane.topology.scheduler._system_operator`
+        precedent. Callers that need a real operator JWT forwarded to
+        Vault construct a real :class:`Operator` and call
+        :func:`dispatch` directly (they never route through this shim).
+        The synthesised ``sub`` and ``tenant_id`` only surface on the
+        dispatcher's own audit row; routed call sites already write a
+        richer audit row via
         :class:`~meho_backplane.audit.AuditMiddleware`, which carries
         the real operator identity from the JWT — the dispatcher's
         synthesised row is a strict subset.
@@ -251,7 +251,7 @@ class VaultConnector(Connector):
         # keeps that initialisation order stable.
         from meho_backplane.operations import dispatch
 
-        operator = self._synthesise_legacy_operator(target)
+        operator = self._synthesise_legacy_operator()
         return await dispatch(
             operator=operator,
             connector_id=self._dispatcher_connector_id(),
@@ -281,12 +281,12 @@ class VaultConnector(Connector):
         return cls.product
 
     @staticmethod
-    def _synthesise_legacy_operator(target: VaultTarget) -> Operator:
+    def _synthesise_legacy_operator() -> Operator:
         """Build a minimal :class:`Operator` for the shim's dispatch call.
 
-        The shim has no access to the real operator's identity claims —
-        :class:`Connector.execute`'s ABC signature predates G0.6's
-        operator-aware dispatch. We synthesise:
+        The shim has no access to a real operator's identity claims —
+        :class:`Connector.execute`'s ABC signature carries no operator.
+        We synthesise:
 
         * ``sub`` — a fixed system sentinel
           (:data:`_SYSTEM_OPERATOR_SUB`) so the dispatcher's audit row
@@ -296,10 +296,13 @@ class VaultConnector(Connector):
           ``tenant_id IS NULL`` so the dispatcher's tenant-scoped
           descriptor lookup falls through to the global row regardless;
           the synthesised tenant_id only lands on the audit row.
-        * ``raw_jwt`` — the target's ``raw_jwt`` so the dispatched
-          handler can forward the operator's token to Vault's OIDC
-          auth method. ``None`` collapses to the empty string because
-          :class:`Operator.raw_jwt` is non-optional.
+        * ``raw_jwt`` — the empty string. The shim's only callers are
+          operator-less and exercise the unauthenticated
+          ``vault.sys.health`` op, which forwards no token to Vault
+          (same contract as
+          :func:`~meho_backplane.topology.scheduler._system_operator`).
+          Authenticated ops require a real operator and call
+          :func:`dispatch` directly, never through this shim.
         * ``tenant_role`` — :attr:`TenantRole.OPERATOR`. The v0.2
           policy gate doesn't read the role for ``safety_level='safe'``
           ops; the value is a placeholder that satisfies the model's
@@ -309,7 +312,7 @@ class VaultConnector(Connector):
             sub=_SYSTEM_OPERATOR_SUB,
             name=None,
             email=None,
-            raw_jwt=target.raw_jwt or "",
+            raw_jwt="",
             tenant_id=_SYSTEM_TENANT_ID,
             tenant_role=TenantRole.OPERATOR,
         )

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing >600-line module (per-op
+# JSON Schema + LLM-instruction blobs for the 5-op KV-v2 group, ~827
+# lines before G0.8-T3 #629). The #629 fix is a localised auth-contract
+# change (handler signature + JWT source); a module split is explicitly
+# out of scope per the issue ("the fix is localised to the vault
+# connector handler"). Splitting tracked separately if it lands.
 
 """Vault typed-op handlers + ``endpoint_descriptor`` registration helper.
 
@@ -30,12 +36,12 @@ register-time signal is the op-id itself; a regression test pins the
 ``classify_op`` contract for both ops.
 
 Each handler is an ``async def`` module-level function with the
-``(target, params) -> dict[str, Any]`` shape the G0.6 dispatcher (T5
-#396) expects from a typed op (see
-:class:`~meho_backplane.operations.typed_register.TypedOpHandler`). The
-dispatcher validates ``params`` against the registered
-``parameter_schema`` before invoking the handler; the handler's only
-job is the Vault HTTP call + the success-payload shape.
+``(operator, target, params) -> dict[str, Any]`` shape the G0.6
+dispatcher (T5 #396) expects from a typed op (see
+:func:`~meho_backplane.operations._branches.dispatch_typed`). The JWT
+is read from ``operator.raw_jwt`` (request-scoped) and forwarded to
+:func:`~meho_backplane.auth.vault.vault_client_for_operator`, never off
+the persisted ``Target`` row (G0.8-T3 #629).
 
 Failure handling differs from the pre-G0.6 ``OP_MAP`` model: handlers
 now **raise** rather than returning a structured ``OperationResult``.
@@ -63,6 +69,7 @@ import asyncio
 from typing import Any
 
 import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vault.ops_auth import register_vault_auth_operations
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
@@ -216,21 +223,21 @@ _VAULT_KV_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
 }
 
 
-async def vault_kv_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_kv_read(operator: Operator, target: Any, params: dict[str, Any]) -> dict[str, Any]:
     """Read a KV v2 secret from Vault via OIDC-forwarded operator JWT.
 
     Op-id: ``vault.kv.read``.
 
     Parameters
     ----------
+    operator
+        Request-scoped operator. ``operator.raw_jwt`` is forwarded to
+        :func:`~meho_backplane.auth.vault.vault_client_for_operator` for
+        the JWT/OIDC login (G0.8-T3 #629).
     target
-        Duck-typed target. Only ``target.raw_jwt`` is read, by way of
-        :func:`~meho_backplane.auth.vault.vault_client_for_operator`.
-        :class:`~meho_backplane.connectors.vault.connector.VaultTarget`
-        is the concrete shape today; once G0.3 (#224) lands its
-        ``Target`` model the connector resolver picks the
-        :class:`VaultConnector` and the dispatcher binds this handler
-        against the resolved target row.
+        The resolved :class:`~meho_backplane.targets.schemas.Target`
+        row (or ``None`` for connector-id-routed calls). Unused by this
+        handler — Vault connection params come from settings.
     params
         Already validated by the dispatcher against
         :data:`VAULT_KV_READ_PARAMETER_SCHEMA`. The handler re-extracts
@@ -282,11 +289,9 @@ async def vault_kv_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
     path: str = str(params["path"]).strip()
 
     # vault_client_for_operator is accessed via the module reference so
-    # that test monkeypatches on vault_module._build_client propagate
-    # through the call chain. The target object is duck-typed:
-    # vault_client_for_operator only accesses target.raw_jwt, which
-    # VaultTarget provides.
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    # test monkeypatches on vault_module._build_client propagate through
+    # the call chain. It reads operator.raw_jwt for the JWT/OIDC login.
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         secret_payload = await asyncio.to_thread(
             client.secrets.kv.v2.read_secret_version,
             path=path,
@@ -364,7 +369,7 @@ _VAULT_KV_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
 }
 
 
-async def vault_kv_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_kv_list(operator: Operator, target: Any, params: dict[str, Any]) -> dict[str, Any]:
     """List key names at a KV v2 folder path.
 
     Op-id: ``vault.kv.list``. Read-only. Classified ``credential_read``
@@ -380,7 +385,7 @@ async def vault_kv_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
 
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         list_payload = await asyncio.to_thread(
             client.secrets.kv.v2.list_secrets,
             path=path,
@@ -469,7 +474,7 @@ _VAULT_KV_PUT_LLM_INSTRUCTIONS: dict[str, Any] = {
 }
 
 
-async def vault_kv_put(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_kv_put(operator: Operator, target: Any, params: dict[str, Any]) -> dict[str, Any]:
     """Write a new version of a KV v2 secret.
 
     Op-id: ``vault.kv.put``. Mutating (``op_class=write``,
@@ -484,7 +489,7 @@ async def vault_kv_put(target: Any, params: dict[str, Any]) -> dict[str, Any]:
     secret: dict[str, Any] = params["data"]
     cas = params.get("cas")
 
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         write_payload = await asyncio.to_thread(
             client.secrets.kv.v2.create_or_update_secret,
             path=path,
@@ -545,7 +550,9 @@ _VAULT_KV_VERSIONS_LLM_INSTRUCTIONS: dict[str, Any] = {
 }
 
 
-async def vault_kv_versions(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_kv_versions(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """Read the version metadata for a KV v2 secret.
 
     Op-id: ``vault.kv.versions``. Read-only (``op_class=read``,
@@ -557,7 +564,7 @@ async def vault_kv_versions(target: Any, params: dict[str, Any]) -> dict[str, An
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
 
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         meta_payload = await asyncio.to_thread(
             client.secrets.kv.v2.read_secret_metadata,
             path=path,
@@ -632,7 +639,9 @@ _VAULT_KV_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
 }
 
 
-async def vault_kv_delete(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_kv_delete(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """Soft-delete specific versions of a KV v2 secret.
 
     Op-id: ``vault.kv.delete``. Mutating (``op_class=write``,
@@ -647,7 +656,7 @@ async def vault_kv_delete(target: Any, params: dict[str, Any]) -> dict[str, Any]
     path: str = str(params["path"]).strip()
     versions: list[int] = list(params["versions"])
 
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         await asyncio.to_thread(
             client.secrets.kv.v2.delete_secret_versions,
             path=path,

--- a/backend/src/meho_backplane/connectors/vault/ops_auth.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth.py
@@ -76,6 +76,7 @@ from typing import Any
 import hvac.exceptions
 
 import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
 from meho_backplane.auth.vault import VaultClientError
 from meho_backplane.connectors.vault.ops_auth_schemas import (
     VAULT_AUTH_APPROLE_LIST_LLM_INSTRUCTIONS,
@@ -130,7 +131,9 @@ class VaultAuthBackendNotMountedError(VaultClientError):
 # --- handlers --------------------------------------------------------------
 
 
-async def vault_auth_userpass_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_auth_userpass_list(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """List usernames on a Vault userpass auth mount.
 
     Op-id: ``vault.auth.userpass.list``. Delegates to hvac's
@@ -149,7 +152,7 @@ async def vault_auth_userpass_list(target: Any, params: dict[str, Any]) -> dict[
         branch surfaces ``extras["exception_class"]``.
     """
     mount: str = str(params.get("mount", "userpass")).strip()
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         try:
             payload = await asyncio.to_thread(client.auth.userpass.list_user, mount_point=mount)
         except hvac.exceptions.InvalidPath as exc:
@@ -159,7 +162,9 @@ async def vault_auth_userpass_list(target: Any, params: dict[str, Any]) -> dict[
         return {"keys": _extract_keys(payload)}
 
 
-async def vault_auth_userpass_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_auth_userpass_read(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """Read one userpass user's config (policies, token TTLs).
 
     Op-id: ``vault.auth.userpass.read``. Delegates to hvac's
@@ -178,7 +183,7 @@ async def vault_auth_userpass_read(target: Any, params: dict[str, Any]) -> dict[
     """
     username: str = str(params["username"]).strip()
     mount: str = str(params.get("mount", "userpass")).strip()
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         try:
             payload = await asyncio.to_thread(
                 client.auth.userpass.read_user,
@@ -190,7 +195,9 @@ async def vault_auth_userpass_read(target: Any, params: dict[str, Any]) -> dict[
         return _extract_data(payload)
 
 
-async def vault_auth_approle_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_auth_approle_list(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """List role names on a Vault approle auth mount.
 
     Op-id: ``vault.auth.approle.list``. Delegates to hvac's
@@ -206,7 +213,7 @@ async def vault_auth_approle_list(target: Any, params: dict[str, Any]) -> dict[s
         Login-side failure (Vault unreachable, role denied).
     """
     mount: str = str(params.get("mount", "approle")).strip()
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         try:
             payload = await asyncio.to_thread(client.auth.approle.list_roles, mount_point=mount)
         except hvac.exceptions.InvalidPath as exc:
@@ -216,7 +223,9 @@ async def vault_auth_approle_list(target: Any, params: dict[str, Any]) -> dict[s
         return {"keys": _extract_keys(payload)}
 
 
-async def vault_auth_approle_read(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_auth_approle_read(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """Read one AppRole's config (policies, token + secret-id TTLs).
 
     Op-id: ``vault.auth.approle.read``. Delegates to hvac's
@@ -232,7 +241,7 @@ async def vault_auth_approle_read(target: Any, params: dict[str, Any]) -> dict[s
     """
     role_name: str = str(params["role_name"]).strip()
     mount: str = str(params.get("mount", "approle")).strip()
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         try:
             payload = await asyncio.to_thread(
                 client.auth.approle.read_role,

--- a/backend/src/meho_backplane/connectors/vault/ops_sys.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_sys.py
@@ -21,11 +21,17 @@ payloads). ``sys`` writes (unseal, mount/unmount, policy write) are out
 of scope for v0.2.
 
 Handler shape mirrors :mod:`meho_backplane.connectors.vault.ops`: each
-handler is a module-level ``async def`` with the ``(target, params) ->
-dict`` signature the G0.6 dispatcher expects from a typed op. The
-dispatcher validates ``params`` against the registered
-``parameter_schema`` before invoking; the handler's only job is the
-Vault HTTP call plus the success-payload shape. Handlers **raise** on
+handler is a module-level ``async def`` typed op. Handlers that forward
+the operator JWT to Vault (``seal_status`` / ``mounts.list`` /
+``auth.list``) take ``(operator, target, params)`` and read the
+request-scoped token from ``operator.raw_jwt`` (G0.8-T3 #629);
+``vault.sys.health`` hits Vault's *unauthenticated* ``/v1/sys/health``
+and keeps the ``(target, params)`` shape (no operator needed). The
+dispatcher's :func:`~meho_backplane.operations._branches.dispatch_typed`
+introspects each signature independently and threads ``operator`` only
+when the handler names it. The dispatcher validates ``params`` against
+the registered ``parameter_schema`` before invoking; the handler's only
+job is the Vault HTTP call plus the success-payload shape. Handlers **raise** on
 failure; the dispatcher's ``connector_error`` branch turns the raised
 exception into a structured :class:`OperationResult` with the exception
 class name in ``extras["exception_class"]`` — so an unreachable or
@@ -65,6 +71,7 @@ import asyncio
 from typing import Any
 
 import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 from meho_backplane.settings import get_settings
@@ -342,7 +349,9 @@ async def vault_sys_health(target: Any, params: dict[str, Any]) -> dict[str, Any
     }
 
 
-async def vault_sys_seal_status(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_sys_seal_status(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """Read Vault's seal status (``GET /v1/sys/seal-status``).
 
     Op-id: ``vault.sys.seal_status``.
@@ -365,11 +374,13 @@ async def vault_sys_seal_status(target: Any, params: dict[str, Any]) -> dict[str
         Any error hvac raises from the seal-status read.
     """
     _ = params  # schema-validated empty object; no inputs to extract.
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         return await asyncio.to_thread(client.sys.read_seal_status)
 
 
-async def vault_sys_mounts_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_sys_mounts_list(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """List enabled secret backends (``GET /v1/sys/mounts``).
 
     Op-id: ``vault.sys.mounts.list``.
@@ -394,7 +405,7 @@ async def vault_sys_mounts_list(target: Any, params: dict[str, Any]) -> dict[str
         Any error hvac raises from the mounts read.
     """
     _ = params
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         response = await asyncio.to_thread(client.sys.list_mounted_secrets_engines)
         # hvac returns the full Vault envelope ({request_id, data, ...}).
         # The mount map lives under ``data``; fall back to the whole
@@ -403,7 +414,9 @@ async def vault_sys_mounts_list(target: Any, params: dict[str, Any]) -> dict[str
         return {"mounts": mounts}
 
 
-async def vault_sys_auth_list(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+async def vault_sys_auth_list(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
     """List enabled auth methods (``GET /v1/sys/auth``).
 
     Op-id: ``vault.sys.auth.list``.
@@ -420,7 +433,7 @@ async def vault_sys_auth_list(target: Any, params: dict[str, Any]) -> dict[str, 
         Any error hvac raises from the auth-methods read.
     """
     _ = params
-    async with _auth_vault.vault_client_for_operator(target) as client:
+    async with _auth_vault.vault_client_for_operator(operator) as client:
         response = await asyncio.to_thread(client.sys.list_auth_methods)
         auth_methods = response.get("data", response) if isinstance(response, dict) else response
         return {"auth_methods": auth_methods}

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -138,12 +138,14 @@ _BULK_KEY_COUNT: int = 60
 
 @dataclass
 class _VaultTarget:
-    """Minimal duck-typed target the dispatcher / handlers read.
+    """Minimal duck-typed target the dispatcher / resolver / audit read.
 
-    The connector handlers only touch ``raw_jwt`` (forwarded to the
-    OIDC login, here short-circuited by the seam). ``id`` / ``name`` /
-    ``product`` / ``host`` / ``port`` / ``auth_model`` cover what the
-    resolver and audit row read.
+    The vault handlers read the operator JWT from the request-scoped
+    :class:`~meho_backplane.auth.operator.Operator` the dispatcher
+    threads (G0.8-T3 #629), **not** from the target — so this stub
+    carries no ``raw_jwt``. ``id`` / ``name`` / ``product`` / ``host``
+    / ``port`` / ``auth_model`` cover what the resolver and audit row
+    read.
     """
 
     product: str = "vault"
@@ -151,7 +153,6 @@ class _VaultTarget:
     host: str = "127.0.0.1"
     port: int = 8200
     auth_model: str = "shared_service_account"
-    raw_jwt: str | None = "<dev-test-jwt>"
 
     def __post_init__(self) -> None:
         import uuid

--- a/backend/tests/test_broadcast_credential_read_dispatch.py
+++ b/backend/tests/test_broadcast_credential_read_dispatch.py
@@ -224,15 +224,15 @@ class _FakeFingerprint:
 
 
 class _VaultDispatchTarget:
-    """Target that satisfies both the dispatcher and the real handlers.
+    """Target that satisfies the dispatcher's resolution + audit reads.
 
     The dispatcher reads ``product`` / ``fingerprint.version`` /
     ``preferred_impl_id`` (connector resolution — tolerated-miss for
     typed ops) and ``id`` / ``name`` (audit row + broadcast
-    ``target_name``). The real Vault handlers read ``raw_jwt`` via
-    :func:`~meho_backplane.auth.vault.vault_client_for_operator`. One
-    object carries both surfaces so the dispatch path is exercised
-    verbatim — no handler-direct shortcut.
+    ``target_name``). The Vault handlers read the operator JWT from the
+    request-scoped :class:`~meho_backplane.auth.operator.Operator` the
+    dispatcher threads (G0.8-T3 #629), **not** from this target — so it
+    carries no ``raw_jwt``.
 
     ``name`` is a benign, non-secret label; the broadcast event is
     *allowed* to carry it (decision #3's aggregate includes the
@@ -246,7 +246,6 @@ class _VaultDispatchTarget:
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
         self.name = "rdc-vault-prod"
-        self.raw_jwt = "header.payload.signature"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -64,11 +64,13 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import hvac.exceptions
 import pytest
 import requests.exceptions
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast.events import classify_op
 from meho_backplane.connectors import all_connectors_v2
 from meho_backplane.connectors.registry import (
@@ -76,12 +78,12 @@ from meho_backplane.connectors.registry import (
     list_connector_impls,
     register_connector_v2,
 )
+from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.connectors.vault import (
     VaultConnector,
-    VaultTarget,
     register_vault_typed_operations,
 )
-from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
 from ._vault_fakes import install_fake_client
@@ -176,8 +178,49 @@ async def _registered_vault_typed_ops(
     yield
 
 
-def _make_target(jwt: str = "fake.jwt.value") -> VaultTarget:
-    return VaultTarget(raw_jwt=jwt)
+def _make_target() -> None:
+    """probe()/fingerprint() read Vault params from settings, not the
+    target — G0.3 #224 dropped the per-connector target stub and G0.8-T3
+    #629 typed these methods against ``Target | None``. Tests pass None.
+    """
+    return None
+
+
+def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
+    """A request-scoped operator carrying the bearer token the vault
+    handlers forward to Vault's JWT/OIDC auth (G0.8-T3 #629). Replaces
+    the pre-#224 ``VaultTarget(raw_jwt=...)`` stub — the token is
+    request-scoped operator context, never persisted target config.
+    """
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_vault(
+    op_id: str, params: dict[str, Any], *, jwt: str = "fake.jwt.value"
+) -> OperationResult:
+    """Dispatch a vault op through the real operator-aware path.
+
+    Mirrors how ``/api/v1/operations/call`` and the MCP
+    ``call_operation`` meta-tool reach the vault handlers: a real
+    :class:`Operator` is threaded by the dispatcher, the connector is
+    resolved by ``connector_id``, ``target`` is ``None`` (vault
+    connection params come from settings). The handler reads the JWT
+    from ``operator.raw_jwt`` — exactly the contract #629 establishes.
+    """
+    return await dispatch(
+        operator=_make_operator(jwt),
+        connector_id="vault-1.x",
+        op_id=op_id,
+        target=None,
+        params=params,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -336,8 +379,7 @@ async def test_execute_unknown_op_returns_dispatcher_unknown_op_shape(
     ``unknown_op`` shape carries only the count, not the enumeration.
     """
     install_fake_client(monkeypatch)
-    connector = VaultConnector()
-    result = await connector.execute(_make_target(), "vault.nonexistent.op", {})
+    result = await _dispatch_vault("vault.nonexistent.op", {})
 
     assert result.status == "error"
     assert "vault.nonexistent.op" in (result.error or "")
@@ -364,11 +406,10 @@ async def test_execute_vault_kv_read_returns_secret_data(
         secret={"username": "demo", "region": "eu-central-1"},
         kv_version=7,
     )
-    connector = VaultConnector()
-    result = await connector.execute(
-        _make_target(jwt="op-jwt"),
+    result = await _dispatch_vault(
         "vault.kv.read",
         {"path": "secret/meho/test/federation"},
+        jwt="op-jwt",
     )
 
     assert result.status == "ok", result.error
@@ -401,8 +442,7 @@ async def test_execute_vault_kv_read_honors_explicit_mount(
     forwarding on ``vault.kv.read`` the wrapper goal is unmet.
     """
     fake = install_fake_client(monkeypatch, secret={"k": "v"})
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.kv.read",
         {"mount": "kv-prod", "path": "team/api"},
     )
@@ -451,7 +491,7 @@ async def test_execute_vault_kv_read_invalid_path_returns_dispatcher_error(
     ``invalid_params`` shape.
     """
     install_fake_client(monkeypatch)
-    result = await VaultConnector().execute(_make_target(), "vault.kv.read", params)
+    result = await _dispatch_vault("vault.kv.read", params)
 
     assert result.status == "error"
     assert result.error is not None
@@ -467,7 +507,7 @@ async def test_execute_vault_kv_read_non_string_path_returns_dispatcher_error(
 ) -> None:
     """A non-string ``path`` hits the schema's ``"type": "string"`` constraint."""
     install_fake_client(monkeypatch)
-    result = await VaultConnector().execute(_make_target(), "vault.kv.read", {"path": 123})
+    result = await _dispatch_vault("vault.kv.read", {"path": 123})
 
     assert result.status == "error"
     assert result.error is not None
@@ -504,8 +544,7 @@ async def test_execute_login_failure_surfaces_vault_client_error_class(
     the known VaultClientError subclass set.
     """
     install_fake_client(monkeypatch, login_exc=login_exc)
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.kv.read",
         {"path": "some/path"},
     )
@@ -543,8 +582,7 @@ async def test_execute_read_failure_surfaces_non_vault_client_error_class(
     the contract by exercising both common read-phase failure shapes.
     """
     install_fake_client(monkeypatch, read_exc=read_exc)
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.kv.read",
         {"path": "some/path"},
     )
@@ -566,10 +604,10 @@ async def test_execute_vault_kv_list_returns_key_names(
     _registered_vault_typed_ops: None,
 ) -> None:
     fake = install_fake_client(monkeypatch, keys=["api-key", "db/"])
-    result = await VaultConnector().execute(
-        _make_target(jwt="op-jwt"),
+    result = await _dispatch_vault(
         "vault.kv.list",
         {"path": "meho/test"},
+        jwt="op-jwt",
     )
 
     assert result.status == "ok", result.error
@@ -586,8 +624,7 @@ async def test_execute_vault_kv_list_honors_explicit_mount(
     _registered_vault_typed_ops: None,
 ) -> None:
     fake = install_fake_client(monkeypatch, keys=["x"])
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.kv.list",
         {"mount": "kv-prod", "path": "team"},
     )
@@ -603,10 +640,10 @@ async def test_execute_vault_kv_put_writes_new_version(
     _registered_vault_typed_ops: None,
 ) -> None:
     fake = install_fake_client(monkeypatch, kv_version=4)
-    result = await VaultConnector().execute(
-        _make_target(jwt="op-jwt"),
+    result = await _dispatch_vault(
         "vault.kv.put",
         {"path": "meho/test", "data": {"token": "s3cr3t"}, "cas": 4},
+        jwt="op-jwt",
     )
 
     assert result.status == "ok", result.error
@@ -628,8 +665,7 @@ async def test_execute_vault_kv_put_cas_omitted_passes_none(
 ) -> None:
     """No ``cas`` ⇒ hvac called with ``cas=None`` (unconditional write)."""
     fake = install_fake_client(monkeypatch)
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.kv.put",
         {"path": "meho/test", "data": {"k": "v"}},
     )
@@ -650,7 +686,7 @@ async def test_execute_vault_kv_put_invalid_params_returns_dispatcher_error(
 ) -> None:
     """Schema enforces ``required`` path+data and ``minProperties`` on data."""
     install_fake_client(monkeypatch)
-    result = await VaultConnector().execute(_make_target(), "vault.kv.put", params)
+    result = await _dispatch_vault("vault.kv.put", params)
 
     assert result.status == "error"
     assert result.error is not None
@@ -670,8 +706,7 @@ async def test_execute_vault_kv_versions_returns_metadata(
             "3": {"created_time": "2026-03-01T00:00:00Z", "destroyed": False},
         },
     )
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.kv.versions",
         {"path": "meho/test"},
     )
@@ -690,10 +725,10 @@ async def test_execute_vault_kv_delete_soft_deletes_versions(
     _registered_vault_typed_ops: None,
 ) -> None:
     fake = install_fake_client(monkeypatch)
-    result = await VaultConnector().execute(
-        _make_target(jwt="op-jwt"),
+    result = await _dispatch_vault(
         "vault.kv.delete",
         {"path": "meho/test", "versions": [2, 3]},
+        jwt="op-jwt",
     )
 
     assert result.status == "ok", result.error
@@ -716,7 +751,7 @@ async def test_execute_vault_kv_delete_invalid_params_returns_dispatcher_error(
 ) -> None:
     """Schema enforces ``required`` path+versions and ``minItems`` on versions."""
     install_fake_client(monkeypatch)
-    result = await VaultConnector().execute(_make_target(), "vault.kv.delete", params)
+    result = await _dispatch_vault("vault.kv.delete", params)
 
     assert result.status == "error"
     assert result.error is not None
@@ -750,7 +785,7 @@ async def test_execute_kv_ops_vault_error_envelope_surfaces_connector_error(
         monkeypatch,
         **{exc_kwarg: RuntimeError("permission denied")},
     )
-    result = await VaultConnector().execute(_make_target(), op_id, params)
+    result = await _dispatch_vault(op_id, params)
 
     assert result.status == "error"
     assert result.error is not None
@@ -770,7 +805,7 @@ async def test_execute_vault_kv_list_malformed_payload_is_structured_error(
         return {"data": {}}  # missing "keys"
 
     monkeypatch.setattr(fake.secrets.kv.v2, "list_secrets", _bad_list)
-    result = await VaultConnector().execute(_make_target(), "vault.kv.list", {"path": "p"})
+    result = await _dispatch_vault("vault.kv.list", {"path": "p"})
 
     assert result.status == "error"
     assert result.extras.get("error_code") == "connector_error"

--- a/backend/tests/test_connectors_vault_auth.py
+++ b/backend/tests/test_connectors_vault_auth.py
@@ -24,16 +24,18 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import hvac.exceptions
 import pytest
 import requests.exceptions
 
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.connectors.vault import (
-    VaultConnector,
-    VaultTarget,
     register_vault_typed_operations,
 )
+from meho_backplane.operations import dispatch
 from meho_backplane.settings import get_settings
 
 from ._vault_fakes import install_fake_client
@@ -80,8 +82,38 @@ async def _registered_vault_typed_ops(
     yield
 
 
-def _make_target(jwt: str = "fake.jwt.value") -> VaultTarget:
-    return VaultTarget(raw_jwt=jwt)
+def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
+    """Request-scoped operator carrying the bearer token the vault
+    handlers forward to Vault's JWT/OIDC auth (G0.8-T3 #629). Replaces
+    the pre-#224 ``VaultTarget(raw_jwt=...)`` stub.
+    """
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_vault(
+    op_id: str, params: dict[str, Any], *, jwt: str = "fake.jwt.value"
+) -> OperationResult:
+    """Dispatch a vault op through the real operator-aware path.
+
+    The dispatcher threads a real :class:`Operator`, resolves the
+    connector by ``connector_id``, and ``target`` is ``None`` (vault
+    connection params come from settings). The handler reads the JWT
+    from ``operator.raw_jwt`` — the #629 contract.
+    """
+    return await dispatch(
+        operator=_make_operator(jwt),
+        connector_id="vault-1.x",
+        op_id=op_id,
+        target=None,
+        params=params,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +166,7 @@ async def test_auth_op_is_dispatchable(
     elif op_id == "vault.auth.approle.read":
         params = {"role_name": "deploy"}
 
-    result = await VaultConnector().execute(_make_target(), op_id, params)
+    result = await _dispatch_vault(op_id, params)
 
     assert result.status == "ok", result.error
     assert result.extras.get("error_code") != "unknown_op"
@@ -152,9 +184,7 @@ async def test_userpass_list_returns_sorted_keys(
     fake = install_fake_client(monkeypatch)
     fake.auth.userpass.users = {"armon": {}, "mitchellh": {}}
 
-    result = await VaultConnector().execute(
-        _make_target(jwt="op-jwt"), "vault.auth.userpass.list", {}
-    )
+    result = await _dispatch_vault("vault.auth.userpass.list", {}, jwt="op-jwt")
 
     assert result.status == "ok", result.error
     assert result.result == {"keys": ["armon", "mitchellh"]}
@@ -171,7 +201,7 @@ async def test_approle_list_returns_sorted_keys(
     fake = install_fake_client(monkeypatch)
     fake.auth.approle.roles = {"prod": {}, "dev": {}, "test": {}}
 
-    result = await VaultConnector().execute(_make_target(), "vault.auth.approle.list", {})
+    result = await _dispatch_vault("vault.auth.approle.list", {})
 
     assert result.status == "ok", result.error
     assert result.result == {"keys": ["dev", "prod", "test"]}
@@ -185,8 +215,8 @@ async def test_list_empty_mount_normalises_to_empty_list(
     """A mounted-but-empty backend yields ``{'keys': []}`` (Vault 204)."""
     install_fake_client(monkeypatch)  # default: no users / no roles
 
-    up = await VaultConnector().execute(_make_target(), "vault.auth.userpass.list", {})
-    ar = await VaultConnector().execute(_make_target(), "vault.auth.approle.list", {})
+    up = await _dispatch_vault("vault.auth.userpass.list", {})
+    ar = await _dispatch_vault("vault.auth.approle.list", {})
 
     assert up.status == "ok" and up.result == {"keys": []}
     assert ar.status == "ok" and ar.result == {"keys": []}
@@ -200,8 +230,7 @@ async def test_list_honours_non_default_mount(
     fake = install_fake_client(monkeypatch)
     fake.auth.userpass.users = {"svc": {}}
 
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.auth.userpass.list",
         {"mount": "userpass-prod"},
     )
@@ -229,8 +258,7 @@ async def test_userpass_read_returns_config(
         }
     }
 
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.auth.userpass.read",
         {"username": "ci", "mount": "userpass-prod"},
     )
@@ -259,9 +287,7 @@ async def test_approle_read_returns_config(
         }
     }
 
-    result = await VaultConnector().execute(
-        _make_target(), "vault.auth.approle.read", {"role_name": "deploy"}
-    )
+    result = await _dispatch_vault("vault.auth.approle.read", {"role_name": "deploy"})
 
     assert result.status == "ok", result.error
     assert result.result["token_policies"] == ["default"]
@@ -298,7 +324,7 @@ async def test_list_backend_not_mounted_surfaces_structured_error(
     fake = install_fake_client(monkeypatch)
     getattr(fake.auth, backend).list_exc = hvac.exceptions.InvalidPath("no handler for route")
 
-    result = await VaultConnector().execute(_make_target(), op_id, params)
+    result = await _dispatch_vault(op_id, params)
 
     assert result.status == "error"
     assert result.error is not None
@@ -332,7 +358,7 @@ async def test_read_backend_not_mounted_surfaces_structured_error(
     target_backend.read_exc = hvac.exceptions.InvalidPath("no handler for route")
     target_backend.list_exc = hvac.exceptions.InvalidPath("no handler for route")
 
-    result = await VaultConnector().execute(_make_target(), op_id, params)
+    result = await _dispatch_vault(op_id, params)
 
     assert result.status == "error"
     assert result.extras.get("error_code") == "connector_error"
@@ -364,7 +390,7 @@ async def test_read_missing_entity_under_mounted_backend_keeps_invalid_path(
     target_backend.read_exc = hvac.exceptions.InvalidPath("no secret found")
     # list_exc stays None -> the probe LIST succeeds (empty roster).
 
-    result = await VaultConnector().execute(_make_target(), op_id, params)
+    result = await _dispatch_vault(op_id, params)
 
     assert result.status == "error"
     assert result.extras.get("error_code") == "connector_error"
@@ -413,7 +439,7 @@ async def test_invalid_params_rejected_by_schema(
     """
     install_fake_client(monkeypatch)
 
-    result = await VaultConnector().execute(_make_target(), op_id, params)
+    result = await _dispatch_vault(op_id, params)
 
     assert result.status == "error"
     assert result.error is not None
@@ -458,7 +484,7 @@ async def test_login_failure_surfaces_vault_client_error_class(
     """
     install_fake_client(monkeypatch, login_exc=login_exc)
 
-    result = await VaultConnector().execute(_make_target(), op_id, params)
+    result = await _dispatch_vault(op_id, params)
 
     assert result.status == "error"
     assert result.error is not None

--- a/backend/tests/test_connectors_vault_sys.py
+++ b/backend/tests/test_connectors_vault_sys.py
@@ -45,22 +45,24 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import hvac.exceptions
 import pytest
 import requests.exceptions
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import classify_op
 from meho_backplane.connectors.registry import (
     clear_registry,
     register_connector_v2,
 )
+from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.connectors.vault import (
     VaultConnector,
-    VaultTarget,
     register_vault_sys_typed_operations,
 )
-from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
 from ._vault_fakes import install_fake_client
@@ -116,8 +118,39 @@ async def _registered_vault_sys_ops(
     yield
 
 
-def _make_target(jwt: str = "fake.jwt.value") -> VaultTarget:
-    return VaultTarget(raw_jwt=jwt)
+def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
+    """Request-scoped operator carrying the bearer token the vault
+    handlers forward to Vault's JWT/OIDC auth (G0.8-T3 #629). Replaces
+    the pre-#224 ``VaultTarget(raw_jwt=...)`` stub.
+    """
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_vault(
+    op_id: str, params: dict[str, Any], *, jwt: str = "fake.jwt.value"
+) -> OperationResult:
+    """Dispatch a vault op through the real operator-aware path.
+
+    Mirrors ``/api/v1/operations/call`` / MCP ``call_operation``: the
+    dispatcher threads a real :class:`Operator`, resolves the connector
+    by ``connector_id``, and ``target`` is ``None`` (vault connection
+    params come from settings). The handler reads the JWT from
+    ``operator.raw_jwt`` — the #629 contract.
+    """
+    return await dispatch(
+        operator=_make_operator(jwt),
+        connector_id="vault-1.x",
+        op_id=op_id,
+        target=None,
+        params=params,
+    )
 
 
 _SYS_OP_IDS = (
@@ -197,7 +230,7 @@ async def test_health_happy_path_returns_classified_payload(
             "cluster_name": "meho-vault",
         },
     )
-    result = await VaultConnector().execute(_make_target(), "vault.sys.health", {})
+    result = await _dispatch_vault("vault.sys.health", {})
 
     assert result.status == "ok", result.error
     assert result.result == {
@@ -224,7 +257,7 @@ async def test_health_sealed_vault_returns_ok_false(
         monkeypatch,
         health_payload={"initialized": True, "sealed": True},
     )
-    result = await VaultConnector().execute(_make_target(), "vault.sys.health", {})
+    result = await _dispatch_vault("vault.sys.health", {})
 
     assert result.status == "ok", result.error
     assert result.result["ok"] is False
@@ -241,7 +274,7 @@ async def test_health_unreachable_vault_surfaces_structured_error(
         monkeypatch,
         health_exc=requests.exceptions.ConnectionError("dns failure"),
     )
-    result = await VaultConnector().execute(_make_target(), "vault.sys.health", {})
+    result = await _dispatch_vault("vault.sys.health", {})
 
     assert result.status == "error"
     assert result.error is not None
@@ -270,7 +303,7 @@ async def test_seal_status_happy_path_returns_raw_object(
         "version": "1.18.0",
     }
     fake = install_fake_client(monkeypatch, seal_status_payload=seal)
-    result = await VaultConnector().execute(_make_target(jwt="op-jwt"), "vault.sys.seal_status", {})
+    result = await _dispatch_vault("vault.sys.seal_status", {}, jwt="op-jwt")
 
     assert result.status == "ok", result.error
     assert result.result == seal
@@ -292,7 +325,7 @@ async def test_mounts_list_unwraps_envelope_data(
         monkeypatch,
         mounts_payload={"request_id": "abc", "data": mounts_data, "warnings": None},
     )
-    result = await VaultConnector().execute(_make_target(), "vault.sys.mounts.list", {})
+    result = await _dispatch_vault("vault.sys.mounts.list", {})
 
     assert result.status == "ok", result.error
     assert result.result == {"mounts": mounts_data}
@@ -311,7 +344,7 @@ async def test_auth_list_unwraps_envelope_data(
         monkeypatch,
         auth_methods_payload={"request_id": "def", "data": auth_data, "warnings": None},
     )
-    result = await VaultConnector().execute(_make_target(), "vault.sys.auth.list", {})
+    result = await _dispatch_vault("vault.sys.auth.list", {})
 
     assert result.status == "ok", result.error
     assert result.result == {"auth_methods": auth_data}
@@ -343,7 +376,7 @@ async def test_authenticated_sys_op_login_failure_surfaces_vault_client_error(
 ) -> None:
     """Login failure on an authenticated sys op → connector_error w/ VaultClientError class."""
     install_fake_client(monkeypatch, login_exc=login_exc, **kwargs)
-    result = await VaultConnector().execute(_make_target(), op_id, {})
+    result = await _dispatch_vault(op_id, {})
 
     assert result.status == "error"
     assert result.error is not None

--- a/backend/tests/test_vault_kv_list_jsonflux.py
+++ b/backend/tests/test_vault_kv_list_jsonflux.py
@@ -62,17 +62,17 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import (
     clear_registry,
     register_connector_v2,
 )
-from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.connectors.schemas import OperationResult, ResultHandle
 from meho_backplane.connectors.vault import (
     VaultConnector,
-    VaultTarget,
     register_vault_typed_operations,
 )
-from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.reducer import PassThroughReducer
 from meho_backplane.settings import get_settings
@@ -216,8 +216,38 @@ def threshold_reducer() -> Iterator[None]:
         reset_dispatcher_caches()
 
 
-def _make_target(jwt: str = "fake.jwt.value") -> VaultTarget:
-    return VaultTarget(raw_jwt=jwt)
+def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
+    """Request-scoped operator carrying the bearer token the vault
+    handlers forward to Vault's JWT/OIDC auth (G0.8-T3 #629). Replaces
+    the pre-#224 ``VaultTarget(raw_jwt=...)`` stub.
+    """
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=uuid.UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_vault(
+    op_id: str, params: dict[str, Any], *, jwt: str = "fake.jwt.value"
+) -> OperationResult:
+    """Dispatch a vault op through the real operator-aware path.
+
+    The dispatcher threads a real :class:`Operator`, resolves the
+    connector by ``connector_id``, and ``target`` is ``None`` (vault
+    connection params come from settings). The handler reads the JWT
+    from ``operator.raw_jwt`` — the #629 contract.
+    """
+    return await dispatch(
+        operator=_make_operator(jwt),
+        connector_id="vault-1.x",
+        op_id=op_id,
+        target=None,
+        params=params,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -241,10 +271,10 @@ async def test_kv_list_under_threshold_returns_inline_list_no_handle(
     small_keys = [f"secret-{i}" for i in range(_THRESHOLD)]  # exactly 50 — at, not over
     install_fake_client(monkeypatch, keys=small_keys)
 
-    result = await VaultConnector().execute(
-        _make_target(jwt="op-jwt"),
+    result = await _dispatch_vault(
         "vault.kv.list",
         {"path": "meho/test"},
+        jwt="op-jwt",
     )
 
     assert result.status == "ok", result.error
@@ -273,8 +303,7 @@ async def test_kv_list_under_threshold_passes_through_even_with_real_reducer(
     boundary_keys = [f"secret-{i}" for i in range(_THRESHOLD)]  # exactly 50
     install_fake_client(monkeypatch, keys=boundary_keys)
 
-    result = await VaultConnector().execute(
-        _make_target(),
+    result = await _dispatch_vault(
         "vault.kv.list",
         {"path": "meho/test"},
     )
@@ -318,10 +347,10 @@ async def test_kv_list_over_threshold_returns_sample_and_handle(
     big_keys = [f"secret-{i}" for i in range(_THRESHOLD + 75)]  # 125 keys, well over
     install_fake_client(monkeypatch, keys=big_keys)
 
-    result = await VaultConnector().execute(
-        _make_target(jwt="op-jwt"),
+    result = await _dispatch_vault(
         "vault.kv.list",
         {"path": "meho/test"},
+        jwt="op-jwt",
     )
 
     assert result.status == "ok", result.error

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -30,8 +30,15 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   the shared `auth.vault` seams. `execute` is a thin shim that
   delegates to the G0.6 dispatcher (parameter validation, policy gate,
   audit, broadcast, JSONFlux) so pre-G0.6 callers keep working.
-- **`VaultTarget`** (`connector.py`) — pre-G0.3 stand-in for the
-  `Target` model; carries only `raw_jwt`.
+- **Operator-aware JWT (G0.8-T3 #629)** — the operator's bearer token
+  is request-scoped state on the `Operator` the dispatcher threads to
+  handlers whose signature names an `operator` parameter
+  (`operations/_branches.py::dispatch_typed`). The Vault handlers read
+  `operator.raw_jwt`; the token is **never** read off the persisted
+  `Target` (a per-request bearer must not live on a shared, persisted
+  target row). The pre-G0.3 `VaultTarget` stub that carried `raw_jwt`
+  was deleted by #629; `probe`/`fingerprint`/`execute` are typed
+  against the real `targets.schemas.Target | None`.
 - **KV-v2 op group** (`ops.py`) — `register_vault_typed_operations()`
   registers the `vault.kv.*` surface (G0.6-T-Refactor shipped
   `vault.kv.read`; G3.3-T1 #545 adds list/put/versions/delete). Group
@@ -265,10 +272,12 @@ and a real Postgres audit store (reusing the integration conftest's
 
 ## Known issues
 
-- `VaultTarget` is a pre-G0.3 placeholder; replace with the real
-  `Target` model once G0.3 (#224) connection-parameter resolution
-  lands. Connection params (address/namespace/timeout) currently come
-  from `get_settings()`, not the target.
+- Connection params (address/namespace/timeout) come from
+  `get_settings()`, not the target — Vault is a deployment-level
+  singleton in v0.2, so `probe`/`fingerprint` accept `Target | None`
+  and ignore the value. (The pre-G0.3 `VaultTarget` stub was removed
+  by G0.8-T3 #629; the operator JWT now comes from request-scoped
+  `Operator` context, not a persisted target field.)
 - `vault.sys.seal_status` is unauthenticated on Vault's side but is
   routed through `vault_client_for_operator` for uniform per-operator
   audit attribution — at the cost of one extra OIDC login + revoke per


### PR DESCRIPTION
## Summary

- The vault connector handlers read the operator JWT off a duck-typed
  `target.raw_jwt` — a pre-#224 stub field. Dispatched through the real
  G0.3 `Target` (no `raw_jwt`), every `operations/call` against a
  registered vault target failed with
  `AttributeError: 'Target' object has no attribute 'raw_jwt'`
  (consumer dogfood signal **Wall-13**, HARD BLOCKER for #634).
- The G0.6 dispatcher already threads the request-scoped `Operator` to
  any typed handler whose signature names an `operator` parameter
  (`operations/_branches.py::dispatch_typed`), and
  `vault_client_for_operator` already takes an `Operator`. The fix:
  give every authenticated vault handler the
  `(operator, target, params)` signature and read `operator.raw_jwt`;
  delete the stub `VaultTarget`; type `probe`/`fingerprint`/`execute`
  against the real `targets.schemas.Target | None`.
- `vault.sys.health` keeps the `(target, params)` shape — it hits
  Vault's *unauthenticated* `/v1/sys/health` and forwards no token.
- No change to the `Target` schema, the dispatcher contract, or any
  persisted model — the per-request bearer stays request-scoped
  operator context, never a persisted target field.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — `Success:
      no issues found in 161 source files` (proves no handler
      references a `Target.raw_jwt` attribute — acceptance criterion 5)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
      (pre-existing `ops.py` >600-line debt suppressed with a
      documented `# code-quality-allow` escape valve; module split is
      explicitly out of scope per the issue)
- [x] Vault unit suites reworked to the real `Operator` shape via a
      `_dispatch_vault` helper that dispatches with a real `Operator`
      and `target=None` — `test_connectors_vault.py` (44),
      `test_connectors_vault_sys.py` (20),
      `test_connectors_vault_auth.py` (29),
      `test_vault_kv_list_jsonflux.py` (3) all pass
- [x] **Integration (acceptance criterion 1):**
      `tests/integration/test_connectors_vault_dev_e2e.py` — 13 tests
      against a **real Vault container**, dispatching through the real
      `dispatch()` path with a target carrying **no `raw_jwt`**; all
      pass (no `AttributeError`)
- [x] `test_api_v1_health.py`, `test_operations_dispatcher.py`,
      `test_auth_vault.py`, `test_vault_failures.py`,
      `test_broadcast_credential_read_dispatch.py` — green/skip-clean

## Out of scope

- Adding `raw_jwt` (or any per-request token) to the persisted
  `Target` — explicitly wrong by design.
- Splitting the pre-existing >600-line `ops.py` — localised
  auth-contract fix only; tracked separately if it lands.
- Broader operator-aware-dispatch refactor across non-vault
  connectors.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #629


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal authentication handling for Vault operations by passing credentials through request-scoped operator context instead of target objects, enabling cleaner separation of concerns and better alignment with the typed-dispatch pipeline architecture.

* **Tests**
  * Updated test suite to validate Vault operations through the updated dispatch path with operator-aware authentication.

* **Documentation**
  * Updated Vault connector documentation to reflect new authentication flow and target parameter handling.

* **Chores**
  * Updated `.gitignore` to exclude VS Code workspace files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->