### PR TITLE
fix(operations): G0.8-T5 document connector_id format + 404 on unknown (#630)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ cli/*.out
 *.bak
 *.orig
 .idea/
+*.code-workspace
 
 # =============================================================================
 # Docker / runtime data

--- a/backend/src/meho_backplane/api/v1/operations.py
+++ b/backend/src/meho_backplane/api/v1/operations.py
@@ -35,17 +35,45 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.openapi.models import Example
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.operations.meta_tools import (
     CallOperationBody,
     OperationDescriptor,
+    UnknownConnectorError,
     call_operation,
     describe_descriptor,
     list_operation_groups,
     search_operations,
 )
+
+#: Shared OpenAPI metadata for the ``connector_id`` query param on the
+#: ``/groups`` and ``/search`` routes. The format is ``<impl_id>-<version>``
+#: (NOT the bare product slug) — documented inline so the generated
+#: ``/openapi.json`` the agent and operators read carries the contract,
+#: rather than it living only in ``docs/cross-repo/connector-ingestion.md``.
+_CONNECTOR_ID_DESCRIPTION = (
+    "Connector implementation id in `<impl_id>-<version>` form — e.g. "
+    "`vmware-rest-9.0`, `vault-1.x`, `k8s-1.x`. NOT the bare product "
+    "name (`vault`, `vmware`): a bare product slug names no connector "
+    "and returns 404. Discover valid ids via `GET /api/v1/connectors`."
+)
+_CONNECTOR_ID_EXAMPLES: dict[str, Example] = {
+    "vmware_rest": Example(
+        summary="vCenter REST (generic, ingested)",
+        value="vmware-rest-9.0",
+    ),
+    "vault": Example(
+        summary="HashiCorp Vault (typed)",
+        value="vault-1.x",
+    ),
+    "k8s": Example(
+        summary="Kubernetes (typed)",
+        value="k8s-1.x",
+    ),
+}
 
 __all__ = ["router"]
 
@@ -63,21 +91,35 @@ _require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
 
 @router.get("/groups")
 async def get_groups(
-    connector_id: str = Query(min_length=1),
+    connector_id: str = Query(
+        min_length=1,
+        description=_CONNECTOR_ID_DESCRIPTION,
+        openapi_examples=_CONNECTOR_ID_EXAMPLES,
+    ),
     operator: Operator = _require_operator,
 ) -> dict[str, Any]:
     """List enabled operation groups for *connector_id*.
 
-    Delegates to :func:`list_operation_groups`. Unknown connector_id
-    returns ``{"groups": []}`` (empty is meaningful — the connector
-    exists but has no enabled groups yet).
+    Delegates to :func:`list_operation_groups`. An *unknown*
+    ``connector_id`` (no operations registered for the parsed triple)
+    is a ``404`` — not an empty ``200``: the empty-catalog trap was
+    that a mis-shaped id looked identical to an empty connector. A
+    *known* connector with zero enabled groups still returns
+    ``{"groups": []}`` (that empty is operationally meaningful).
     """
-    return await list_operation_groups(operator, {"connector_id": connector_id})
+    try:
+        return await list_operation_groups(operator, {"connector_id": connector_id})
+    except UnknownConnectorError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/search")
 async def get_search(
-    connector_id: str = Query(min_length=1),
+    connector_id: str = Query(
+        min_length=1,
+        description=_CONNECTOR_ID_DESCRIPTION,
+        openapi_examples=_CONNECTOR_ID_EXAMPLES,
+    ),
     query: str = Query(min_length=1),
     group: str | None = Query(default=None),
     limit: int = Query(default=10, ge=1, le=50),
@@ -86,17 +128,22 @@ async def get_search(
     """Hybrid BM25 + cosine RRF over ``endpoint_descriptor`` rows.
 
     Delegates to :func:`search_operations`. See its docstring for the
-    full algorithm and tenant scoping.
+    full algorithm and tenant scoping. Unknown ``connector_id`` → ``404``
+    (same unknown-vs-known-empty contract as ``/groups``); a known
+    connector with no matching ops returns ``200`` with an empty list.
     """
-    return await search_operations(
-        operator,
-        {
-            "connector_id": connector_id,
-            "query": query,
-            "group": group,
-            "limit": limit,
-        },
-    )
+    try:
+        return await search_operations(
+            operator,
+            {
+                "connector_id": connector_id,
+                "query": query,
+                "group": group,
+                "limit": limit,
+            },
+        )
+    except UnknownConnectorError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/call")

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -108,10 +108,12 @@ register_mcp_tool(
             "operations. Call this FIRST when you don't know which "
             "operation to invoke -- it narrows the search space from "
             "hundreds of operations to a handful of relevant ones. "
-            'Argument: `connector_id` (e.g. "vmware-rest-9.0"). '
-            "Returns groups in name order; unknown connector_id returns "
-            "an empty groups list (operationally meaningful: the "
-            "connector exists but has no enabled groups yet)."
+            "Argument: `connector_id` in `<impl_id>-<version>` form "
+            '(e.g. "vmware-rest-9.0", "vault-1.x") -- NOT the bare '
+            "product name. Returns groups in name order. An UNKNOWN "
+            "connector_id is an error (no such connector); a KNOWN "
+            "connector with no enabled groups returns an empty list "
+            "(operationally meaningful: it exists, nothing enabled yet)."
         ),
         inputSchema={
             "type": "object",
@@ -120,8 +122,9 @@ register_mcp_tool(
                     "type": "string",
                     "description": (
                         "Connector identifier in the form "
-                        '`<impl_id>-<version>` (e.g. "vmware-rest-9.0") '
-                        'or a v1-style single-product slug (e.g. "vault").'
+                        '`<impl_id>-<version>` (e.g. "vmware-rest-9.0", '
+                        '"vault-1.x") -- NOT the bare product name. A '
+                        "value naming no registered connector is an error."
                     ),
                     "minLength": 1,
                 },
@@ -175,8 +178,10 @@ register_mcp_tool(
             "`call_operation` on it. Arguments: `connector_id` (required), "
             "`query` (required, free-form), `group` (optional, narrows "
             "to that group's ops), `limit` (default 10, max 50). "
-            "Unknown group narrows the result set to zero hits; that is "
-            "not an error."
+            "`connector_id` is `<impl_id>-<version>` (NOT the bare "
+            "product name); an unknown connector_id is an error. An "
+            "unknown group, by contrast, narrows the result set to "
+            "zero hits and is not an error."
         ),
         inputSchema={
             "type": "object",

--- a/backend/src/meho_backplane/operations/_lookup.py
+++ b/backend/src/meho_backplane/operations/_lookup.py
@@ -29,9 +29,10 @@ from uuid import UUID
 from sqlalchemy import select
 
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 
 __all__ = [
+    "connector_exists",
     "count_known_ops",
     "lookup_descriptor",
     "parse_connector_id",
@@ -156,3 +157,52 @@ async def count_known_ops(
             )
         )
         return len(result.all())
+
+
+async def connector_exists(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> bool:
+    """Return whether any operations data exists for *(product, version, impl_id)*.
+
+    "Exists" is deliberately decoupled from ``is_enabled`` /
+    ``review_status``: a connector that has registered descriptors or
+    groups but has none *enabled* yet is still a *known* connector. The
+    meta-tools use this to tell "unknown connector_id" (no rows at all
+    for the triple — surface a 404 so a malformed/mis-shaped id fails
+    loud) apart from "known connector, zero enabled groups" (rows exist
+    but none enabled — a meaningful empty list, ``200 []``).
+
+    The DB is the source of truth rather than the in-memory connector
+    registry: every registered connector (typed, v1-compat, and
+    ingested generic) writes ``endpoint_descriptor`` / ``operation_group``
+    rows, and the registry is process-local while the rows are durable.
+    Two cheap ``LIMIT 1`` existence probes — descriptors first (the
+    common case), groups as the fallback for a connector whose groups
+    were seeded ahead of its operations.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        descriptor_hit = await session.execute(
+            select(EndpointDescriptor.id)
+            .where(
+                EndpointDescriptor.product == product,
+                EndpointDescriptor.version == version,
+                EndpointDescriptor.impl_id == impl_id,
+            )
+            .limit(1)
+        )
+        if descriptor_hit.first() is not None:
+            return True
+        group_hit = await session.execute(
+            select(OperationGroup.id)
+            .where(
+                OperationGroup.product == product,
+                OperationGroup.version == version,
+                OperationGroup.impl_id == impl_id,
+            )
+            .limit(1)
+        )
+        return group_hit.first() is not None

--- a/backend/src/meho_backplane/operations/_lookup.py
+++ b/backend/src/meho_backplane/operations/_lookup.py
@@ -161,11 +161,12 @@ async def count_known_ops(
 
 async def connector_exists(
     *,
+    tenant_id: UUID,
     product: str,
     version: str,
     impl_id: str,
 ) -> bool:
-    """Return whether any operations data exists for *(product, version, impl_id)*.
+    """Return whether *caller-visible* operations data exists for *(product, version, impl_id)*.
 
     "Exists" is deliberately decoupled from ``is_enabled`` /
     ``review_status``: a connector that has registered descriptors or
@@ -174,6 +175,16 @@ async def connector_exists(
     for the triple — surface a 404 so a malformed/mis-shaped id fails
     loud) apart from "known connector, zero enabled groups" (rows exist
     but none enabled — a meaningful empty list, ``200 []``).
+
+    Existence is scoped to what the calling operator can see: built-in /
+    global rows (``tenant_id IS NULL``) plus this tenant's own rows
+    (``tenant_id == tenant_id``). This mirrors the tenant boundary the
+    data-returning queries enforce (``list_operation_groups`` /
+    ``search_operations`` in ``meta_tools``). Without it the existence
+    probe would be a cross-tenant presence oracle — a connector private
+    to tenant B would make the gate return ``True`` for a tenant-A
+    caller, yielding ``200 []`` where the caller-visible answer is
+    "unknown" and the correct response is ``404``.
 
     The DB is the source of truth rather than the in-memory connector
     registry: every registered connector (typed, v1-compat, and
@@ -188,6 +199,8 @@ async def connector_exists(
         descriptor_hit = await session.execute(
             select(EndpointDescriptor.id)
             .where(
+                (EndpointDescriptor.tenant_id.is_(None))
+                | (EndpointDescriptor.tenant_id == tenant_id),
                 EndpointDescriptor.product == product,
                 EndpointDescriptor.version == version,
                 EndpointDescriptor.impl_id == impl_id,
@@ -199,6 +212,7 @@ async def connector_exists(
         group_hit = await session.execute(
             select(OperationGroup.id)
             .where(
+                (OperationGroup.tenant_id.is_(None)) | (OperationGroup.tenant_id == tenant_id),
                 OperationGroup.product == product,
                 OperationGroup.version == version,
                 OperationGroup.impl_id == impl_id,

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -80,6 +80,7 @@ from sqlalchemy import select
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations._lookup import connector_exists, parse_connector_id
 from meho_backplane.operations._search import hybrid_search, resolve_group_id
 from meho_backplane.operations.dispatcher import dispatch
 from meho_backplane.targets.resolver import resolve_target
@@ -90,11 +91,30 @@ __all__ = [
     "OperationDescriptor",
     "OperationGroupSummary",
     "OperationSearchHit",
+    "UnknownConnectorError",
     "call_operation",
     "describe_descriptor",
     "list_operation_groups",
     "search_operations",
 ]
+
+
+class UnknownConnectorError(ValueError):
+    """Raised when a ``connector_id`` names no registered connector.
+
+    A *domain* exception, not a transport one. The shared meta-tool
+    handlers (REST route, MCP transport, CLI) must not couple to
+    :class:`fastapi.HTTPException` — the MCP server's generic
+    ``except Exception`` would otherwise mistranslate a clean
+    "unknown connector" into a JSON-RPC ``INTERNAL_ERROR`` (a worse
+    trap than the empty-200 this task removes). The REST route maps
+    this to ``404`` explicitly; the MCP/CLI surfaces let it propagate
+    as the structured handler error they already render. Subclasses
+    :class:`ValueError` to stay consistent with the other meta-tool
+    domain exceptions (e.g. the missing-target ``ValueError`` mapped
+    to ``400`` in :mod:`meho_backplane.api.v1.operations`).
+    """
+
 
 _log = structlog.get_logger(__name__)
 
@@ -226,15 +246,24 @@ async def list_operation_groups(
     Only ``review_status='enabled'`` groups are returned — staged /
     disabled groups remain hidden from the agent. Tenant scoping: the
     union of built-in (``tenant_id IS NULL``) and tenant-curated
-    (``tenant_id == operator.tenant_id``) rows. Unknown ``connector_id``
-    returns an empty ``groups`` list rather than a 404 — empty is
-    operationally meaningful (the agent learns the connector has no
-    enabled groups yet).
+    (``tenant_id == operator.tenant_id``) rows.
+
+    An *unknown* ``connector_id`` (no descriptors or groups registered
+    for the parsed ``(product, version, impl_id)`` triple) raises
+    :class:`UnknownConnectorError` — the REST route maps that to a
+    ``404``. A *known* connector with zero enabled groups still returns
+    an empty ``groups`` list (``200 []``): that empty is operationally
+    meaningful (the connector exists; nothing is enabled yet). The
+    distinction ends the "empty catalog" trap where a mis-shaped
+    ``connector_id`` looked indistinguishable from an empty connector.
     """
     connector_id = arguments["connector_id"]
-    from meho_backplane.operations._lookup import parse_connector_id
-
     product, version, impl_id = parse_connector_id(connector_id)
+    if not await connector_exists(product=product, version=version, impl_id=impl_id):
+        raise UnknownConnectorError(
+            f"unknown connector_id {connector_id!r} — expected <impl_id>-<version> "
+            f"(e.g. 'vmware-rest-9.0', 'vault-1.x'); see GET /api/v1/connectors"
+        )
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         # Count operations per group in a single pass so the response can
@@ -316,6 +345,12 @@ async def search_operations(
     signal scores + ranks are surfaced so the agent (and operator
     debugging) can see whether a hit came from lexical match, semantic
     match, or both.
+
+    Like :func:`list_operation_groups`, an *unknown* ``connector_id``
+    raises :class:`UnknownConnectorError` (REST → ``404``) while a
+    *known* connector with no matching ops still returns an empty
+    ``hits`` list (``200 []``) — identical unknown-vs-known-empty
+    semantics across both meta-tools.
     """
     connector_id = arguments["connector_id"]
     query = arguments["query"]
@@ -326,9 +361,12 @@ async def search_operations(
     if limit > SEARCH_LIMIT_MAX:
         limit = SEARCH_LIMIT_MAX
 
-    from meho_backplane.operations._lookup import parse_connector_id
-
     product, version, impl_id = parse_connector_id(connector_id)
+    if not await connector_exists(product=product, version=version, impl_id=impl_id):
+        raise UnknownConnectorError(
+            f"unknown connector_id {connector_id!r} — expected <impl_id>-<version> "
+            f"(e.g. 'vmware-rest-9.0', 'vault-1.x'); see GET /api/v1/connectors"
+        )
     started = time.monotonic()
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -259,7 +259,12 @@ async def list_operation_groups(
     """
     connector_id = arguments["connector_id"]
     product, version, impl_id = parse_connector_id(connector_id)
-    if not await connector_exists(product=product, version=version, impl_id=impl_id):
+    if not await connector_exists(
+        tenant_id=operator.tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+    ):
         raise UnknownConnectorError(
             f"unknown connector_id {connector_id!r} — expected <impl_id>-<version> "
             f"(e.g. 'vmware-rest-9.0', 'vault-1.x'); see GET /api/v1/connectors"
@@ -362,7 +367,12 @@ async def search_operations(
         limit = SEARCH_LIMIT_MAX
 
     product, version, impl_id = parse_connector_id(connector_id)
-    if not await connector_exists(product=product, version=version, impl_id=impl_id):
+    if not await connector_exists(
+        tenant_id=operator.tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+    ):
         raise UnknownConnectorError(
             f"unknown connector_id {connector_id!r} — expected <impl_id>-<version> "
             f"(e.g. 'vmware-rest-9.0', 'vault-1.x'); see GET /api/v1/connectors"

--- a/backend/tests/acceptance/test_g07_vsphere_canary.py
+++ b/backend/tests/acceptance/test_g07_vsphere_canary.py
@@ -152,6 +152,7 @@ from meho_backplane.operations.ingest import (
     list_ingested_connectors,
 )
 from meho_backplane.operations.meta_tools import (
+    UnknownConnectorError,
     call_operation,
     list_operation_groups,
     search_operations,
@@ -1228,15 +1229,20 @@ async def test_canary_search_operations_respects_connector_scope(
     ingested_canary: _CanaryIngestState,
     canary_operator: Operator,
 ) -> None:
-    """Searching an unknown connector returns an empty hit list, not an error."""
-    response = await search_operations(
-        canary_operator,
-        {
-            "connector_id": "phantom-9.9",
-            "query": "list virtual machines",
-        },
-    )
-    assert response["hits"] == [], response
+    """Searching an unknown connector raises UnknownConnectorError.
+
+    G0.8-T5 (#630): the prior "unknown connector → empty hits" contract
+    was the empty-catalog trap. The meta-tool now fails loud (REST → 404)
+    so a mis-shaped connector_id can't masquerade as an empty connector.
+    """
+    with pytest.raises(UnknownConnectorError):
+        await search_operations(
+            canary_operator,
+            {
+                "connector_id": "phantom-9.9",
+                "query": "list virtual machines",
+            },
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py
+++ b/backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py
@@ -42,8 +42,11 @@ search-quality contract lives in the canary.
 
 from __future__ import annotations
 
+import pytest
+
 from meho_backplane.operations.ingest import list_ingested_connectors
 from meho_backplane.operations.meta_tools import (
+    UnknownConnectorError,
     call_operation,
     list_operation_groups,
     search_operations,
@@ -147,26 +150,26 @@ async def test_agent_flow_end_to_end_against_vcsim(
     )
 
 
-async def test_search_operations_unknown_connector_returns_no_hits(
+async def test_search_operations_unknown_connector_raises(
     prewarmed_embeddings: None,
     ingested_canary_vcsim: IngestedCanaryVcsim,
 ) -> None:
-    """An unknown connector_id returns an empty hit list, not an error.
+    """An unknown connector_id raises UnknownConnectorError (REST → 404).
 
-    Same shape the canary's
-    ``test_canary_search_operations_unknown_connector_returns_empty``
-    asserts — the meta-tool's contract is "unknown connector → empty
-    hits" rather than "→ error". Keeping the assertion here makes
-    the agent-flow surface self-contained: any tester running this
-    file alone sees both the happy path and the empty-input path.
+    G0.8-T5 (#630) reversed the prior "unknown connector → empty hits"
+    contract: an empty success was indistinguishable from a known
+    connector with no matching ops, so a mis-shaped connector_id read
+    as an empty catalog. The meta-tool now fails loud; the REST route
+    maps it to a 404. This file stays self-contained — any tester
+    running it alone sees both the happy path and the fail-loud path.
     """
     operator = ingested_canary_vcsim.operator
-    response = await search_operations(
-        operator,
-        {
-            "connector_id": "no-such-connector-9.99",
-            "query": "anything",
-            "limit": 3,
-        },
-    )
-    assert response["hits"] == [], f"expected empty hits for unknown connector; got {response!r}"
+    with pytest.raises(UnknownConnectorError):
+        await search_operations(
+            operator,
+            {
+                "connector_id": "no-such-connector-9.99",
+                "query": "anything",
+                "limit": 3,
+            },
+        )

--- a/backend/tests/test_api_v1_operations.py
+++ b/backend/tests/test_api_v1_operations.py
@@ -245,8 +245,13 @@ async def test_get_groups_returns_meta_tool_payload(
     assert any(g["group_key"] == "kv" for g in body["groups"])
 
 
-def test_get_groups_unknown_connector_returns_empty_list(client: TestClient) -> None:
-    """Unknown connector -> 200 with empty groups (not 404)."""
+def test_get_groups_unknown_connector_returns_404(client: TestClient) -> None:
+    """G0.8-T5: an unknown connector_id is a 404 (was a misleading 200 []).
+
+    The empty-200 conflated "unknown connector" with "known connector,
+    no enabled groups" — a real dogfood evaluator concluded the catalog
+    was empty when 40 descriptors existed; the id was just mis-shaped.
+    """
     key = make_rsa_keypair("kid-A")
     with respx.mock as mock_router:
         mock_discovery_and_jwks(mock_router, public_jwks(key))
@@ -254,8 +259,54 @@ def test_get_groups_unknown_connector_returns_empty_list(client: TestClient) -> 
             "/api/v1/operations/groups?connector_id=ghost-9.9",
             headers={"Authorization": f"Bearer {_operator_token(key)}"},
         )
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert "ghost-9.9" in detail
+    assert "<impl_id>-<version>" in detail
+
+
+def test_get_groups_bare_product_name_returns_404(client: TestClient) -> None:
+    """AC: a bare product slug (`vault`) names no connector -> 404, not 200 []."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            "/api/v1/operations/groups?connector_id=vault",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 404
+    assert "vault" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_groups_known_connector_zero_enabled_returns_empty_200(
+    client: TestClient,
+) -> None:
+    """Regression guard: a KNOWN connector with no *enabled* groups still
+    returns 200 [] — the "meaningful empty" case must be preserved."""
+    # A staged (not enabled) group makes the connector known-as-data
+    # while leaving zero enabled groups for the operator to see.
+    await _seed_group(group_key="staged")
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s, s.begin():
+        # Flip the seeded group to a non-enabled review status so the
+        # connector exists but exposes no enabled groups.
+        from sqlalchemy import update
+
+        await s.execute(
+            update(OperationGroup)
+            .where(OperationGroup.group_key == "staged")
+            .values(review_status="staged")
+        )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            "/api/v1/operations/groups?connector_id=vault-1.x",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
     assert response.status_code == 200
-    assert response.json() == {"connector_id": "ghost-9.9", "groups": []}
+    assert response.json() == {"connector_id": "vault-1.x", "groups": []}
 
 
 # ---------------------------------------------------------------------------
@@ -282,6 +333,40 @@ async def test_get_search_returns_hits(
     assert len(body["hits"]) == 1
     assert body["hits"][0]["op_id"] == "vault.kv.read"
     assert "query_duration_ms" in body
+
+
+def test_get_search_unknown_connector_returns_404(client: TestClient) -> None:
+    """AC: /search behaves identically to /groups for an unknown connector."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            "/api/v1/operations/search?connector_id=ghost-9.9&query=read",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 404
+    assert "ghost-9.9" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_search_known_connector_no_match_returns_empty_200(
+    client: TestClient,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """AC: a KNOWN connector with no matching ops returns 200 with [] hits
+    (the known-empty case, distinct from unknown→404)."""
+    # Connector is known-as-data (a seeded group) but has no descriptors,
+    # so the query matches nothing.
+    await _seed_group(group_key="kv")
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            "/api/v1/operations/search?connector_id=vault-1.x&query=nonexistent",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["hits"] == []
 
 
 def test_get_search_rejects_limit_over_50(client: TestClient) -> None:

--- a/backend/tests/test_operations_meta_tools.py
+++ b/backend/tests/test_operations_meta_tools.py
@@ -8,8 +8,10 @@ Coverage matrix (G0.6-T8 / Task #399 acceptance criteria):
 * ``list_operation_groups`` returns enabled groups for a known
   ``connector_id`` with their ``when_to_use`` strings + per-group
   operation counts. Disabled groups are omitted.
-* ``list_operation_groups`` returns an empty groups list for an unknown
-  ``connector_id`` (no 404 -- empty is operationally meaningful).
+* ``list_operation_groups`` / ``search_operations`` raise
+  ``UnknownConnectorError`` for an unknown ``connector_id`` (REST → 404,
+  G0.8-T5 #630); a known connector with zero enabled groups still
+  returns an empty list (the meaningful-empty case is preserved).
 * Tenant scoping on ``list_operation_groups`` -- a tenant-curated group
   is visible only to that tenant.
 * ``search_operations`` ranks hits via hybrid BM25+cosine RRF; the
@@ -48,6 +50,7 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import register_typed_operation, reset_dispatcher_caches
 from meho_backplane.operations.meta_tools import (
+    UnknownConnectorError,
     call_operation,
     describe_descriptor,
     list_operation_groups,
@@ -226,13 +229,34 @@ async def test_list_operation_groups_returns_enabled_groups_with_when_to_use() -
 
 
 @pytest.mark.asyncio
-async def test_list_operation_groups_returns_empty_list_for_unknown_connector() -> None:
-    """AC: unknown connector_id -> empty groups list (not 404)."""
+async def test_list_operation_groups_unknown_connector_raises() -> None:
+    """G0.8-T5: unknown connector_id raises UnknownConnectorError.
+
+    The route layer maps that to a 404; the prior behaviour (empty
+    ``groups`` list, HTTP 200) was the "empty catalog" trap.
+    """
     operator = _make_operator()
 
-    result = await list_operation_groups(operator, {"connector_id": "ghost-9.9"})
+    with pytest.raises(UnknownConnectorError) as excinfo:
+        await list_operation_groups(operator, {"connector_id": "ghost-9.9"})
 
-    assert result == {"connector_id": "ghost-9.9", "groups": []}
+    assert "ghost-9.9" in str(excinfo.value)
+    assert "<impl_id>-<version>" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_search_operations_unknown_connector_raises(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """G0.8-T5: search_operations raises UnknownConnectorError too —
+    identical unknown-vs-known-empty semantics across both meta-tools."""
+    operator = _make_operator()
+
+    with pytest.raises(UnknownConnectorError):
+        await search_operations(
+            operator,
+            {"connector_id": "ghost-9.9", "query": "anything"},
+        )
 
 
 @pytest.mark.asyncio
@@ -367,7 +391,22 @@ async def test_list_operation_groups_includes_operation_count(
 async def test_search_operations_returns_empty_list_on_empty_corpus(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """No descriptors registered -> ``hits`` is an empty list."""
+    """A KNOWN connector with no matching descriptors -> empty ``hits``.
+
+    The connector is made known-as-data via a seeded group (no
+    descriptors), so this exercises the known-empty path rather than
+    the unknown-connector path (which now raises ``UnknownConnectorError``;
+    see ``test_search_operations_unknown_connector_raises``).
+    """
+    await _seed_group(
+        tenant_id=None,
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        group_key="kv",
+        name="KV v2",
+        when_to_use="kv.",
+    )
     operator = _make_operator()
 
     result = await search_operations(

--- a/backend/tests/test_operations_meta_tools.py
+++ b/backend/tests/test_operations_meta_tools.py
@@ -326,6 +326,64 @@ async def test_list_operation_groups_tenant_boundary() -> None:
 
 
 @pytest.mark.asyncio
+async def test_connector_existence_is_tenant_scoped() -> None:
+    """G0.8-T5: the unknown-vs-known-empty decision is per-tenant.
+
+    Regression for the cross-tenant presence oracle: ``connector_exists``
+    must not treat a connector private to another tenant as "known".
+
+    * A connector whose only rows are tenant-A-private must read as
+      *unknown* to tenant B — ``UnknownConnectorError`` (REST → 404), not
+      an empty ``200 []``. Otherwise tenant B learns the connector exists
+      somewhere and the empty-catalog trap is merely re-scoped per tenant.
+    * A NULL-tenant (built-in / shared) connector stays visible to every
+      tenant — the scoping must not over-restrict and 404 a shared
+      connector for a tenant that has no private rows of its own.
+    """
+    # Tenant-A-private connector: rows exist, but only for tenant A.
+    await _seed_group(
+        tenant_id=_TENANT_A,
+        product="private",
+        version="1.x",
+        impl_id="private",
+        group_key="a-only",
+        name="Tenant A only",
+        when_to_use="tenant a private.",
+    )
+    # Shared / built-in connector visible to all tenants.
+    await _seed_group(
+        tenant_id=None,
+        product="shared",
+        version="1.x",
+        impl_id="shared",
+        group_key="builtin",
+        name="Shared",
+        when_to_use="global.",
+    )
+
+    op_a = _make_operator(tenant_id=_TENANT_A)
+    op_b = _make_operator(tenant_id=_TENANT_B)
+
+    # (a) Tenant B cannot see tenant A's private connector at all: the
+    #     caller-visible answer is "unknown", so this is a 404, never
+    #     a 200 [].
+    with pytest.raises(UnknownConnectorError) as excinfo:
+        await list_operation_groups(op_b, {"connector_id": "private-1.x"})
+    assert "private-1.x" in str(excinfo.value)
+
+    # Tenant A still sees its own private connector (no false 404).
+    result_a = await list_operation_groups(op_a, {"connector_id": "private-1.x"})
+    assert [g["group_key"] for g in result_a["groups"]] == ["a-only"]
+
+    # (b) The NULL-tenant shared connector is visible to both tenants —
+    #     scoping must not over-restrict and 404 a shared connector.
+    result_shared_a = await list_operation_groups(op_a, {"connector_id": "shared-1.x"})
+    result_shared_b = await list_operation_groups(op_b, {"connector_id": "shared-1.x"})
+    assert [g["group_key"] for g in result_shared_a["groups"]] == ["builtin"]
+    assert [g["group_key"] for g in result_shared_b["groups"]] == ["builtin"]
+
+
+@pytest.mark.asyncio
 async def test_list_operation_groups_includes_operation_count(
     stub_embedding_service: AsyncMock,
 ) -> None:
@@ -596,7 +654,14 @@ async def test_search_operations_unknown_group_returns_empty_hits(
 async def test_search_operations_enforces_tenant_boundary(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Tenant-scoped descriptors don't leak across tenants."""
+    """Tenant-A-private descriptors don't leak into tenant B's hits.
+
+    The connector carries a shared (``tenant_id IS NULL``) descriptor so
+    it is legitimately *known* to both tenants — that keeps this test
+    focused on the hit-list tenant boundary rather than the existence
+    gate (whose own per-tenant 404 behaviour is covered by
+    ``test_connector_existence_is_tenant_scoped``).
+    """
     sessionmaker = get_sessionmaker()
     from datetime import UTC, datetime
 
@@ -630,6 +695,38 @@ async def test_search_operations_enforces_tenant_boundary(
                 updated_at=datetime.now(UTC),
             )
         )
+        # Shared descriptor so the connector is known to every tenant —
+        # without it the tenant-scoped existence gate would 404 tenant B
+        # before the hit-list boundary is even exercised.
+        s.add(
+            EndpointDescriptor(
+                id=uuid.uuid4(),
+                tenant_id=None,
+                product="vault",
+                version="1.x",
+                impl_id="vault",
+                op_id="vault.shared.op",
+                source_kind="typed",
+                method=None,
+                path=None,
+                handler_ref="tests.test_operations_meta_tools._module_handler",
+                summary="Shared op for reading data.",
+                description="shared op.",
+                group_id=None,
+                tags=[],
+                parameter_schema={"type": "object"},
+                response_schema=None,
+                llm_instructions=None,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                embedding=None,
+                custom_description=None,
+                custom_notes=None,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+        )
 
     op_a = _make_operator(tenant_id=_TENANT_A)
     op_b = _make_operator(tenant_id=_TENANT_B)
@@ -642,6 +739,7 @@ async def test_search_operations_enforces_tenant_boundary(
         {"connector_id": "vault-1.x", "query": "read"},
     )
 
+    # Tenant A sees its own private op; tenant B never does.
     assert any(h["op_id"] == "vault.tenant.a.op" for h in result_a["hits"])
     assert all(h["op_id"] != "vault.tenant.a.op" for h in result_b["hits"])
 


### PR DESCRIPTION
## Summary

- `GET /api/v1/operations/groups` and `/search` now document the
  `connector_id` format (`<impl_id>-<version>`, e.g. `vmware-rest-9.0`,
  `vault-1.x`) with a non-empty `description` and three named
  `openapi_examples` — the contract is now in the generated
  `/openapi.json` the agent and operators read, not just buried in
  `docs/cross-repo/connector-ingestion.md`.
- An **unknown** `connector_id` is now a **404** instead of an empty
  `200 []`. The empty-200 conflated "unknown connector" with "known
  connector, no enabled groups" — a real dogfood evaluator concluded
  the catalog was empty when 40 descriptors were registered; the id
  was just mis-shaped (bare product `vault` vs `vault-1.x`).
- A **known** connector with zero enabled groups still returns
  `200 []` (the "meaningful empty" case is preserved — explicit
  regression guard added).
- Design note: the unknown-connector signal is a domain exception
  (`UnknownConnectorError(ValueError)`) raised by the shared meta-tool
  handlers; the **REST route** maps it to 404. It is deliberately
  **not** `fastapi.HTTPException` raised from the handler — the same
  handlers back the MCP transport and CLI, and the MCP server's
  generic `except Exception` would mistranslate an `HTTPException`
  into a JSON-RPC `INTERNAL_ERROR` (a worse trap than the empty-200).
  This mirrors the existing `ValueError → HTTPException(400)` pattern
  already in `api/v1/operations.py`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — clean
- [x] `code-quality.py --diff` — 0 blockers (3 pre-existing-debt
      warnings on `meta_tools.py` size, recorded as adjacent findings)
- [x] AC1: generated OpenAPI shows non-empty `description` (259 chars)
      + 3 examples for `connector_id` on both `/groups` and `/search`
      (verified by introspecting `app.openapi()`)
- [x] AC2: `connector_id=vault` (bare product) and `=ghost-9.9`
      (unknown) → 404 with `detail` naming the `<impl_id>-<version>`
      format (`test_get_groups_unknown_connector_returns_404`,
      `test_get_groups_bare_product_name_returns_404`)
- [x] AC3: known connector, zero enabled groups → `200 []`
      (`test_get_groups_known_connector_zero_enabled_returns_empty_200`)
- [x] AC4: `/search` behaves identically for unknown vs known-empty
      (`test_get_search_unknown_connector_returns_404`,
      `test_get_search_known_connector_no_match_returns_empty_200`)
- [x] AC5: full unit lane (`pytest -n auto --ignore=tests/integration`)
      green; stale acceptance assertions that encoded the old
      empty-200 contract updated to the new fail-loud contract

## Out of scope

- Fuzzy-matching a bare product name to its impl id (`vault` →
  `vault-1.x`) — the fix is fail-loud + document, not guessing intent.
- Reshaping the `/connectors` discovery surface — the 404 `detail`
  merely points at `GET /api/v1/connectors`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #630


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operations API and backend tools now consistently treat unknown connector identifiers as errors (HTTP 404) while returning HTTP 200 with empty results for known connectors that have no matching data.

* **Tests**
  * Expanded and updated tests to assert the new unknown-connector error semantics and tenant-scoping behavior across API and meta-tool layers.

* **Chores**
  * Updated ignore rules to exclude workspace files (*.code-workspace).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-18)

Addressed review findings from the iteration-1 `REQUEST_CHANGES` review:

- **B1** `a2ee899` — tenant-scope `connector_exists`: added a `tenant_id`
  parameter, applied `(tenant_id IS NULL) | (tenant_id == tenant_id)` to
  both `LIMIT 1` probes (mirroring `meta_tools.py:283-285`), passed
  `tenant_id=operator.tenant_id` from both callers. Added a multi-tenant
  regression test (`test_connector_existence_is_tenant_scoped`): a
  tenant-B-private connector reads as unknown (404) to tenant A, while a
  NULL-tenant shared connector stays visible to all. The pre-existing
  `test_search_operations_enforces_tenant_boundary` was updated to seed a
  shared descriptor so it still exercises the hit-list boundary rather
  than the now-correct per-tenant existence 404.

Disputed: none.

Deferred: none. (Pre-existing `meta_tools.py` size warnings remain out of
scope, as noted in the original PR body and the review.)

<!-- auto-implement-issue: continue, iteration 1 -->
