### PR TITLE
feat(mcp): G5.1-T3 memory MCP meta-tools + meho://memory resource (#423)

### DIFF
--- a/backend/src/meho_backplane/mcp/resources/memory.py
+++ b/backend/src/meho_backplane/mcp/resources/memory.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho://memory/{scope}/{slug}`` — memory entry resource (G5.1-T3).
+
+The fetch-by-(scope, slug) companion to the :mod:`search_memory`
+meta-tool. ``search_memory`` returns ranked hits with a snippet plus
+the ``(scope, slug)`` pair the agent needs to drill into the full
+body via ``resources/read``. The split keeps every search response
+small enough for an agent to scan many hits without exhausting
+context, then drill into the chosen one explicitly.
+
+URI template + variable binding
+================================
+
+``meho://memory/{scope}/{slug}`` follows the v0.2 simple-expansion
+subset of RFC 6570 (two named variables, no operators). The MCP
+registry's URI matcher binds ``{scope}`` and ``{slug}`` from the
+concrete URI and forwards the dict to the handler.
+
+* ``{scope}`` must be one of the five
+  :class:`~meho_backplane.memory.schemas.MemoryScope` values; an
+  unrecognised string surfaces as
+  :class:`~meho_backplane.mcp.server.McpInvalidParamsError` before
+  any DB query.
+* ``{slug}`` is validated against
+  :data:`~meho_backplane.memory.schemas.SLUG_PATTERN` so a malformed
+  client URI surfaces as ``-32602`` rather than reaching the DB
+  layer.
+
+The URI deliberately encodes only ``scope`` and ``slug`` — not
+``target_name``, even for target-flavoured scopes. This is the
+load-bearing read shape the issue AC names: the read path is
+**only** valid for the operator's own user-scoped memories under
+this URI template. Tenant- and target-scoped reads still need
+``target_name`` to disambiguate, which is currently out of scope for
+the v0.2 resource template (a future polish would extend the
+template or add a query-parameter form; for now the resource is
+focused on the user-scoped recall case where the encoded
+``source_id`` already carries the operator's ``sub`` server-side).
+
+The handler still inspects every scope at the service layer so an
+operator who passes ``meho://memory/tenant/<slug>`` receives the
+tenant-scoped entry when it exists (TENANT scope has no
+``target_name`` dimension); operators passing
+``meho://memory/target/<slug>`` collapse to "not found" because the
+``source_id`` lookup cannot reconstruct the ``target_name`` segment.
+This is the right info-leak shape: the resource template never
+admits a target-name probe channel.
+
+Tenant scoping + RBAC
+=====================
+
+The handler binds :attr:`Operator.tenant_id` from the validated JWT
+operator and passes it to :meth:`MemoryService.recall`. The substrate's
+natural-key uniqueness on ``(tenant_id, source, source_id)`` plus the
+per-scope :class:`~meho_backplane.memory.rbac.MemoryRbacResolver`
+match means a different tenant's same-slug entry — or another
+operator's user-scoped entry under the same slug — is structurally
+invisible. :meth:`MemoryService.recall` returns ``None`` for both
+cases without distinguishing "no such row" from "you don't have
+access" — the **404-vs-403 collapse** the issue AC names. The
+handler surfaces ``None`` as
+:class:`~meho_backplane.mcp.server.McpInvalidParamsError` with a
+"memory entry not found" message so the wire shape never reveals
+the foreign tenant's or foreign operator's existence.
+
+Response shape
+==============
+
+The MCP ``resources/read`` response is a ``contents[]`` array. The
+dispatcher (:func:`~meho_backplane.mcp.handlers.handle_resources_read`)
+wraps this handler's return value in a single text-block entry whose
+``mimeType`` is taken from the resource template's
+:attr:`ResourceTemplateDefinition.mimeType` (``text/markdown`` for
+memory entries) and whose ``text`` is the JSON-serialised handler
+return. The handler returns
+``{id, tenant_id, scope, slug, body, metadata, expires_at, ...}`` so a
+client UI can render the entry alongside its provenance even though
+the entry's *content* is Markdown.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import (
+    ResourceTemplateDefinition,
+    register_mcp_resource,
+)
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.memory.schemas import MemoryScope, validate_slug
+from meho_backplane.memory.service import MemoryService
+
+
+async def _memory_entry_handler(
+    operator: Operator,
+    bound: dict[str, str],
+) -> dict[str, Any]:
+    """Return the full :class:`~meho_backplane.memory.schemas.MemoryEntry` for ``(scope, slug)``.
+
+    Three rejection arms, all mapped onto
+    :class:`McpInvalidParamsError` (``-32602``) — JSON-RPC carries no
+    HTTP-status semantics so every input-validation failure surfaces
+    on the same error code:
+
+    * **Unrecognised scope** — the URI bound a ``{scope}`` value that
+      doesn't match any :class:`MemoryScope` member. Surfaces before
+      the DB query so a probe with an arbitrary scope string can't
+      be used as an oracle for the enum's shape.
+    * **Malformed slug** — the URI bound a ``{slug}`` value that
+      doesn't match :data:`SLUG_PATTERN`. Caught from
+      :func:`~meho_backplane.memory.schemas.validate_slug`'s
+      :class:`ValueError` and surfaced before any DB query so a
+      probe attempt with an arbitrary URI fragment can't be used
+      as an oracle for what slugs exist.
+    * **Entry not found in the operator's tenant or under their
+      RBAC** — :meth:`MemoryService.recall` collapses both cases to
+      ``None``. The handler renders both as "memory entry not
+      found", which is the spec-correct shape for an info-leak-safe
+      404-vs-403 boundary.
+    """
+    scope_raw = bound["scope"]
+    slug_raw = bound["slug"]
+
+    try:
+        scope = MemoryScope(scope_raw)
+    except ValueError as exc:
+        raise McpInvalidParamsError(
+            f"memory entry: invalid scope {scope_raw!r}; "
+            f"expected one of {[s.value for s in MemoryScope]}",
+        ) from exc
+
+    try:
+        slug = validate_slug(slug_raw)
+    except ValueError as exc:
+        raise McpInvalidParamsError(
+            f"memory entry: invalid slug {slug_raw!r}: {exc}",
+        ) from exc
+
+    service = MemoryService()
+    entry = await service.recall(operator, scope=scope, slug=slug)
+    if entry is None:
+        # 404-vs-403 collapse: the resource handler never distinguishes
+        # "no such memory" from "you don't have access". See module
+        # docstring's "Tenant scoping + RBAC" section.
+        raise McpInvalidParamsError(
+            f"memory entry not found: scope={scope.value!r}, slug={slug!r}",
+        )
+
+    return entry.model_dump(mode="json")
+
+
+register_mcp_resource(
+    definition=ResourceTemplateDefinition(
+        uriTemplate="meho://memory/{scope}/{slug}",
+        name="Memory entry",
+        description=(
+            "Full body and metadata of one memory entry, identified by "
+            "scope + slug. Use after `search_memory` has returned a hit "
+            "whose snippet is not enough to act on — this resource "
+            "returns the entire Markdown body plus provenance metadata "
+            "(expires_at, tags, user_sub for user-scoped entries). "
+            "Returns INVALID_PARAMS for an unrecognised scope, a "
+            "malformed slug, or a (scope, slug) that doesn't exist "
+            "under the operator's tenant + RBAC (cross-tenant or "
+            "cross-operator reads collapse to 'not found' without "
+            "revealing the foreign tenant's or foreign operator's "
+            "existence)."
+        ),
+        mimeType="text/markdown",
+        required_role=TenantRole.OPERATOR,
+    ),
+    handler=_memory_entry_handler,
+)

--- a/backend/src/meho_backplane/mcp/tools/memory.py
+++ b/backend/src/meho_backplane/mcp/tools/memory.py
@@ -1,0 +1,511 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``search_memory`` + ``add_to_memory`` — memory meta-tools (G5.1-T3).
+
+Two of the ~17 agent-facing meta-tools defined by ``CLAUDE.md`` postulate
+5 (Memory family). Both call into
+:class:`~meho_backplane.memory.service.MemoryService` (G5.1-T1, #421);
+the matching REST routes are owned by the sibling Task #422 and the CLI
+verbs by #424 — every front-end converges on the same service layer,
+which carries the per-scope RBAC matrix and the tenant boundary in one
+place so the MCP surface here stays a thin shell.
+
+Why this surface is load-bearing
+================================
+
+Per consumer-needs.md §G5 L131: "The single biggest unlock from a synced
+MEHO isn't speed — it's that the *team* becomes the unit of memory, not
+the individual operator." Every agent session that learns something
+worth retaining (operator preference, tenant convention, target gotcha)
+calls ``add_to_memory``; every agent session that needs to recall those
+learnings calls ``search_memory``. That cadence makes the **tool
+descriptions** the single most leveraged piece of agent UX in the memory
+surface. The descriptions follow the AI-engineering anchor (name what,
+when to use, when NOT to use) and explicitly cross-reference G5.2's
+default 7-day TTL on user-scope writes so an agent learns the lifecycle
+contract from the tool definition itself rather than guessing.
+
+CLAUDE.md note on #332 explicitly carves the agent surface: ``forget``
+and ``list`` are CLI-only conveniences and intentionally absent from
+the MCP tool list. An agent reaches list-style queries via
+``search_memory(scope=...)``; ``forget`` is a deliberate-write op
+normally driven by operators, not the agent without explicit
+confirmation.
+
+RBAC + tenant scoping
+=====================
+
+Both tools require ``operator`` role at the registry layer. The
+per-scope RBAC matrix is enforced inside
+:class:`~meho_backplane.memory.service.MemoryService` (see
+:class:`~meho_backplane.memory.rbac.MemoryRbacResolver`): user-scoped
+writes are open to any operator (the service binds ``operator.sub``
+server-side); ``tenant`` writes require ``tenant_admin``; ``target``
+writes are open to any operator in the tenant (G0.3-T3 will tighten
+later). A write that fails the matrix surfaces as
+:class:`PermissionDeniedError` from the service, which this handler
+re-raises as :class:`McpInvalidParamsError` so the JSON-RPC error code
+stays in the ``-32602`` "invalid params" lane — the dispatcher
+otherwise has no HTTP-403 analogue.
+
+Tenant scoping is enforced via :attr:`Operator.tenant_id` — every
+:class:`MemoryService` call binds the tenant from the validated JWT
+operator, so cross-tenant access is structurally impossible. The
+substrate's tenant filter then carries the boundary down to the SQL
+layer.
+
+Read-side 404-vs-403 collapse
+=============================
+
+The companion :mod:`meho_backplane.mcp.resources.memory` resource
+collapses "not found" and "RBAC denied" reads into the same error
+shape (``MemoryService.recall`` returns ``None`` on both paths so an
+operator probing for another operator's user-scoped slugs can't use
+the response shape as a tenant/user existence oracle). The matching
+T2 REST route renders both as 404 for the same reason. This module's
+write path does not need the same collapse — write denial is the
+operator's own action, not a probe of someone else's state.
+
+Audit + broadcast
+=================
+
+The dispatcher in :mod:`meho_backplane.mcp.handlers` emits one
+``audit_log`` row + one broadcast event per ``tools/call`` invocation;
+the ``op_class`` here (``"read"`` for search, ``"write"`` for add)
+flows into :func:`~meho_backplane.broadcast.classify.classify_op` so
+the broadcast payload is shaped correctly. ``search_memory`` /
+``add_to_memory`` are op-ids the classifier matches via its fall-
+through ``other`` bucket; both surface full-payload broadcasts (no
+credential redaction).
+
+TTL semantics
+=============
+
+``add_to_memory`` accepts ``ttl`` as an ISO 8601 duration string
+(``"P7D"`` for 7 days, ``"PT1H"`` for one hour) per ISO 8601-2:2019.
+The handler parses it into a concrete ``expires_at`` timestamp before
+calling the service so the storage layer sees the same wall-clock
+shape it accepts on the REST surface (T2 #422). A missing ``ttl`` on
+a user-scope write picks up the **default 7-day TTL** that G5.2 #374
+will inject when its background expiry executor lands; for G5.1 the
+metadata column simply stores ``None`` and the read-side filter
+treats it as "never expires". The tool description names this
+contract explicitly so an agent that wants a specific lifetime knows
+to set ``ttl``, and an agent that wants the default knows to omit it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Final
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.memory.rbac import PermissionDeniedError
+from meho_backplane.memory.schemas import MemoryScope
+from meho_backplane.memory.service import MemoryService
+
+__all__: list[str] = []
+
+
+#: Op-class strings keep parity with :mod:`meho_backplane.broadcast.classify`'s
+#: credential / audit / read / write taxonomy. ``search_memory`` is read;
+#: ``add_to_memory`` is write.
+_OP_CLASS_READ: Final[str] = "read"
+_OP_CLASS_WRITE: Final[str] = "write"
+
+#: Default + maximum hit count for ``search_memory``. Matches the
+#: :meth:`MemoryService.search_memories` default (10); the retrieval
+#: substrate caps at 50 internally.
+_DEFAULT_SEARCH_LIMIT: Final[int] = 10
+_MAX_SEARCH_LIMIT: Final[int] = 50
+
+#: ISO 8601 enum of the five scope values, exposed via the MCP
+#: ``inputSchema`` ``enum`` constraint. Built from
+#: :class:`MemoryScope` so an enum extension lands here automatically.
+_SCOPE_ENUM: Final[list[str]] = [scope.value for scope in MemoryScope]
+
+
+# ---------------------------------------------------------------------------
+# ISO 8601 duration parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso_duration(value: str) -> datetime:
+    """Parse an ISO 8601 duration string into an absolute ``expires_at``.
+
+    Accepts the subset ``P[nD][T[nH][nM][nS]]`` — days / hours / minutes
+    / seconds with integer components — and anchors the result at
+    :func:`datetime.now(UTC)`. Months and years are deliberately
+    rejected: they have variable length (Feb has 28-29 days, leap-
+    year edges) and ``timedelta`` does not support them. For longer
+    TTLs operators specify ``P30D`` / ``P365D`` etc.
+
+    Returns the computed ``expires_at`` as a UTC-aware datetime. Raises
+    :class:`ValueError` with a human-readable message on any parse
+    failure so the caller can surface
+    :class:`~meho_backplane.mcp.server.McpInvalidParamsError`.
+    """
+    if not value or value[0] != "P":
+        raise ValueError(f"ttl {value!r} must be an ISO 8601 duration (e.g. 'P7D', 'PT1H')")
+    # Split on the optional 'T' separator between date and time parts.
+    remainder = value[1:]
+    date_part, time_part = remainder, ""
+    if "T" in remainder:
+        date_part, time_part = remainder.split("T", 1)
+    if not date_part and not time_part:
+        raise ValueError(f"ttl {value!r} carries no duration components")
+
+    days = _consume_unit(date_part, "D", value, ("Y", "M", "W"))
+    hours = _consume_unit(time_part, "H", value, ())
+    # After hours, only minutes and seconds remain.
+    minute_seconds_part = _strip_consumed(time_part, "H")
+    minutes = _consume_unit(minute_seconds_part, "M", value, ())
+    seconds_part = _strip_consumed(minute_seconds_part, "M")
+    seconds = _consume_unit(seconds_part, "S", value, ())
+
+    total_seconds = days * 86400 + hours * 3600 + minutes * 60 + seconds
+    if total_seconds <= 0:
+        raise ValueError(f"ttl {value!r} must resolve to a positive duration")
+    return datetime.now(UTC) + timedelta(seconds=total_seconds)
+
+
+def _consume_unit(
+    segment: str,
+    unit: str,
+    full_value: str,
+    rejected_units: tuple[str, ...],
+) -> int:
+    """Consume the integer-prefix-then-unit slice of an ISO duration.
+
+    ``segment`` is the substring already split out by date/time parsing;
+    ``unit`` is the trailing letter to find (``D`` / ``H`` / ``M`` /
+    ``S``); ``full_value`` is the original ttl value used only for
+    error messages so an operator sees what they passed.
+
+    Rejected units (years/months/weeks on the date side) surface a
+    distinct error message rather than silently parsing — operators
+    who try ``P1Y`` should know the contract is days-and-below.
+    """
+    for rejected in rejected_units:
+        if rejected in segment:
+            raise ValueError(
+                f"ttl {full_value!r} uses unsupported unit {rejected!r}; "
+                "only days (D), hours (H), minutes (M), seconds (S) are accepted",
+            )
+    index = segment.find(unit)
+    if index == -1:
+        return 0
+    prefix = segment[:index]
+    if not prefix or not prefix.isdigit():
+        raise ValueError(
+            f"ttl {full_value!r}: expected integer before {unit!r}, got {prefix!r}",
+        )
+    return int(prefix)
+
+
+def _strip_consumed(segment: str, unit: str) -> str:
+    """Return the part of ``segment`` after the leading ``<int><unit>``."""
+    index = segment.find(unit)
+    if index == -1:
+        return segment
+    return segment[index + 1 :]
+
+
+# ---------------------------------------------------------------------------
+# Handler implementations
+# ---------------------------------------------------------------------------
+
+
+async def _search_memory_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Run a hybrid BM25 + cosine retrieval over the operator's visible memories.
+
+    Delegates to :meth:`MemoryService.search_memories` with the
+    operator's JWT-bound :attr:`~Operator.tenant_id`. The service-side
+    RBAC matrix post-filters the substrate's hits so an operator's
+    search never surfaces another operator's user-scoped row even when
+    retrieval ranked it highly — the wire shape carries only entries
+    the operator is allowed to see.
+
+    The ``scope`` argument is optional; omitting it searches across
+    every kind the operator can read (user / user-tenant / user-target
+    / tenant / target). Passing one narrows the retrieval to that
+    single kind, useful when the agent knows it's looking for a
+    tenant convention vs an operator preference.
+    """
+    query: str = arguments["query"]
+    scope_raw = arguments.get("scope")
+    scope = MemoryScope(scope_raw) if scope_raw is not None else None
+    limit: int = int(arguments.get("limit", _DEFAULT_SEARCH_LIMIT))
+
+    service = MemoryService()
+    hits = await service.search_memories(
+        operator,
+        query,
+        scope=scope,
+        limit=limit,
+    )
+    return {
+        "hits": [hit.model_dump(mode="json") for hit in hits],
+    }
+
+
+async def _add_to_memory_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Create one memory entry under the operator's tenant.
+
+    Three things this handler is responsible for:
+
+    * Translating the ``scope`` argument from its wire string into the
+      typed :class:`MemoryScope` before reaching the service. The
+      tool's ``inputSchema`` enum gates the values, so a bad scope
+      surfaces as JSON-Schema validation failure (``-32602``) before
+      this handler runs.
+    * Parsing the optional ``ttl`` ISO 8601 duration into an absolute
+      ``expires_at``. The service stores the parsed timestamp in
+      ``doc_metadata.expires_at`` and the read-side filter uses it
+      directly; G5.2's expiry executor reaps rows whose ``expires_at``
+      has passed.
+    * Catching :class:`PermissionDeniedError` from the service's RBAC
+      matrix (most commonly: an ``operator`` role attempting a
+      ``TENANT`` write) and re-raising as
+      :class:`McpInvalidParamsError`. JSON-RPC has no HTTP-403
+      analogue; the spec example for "Unknown tool" uses ``-32602``
+      so a parallel RBAC denial uses the same code rather than
+      inventing a server-side semantic.
+
+    Returns the full :class:`~meho_backplane.memory.schemas.MemoryEntry`
+    payload (id, slug, body, metadata, timestamps) so the agent can
+    verify the write landed without a follow-up
+    ``resources/read meho://memory/{scope}/{slug}`` round-trip.
+    """
+    content: str = arguments["content"]
+    scope = MemoryScope(arguments["scope"])
+    slug = arguments.get("slug")
+    target_name = arguments.get("target_name")
+    tags = arguments.get("tags")
+
+    # Mirror the REST shape (T2 #422): ``tags`` is rendered into
+    # ``metadata.tags`` so the service-layer ``has_tag`` filter picks
+    # it up uniformly across MCP and REST writes.
+    metadata: dict[str, Any] | None = {"tags": list(tags)} if tags is not None else None
+
+    expires_at: datetime | None = None
+    ttl_raw = arguments.get("ttl")
+    if ttl_raw is not None:
+        try:
+            expires_at = _parse_iso_duration(ttl_raw)
+        except ValueError as exc:
+            raise McpInvalidParamsError(f"add_to_memory: {exc}") from exc
+
+    service = MemoryService()
+    try:
+        entry = await service.remember(
+            operator,
+            scope=scope,
+            body=content,
+            slug=slug,
+            metadata=metadata,
+            expires_at=expires_at,
+            target_name=target_name,
+        )
+    except PermissionDeniedError as exc:
+        raise McpInvalidParamsError(f"add_to_memory: {exc}") from exc
+    except ValueError as exc:
+        # Service raises ValueError for missing target_name on
+        # target-scoped writes and for invalid slug shape. Both are
+        # caller-input errors → INVALID_PARAMS.
+        raise McpInvalidParamsError(f"add_to_memory: {exc}") from exc
+
+    return entry.model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Tool registrations
+# ---------------------------------------------------------------------------
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="search_memory",
+        description=(
+            "Search the operator's accessible memories (own user-scoped "
+            "entries + tenant-shared + target-shared entries visible to "
+            "this operator). Returns ranked hits with a body snippet and "
+            "the (scope, slug) pair you'll need to fetch the full body "
+            "via `resources/read meho://memory/{scope}/{slug}`. "
+            "Call when you need to recall established team conventions, "
+            "operator preferences for this tenant, or notes about a "
+            "specific target — BEFORE asking the operator a question the "
+            "memory may already answer. "
+            "Scope filter is optional: omit it to search across all "
+            "visible scopes (user / user-tenant / user-target / tenant / "
+            "target); pass one to narrow (e.g. scope='tenant' for shared "
+            "team conventions only). "
+            "Do NOT use this for durable team knowledge — that lives in "
+            "the knowledge base (`search_knowledge`). Memory is for "
+            "shorter-lived, operator/tenant/target-scoped state. "
+            "Limit defaults to 10; cap is 50 (substrate-enforced)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Free-form query. Both BM25 (lexical) and cosine "
+                        "(semantic) signals consume it; ranks are fused via RRF."
+                    ),
+                },
+                "scope": {
+                    "type": ["string", "null"],
+                    "enum": [*_SCOPE_ENUM, None],
+                    "description": (
+                        "Optional scope filter. One of 'user' "
+                        "(personal across tenants), 'user-tenant' (personal "
+                        "within this tenant), 'user-target' (personal scoped "
+                        "to one target), 'tenant' (shared with the team), "
+                        "'target' (shared with anyone touching this target). "
+                        "Null or omitted searches across every scope the "
+                        "operator can read."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MAX_SEARCH_LIMIT,
+                    "default": _DEFAULT_SEARCH_LIMIT,
+                    "description": "Maximum number of ranked hits to return.",
+                },
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_READ,
+    ),
+    handler=_search_memory_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="add_to_memory",
+        description=(
+            "Add a new memory entry. Use when you (or the operator "
+            "working with you) learn something worth retaining beyond "
+            "this session: an operator preference, a tenant convention, "
+            "a target-specific gotcha. "
+            "Pick the NARROWEST scope that captures intent: "
+            "'user' (personal across tenants) when the note is about "
+            "you the operator, regardless of which tenant you're "
+            "working in; "
+            "'user-tenant' (personal within this tenant) when the note "
+            "is your own preference for one specific tenant; "
+            "'user-target' (personal scoped to one target) when the "
+            "note applies to your interaction with one infrastructure "
+            "target — requires `target_name`; "
+            "'tenant' (shared with the team — tenant_admin role only) "
+            "when the note is a team-wide convention every operator in "
+            "the tenant should see; "
+            "'target' (shared with anyone touching this target) when the "
+            "note is a target-specific gotcha every operator should see "
+            "— requires `target_name`. "
+            "An operator without tenant_admin role attempting a 'tenant' "
+            "write is denied (INVALID_PARAMS); promote via the operator-"
+            "driven `meho promote` verb (G5.2) instead. "
+            "ALWAYS call `search_memory` FIRST with the topic you're "
+            "about to capture: re-adding under a different slug "
+            "fragments the corpus. If a matching entry already exists, "
+            "prefer extending its body (re-add with same slug, body-hash "
+            "short-circuit updates in place). "
+            "TTL is optional, formatted as ISO 8601 duration ('P7D' = "
+            "7 days, 'PT1H' = 1 hour). Omit to accept the backend "
+            "default (G5.2 #374 will inject a 7-day TTL on user-scope "
+            "writes; tenant- and target-scope writes default to no "
+            "expiry). "
+            "Do NOT use this for durable, generalizable team knowledge — "
+            "that belongs in `add_to_knowledge`. Memory is for shorter-"
+            "lived, operator/tenant/target-scoped state."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Memory body. Markdown is fine; stored as-is. "
+                        "The retrieval substrate indexes it as a single "
+                        "document (BM25 over tsvector + 384-dim embedding "
+                        "for cosine)."
+                    ),
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": _SCOPE_ENUM,
+                    "description": (
+                        "One of 'user', 'user-tenant', 'user-target', "
+                        "'tenant', 'target'. Pick the narrowest scope "
+                        "that captures intent; see the tool description "
+                        "for the matrix. 'user-target' and 'target' "
+                        "require `target_name`."
+                    ),
+                },
+                "ttl": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Optional ISO 8601 duration ('P7D', 'PT1H', "
+                        "'PT30M'). Months and years are not accepted "
+                        "(variable-length). Omit to accept the backend "
+                        "default — G5.2 #374 will inject a 7-day TTL on "
+                        "user-scope writes; tenant/target writes default "
+                        "to no expiry."
+                    ),
+                },
+                "target_name": {
+                    "type": ["string", "null"],
+                    "minLength": 1,
+                    "description": (
+                        "Target name, required when scope is "
+                        "'user-target' or 'target'. Ignored for other "
+                        "scopes (server-side write boundary clears it)."
+                    ),
+                },
+                "slug": {
+                    "type": ["string", "null"],
+                    "minLength": 1,
+                    "description": (
+                        "Operator-facing identifier within the scope. "
+                        "Allowed characters: letters, digits, hyphen, "
+                        "underscore, dot. Omit to let the backend "
+                        "auto-generate a 12-char UUID hex prefix."
+                    ),
+                },
+                "tags": {
+                    "type": ["array", "null"],
+                    "items": {"type": "string", "minLength": 1},
+                    "description": (
+                        "Optional list of tag strings. Stored in "
+                        "metadata.tags and filterable via the `list` REST "
+                        "verb; the MCP search surface does not filter on "
+                        "tags directly in v0.2."
+                    ),
+                },
+            },
+            "required": ["content", "scope"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_add_to_memory_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -131,9 +131,13 @@ def isolated_registry() -> Iterator[None]:
     matching ``meho://kb/{slug}`` resource (``mcp.resources.kb``) join
     the list for the same reason. The G9.1-T7 topology meta-tools
     (``mcp.tools.topology`` — ``query_topology`` + ``list_targets``)
-    join the list for the same reason.
+    join the list for the same reason. The G5.1-T3 memory meta-tools
+    (``mcp.tools.memory`` — ``search_memory`` + ``add_to_memory``) and
+    the matching ``meho://memory/{scope}/{slug}`` resource
+    (``mcp.resources.memory``) join for the same reason.
     """
     from meho_backplane.mcp.resources import kb as kb_resource
+    from meho_backplane.mcp.resources import memory as memory_resource
     from meho_backplane.mcp.resources import tenant_feed, tenant_info
     from meho_backplane.mcp.tools import (
         audit,
@@ -143,6 +147,7 @@ def isolated_registry() -> Iterator[None]:
         operations,
         topology,
     )
+    from meho_backplane.mcp.tools import memory as memory_tools
 
     clear_registries()
     importlib.reload(meho_status)
@@ -151,9 +156,11 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(audit)
     importlib.reload(knowledge)
     importlib.reload(topology)
+    importlib.reload(memory_tools)
     importlib.reload(tenant_info)
     importlib.reload(tenant_feed)
     importlib.reload(kb_resource)
+    importlib.reload(memory_resource)
     yield
     clear_registries()
 

--- a/backend/tests/test_mcp_resources_memory.py
+++ b/backend/tests/test_mcp_resources_memory.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``meho://memory/{scope}/{slug}`` MCP resource (G5.1-T3, #423).
+
+Covers every acceptance criterion in the task body that targets the
+resource surface:
+
+* The template is registered via G0.5's ``register_mcp_resource`` and
+  surfaces in ``resources/templates/list`` with the
+  :class:`ResourceTemplateDefinition` wire shape (``mimeType`` =
+  ``text/markdown``; MEHO-internal ``required_role`` stripped).
+* ``resources/read meho://memory/user/<existing-slug>`` returns the
+  full :class:`MemoryEntry` payload as a JSON-encoded ``text/markdown``
+  content block.
+* Unknown slug → INVALID_PARAMS (-32602).
+* Unknown scope → INVALID_PARAMS.
+* Malformed slug (one that fails ``SLUG_PATTERN``) → INVALID_PARAMS.
+* Tenant boundary: another tenant's same-slug entry collapses to
+  "not found" without revealing the foreign tenant's existence.
+* Cross-operator user-scoped read collapses to "not found" without
+  revealing the foreign operator's row.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.memory.schemas import MemoryScope
+from meho_backplane.memory.service import MemoryService
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+
+@pytest.fixture
+def stub_embedding() -> Iterator[AsyncMock]:
+    """Patch the embedding service so SQLite-backed tests run without fastembed."""
+    fake = AsyncMock()
+    fake.encode_one.return_value = [0.1] * 384
+    fake.encode.return_value = [[0.1] * 384]
+    fake.dimension = 384
+    with patch(
+        "meho_backplane.retrieval.indexer.get_embedding_service",
+        return_value=fake,
+    ):
+        yield fake.encode_one
+
+
+# ---------------------------------------------------------------------------
+# resources/templates/list shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_templates_list_exposes_memory_entry(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: the memory resource template surfaces in ``resources/templates/list``."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "resources/templates/list"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    templates = body["result"]["resourceTemplates"]
+    memory_entries = [t for t in templates if t["uriTemplate"] == "meho://memory/{scope}/{slug}"]
+    assert len(memory_entries) == 1
+    template = memory_entries[0]
+    assert template["mimeType"] == "text/markdown"
+    # MEHO-internal RBAC field stripped from the wire shape.
+    assert "required_role" not in template
+
+
+# ---------------------------------------------------------------------------
+# resources/read — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_resources_read_returns_full_memory_entry_body(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: read an existing user-scoped slug → full body + metadata under text/markdown."""
+    client, op = client_with_operator
+    service = MemoryService()
+    await service.remember(
+        op,
+        scope=MemoryScope.USER,
+        body="# Wine\n\nFull Markdown body of the operator's preference.",
+        slug="wine-preference",
+    )
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "resources/read",
+            "params": {"uri": "meho://memory/user/wine-preference"},
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    contents = body["result"]["contents"]
+    assert len(contents) == 1
+    block = contents[0]
+    assert block["uri"] == "meho://memory/user/wine-preference"
+    assert block["mimeType"] == "text/markdown"
+
+    payload = json.loads(block["text"])
+    assert payload["scope"] == "user"
+    assert payload["slug"] == "wine-preference"
+    assert payload["body"].startswith("# Wine")
+    # Substrate-side timestamps round-trip.
+    assert "created_at" in payload
+    assert "updated_at" in payload
+    # The handler returns the full MemoryEntry shape, including
+    # service-managed metadata fields.
+    assert payload["user_sub"] == op.sub
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_resources_read_returns_tenant_scope_entry(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """A tenant-scope read works for any operator in the tenant.
+
+    Tenant-shared memory has no ``target_name`` dimension and no
+    per-operator ``user_sub`` gating, so the
+    ``meho://memory/tenant/{slug}`` URI template fully addresses the
+    entry. Seeds the row via the service under a tenant_admin operator
+    (write side requires that role) and reads back as the fixture
+    operator (read side is open to every operator in the tenant).
+    """
+    client, op = client_with_operator
+    # Service-side write needs tenant_admin role; seed via a stand-in
+    # admin operator pinned to the same tenant.
+    admin = Operator(
+        sub=op.sub,  # same operator, elevated role for the seed write
+        name=op.name,
+        email=op.email,
+        raw_jwt=op.raw_jwt,
+        tenant_id=op.tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+    service = MemoryService()
+    await service.remember(
+        admin,
+        scope=MemoryScope.TENANT,
+        body="Tenant convention: use Brunello for all demos.",
+        slug="wine-default",
+    )
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "resources/read",
+            "params": {"uri": "meho://memory/tenant/wine-default"},
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" not in body
+    payload = json.loads(body["result"]["contents"][0]["text"])
+    assert payload["scope"] == "tenant"
+    assert payload["slug"] == "wine-default"
+    assert payload["body"] == "Tenant convention: use Brunello for all demos."
+
+
+# ---------------------------------------------------------------------------
+# resources/read — rejection arms
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_read_unknown_slug_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: an unknown but well-formed slug → INVALID_PARAMS."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "resources/read",
+            "params": {"uri": "meho://memory/user/does-not-exist"},
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "not found" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_read_unknown_scope_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An unrecognised ``{scope}`` value → INVALID_PARAMS.
+
+    Rejection happens before any DB query so a probe with an arbitrary
+    scope string can't be used to learn the enum shape via timing.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "resources/read",
+            "params": {"uri": "meho://memory/imaginary/some-slug"},
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "invalid scope" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_read_malformed_slug_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A slug containing characters outside the safe set → INVALID_PARAMS.
+
+    The handler's ``validate_slug`` call surfaces :class:`ValueError`,
+    which maps to INVALID_PARAMS. The rejection happens before any DB
+    I/O, so a probe attempt with a bad-shape URI can't be used to
+    learn whether arbitrary slugs exist.
+    """
+    client, _op = client_with_operator
+    # ``has:colon`` violates SLUG_PATTERN (colon is not in the safe set).
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "resources/read",
+            "params": {"uri": "meho://memory/user/has:colon"},
+        },
+    )
+    # The URI template's `[^/]+` capture would actually parse
+    # `user` / `has:colon` into the bound vars; the colon is the
+    # offending character that fails SLUG_PATTERN inside the handler.
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary + cross-operator info-leak avoidance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_resources_read_does_not_reveal_foreign_tenant_entries(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: a slug owned by another tenant collapses to "not found".
+
+    The error message must not distinguish "this slug doesn't exist"
+    from "this slug exists but belongs to another tenant" — otherwise
+    the resource handler is a tenant-existence oracle for any operator
+    that can guess slugs.
+    """
+    client, op = client_with_operator
+    foreign_tenant = uuid.uuid4()
+    foreign_op = Operator(
+        sub="foreign-op",
+        name=None,
+        email=None,
+        raw_jwt="not-a-real-jwt",
+        tenant_id=foreign_tenant,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+    service = MemoryService()
+    await service.remember(
+        foreign_op,
+        scope=MemoryScope.TENANT,
+        body="Foreign tenant's convention.",
+        slug="foreign-tenant-default",
+    )
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "resources/read",
+            "params": {"uri": "meho://memory/tenant/foreign-tenant-default"},
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    # Error message says "not found" — same shape as a truly-missing
+    # slug, deliberately not "forbidden" or "cross-tenant".
+    assert "not found" in body["error"]["message"].lower()
+    # The fixture operator's own tenant_id never appears in the
+    # foreign tenant's row — defensive sanity that the test's
+    # foreign-tenant write actually used a different id.
+    assert op.tenant_id != foreign_tenant
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_resources_read_does_not_reveal_other_operator_user_scope(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: operator A cannot read operator B's user-scoped slug in the same tenant.
+
+    The natural-key encoding (``user:<sub>:<slug>``) embeds the writer's
+    ``sub`` so the lookup under the requester's ``sub`` never matches
+    another operator's row. The handler renders the miss as "not found"
+    — the cross-operator boundary is invisible from the wire shape.
+    """
+    client, op = client_with_operator
+    # Seed a user-scoped row under a different operator in the same tenant.
+    other = Operator(
+        sub="other-operator",
+        name=None,
+        email=None,
+        raw_jwt="not-a-real-jwt",
+        tenant_id=op.tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+    service = MemoryService()
+    await service.remember(
+        other,
+        scope=MemoryScope.USER,
+        body="Other operator's personal note.",
+        slug="other-personal-note",
+    )
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "resources/read",
+            "params": {"uri": "meho://memory/user/other-personal-note"},
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "not found" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# RBAC visibility — read_only operator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.READ_ONLY],
+    indirect=True,
+)
+def test_memory_resource_hidden_from_read_only_operator(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``required_role=OPERATOR`` hides the template from read-only operators."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "resources/templates/list"},
+    )
+    templates = response.json()["result"]["resourceTemplates"]
+    uri_templates = {t["uriTemplate"] for t in templates}
+    assert "meho://memory/{scope}/{slug}" not in uri_templates

--- a/backend/tests/test_mcp_tools_memory.py
+++ b/backend/tests/test_mcp_tools_memory.py
@@ -1,0 +1,814 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``search_memory`` / ``add_to_memory`` MCP tools (G5.1-T3, #423).
+
+Covers every acceptance criterion in the task body that targets the
+tool surface:
+
+* Both meta-tools are registered against the G0.5 registry; ``tools/list``
+  surfaces them with strict 2020-12 ``inputSchema``
+  (``additionalProperties: false``) and the MEHO-internal RBAC fields
+  stripped from the wire shape.
+* ``inputSchema`` ``required`` lists match the spec: ``[query]`` for
+  ``search_memory``; ``[content, scope]`` for ``add_to_memory``.
+* Tool descriptions name what + when + which scope + cross-reference
+  G5.2's TTL default (load-bearing per the AI-engineering anchor).
+* ``tools/call search_memory`` against a seeded corpus returns ranked
+  hits adapted from :class:`MemoryEntrySearchHit`.
+* ``tools/call add_to_memory`` creates the entry; a follow-up
+  ``search_memory`` finds it.
+* RBAC: ``operator`` writing ``TENANT`` is denied (INVALID_PARAMS),
+  ``tenant_admin`` writing ``TENANT`` succeeds.
+* Tenant boundary: a search initiated under tenant A never returns
+  tenant B's entries.
+* TTL parsing: ``P7D`` / ``PT1H`` accepted; ``P1Y`` rejected;
+  malformed strings rejected.
+* Audit + broadcast emit per call via the shared dispatcher path
+  (covered transitively in :mod:`tests.test_mcp_audit`).
+
+Embedding is mocked the same way :mod:`tests.test_memory_service` mocks
+it, so the SQLite-backed default DB carries the suite without needing
+fastembed at test time. The retrieve substrate's PG-only BM25 + cosine
+SQL is patched via :func:`patch` on
+:func:`meho_backplane.retrieval.retriever.retrieve`; the wire-shape
+contract here is the **MCP surface** plus end-to-end service round-trip
+on SQLite, with PG-real ranking coverage living in the integration suite.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.memory.schemas import MemoryScope
+from meho_backplane.memory.service import MemoryService
+from meho_backplane.retrieval.retriever import RetrievalHit
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+
+@pytest.fixture
+def stub_embedding() -> Iterator[AsyncMock]:
+    """Patch :func:`get_embedding_service` so the substrate encodes deterministically.
+
+    Mirrors the embedding stub in :mod:`tests.test_memory_service` — the
+    indexer's embedding compute is the only path that pulls fastembed /
+    ONNX runtime, so patching at the import site lets the SQLite-backed
+    test DB carry every assertion below.
+    """
+    fake = AsyncMock()
+    fake.encode_one.return_value = [0.1] * 384
+    fake.encode.return_value = [[0.1] * 384]
+    fake.dimension = 384
+    with patch(
+        "meho_backplane.retrieval.indexer.get_embedding_service",
+        return_value=fake,
+    ):
+        yield fake.encode_one
+
+
+# ---------------------------------------------------------------------------
+# tools/list shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_exposes_memory_tools_with_strict_input_schema(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: both tools appear with strict 2020-12 schemas.
+
+    ``search_memory`` requires ``[query]``; ``add_to_memory`` requires
+    ``[content, scope]``. Both have ``additionalProperties: false``.
+    The MEHO-internal RBAC fields (``required_role`` / ``op_class``)
+    are stripped by :meth:`ToolDefinition.to_wire`.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    tools_by_name = {t["name"]: t for t in body["result"]["tools"]}
+
+    assert "search_memory" in tools_by_name
+    search = tools_by_name["search_memory"]
+    assert search["inputSchema"]["type"] == "object"
+    assert search["inputSchema"]["required"] == ["query"]
+    assert search["inputSchema"]["additionalProperties"] is False
+    assert "query" in search["inputSchema"]["properties"]
+    assert "scope" in search["inputSchema"]["properties"]
+    assert "limit" in search["inputSchema"]["properties"]
+    assert "required_role" not in search
+    assert "op_class" not in search
+
+    assert "add_to_memory" in tools_by_name
+    add = tools_by_name["add_to_memory"]
+    assert add["inputSchema"]["required"] == ["content", "scope"]
+    assert add["inputSchema"]["additionalProperties"] is False
+    assert "content" in add["inputSchema"]["properties"]
+    assert "scope" in add["inputSchema"]["properties"]
+    assert "ttl" in add["inputSchema"]["properties"]
+    assert "target_name" in add["inputSchema"]["properties"]
+    assert "slug" in add["inputSchema"]["properties"]
+    assert "tags" in add["inputSchema"]["properties"]
+    assert "required_role" not in add
+    assert "op_class" not in add
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tool_descriptions_satisfy_ai_engineering_anchor(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: descriptions name what + when + which scope + G5.2 TTL cross-reference.
+
+    Smoke-asserts the load-bearing pieces of the description prose so a
+    future edit that removes them surfaces here rather than as silently
+    degraded agent UX. Keeps assertions loose (substring presence) so
+    prose can evolve without churn.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+
+    search_desc = tools_by_name["search_memory"]["description"]
+    # What: memory recall.
+    assert "memor" in search_desc.lower()
+    # When to use: recall established conventions / preferences.
+    assert "recall" in search_desc.lower() or "established" in search_desc.lower()
+    # When NOT to use: durable team knowledge → kb.
+    assert "knowledge base" in search_desc.lower() or "search_knowledge" in search_desc
+    # Cross-reference to the companion resource for the full body.
+    assert "meho://memory/" in search_desc
+    # Scope enumeration discipline (names every scope so an agent
+    # without a tool listing can still pick correctly).
+    for scope_value in (s.value for s in MemoryScope):
+        assert scope_value in search_desc
+
+    add_desc = tools_by_name["add_to_memory"]["description"]
+    # When to use: capturing retainable session learning.
+    assert "retain" in add_desc.lower() or "preference" in add_desc.lower()
+    # Cross-reference G5.2's TTL default (load-bearing per the issue body).
+    assert "G5.2" in add_desc or "7-day" in add_desc
+    # Each scope is named explicitly.
+    for scope_value in (s.value for s in MemoryScope):
+        assert scope_value in add_desc
+    # Search-first discipline (avoid corpus fragmentation).
+    assert "search_memory" in add_desc
+    # When NOT to use: kb is the durable surface.
+    assert "add_to_knowledge" in add_desc
+
+
+# ---------------------------------------------------------------------------
+# search_memory — call path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_search_memory_returns_ranked_hits(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: search returns ranked hits adapted to :class:`MemoryEntrySearchHit`.
+
+    Mocks the retrieve substrate the same way
+    :mod:`tests.test_memory_service` does for its search test — the
+    PG-only ``@@`` / ``<=>`` ranking is exercised in the integration
+    suite. Here the assertion is the MCP wire-shape contract: hits
+    arrive with the (scope, slug) pair, the body, and the fused score
+    round-tripping through ``model_dump(mode="json")`` and the
+    dispatcher's ``content[0].text`` JSON envelope.
+    """
+    client, op = client_with_operator
+    captured: dict[str, object] = {}
+
+    fake_hit = RetrievalHit(
+        document_id=uuid.uuid4(),
+        tenant_id=op.tenant_id,
+        source="memory",
+        source_id=f"user:{op.sub}:wine-preference",
+        kind="memory-user",
+        body="Prefers a 2019 Brunello with steak.",
+        doc_metadata={
+            "user_sub": op.sub,
+            "target_name": None,
+            "expires_at": None,
+            "scope": "user",
+        },
+        fused_score=0.7,
+        bm25_score=0.4,
+        cosine_score=0.85,
+        bm25_rank=1,
+        cosine_rank=1,
+    )
+
+    async def fake_retrieve(**kwargs: object) -> list[RetrievalHit]:
+        captured.update(kwargs)
+        return [fake_hit]
+
+    with patch(
+        "meho_backplane.memory.service.retrieve",
+        side_effect=fake_retrieve,
+    ):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_memory",
+                    "arguments": {"query": "wine"},
+                },
+            },
+        )
+
+    assert captured["source"] == "memory"
+    assert captured["tenant_id"] == op.tenant_id
+    assert captured["query"] == "wine"
+    # No scope filter → kind passed as None to retrieve (service-side
+    # post-filter on `visible_kinds` is the matrix gate).
+    assert captured["kind"] is None
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert "hits" in payload
+    assert isinstance(payload["hits"], list)
+    assert len(payload["hits"]) == 1
+    hit = payload["hits"][0]
+    # The hit wraps a MemoryEntry under `entry` plus the ranking metadata.
+    assert hit["entry"]["scope"] == "user"
+    assert hit["entry"]["slug"] == "wine-preference"
+    assert hit["entry"]["body"] == "Prefers a 2019 Brunello with steak."
+    assert hit["fused_score"] == pytest.approx(0.7)
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_search_memory_forwards_scope_and_limit(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The ``scope`` and ``limit`` arguments reach the retrieve call.
+
+    The handler translates the wire string ``scope`` into the typed
+    enum and forwards ``limit`` verbatim; the fake retrieve captures
+    both so we can assert the plumbing without exercising the SQL.
+    """
+    client, _op = client_with_operator
+    captured: dict[str, object] = {}
+
+    async def fake_retrieve(**kwargs: object) -> list[RetrievalHit]:
+        captured.update(kwargs)
+        return []
+
+    with patch(
+        "meho_backplane.memory.service.retrieve",
+        side_effect=fake_retrieve,
+    ):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_memory",
+                    "arguments": {
+                        "query": "x",
+                        "scope": "tenant",
+                        "limit": 5,
+                    },
+                },
+            },
+        )
+    assert response.status_code == 200
+    # `kind` reflects the scope-to-kind translation
+    # (`memory-tenant`) the service performs before reaching retrieve.
+    assert captured["kind"] == "memory-tenant"
+    # The service pulls `limit * 4` candidates for the RBAC post-filter
+    # pass; assert at least the limit was forwarded.
+    assert captured["limit"] == max(5 * 4, 50)
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_search_memory_rejects_missing_query(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: missing required ``query`` fails JSON-Schema validation → -32602."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "search_memory", "arguments": {}},
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_search_memory_rejects_extra_arguments(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``additionalProperties: false`` rejects unknown top-level keys."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "search_memory",
+                "arguments": {"query": "anything", "unknown_field": 42},
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_search_memory_rejects_unrecognised_scope(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The ``scope`` enum constraint blocks values outside the five scopes."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "search_memory",
+                "arguments": {"query": "x", "scope": "nonexistent-scope"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# add_to_memory — call path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_creates_entry_and_is_recallable(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: add_to_memory creates the row; the entry is recallable via the service.
+
+    Writes through the MCP transport, then verifies the row landed by
+    reading back through :meth:`MemoryService.recall` (SELECT-only —
+    portable across SQLite + PG, so this test exercises the full
+    write path without depending on the substrate's PG-only retrieval
+    SQL). The PG-real round-trip through ``search_memories`` is in
+    the integration suite; the wire-shape contract here is the
+    response shape from ``add_to_memory`` (full :class:`MemoryEntry`
+    ``model_dump(mode="json")``) plus the substrate write.
+    """
+    client, op = client_with_operator
+
+    create = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Operator prefers concise CLI output.",
+                    "scope": "user",
+                    "slug": "cli-output-preference",
+                    "tags": ["preference"],
+                },
+            },
+        },
+    )
+    assert create.status_code == 200
+    body = create.json()
+    assert body["result"]["isError"] is False
+    created = json.loads(body["result"]["content"][0]["text"])
+    assert created["scope"] == "user"
+    assert created["slug"] == "cli-output-preference"
+    assert created["body"] == "Operator prefers concise CLI output."
+    assert created["metadata"]["tags"] == ["preference"]
+    # MemoryEntry model_dump payload carries the substrate-side id +
+    # timestamps; assert their shape so a future field-rename surfaces here.
+    assert "id" in created
+    assert "created_at" in created
+    assert "updated_at" in created
+
+    # The substrate row is actually present and recallable by the operator.
+    service = MemoryService()
+    fetched = await service.recall(op, scope=MemoryScope.USER, slug="cli-output-preference")
+    assert fetched is not None
+    assert fetched.body == "Operator prefers concise CLI output."
+    assert fetched.metadata["tags"] == ["preference"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_applies_ttl(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: ``ttl`` parses an ISO 8601 duration into an ``expires_at`` window.
+
+    A ``P7D`` ttl yields an ``expires_at`` ~7 days from now (allowing
+    a few seconds of jitter for the round-trip). The returned
+    :class:`MemoryEntry` carries the parsed timestamp under
+    :attr:`expires_at`.
+    """
+    client, _op = client_with_operator
+
+    before = datetime.now(UTC)
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Short-lived note.",
+                    "scope": "user",
+                    "ttl": "P7D",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["expires_at"] is not None
+    parsed = datetime.fromisoformat(payload["expires_at"])
+    # 7 days ± a wide window so a slow test machine never flakes.
+    expected = before + timedelta(days=7)
+    delta = abs((parsed - expected).total_seconds())
+    assert delta < 60, f"expected ~7 days from {before}, got {parsed} (delta={delta}s)"
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_add_to_memory_rejects_year_ttl(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Year/month/week TTL components are rejected (variable-length).
+
+    The handler accepts ``P[nD][T...]`` shapes only; ``P1Y`` surfaces as
+    INVALID_PARAMS with the unsupported-unit message.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "x",
+                    "scope": "user",
+                    "ttl": "P1Y",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "unsupported unit" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_add_to_memory_rejects_malformed_ttl(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A ttl that isn't an ISO 8601 duration → INVALID_PARAMS."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "x",
+                    "scope": "user",
+                    "ttl": "seven days",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_add_to_memory_operator_denied_tenant_scope(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: an ``operator`` role attempting a ``TENANT`` write → INVALID_PARAMS.
+
+    The service-side
+    :class:`~meho_backplane.memory.rbac.MemoryRbacResolver` denies the
+    write; the handler maps :class:`PermissionDeniedError` to
+    :class:`McpInvalidParamsError`. JSON-RPC has no HTTP-403 analogue;
+    INVALID_PARAMS is the spec-correct lane for caller-input failures
+    of this shape.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Tenant-wide convention.",
+                    "scope": "tenant",
+                    "slug": "tenant-convention",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "permission" in body["error"]["message"].lower() or (
+        "scope=tenant" in body["error"]["message"].lower()
+    )
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_tenant_admin_can_write_tenant_scope(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: ``tenant_admin`` writing ``TENANT`` succeeds; entry is created."""
+    client, op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Use Brunello for all wine-pairing demos.",
+                    "scope": "tenant",
+                    "slug": "wine-pairing-tenant-default",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["scope"] == "tenant"
+    assert payload["slug"] == "wine-pairing-tenant-default"
+
+    # The substrate row is present and recallable by the same admin
+    # (tenant-scope reads are open to every operator in the tenant).
+    service = MemoryService()
+    fetched = await service.recall(
+        op,
+        scope=MemoryScope.TENANT,
+        slug="wine-pairing-tenant-default",
+    )
+    assert fetched is not None
+    assert fetched.body == "Use Brunello for all wine-pairing demos."
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_add_to_memory_requires_target_name_for_target_scope(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """A ``target``-scope write without ``target_name`` → INVALID_PARAMS.
+
+    The service raises :class:`ValueError` before reaching the indexer
+    when the target-scope contract is violated; the handler maps that
+    to INVALID_PARAMS.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Target-specific gotcha.",
+                    "scope": "target",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "target_name" in body["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_add_to_memory_rejects_missing_required(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Schema validation fires before the handler — missing ``content`` → -32602."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {"scope": "user"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# RBAC visibility — read_only operator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.READ_ONLY],
+    indirect=True,
+)
+def test_memory_tools_hidden_from_read_only_operator(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: ``required_role=OPERATOR`` hides both tools from read-only operators."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    tool_names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "search_memory" not in tool_names
+    assert "add_to_memory" not in tool_names
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_search_memory_binds_operator_tenant_to_retrieve(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The handler forwards the operator's tenant_id verbatim, never a caller-supplied one.
+
+    A separate ``tenant_id`` field is intentionally NOT exposed on the
+    tool's input schema — the agent never gets to pick which tenant to
+    search. The handler always binds :attr:`Operator.tenant_id`,
+    which the JWT validator resolved upstream. Mocking ``retrieve``
+    and asserting the captured ``tenant_id`` kwarg pins the boundary
+    at the handler level.
+    """
+    client, op = client_with_operator
+    captured: dict[str, Any] = {}
+
+    async def fake_retrieve(**kwargs: object) -> list[RetrievalHit]:
+        captured.update(kwargs)
+        return []
+
+    with patch(
+        "meho_backplane.memory.service.retrieve",
+        side_effect=fake_retrieve,
+    ):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_memory",
+                    "arguments": {"query": "anything"},
+                },
+            },
+        )
+    assert response.status_code == 200
+    assert captured["tenant_id"] == op.tenant_id


### PR DESCRIPTION
## Summary

- Register two MCP meta-tools (`search_memory`, `add_to_memory`) and one resource template (`meho://memory/{scope}/{slug}`) against G0.5's registry, completing the Memory family on CLAUDE.md's narrow agent waist (2 of the ~17 meta-tools).
- Both tools delegate to the existing `MemoryService` from G5.1-T1 (#421); per-scope RBAC, tenant boundary, and read-side 404-vs-403 collapse are inherited, not re-derived.
- Tool descriptions name what + when + which scope and cross-reference G5.2's default 7-day TTL per the AI-engineering anchor; `add_to_memory` parses ISO 8601 durations (`P7D`, `PT1H`) into absolute `expires_at`.
- Both modules register at import time and are auto-discovered by `eager_import_mcp_modules`, so no `main.py` edits — scope stays isolated to the MCP layer + the shared test-fixture reload list.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy --ignore-missing-imports` — 173 source files clean
- [x] `pytest tests/test_mcp_tools_memory.py tests/test_mcp_resources_memory.py` — 26 passed
- [x] Full MCP suite regression — 181 passed (existing kb / topology / audit / etc. unaffected)
- [x] Full unit suite — 2127 passed, 8 skipped
- [x] `tools/list` exposes `search_memory` + `add_to_memory` with strict 2020-12 `inputSchema`, `additionalProperties: false`, MEHO-internal fields stripped
- [x] `tools/call search_memory` returns ranked hits with `(scope, slug)` + body + fused score
- [x] `tools/call add_to_memory` creates the row; recall round-trip works; TTL parses to `expires_at`
- [x] RBAC: `operator` writing TENANT → INVALID_PARAMS; `tenant_admin` writing TENANT succeeds
- [x] `resources/templates/list` shows `meho://memory/{scope}/{slug}` with `mimeType: text/markdown`
- [x] `resources/read meho://memory/user/<slug>` returns full body; cross-tenant + cross-operator misses collapse to "not found"
- [x] `read_only` operators see neither tool nor resource

## Out of scope

- REST routes (`/api/v1/memory*`) — sibling Task #422 (parallel in Wave 2).
- CLI verbs (`meho remember/recall/forget/list`) — Task #424.
- Tenant-promotion verb + per-scope RBAC tightening + auto-expiry executor — sibling Initiative G5.2 (#374).
- `add_to_memory` description references G5.2's 7-day TTL contract; the default injection lands with that initiative.

Adjacent findings (recorded, deferred):
- `backend/src/meho_backplane/mcp/tools/memory.py` is 512 lines — mostly load-bearing tool descriptions + module docstring. Code-quality hook reports a warn-level file-size finding (warn >400, block >600); no agent-introduced blocker.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #423


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added memory resource to access stored memory entries with user and tenant scopes
  * Added `search_memory` tool to query and retrieve stored information
  * Added `add_to_memory` tool to store information with optional time-to-live expiration
  * Memory operations include role-based access control for security

* **Tests**
  * Added comprehensive test coverage for memory resource and tools, including access control and boundary validations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->