### PR TITLE
docs(retrieval): G0.8-T6 de-silence the REST-excluded retrieve/usage zero

### DIFF
--- a/backend/src/meho_backplane/retrieval/retire.py
+++ b/backend/src/meho_backplane/retrieval/retire.py
@@ -93,7 +93,9 @@ from meho_backplane.retrieval.eval.runner import (
     eval_all,
 )
 from meho_backplane.retrieval.usage import (
+    COUNTED_SEARCH_SURFACES,
     MCP_TOOL_PATH_PREFIX,
+    REST_RETRIEVE_EXCLUDED,
     SEARCH_OPS,
     SUPPORTED_SURFACES,
 )
@@ -243,6 +245,28 @@ class RetireChecklistReport(BaseModel):
     until: datetime
     surfaces: list[SurfaceChecklist]
     overall_verdict: ChecklistVerdict
+
+    #: The fully-qualified surface labels whose audit_log rows feed
+    #: criterion 1 (days since first daily use) and criterion 2
+    #: (operator breadth) — the same audited MCP search meta-tools
+    #: :mod:`meho_backplane.retrieval.usage` counts. Surfaced here so an
+    #: operator whose overlap clock is stuck (criteria 1 + 2 perpetually
+    #: red) can see *why*: REST ``POST /api/v1/retrieve`` does not feed
+    #: these criteria; only the audited ``/mcp`` search tools do.
+    #: Defaulted from :data:`COUNTED_SEARCH_SURFACES` so the verdict
+    #: surface cannot drift from the audit-log scan filter.
+    counted_surfaces: list[str] = Field(
+        default_factory=lambda: list(COUNTED_SEARCH_SURFACES),
+    )
+
+    #: ``True`` whenever REST ``POST /api/v1/retrieve`` is excluded from
+    #: the audit-log scan that feeds the daily-use + operator-breadth
+    #: criteria (always, in v0.2 — see
+    #: :data:`meho_backplane.retrieval.usage.REST_RETRIEVE_EXCLUDED`).
+    #: De-silences the "GREEN never arrives" trap for a REST-only
+    #: dogfood: the retire decision is fed by the counted MCP surface,
+    #: not REST ``/retrieve``.
+    rest_excluded: bool = Field(default=REST_RETRIEVE_EXCLUDED)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/retrieval/usage.py
+++ b/backend/src/meho_backplane/retrieval/usage.py
@@ -115,7 +115,7 @@ from datetime import date as date_type
 from typing import Any, Final, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -124,8 +124,10 @@ from meho_backplane.db.models import AuditLog
 __all__ = [
     "ADD_OPS",
     "CONVERSION_WINDOW",
+    "COUNTED_SEARCH_SURFACES",
     "DEFAULT_SINCE",
     "MCP_TOOL_PATH_PREFIX",
+    "REST_RETRIEVE_EXCLUDED",
     "SEARCH_OPS",
     "SUPPORTED_SURFACES",
     "DailyUsageBucket",
@@ -167,6 +169,29 @@ ADD_OPS: Final[Mapping[str, str]] = {
 #: validate ``surface=`` query strings and to construct the bucket
 #: cross-product when the surface had zero searches.
 SUPPORTED_SURFACES: Final[tuple[str, ...]] = ("kb", "memory", "operations")
+
+#: The fully-qualified labels of the surfaces this counter actually
+#: counts. Derived from :data:`SEARCH_OPS` (the single source of truth
+#: for which audit_log paths feed the aggregation) so the documented
+#: contract cannot drift from the query filter. Only the audited MCP
+#: search meta-tools tick the counter: a row lands in ``audit_log`` with
+#: ``path = f"{MCP_TOOL_PATH_PREFIX}{tool}"`` only when the tool is
+#: invoked over the ``/mcp`` surface. ``POST /api/v1/retrieve`` runs the
+#: same retrieval substrate but audits under ``/api/v1/retrieve`` — not
+#: a counted path — so it is deliberately excluded (see
+#: :data:`REST_RETRIEVE_EXCLUDED`). Surfaced verbatim on
+#: :class:`UsageReport` so a ``total_searches=0`` reads as "REST is not
+#: counted", not "no usage".
+COUNTED_SEARCH_SURFACES: Final[tuple[str, ...]] = tuple(f"mcp:{op_id}" for op_id in SEARCH_OPS)
+
+#: Whether the operator-facing REST ``POST /api/v1/retrieve`` surface
+#: increments this counter. Always ``False`` in v0.2 by design: REST
+#: ``/retrieve`` audits under its own path, not a counted MCP tool
+#: path, so dogfooding exclusively through REST shows a permanent
+#: silent zero. Counting REST would change audit volume and risk
+#: double-counting against the MCP path — a separate scoped change if
+#: ever wanted. This flag exists so the zero is self-explaining.
+REST_RETRIEVE_EXCLUDED: Final[bool] = True
 
 #: Conversion window — a search "converts" if the same operator emits
 #: any subsequent audit_log row within this window. Five minutes is the
@@ -301,6 +326,25 @@ class UsageReport(BaseModel):
     tenant_id: UUID | None
     buckets: list[DailyUsageBucket]
     total_searches: int
+
+    #: The fully-qualified surface labels that actually feed
+    #: ``total_searches`` (``["mcp:search_knowledge", …]``). De-silences
+    #: a zero: an operator who dogfoods exclusively via REST
+    #: ``POST /api/v1/retrieve`` sees ``total_searches=0`` with this
+    #: list present, so the zero reads as "REST is not counted" instead
+    #: of "no retrieval activity". Defaulted from
+    #: :data:`COUNTED_SEARCH_SURFACES` so the response cannot drift from
+    #: the query filter.
+    counted_surfaces: list[str] = Field(
+        default_factory=lambda: list(COUNTED_SEARCH_SURFACES),
+    )
+
+    #: ``True`` whenever REST ``POST /api/v1/retrieve`` is excluded from
+    #: the counter (always, in v0.2 — see :data:`REST_RETRIEVE_EXCLUDED`).
+    #: The machine-readable companion to ``counted_surfaces`` for
+    #: consumers (T6 retire-checklist, dashboards) that want a boolean
+    #: rather than to diff the surface list.
+    rest_excluded: bool = Field(default=REST_RETRIEVE_EXCLUDED)
 
 
 def _search_paths_for(surfaces: Iterable[str]) -> tuple[list[str], dict[str, str]]:

--- a/backend/src/meho_backplane/retrieval/usage.py
+++ b/backend/src/meho_backplane/retrieval/usage.py
@@ -185,7 +185,7 @@ SUPPORTED_SURFACES: Final[tuple[str, ...]] = ("kb", "memory", "operations")
 COUNTED_SEARCH_SURFACES: Final[tuple[str, ...]] = tuple(f"mcp:{op_id}" for op_id in SEARCH_OPS)
 
 #: Whether the operator-facing REST ``POST /api/v1/retrieve`` surface
-#: increments this counter. Always ``False`` in v0.2 by design: REST
+#: is excluded from this counter. Always ``True`` in v0.2 by design: REST
 #: ``/retrieve`` audits under its own path, not a counted MCP tool
 #: path, so dogfooding exclusively through REST shows a permanent
 #: silent zero. Counting REST would change audit volume and risk

--- a/backend/tests/test_retrieval_retire.py
+++ b/backend/tests/test_retrieval_retire.py
@@ -76,7 +76,10 @@ from meho_backplane.retrieval.retire import (
     _worst_band,
     compute_retire_checklist,
 )
-from meho_backplane.retrieval.usage import MCP_TOOL_PATH_PREFIX
+from meho_backplane.retrieval.usage import (
+    COUNTED_SEARCH_SURFACES,
+    MCP_TOOL_PATH_PREFIX,
+)
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
@@ -539,6 +542,17 @@ async def test_compute_retire_empty_audit_log_returns_not_yet() -> None:
     assert report.surfaces[0].verdict == "NOT YET"
     daily_use = next(c for c in report.surfaces[0].criteria if c.name == "daily_use_duration")
     assert daily_use.verdict == "red"
+    # #632 de-silencing: a REST-only dogfood produces exactly this
+    # all-red, no-audit-rows state. The report now states *why* the
+    # clock is stuck — the counted surfaces are the audited MCP search
+    # tools, not REST /retrieve.
+    assert report.counted_surfaces == list(COUNTED_SEARCH_SURFACES)
+    assert report.counted_surfaces == [
+        "mcp:search_knowledge",
+        "mcp:search_memory",
+        "mcp:search_operations",
+    ]
+    assert report.rest_excluded is True
 
 
 @pytest.mark.asyncio
@@ -837,7 +851,13 @@ def test_report_json_shape_is_stable() -> None:
         "until",
         "surfaces",
         "overall_verdict",
+        "counted_surfaces",
+        "rest_excluded",
     }
+    # #632: the counted-surface signal ships defaulted from the single
+    # source of truth and is part of the CLI-consumer contract.
+    assert blob["counted_surfaces"] == list(COUNTED_SEARCH_SURFACES)
+    assert blob["rest_excluded"] is True
     assert set(blob["surfaces"][0].keys()) == {"surface", "verdict", "criteria"}
     assert set(blob["surfaces"][0]["criteria"][0].keys()) == {
         "name",

--- a/backend/tests/test_retrieval_usage.py
+++ b/backend/tests/test_retrieval_usage.py
@@ -57,7 +57,10 @@ from meho_backplane.db.models import AuditLog
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.retrieval.usage import (
     CONVERSION_WINDOW,
+    COUNTED_SEARCH_SURFACES,
     MCP_TOOL_PATH_PREFIX,
+    REST_RETRIEVE_EXCLUDED,
+    SEARCH_OPS,
     SUPPORTED_SURFACES,
     DailyUsageBucket,
     SinceValueError,
@@ -288,6 +291,96 @@ async def test_compute_usage_no_matching_surface_returns_empty() -> None:
         )
     assert report.buckets == []
     assert report.total_searches == 0
+
+
+# ---------------------------------------------------------------------------
+# Counted-surface de-silencing (#632) — the REST-excluded zero is no
+# longer context-free.
+# ---------------------------------------------------------------------------
+
+
+def test_counted_search_surfaces_derived_from_search_ops() -> None:
+    """``COUNTED_SEARCH_SURFACES`` mirrors ``SEARCH_OPS`` (single source).
+
+    The documented contract cannot drift from the audit_log query
+    filter: every counted surface label is exactly ``mcp:<tool>`` for a
+    tool in ``SEARCH_OPS``.
+    """
+    assert tuple(f"mcp:{op}" for op in SEARCH_OPS) == COUNTED_SEARCH_SURFACES
+    assert REST_RETRIEVE_EXCLUDED is True
+
+
+@pytest.mark.asyncio
+async def test_usage_report_carries_counted_surface_signal() -> None:
+    """Every ``UsageReport`` carries ``counted_surfaces`` + ``rest_excluded``.
+
+    Asserted on the empty (zero-row) report specifically: the field is
+    present *alongside* ``total_searches=0`` so the zero is
+    self-explaining.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        report = await compute_usage(
+            session=session,
+            since=_NOW - timedelta(days=30),
+            until=_NOW,
+            surfaces=SUPPORTED_SURFACES,
+            tenant_id=_FIXED_TENANT,
+        )
+    assert report.total_searches == 0
+    assert report.counted_surfaces == list(COUNTED_SEARCH_SURFACES)
+    assert report.counted_surfaces == [
+        "mcp:search_knowledge",
+        "mcp:search_memory",
+        "mcp:search_operations",
+    ]
+    assert report.rest_excluded is True
+
+
+@pytest.mark.asyncio
+async def test_rest_only_dogfood_zero_is_not_context_free(
+    usage_client: TestClient,
+) -> None:
+    """REST-only dogfood scenario: the silent zero now self-explains.
+
+    Reproduces the #632 trap end-to-end over the HTTP surface: an
+    operator who has only ever called ``POST /api/v1/retrieve`` (never
+    an audited MCP ``search_knowledge``) queries ``retrieve/usage``.
+    Two ``/api/v1/retrieve``-pathed audit rows stand in for a month of
+    REST-only dogfooding. They are NOT on a counted MCP path, so
+    ``total_searches`` stays ``0`` — but the response now states which
+    surfaces *do* count and that REST is excluded, so the zero reads as
+    "REST is not counted", not "no usage".
+    """
+    await _seed_audit_row(
+        operator_sub="op-rest",
+        tenant_id=_FIXED_TENANT,
+        path="/api/v1/retrieve",
+        occurred_at=_NOW - timedelta(days=10),
+    )
+    await _seed_audit_row(
+        operator_sub="op-rest",
+        tenant_id=_FIXED_TENANT,
+        path="/api/v1/retrieve",
+        occurred_at=_NOW - timedelta(days=2),
+    )
+
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-rest", tenant_role=TenantRole.OPERATOR.value)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = usage_client.get(
+            "/api/v1/retrieve/usage?surface=kb",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 200
+    body = response.json()
+    # The trap: REST /retrieve calls never tick the counter.
+    assert body["total_searches"] == 0
+    assert body["buckets"] == []
+    # The de-silencing: the zero is no longer context-free.
+    assert body["counted_surfaces"] == list(COUNTED_SEARCH_SURFACES)
+    assert body["rest_excluded"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -723,7 +816,13 @@ def test_usage_report_serialises_to_stable_json() -> None:
         "tenant_id",
         "buckets",
         "total_searches",
+        "counted_surfaces",
+        "rest_excluded",
     }
+    # #632: the counted-surface signal ships defaulted from the single
+    # source of truth and is part of the CLI-consumer contract.
+    assert blob["counted_surfaces"] == list(COUNTED_SEARCH_SURFACES)
+    assert blob["rest_excluded"] is True
     assert set(blob["buckets"][0].keys()) == {
         "date",
         "surface",

--- a/docs/cross-repo/kb-migration.md
+++ b/docs/cross-repo/kb-migration.md
@@ -98,6 +98,12 @@ meho retrieval retire-checklist --json
 
 It combines the eval results with the open-blocker count (GitHub issues labelled `retrieval-migration-blocker`) into a per-surface GREEN / YELLOW / RED verdict over five criteria. When the **kb** surface is GREEN on all five and the team agrees daily use has shifted:
 
+> **Which surface feeds the overlap clock — read this before you start dogfooding.** The daily-use criteria (criterion 1 "days since first daily use" and criterion 2 "operator breadth") are fed **only by the audited MCP search meta-tools**: `search_knowledge` (kb), `search_memory` (memory), `search_operations` (operations). Those land in `audit_log` under `/mcp/tools/call/<tool>` and are the surfaces named in the `counted_surfaces` field of both `meho retrieval usage --json` and `meho retrieval retire-checklist --json` (e.g. `["mcp:search_knowledge", "mcp:search_memory", "mcp:search_operations"]`).
+>
+> **REST `POST /api/v1/retrieve` is deliberately excluded** (`rest_excluded: true` in the same responses). It runs the identical retrieval substrate but audits under `/api/v1/retrieve`, which is not a counted path — so a `search_knowledge` call ticks the clock while a REST `/retrieve` call does not. Counting REST too is intentionally out of scope for v0.2 (it would change audit volume and risk double-counting against the MCP path).
+>
+> **Practical consequence:** if you dogfood the ≥1-month overlap exclusively through REST `/retrieve` (or before `/mcp` is configured at all), `total_searches` stays `0` and the retire checklist stays RED on criteria 1 + 2 for the entire window — not because the migration failed, but because the counted surface saw no traffic. Dogfood through the MCP `search_knowledge` tool (the agent-facing surface) so the overlap clock actually ticks. The zero is no longer silent: `counted_surfaces` + `rest_excluded` on every `usage` / `retire-checklist` response tell you exactly why a zero is a zero.
+
 1. Open a PR in `evoila-bosnia/claude-rdc-hetzner-dc` removing `kb/`.
 2. Update the consumer's `CLAUDE.md` to drop "grep `kb/`" patterns in favour of "use `meho kb search`".
 3. Keep the deleted directory recoverable from git history (a tag or the merge commit SHA is enough — see Rollback).


### PR DESCRIPTION
## Summary

- The ≥1-month kb-migration overlap clock (`retrieve/usage` + `retrieve/retire-checklist`) is fed **only** by the audited MCP search meta-tools (`search_knowledge` / `search_memory` / `search_operations`). REST `POST /api/v1/retrieve` runs the same retrieval substrate but audits under `/api/v1/retrieve` — not a counted MCP tool path — so a REST-only dogfooder watches a permanent silent zero with no explanation.
- De-silenced (not "count REST too" — deliberately out of scope; counting REST would change audit volume and risk double-counting against the MCP path). Added `COUNTED_SEARCH_SURFACES` + `REST_RETRIEVE_EXCLUDED`, both **derived from the existing `SEARCH_OPS` single source of truth** so the documented contract cannot drift from the audit-log query filter.
- Surfaced as defaulted `counted_surfaces` + `rest_excluded` fields on both `UsageReport` and `RetireChecklistReport` — additive, no change to what increments the counter.
- Documented the trap in the `docs/cross-repo/kb-migration.md` retire-checklist runbook section: which surfaces feed the clock, that REST is excluded and why, and the practical consequence (dogfood through the MCP `search_knowledge` tool).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (4 changed files)
- [x] `mypy src/.../usage.py src/.../retire.py` — clean
- [x] `pytest tests/test_retrieval_usage.py tests/test_retrieval_retire.py` — 89 passed
- [x] `pytest tests/test_api_v1_retrieve.py tests/test_api_v1_retrieve_eval.py tests/test_retrieval_eval_runner.py` — 48 passed (adjacent consumers)
- [x] `code-quality.py --diff` — 0 blockers (7 pre-existing size warnings, none introduced)
- [x] **AC1** docs name counted surfaces + REST-excluded + why — grep-verified in the retire-checklist section
- [x] **AC2** `usage` / `retire-checklist` responses carry `counted_surfaces` + `rest_excluded` — pinned by `test_usage_report_serialises_to_stable_json` + `test_report_json_shape_is_stable`
- [x] **AC3** REST-only dogfood scenario test shows the field alongside `total_searches=0` — `test_rest_only_dogfood_zero_is_not_context_free`
- [x] **AC4** scope guard: no change to what increments the counter — `SEARCH_OPS` / `_fetch_search_rows` / `_fetch_surface_audit_scan` query filters untouched; new fields are defaulted and derived from `SEARCH_OPS`

## Out of scope

- Making REST `/retrieve` increment the counter — deliberately deferred (separate scoped Task if ever wanted).
- Changing retire-checklist thresholds — unrelated.
- `#634` Child-Tasks checklist tick — handled on merge via `Closes #632` auto-close (skill does not move board state pre-merge).

## Adjacent findings (deferred, not edited)

- Pre-existing `code-quality` size warnings: `retire.py::compute_retire_checklist` (143 lines, flagged not-in-this-diff), `usage.py` file 590 lines, `compute_usage` 72 lines, a few 60-line helpers. Out of scope for this Task.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #632


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports now include counted_surfaces and rest_excluded to show which search surfaces are used for daily-use criteria and whether REST retrieval is excluded.

* **Documentation**
  * Operator docs updated to explain how counted_surfaces and rest_excluded affect usage metrics and checklist progression.

* **Tests**
  * Test suites updated to assert the new reported fields and their default behavior in CLI/JSON outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-18)

Addressed review findings from the iteration-1 `REQUEST_CHANGES` review (CodeRabbit + auto-review-pr B1):

- **B1** `cc2c92a` — corrected the `REST_RETRIEVE_EXCLUDED` docstring contradiction: it now states REST `/retrieve` is *excluded* from the counter (value `True` = excluded), matching the variable's name/value and the `rest_excluded: true` API field. One-line wording fix, no behavior change.

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 1 -->
