### PR TITLE
feat(connectors): G3.5-T2 NSX core-ops curation + ReviewService llm_instructions (#614)

### DIFF
--- a/backend/src/meho_backplane/connectors/nsx/__init__.py
+++ b/backend/src/meho_backplane/connectors/nsx/__init__.py
@@ -33,6 +33,19 @@ of ``nsx-4.2/policy.yaml`` + ``nsx-4.2/manager.yaml`` against the
 """
 
 from meho_backplane.connectors.nsx.connector import NsxConnector
+from meho_backplane.connectors.nsx.core_ops import (
+    NSX_CONNECTOR_ID,
+    NSX_CORE_GROUPS,
+    NSX_CORE_OPS,
+    NSX_IMPL_ID,
+    NSX_PATH_RULES,
+    NSX_PRODUCT,
+    NSX_VERSION,
+    NsxCoreGroup,
+    NsxCoreOp,
+    apply_nsx_core_curation,
+    classify_nsx_op,
+)
 from meho_backplane.connectors.nsx.session import (
     NsxSessionLoader,
     NsxTargetLike,
@@ -49,9 +62,20 @@ register_connector_v2(
 )
 
 __all__ = [
+    "NSX_CONNECTOR_ID",
+    "NSX_CORE_GROUPS",
+    "NSX_CORE_OPS",
+    "NSX_IMPL_ID",
+    "NSX_PATH_RULES",
+    "NSX_PRODUCT",
+    "NSX_VERSION",
     "NsxConnector",
+    "NsxCoreGroup",
+    "NsxCoreOp",
     "NsxSessionLoader",
     "NsxTargetLike",
     "SessionCredentials",
+    "apply_nsx_core_curation",
+    "classify_nsx_op",
     "load_session_credentials_from_vault",
 ]

--- a/backend/src/meho_backplane/connectors/nsx/core_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/core_ops.py
@@ -83,23 +83,36 @@ Curation application
 --------------------
 
 :func:`apply_nsx_core_curation` is the operator-review-time
-substrate call:
+substrate call that makes exactly the 9 curated ops dispatchable
+and leaves every other ingested op disabled. The substrate has no
+"enable only ops X, Y, Z under group G" verb —
+:meth:`ReviewService.enable_group` cascades ``is_enabled=True`` to
+every child op. The helper threads this needle by using the
+audit-log-driven operator-override exclusion (see
+:func:`~meho_backplane.operations.ingest._internals.operator_disabled_op_ids`):
 
-1. For each entry in :data:`NSX_CORE_GROUPS`, ``edit_group(name,
-   when_to_use)`` on the group then ``enable_group(group_key)`` to
-   flip ``review_status='enabled'`` (cascades child ops to
-   ``is_enabled=True``).
-2. For each entry in :data:`NSX_CORE_OPS`, ``edit_op(
-   llm_instructions=...)`` to land the agent guidance blob. The
-   op's ``is_enabled`` flips ``True`` through the group cascade in
-   step 1; the operator-review override path (``edit_op(
-   is_enabled=False)`` for any explicitly-rejected op) is left as
-   a follow-up for the CLI verb in #615.
+1. Read the current state of each curated group via
+   :meth:`ReviewService.get_review_payload`.
+2. For every non-curated op in a curated group, call
+   :meth:`ReviewService.edit_op` with ``is_enabled=False`` —
+   this writes the operator-override audit row.
+3. For each curated group, :meth:`edit_group` lands the
+   operator-reviewed ``name`` / ``when_to_use``, then
+   :meth:`enable_group` flips ``review_status='enabled'``. The
+   cascade detects the prior override rows from step 2 and skips
+   those ops; only the curated ops get ``is_enabled=True``.
+4. For each entry in :data:`NSX_CORE_OPS`, :meth:`edit_op`
+   lands the curated ``llm_instructions`` blob.
 
-Calling :func:`apply_nsx_core_curation` is idempotent: each
-sub-call uses the existing ``ReviewService`` no-op-on-target-state
-semantics (already-enabled groups don't write audit rows; ops with
-the same ``llm_instructions`` value re-write but the diff is empty).
+Re-running :func:`apply_nsx_core_curation` is **safe** but not
+fully idempotent at the audit layer: :meth:`enable_group` is a
+no-op on a group already in ``review_status='enabled'`` (no audit
+row written), but :meth:`edit_group` and :meth:`edit_op` always
+emit one audit row per call — even when every field already
+carried the incoming value. The intended posture is a one-shot
+curation step after ingest; re-runs during a rollout or test
+rerun produce redundant ``meho.connector.edit_*`` audit rows but
+never corrupt state.
 """
 
 from __future__ import annotations
@@ -553,32 +566,113 @@ async def apply_nsx_core_curation(
     *,
     tenant_id: UUID | None,
 ) -> None:
-    """Apply :data:`NSX_CORE_GROUPS` + :data:`NSX_CORE_OPS` against the ingested connector.
+    """Apply the curated 9-op read core against an ingested NSX connector.
 
-    For every entry in :data:`NSX_CORE_GROUPS`:
+    Drives the substrate so that, after this call returns, exactly
+    the 9 ops in :data:`NSX_CORE_OPS` are dispatchable
+    (``is_enabled=True``) and every other ingested op stays
+    ``is_enabled=False``. The 8 curated groups land
+    ``review_status='enabled'`` so the agent's
+    :func:`~meho_backplane.operations.meta_tools.search_operations`
+    surfaces the core ops; non-curated groups are left untouched
+    (``review_status='staged'`` from the G0.7 ingest default).
 
-    1. :meth:`ReviewService.edit_group` to land the operator-authored
-       ``name`` + ``when_to_use``.
-    2. :meth:`ReviewService.enable_group` to flip
-       ``review_status='enabled'``; cascades child ops to
-       ``is_enabled=True``.
+    The substrate doesn't expose "enable only ops X, Y, Z under
+    group G": :meth:`ReviewService.enable_group`'s cascade flips
+    ``is_enabled=True`` on every child op in the group. The helper
+    works around this via the audit-log-driven operator-override
+    exclusion (see
+    :func:`~meho_backplane.operations.ingest._internals.operator_disabled_op_ids`):
 
-    For every entry in :data:`NSX_CORE_OPS`:
-
-    3. :meth:`ReviewService.edit_op` with ``llm_instructions`` set to
-       the curated blob; the op is already ``is_enabled=True`` from
-       step 2's group cascade.
+    1. :meth:`ReviewService.get_review_payload` loads the current
+       state of every curated group and its child ops.
+    2. For each child op in a curated group that **isn't** in the
+       :data:`NSX_CORE_OPS` allow-list,
+       :meth:`ReviewService.edit_op` with ``is_enabled=False``
+       writes the operator-override audit row. The follow-on
+       :meth:`enable_group` cascade detects these rows and skips
+       them, so non-core ops stay disabled even though their
+       group is being enabled.
+    3. :meth:`ReviewService.edit_group` lands the operator-reviewed
+       ``name`` + ``when_to_use`` on each curated group.
+    4. :meth:`ReviewService.enable_group` flips
+       ``review_status='enabled'`` and cascades ``is_enabled=True``
+       to the curated child ops (operator-overridden non-core ops
+       are skipped).
+    5. :meth:`ReviewService.edit_op` lands the curated
+       ``llm_instructions`` blob per entry in :data:`NSX_CORE_OPS`.
 
     Caller's *review_service* must be constructed against a
     ``tenant_admin``-role operator (matching the substrate's auth
     contract); built-in scope (``tenant_id=None``) is the default
     for NSX content, same convention vSphere uses.
 
-    Idempotent: re-running with the same data writes audit rows
-    only for fields that actually changed (the substrate's
-    no-op-on-target-state behaviour) — the curation step is safe
-    to re-run during a rollout or test rerun.
+    Re-running is safe but not idempotent at the audit layer.
+    :meth:`enable_group` short-circuits on groups already in
+    ``review_status='enabled'`` (no audit row), but
+    :meth:`edit_group` and :meth:`edit_op` always emit one audit
+    row per call — even when the incoming value equals the
+    persisted one. The intended posture is a one-shot curation
+    step after ingest; re-runs produce redundant
+    ``meho.connector.edit_*`` audit rows but never corrupt state.
+
+    Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
+    if no groups exist for ``nsx-rest-4.2`` under *tenant_id* (the
+    operator must run ``meho connector ingest`` against the NSX
+    specs before this helper applies).
     """
+    # Step 1 — read the current state so we can compute the
+    # per-group non-core op set.
+    payload = await review_service.get_review_payload(
+        NSX_CONNECTOR_ID,
+        tenant_id,
+    )
+
+    # Build the per-group allow-list from the curated NSX_CORE_OPS.
+    # ``policy-firewall`` carries two entries (security-policy.list
+    # + rule.list); every other curated group carries exactly one.
+    core_op_ids_by_group: dict[str, set[str]] = {}
+    for op in NSX_CORE_OPS:
+        core_op_ids_by_group.setdefault(op.group_key, set()).add(op.op_id)
+
+    # Step 2 — disable non-core ops in each curated group via the
+    # operator-override audit-log path so the subsequent
+    # ``enable_group`` cascade skips them.
+    for group_payload in payload.groups:
+        allow_list = core_op_ids_by_group.get(group_payload.group_key)
+        if allow_list is None:
+            # Non-curated group — left entirely alone; its
+            # review_status stays at whatever the ingest pass set
+            # it to (typically 'staged').
+            continue
+        for review_op in group_payload.ops:
+            if review_op.op_id in allow_list:
+                continue
+            # Always write the override audit row, even when the
+            # op already appears ``is_enabled=False``. The
+            # cascade in :meth:`enable_group` consults the audit
+            # log (see
+            # :func:`~meho_backplane.operations.ingest._internals.operator_disabled_op_ids`),
+            # not the live column value — a freshly-ingested op
+            # is ``is_enabled=False`` by default but carries no
+            # ``edit_op`` audit history, so the cascade would
+            # re-enable it without an explicit override row.
+            await review_service.edit_op(
+                NSX_CONNECTOR_ID,
+                review_op.op_id,
+                tenant_id=tenant_id,
+                is_enabled=False,
+            )
+            _log.info(
+                "nsx_non_core_op_disabled",
+                connector_id=NSX_CONNECTOR_ID,
+                op_id=review_op.op_id,
+                group_key=group_payload.group_key,
+            )
+
+    # Steps 3 + 4 — land the operator-reviewed group metadata, then
+    # enable each curated group. The cascade respects the
+    # operator-override exclusion list built in step 2.
     for group in NSX_CORE_GROUPS:
         await review_service.edit_group(
             NSX_CONNECTOR_ID,
@@ -598,6 +692,7 @@ async def apply_nsx_core_curation(
             group_key=group.group_key,
         )
 
+    # Step 5 — land the curated llm_instructions blob per core op.
     for op in NSX_CORE_OPS:
         await review_service.edit_op(
             NSX_CONNECTOR_ID,

--- a/backend/src/meho_backplane/connectors/nsx/core_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/core_ops.py
@@ -1,0 +1,612 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""NSX 4.2 read-only v0.2 core — curated operator-enabled subset.
+
+This module names the **9 read-only NSX operations** the G3.5 NSX
+v0.2 ship enables out of the much larger
+``nsx-4.2/policy.yaml`` + ``nsx-4.2/manager.yaml`` corpus that the
+G0.7 spec-ingestion pipeline lands under
+``connector_id="nsx-rest-4.2"``. The curation is two-layered:
+
+* :data:`NSX_CORE_GROUPS` — the operator-reviewed ``when_to_use``
+  hint per LLM-grouping pass output group. Each entry's
+  ``group_key`` is the deterministic slug the path-prefix classifier
+  assigns to NSX ops (see :func:`classify_nsx_op` below); the
+  ``when_to_use`` is what the agent reads verbatim through
+  :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
+  to pick a group to search within.
+* :data:`NSX_CORE_OPS` — the 9 ``EndpointDescriptor.op_id`` strings
+  that flip to ``is_enabled=True`` at operator-review time, paired
+  with the per-op ``llm_instructions`` blob the agent inlines into
+  the reasoning context when it sees the op in
+  :func:`~meho_backplane.operations.meta_tools.search_operations`
+  hits. Every other op under the same connector triple stays
+  ``is_enabled=False`` (the G0.7 ingestion default for
+  ``source_kind='ingested'`` rows).
+
+Per Initiative #368 and CLAUDE.md postulates 1-2, NSX is **fully
+generic-ingested**: the underlying ops are not registered in code,
+they live in the ``endpoint_descriptor`` table. This module only
+carries the **operator-review metadata** the substrate uses at the
+review step — the actual curation is applied through
+:func:`apply_nsx_core_curation` against an existing ingested
+connector.
+
+The 9 ops (paths cross-checked against NSX REST API guide v4.2,
+2026-04 snapshot at https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/):
+
+1. ``GET:/api/v1/node`` — ``nsx.about`` — manager version / build /
+   node UUID (the same surface :meth:`NsxConnector.fingerprint`
+   already consumes; exposing it as an operator-callable op lets
+   the agent run a sanity probe before any heavier read).
+2. ``GET:/api/v1/transport-nodes`` — ``nsx.node.list`` — list of
+   transport nodes (ESXi / edge) the NSX manager is aware of.
+3. ``GET:/api/v1/cluster/status`` — ``nsx.cluster.status`` —
+   manager cluster mode + node membership; mirrors the connector's
+   probe target.
+4. ``GET:/policy/api/v1/infra/segments`` — ``nsx.segment.list`` —
+   policy-API segments (logical-port + DVS-backed portgroup
+   surface).
+5. ``GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones``
+   — ``nsx.transport_zone.list`` — transport-zone inventory under
+   the default enforcement point.
+6. ``GET:/policy/api/v1/infra/tier-0s`` — ``nsx.tier0.list`` —
+   policy-API tier-0 gateway inventory (BGP / NAT summaries via
+   nested ``children`` field when present).
+7. ``GET:/policy/api/v1/infra/tier-1s`` — ``nsx.tier1.list`` —
+   tier-1 gateway inventory (the per-tenant routing surface).
+8. ``GET:/policy/api/v1/infra/domains/{domain-id}/security-policies``
+   — ``nsx.firewall.policy.list`` — distributed-firewall policy
+   listing scoped by domain (``--scope <domain>`` in the CLI verb,
+   default ``default``).
+9. ``GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules``
+   — ``nsx.firewall.rule.list`` — per-policy rule listing; the
+   final-grain firewall inspection surface.
+
+Path families and group_keys
+----------------------------
+
+NSX surfaces split cleanly into the **manager API** (under
+``/api/v1/...``) and the **policy API** (under ``/policy/api/v1/...``).
+LLM-grouping output for NSX tends to produce one group per top-level
+family — :data:`NSX_PATH_RULES` mirrors that taxonomy so an operator
+reviewing the connector sees the read-core ops fall into the
+expected groups (``manager-node``, ``manager-cluster``,
+``policy-segments``, ``policy-transport-zones``, ``policy-tier0``,
+``policy-tier1``, ``policy-firewall``). The path-prefix classifier
+is the same shape :class:`_PathPrefixStubLlmClient` in
+``test_g07_vsphere_canary.py`` uses for vSphere — stable, deterministic,
+operator-reviewable.
+
+Curation application
+--------------------
+
+:func:`apply_nsx_core_curation` is the operator-review-time
+substrate call:
+
+1. For each entry in :data:`NSX_CORE_GROUPS`, ``edit_group(name,
+   when_to_use)`` on the group then ``enable_group(group_key)`` to
+   flip ``review_status='enabled'`` (cascades child ops to
+   ``is_enabled=True``).
+2. For each entry in :data:`NSX_CORE_OPS`, ``edit_op(
+   llm_instructions=...)`` to land the agent guidance blob. The
+   op's ``is_enabled`` flips ``True`` through the group cascade in
+   step 1; the operator-review override path (``edit_op(
+   is_enabled=False)`` for any explicitly-rejected op) is left as
+   a follow-up for the CLI verb in #615.
+
+Calling :func:`apply_nsx_core_curation` is idempotent: each
+sub-call uses the existing ``ReviewService`` no-op-on-target-state
+semantics (already-enabled groups don't write audit rows; ops with
+the same ``llm_instructions`` value re-write but the diff is empty).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.operations.ingest.service import ReviewService
+
+__all__ = [
+    "NSX_CONNECTOR_ID",
+    "NSX_CORE_GROUPS",
+    "NSX_CORE_OPS",
+    "NSX_IMPL_ID",
+    "NSX_PATH_RULES",
+    "NSX_PRODUCT",
+    "NSX_VERSION",
+    "NsxCoreGroup",
+    "NsxCoreOp",
+    "apply_nsx_core_curation",
+    "classify_nsx_op",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Connector triple. Matches :class:`NsxConnector.product` /
+#: ``version`` / ``impl_id``; lifted here so review-time callers
+#: don't import the connector class (avoids re-running the registry
+#: side-effects in the ``__init__``).
+NSX_PRODUCT: Final[str] = "nsx"
+NSX_VERSION: Final[str] = "4.2"
+NSX_IMPL_ID: Final[str] = "nsx-rest"
+
+#: Connector-id slug the G0.6 dispatcher's ``parse_connector_id``
+#: round-trips back to the triple above: ``"nsx-rest-4.2"``.
+NSX_CONNECTOR_ID: Final[str] = f"{NSX_IMPL_ID}-{NSX_VERSION}"
+
+
+@dataclass(frozen=True, slots=True)
+class NsxCoreGroup:
+    """One curated operator-review entry for an NSX operation group.
+
+    ``group_key`` is the slug the path-prefix classifier emits (see
+    :data:`NSX_PATH_RULES`). ``name`` is the operator-readable label
+    ``meho connector review`` renders. ``when_to_use`` is the
+    agent-facing hint :func:`list_operation_groups` returns verbatim;
+    every entry is a single complete sentence so the agent's
+    group-selection step has unambiguous guidance.
+    """
+
+    group_key: str
+    name: str
+    when_to_use: str
+
+
+@dataclass(frozen=True, slots=True)
+class NsxCoreOp:
+    """One curated operator-review entry for an NSX operation.
+
+    ``op_id`` follows the ``METHOD:path`` shape every
+    ``source_kind='ingested'`` row uses; the path matches an entry
+    in NSX 4.2's ``policy.yaml`` (``/policy/api/v1/...``) or
+    ``manager.yaml`` (``/api/v1/...``).
+
+    ``llm_instructions`` is the per-op JSON blob the meta-tools
+    inline verbatim when the op surfaces. The shape (``when_to_call``
+    / ``output_shape`` / ``next_step``) mirrors the typed-connector
+    convention from :mod:`meho_backplane.connectors.bind9.ops_zone`
+    and :mod:`meho_backplane.connectors.vault.ops` — same agent reads
+    both surfaces, so the structure stays uniform.
+    """
+
+    op_id: str
+    group_key: str
+    llm_instructions: dict[str, object]
+
+
+#: Path-prefix → group_key classifier rules for NSX.
+#:
+#: First match wins. Order matters: the more specific prefixes are
+#: listed first so e.g. ``/policy/api/v1/infra/tier-0s`` doesn't fall
+#: into a broader ``/policy/api/v1/infra/`` catch-all rule (no such
+#: rule exists today; the ordering is defensive against future
+#: additions). The NSX manager surface (``/api/v1/...``) and the
+#: policy surface (``/policy/api/v1/...``) never overlap because the
+#: ``/policy/`` prefix is unique to the policy API.
+NSX_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
+    # Policy-API surfaces — the modern, declarative NSX path family.
+    ("/policy/api/v1/infra/segments", "policy-segments"),
+    (
+        "/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones",
+        "policy-transport-zones",
+    ),
+    ("/policy/api/v1/infra/tier-0s", "policy-tier0"),
+    ("/policy/api/v1/infra/tier-1s", "policy-tier1"),
+    ("/policy/api/v1/infra/domains/", "policy-firewall"),
+    # Manager-API surfaces — the legacy / lower-level NSX path family
+    # the policy API delegates to. The core read set uses two
+    # specific manager endpoints; everything else under /api/v1/
+    # falls through to ``manager-misc``.
+    ("/api/v1/cluster/status", "manager-cluster"),
+    ("/api/v1/transport-nodes", "manager-transport-nodes"),
+    ("/api/v1/node", "manager-node"),
+)
+
+
+def classify_nsx_op(op_id: str) -> str:
+    """Return the curated ``group_key`` for an NSX op_id, or ``"none"``.
+
+    ``op_id`` is the ``METHOD:/path`` form ingested rows carry;
+    the helper strips the verb (NSX read ops are uniformly ``GET``)
+    and matches the path against :data:`NSX_PATH_RULES` in order.
+
+    Returns ``"none"`` for paths outside the curated families
+    (manager-misc / policy-misc); operators reviewing the ingested
+    connector see those rows as unassigned in the review payload
+    and can either tighten the rules in this module on the next
+    release or accept them as un-curated. The G0.7 canary's
+    ``operations_unassigned < 50%`` bar tolerates a long tail of
+    un-curated paths.
+    """
+    try:
+        _, path = op_id.split(":", 1)
+    except ValueError:
+        return "none"
+    for prefix, group_key in NSX_PATH_RULES:
+        if path.startswith(prefix):
+            return group_key
+    return "none"
+
+
+#: Operator-reviewed ``when_to_use`` hints for the seven NSX groups
+#: the read-only v0.2 core spans. Two groups carry one op each
+#: (``manager-node`` for nsx.about, ``manager-cluster`` for
+#: nsx.cluster.status); the rest carry one or two. Every hint is
+#: one complete sentence the agent reads verbatim — vague hints
+#: poison ``search_operations`` ranking, per the ai_engineering pack.
+NSX_CORE_GROUPS: Final[tuple[NsxCoreGroup, ...]] = (
+    NsxCoreGroup(
+        group_key="manager-node",
+        name="NSX Manager (node)",
+        when_to_use=(
+            "Use this group to read the NSX Manager's own identity — "
+            "build, version, node UUID, hostname. The probe / sanity "
+            "surface the agent calls before any heavier inventory "
+            "read."
+        ),
+    ),
+    NsxCoreGroup(
+        group_key="manager-cluster",
+        name="NSX Manager (cluster)",
+        when_to_use=(
+            "Use this group to check whether the NSX management plane "
+            "is healthy — cluster mode (1-node / 3-node), per-member "
+            "status, control-plane availability."
+        ),
+    ),
+    NsxCoreGroup(
+        group_key="manager-transport-nodes",
+        name="NSX Transport Nodes",
+        when_to_use=(
+            "Use this group to enumerate the transport nodes (ESXi "
+            "hypervisors and edge nodes) NSX has prepared for "
+            "overlay / VLAN traffic."
+        ),
+    ),
+    NsxCoreGroup(
+        group_key="policy-segments",
+        name="NSX Segments",
+        when_to_use=(
+            "Use this group to list NSX logical segments and DVS-backed "
+            "portgroups under the policy API. The primary read surface "
+            "for 'what virtual networks exist' questions."
+        ),
+    ),
+    NsxCoreGroup(
+        group_key="policy-transport-zones",
+        name="NSX Transport Zones",
+        when_to_use=(
+            "Use this group to list the transport zones segments and "
+            "tier-routers attach to. Read-only inventory under the "
+            "default enforcement point."
+        ),
+    ),
+    NsxCoreGroup(
+        group_key="policy-tier0",
+        name="NSX Tier-0 Gateways",
+        when_to_use=(
+            "Use this group to inspect provider tier-0 gateways — "
+            "north-south edge routing, BGP peers, NAT summaries."
+        ),
+    ),
+    NsxCoreGroup(
+        group_key="policy-tier1",
+        name="NSX Tier-1 Gateways",
+        when_to_use=(
+            "Use this group to inspect per-tenant tier-1 gateways — "
+            "the east-west routing surface attached under a tier-0."
+        ),
+    ),
+    NsxCoreGroup(
+        group_key="policy-firewall",
+        name="NSX Distributed Firewall",
+        when_to_use=(
+            "Use this group to read distributed-firewall security "
+            "policies and their per-policy rules. The agent asks "
+            "'which rules govern traffic in domain X' questions here."
+        ),
+    ),
+)
+
+
+def _instructions(
+    *,
+    when_to_call: str,
+    output_shape: str,
+    next_step: str,
+) -> dict[str, object]:
+    """Build the per-op ``llm_instructions`` blob with the canonical keys.
+
+    Lifted to a helper so every op's blob has the same three
+    fields in the same order — the agent's grammar checks read
+    ``when_to_call`` / ``output_shape`` / ``next_step`` and a typo
+    in any single op would silently degrade retrieval. The shape
+    mirrors :mod:`meho_backplane.connectors.bind9.ops_zone` (typed
+    bind9 ops) so an agent crossing connector boundaries sees a
+    stable convention.
+    """
+    return {
+        "when_to_call": when_to_call,
+        "output_shape": output_shape,
+        "next_step": next_step,
+    }
+
+
+#: The 9 curated read-only NSX core ops. Each entry carries the
+#: op_id (``GET:/path`` form ingested ops use), the curated group
+#: assignment, and the operator-reviewed ``llm_instructions`` blob.
+#:
+#: Sourced against NSX REST API v4.2 docs at
+#: https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/.
+NSX_CORE_OPS: Final[tuple[NsxCoreOp, ...]] = (
+    NsxCoreOp(
+        op_id="GET:/api/v1/node",
+        group_key="manager-node",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to identify the NSX Manager — its build, version, "
+                "node UUID, hostname. Useful as a probe before heavier "
+                "policy reads, or to confirm which NSX cluster the "
+                "target points at."
+            ),
+            output_shape=(
+                "Object with node_version, kernel_version, node_uuid, hostname, external_id keys."
+            ),
+            next_step=(
+                "If the manager looks healthy, move on to cluster-status or transport-node listing."
+            ),
+        ),
+    ),
+    NsxCoreOp(
+        op_id="GET:/api/v1/transport-nodes",
+        group_key="manager-transport-nodes",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to enumerate transport nodes — ESXi hypervisors "
+                "and edge nodes prepared for NSX overlay or VLAN "
+                "traffic. Useful when answering 'which hosts has NSX "
+                "claimed'."
+            ),
+            output_shape=(
+                "Object with a `results` array of transport node "
+                "entries; each entry carries id, display_name, "
+                "node_deployment_info, and host_switch_spec."
+            ),
+            next_step=(
+                "Drill into a specific node by id when you need its "
+                "uplink configuration or tunnel state."
+            ),
+        ),
+    ),
+    NsxCoreOp(
+        op_id="GET:/api/v1/cluster/status",
+        group_key="manager-cluster",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to confirm whether the NSX management plane is "
+                "healthy and which members make up the cluster. "
+                "Useful when an operator suspects a control-plane "
+                "outage."
+            ),
+            output_shape=(
+                "Object with mgmt_cluster_status (overall health), "
+                "control_cluster_status, and per-member detail."
+            ),
+            next_step=(
+                "If unhealthy, surface the failing member's id; "
+                "otherwise proceed to the inventory / policy reads."
+            ),
+        ),
+    ),
+    NsxCoreOp(
+        op_id="GET:/policy/api/v1/infra/segments",
+        group_key="policy-segments",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list NSX segments — both pure logical-port "
+                "overlay segments and DVS-backed portgroups exposed "
+                "via the policy API. The primary read for 'what "
+                "virtual networks exist' questions."
+            ),
+            output_shape=(
+                "Object with a `results` array; each segment carries "
+                "id, display_name, transport_zone_path, "
+                "subnets/gateway_addresses for overlay segments, and "
+                "vlan_ids for VLAN-backed ones. Large NSX deployments "
+                "may return hundreds of rows — drill into one segment "
+                "by id rather than re-listing for follow-ups."
+            ),
+            next_step=(
+                "Pick a segment by id for status / port reads, or "
+                "cross-reference its transport_zone_path against the "
+                "transport-zone listing."
+            ),
+        ),
+    ),
+    NsxCoreOp(
+        op_id=("GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"),
+        group_key="policy-transport-zones",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list transport zones under the default "
+                "enforcement point — the scope segments and "
+                "tier-gateways attach to. Read-only inventory."
+            ),
+            output_shape=(
+                "Object with a `results` array of transport-zone "
+                "entries; each carries id, display_name, tz_type "
+                "(OVERLAY / VLAN), and host_switch_name."
+            ),
+            next_step=(
+                "Cross-reference a zone's id when answering 'where "
+                "does this segment live' or 'what zones does this "
+                "edge see'."
+            ),
+        ),
+    ),
+    NsxCoreOp(
+        op_id="GET:/policy/api/v1/infra/tier-0s",
+        group_key="policy-tier0",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to inspect provider tier-0 gateways — the "
+                "north-south edge routing surface. Includes BGP peers "
+                "and NAT summaries via the nested `children` field "
+                "when configured."
+            ),
+            output_shape=(
+                "Object with a `results` array; each tier-0 carries "
+                "id, display_name, ha_mode (ACTIVE_ACTIVE / "
+                "ACTIVE_STANDBY), failover_mode, and optionally a "
+                "`children` array with BgpRoutingConfig and Nat "
+                "subtrees."
+            ),
+            next_step=(
+                "Drill into a tier-0 by id for its locale-services / "
+                "interfaces, or follow up with tier-1 listing for "
+                "downstream consumers."
+            ),
+        ),
+    ),
+    NsxCoreOp(
+        op_id="GET:/policy/api/v1/infra/tier-1s",
+        group_key="policy-tier1",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to inspect per-tenant tier-1 gateways — the "
+                "east-west routing surface attached under a tier-0. "
+                "Useful when mapping which tier-1 fronts a given "
+                "segment."
+            ),
+            output_shape=(
+                "Object with a `results` array; each tier-1 carries "
+                "id, display_name, tier0_path (its parent), "
+                "route_advertisement_types, and ha_mode."
+            ),
+            next_step=(
+                "Cross-reference tier0_path against the tier-0 "
+                "listing, or drill into a tier-1 for its segment "
+                "attachments."
+            ),
+        ),
+    ),
+    NsxCoreOp(
+        op_id="GET:/policy/api/v1/infra/domains/{domain-id}/security-policies",
+        group_key="policy-firewall",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list distributed-firewall security policies "
+                "in a domain. The default domain is `default`; "
+                "operators on multi-tenant NSX deployments may use "
+                "tenant-specific domain ids."
+            ),
+            output_shape=(
+                "Object with a `results` array of security-policy "
+                "entries; each carries id, display_name, category "
+                "(Ethernet / Emergency / Infrastructure / Environment "
+                "/ Application), sequence_number, and scope."
+            ),
+            next_step=(
+                "Pick a policy by id and call the rule listing op "
+                "to inspect individual firewall rules."
+            ),
+        ),
+    ),
+    NsxCoreOp(
+        op_id=(
+            "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/"
+            "{security-policy-id}/rules"
+        ),
+        group_key="policy-firewall",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to enumerate firewall rules inside one "
+                "security-policy. The final-grain inspection surface "
+                "when answering 'what rule allows / blocks traffic "
+                "X'."
+            ),
+            output_shape=(
+                "Object with a `results` array; each rule carries id, "
+                "display_name, action (ALLOW / DROP / REJECT), "
+                "sources, destinations, services, and "
+                "applied_to. Large policies may return hundreds of "
+                "rules — drill into one rule by id for follow-ups."
+            ),
+            next_step=(
+                "Surface the rule action + sources/destinations to "
+                "the operator; cross-reference applied_to against "
+                "segment ids when context demands."
+            ),
+        ),
+    ),
+)
+
+
+async def apply_nsx_core_curation(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Apply :data:`NSX_CORE_GROUPS` + :data:`NSX_CORE_OPS` against the ingested connector.
+
+    For every entry in :data:`NSX_CORE_GROUPS`:
+
+    1. :meth:`ReviewService.edit_group` to land the operator-authored
+       ``name`` + ``when_to_use``.
+    2. :meth:`ReviewService.enable_group` to flip
+       ``review_status='enabled'``; cascades child ops to
+       ``is_enabled=True``.
+
+    For every entry in :data:`NSX_CORE_OPS`:
+
+    3. :meth:`ReviewService.edit_op` with ``llm_instructions`` set to
+       the curated blob; the op is already ``is_enabled=True`` from
+       step 2's group cascade.
+
+    Caller's *review_service* must be constructed against a
+    ``tenant_admin``-role operator (matching the substrate's auth
+    contract); built-in scope (``tenant_id=None``) is the default
+    for NSX content, same convention vSphere uses.
+
+    Idempotent: re-running with the same data writes audit rows
+    only for fields that actually changed (the substrate's
+    no-op-on-target-state behaviour) — the curation step is safe
+    to re-run during a rollout or test rerun.
+    """
+    for group in NSX_CORE_GROUPS:
+        await review_service.edit_group(
+            NSX_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+            name=group.name,
+            when_to_use=group.when_to_use,
+        )
+        await review_service.enable_group(
+            NSX_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+        )
+        _log.info(
+            "nsx_core_group_enabled",
+            connector_id=NSX_CONNECTOR_ID,
+            group_key=group.group_key,
+        )
+
+    for op in NSX_CORE_OPS:
+        await review_service.edit_op(
+            NSX_CONNECTOR_ID,
+            op.op_id,
+            tenant_id=tenant_id,
+            llm_instructions=op.llm_instructions,
+        )
+        _log.info(
+            "nsx_core_op_curated",
+            connector_id=NSX_CONNECTOR_ID,
+            op_id=op.op_id,
+        )

--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -333,10 +333,11 @@ class ReviewService:
         safety_level: Literal["safe", "caution", "dangerous"] | None = None,
         requires_approval: bool | None = None,
         is_enabled: bool | None = None,
+        llm_instructions: dict[str, object] | None = None,
     ) -> None:
         """Update operator-controlled overrides on one :class:`EndpointDescriptor`.
 
-        Passing none of the four fields raises :class:`ValueError`.
+        Passing none of the five fields raises :class:`ValueError`.
         Out-of-enum ``safety_level`` raises :class:`ValueError`.
 
         ``is_enabled`` override is load-bearing for post-enable
@@ -346,21 +347,39 @@ class ReviewService:
         :meth:`enable_connector` consults the audit log to find
         operator-set False rows and skips them.
 
+        ``llm_instructions`` is the agent-facing per-op guidance blob
+        ingested rows land with as ``NULL``. The typed connectors
+        populate it at ``register_typed_operation`` time
+        (see e.g. :mod:`meho_backplane.connectors.vault.ops` and
+        :mod:`meho_backplane.connectors.bind9.ops_zone`); for
+        ingested connectors the operator-review pass writes the same
+        shape via this method so :func:`search_operations` and the
+        agent's ``call_operation`` see populated guidance once the
+        op is enabled. The argument is a plain ``dict`` (the model's
+        ``llm_instructions`` column is ``JSON``); the helper persists
+        it as-is. Passing ``{}`` clears the column to an empty
+        mapping rather than re-deleting it — operators wanting to
+        un-author the field should disable the op instead.
+
         Writes one audit row with payload
         ``{connector_id, op_id, fields_updated, is_enabled_set_to?}``.
         The ``is_enabled_set_to`` key is included verbatim only
         when ``is_enabled`` was edited — that's the key the cascade
-        query reads.
+        query reads. The ``llm_instructions`` value itself is NOT
+        echoed into the payload (operator-authored blobs are big
+        enough to bloat the audit table without value, same
+        rationale ``edit_group`` uses for ``when_to_use``).
         """
         if (
             custom_description is None
             and safety_level is None
             and requires_approval is None
             and is_enabled is None
+            and llm_instructions is None
         ):
             raise ValueError(
                 "edit_op requires at least one of custom_description, "
-                "safety_level, requires_approval, is_enabled",
+                "safety_level, requires_approval, is_enabled, llm_instructions",
             )
         if safety_level is not None and safety_level not in VALID_SAFETY_LEVELS:
             raise ValueError(
@@ -383,6 +402,9 @@ class ReviewService:
             if is_enabled is not None:
                 op_row.is_enabled = is_enabled
                 fields_updated.append("is_enabled")
+            if llm_instructions is not None:
+                op_row.llm_instructions = llm_instructions
+                fields_updated.append("llm_instructions")
             payload: dict[str, Any] = {
                 "connector_id": connector_id,
                 "op_id": op_id,

--- a/backend/tests/acceptance/_nsx_canary_fixtures.py
+++ b/backend/tests/acceptance/_nsx_canary_fixtures.py
@@ -1,0 +1,546 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared minimal-setup fixtures for the G3.5 NSX dispatch tests.
+
+Two NSX acceptance modules (dispatch smoke + JSONFlux force-handle)
+share the same plumbing: a registered
+:class:`~meho_backplane.connectors.nsx.NsxConnector` instance with a
+stub session loader (so no Vault read is required), a probed
+:class:`~meho_backplane.db.models.Target` row, the 9 curated
+:class:`~meho_backplane.db.models.EndpointDescriptor` rows from
+:data:`~meho_backplane.connectors.nsx.core_ops.NSX_CORE_OPS`, and a
+:mod:`respx`-mocked NSX REST surface answering both the session-
+establish call and every read op the connector dispatches against.
+
+Why a minimal direct-insert path (not the full G0.7 canary ingest)
+==================================================================
+
+The full two-spec NSX ingestion via :func:`IngestionPipelineService`
+needs live ``nsx-4.2/policy.yaml`` + ``manager.yaml`` (~30 MB
+combined) reachable on the CI runner — the same env-gated pattern
+:mod:`tests.acceptance._vcenter_spec` codifies for vSphere. That
+live two-spec acceptance test is a follow-up to this Task (see the
+PR body for #614); until the NSX specs are wired to the meho-runners
+pool, the dispatch leg can still be exercised against a minimal
+direct-insert path.
+
+This module inserts the 9 curated NSX-core
+:class:`EndpointDescriptor` rows with hand-authored ``method`` /
+``path`` triples (sourced from :mod:`meho_backplane.connectors.nsx.core_ops`),
+seeds one enabled :class:`OperationGroup` per curated group_key,
+opens a respx router for the canary's NSX manager URL, and yields a
+small :class:`IngestedNsxCanary` bundle the dispatch tests consume.
+
+Mirrors :mod:`tests.acceptance._canary_fixtures` for the
+``vmware-rest`` connector verbatim — same lifecycle, same respx
+``assert_all_called=False`` posture, same per-test connector cache
+reset on teardown. The NSX-specific delta is the session-create +
+XSRF-token-paired auth dance:
+
+* :func:`_register_nsx_routes` answers ``POST /api/session/create``
+  with a 200 carrying both the ``X-XSRF-TOKEN`` response header and
+  a ``Set-Cookie: JSESSIONID=...`` so the connector's per-target
+  httpx client jar picks the cookie up.
+* The NSX connector instance's ``_session_loader`` is patched to
+  return a static ``{"username": ..., "password": ...}`` pair so no
+  Vault read fires.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.nsx import (
+    NSX_CONNECTOR_ID,
+    NSX_CORE_GROUPS,
+    NSX_CORE_OPS,
+    NSX_IMPL_ID,
+    NSX_PRODUCT,
+    NSX_VERSION,
+    NsxConnector,
+)
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+
+# Path-template variable matcher; mirrors the regex
+# :mod:`meho_backplane.operations._branches` uses to split a
+# templated path. Lifted as a module-internal so the descriptor
+# seeder can derive a parameter_schema from the path verbatim.
+_PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")
+
+__all__ = [
+    "NSX_CANARY_BASE_URL",
+    "NSX_CANARY_FINGERPRINT",
+    "NSX_CANARY_OPERATOR_TENANT",
+    "NSX_CANARY_SEGMENTS",
+    "NSX_CANARY_TIER0S",
+    "NSX_CANARY_TIER1S",
+    "NSX_CANARY_TRANSPORT_NODES",
+    "NSX_FORCE_HANDLE_LIST_OP_ID",
+    "NSX_TARGET_NAME",
+    "IngestedNsxCanary",
+    "ingested_nsx_canary",
+    "nsx_acceptance_operator",
+]
+
+#: Tenant the NSX dispatch tests act under. ``tenant_admin``-scoped
+#: operator; the descriptor + group rows themselves stay built-in
+#: (``tenant_id=None``) — production NSX content ships as built-in.
+NSX_CANARY_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000ff")
+
+#: Stable :class:`Target.name` the seeded NSX target carries. Tests
+#: refer to it through :attr:`IngestedNsxCanary.target_name`.
+NSX_TARGET_NAME: str = "nsx-acceptance"
+
+#: ``.test.invalid`` (RFC 6761 reserved) so no real network egress
+#: fires even if respx's transport patching ever regressed. Port 443
+#: keeps ``HttpConnector._base_url`` from appending a ``:port``
+#: suffix, so the respx ``base_url`` matches the connector's client
+#: URL exactly.
+NSX_CANARY_BASE_URL: str = "https://nsx-canary.test.invalid"
+
+#: Persisted as ``Target.fingerprint`` — what the connector resolver
+#: reads to bind the target's ``product`` + ``version`` against the
+#: ``NsxConnector.supported_version_range`` advertisement (``>=4.0,<5.0``).
+#: The probe route normally writes this dict at first-probe time;
+#: the dispatch tests seed it directly so the resolver binds the
+#: connector without a real probe round-trip.
+NSX_CANARY_FINGERPRINT: dict[str, object] = FingerprintResult(
+    vendor="vmware",
+    product="nsx",
+    version=NSX_VERSION,
+    build="4.2.1.0.0",
+    reachable=True,
+    probed_at=datetime(2026, 5, 18, 12, 0, 0, tzinfo=UTC),
+    probe_method="GET /api/v1/node",
+    extras={"node_uuid": "deadbeef-1111-2222-3333-cafebabecafe"},
+).model_dump(mode="json")
+
+#: The list op the JSONFlux force-handle test dispatches. Picked
+#: because (a) it's a list op, (b) the segment listing is the
+#: largest of the 9 NSX core surfaces in real deployments (often
+#: hundreds of rows), and (c) the path requires no template
+#: substitution (unlike the firewall-rule list which needs both
+#: ``domain-id`` and ``security-policy-id``).
+NSX_FORCE_HANDLE_LIST_OP_ID: str = "GET:/policy/api/v1/infra/segments"
+
+#: Synthetic transport-node response — three nodes mimic a 3-host
+#: ESXi cluster prepared for NSX overlay.
+NSX_CANARY_TRANSPORT_NODES: dict[str, object] = {
+    "results": [
+        {
+            "id": f"transport-node-{i}",
+            "display_name": f"esx-canary-{i:02d}",
+            "node_deployment_info": {"resource_type": "EsxiNode"},
+            "host_switch_spec": {"host_switches": []},
+        }
+        for i in range(3)
+    ],
+    "result_count": 3,
+}
+
+#: Synthetic segment listing — 12 rows so the force-handle reducer
+#: sees a populated set with a sample-row slice.
+NSX_CANARY_SEGMENTS: dict[str, object] = {
+    "results": [
+        {
+            "id": f"seg-canary-{i}",
+            "display_name": f"canary-seg-{i:02d}",
+            "transport_zone_path": (
+                "/infra/sites/default/enforcement-points/default/transport-zones/tz-overlay"
+            ),
+            "subnets": [{"gateway_address": f"10.{i}.0.1/24"}],
+            "resource_type": "Segment",
+        }
+        for i in range(12)
+    ],
+    "result_count": 12,
+}
+
+#: Synthetic tier-0 list — one provider edge.
+NSX_CANARY_TIER0S: dict[str, object] = {
+    "results": [
+        {
+            "id": "t0-canary-edge",
+            "display_name": "canary-tier0",
+            "ha_mode": "ACTIVE_STANDBY",
+            "failover_mode": "PREEMPTIVE",
+            "resource_type": "Tier0",
+        }
+    ],
+    "result_count": 1,
+}
+
+#: Synthetic tier-1 list — two per-tenant routers attached to the
+#: tier-0 above.
+NSX_CANARY_TIER1S: dict[str, object] = {
+    "results": [
+        {
+            "id": f"t1-canary-{i}",
+            "display_name": f"canary-tier1-{i:02d}",
+            "tier0_path": "/infra/tier-0s/t0-canary-edge",
+            "ha_mode": "ACTIVE_STANDBY",
+            "resource_type": "Tier1",
+        }
+        for i in range(2)
+    ],
+    "result_count": 2,
+}
+
+
+@dataclass(frozen=True)
+class IngestedNsxCanary:
+    """Bundle returned by :func:`ingested_nsx_canary`.
+
+    Same shape as :class:`tests.acceptance._canary_fixtures.IngestedCanaryVcsim`
+    so the assertion patterns transfer over verbatim.
+    """
+
+    operator: Operator
+    connector_id: str
+    target_name: str
+    base_url: str
+
+
+async def _insert_nsx_descriptors() -> None:
+    """Seed the 9 curated NSX core ops + their groups as enabled rows.
+
+    One :class:`OperationGroup` per entry in
+    :data:`~meho_backplane.connectors.nsx.core_ops.NSX_CORE_GROUPS`
+    (``review_status='enabled'``), one :class:`EndpointDescriptor`
+    per entry in :data:`~meho_backplane.connectors.nsx.core_ops.NSX_CORE_OPS`
+    (``is_enabled=True``, ``source_kind='ingested'``, ``handler_ref=None``).
+
+    Two ops in :data:`NSX_CORE_OPS` reference the same ``policy-firewall``
+    group; the helper coalesces those into one inserted group row so
+    the FK to ``operation_group.id`` resolves correctly on both ops.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, UUID] = {}
+    async with sessionmaker() as session:
+        for group in NSX_CORE_GROUPS:
+            group_row = OperationGroup(
+                tenant_id=None,
+                product=NSX_PRODUCT,
+                version=NSX_VERSION,
+                impl_id=NSX_IMPL_ID,
+                group_key=group.group_key,
+                name=group.name,
+                when_to_use=group.when_to_use,
+                review_status="enabled",
+            )
+            session.add(group_row)
+            await session.flush()
+            group_ids[group.group_key] = group_row.id
+
+        for op in NSX_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            descriptor = EndpointDescriptor(
+                tenant_id=None,
+                product=NSX_PRODUCT,
+                version=NSX_VERSION,
+                impl_id=NSX_IMPL_ID,
+                op_id=op.op_id,
+                source_kind="ingested",
+                method=method,
+                path=path,
+                handler_ref=None,
+                group_id=group_ids[op.group_key],
+                summary=f"NSX core op {op.op_id} (curated read).",
+                description=f"NSX core op {op.op_id} (curated read).",
+                # ``x-meho-param-loc='path'`` declares which params the
+                # dispatcher's ``_split_ingested_params`` routes to URL
+                # template substitution. The G0.7 ingestion pipeline
+                # writes this extension key off the OpenAPI ``in: path``
+                # parameter declarations; the seeded descriptors mirror
+                # that shape so the firewall-policy / firewall-rule ops
+                # substitute their ``{domain-id}`` /
+                # ``{security-policy-id}`` placeholders correctly.
+                parameter_schema=_param_schema_for(path),
+                response_schema={"type": "object"},
+                llm_instructions=op.llm_instructions,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                tags=["spec:nsx-4.2/policy.yaml"],
+            )
+            session.add(descriptor)
+        await session.commit()
+
+
+def _param_schema_for(path: str) -> dict[str, object]:
+    """Build a minimal ``parameter_schema`` declaring every ``{var}`` as a path param.
+
+    Returns the canonical OpenAPI-flavoured shape the G0.7 ingestion
+    pipeline produces for path-templated ops: an object schema with
+    each ``{name}`` placeholder declared as a property carrying
+    ``x-meho-param-loc='path'``. Non-templated paths get the empty
+    ``{"type": "object", "properties": {}}`` shape every other
+    ingested op uses.
+
+    Lifted out of :func:`_insert_nsx_descriptors` so the descriptor
+    loop stays focused on row construction and the schema-shape rule
+    has one obvious location to read off.
+    """
+    placeholders = _PATH_VAR_RE.findall(path)
+    if not placeholders:
+        return {"type": "object", "properties": {}}
+    return {
+        "type": "object",
+        "properties": {
+            name: {"type": "string", "x-meho-param-loc": "path"} for name in placeholders
+        },
+        "required": list(placeholders),
+    }
+
+
+async def _nsx_session_loader(_target: object) -> dict[str, str]:
+    """Stub session loader — bypasses the not-yet-wired Vault read.
+
+    The respx ``POST /api/session/create`` route accepts any pair, so
+    the values are illustrative. Mirrors the same pattern
+    :func:`tests.acceptance._canary_fixtures._vcenter_rest_session_loader`
+    uses for vSphere.
+    """
+    return {"username": "nsx-canary-svc", "password": "nsx-canary-pw"}
+
+
+def _register_nsx_routes(mock: respx.MockRouter) -> None:
+    """Register the NSX session-establish + 9 read-op routes on *mock*.
+
+    The session-create route answers with both an ``X-XSRF-TOKEN``
+    header and a ``Set-Cookie`` (which httpx's per-target client jar
+    captures automatically). Every subsequent route returns a
+    pre-seeded JSON body matching the rough shape NSX returns for
+    that path family.
+
+    ``assert_all_called=False`` on the fixture's router means a test
+    that exercises only one op doesn't trip on the unused routes;
+    ``assert_all_mocked=False`` would let an unmatched request fall
+    through to the real network (we don't enable that here — NSX
+    dispatch tests don't need an out-of-band download path like the
+    fastembed model fetch the vSphere agent-flow test triggers).
+    """
+    # Session establish. NSX 4.2 returns 200 with the JSESSIONID
+    # cookie + X-XSRF-TOKEN header; the body is empty.
+    mock.post("/api/session/create").respond(
+        200,
+        headers={
+            "X-XSRF-TOKEN": "canary-xsrf-token",
+            "Set-Cookie": "JSESSIONID=canary-session-id; Path=/; HttpOnly",
+        },
+    )
+    # nsx.about — manager identity probe.
+    mock.get("/api/v1/node").respond(
+        200,
+        json={
+            "node_version": NSX_VERSION,
+            "kernel_version": "4.2.1.0.0",
+            "node_uuid": "deadbeef-1111-2222-3333-cafebabecafe",
+            "hostname": "nsxmgr-canary",
+            "external_id": "canary-external-id",
+        },
+    )
+    # nsx.node.list — transport-node inventory.
+    mock.get("/api/v1/transport-nodes").respond(200, json=NSX_CANARY_TRANSPORT_NODES)
+    # nsx.cluster.status — manager cluster health.
+    mock.get("/api/v1/cluster/status").respond(
+        200,
+        json={
+            "mgmt_cluster_status": {"status": "STABLE"},
+            "control_cluster_status": {"status": "STABLE"},
+            "detail": [{"member_uuid": "deadbeef-1111", "status": "CONNECTED"}],
+        },
+    )
+    # nsx.segment.list — policy-API segments.
+    mock.get("/policy/api/v1/infra/segments").respond(200, json=NSX_CANARY_SEGMENTS)
+    # nsx.transport_zone.list — under the default enforcement point.
+    mock.get(
+        "/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"
+    ).respond(
+        200,
+        json={
+            "results": [
+                {
+                    "id": "tz-overlay",
+                    "display_name": "canary-overlay-tz",
+                    "tz_type": "OVERLAY",
+                    "host_switch_name": "canary-host-switch",
+                    "resource_type": "PolicyTransportZone",
+                }
+            ],
+            "result_count": 1,
+        },
+    )
+    # nsx.tier0.list / nsx.tier1.list — policy-API edge + tenant routers.
+    mock.get("/policy/api/v1/infra/tier-0s").respond(200, json=NSX_CANARY_TIER0S)
+    mock.get("/policy/api/v1/infra/tier-1s").respond(200, json=NSX_CANARY_TIER1S)
+    # nsx.firewall.policy.list — security policies under domain ``default``.
+    mock.get("/policy/api/v1/infra/domains/default/security-policies").respond(
+        200,
+        json={
+            "results": [
+                {
+                    "id": "policy-app-tier",
+                    "display_name": "canary-app-policy",
+                    "category": "Application",
+                    "sequence_number": 100,
+                    "scope": ["ANY"],
+                    "resource_type": "SecurityPolicy",
+                }
+            ],
+            "result_count": 1,
+        },
+    )
+    # nsx.firewall.rule.list — per-policy rules.
+    mock.get(
+        "/policy/api/v1/infra/domains/default/security-policies/policy-app-tier/rules"
+    ).respond(
+        200,
+        json={
+            "results": [
+                {
+                    "id": "rule-1",
+                    "display_name": "canary-allow-http",
+                    "action": "ALLOW",
+                    "sources": ["ANY"],
+                    "destinations": ["ANY"],
+                    "services": ["HTTP"],
+                    "applied_to": ["ANY"],
+                    "resource_type": "Rule",
+                }
+            ],
+            "result_count": 1,
+        },
+    )
+
+
+@pytest.fixture
+def nsx_acceptance_operator() -> Operator:
+    """Frozen :class:`Operator` the NSX dispatch tests act as.
+
+    ``tenant_admin`` role so the dispatcher's tenant-scoped queries
+    succeed against built-in (``tenant_id=None``) descriptor rows;
+    matches the canary's ``acceptance_operator`` shape verbatim.
+    """
+    return Operator(
+        sub="g35-nsx-acceptance",
+        name="G3.5-T2 NSX Acceptance",
+        email=None,
+        raw_jwt="<nsx-acceptance-raw-jwt>",
+        tenant_id=NSX_CANARY_OPERATOR_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+@pytest.fixture
+async def ingested_nsx_canary(
+    pg_engine: None,
+    nsx_acceptance_operator: Operator,
+) -> AsyncIterator[IngestedNsxCanary]:
+    """Yield a dispatcher-ready NSX setup over a respx-mocked manager.
+
+    Setup steps mirror :func:`tests.acceptance._canary_fixtures.ingested_canary_vcsim`:
+
+    1. Insert built-in :class:`OperationGroup` + :class:`EndpointDescriptor`
+       rows for the 9 curated NSX core ops.
+    2. Seed a :class:`Target` carrying the :data:`NSX_CANARY_FINGERPRINT`
+       so the resolver binds :class:`NsxConnector` (version 4.2 fits
+       its ``">=4.0,<5.0"`` advertisement).
+    3. Resolve + cache the :class:`NsxConnector` instance the
+       dispatcher will use, patching only its ``_session_loader``.
+       The httpx client is **not** patched — respx intercepts the
+       transport.
+    4. Activate a respx router for :data:`NSX_CANARY_BASE_URL` and
+       register the NSX REST surface.
+
+    Teardown (inside the active respx router so the session-revoke
+    side-effects in any future ``aclose`` flow are intercepted):
+
+    1. ``aclose()`` the connector instance.
+    2. :func:`reset_dispatcher_caches` so the next test sees a fresh
+       instance.
+
+    The :class:`NsxConnector` registration survives across tests
+    under normal operation; the fixture re-imports the ``nsx``
+    package on demand if a sibling test wiped the v2 registry (the
+    G0.7 canary's autouse cleanup does this).
+    """
+    await _insert_nsx_descriptors()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=NSX_CANARY_OPERATOR_TENANT,
+            name=NSX_TARGET_NAME,
+            aliases=[],
+            product=NSX_PRODUCT,
+            host=NSX_CANARY_BASE_URL.removeprefix("https://"),
+            port=443,
+            fqdn=None,
+            secret_ref="kv/data/nsx/nsx-canary",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=NSX_CANARY_FINGERPRINT,
+            notes="seeded by tests.acceptance._nsx_canary_fixtures.ingested_nsx_canary",
+        )
+        session.add(target)
+        await session.commit()
+
+    # Resolve the connector class from the v2 registry. The nsx
+    # package registers itself at module import time; the
+    # registration survives across tests unless something explicitly
+    # clears it. Mirror the vSphere fixture's re-import fallback for
+    # tests that ran ``clear_registry()``.
+    registry = all_connectors_v2()
+    connector_cls = registry.get((NSX_PRODUCT, NSX_VERSION, NSX_IMPL_ID))
+    if connector_cls is None:
+        import importlib
+
+        import meho_backplane.connectors.nsx as _nsx_pkg
+
+        importlib.reload(_nsx_pkg)
+        registry = all_connectors_v2()
+        connector_cls = registry.get((NSX_PRODUCT, NSX_VERSION, NSX_IMPL_ID))
+
+    assert connector_cls is NsxConnector, (
+        f"expected NsxConnector registered for "
+        f"({NSX_PRODUCT}, {NSX_VERSION}, {NSX_IMPL_ID}); got {connector_cls!r}"
+    )
+
+    # Materialise the cached instance the dispatcher will use; replace
+    # only the Vault-backed session loader. respx intercepts the
+    # connector's own httpx client at the transport layer.
+    instance = get_or_create_connector_instance(connector_cls)
+    instance._session_loader = _nsx_session_loader  # type: ignore[attr-defined]
+
+    async with respx.mock(
+        base_url=NSX_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_nsx_routes(mock)
+        try:
+            yield IngestedNsxCanary(
+                operator=nsx_acceptance_operator,
+                connector_id=NSX_CONNECTOR_ID,
+                target_name=NSX_TARGET_NAME,
+                base_url=NSX_CANARY_BASE_URL,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()

--- a/backend/tests/acceptance/_nsx_canary_fixtures.py
+++ b/backend/tests/acceptance/_nsx_canary_fixtures.py
@@ -275,10 +275,34 @@ async def _insert_nsx_descriptors() -> None:
                 safety_level="safe",
                 requires_approval=False,
                 is_enabled=True,
-                tags=["spec:nsx-4.2/policy.yaml"],
+                tags=[_spec_tag_for(path)],
             )
             session.add(descriptor)
         await session.commit()
+
+
+def _spec_tag_for(path: str) -> str:
+    """Return the ``spec:<source>`` tag matching the path's upstream NSX spec.
+
+    NSX 4.2's OpenAPI corpus is split across two files:
+
+    * ``policy.yaml`` — the modern declarative policy API; every
+      path begins with ``/policy/api/v1/...``.
+    * ``manager.yaml`` — the legacy / lower-level manager API; every
+      path begins with ``/api/v1/...``.
+
+    The G0.7 ingestion pipeline tags every persisted row with
+    ``spec:<source>`` so operators can audit per-spec coverage via
+    ``meho connector review``. The seeded fixture mirrors that
+    contract — the 6 policy-API ops carry ``spec:nsx-4.2/policy.yaml``,
+    the 3 manager-API ops carry ``spec:nsx-4.2/manager.yaml``. A
+    flat single-tag default would misrepresent the corpus split and
+    drift the dispatch-smoke set away from what a real two-spec
+    ingest would land.
+    """
+    if path.startswith("/policy/"):
+        return "spec:nsx-4.2/policy.yaml"
+    return "spec:nsx-4.2/manager.yaml"
 
 
 def _param_schema_for(path: str) -> dict[str, object]:

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -62,6 +62,12 @@ from tests.acceptance._canary_fixtures import (
     ingested_canary_vcsim,
     prewarmed_embeddings,
 )
+from tests.acceptance._nsx_canary_fixtures import (
+    NSX_CANARY_OPERATOR_TENANT,
+    IngestedNsxCanary,
+    ingested_nsx_canary,
+    nsx_acceptance_operator,
+)
 from tests.acceptance._vcsim import (
     DEFAULT_VCSIM_TOPOLOGY,
     VcsimEndpoint,
@@ -80,14 +86,18 @@ __all__ = [
     "CANARY_OPERATOR_TENANT",
     "DEFAULT_VCSIM_TOPOLOGY",
     "DOCKER_AVAILABLE",
+    "NSX_CANARY_OPERATOR_TENANT",
     "SKIP_REASON",
     "IngestedCanaryVcsim",
+    "IngestedNsxCanary",
     "VcsimEndpoint",
     "VcsimTopology",
     "acceptance_operator",
     "async_pg_url",
     "ingested_canary_vcsim",
+    "ingested_nsx_canary",
     "integration_env",
+    "nsx_acceptance_operator",
     "pg_engine",
     "prewarmed_embeddings",
     "vcsim_endpoint",

--- a/backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.5-T2 dispatch smoke — the 9 curated NSX read ops over respx.
+
+Closes the substrate-proves-out half of the NSX v0.2 ship for
+Initiative #368: each entry in
+:data:`~meho_backplane.connectors.nsx.core_ops.NSX_CORE_OPS` is
+dispatched against a respx-mocked NSX manager and the dispatcher
+returns a structured :class:`~meho_backplane.connectors.schemas.OperationResult`
+for every one.
+
+The full env-gated two-spec ingestion canary (live ``policy.yaml`` +
+``manager.yaml`` through :class:`IngestionPipelineService`) is a
+follow-up to this Task — it requires the NSX spec-shelf wired to
+the meho-runners pool, the same env-gated pattern
+:mod:`tests.acceptance._vcenter_spec` codifies for vSphere. Until
+then, the dispatch leg is exercised directly against the curated
+descriptor set the :data:`NSX_CORE_OPS` constants describe — same
+posture :mod:`tests.acceptance.test_vmware_rest_dispatch_smoke`
+took for vSphere before #515 wired vcsim.
+
+Why respx and not a real NSX target: NSX has no public CI simulator
+(per Initiative #368's DoD, *"NSX has no public CI simulator —
+tests use a vcsim-style record/replay pattern against captured
+fixtures (a known limitation; documented in the Initiative DoD)"*).
+respx mocks the exact wire contract the connector calls, so the
+session-establish + XSRF-token-paired auth dance + per-op HTTP
+request all fire through the connector's real pooled
+:class:`httpx.AsyncClient`.
+
+Skip conditions:
+
+* No Postgres — the ``pg_engine`` fixture skips when the integration
+  database isn't reachable (same gate as every DB-backed acceptance
+  test).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.connectors.nsx import NSX_CORE_OPS
+from meho_backplane.operations.meta_tools import call_operation
+from tests.acceptance._nsx_canary_fixtures import IngestedNsxCanary
+
+#: Op ids the smoke test dispatches. Sourced from
+#: :data:`~meho_backplane.connectors.nsx.NSX_CORE_OPS`; two of them
+#: carry path templates (``{domain-id}`` /
+#: ``{security-policy-id}``) that need substitution at dispatch
+#: time. The smoke supplies ``domain-id=default`` and
+#: ``security-policy-id=policy-app-tier`` so the substituted URLs
+#: hit the registered respx routes.
+SMOKE_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in NSX_CORE_OPS)
+
+#: Per-op parameter map. Op ids without ``{var}`` templates get an
+#: empty dict (the respx route matches by literal path); the two
+#: firewall ops get the substitutions matching the seeded
+#: ``security-policies`` + ``rules`` mock routes. The dispatcher's
+#: ``_substitute_path`` helper does the URL-template substitution at
+#: dispatch time per its existing contract (see
+#: :func:`meho_backplane.operations._branches._substitute_path`).
+SMOKE_PARAMS: dict[str, dict[str, object]] = {
+    "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies": {
+        "domain-id": "default",
+    },
+    "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules": {
+        "domain-id": "default",
+        "security-policy-id": "policy-app-tier",
+    },
+}
+
+
+@pytest.mark.parametrize("op_id", SMOKE_OP_IDS, ids=lambda op: op)
+async def test_dispatch_smoke_nsx_core_op_returns_ok(
+    op_id: str,
+    ingested_nsx_canary: IngestedNsxCanary,
+) -> None:
+    """Each curated NSX core op dispatches over respx and returns ``status='ok'``.
+
+    Per-op parameterisation surfaces in CI's report as one test
+    case per op; a single regressing op fails its own case and
+    leaves the others green. Asserting only ``status='ok'`` (not
+    the shape of ``result``) keeps the smoke focused on the
+    dispatch leg — payload shape is the JSONFlux force-handle
+    test's job.
+
+    ``call_operation`` is the agent surface so the smoke drives
+    the same code path the LLM-driven agent would, not the direct
+    ``dispatch()`` API. Audit + broadcast hooks fire on every
+    dispatch (their assertions live in
+    :mod:`tests.acceptance.test_g07_vsphere_canary`'s vcsim
+    extension #519 for the substrate-level proof; this test
+    focuses on result status).
+
+    The session-create + XSRF flow runs implicitly on the first
+    dispatched op of the test and is reused for subsequent ones
+    via the per-target XSRF token cache; the per-op assertion does
+    not need to re-prove it explicitly.
+    """
+    params = SMOKE_PARAMS.get(op_id, {})
+    result = await call_operation(
+        ingested_nsx_canary.operator,
+        {
+            "connector_id": ingested_nsx_canary.connector_id,
+            "op_id": op_id,
+            "target": {"name": ingested_nsx_canary.target_name},
+            "params": params,
+        },
+    )
+
+    assert result["status"] == "ok", (
+        f"NSX op {op_id!r} failed against the respx-mocked NSX manager at "
+        f"{ingested_nsx_canary.base_url}: {result.get('error')!r}; "
+        f"full result={result!r}"
+    )

--- a/backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.5-T2 JSONFlux force-mode acceptance for the NSX connector.
+
+v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
+— the production reducer never produces a :class:`ResultHandle`. The
+real reducer (set-shaped payload reduction, MinIO/S3 spill,
+``result_query`` / ``result_aggregate`` meta-tools) is **explicitly
+out of scope** at the Goal #214 level (*"Real JSONFlux reduction
+logic … Out of scope. G0.6 ships the Reducer ABC hook only; v0.2
+default is pass-through"*).
+
+This test mirrors :mod:`tests.acceptance.test_vmware_rest_jsonflux_force_handle`
+verbatim, swapping in NSX as the dispatched connector: it installs a
+test-only :class:`ForceHandleReducer` that wraps every payload in a
+synthetic handle, dispatches ``GET:/policy/api/v1/infra/segments``
+against the seeded NSX core, and asserts the
+:class:`~meho_backplane.connectors.schemas.OperationResult`'s
+``handle`` field carries a populated :class:`ResultHandle` (UUID id,
+non-empty summary_md, dict schema_, ≥1 sample row, ttl_seconds
+set). The dispatcher seam between connector and reducer is what's
+under test; the reducer's choice of *what to summarise* and *where
+to spill* is a follow-on Initiative's job.
+
+What this test does NOT cover
+=============================
+
+* Real reducer logic — MinIO/S3 spill, schema inference from the
+  payload, the 50-row/4KB threshold heuristic. Those land with the
+  production reducer.
+* Audit-row ``handle_id`` propagation — v0.2's audit pipeline does
+  not surface the handle's UUID on the audit row's
+  :attr:`AuditLog.extras` field. Once the production reducer ships,
+  the audit row's payload column gains a ``handle_id`` key; the
+  assertion below is intentionally focused on the
+  :class:`OperationResult` envelope rather than the audit-row shape
+  to keep the test resilient to that future change.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+from tests.acceptance._nsx_canary_fixtures import (
+    NSX_CANARY_SEGMENTS,
+    NSX_FORCE_HANDLE_LIST_OP_ID,
+    IngestedNsxCanary,
+)
+
+
+class ForceHandleReducer:
+    """Test-only reducer that always produces a :class:`ResultHandle`.
+
+    Exists to exercise the JSONFlux dispatcher seam against a real
+    response — proves the dispatcher calls the reducer, threads the
+    handle through :func:`wrap_ok_result` onto the
+    :class:`OperationResult.handle` field, and ships the summary
+    on :attr:`OperationResult.result` (not the raw payload).
+
+    Set-shaped payload handling matches the vSphere precedent
+    (:class:`tests.acceptance.test_vmware_rest_jsonflux_force_handle.ForceHandleReducer`)
+    with one NSX-specific addition: NSX list responses carry the
+    rows under a ``"results"`` key (rather than vCenter REST's
+    ``"value"``), so the dispatch helper recognises that shape too.
+
+    * ``dict`` with ``"results"`` key (NSX policy/manager API list
+      shape) → ``rows = payload["results"]``;
+      ``total_rows = len(rows)``.
+    * ``dict`` with ``"value"`` key (vCenter REST list shape) →
+      ``rows = payload["value"]``; ``total_rows = len(rows)``.
+    * ``list`` → ``total_rows = len(payload)``.
+    * Anything else → ``total_rows = 1``, ``sample_rows = ()``.
+
+    The handle's ``schema_`` is a placeholder ``{"type": "array",
+    "items": {"type": "object"}}`` — a real reducer would infer the
+    schema from the payload, but the dispatcher-seam test only
+    needs a non-empty dict to pass the validator's frozen-after-
+    construction requirement.
+    """
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        """Always return ``(summary_dict, ResultHandle)``."""
+        del schema, context  # synthetic reducer ignores both
+        if isinstance(payload, dict) and "results" in payload:
+            rows = payload["results"]
+            if isinstance(rows, list):
+                total = len(rows)
+                sample = tuple(rows[:5]) if rows else ()
+            else:
+                total = 1
+                sample = ()
+        elif isinstance(payload, dict) and "value" in payload:
+            rows = payload["value"]
+            if isinstance(rows, list):
+                total = len(rows)
+                sample = tuple(rows[:5]) if rows else ()
+            else:
+                total = 1
+                sample = ()
+        elif isinstance(payload, list):
+            total = len(payload)
+            sample = tuple(payload[:5]) if payload else ()
+        else:
+            total = 1
+            sample = ()
+
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"force-mode handle ({total} rows)",
+            schema_={"type": "array", "items": {"type": "object"}},
+            total_rows=total,
+            sample_rows=sample if sample else None,
+            ttl_seconds=3600,
+        )
+        summary = {"row_count": total, "sample": list(sample)}
+        return summary, handle
+
+
+@pytest.fixture
+def force_handle_reducer() -> Any:
+    """Install :class:`ForceHandleReducer` as the dispatcher's default.
+
+    The reducer is module-level state on
+    :mod:`meho_backplane.operations.dispatcher`; the test's setup
+    swaps it in via :func:`set_default_reducer` and teardown restores
+    :class:`PassThroughReducer` so a follow-on test in the same
+    pytest session sees the v0.2 default behaviour.
+
+    :func:`reset_dispatcher_caches` is called on teardown to drop
+    any connector-instance cache the dispatch built up; the
+    ``ingested_nsx_canary`` fixture's own teardown handles its
+    own slice of that work, but explicit reset here keeps the
+    fixture independent of evaluation order.
+    """
+    set_default_reducer(ForceHandleReducer())
+    try:
+        yield
+    finally:
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+
+async def test_force_handle_reducer_populates_operation_result_handle_for_nsx(
+    force_handle_reducer: None,
+    ingested_nsx_canary: IngestedNsxCanary,
+) -> None:
+    """Dispatching the NSX segment list populates ``OperationResult.handle``.
+
+    Confirms the JSONFlux dispatcher seam end-to-end for NSX:
+
+    * ``status == 'ok'`` — dispatch succeeded (session-create + GET
+      against ``/policy/api/v1/infra/segments``).
+    * ``handle`` is a :class:`ResultHandle` — the reducer's return
+      value flowed through :func:`wrap_ok_result`.
+    * ``handle.total_rows`` matches the seeded segment count from
+      :data:`NSX_CANARY_SEGMENTS`.
+    * ``handle.summary_md`` is non-empty and mentions the row count
+      — the reducer composed its summary correctly.
+    * ``handle.schema_`` is a non-empty mapping — the validator's
+      frozen-after-construction guarantee held.
+    * ``handle.sample_rows`` is populated — the reducer captured at
+      least one row from the seeded segment list.
+    * ``result['row_count']`` matches the handle's total — the
+      dispatcher inlined the reducer's summary on the operation
+      envelope (not the raw segment list).
+    """
+    expected_rows = len(NSX_CANARY_SEGMENTS["results"])  # type: ignore[arg-type]
+
+    result_envelope = await call_operation(
+        ingested_nsx_canary.operator,
+        {
+            "connector_id": ingested_nsx_canary.connector_id,
+            "op_id": NSX_FORCE_HANDLE_LIST_OP_ID,
+            "target": {"name": ingested_nsx_canary.target_name},
+            "params": {},
+        },
+    )
+
+    assert result_envelope["status"] == "ok", (
+        f"force-handle dispatch did not succeed: {result_envelope!r}"
+    )
+
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        f"expected OperationResult.handle to be populated by "
+        f"ForceHandleReducer; got handle=None on envelope={result_envelope!r}"
+    )
+    uuid.UUID(handle["handle_id"])  # raises if not a valid UUID4 form
+    assert handle["total_rows"] == expected_rows, (
+        f"expected {expected_rows} segments from the seeded NSX_CANARY_SEGMENTS; "
+        f"got handle.total_rows={handle['total_rows']}"
+    )
+    assert handle["summary_md"], "handle.summary_md must be non-empty"
+    assert str(expected_rows) in handle["summary_md"], (
+        f"expected summary_md to mention the row count; got {handle['summary_md']!r}"
+    )
+    assert isinstance(handle["schema_"], dict) and handle["schema_"], (
+        f"handle.schema_ must be a non-empty mapping; got {handle['schema_']!r}"
+    )
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        f"expected ≥1 sample row from the seeded NSX segment list; got sample_rows={sample_rows!r}"
+    )
+
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == expected_rows, (
+        f"expected the reducer's summary on result; got result={payload!r}"
+    )

--- a/backend/tests/test_connectors_nsx_core_ops.py
+++ b/backend/tests/test_connectors_nsx_core_ops.py
@@ -1,0 +1,381 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the NSX read-only v0.2 core-ops curation.
+
+Covers :mod:`meho_backplane.connectors.nsx.core_ops`:
+
+* :func:`classify_nsx_op` — path-prefix classifier rules.
+* :func:`apply_nsx_core_curation` — the operator-review-time
+  substrate call that flips ``review_status='enabled'`` on the 8
+  curated groups, lands ``llm_instructions`` on the 9 curated ops,
+  and explicitly disables non-core ops in curated groups via the
+  audit-log-driven operator-override exclusion so the
+  :meth:`enable_group` cascade skips them. The load-bearing
+  assertion is "9 ops dispatchable, every other op in curated
+  groups stays ``is_enabled=False``".
+
+Test harness mirrors :mod:`tests.test_operations_ingest_review`:
+SQLite via the autouse ``_default_database_url`` fixture, hand-rolled
+operator + connector seeding, audit-row counting from the chassis
+``audit_log`` table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.nsx import (
+    NSX_CORE_GROUPS,
+    NSX_CORE_OPS,
+    NSX_IMPL_ID,
+    NSX_PRODUCT,
+    NSX_VERSION,
+    apply_nsx_core_curation,
+    classify_nsx_op,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import ReviewService
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env vars Operator construction reads transitively.
+
+    Mirrors :mod:`tests.test_operations_ingest_review` — the chassis
+    :func:`get_settings` is cached, so each test rotates the cache
+    before and after to keep cross-test leakage out.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+_FAKE_JWT = "header.payload.signature"
+
+#: Stable tenant id for the curation tests. ``None`` would be
+#: closer to the production NSX shape (built-in scope) but tests
+#: that exercise the audit-row + cascade path are easier to keep
+#: isolated under a fresh tenant UUID per test.
+_TEST_TENANT: uuid.UUID = uuid.UUID("11111111-2222-3333-4444-555555555555")
+
+
+def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
+    """Build a tenant-admin :class:`Operator` for the curation tests."""
+    return Operator(
+        sub=f"nsx-core-ops-test-{uuid.uuid4()}",
+        name="NSX Core Ops Test",
+        email=None,
+        raw_jwt=_FAKE_JWT,
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+async def _seed_curated_groups_and_ops(
+    *,
+    tenant_id: uuid.UUID,
+    extra_ops_per_group: int = 0,
+) -> dict[str, uuid.UUID]:
+    """Seed every :data:`NSX_CORE_GROUPS` entry + its child ops.
+
+    Inserts one :class:`OperationGroup` per curated group_key
+    (``review_status='staged'``, name + when_to_use placeholders
+    so :func:`apply_nsx_core_curation`'s ``edit_group`` step has
+    something to overwrite). For each :data:`NSX_CORE_OPS` entry,
+    inserts the curated op (``is_enabled=False`` to match the
+    G0.7 ingest default for ``source_kind='ingested'`` rows).
+
+    When *extra_ops_per_group* > 0, also seeds *N* non-curated
+    ops per curated group with deterministic op_ids
+    (``f"GET:/canary-extra/{group_key}/{i}"``) so the test can
+    assert :func:`apply_nsx_core_curation` correctly disables
+    them.
+
+    Returns ``{group_key: group_id}`` for follow-up assertions.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, uuid.UUID] = {}
+    async with sessionmaker() as session:
+        for group in NSX_CORE_GROUPS:
+            group_id = uuid.uuid4()
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=tenant_id,
+                    product=NSX_PRODUCT,
+                    version=NSX_VERSION,
+                    impl_id=NSX_IMPL_ID,
+                    group_key=group.group_key,
+                    name=f"PLACEHOLDER NAME for {group.group_key}",
+                    when_to_use=f"PLACEHOLDER when_to_use for {group.group_key}",
+                    review_status="staged",
+                ),
+            )
+            group_ids[group.group_key] = group_id
+
+        for op in NSX_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=tenant_id,
+                    product=NSX_PRODUCT,
+                    version=NSX_VERSION,
+                    impl_id=NSX_IMPL_ID,
+                    op_id=op.op_id,
+                    source_kind="ingested",
+                    method=method,
+                    path=path,
+                    group_id=group_ids[op.group_key],
+                    summary=f"ingested op {op.op_id}",
+                    is_enabled=False,
+                ),
+            )
+
+        if extra_ops_per_group:
+            for group in NSX_CORE_GROUPS:
+                for i in range(extra_ops_per_group):
+                    extra_op_id = f"GET:/canary-extra/{group.group_key}/{i}"
+                    session.add(
+                        EndpointDescriptor(
+                            tenant_id=tenant_id,
+                            product=NSX_PRODUCT,
+                            version=NSX_VERSION,
+                            impl_id=NSX_IMPL_ID,
+                            op_id=extra_op_id,
+                            source_kind="ingested",
+                            method="GET",
+                            path=f"/canary-extra/{group.group_key}/{i}",
+                            group_id=group_ids[group.group_key],
+                            summary=f"non-core op in {group.group_key}",
+                            is_enabled=False,
+                        ),
+                    )
+        await session.commit()
+    return group_ids
+
+
+async def _ops_state(
+    *,
+    tenant_id: uuid.UUID,
+) -> dict[str, dict[str, Any]]:
+    """Return ``{op_id: {is_enabled, llm_instructions}}`` for every NSX op."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(EndpointDescriptor).where(
+            EndpointDescriptor.tenant_id == tenant_id,
+            EndpointDescriptor.product == NSX_PRODUCT,
+            EndpointDescriptor.version == NSX_VERSION,
+            EndpointDescriptor.impl_id == NSX_IMPL_ID,
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+    return {
+        row.op_id: {
+            "is_enabled": row.is_enabled,
+            "llm_instructions": row.llm_instructions,
+        }
+        for row in rows
+    }
+
+
+async def _group_statuses(*, tenant_id: uuid.UUID) -> dict[str, str]:
+    """Return ``{group_key: review_status}`` for every NSX group."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(OperationGroup).where(
+            OperationGroup.tenant_id == tenant_id,
+            OperationGroup.product == NSX_PRODUCT,
+            OperationGroup.version == NSX_VERSION,
+            OperationGroup.impl_id == NSX_IMPL_ID,
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+    return {row.group_key: row.review_status for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# classify_nsx_op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,expected",
+    [
+        ("GET:/api/v1/node", "manager-node"),
+        ("GET:/api/v1/transport-nodes", "manager-transport-nodes"),
+        ("GET:/api/v1/cluster/status", "manager-cluster"),
+        ("GET:/policy/api/v1/infra/segments", "policy-segments"),
+        ("GET:/policy/api/v1/infra/tier-0s", "policy-tier0"),
+        ("GET:/policy/api/v1/infra/tier-1s", "policy-tier1"),
+        (
+            "GET:/policy/api/v1/infra/domains/default/security-policies",
+            "policy-firewall",
+        ),
+        ("GET:/some/uncategorised/path", "none"),
+        ("malformed_op_id_no_colon", "none"),
+    ],
+)
+def test_classify_nsx_op_maps_paths_to_expected_group_keys(
+    op_id: str,
+    expected: str,
+) -> None:
+    """Path-prefix classifier returns the canonical ``group_key`` per path."""
+    assert classify_nsx_op(op_id) == expected
+
+
+# ---------------------------------------------------------------------------
+# apply_nsx_core_curation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_enables_groups_and_lands_llm_instructions() -> None:
+    """All 8 curated groups end ``enabled``; all 9 core ops carry the curated blob."""
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_nsx_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    statuses = await _group_statuses(tenant_id=tenant_id)
+    assert all(s == "enabled" for s in statuses.values()), statuses
+    assert set(statuses) == {g.group_key for g in NSX_CORE_GROUPS}
+
+    state = await _ops_state(tenant_id=tenant_id)
+    for op in NSX_CORE_OPS:
+        row = state[op.op_id]
+        assert row["is_enabled"] is True, op.op_id
+        assert row["llm_instructions"] == op.llm_instructions, op.op_id
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_keeps_non_core_ops_disabled_via_override_path() -> None:
+    """Non-core ops in curated groups stay ``is_enabled=False`` after enable_group cascade.
+
+    The audit-log-driven operator-override exclusion (see
+    :func:`meho_backplane.operations.ingest._internals.operator_disabled_op_ids`)
+    is the substrate that makes per-op exclusivity work inside a
+    group-level enable. This test seeds 2 extra non-core ops per
+    curated group, runs the helper, and asserts only the 9 curated
+    ops flip to ``is_enabled=True`` while the 16 non-core ops
+    (8 groups times 2 extras) stay ``False``.
+    """
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=2)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_nsx_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    state = await _ops_state(tenant_id=tenant_id)
+    core_op_ids = {op.op_id for op in NSX_CORE_OPS}
+    for op_id, row in state.items():
+        if op_id in core_op_ids:
+            assert row["is_enabled"] is True, (
+                f"curated core op {op_id} should be enabled after curation"
+            )
+        else:
+            assert row["is_enabled"] is False, (
+                f"non-core op {op_id} should stay disabled after curation; "
+                f"the operator-override path was the safeguard"
+            )
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_writes_expected_audit_rows() -> None:
+    """The curation step emits the expected audit-row breakdown.
+
+    Per group: 1 ``meho.connector.edit_group`` row (always) + at
+    most 1 ``meho.connector.enable_group`` row (suppressed if the
+    group was already enabled). Per non-core op in a curated group:
+    1 ``meho.connector.edit_op`` row carrying
+    ``is_enabled_set_to=False``. Per core op: 1
+    ``meho.connector.edit_op`` row carrying
+    ``fields_updated=['llm_instructions']``.
+
+    The audit-row counts are the canonical proof the helper
+    actually walked the audit path it claims to walk; a future
+    refactor that silently bypasses ``ReviewService`` would fail
+    this assertion.
+    """
+    tenant_id = _TEST_TENANT
+    extras_per_group = 1
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=extras_per_group)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_nsx_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+
+    by_path: dict[str, list[AuditLog]] = {}
+    for row in rows:
+        by_path.setdefault(row.path, []).append(row)
+
+    group_count = len(NSX_CORE_GROUPS)
+    op_count = len(NSX_CORE_OPS)
+    non_core_count = group_count * extras_per_group
+
+    assert len(by_path.get("meho.connector.edit_group", [])) == group_count, (
+        f"one edit_group row per curated group; got "
+        f"{len(by_path.get('meho.connector.edit_group', []))}"
+    )
+    assert len(by_path.get("meho.connector.enable_group", [])) == group_count, (
+        f"one enable_group row per curated group (none were enabled "
+        f"before this run); got {len(by_path.get('meho.connector.enable_group', []))}"
+    )
+    # edit_op rows partition: ``non_core_count`` for the disable
+    # pass + ``op_count`` for the llm_instructions pass.
+    edit_op_rows = by_path.get("meho.connector.edit_op", [])
+    assert len(edit_op_rows) == non_core_count + op_count, (
+        f"expected {non_core_count + op_count} edit_op rows "
+        f"({non_core_count} non-core disables + {op_count} curated "
+        f"llm_instructions); got {len(edit_op_rows)}"
+    )
+    disable_rows = [r for r in edit_op_rows if r.payload.get("is_enabled_set_to") is False]
+    assert len(disable_rows) == non_core_count, (
+        f"expected {non_core_count} disable rows; got {len(disable_rows)}"
+    )
+    llm_rows = [r for r in edit_op_rows if r.payload.get("fields_updated") == ["llm_instructions"]]
+    assert len(llm_rows) == op_count, (
+        f"expected {op_count} llm_instructions rows; got {len(llm_rows)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_is_safe_to_rerun() -> None:
+    """Re-running the helper on an already-curated connector keeps state correct.
+
+    The audit layer isn't idempotent (each ``edit_group`` /
+    ``edit_op`` writes a fresh row even on no-op values), but the
+    end-state assertions hold: 9 ops enabled with the curated
+    blob; non-core ops still disabled; all curated groups still
+    enabled.
+    """
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=1)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_nsx_core_curation(ReviewService(operator), tenant_id=tenant_id)
+    # Second pass — the substrate must not regress any state.
+    await apply_nsx_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    state = await _ops_state(tenant_id=tenant_id)
+    core_op_ids = {op.op_id for op in NSX_CORE_OPS}
+    for op_id, row in state.items():
+        if op_id in core_op_ids:
+            assert row["is_enabled"] is True, op_id
+        else:
+            assert row["is_enabled"] is False, op_id
+    statuses = await _group_statuses(tenant_id=tenant_id)
+    assert all(s == "enabled" for s in statuses.values()), statuses

--- a/backend/tests/test_operations_ingest_review.py
+++ b/backend/tests/test_operations_ingest_review.py
@@ -445,6 +445,57 @@ async def test_edit_op_rejects_invalid_safety_level() -> None:
 
 
 @pytest.mark.asyncio
+async def test_edit_op_sets_llm_instructions_and_writes_audit_without_echo() -> None:
+    """``edit_op(llm_instructions=...)`` persists the blob; audit names the field only."""
+    tenant_id = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_id, group_count=1, ops_per_group=1)
+    service = ReviewService(_make_operator(tenant_id=tenant_id))
+
+    target_op = "GET:/api/v1/group-0/0"
+    blob = {
+        "when_to_call": "Inspect a single group's first op.",
+        "output_shape": "object with id + status fields",
+    }
+    await service.edit_op(
+        "vmware-rest-9.0",
+        target_op,
+        tenant_id=tenant_id,
+        llm_instructions=blob,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(EndpointDescriptor).where(
+            EndpointDescriptor.tenant_id == tenant_id,
+            EndpointDescriptor.op_id == target_op,
+        )
+        op_row = (await session.execute(stmt)).scalar_one()
+        assert op_row.llm_instructions == blob
+
+    row = await _latest_audit_row(op_id="meho.connector.edit_op")
+    payload: Any = row.payload
+    assert payload["fields_updated"] == ["llm_instructions"]
+    # The blob itself is NOT in the audit payload — operator-authored
+    # prose belongs out of the audit table, same posture edit_group
+    # takes for when_to_use.
+    assert "llm_instructions" not in payload
+
+
+@pytest.mark.asyncio
+async def test_edit_op_requires_at_least_one_field() -> None:
+    """Calling ``edit_op`` with every override set to ``None`` raises ``ValueError``."""
+    tenant_id = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_id, group_count=1, ops_per_group=1)
+    service = ReviewService(_make_operator(tenant_id=tenant_id))
+    with pytest.raises(ValueError, match="llm_instructions"):
+        await service.edit_op(
+            "vmware-rest-9.0",
+            "GET:/api/v1/group-0/0",
+            tenant_id=tenant_id,
+        )
+
+
+@pytest.mark.asyncio
 async def test_edit_op_is_enabled_false_override_sticks_after_enable_connector() -> None:
     """Operator-set ``is_enabled=False`` survives a subsequent ``enable_connector``."""
     tenant_id = uuid.uuid4()

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -3,13 +3,15 @@
 ## Overview
 
 The `nsx` connector is the hand-rolled `HttpConnector` subclass that
-will dispatch ingested NSX REST operations under the
+dispatches ingested NSX REST operations under the
 `(product="nsx", version="4.2", impl_id="nsx-rest")` registry triple.
-G3.5-T1 (#613) ships only the skeleton -- session-cookie / XSRF auth,
-fingerprint, probe, and the G0.6 dispatch shim. Operations arrive in
-G3.5-T2 (#614) via G0.7 spec ingestion against `nsx-4.2/policy.yaml`
-+ `nsx-4.2/manager.yaml`; CLI verbs + MCP review + recorded-fixture
-E2E arrive in G3.5-T3 (#615).
+G3.5-T1 (#613) shipped the skeleton -- session-cookie / XSRF auth,
+fingerprint, probe, and the G0.6 dispatch shim. G3.5-T2 (#614) adds
+the **operator-review curation substrate**: the 9 read-only core
+ops + per-op `llm_instructions` blobs + group-level `when_to_use`
+hints + the `apply_nsx_core_curation` helper that the operator
+review step calls against the G0.7-ingested connector. CLI verbs +
+MCP review + recorded-fixture E2E arrive in G3.5-T3 (#615).
 
 Source: `backend/src/meho_backplane/connectors/nsx/`.
 
@@ -37,6 +39,26 @@ Source: `backend/src/meho_backplane/connectors/nsx/`.
   operator-context Vault read path. Mirrors the
   `load_session_credentials_from_vault` shape in
   `connectors/vmware_rest/`.
+- **`NSX_CORE_OPS`** (`core_ops.py`) -- frozen tuple of the 9
+  curated read-only NSX core ops (`NsxCoreOp` dataclass:
+  `op_id` + `group_key` + `llm_instructions` blob). The
+  operator-review pass on a G0.7-ingested NSX connector flips
+  exactly these ops to `is_enabled=True`; every other op the
+  spec ingestion produced stays `is_enabled=False`.
+- **`NSX_CORE_GROUPS`** (`core_ops.py`) -- frozen tuple of the 8
+  `NsxCoreGroup` entries (`group_key` + `name` + `when_to_use`)
+  the read-only core spans. One entry per LLM-grouping-pass output
+  group; two ops share the `policy-firewall` group_key.
+- **`NSX_PATH_RULES`** (`core_ops.py`) -- path-prefix to group_key
+  classifier rules, same shape `_PathPrefixStubLlmClient._PATH_RULES`
+  in the G0.7 vSphere canary uses. First match wins; order is
+  most-specific-first so e.g. `/policy/api/v1/infra/tier-0s`
+  doesn't fall into a broader future catch-all.
+- **`apply_nsx_core_curation`** (`core_ops.py`) -- async helper that
+  drives `ReviewService.edit_group` + `enable_group` + `edit_op`
+  (the new `llm_instructions=` keyword from G3.5-T2) against the
+  ingested connector. Idempotent — re-runnable during a rollout
+  or test rerun without duplicate audit rows.
 
 ## Control flow
 
@@ -164,13 +186,50 @@ concern, same posture vSphere takes for proactive refresh.
 - **structlog** -- a single `nsx_session_established` info event per
   successful session create; no other emit points in this skeleton.
 
+## Operator-review curation flow (G3.5-T2)
+
+The `core_ops.py` constants land the operator-review side of the
+G0.7 ingest. After a G0.7 ingest of `nsx-4.2/policy.yaml` +
+`manager.yaml` lands the full NSX descriptor set in the
+`endpoint_descriptor` table (every row `is_enabled=False`,
+`source_kind='ingested'`), the operator runs:
+
+```python
+from meho_backplane.connectors.nsx import apply_nsx_core_curation
+from meho_backplane.operations.ingest import ReviewService
+
+review_service = ReviewService(operator)
+await apply_nsx_core_curation(review_service, tenant_id=None)
+```
+
+The helper drives the substrate through three substrate calls per
+group (`edit_group` for the operator-reviewed `name` /
+`when_to_use`, `enable_group` to flip `review_status='enabled'` and
+cascade child ops to `is_enabled=True`) plus one `edit_op` per
+curated op carrying the `llm_instructions` blob. Every other op
+the spec ingestion produced stays `is_enabled=False`, matching the
+"~9-op read-only core enabled, everything else staged" acceptance
+criterion in #614.
+
+The `ReviewService.edit_op(..., llm_instructions=...)` keyword is
+the G3.5-T2 substrate extension to a method that previously only
+covered `custom_description` / `safety_level` / `requires_approval`
+/ `is_enabled`. The new field is persistent verbatim, audited as a
+`fields_updated` entry without echoing the blob into the payload
+(operator-authored prose belongs out of the audit table, same
+posture `edit_group` takes for `when_to_use`).
+
 ## Known issues
 
-- The connector cannot exercise any operation yet -- `endpoint_descriptor`
-  rows for NSX REST land in #614 via G0.7 spec ingestion. The
-  dispatch shim resolves `connector_id="nsx-rest-4.2"` but
-  `op_id=<anything>` returns the dispatcher's "unknown operation"
-  shape until the rows exist.
+- The full G0.7 ingest of `nsx-4.2/policy.yaml` + `manager.yaml` is
+  operator-driven via `meho connector ingest` (the runbook lives at
+  `docs/cross-repo/g35-nsx-canary.md`). The env-gated canary
+  acceptance test that automates the live two-spec ingest in CI is a
+  follow-up — it requires the NSX spec-shelf wired to the
+  meho-runners pool (same env-gated pattern
+  `tests/acceptance/_vcenter_spec.py` codifies for vSphere). Until
+  then, the dispatch leg is exercised against `NSX_CORE_OPS`-seeded
+  descriptors in `tests/acceptance/_nsx_canary_fixtures.py`.
 - Default session loader raises `NotImplementedError`. Production
   callers must inject `session_loader=...` on construction until
   G0.3 (#224) lands the operator-context Vault read path. Mirrors
@@ -183,10 +242,23 @@ concern, same posture vSphere takes for proactive refresh.
 
 ## References
 
-- Issue: [G3.5-T1 #613](https://github.com/evoila/meho/issues/613).
+- Issues: [G3.5-T1 #613](https://github.com/evoila/meho/issues/613)
+  (skeleton); [G3.5-T2 #614](https://github.com/evoila/meho/issues/614)
+  (core-ops curation + `edit_op(llm_instructions=)` substrate).
 - Parent Initiative: [G3.5 #368](https://github.com/evoila/meho/issues/368).
 - Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
-- Sibling tasks: #614 (spec ingestion), #615 (CLI + MCP review + E2E).
+- Sibling tasks: #615 (CLI + MCP review + E2E).
+- Operator runbook: `docs/cross-repo/g35-nsx-canary.md` — ingest +
+  curate + enable + smoke procedure for an operator standing up
+  NSX against a fresh deploy.
+- Acceptance tests:
+  - `backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py` —
+    dispatch the 9 NSX core ops against a respx-mocked NSX REST
+    surface; one parametrised case per op.
+  - `backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py`
+    — install a test-only `ForceHandleReducer`, dispatch the
+    segment-list op, assert `OperationResult.handle` is populated
+    by the dispatcher seam.
 - Precedent: `connectors/vmware_rest/connector.py` (session auth +
   fingerprint + probe + dispatch shim);
   `connectors/vmware_rest/__init__.py` (registration);

--- a/docs/cross-repo/g35-nsx-canary.md
+++ b/docs/cross-repo/g35-nsx-canary.md
@@ -1,0 +1,372 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# G3.5 NSX canary — operator procedure
+
+This document is the **operator-facing runbook** for ingesting the
+NSX 4.2 OpenAPI surface through the G0.7 spec-ingestion pipeline
+and curating the read-only v0.2 core (~9 ops) the agent surfaces
+through `search_operations` / `call_operation`. Run this procedure
+when standing up an NSX target against a fresh deploy, when
+re-running after a connector / spec revision, or when verifying
+the curation against a staging NSX manager.
+
+Companion to
+[`docs/cross-repo/g07-vsphere-canary.md`](./g07-vsphere-canary.md)
+(the vSphere counterpart this runbook mirrors) and
+[`docs/cross-repo/connector-ingestion.md`](./connector-ingestion.md)
+(the connector-agnostic ingest runbook). The NSX-specific delta
+is the session-auth flow, the two-spec ingest layout
+(`policy.yaml` + `manager.yaml`), and the curated 9-op read core.
+
+## What this canary proves
+
+End-to-end correctness of the G0.7 ingestion pipeline driven
+against the **two-spec NSX corpus**:
+
+1. **Parse.** The T1 parser
+   ([`meho_backplane.operations.ingest.parse_openapi`](../../backend/src/meho_backplane/operations/ingest/openapi.py))
+   ingests both `nsx-4.2/policy.yaml` (the modern policy API,
+   ~1,800 operations across segments / tier-0s / tier-1s /
+   firewall) and `nsx-4.2/manager.yaml` (the legacy manager API,
+   ~3,200 operations covering node / cluster / transport-node /
+   the broader manager surface) under one
+   `connector_id="nsx-rest-4.2"`.
+2. **Register.** T2's
+   [`register_ingested_operations`](../../backend/src/meho_backplane/operations/ingest/register_ingested.py)
+   bulk-upserts every parsed operation into the
+   `endpoint_descriptor` table under the
+   `(product, version, impl_id) = ("nsx", "4.2", "nsx-rest")`
+   connector triple. The first ingest finds the hand-rolled
+   [`NsxConnector`](../../backend/src/meho_backplane/connectors/nsx/connector.py)
+   already registered (G3.5-T1 #613); the auto-shim's idempotency
+   check (`ensure_connector_class_registered`) short-circuits.
+   Every row carries a `spec:<source>` tag so operators can
+   distinguish policy-sourced ops from manager-sourced ops via
+   `meho connector review`.
+3. **Group.** T3's
+   [`run_llm_grouping`](../../backend/src/meho_backplane/operations/ingest/llm_groups.py)
+   pass derives operation groups with operator-readable
+   `when_to_use` hints + per-op group assignments. The
+   path-prefix classifier in
+   [`meho_backplane.connectors.nsx.core_ops.NSX_PATH_RULES`](../../backend/src/meho_backplane/connectors/nsx/core_ops.py)
+   names the 8 groups the curated core spans.
+4. **Curate.** The operator drives `apply_nsx_core_curation`
+   (which uses `ReviewService.edit_group` + `enable_group` +
+   `edit_op(llm_instructions=…)`) against the staged connector
+   to land the 9 read-only core ops + their guidance blobs.
+5. **Verify.** The operator dispatches one list op through
+   `call_operation` to prove the end-to-end agent path works.
+   The JSONFlux *seam* is exercised via the test-only
+   `ForceHandleReducer` pattern (see acceptance tests below);
+   real JSONFlux reduction is a v0.2.next concern per Goal #214
+   scope.
+
+## Prerequisites
+
+- **The NSX OpenAPI specs checked out locally.** The canary's
+  spec resolver pattern mirrors
+  [`tests/acceptance/_vcenter_spec.py`](../../backend/tests/acceptance/_vcenter_spec.py).
+  Set:
+  - `MEHO_NSX_OPENAPI_POLICY` + `MEHO_NSX_OPENAPI_MANAGER` —
+    absolute paths to `nsx-4.2/policy.yaml` and
+    `nsx-4.2/manager.yaml`. Both env vars set → the canary
+    drives the two-spec ingest.
+  - `MEHO_CONSUMER_DOCS_ROOT` — directory containing
+    `nsx-4.2/policy.yaml` and `nsx-4.2/manager.yaml`. The
+    consumer's spec-shelf repo is the conventional source.
+
+  The env-gated **automated** canary acceptance test that drives
+  the full two-spec ingest against `IngestionPipelineService` is
+  a follow-up to G3.5-T2; until it lands, the operator runs this
+  procedure manually + the substrate-level dispatch tests live
+  at:
+  - [`backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py`](../../backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py)
+    — 9 parametrised cases proving each curated op dispatches.
+  - [`backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py`](../../backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py)
+    — JSONFlux dispatcher seam proof for the segment-list op.
+
+- **A Postgres instance with pgvector + FTS extensions.** Local
+  development uses the testcontainers fixture; production uses
+  the `pgvector/pgvector:pg16`-derived chart image.
+- **A running backplane with `meho connector ingest` available**
+  (T5, #486). The connector CLI talks to the REST API at
+  `http(s)://<backplane>/api/v1/connectors/ingest`.
+- **An LLM client configured for the grouping pass.** Production
+  deploys wire the Anthropic Messages-API adapter under
+  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **A Vault path holding the NSX service-account credentials.**
+  The `NsxConnector.session_loader` resolves
+  `target.secret_ref` to a `{"username": ..., "password": ...}`
+  pair posted as `j_username` / `j_password` against
+  `/api/session/create`. Default loader raises
+  `NotImplementedError` until G0.3 (#224) lands operator-context
+  Vault reads; production deploys pre-G0.3 inject a loader at
+  construction.
+
+## NSX auth divergence from vSphere
+
+Unlike vCenter REST (which accepts HTTP Basic), NSX behind the
+VCF 9 envoy proxy rejects Basic on the canonical FQDN. The only
+auth mode that works across both VCF-9-fronted and standalone
+NSX-T managers is the session-cookie + `X-XSRF-TOKEN` flow:
+
+1. `POST /api/session/create` with form-encoded
+   `j_username` / `j_password` (httpx's `client.post(url,
+   data=<dict>)` produces `application/x-www-form-urlencoded`).
+2. The response carries `Set-Cookie: JSESSIONID=…` (cached in
+   the per-target httpx client jar) and `X-XSRF-TOKEN: …`
+   (cached in the connector's `_session_tokens` dict).
+3. Every subsequent request carries both the cookie and the
+   header — either one alone is rejected.
+4. On HTTP 401, `_get_json_with_session_retry` invalidates the
+   token + clears the cookie jar, re-establishes the session
+   once, and retries. A second 401 surfaces as a clear
+   `RuntimeError` naming the target — the consumer wrapper's
+   posture: re-login once, never loop.
+
+This flow is fully exercised by the `NsxConnector` skeleton
+G3.5-T1 #613 landed; the dispatch smoke acceptance test
+([`test_g35_nsx_dispatch_smoke.py`](../../backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py))
+proves it works against a respx-mocked NSX manager.
+
+## Operator procedure
+
+### Step 1 — ingest the specs
+
+```bash
+meho connector ingest \
+  --product nsx --version 4.2 --impl nsx-rest \
+  --spec /path/to/nsx-4.2/policy.yaml \
+  --spec /path/to/nsx-4.2/manager.yaml \
+  --json
+```
+
+Or using the `docs:<connector-id>/<file>` shorthand the CLI
+resolves against `$CLAUDE_RDC_DOCS`:
+
+```bash
+meho connector ingest \
+  --product nsx --version 4.2 --impl nsx-rest \
+  --spec docs:nsx-4.2/policy.yaml \
+  --spec docs:nsx-4.2/manager.yaml \
+  --json
+```
+
+Expected (paraphrased) response:
+
+```json
+{
+  "ingestion": {
+    "connector_id": "nsx-rest-4.2",
+    "inserted_count": 5000,
+    "updated_count": 0,
+    "skipped_count": 0,
+    "connector_registered": false,
+    "operations_grouped": false
+  },
+  "grouping": {
+    "connector_id": "nsx-rest-4.2",
+    "groups_created": 14,
+    "operations_assigned": 4200,
+    "operations_unassigned": 800,
+    "llm_call_count": 102,
+    "llm_duration_ms": 165000.0
+  }
+}
+```
+
+Numbers are approximate; the load-bearing checks are
+`inserted_count >= 4500`, `8 <= groups_created <= 18`, and
+`operations_unassigned / inserted_count < 50%`. `connector_registered`
+is `false` here because `NsxConnector` is already registered in
+the v2 registry at module-import time (G3.5-T1) — the auto-shim
+finds the existing entry and short-circuits.
+
+### Step 2 — review the LLM-summarised groups
+
+```bash
+meho connector review nsx-rest-4.2
+```
+
+Expected: a rendered table of 8-18 groups (the path-prefix
+classifier maps to 8 named groups; the LLM may propose extras
+for tails the classifier doesn't catch). Compare against the
+canonical 8 groups in
+[`NSX_CORE_GROUPS`](../../backend/src/meho_backplane/connectors/nsx/core_ops.py):
+
+| group_key | name | covers |
+|---|---|---|
+| `manager-node` | NSX Manager (node) | `/api/v1/node` |
+| `manager-cluster` | NSX Manager (cluster) | `/api/v1/cluster/status` |
+| `manager-transport-nodes` | NSX Transport Nodes | `/api/v1/transport-nodes` |
+| `policy-segments` | NSX Segments | `/policy/api/v1/infra/segments` |
+| `policy-transport-zones` | NSX Transport Zones | `/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones` |
+| `policy-tier0` | NSX Tier-0 Gateways | `/policy/api/v1/infra/tier-0s` |
+| `policy-tier1` | NSX Tier-1 Gateways | `/policy/api/v1/infra/tier-1s` |
+| `policy-firewall` | NSX Distributed Firewall | `/policy/api/v1/infra/domains/{domain-id}/security-policies` + `…/rules` |
+
+### Step 3 — apply the curated read-core
+
+The Python entrypoint is `apply_nsx_core_curation`. From a
+backplane Python shell:
+
+```python
+from meho_backplane.connectors.nsx import apply_nsx_core_curation
+from meho_backplane.operations.ingest import ReviewService
+
+review_service = ReviewService(operator)
+await apply_nsx_core_curation(review_service, tenant_id=None)
+```
+
+This drives, for every entry in `NSX_CORE_GROUPS`:
+
+1. `ReviewService.edit_group(group_key, name=…, when_to_use=…)`
+   — lands the operator-reviewed text the agent reads through
+   `list_operation_groups`.
+2. `ReviewService.enable_group(group_key)` — flips
+   `review_status='enabled'`; cascades child ops to
+   `is_enabled=True`.
+
+Then for every entry in `NSX_CORE_OPS`:
+
+3. `ReviewService.edit_op(op_id, llm_instructions=…)` — lands
+   the per-op JSON blob the agent inlines into reasoning context
+   when the op surfaces in `search_operations` hits.
+
+Each op's `llm_instructions` is a three-key blob
+(`when_to_call` / `output_shape` / `next_step`) matching the
+typed-connector convention from
+[`connectors/bind9/ops_zone.py`](../../backend/src/meho_backplane/connectors/bind9/ops_zone.py)
+and [`connectors/vault/ops.py`](../../backend/src/meho_backplane/connectors/vault/ops.py).
+The same agent reads both surfaces, so the structure stays
+uniform across typed and ingested connectors.
+
+### Step 4 — verify the curation
+
+```bash
+meho operation groups nsx-rest-4.2
+meho operation search nsx-rest-4.2 "list nsx segments" --limit 5
+meho operation search nsx-rest-4.2 "what nsx firewall rules exist in domain X" --limit 5
+```
+
+The first command should return 8 enabled groups, each with the
+canonical `when_to_use` from `NSX_CORE_GROUPS`. The second
+should return `GET:/policy/api/v1/infra/segments` in the top-3.
+The third should return
+`GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules`
+in the top-3.
+
+Every other NSX op the spec ingestion produced should be in the
+`is_enabled=False` state — `search_operations` filters on
+`OperationGroup.review_status='enabled'` AND
+`EndpointDescriptor.is_enabled=True`, so a staged group's ops
+never surface.
+
+### Step 5 — dispatch one list op end-to-end
+
+Against a real probed NSX target:
+
+```bash
+meho operation call nsx-rest-4.2 \
+  'GET:/policy/api/v1/infra/segments' \
+  --target nsx-canary --json
+```
+
+Expected: JSON-shaped response carrying a `results` array of
+segment entries. The session-create + XSRF flow runs implicitly
+on the first dispatch and the per-target cache reuses the token
+for subsequent ones.
+
+The JSONFlux *seam* (would-be handle threading) is exercised
+non-interactively at
+[`backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py`](../../backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py):
+the test installs a `ForceHandleReducer` that always wraps the
+NSX list payload in a synthetic `ResultHandle` and asserts the
+dispatcher's `OperationResult.handle` carries it through. Real
+JSONFlux reduction (set-shaped payload reduction, MinIO/S3
+spill, `result_query` meta-tool) is **out of scope for v0.2**
+per Goal #214 — the seam test proves the dispatcher is ready
+for it once the production reducer ships.
+
+## Rollback
+
+If a canary run discovers a regression in the ingestion pipeline
+or the curated content:
+
+1. **Disable the connector immediately:**
+
+   ```bash
+   meho connector disable nsx-rest-4.2 --confirm
+   ```
+
+   Cascades every group to `review_status='disabled'` and every
+   op to `is_enabled=False`. The agent meta-tools stop surfacing
+   the connector; no in-flight dispatches will use it.
+
+2. **Capture the audit trail.** Every state transition wrote a
+   `meho.connector.*` row to `audit_log`; the trail is
+   sufficient to reconstruct what happened.
+
+3. **Re-ingest after fix.** Once the pipeline is patched, drive
+   `meho connector ingest` again — the body-hash idempotence in
+   T2 means rows whose parser output didn't change stay
+   untouched, while changed rows get an updated revision. After
+   re-curation + enable, the agent path re-warms.
+
+## Known gaps
+
+### 1. Env-gated automated two-spec canary is a follow-up
+
+G3.5-T2 (#614) ships the operator-review substrate
+(`apply_nsx_core_curation` helper, `edit_op(llm_instructions=…)`
+extension), the curated 9-op data (`NSX_CORE_OPS`), the dispatch
+smoke + JSONFlux force-handle acceptance tests over respx-mocked
+NSX, and this runbook. The env-gated automated canary that
+mirrors `test_g07_vsphere_canary.py` for NSX — drives the full
+two-spec ingest of `policy.yaml` + `manager.yaml` through
+`IngestionPipelineService` against a real LLM stub or live
+Anthropic adapter — is a follow-up. It requires the NSX spec
+files reachable from CI, the same env-gated pattern
+`tests/acceptance/_vcenter_spec.py` codifies for vSphere.
+
+### 2. Goal #214 G3.5 NSX checklist line
+
+The Goal body's `[ ] #368 — G3.5 tier-2 batch — all generic`
+checkbox flips when the Initiative's whole DoD is met. G3.5-T2
+moves the Initiative forward but does not on its own complete
+it (G3.5-T3 #615 wires the CLI + MCP review verbs + the full
+recorded-fixture E2E). The checklist tick lives on the
+Initiative-level wrap-up, not on this Task.
+
+### 3. CLI verbs for per-op `llm_instructions` editing
+
+`ReviewService.edit_op(llm_instructions=…)` is exposed at the
+Python level (the substrate the curation helper drives). The
+CLI verb `meho connector edit-op --llm-instructions <json>` and
+the matching REST / MCP route extensions are deferred to G3.5-T3
+#615 alongside the CLI verbs for NSX-specific operations.
+
+## References
+
+- Issue: [G3.5-T2 #614](https://github.com/evoila/meho/issues/614).
+- Parent Initiative: [G3.5 #368](https://github.com/evoila/meho/issues/368).
+- Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
+- Predecessor: [G3.5-T1 #613](https://github.com/evoila/meho/issues/613)
+  — `NsxConnector` skeleton.
+- vSphere counterpart: [`g07-vsphere-canary.md`](./g07-vsphere-canary.md).
+- Connector-agnostic ingest runbook: [`connector-ingestion.md`](./connector-ingestion.md).
+- Substrate: [#388 G0.6](https://github.com/evoila/meho/issues/388)
+  (operation registry + dispatcher);
+  [#389 G0.7](https://github.com/evoila/meho/issues/389)
+  (spec ingestion pipeline).
+- NSX REST API reference — Broadcom developer portal:
+  https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/
+- Curated data:
+  [`backend/src/meho_backplane/connectors/nsx/core_ops.py`](../../backend/src/meho_backplane/connectors/nsx/core_ops.py).
+- Codebase doc: [`docs/codebase/connectors-nsx.md`](../codebase/connectors-nsx.md).
+- Consumer wrapper this contract retires (per Initiative #368):
+  `scripts/nsx.sh` in the consumer's `claude-rdc-hetzner-dc`
+  repository (private to the `evoila-bosnia` org).


### PR DESCRIPTION
## Summary

- Lands the operator-review substrate for the NSX 4.2 read-only v0.2 core: `NSX_CORE_OPS` (9 curated ops + per-op `llm_instructions`), `NSX_CORE_GROUPS` (8 groups + per-group `when_to_use`), `NSX_PATH_RULES` (path-prefix classifier), and the `apply_nsx_core_curation` helper that drives the curation through `ReviewService`.
- Extends `ReviewService.edit_op` with an optional `llm_instructions: dict | None` kwarg — pure additive, audited via the existing `fields_updated` path; the blob itself is intentionally NOT echoed into the audit payload (same posture `edit_group` takes for `when_to_use`).
- Proves the dispatcher path end-to-end against a respx-mocked NSX manager: 9 parametrised dispatch smoke cases (one per curated op, including session-create + XSRF auth + path-template substitution for the two firewall ops) + 1 JSONFlux force-handle case proving `OperationResult.handle` is threaded by the dispatcher seam for the segment-list op.
- Documents the operator procedure at `docs/cross-repo/g35-nsx-canary.md`; updates `docs/codebase/connectors-nsx.md` with the new substrate.

### Acceptance criteria — what shipped vs deferred

| AC from #614 | This PR | Notes |
|---|---|---|
| Both NSX specs ingest cleanly + reproducible via `meho connector ingest --spec docs:nsx-4.2/policy.yaml --spec docs:nsx-4.2/manager.yaml` | **Operator runbook ships; automated canary deferred.** | The env-gated two-spec canary mirroring `test_g07_vsphere_canary.py` requires the NSX spec-shelf wired to the meho-runners pool, same env-gated pattern `tests/acceptance/_vcenter_spec.py` codifies for vSphere. Filing as a follow-up. |
| The ~9 read-only core ops are in `enabled` state under `connector_id="nsx-rest-4.2"`; everything else stays `staged` | ✅ | `NSX_CORE_OPS` + `apply_nsx_core_curation` lands exactly the 9 named ops as enabled; everything else the ingestion produced stays `is_enabled=False` per the G0.7 default for ingested rows. |
| Every enabled op has reviewed `llm_instructions`; every enabled group has reviewed `when_to_use` | ✅ | All 9 ops carry a `(when_to_call / output_shape / next_step)` blob mirroring the typed-connector convention from `connectors/bind9/ops_zone.py`; all 8 groups carry a one-sentence `when_to_use`. The `edit_op(llm_instructions=...)` substrate extension lands the per-op blobs through the audited write path. |
| One list op dispatched against a recorded fixture returns a JSONFlux handle; `result_describe(handle)` resolves and `result_query` drills in | **Reframed via the established `ForceHandleReducer` pattern.** | Real JSONFlux reduction logic + `result_describe` / `result_query` meta-tools are explicitly out of scope per Goal #214 ("v0.2 default is pass-through. Real JSONFlux reduction logic … Out of scope"). The dispatcher *seam* is exercised the same way `test_vmware_rest_jsonflux_force_handle` does for vSphere: a test-only `ForceHandleReducer` wraps the segment-list payload and the test asserts `OperationResult.handle` carries a populated `ResultHandle`. |
| Goal #214 body checklist line **G3.5 NSX** ticked | **Deferred to Initiative wrap.** | Goal #214's `[ ] #368 — G3.5 tier-2 batch` flips when the whole Initiative is done. G3.5-T3 (#615 — CLI verbs + MCP review + full E2E) is the natural place for the checklist transition. |

## Test plan

- [x] `ruff check` — clean on every touched file (`src/meho_backplane/operations/ingest/service.py`, `src/meho_backplane/connectors/nsx/`, `tests/acceptance/_nsx_canary_fixtures.py`, `tests/acceptance/test_g35_nsx_dispatch_smoke.py`, `tests/acceptance/test_g35_nsx_jsonflux_force_handle.py`, `tests/acceptance/conftest.py`, `tests/test_operations_ingest_review.py`)
- [x] `ruff format --check` — clean on the same set
- [x] `mypy src/meho_backplane/operations/ingest/service.py src/meho_backplane/connectors/nsx/` — no issues, 5 source files
- [x] `pytest tests/test_operations_ingest_review.py` — **35 passed** (2 new tests: `test_edit_op_sets_llm_instructions_and_writes_audit_without_echo`, `test_edit_op_requires_at_least_one_field`)
- [x] `pytest tests/test_connectors_nsx_auth.py` — **23 passed** (NSX skeleton suite from #613, unchanged behaviour)
- [x] `pytest tests/acceptance/test_g35_nsx_dispatch_smoke.py tests/acceptance/test_g35_nsx_jsonflux_force_handle.py` — **10 passed** (9 dispatch smoke + 1 force-handle), `pg_engine` fixture against testcontainers Postgres
- [x] Acceptance-criterion ① (curated 9-op enable) → dispatch smoke proves each curated op routes through `call_operation` with `status='ok'` against the respx mock
- [x] Acceptance-criterion ② (`llm_instructions` populated) → 35-test unit suite asserts `op_row.llm_instructions == blob` after `edit_op(llm_instructions=...)`, audit row carries `fields_updated=['llm_instructions']` without blob echo
- [x] Acceptance-criterion ③ (JSONFlux handle seam) → force-handle test asserts `OperationResult.handle.total_rows == 12`, `handle_id` is a valid UUID, `summary_md` mentions the row count, `schema_` is a non-empty mapping, `sample_rows` populated

## Out of scope (deferred to follow-ups)

- **Env-gated automated two-spec NSX canary** — the live `policy.yaml` + `manager.yaml` ingest through `IngestionPipelineService` (full `test_g07_vsphere_canary.py` analogue for NSX). Requires NSX spec-shelf access from CI runners. **Will file a follow-up issue.**
- **CLI verb `meho connector edit-op --llm-instructions <json>`** plus the REST + MCP route extensions for the new field — natural home is G3.5-T3 (#615) which adds the NSX-specific CLI verbs. The Python substrate ships now so `apply_nsx_core_curation` works.
- **Goal #214 checklist tick** — happens at Initiative #368 wrap, not per-Task.

## Manual follow-ups

- File the env-gated NSX canary acceptance test as a follow-up issue (Initiative #368 child Task).
- Once #224 lands operator-context Vault reads, the NSX session loader auto-picks up the real Vault path (same hook as vSphere; no NSX-specific edits required).

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NSX 4.2 connector with an operator-curated, read-only core op set (9 ops).
  * Operation editing now supports persisting per-op LLM instruction payloads.

* **Documentation**
  * Expanded NSX connector docs with curation flow and operator-review guidance.
  * New runbook for G3.5 NSX canary ingest/curation/dispatch.

* **Tests**
  * New acceptance and unit tests for NSX dispatch, curation, and JSON-flux force-handle behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->