### PR TITLE
fix(devops): G0.8-T7 stamp git_sha/build_date/chart_version into /version

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -195,6 +195,25 @@ jobs:
             -summary \
             /tmp/rendered.yaml
 
+      - name: Assert Deployment carries CHART_VERSION env (#631)
+        # GET /version reports a real chart_version only if the chart's
+        # Deployment injects CHART_VERSION from .Chart.Version. Render the
+        # chart and assert the env var is present with the in-tree
+        # Chart.yaml `version` value (0.1.0 on a fresh checkout; the
+        # publish job rewrites it to the calver at package time, but the
+        # template binding — `value: {{ .Chart.Version | quote }}` — is
+        # what this gate proves). grep -F on the exact `name:`/`value:`
+        # pair fails the job loud if the env binding ever regresses.
+        run: |
+          set -euo pipefail
+          CHART_VER="$(grep -E '^version:' deploy/charts/meho/Chart.yaml \
+            | head -1 | awk '{print $2}')"
+          echo ">> Chart.yaml version = ${CHART_VER}"
+          grep -F -A1 'name: CHART_VERSION' /tmp/rendered.yaml \
+            | grep -F "value: \"${CHART_VER}\"" \
+            || { echo "::error title=CHART_VERSION env missing::Deployment must inject CHART_VERSION=${CHART_VER} from .Chart.Version (#631)" >&2; exit 1; }
+          echo ">> CHART_VERSION env present with value ${CHART_VER}"
+
   helm-test:
     name: helm install + helm test (pgvector preflight)
     # G0.4-T6 (#263) -- spins up a kind cluster, installs a

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -177,6 +177,18 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Build-identity stamps surfaced via GET /version (#631). The
+          # Dockerfile already declares `ARG GIT_SHA` / `ARG BUILD_DATE`
+          # and re-exports them as ENV; without these build-args the ARGs
+          # keep their `unknown` defaults and the shipped image cannot
+          # self-report which commit it was built from. BUILD_DATE reuses
+          # docker/metadata-action's `org.opencontainers.image.created`
+          # label (RFC3339, UTC) so the /version build_date and the OCI
+          # `created` annotation are the same single value — no second
+          # `date -u` step that could drift between the two.
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
           # GHA-backed remote cache. The first build cold-fills it; subsequent
           # builds reuse layers across branches.
           cache-from: type=gha

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -203,6 +203,15 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}
+          # Build-identity stamps (#631) — same Dockerfile ARG/ENV path as
+          # image.yml. Without these the PR image ships GIT_SHA=unknown and
+          # the smoke script's `git_sha != "unknown"` assertion is
+          # unsatisfiable. PR_HEAD_SHA (the immutable head sha the build
+          # is pinned to) is the honest source here, not github.sha (which
+          # under pull_request_target is the base merge commit).
+          build-args: |
+            GIT_SHA=${{ env.PR_HEAD_SHA }}
+            BUILD_DATE=${{ github.event.pull_request.updated_at }}
           # GHA-backed remote cache. Shared scope with image.yml means the
           # PR build reuses every layer the main-push cache already has,
           # dropping cold-build wall-clock to a handful of seconds when

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ cli/*.out
 *.bak
 *.orig
 .idea/
+*.code-workspace
 
 # =============================================================================
 # Docker / runtime data

--- a/backend/src/meho_backplane/version.py
+++ b/backend/src/meho_backplane/version.py
@@ -9,8 +9,11 @@ is running in the cluster:
 * ``git_sha`` — full commit hash injected by CI at ``docker build`` time
   via ``--build-arg GIT_SHA``.
 * ``build_date`` — ISO-8601 UTC timestamp injected the same way.
-* ``chart_version`` — populated in G2.5 once the helm chart owns the
-  release-version concept; intentionally ``null`` at the chassis stage.
+* ``chart_version`` — the deployed helm chart's ``.Chart.Version``,
+  injected as the ``CHART_VERSION`` env var by the chart's Deployment
+  template. ``null`` when unset (local ``uvicorn`` runs, bare-image
+  starts) so the field never pretends an unknown release is a known
+  one.
 
 Reading the values from environment variables (rather than baking them
 into a generated ``_version.py``) keeps the runtime image generic and
@@ -43,5 +46,5 @@ async def version() -> dict[str, str | None]:
     return {
         "git_sha": os.environ.get("GIT_SHA") or _UNKNOWN,
         "build_date": os.environ.get("BUILD_DATE") or _UNKNOWN,
-        "chart_version": None,
+        "chart_version": os.environ.get("CHART_VERSION") or None,
     }

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -7,8 +7,10 @@ Coverage matrix (per Task #19 acceptance criteria):
 
 * ``/healthz`` always returns 200, even with a failing probe registered.
 * ``/version`` returns the env-injected triple (``GIT_SHA``,
-  ``BUILD_DATE``) and falls back to ``"unknown"`` when env vars are
-  absent. ``chart_version`` is always ``None`` at the chassis stage.
+  ``BUILD_DATE``, ``CHART_VERSION``). ``git_sha`` / ``build_date`` fall
+  back to ``"unknown"`` when their env vars are absent or empty;
+  ``chart_version`` falls back to ``None`` (#631 — the chart's
+  Deployment injects ``CHART_VERSION`` from ``.Chart.Version``).
 * ``/ready`` returns 503 with an empty registry (default v0.1 state),
   200 once a passing probe is registered, and 503 again with one
   failing probe registered alongside a passing one (so the failure
@@ -91,6 +93,7 @@ def test_healthz_ignores_failing_probes(client: TestClient) -> None:
 def test_version_falls_back_to_unknown(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GIT_SHA", raising=False)
     monkeypatch.delenv("BUILD_DATE", raising=False)
+    monkeypatch.delenv("CHART_VERSION", raising=False)
 
     response = client.get("/version")
 
@@ -105,6 +108,7 @@ def test_version_falls_back_to_unknown(client: TestClient, monkeypatch: pytest.M
 def test_version_reads_env_vars(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GIT_SHA", "abc1234")
     monkeypatch.setenv("BUILD_DATE", "2026-05-09T12:00:00Z")
+    monkeypatch.setenv("CHART_VERSION", "0.1.20260518-abc1234")
 
     response = client.get("/version")
 
@@ -112,16 +116,24 @@ def test_version_reads_env_vars(client: TestClient, monkeypatch: pytest.MonkeyPa
     assert response.json() == {
         "git_sha": "abc1234",
         "build_date": "2026-05-09T12:00:00Z",
-        "chart_version": None,
+        "chart_version": "0.1.20260518-abc1234",
     }
 
 
 def test_version_treats_empty_env_as_unknown(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Empty strings are as uninformative as unset; coerce to ``"unknown"``."""
+    """Empty strings are as uninformative as unset.
+
+    ``git_sha`` / ``build_date`` coerce to ``"unknown"``;
+    ``chart_version`` coerces to ``None`` (its unset sentinel — the
+    field is typed ``str | None`` and a null release is more honest
+    than the string ``"unknown"`` for a value that is only ever a
+    semver-shaped chart version when known).
+    """
     monkeypatch.setenv("GIT_SHA", "")
     monkeypatch.setenv("BUILD_DATE", "")
+    monkeypatch.setenv("CHART_VERSION", "")
 
     response = client.get("/version")
 
@@ -131,6 +143,20 @@ def test_version_treats_empty_env_as_unknown(
         "build_date": "unknown",
         "chart_version": None,
     }
+
+
+def test_version_chart_version_unset_is_null(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``CHART_VERSION`` unset (bare-image / local run) → ``null``, no exception."""
+    monkeypatch.setenv("GIT_SHA", "deadbeef")
+    monkeypatch.setenv("BUILD_DATE", "2026-05-18T00:00:00Z")
+    monkeypatch.delenv("CHART_VERSION", raising=False)
+
+    response = client.get("/version")
+
+    assert response.status_code == 200
+    assert response.json()["chart_version"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -45,6 +45,13 @@ spec:
             - configMapRef:
                 name: {{ include "meho.fullname" . }}-config
           env:
+            # Surfaces the deployed chart's version to the backplane so
+            # GET /version reports a real `chart_version` (#631). chart.yml
+            # stamps `.Chart.Version` to the calver at package time; this
+            # is the only path that carries that value into the running
+            # container (the image build does not know its chart release).
+            - name: CHART_VERSION
+              value: {{ .Chart.Version | quote }}
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -578,7 +578,7 @@ PYTHONPATH-leak imports.
 | `ProbeResult` (`dataclass`) | `src/meho_backplane/health.py` | Frozen record `(name, ok, detail)` returned by every readiness probe. Surfaced verbatim in the `/ready` response body. |
 | `register_probe` / `run_probes` / `run_probes_async` / `clear_probes` | `src/meho_backplane/health.py` | Public registry API. G2.2 (Vault, Keycloak) and G2.3 (DB migrations) call `register_probe` at startup. `run_probes()` returns the sync subset (test-friendly); `run_probes_async()` awaits async probes too and is what `/ready` calls. `clear_probes` is test-only. |
 | `health.router` (`/healthz`, `/ready`) | `src/meho_backplane/health.py` | Liveness and readiness endpoints. `/healthz` is unconditional 200; `/ready` aggregates the probe registry and **fails closed on the empty default** (vacuous-truth trap explicitly guarded). |
-| `version.router` (`/version`) | `src/meho_backplane/version.py` | Build identity. Reads `GIT_SHA` and `BUILD_DATE` env vars (injected via `docker build --build-arg`); falls back to `"unknown"` when unset or empty. `chart_version` is `None` until G2.5. |
+| `version.router` (`/version`) | `src/meho_backplane/version.py` | Build identity. Reads `GIT_SHA`, `BUILD_DATE` (injected via `docker build --build-arg` by `image.yml` / `pr-smoke.yml`, #631) and `CHART_VERSION` (injected by the chart's Deployment from `.Chart.Version`, #631) env vars. `git_sha` / `build_date` fall back to `"unknown"` when unset or empty; `chart_version` falls back to `None`. |
 | `configure_logging` | `src/meho_backplane/logging.py` | Configures structlog: `merge_contextvars` → `add_log_level` → `TimeStamper(iso, utc)` → `dict_tracebacks` → `JSONRenderer`, writing to stdout. Idempotent. The logger factory is constructed as `PrintLoggerFactory()` with **no `file=` argument** — structlog's `PrintLogger.msg` then resolves `sys.stdout` lazily at write time (calls `print()` with no `file=` keyword whenever `self._file is sys.stdout`). Tests under `pytest`'s `capfd` swap `sys.stdout` for a wrapped fd that gets closed on test teardown; the lazy shape avoids capturing that wrapped fd at lifespan-startup time and surviving into a later test as a closed-fd `ValueError` from `cache_logger_on_first_use=True`. Production behaviour unchanged because the real process `sys.stdout` does not get rebound at runtime. |
 | `RequestContextMiddleware` | `src/meho_backplane/middleware.py` | Pure-ASGI middleware. Per request: extracts/mints a `request_id`, clears any leftover contextvars and binds the new `request_id`, mirrors it onto the `X-Request-Id` response header, increments `http_requests_total{method,path,status}`, emits one `request_completed` JSON log line with method / path / status / duration_ms (which inherits any contextvars bound during the request, including `operator_sub` and `tenant_id` from `verify_jwt_and_bind`). |
 | `verify_jwt_and_bind` | `src/meho_backplane/middleware.py` | FastAPI dependency wrapper around `verify_jwt`. On successful validation, binds `operator_sub` (the JWT's `sub` claim) and `tenant_id` (`str(operator.tenant_id)` — JSON renderer cannot serialise raw `uuid.UUID`) into structlog contextvars so every subsequent log line in the request scope carries both fields automatically. Authenticated routes use `Depends(verify_jwt_and_bind)` instead of `Depends(verify_jwt)` directly. Lives alongside the middleware because `RequestContextMiddleware`'s request-entry `clear_contextvars` call is what guarantees the bound keys do not leak across requests reusing the same asyncio task. `tenant_role` is intentionally *not* bound — it's enforced at the dependency layer (G0.1-T4 `require_role`) so handlers reach for the typed `Operator` instead of pulling roles out of contextvars. |
@@ -683,8 +683,8 @@ PYTHONPATH-leak imports.
 6. The wrapped app dispatches each request to its route handler:
    - `GET /` → `root()` returns the identity dict.
    - `GET /healthz` → `healthz()` returns `{"status": "ok"}` with 200.
-   - `GET /version` → reads `GIT_SHA` / `BUILD_DATE` env vars per
-     request (cheap; no caching needed).
+   - `GET /version` → reads `GIT_SHA` / `BUILD_DATE` / `CHART_VERSION`
+     env vars per request (cheap; no caching needed).
    - `GET /ready` → calls `run_probes_async()` (which awaits async
      probes and calls sync probes inline) and translates the
      aggregate into a 200 / 503 `JSONResponse`.
@@ -833,7 +833,16 @@ The runtime stage stamps the published image with OCI annotations
 - `org.opencontainers.image.vendor=evoila`
 
 `revision` and `created` flow into `GET /version` via the same build
-args, so the registry view and the running app agree on identity.
+args, so the registry view and the running app agree on identity. In
+`image.yml` the `BUILD_DATE` build-arg is sourced from
+`docker/metadata-action`'s `org.opencontainers.image.created` label
+output (`fromJSON(steps.meta.outputs.json).labels[...]`), so the OCI
+`created` annotation and the `/version` `build_date` are guaranteed to
+be the same single value rather than two independently-computed
+timestamps that can drift (#631). The third `/version` field,
+`chart_version`, is **not** an image build-arg — it is injected at
+deploy time by the chart's Deployment template from `.Chart.Version`,
+because the image build cannot know which chart release wraps it.
 
 ### Cosign keyless signing (Task #34, ADR 0006)
 

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -874,12 +874,13 @@ Steps, in order:
 ### Smoke contract (`scripts/ci/pr-smoke.sh`)
 
 The smoke script is deliberately scoped to the **unauthenticated
-operator surface** — three assertions, no Keycloak access token:
+operator surface** — four assertions, no Keycloak access token:
 
 | Endpoint | Assertion | Why |
 | --- | --- | --- |
 | `/healthz` | HTTP 200 | Liveness probe contract; the in-cluster kubelet uses this exact path |
-| `/version` | `git_sha` present and not `"unknown"` | Confirms the deployed image carries build metadata (image.yml stamps it) and isn't a fallback build |
+| `/version` | `git_sha` present and not `"unknown"` | Confirms the deployed image carries build metadata (`image.yml` / `pr-smoke.yml` pass `GIT_SHA` as a Docker `build-arg`, #631) and isn't a fallback build |
+| `/version` | `chart_version` present, not `"unknown"`, non-empty | Confirms the helm-installed chart injected `CHART_VERSION` from `.Chart.Version` (#631) — the deployed-chart provenance the governance backplane exists to answer |
 | `/api/v1/health` | HTTP 401 unauthenticated | Negative auth test — a 200 here would mean auth middleware regressed open OR Keycloak realm is wired wrong; both are PR-blocking regressions Goal #11 considers non-negotiable |
 
 The full authenticated federation-chain smoke

--- a/scripts/ci/pr-smoke.sh
+++ b/scripts/ci/pr-smoke.sh
@@ -97,6 +97,15 @@ version_json="$(curl -sSf \
 echo "$version_json" \
   | jq -e '.git_sha and .git_sha != "unknown" and (.git_sha | length) > 0' >/dev/null
 
+echo ">> assert /version exposes a non-null chart_version (#631)"
+# The chart's Deployment injects CHART_VERSION from .Chart.Version, so a
+# helm-installed backplane MUST report a real chart_version. A null (the
+# bare-image / local fallback) or the literal "unknown" both fail: this
+# is the deployed-chart provenance the governance backplane exists to
+# answer. Same `jq -e` gotcha guard as the git_sha assertion above.
+echo "$version_json" \
+  | jq -e '.chart_version and .chart_version != "unknown" and (.chart_version | length) > 0' >/dev/null
+
 echo ">> assert /api/v1/health unauthenticated returns 401"
 # Negative authentication test: hitting the federation-proof endpoint
 # without a Keycloak access token MUST be rejected as 401. A 200 here


### PR DESCRIPTION
## Summary

- `GET /version` on the shipped v0.2 image returned `unknown/unknown/null` — for a governance/audit backplane whose job is answering "which code is running?", an instance that can't self-report its build is a real incident-response gap.
- Three missing wiring links fixed end to end: `image.yml` now passes `GIT_SHA`/`BUILD_DATE` as Docker build-args (was building with none, so the Dockerfile ARGs kept their `unknown` defaults); the chart's Deployment injects `CHART_VERSION` from `.Chart.Version`; `version.py` reads `CHART_VERSION` instead of hard-coding `None`.
- `BUILD_DATE` reuses `docker/metadata-action`'s `org.opencontainers.image.created` label rather than a separate `date -u` step, so the OCI `created` annotation and `/version` `build_date` are guaranteed identical instead of two independently-computed timestamps that can drift.
- `pr-smoke.yml` also gets build-args (its existing smoke assertion `git_sha != "unknown"` was unsatisfiable against its own freshly-built PR image without them); the smoke script gains a `chart_version` non-null assertion.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (`version.py`, `test_health.py`)
- [x] `mypy src/meho_backplane/version.py` — clean
- [x] `pytest tests/test_health.py tests/test_app_starts.py` — 12 passed (10 in test_health; added `test_version_chart_version_unset_is_null`; existing /version tests extended to set/clear `CHART_VERSION`)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] **AC: `version.py` reads `CHART_VERSION`** — unit-proven: env-set → value surfaced; env-unset / empty → graceful `null`, no exception
- [x] **AC: `helm template` renders `CHART_VERSION` == `.Chart.Version`** — verified locally (`CHART_VERSION: "0.1.0"` on fresh checkout) and gated in CI by a new `chart.yml` render-assertion step
- [x] **AC: `image.yml` passes `build-args:` for `GIT_SHA` + `BUILD_DATE`** — present; workflow YAML parses
- [x] **AC: `/version` reports real values on the built image** — asserted in CI by the extended `scripts/ci/pr-smoke.sh` (`git_sha` and `chart_version` both non-`unknown`, non-empty) which runs against the helm-installed freshly-built image; that lane is gated by the consumer-side `RKE2_SMOKE_ENABLED` repo variable and runs on enablement, not at PR time in this sandbox

## Out of scope

- Full SLSA/provenance attestation beyond what `image.yml` already emits (it already does sbom/provenance).
- Reworking the chart calver scheme in `chart.yml` — it already produces the value; this only surfaces it.
- `/version` schema change beyond filling the three existing fields.

## Notes / adjacent findings

- `deploy/charts/meho/Chart.lock` was produced locally by `helm dependency build` during verification — a build artefact, deliberately **not** committed.
- The runtime-container `/version` assertion runs only in `pr-smoke.yml`, which is gated behind `vars.RKE2_SMOKE_ENABLED == 'true'` (consumer-side enablement, Task #53). Until that flips, the chart-render gate (`chart.yml`) and the unit suite are the PR-time proofs; the live-image assertion is CI-on-enable.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #631


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/version` endpoint now includes the deployed chart version, improving deployment observability and version tracking.

* **Documentation**
  * Updated documentation to reflect the new chart version field in the `/version` endpoint response and build identity injection process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->