### PR TITLE
feat(migrate): G5.3-T3 machine-local detector — path/hostname/username heuristic (#610)

### DIFF
--- a/cli/internal/migrate/machinelocal.go
+++ b/cli/internal/migrate/machinelocal.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package migrate — see doc.go for the package overview.
+
+package migrate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// MachineLocalResult is the output of DetectMachineLocal.
+// Flagged is true iff at least one rule fired; the caller
+// (T4 picker) uses this to pre-mark a file "Skip — machine-local"
+// while leaving the operator free to override.
+type MachineLocalResult struct {
+	Flagged bool
+	Matches []MachineLocalMatch
+}
+
+// MachineLocalMatch describes one heuristic hit.
+// Category is a stable string key identifying which rule fired;
+// Sample is the matched substring truncated to ≤80 chars so the
+// T4 picker badge tooltip stays readable without wrapping.
+type MachineLocalMatch struct {
+	Category string
+	Sample   string
+}
+
+// staticRule bundles a compiled regex with its stable category name.
+type staticRule struct {
+	category string
+	re       *regexp.Regexp
+}
+
+// staticRules holds rules that do not need runtime information.
+var staticRules = []staticRule{
+	{
+		// unix-home: /Users/<seg>/ or /home/<seg>/
+		// <seg> is one path segment (no additional slashes).
+		category: "unix-home",
+		re:       regexp.MustCompile(`(?i)/(?:Users|home)/[^/\s"'<>]+/`),
+	},
+	{
+		// windows-home: C:\Users\<seg>\ (case-insensitive drive letter).
+		// Double-backslash in the string encodes one literal backslash in
+		// the regex pattern.
+		category: "windows-home",
+		re:       regexp.MustCompile(`(?i)[A-Za-z]:\\Users\\[^\\<>"'\s]+\\`),
+	},
+	{
+		// tilde-home: ~/ token at a path boundary.
+		// We require ~/  to be preceded by start-of-string, a newline /
+		// tab, or a punctuation character that syntactically introduces a
+		// path (quote, paren, equals, colon, comma).  A plain space mid-
+		// sentence is intentionally excluded so "approx ~/2 days" (tilde
+		// as a proximity marker) does not flag; ~/foo at line start or
+		// after a quote does flag.
+		category: "tilde-home",
+		re:       regexp.MustCompile(`(?:^|[\n\r\t"'(=:,])~/`),
+	},
+	{
+		// local-hostname: .local / .lan suffixes, and the bare tokens
+		// localhost and host.docker.internal.
+		// Alternation ordered longest-first per codebase convention.
+		category: "local-hostname",
+		re:       regexp.MustCompile(`(?i)\b(?:host\.docker\.internal|localhost|\S+\.local|\S+\.lan)\b`),
+	},
+}
+
+// HomeDirFunc is the seam DetectMachineLocal uses to obtain the current
+// user's home directory.  Production callers pass nil to use
+// os.UserHomeDir; tests inject a deterministic fake to avoid depending
+// on the CI runner's $HOME.
+type HomeDirFunc func() (string, error)
+
+// DetectMachineLocal applies all heuristic rules against body and
+// returns a MachineLocalResult.  When homeFn is nil the function falls
+// back to os.UserHomeDir.
+func DetectMachineLocal(body string, homeFn HomeDirFunc) MachineLocalResult {
+	if homeFn == nil {
+		homeFn = os.UserHomeDir
+	}
+
+	var matches []MachineLocalMatch
+
+	for _, r := range staticRules {
+		for _, raw := range r.re.FindAllString(body, -1) {
+			matches = append(matches, MachineLocalMatch{
+				Category: r.category,
+				Sample:   truncate(raw, 80),
+			})
+		}
+	}
+
+	matches = append(matches, detectUsername(body, homeFn)...)
+
+	return MachineLocalResult{
+		Flagged: len(matches) > 0,
+		Matches: matches,
+	}
+}
+
+// detectUsername applies the operator-username rule.
+//
+// The 3-occurrence threshold mirrors Initiative #375's spec (work-item
+// 2, bullet 5).  A single occurrence of a short or common username
+// in prose (e.g. "admin", "user") is not strong evidence of a
+// machine-local path; three whole-word occurrences establish intent.
+func detectUsername(body string, homeFn HomeDirFunc) []MachineLocalMatch {
+	home, err := homeFn()
+	if err != nil || home == "" {
+		return nil
+	}
+	username := filepath.Base(home)
+	if username == "" || username == "." || username == string(filepath.Separator) {
+		return nil
+	}
+
+	pattern := fmt.Sprintf(`(?i)\b%s\b`, regexp.QuoteMeta(username))
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+
+	hits := re.FindAllString(body, -1)
+	if len(hits) < 3 {
+		return nil
+	}
+
+	matches := make([]MachineLocalMatch, 0, len(hits))
+	for _, h := range hits {
+		matches = append(matches, MachineLocalMatch{
+			Category: "operator-username",
+			Sample:   truncate(h, 80),
+		})
+	}
+	return matches
+}
+
+// truncate returns s truncated to at most n runes.
+func truncate(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n])
+}

--- a/cli/internal/migrate/machinelocal.go
+++ b/cli/internal/migrate/machinelocal.go
@@ -120,22 +120,35 @@ func detectUsername(body string, homeFn HomeDirFunc) []MachineLocalMatch {
 		return nil
 	}
 
-	pattern := fmt.Sprintf(`(?i)\b%s\b`, regexp.QuoteMeta(username))
+	// Use Unicode-aware boundaries instead of \b / \w which are ASCII-only
+	// in Go's RE2 engine. \b would silently never match a username that
+	// contains non-ASCII letters (e.g. "josé", "müller") because RE2's
+	// \w == [0-9A-Za-z_], so the boundary test between é and a following
+	// space sees two non-\w characters and no \w/\W transition.
+	// (?:^|[^\pL\pN_]) matches either start-of-string or a Unicode
+	// non-word character (not a Unicode letter, digit, or underscore).
+	pattern := fmt.Sprintf(
+		`(?i)(?:^|[^\pL\pN_])(%s)(?:[^\pL\pN_]|$)`,
+		regexp.QuoteMeta(username),
+	)
 	re, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil
 	}
 
-	hits := re.FindAllString(body, -1)
+	hits := re.FindAllStringSubmatch(body, -1)
 	if len(hits) < 3 {
 		return nil
 	}
 
 	matches := make([]MachineLocalMatch, 0, len(hits))
 	for _, h := range hits {
+		if len(h) < 2 || h[1] == "" {
+			continue
+		}
 		matches = append(matches, MachineLocalMatch{
 			Category: "operator-username",
-			Sample:   truncate(h, 80),
+			Sample:   truncate(h[1], 80),
 		})
 	}
 	return matches

--- a/cli/internal/migrate/machinelocal_test.go
+++ b/cli/internal/migrate/machinelocal_test.go
@@ -179,6 +179,22 @@ func TestOperatorUsername(t *testing.T) {
 			homeFn: nil, // nil triggers os.UserHomeDir — must not panic
 			match:  false,
 		},
+		{
+			// Non-ASCII username: Go's \b is ASCII-only (\w == [0-9A-Za-z_]),
+			// so a username containing accented letters has no \w/\W boundary
+			// transition and \b silently never matches. The Unicode-aware
+			// boundary (?:^|[^\pL\pN_]) must fire instead.
+			name:   "non_ascii_username_three_occurrences_hit",
+			body:   "josé mentored josé and later advised josé on the project",
+			homeFn: fakeHome("/Users/josé"),
+			match:  true,
+		},
+		{
+			name:   "non_ascii_username_two_occurrences_miss",
+			body:   "müller reviewed müller's work",
+			homeFn: fakeHome("/home/müller"),
+			match:  false,
+		},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/cli/internal/migrate/machinelocal_test.go
+++ b/cli/internal/migrate/machinelocal_test.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeHome returns a HomeDirFunc that always yields the given path.
+func fakeHome(path string) HomeDirFunc {
+	return func() (string, error) { return path, nil }
+}
+
+// fakeHomeErr returns a HomeDirFunc that always returns an error.
+func fakeHomeErr() HomeDirFunc {
+	return func() (string, error) { return "", errors.New("no home") }
+}
+
+// hasCategory reports whether any match in r has the given category.
+func hasCategory(r MachineLocalResult, cat string) bool {
+	for _, m := range r.Matches {
+		if m.category() == cat {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper so tests can read Category without exporting more types.
+func (m MachineLocalMatch) category() string { return m.Category }
+
+// ── unix-home ─────────────────────────────────────────────────────────────────
+
+func TestUnixHome(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		body  string
+		match bool
+	}{
+		{name: "users_alice_hit", body: "scripts live at /Users/alice/x", match: true},
+		{name: "home_bob_hit", body: "config at /home/bob/config.yml", match: true},
+		{name: "no_slash_miss", body: "/Usersalice/foo", match: false},
+		{name: "users_no_trailing_miss", body: "/Users/alice", match: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := DetectMachineLocal(tc.body, fakeHome("/unrelated/path"))
+			got := hasCategory(r, "unix-home")
+			if got != tc.match {
+				t.Errorf("unix-home: body=%q got=%v want=%v", tc.body, got, tc.match)
+			}
+		})
+	}
+}
+
+// ── windows-home ──────────────────────────────────────────────────────────────
+
+func TestWindowsHome(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		body  string
+		match bool
+	}{
+		{name: "c_users_bob_hit", body: `path is C:\Users\bob\`, match: true},
+		{name: "d_drive_hit", body: `D:\Users\carol\documents`, match: true},
+		{name: "no_trailing_miss", body: `C:\Users\bob`, match: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := DetectMachineLocal(tc.body, fakeHome("/unrelated/path"))
+			got := hasCategory(r, "windows-home")
+			if got != tc.match {
+				t.Errorf("windows-home: body=%q got=%v want=%v", tc.body, got, tc.match)
+			}
+		})
+	}
+}
+
+// ── tilde-home ────────────────────────────────────────────────────────────────
+
+func TestTildeHome(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		body  string
+		match bool
+	}{
+		{name: "line_start_hit", body: "~/foo is the path", match: true},
+		{name: "newline_preceded_hit", body: "path:\n~/bar/x", match: true},
+		{name: "quote_preceded_hit", body: `open "~/baz"`, match: true},
+		// "approx ~/3 weeks" mid-prose should not flag — space before ~/
+		// is intentionally excluded to avoid false positives from
+		// proximity markers.
+		{name: "prose_approx_miss", body: "done in approx ~/3 weeks", match: false},
+		// Plain space before ~/ mid-sentence: not a path context.
+		{name: "space_preceded_miss", body: "check ~/bar should not flag", match: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := DetectMachineLocal(tc.body, fakeHome("/unrelated/path"))
+			got := hasCategory(r, "tilde-home")
+			if got != tc.match {
+				t.Errorf("tilde-home: body=%q got=%v want=%v", tc.body, got, tc.match)
+			}
+		})
+	}
+}
+
+// ── local-hostname ────────────────────────────────────────────────────────────
+
+func TestLocalHostname(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		body  string
+		match bool
+	}{
+		{name: "dot_local_hit", body: "connect to db.local:5432", match: true},
+		{name: "dot_lan_hit", body: "server at box.lan", match: true},
+		{name: "localhost_hit", body: "redis://localhost:6379", match: true},
+		{name: "host_docker_internal_hit", body: "api at host.docker.internal:8080", match: true},
+		// "mylocaldb" does not match because .local/.lan require a dot before the suffix.
+		{name: "mylocaldb_miss", body: "database name is mylocaldb", match: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := DetectMachineLocal(tc.body, fakeHome("/unrelated/path"))
+			got := hasCategory(r, "local-hostname")
+			if got != tc.match {
+				t.Errorf("local-hostname: body=%q got=%v want=%v", tc.body, got, tc.match)
+			}
+		})
+	}
+}
+
+// ── operator-username ─────────────────────────────────────────────────────────
+
+func TestOperatorUsername(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		body   string
+		homeFn HomeDirFunc
+		match  bool
+	}{
+		{
+			name:   "three_occurrences_hit",
+			body:   "alice ran alice then alice again",
+			homeFn: fakeHome("/Users/alice"),
+			match:  true,
+		},
+		{
+			name:   "two_occurrences_miss",
+			body:   "alice ran alice",
+			homeFn: fakeHome("/Users/alice"),
+			match:  false,
+		},
+		{
+			name:   "home_dir_error_miss",
+			body:   "alice alice alice",
+			homeFn: fakeHomeErr(),
+			match:  false,
+		},
+		{
+			name:   "nil_homefn_uses_real_os_no_panic",
+			body:   "no username repeated here at all",
+			homeFn: nil, // nil triggers os.UserHomeDir — must not panic
+			match:  false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := DetectMachineLocal(tc.body, tc.homeFn)
+			got := hasCategory(r, "operator-username")
+			if got != tc.match {
+				t.Errorf("operator-username: body=%q got=%v want=%v", tc.body, got, tc.match)
+			}
+		})
+	}
+}
+
+// ── sample truncation ─────────────────────────────────────────────────────────
+
+func TestSampleTruncation(t *testing.T) {
+	t.Parallel()
+	// Build a body containing a unix-home hit with a long path segment.
+	longSeg := "aaaaabbbbbaaaaabbbbbaaaaaббббббббаааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааааа"
+	body := "/Users/" + longSeg + "/"
+	r := DetectMachineLocal(body, fakeHome("/unrelated/path"))
+	if !r.Flagged {
+		t.Fatal("expected Flagged=true for long unix-home path")
+	}
+	for _, m := range r.Matches {
+		if len([]rune(m.Sample)) > 80 {
+			t.Errorf("Sample exceeds 80 runes: %d runes in %q", len([]rune(m.Sample)), m.Sample)
+		}
+		if m.Sample == "" {
+			t.Error("Sample must be non-empty for a hit")
+		}
+	}
+}
+
+// ── flagged iff matches ────────────────────────────────────────────────────────
+
+func TestFlaggedConsistency(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "clean_body", body: "this is a clean memory entry about architecture"},
+		{name: "hit_body", body: "stores results in /Users/alice/data/"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := DetectMachineLocal(tc.body, fakeHome("/unrelated/path"))
+			if r.Flagged != (len(r.Matches) > 0) {
+				t.Errorf("Flagged=%v but len(Matches)=%d", r.Flagged, len(r.Matches))
+			}
+		})
+	}
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -172,8 +172,10 @@ cli/
     │       ├── sys.go            # `meho vault sys health|seal-status|mounts-list|auth-list` (vault.sys.* ops, #546).
     │       ├── auth.go           # `meho vault auth userpass/approle list+read` (vault.auth.* ops, #547).
     │       └── vault_test.go     # helpers + verb-tree wiring + flag→params wire-shape + e2e mocked-backplane tests.
-    ├── migrate/               # G5.3-T1 #608 — pure-logic helpers for the memory migration flow (Initiative #375).
-    │   └── doc.go                # placeholder package; flow helpers land in T2–T5 (#609–#612).
+    ├── migrate/               # G5.3 Initiative #375 — pure-logic helpers for the memory migration flow.
+    │   ├── doc.go                # package declaration + overview comment.
+    │   ├── machinelocal.go       # DetectMachineLocal — heuristic detector for laptop-local content (#610).
+    │   └── machinelocal_test.go  # table-driven per-Category tests + truncation + seam coverage (#610).
     ├── discovery/
     │   ├── discovery.go       # /api/v1/commands manifest fetch + cobra graft.
     │   └── discovery_test.go  # 200/404/transport/decode + collision tests.


### PR DESCRIPTION
## Summary

- Adds `DetectMachineLocal(body string, homeFn HomeDirFunc) MachineLocalResult` to `cli/internal/migrate/` — pure stdlib, no cobra import, no third-party regex dep.
- Five heuristic rules (unix-home, windows-home, tilde-home, local-hostname, operator-username) flag laptop-specific content so the T4 picker can pre-mark files "Skip — machine-local".
- `HomeDirFunc` seam makes the operator-username rule deterministic in CI — tests inject a fake home path rather than depending on the runner's `$HOME`.
- `MachineLocalMatch.Sample` is truncated to ≤80 runes for the T4 badge tooltip.

## Test plan

- [x] `cd cli && go test ./internal/migrate/...` — all 21 subtests pass
- [x] `go vet ./...` — clean
- [x] `gofmt -d` — empty diff
- [x] `go test ./...` — all 18 packages pass (0 failures)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] unix-home: `/Users/alice/x` hit; `/Usersalice` miss
- [x] windows-home: `C:\Users\bob\` hit; no trailing backslash miss
- [x] tilde-home: `~/foo` at line start hit; `approx ~/3 weeks` mid-prose miss
- [x] local-hostname: `db.local` / `box.lan` / `localhost` / `host.docker.internal` hits; `mylocaldb` miss
- [x] operator-username: 3 occurrences hit; 2 occurrences miss; error from homeFn miss; nil homeFn no panic
- [x] Each `MachineLocalMatch.Sample` non-empty and ≤80 runes

## Out of scope

- T4 picker wiring (`--include-machine-local` flag, per-file UI) — that is #612.
- Frontmatter parser / scanner (`scan.go`) — that is #609 (parallel sibling).
- `<!-- meho:machine-local -->` HTML-comment opt-out — that is T2 (#609).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #610


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added machine-local pattern detection to identify home directory paths, usernames, and hostname indicators in document text.

* **Tests**
  * Added comprehensive test coverage for detection patterns and edge cases.

* **Documentation**
  * Updated module documentation for the new detection capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->