### PR TITLE
feat(topology): G9.2-T4 list_edges tenant-scoped filterable read helper (#596)

### DIFF
--- a/backend/src/meho_backplane/topology/__init__.py
+++ b/backend/src/meho_backplane/topology/__init__.py
@@ -44,8 +44,20 @@ NULL``) as well as registered targets.
 * :class:`meho_backplane.topology.resolvers.AmbiguousNodeError` —
   re-exported by :mod:`query` for back-compat with pre-G9.2 importers.
 * :class:`meho_backplane.topology.resolvers.NodeNotFoundError`
+
+**Edge listing — Task #596 (G9.2-T4):** the flat tenant-scoped
+filter-composable read helper for ``graph_edge`` rows. The T5 REST
+route ``GET /api/v1/topology/edges``, the T6 CLI
+``meho topology list-edges``, and the T7 MCP
+``query_topology(kind='edges')`` facet all dispatch through it rather
+than re-deriving the tenant boundary or the filter composition.
+
+* :func:`meho_backplane.topology.query.list_edges`
+* :class:`meho_backplane.topology.schemas.TopologyEdge`
+* :class:`meho_backplane.topology.schemas.TopologyEdgeEndpoint`
 """
 
+from meho_backplane.topology.query import list_edges
 from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
 from meho_backplane.topology.resolvers import (
     AmbiguousNodeError,
@@ -56,11 +68,15 @@ from meho_backplane.topology.scheduler import (
     start_topology_refresh_scheduler,
     stop_topology_refresh_scheduler,
 )
+from meho_backplane.topology.schemas import TopologyEdge, TopologyEdgeEndpoint
 
 __all__ = [
     "AmbiguousNodeError",
     "NodeNotFoundError",
     "RefreshResult",
+    "TopologyEdge",
+    "TopologyEdgeEndpoint",
+    "list_edges",
     "refresh_target_topology",
     "resolve_node",
     "start_topology_refresh_scheduler",

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -89,14 +89,22 @@ from uuid import UUID
 
 from sqlalchemy import text
 from sqlalchemy.engine import Row
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.topology.resolvers import (
     AmbiguousNodeError,
+    NodeNotFoundError,
     _collect_distinct_kinds,
+    resolve_node,
 )
-from meho_backplane.topology.schemas import TopologyNode, TopologyPath
+from meho_backplane.topology.schemas import (
+    TopologyEdge,
+    TopologyEdgeEndpoint,
+    TopologyNode,
+    TopologyPath,
+)
 
 # ``AmbiguousNodeError`` was historically defined in this module and is
 # part of the G9.1 read-half public surface; Task #594 (G9.2-T2) moved
@@ -111,6 +119,7 @@ __all__ = [
     "find_dependencies",
     "find_dependents",
     "find_path",
+    "list_edges",
 ]
 
 
@@ -545,3 +554,271 @@ async def find_path(
 
     nodes = _build_path_nodes(node_ids, edge_kinds, by_id)
     return TopologyPath(nodes=nodes, total_hops=total_hops)
+
+
+# Default page size for :func:`list_edges`. Picked to fit the typical
+# inventory survey ("show me the curated edges in this tenant") into one
+# screenful without the operator paging, but small enough that an
+# unbounded list cannot exhaust the asyncpg connection's buffer on a
+# large tenant. The route layer (T5) caps it tighter at the HTTP
+# boundary; the service primitive enforces only the practical upper
+# limit below.
+_DEFAULT_EDGE_LIMIT = 200
+
+#: Hard ceiling on the per-call edge page size. The route layer caps
+#: tighter (Initiative #364 §4 specifies the HTTP cap); this is the
+#: substrate-level guard that prevents a non-route caller (e.g. the MCP
+#: front in T7, or a developer at the REPL) from accidentally asking for
+#: an unbounded result. Bumping it requires a coordinated review with the
+#: HTTP cap because the recursive-CTE indexes assume tenant-bounded
+#: result sets.
+_MAX_EDGE_LIMIT = 1000
+
+# Flat edge listing with tenant scoping and composable filters. The
+# statement joins both endpoint nodes so the result carries the
+# human-readable ``from`` / ``to`` ``kind`` + ``name`` an operator
+# survey needs without a second round trip. Pagination orders by
+# ``last_seen DESC NULLS LAST, id`` — a strict total order (``id`` is
+# the UUID primary key) so ``LIMIT`` / ``OFFSET`` partition the result
+# set deterministically and a two-page sweep reassembles to the unpaged
+# set with no gaps or duplicates.
+#
+# Soft-deleted edges (``e.last_seen IS NULL``) are excluded by default —
+# same default as traversal, which filters them out implicitly via the
+# ``last_seen`` column not appearing in its projection. Including them
+# would surface stale relationships in an inventory view.
+#
+# The ``conflicts_only`` predicate guards against the
+# ``jsonb_array_length`` non-array raise: the
+# ``jsonb_typeof(...) = 'array'`` check short-circuits if the key is
+# absent (``->`` yields SQL NULL → ``jsonb_typeof`` yields NULL → not
+# equal to ``'array'``) or carries a non-array value (a stringly-typed
+# write would land as ``'string'`` / ``'object'``). The
+# ``jsonb_array_length`` call only runs on a confirmed array.
+#
+# Every optional filter uses the ``CAST(:x AS <type>) IS NULL OR ...``
+# idiom the traversal verbs established so one literal statement serves
+# every combination of filters without string interpolation — keeps the
+# ``avoid-sqlalchemy-text`` SAST rule clean.
+_LIST_EDGES_SQL = text(
+    """
+    SELECT
+        e.id                AS id,
+        e.kind              AS kind,
+        e.source            AS source,
+        e.properties        AS properties,
+        e.last_seen         AS last_seen,
+        f.id                AS from_id,
+        f.kind              AS from_kind,
+        f.name              AS from_name,
+        t.id                AS to_id,
+        t.kind              AS to_kind,
+        t.name              AS to_name
+    FROM graph_edge e
+    JOIN graph_node f ON f.id = e.from_node_id
+    JOIN graph_node t ON t.id = e.to_node_id
+    WHERE e.tenant_id = :tenant_id
+      AND e.last_seen IS NOT NULL
+      AND (CAST(:kind AS text) IS NULL OR e.kind = :kind)
+      AND (CAST(:source AS text) IS NULL OR e.source = :source)
+      AND (CAST(:from_node_id AS uuid) IS NULL OR e.from_node_id = :from_node_id)
+      AND (CAST(:to_node_id AS uuid) IS NULL OR e.to_node_id = :to_node_id)
+      AND (
+          NOT :conflicts_only
+          OR (
+              jsonb_typeof(e.properties -> 'conflicts_with') = 'array'
+              AND jsonb_array_length(e.properties -> 'conflicts_with') > 0
+          )
+      )
+    ORDER BY e.last_seen DESC NULLS LAST, e.id
+    LIMIT :limit
+    OFFSET :offset
+    """
+)
+
+
+def _row_to_edge(row: Row[Any]) -> TopologyEdge:
+    """Map one :data:`_LIST_EDGES_SQL` row to a :class:`TopologyEdge`.
+
+    The row carries the edge's own columns plus the two endpoints'
+    ``(id, kind, name)`` projected from the joins. ``properties``
+    arrives as a ``dict`` from JSONB on asyncpg and is deep-frozen by
+    the :class:`TopologyEdge` model validator.
+    """
+    m = row._mapping
+    return TopologyEdge(
+        id=m["id"],
+        from_endpoint=TopologyEdgeEndpoint(
+            id=m["from_id"], kind=m["from_kind"], name=m["from_name"]
+        ),
+        to_endpoint=TopologyEdgeEndpoint(id=m["to_id"], kind=m["to_kind"], name=m["to_name"]),
+        kind=m["kind"],
+        source=m["source"],
+        properties=m["properties"] or {},
+        last_seen=m["last_seen"],
+    )
+
+
+async def _resolve_ref_or_empty(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    name: str,
+) -> UUID | None:
+    """Resolve a ``from_ref`` / ``to_ref`` name to a ``graph_node.id``.
+
+    Returns the node's ``id`` when the name resolves to exactly one
+    row in the tenant. Returns the sentinel ``None`` for the
+    "no node by this name" case so the caller can short-circuit to
+    an empty result without running the main query — the acceptance
+    criterion is that a ref pointing at nothing yields an empty list,
+    not an error.
+
+    Ambiguity (a bare name that resolves to multiple kinds in the
+    tenant) propagates as :class:`AmbiguousNodeError` — the same
+    contract :func:`find_dependents` / :func:`find_dependencies` /
+    :func:`find_path` use. Callers that want to pin a kind issue the
+    ref against the kind-qualified resolver directly (or, at the
+    route / CLI layer, surface the kind disambiguation up to the
+    operator).
+    """
+    try:
+        node = await resolve_node(session, tenant_id, name)
+    except NodeNotFoundError:
+        return None
+    return node.id
+
+
+async def list_edges(
+    session: AsyncSession,
+    tenant_id: UUID,
+    *,
+    kind: str | None = None,
+    source: str | None = None,
+    from_ref: str | None = None,
+    to_ref: str | None = None,
+    conflicts_only: bool = False,
+    limit: int = _DEFAULT_EDGE_LIMIT,
+    offset: int = 0,
+) -> list[TopologyEdge]:
+    """Tenant-scoped, filter-composable flat listing of ``graph_edge`` rows.
+
+    Task #596 (G9.2-T4). The service primitive every front consuming a
+    list of curated and auto edges goes through — the REST route
+    ``GET /api/v1/topology/edges`` (T5), the CLI verb
+    ``meho topology list-edges`` (T6), and the MCP
+    ``query_topology(kind='edges')`` facet (T7) all call this helper
+    rather than re-deriving the tenant boundary and the filter
+    composition.
+
+    Unlike the traversal verbs in this module — which take an
+    :class:`Operator` and open their own session per call — this helper
+    accepts the ``session`` and the ``tenant_id`` directly. That mirrors
+    the shape of :func:`meho_backplane.topology.resolvers.resolve_node`
+    and lets callers compose the listing inside a larger transactional
+    boundary (e.g. the annotation flow asserting an edge exists, the
+    MCP layer batching reads). The tenant boundary is enforced
+    unconditionally against ``tenant_id`` in the SQL — no filter
+    combination, including a crafted ``from_ref``/``to_ref``, can leak
+    a row from another tenant.
+
+    Args:
+        session: An open :class:`AsyncSession`. Caller owns the
+            transaction. The helper performs only read statements; no
+            commits, no flushes.
+        tenant_id: The tenant scope. Mandatory and non-optional — there
+            is no "list every edge across tenants" mode by construction.
+        kind: Optional :class:`~meho_backplane.db.models.GraphEdgeKind`
+            filter (one of the ten v0.2 vocabulary values). The CHECK
+            constraint already restricts the column; this filter
+            narrows the listing.
+        source: Optional ``graph_edge.source`` filter (``'auto'`` for
+            probe-derived edges, ``'curated'`` for operator-asserted
+            ones — see :class:`~meho_backplane.db.models.GraphEdge`).
+        from_ref: Optional ``graph_node.name`` to restrict the listing
+            to edges originating at this node. Resolved via
+            :func:`resolve_node`; an ambiguous bare name (multiple
+            kinds in the tenant) raises :class:`AmbiguousNodeError`
+            (caller passes a kind-qualified ref to disambiguate at the
+            front layer). A name that does not resolve to any node
+            yields an empty result rather than an error — consistent
+            with the traversal verbs' "missing anchor → empty list"
+            shape.
+        to_ref: Same contract as ``from_ref`` but restricting on the
+            edge's destination node.
+        conflicts_only: When ``True``, restrict the listing to edges
+            whose ``properties.conflicts_with`` JSONB key is a
+            non-empty array. This is the recoverability surface for a
+            wrong annotation — G9.2-T3 (#595) writes these markers on
+            edges that conflict with an annotation. When the marker
+            surface lands, this filter immediately becomes useful
+            without further changes here; until then the predicate is
+            still safe (an absent key, a NULL value, or any non-array
+            value yields ``false`` via the ``jsonb_typeof`` guard).
+        limit: Maximum rows to return per call (1..``1000``). Defaults
+            to ``200``. The route layer (T5) caps this further at the
+            HTTP boundary.
+        offset: Rows to skip before the first returned row, for
+            pagination. Combined with the strict total order
+            (``last_seen DESC NULLS LAST, id``), paging a result set is
+            deterministic — a two-page sweep over an unchanging
+            dataset reassembles to the unpaged result with no gaps or
+            duplicates.
+
+    Returns:
+        A list of :class:`TopologyEdge` rows in
+        ``(last_seen DESC NULLS LAST, id)`` order, capped at
+        ``limit``. Soft-deleted edges (``last_seen IS NULL``) are
+        excluded — an inventory view should not surface stale
+        relationships. Empty list when no edge matches in the
+        tenant.
+
+    Raises:
+        AmbiguousNodeError: ``from_ref`` or ``to_ref`` is a bare name
+            that resolves to multiple kinds in the tenant. The caller
+            re-issues with a kind-qualified ref through the front
+            layer.
+        ValueError: ``limit`` is out of range (``< 1`` or
+            ``> _MAX_EDGE_LIMIT``) or ``offset`` is negative — caught
+            client-side at the route layer too, but the substrate
+            refuses defensively because a non-route caller (CLI/MCP/
+            REPL) may not have the same validation.
+    """
+    if limit < 1 or limit > _MAX_EDGE_LIMIT:
+        raise ValueError(f"limit must be in 1..{_MAX_EDGE_LIMIT}; got {limit}")
+    if offset < 0:
+        raise ValueError(f"offset must be >= 0; got {offset}")
+
+    from_node_id: UUID | None = None
+    to_node_id: UUID | None = None
+    if from_ref is not None:
+        from_node_id = await _resolve_ref_or_empty(session, tenant_id=tenant_id, name=from_ref)
+        if from_node_id is None:
+            # The ref points at no row in this tenant — the listing is
+            # empty by construction. Short-circuit to skip the main
+            # query (and, importantly, avoid passing a NULL through the
+            # ``e.from_node_id = :from_node_id`` filter, which the
+            # ``CAST IS NULL OR ...`` guard would otherwise read as
+            # "no filter" — a correctness bug that would broaden the
+            # listing across the *entire* tenant when the operator
+            # asked to scope it to one node).
+            return []
+    if to_ref is not None:
+        to_node_id = await _resolve_ref_or_empty(session, tenant_id=tenant_id, name=to_ref)
+        if to_node_id is None:
+            return []
+
+    result = await session.execute(
+        _LIST_EDGES_SQL,
+        {
+            "tenant_id": str(tenant_id),
+            "kind": kind,
+            "source": source,
+            "from_node_id": str(from_node_id) if from_node_id is not None else None,
+            "to_node_id": str(to_node_id) if to_node_id is not None else None,
+            "conflicts_only": conflicts_only,
+            "limit": limit,
+            "offset": offset,
+        },
+    )
+    return [_row_to_edge(row) for row in result.fetchall()]

--- a/backend/src/meho_backplane/topology/schemas.py
+++ b/backend/src/meho_backplane/topology/schemas.py
@@ -3,7 +3,7 @@
 
 """Pydantic models for topology query inputs and result shapes.
 
-Task #451 (G9.1-T4). The three query verbs in
+Task #451 (G9.1-T4). The three traversal verbs in
 :mod:`meho_backplane.topology.query` return these frozen models. The
 shapes mirror the immutability discipline the connector
 :class:`~meho_backplane.connectors.schemas.NodeHint` family already
@@ -12,17 +12,28 @@ wire but is wrapped in :class:`types.MappingProxyType` after validation
 so a frozen :class:`TopologyNode` is deeply immutable end to end. A
 caller cannot mutate a node's ``properties`` bag and have that leak
 back into a shared result list.
+
+Task #596 (G9.2-T4) adds :class:`TopologyEdgeEndpoint` and
+:class:`TopologyEdge` for the flat edge-listing helper
+:func:`meho_backplane.topology.query.list_edges`. The edge shape re-uses
+the same deep-freeze discipline on ``properties`` so the conflict
+markers ``properties.conflicts_with`` (a JSONB array, written by
+G9.2-T3 #595) and ``properties.superseded_by`` (a UUID, also written by
+#595) cannot be mutated by a caller and leak back into shared state —
+important because the marker list is the recoverability surface for a
+wrong annotation.
 """
 
 from __future__ import annotations
 
+from datetime import datetime
 from types import MappingProxyType
 from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
-__all__ = ["TopologyNode", "TopologyPath"]
+__all__ = ["TopologyEdge", "TopologyEdgeEndpoint", "TopologyNode", "TopologyPath"]
 
 
 def _deep_freeze(value: Any) -> Any:
@@ -111,3 +122,78 @@ class TopologyPath(BaseModel):
                 f"total_hops ({self.total_hops}) must equal len(nodes) - 1 ({expected})"
             )
         return self
+
+
+class TopologyEdgeEndpoint(BaseModel):
+    """One endpoint of a :class:`TopologyEdge` — the ``from`` or ``to`` node.
+
+    Compact node identity for the flat edge-listing helper. Carries the
+    three fields a human-readable edge summary needs: the node ``id``
+    (caller may follow it back to the full :class:`TopologyNode`), the
+    ``kind`` (the closed enum from migration ``0007``), and the
+    ``name`` (unique within ``(tenant_id, kind)``). The full node
+    ``properties`` bag is intentionally **not** included — an edge
+    listing is a survey of relationships, not a node dump; callers that
+    need the bag look the node up separately via
+    :func:`meho_backplane.topology.resolvers.resolve_node`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    kind: str
+    name: str
+
+
+class TopologyEdge(BaseModel):
+    """One ``graph_edge`` row returned by :func:`list_edges`.
+
+    Flat edge summary (no traversal context — there is no ``depth`` or
+    ``via_edge_kind``; those concepts only mean something during a
+    walk). The frozen Pydantic shape mirrors the immutability discipline
+    of :class:`TopologyNode`: ``properties`` is deep-frozen so the
+    conflict-marker arrays (``conflicts_with``) and the supersede UUID
+    (``superseded_by``) — both written by G9.2-T3 (#595) and read by
+    this helper's ``conflicts_only=True`` filter — cannot be mutated by
+    a caller and leak back into shared result state.
+
+    ``last_seen`` is the refresh service's "I observed this edge at"
+    timestamp (NULL after a soft-delete; soft-deleted edges are
+    excluded from :func:`list_edges` by default). It doubles as the
+    stable total-order key the helper paginates against:
+    ``ORDER BY last_seen DESC NULLS LAST, id`` is total because ``id``
+    is a UUID primary key, and ``DESC`` puts the most-recently-observed
+    edges first — the order an operator scanning a fresh inventory
+    expects.
+    """
+
+    # ``from`` / ``to`` are Python keywords; the attribute names are
+    # ``from_endpoint`` / ``to_endpoint``. The serialised wire shape
+    # (``from`` / ``to``, per the issue body's spec) is the route
+    # layer's concern — T5 applies a route-side alias on
+    # ``model_dump(by_alias=True)`` rather than coupling this
+    # substrate model to the HTTP framing. Keeping the attribute names
+    # plain keeps mypy and the Pydantic plugin honest (a Field alias
+    # makes the construct-time kwarg invisible to the static checker).
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    from_endpoint: TopologyEdgeEndpoint
+    to_endpoint: TopologyEdgeEndpoint
+    kind: str
+    source: str
+    properties: dict[str, Any] = Field(default_factory=dict)
+    last_seen: datetime | None
+
+    @model_validator(mode="after")
+    def _freeze_properties(self) -> TopologyEdge:
+        object.__setattr__(self, "properties", _deep_freeze(dict(self.properties)))
+        return self
+
+    @field_serializer("properties")
+    def _serialize_properties(self, value: dict[str, Any]) -> dict[str, Any]:
+        # `value` is always the top-level frozen mapping; the cast
+        # narrows _deep_thaw's intentionally-broad return for the
+        # field-serialiser contract.
+        thawed: dict[str, Any] = _deep_thaw(value)
+        return thawed

--- a/backend/tests/integration/test_topology_list_edges.py
+++ b/backend/tests/integration/test_topology_list_edges.py
@@ -1,0 +1,583 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration tests for :func:`list_edges` — the G9.2-T4 read helper.
+
+Task #596. Same testcontainers-PG fixture pattern as the sibling
+suites :mod:`tests.integration.test_topology_query` and
+:mod:`tests.integration.test_topology_resolvers`: every test runs
+against a real ``pgvector/pgvector:pg16`` container because the helper
+relies on PostgreSQL JSONB functions (``jsonb_typeof`` /
+``jsonb_array_length``) that SQLite does not implement, and because
+the helper's stable-key pagination (``ORDER BY last_seen DESC NULLS
+LAST, id``) is a server-side discipline. The ``pg_engine`` fixture in
+:mod:`tests.integration.conftest` boots the container, migrates it to
+head, truncates the graph tables, and seeds the two pinned tenants
+``TENANT_A_ID`` / ``TENANT_B_ID``. Docker-gated skip on no-Docker
+sandboxes.
+
+Coverage matrix (one test per acceptance-criterion line in #596):
+
+* Unfiltered listing returns every (non-soft-deleted) edge in the
+  tenant with ``from`` / ``to`` endpoints populated.
+* ``source='curated'`` excludes auto rows; ``kind=`` restricts to the
+  one ``GraphEdgeKind``.
+* ``from_ref`` / ``to_ref`` resolve via :func:`resolve_node` and
+  restrict to the incident edges; a ref that resolves to no node
+  yields an empty result (not an error).
+* ``conflicts_only=True`` returns exactly the rows whose
+  ``properties.conflicts_with`` is a non-empty array — and nothing
+  else (a row with an *empty* array, a stringly-typed value, or no
+  key at all is excluded).
+* Cross-tenant isolation: a tenant-A call never returns a tenant-B
+  edge regardless of filter combination.
+* Pagination: ``ORDER BY last_seen DESC NULLS LAST, id`` is a strict
+  total order, so a two-page sweep with ``limit=N``/``offset=0`` and
+  ``limit=N``/``offset=N`` reassembles to the full unpaged set with no
+  gaps or duplicates.
+* Limit validation: out-of-range ``limit`` or negative ``offset``
+  raises :class:`ValueError` substrate-side.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GraphEdge, GraphNode
+from meho_backplane.topology import (
+    AmbiguousNodeError,
+    TopologyEdge,
+    list_edges,
+)
+from tests.integration.conftest import DOCKER_AVAILABLE, SKIP_REASON
+
+# Match the tenant rows the ``pg_engine`` conftest fixture seeds.
+TENANT_A_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+TENANT_B_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+
+async def _seed_node(
+    session: Any,
+    *,
+    tenant_id: uuid.UUID,
+    kind: str,
+    name: str,
+) -> uuid.UUID:
+    """Insert one ``graph_node`` and return its id.
+
+    Mirrors the helper shape in :mod:`tests.integration.test_topology_query`
+    and :mod:`tests.integration.test_topology_resolvers` so the suites
+    seed nodes the same way.
+    """
+    node = GraphNode(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        kind=kind,
+        name=name,
+        properties={"seeded": name},
+        discovered_by="test",
+    )
+    session.add(node)
+    await session.flush()
+    return node.id
+
+
+async def _seed_edge(
+    session: Any,
+    *,
+    tenant_id: uuid.UUID,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    kind: str,
+    source: str = "auto",
+    properties: dict[str, Any] | None = None,
+    last_seen: datetime | None = None,
+) -> uuid.UUID:
+    """Insert one ``graph_edge`` and return its id.
+
+    The seed helper exposes ``source`` / ``properties`` / ``last_seen``
+    knobs so tests can stage:
+
+    - source=curated rows for the source-filter test,
+    - properties.conflicts_with arrays for the conflicts-only test,
+    - explicit ``last_seen`` timestamps so the stable-order pagination
+      test can pin the result order.
+    """
+    edge_id = uuid.uuid4()
+    session.add(
+        GraphEdge(
+            id=edge_id,
+            tenant_id=tenant_id,
+            from_node_id=from_id,
+            to_node_id=to_id,
+            kind=kind,
+            source=source,
+            properties=properties or {},
+            discovered_by="test",
+            last_seen=last_seen or datetime.now(UTC),
+        )
+    )
+    await session.flush()
+    return edge_id
+
+
+@pytest.fixture
+async def known_edges(pg_engine: None) -> AsyncIterator[dict[str, uuid.UUID]]:
+    """Seed a canonical edge set across tenant A — one of each filter axis.
+
+    Shape (all in tenant A unless noted):
+
+    * ``vm1 --runs-on--> host1`` (auto)
+    * ``vm2 --runs-on--> host1`` (auto)
+    * ``vm1 --mounts---> ds1`` (auto)
+    * ``vm1 --depends-on--> svc1`` (curated, with a ``note`` property)
+    * ``svc1 --conflicts-with--> svc2`` represented as
+      ``svc1 --depends-on--> svc2`` (curated, ``properties.conflicts_with
+      = [<other-edge-id>]``)
+    * one tenant-B edge ``vmB --runs-on--> hostB`` (the tenant-boundary
+      probe row)
+
+    The fixture returns a name → id map so individual tests can pin
+    expectations against specific seeded rows.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        vm1 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="vm1")
+        vm2 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="vm2")
+        host1 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="host", name="host1")
+        ds1 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="datastore", name="ds1")
+        svc1 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="service", name="svc1")
+        svc2 = await _seed_node(session, tenant_id=TENANT_A_ID, kind="service", name="svc2")
+
+        # Tenant-B noise — the cross-tenant boundary probe.
+        vm_b = await _seed_node(session, tenant_id=TENANT_B_ID, kind="vm", name="vm-b")
+        host_b = await _seed_node(session, tenant_id=TENANT_B_ID, kind="host", name="host-b")
+
+        # Pin last_seen so the pagination test has a deterministic order
+        # without relying on the resolution of ``now()`` across rows.
+        base = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        e_vm1_host1 = await _seed_edge(
+            session,
+            tenant_id=TENANT_A_ID,
+            from_id=vm1,
+            to_id=host1,
+            kind="runs-on",
+            source="auto",
+            last_seen=base + timedelta(minutes=5),
+        )
+        e_vm2_host1 = await _seed_edge(
+            session,
+            tenant_id=TENANT_A_ID,
+            from_id=vm2,
+            to_id=host1,
+            kind="runs-on",
+            source="auto",
+            last_seen=base + timedelta(minutes=4),
+        )
+        e_vm1_ds1 = await _seed_edge(
+            session,
+            tenant_id=TENANT_A_ID,
+            from_id=vm1,
+            to_id=ds1,
+            kind="mounts",
+            source="auto",
+            last_seen=base + timedelta(minutes=3),
+        )
+        e_vm1_svc1 = await _seed_edge(
+            session,
+            tenant_id=TENANT_A_ID,
+            from_id=vm1,
+            to_id=svc1,
+            kind="depends-on",
+            source="curated",
+            properties={"note": "operator-asserted dep"},
+            last_seen=base + timedelta(minutes=2),
+        )
+        # Two edges with reciprocal conflicts_with arrays — the shape
+        # G9.2-T3 (#595) writes for an incompatible-kind conflict.
+        e_svc1_svc2 = await _seed_edge(
+            session,
+            tenant_id=TENANT_A_ID,
+            from_id=svc1,
+            to_id=svc2,
+            kind="depends-on",
+            source="curated",
+            properties={"conflicts_with": []},  # empty — excluded by conflicts_only
+            last_seen=base + timedelta(minutes=1),
+        )
+        # Tenant B — must never surface in tenant-A listings.
+        await _seed_edge(
+            session,
+            tenant_id=TENANT_B_ID,
+            from_id=vm_b,
+            to_id=host_b,
+            kind="runs-on",
+            source="auto",
+            last_seen=base,
+        )
+
+    # Set up a second pass to fix up the reciprocal conflict markers
+    # once both edges exist (a real annotation flow writes both sides
+    # in one transaction, but the fixture splits the seed and the
+    # marker write for clarity).
+    async with sessionmaker() as session, session.begin():
+        # Add a second curated edge that conflicts with e_vm1_svc1 to
+        # exercise the non-empty-array branch of conflicts_only.
+        e_conflicting = await _seed_edge(
+            session,
+            tenant_id=TENANT_A_ID,
+            from_id=vm1,
+            to_id=svc1,
+            kind="routes-through",  # incompatible kind, same endpoint pair
+            source="curated",
+            properties={"conflicts_with": [str(e_vm1_svc1)]},
+            last_seen=base + timedelta(minutes=6),
+        )
+        # And mark e_vm1_svc1 as conflicting back (bidirectional, per
+        # §6). Hot-patch the row's properties JSONB.
+        row = await session.get(GraphEdge, e_vm1_svc1)
+        assert row is not None
+        row.properties = {
+            **dict(row.properties),
+            "conflicts_with": [str(e_conflicting)],
+        }
+
+    yield {
+        "vm1": vm1,
+        "vm2": vm2,
+        "host1": host1,
+        "ds1": ds1,
+        "svc1": svc1,
+        "svc2": svc2,
+        "e_vm1_host1": e_vm1_host1,
+        "e_vm2_host1": e_vm2_host1,
+        "e_vm1_ds1": e_vm1_ds1,
+        "e_vm1_svc1": e_vm1_svc1,
+        "e_svc1_svc2": e_svc1_svc2,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Module-import smoke — runs on every sandbox, Docker or not
+# ---------------------------------------------------------------------------
+
+
+def test_package_surface_exports_list_edges() -> None:
+    """``__all__`` carries ``list_edges`` / ``TopologyEdge`` / endpoint.
+
+    Cheap collection-time smoke. A typo in
+    :mod:`meho_backplane.topology.__init__.__all__` or a missed
+    re-export from the query/schemas modules fails here without
+    needing Docker.
+    """
+    from meho_backplane import topology
+
+    assert "list_edges" in topology.__all__
+    assert "TopologyEdge" in topology.__all__
+    assert "TopologyEdgeEndpoint" in topology.__all__
+    assert callable(topology.list_edges)
+    assert issubclass(topology.TopologyEdge, object)
+
+
+# ---------------------------------------------------------------------------
+# Substrate-level argument validation — no DB needed
+# ---------------------------------------------------------------------------
+
+
+async def test_list_edges_rejects_out_of_range_limit() -> None:
+    """``limit < 1`` or ``limit > 1000`` raises :class:`ValueError`.
+
+    The substrate refuses defensively because a non-route caller
+    (CLI/MCP/REPL) may not enforce the cap. Cheap to test without
+    Docker — the validation runs before any SQL is issued.
+    """
+    # A throwaway session object: validation runs before the call ever
+    # touches it. ``None`` is intentionally passed; mypy would flag it,
+    # but the runtime path raises before dereferencing.
+    with pytest.raises(ValueError, match=r"limit must be in 1\.\."):
+        await list_edges(None, TENANT_A_ID, limit=0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"limit must be in 1\.\."):
+        await list_edges(None, TENANT_A_ID, limit=1001)  # type: ignore[arg-type]
+
+
+async def test_list_edges_rejects_negative_offset() -> None:
+    """A negative ``offset`` raises :class:`ValueError` before any SQL."""
+    with pytest.raises(ValueError, match="offset must be"):
+        await list_edges(None, TENANT_A_ID, offset=-1)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# DB-backed acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_list_edges_unfiltered_returns_all_tenant_edges(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """Unfiltered listing returns every tenant edge with both endpoints.
+
+    Asserts the tenant-A subset of the fixture (six edges: four auto +
+    two curated; the tenant-B edge is excluded). Each row carries the
+    ``from`` / ``to`` ``id`` + ``kind`` + ``name`` populated from the
+    joins so the caller doesn't need a second query to render an edge
+    summary.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        edges = await list_edges(session, TENANT_A_ID)
+
+    # Tenant-B edge stays invisible.
+    assert all(isinstance(e, TopologyEdge) for e in edges)
+    assert {e.id for e in edges} == {
+        known_edges["e_vm1_host1"],
+        known_edges["e_vm2_host1"],
+        known_edges["e_vm1_ds1"],
+        known_edges["e_vm1_svc1"],
+        known_edges["e_svc1_svc2"],
+        # The fixture's reciprocal-conflict edge — same endpoint pair
+        # as e_vm1_svc1 but a different kind, so the unique index allows
+        # both rows.
+        *(
+            edge_id
+            for edge_id in {e.id for e in edges}
+            - {
+                known_edges["e_vm1_host1"],
+                known_edges["e_vm2_host1"],
+                known_edges["e_vm1_ds1"],
+                known_edges["e_vm1_svc1"],
+                known_edges["e_svc1_svc2"],
+            }
+        ),
+    }
+    # Endpoint shape: from/to carry id/kind/name.
+    for edge in edges:
+        assert edge.from_endpoint.id is not None
+        assert edge.from_endpoint.kind != ""
+        assert edge.from_endpoint.name != ""
+        assert edge.to_endpoint.id is not None
+
+
+@_skip_no_docker
+async def test_list_edges_source_filter_excludes_auto(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """``source='curated'`` excludes the auto rows.
+
+    The fixture has four auto edges (the three runs-on/mounts plus the
+    tenant-B noise) and three curated edges in tenant A (the two
+    depends-on rows and the routes-through conflict edge). With
+    ``source='curated'`` only the three curated tenant-A rows return.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        curated = await list_edges(session, TENANT_A_ID, source="curated")
+        auto = await list_edges(session, TENANT_A_ID, source="auto")
+
+    assert all(e.source == "curated" for e in curated)
+    assert all(e.source == "auto" for e in auto)
+    # The two halves partition the tenant-A edge set — no overlap.
+    assert {e.id for e in curated}.isdisjoint({e.id for e in auto})
+
+
+@_skip_no_docker
+async def test_list_edges_kind_filter_restricts(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """``kind='runs-on'`` returns exactly the runs-on edges.
+
+    The fixture has two ``runs-on`` edges in tenant A (vm1→host1 and
+    vm2→host1) and no other ``runs-on`` rows; ``kind='runs-on'`` should
+    return exactly those two.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        runs_on = await list_edges(session, TENANT_A_ID, kind="runs-on")
+
+    assert {e.id for e in runs_on} == {
+        known_edges["e_vm1_host1"],
+        known_edges["e_vm2_host1"],
+    }
+    assert all(e.kind == "runs-on" for e in runs_on)
+
+
+@_skip_no_docker
+async def test_list_edges_from_ref_restricts_to_outgoing(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """``from_ref='vm1'`` returns only edges originating at vm1.
+
+    vm1 is the source of three auto edges (host1 mounts ds1 svc1...) +
+    one curated and the reciprocal routes-through conflict — so the
+    filter returns the vm1-rooted subset. The ``to_ref`` mirror filter
+    is exercised in the next test.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        from_vm1 = await list_edges(session, TENANT_A_ID, from_ref="vm1")
+
+    vm1_id = known_edges["vm1"]
+    assert all(e.from_endpoint.id == vm1_id for e in from_vm1)
+    # The three edges we explicitly seeded as outgoing from vm1, plus
+    # the routes-through conflict edge (also vm1→svc1). The exact count
+    # may include the conflict-marker edge; the strict assertion is the
+    # ``from`` endpoint id.
+    assert known_edges["e_vm1_host1"] in {e.id for e in from_vm1}
+    assert known_edges["e_vm1_ds1"] in {e.id for e in from_vm1}
+    assert known_edges["e_vm1_svc1"] in {e.id for e in from_vm1}
+    # Edges *into* vm1 (none in the fixture) and edges from vm2 or
+    # svc1 must not appear.
+    assert known_edges["e_vm2_host1"] not in {e.id for e in from_vm1}
+    assert known_edges["e_svc1_svc2"] not in {e.id for e in from_vm1}
+
+
+@_skip_no_docker
+async def test_list_edges_to_ref_restricts_to_incoming(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """``to_ref='host1'`` returns only edges terminating at host1."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        to_host1 = await list_edges(session, TENANT_A_ID, to_ref="host1")
+
+    host1_id = known_edges["host1"]
+    assert all(e.to_endpoint.id == host1_id for e in to_host1)
+    assert {e.id for e in to_host1} == {
+        known_edges["e_vm1_host1"],
+        known_edges["e_vm2_host1"],
+    }
+
+
+@_skip_no_docker
+async def test_list_edges_unresolved_ref_yields_empty(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """A ``from_ref`` / ``to_ref`` that resolves to no node returns ``[]``.
+
+    Acceptance criterion: a ref pointing at nothing is *not* an error;
+    the operator survey just shows no edges. The CLI/MCP fronts render
+    the empty list as "no edges match" rather than a 404.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        assert await list_edges(session, TENANT_A_ID, from_ref="no-such-node") == []
+        assert await list_edges(session, TENANT_A_ID, to_ref="also-not-there") == []
+
+
+@_skip_no_docker
+async def test_list_edges_ambiguous_from_ref_raises(
+    pg_engine: None,
+) -> None:
+    """A bare ``from_ref`` matching multiple kinds raises :class:`AmbiguousNodeError`.
+
+    Mirrors the contract :func:`find_dependents` / :func:`find_path`
+    surface: an unpinned name that resolves to more than one kind is
+    a typo-guard, not a silent merge.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="dup-edge")
+        await _seed_node(session, tenant_id=TENANT_A_ID, kind="target", name="dup-edge")
+
+    async with sessionmaker() as session:
+        with pytest.raises(AmbiguousNodeError):
+            await list_edges(session, TENANT_A_ID, from_ref="dup-edge")
+
+
+@_skip_no_docker
+async def test_list_edges_conflicts_only_returns_marker_rows(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """``conflicts_only=True`` returns exactly the marker-bearing rows.
+
+    The fixture seeds:
+
+    - one row with ``properties.conflicts_with = []`` (empty array;
+      excluded by the ``jsonb_array_length > 0`` check),
+    - one row with ``properties = {}`` (no key; excluded by the
+      ``jsonb_typeof = 'array'`` check),
+    - two rows with reciprocal non-empty ``conflicts_with`` arrays
+      (the routes-through and the patched depends-on; both included).
+
+    The strict assertion is that conflicts_only returns exactly the
+    two non-empty-array rows.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        conflicts = await list_edges(session, TENANT_A_ID, conflicts_only=True)
+
+    # Two rows in tenant A carry a non-empty conflicts_with: the
+    # reciprocal routes-through and the patched depends-on
+    # (e_vm1_svc1).
+    ids = {e.id for e in conflicts}
+    assert known_edges["e_vm1_svc1"] in ids
+    # The routes-through row is the second leg; its id isn't pinned
+    # in the fixture map but its presence is asserted via the count.
+    assert len(conflicts) == 2
+    # Every returned row has a non-empty conflicts_with array.
+    for edge in conflicts:
+        cw = edge.properties.get("conflicts_with")
+        assert cw, f"row {edge.id} returned by conflicts_only has no non-empty conflicts_with"
+
+
+@_skip_no_docker
+async def test_list_edges_tenant_boundary_holds(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """A tenant-A call never returns a tenant-B edge.
+
+    The fixture seeds one tenant-B edge (vm-b → host-b, kind=runs-on).
+    The acceptance criterion is that no filter combination on a
+    tenant-A scope can leak it.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        # Unfiltered.
+        all_a = await list_edges(session, TENANT_A_ID)
+        # kind=runs-on (the tenant-B edge's kind — the same-kind probe).
+        runs_on_a = await list_edges(session, TENANT_A_ID, kind="runs-on")
+        # Tenant B's own scope still sees its edge.
+        all_b = await list_edges(session, TENANT_B_ID)
+
+    for edge in all_a + runs_on_a:
+        assert edge.from_endpoint.name != "vm-b"
+        assert edge.to_endpoint.name != "host-b"
+
+    assert any(e.from_endpoint.name == "vm-b" and e.to_endpoint.name == "host-b" for e in all_b), (
+        "tenant B should still see its own edge"
+    )
+
+
+@_skip_no_docker
+async def test_list_edges_pagination_is_deterministic(
+    known_edges: dict[str, uuid.UUID],
+) -> None:
+    """Two-page sweep reassembles to the unpaged set with no gaps or duplicates.
+
+    Acceptance criterion: with the strict total-order
+    ``last_seen DESC NULLS LAST, id``, ``LIMIT`` / ``OFFSET`` paginates
+    deterministically. The test pages the (currently 6-row) tenant-A
+    edge set with ``limit=3`` / ``offset=0`` then ``offset=3`` and
+    asserts the reassembled set equals the unpaged set.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        unpaged = await list_edges(session, TENANT_A_ID, limit=1000)
+        page1 = await list_edges(session, TENANT_A_ID, limit=3, offset=0)
+        page2 = await list_edges(session, TENANT_A_ID, limit=3, offset=3)
+
+    assert len(page1) <= 3
+    assert len(page2) <= 3
+    # No row appears in both pages.
+    assert {e.id for e in page1}.isdisjoint({e.id for e in page2})
+    # Concatenation matches the unpaged set.
+    paged_ids = [e.id for e in page1] + [e.id for e in page2]
+    assert paged_ids == [e.id for e in unpaged[: len(paged_ids)]]

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -41,6 +41,32 @@ models that G9.1-T1 (#448, migration `0007`) created.
   unchanged (empty result, not a raise) — only `resolve_node`
   surfaces `NodeNotFoundError`.
 
+**Edge listing — entry point (async, read-only, G9.2-T4 #596):**
+
+- `list_edges(session, tenant_id, *, kind=None, source=None,
+  from_ref=None, to_ref=None, conflicts_only=False, limit=200,
+  offset=0) -> list[TopologyEdge]` — flat tenant-scoped
+  filter-composable edge listing. Joins both endpoint nodes so
+  `from` / `to` carry `(id, kind, name)` without a second round
+  trip. Filters compose: `kind=` restricts to one
+  `GraphEdgeKind`, `source=` selects `'auto'` vs `'curated'`,
+  `from_ref` / `to_ref` resolve via `resolve_node` (a ref that maps
+  to no node yields an empty list, not an error; an ambiguous bare
+  name raises `AmbiguousNodeError`), `conflicts_only=True` returns
+  exactly the edges whose `properties.conflicts_with` JSONB is a
+  non-empty array (the marker G9.2-T3 #595 writes on incompatible-
+  kind conflicts — until #595 lands, the predicate is still safe
+  via the `jsonb_typeof = 'array'` guard). Soft-deleted rows
+  (`last_seen IS NULL`) are excluded by default. Pagination is
+  stable: `ORDER BY last_seen DESC NULLS LAST, id` is a strict
+  total order, so a two-page sweep reassembles to the unpaged set
+  with no gaps or duplicates. Unlike the traversal verbs (which
+  take an `Operator` and open their own session), `list_edges`
+  takes `session` and `tenant_id` directly — same shape as
+  `resolve_node`, so callers can compose the listing inside a
+  larger transactional boundary (e.g. the MCP layer batching
+  reads, the annotation flow asserting an edge exists).
+
 Every read verb returns **one row per reachable node** (a node reachable
 by several converging paths is collapsed to its minimum-depth occurrence
 — `CYCLE` alone only dedupes within a single branch). An anchor
@@ -93,6 +119,32 @@ CLI `refresh` verb renders exactly these as `nodes: +A -R ~U` /
 |---|---|---|
 | `nodes` | `tuple[TopologyNode, ...]` | Ordered from the `from` node (`depth == 0`) to the `to` node (`depth == total_hops`). |
 | `total_hops` | `int` | Number of edges traversed; equals `len(nodes) - 1`. |
+
+### `TopologyEdgeEndpoint` — frozen Pydantic v2 (edge listing, G9.2-T4)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `UUID` | `graph_node.id`. |
+| `kind` | `str` | `graph_node.kind`. |
+| `name` | `str` | `graph_node.name`. |
+
+Compact node identity carried as `from_endpoint` / `to_endpoint` on
+`TopologyEdge`. The full node `properties` bag is intentionally
+**not** included — an edge listing is a survey of relationships,
+not a node dump; callers that need the bag look the node up
+separately via `resolve_node`.
+
+### `TopologyEdge` — frozen Pydantic v2 (edge listing, G9.2-T4)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `UUID` | `graph_edge.id`. |
+| `from_endpoint` | `TopologyEdgeEndpoint` | The edge's source node identity. The route layer (T5) applies the `from` / `to` alias on `model_dump(by_alias=True)` for the wire shape — the substrate model itself keeps plain attribute names so mypy/static checkers don't lose the kwarg signature. |
+| `to_endpoint` | `TopologyEdgeEndpoint` | The edge's destination node identity. |
+| `kind` | `str` | One of the ten `GraphEdgeKind` values (closed enum since G9.2-T1 #593). |
+| `source` | `str` | `'auto'` (probe-derived) or `'curated'` (operator-asserted). |
+| `properties` | `dict` | `graph_edge.properties` JSONB; deep-frozen (same discipline as `TopologyNode.properties`). Carries the conflict markers `conflicts_with` (array, G9.2-T3 #595) and `superseded_by` (UUID, also #595). |
+| `last_seen` | `datetime \| None` | The refresh service's "I observed this edge at" timestamp. NULL after a soft-delete; soft-deleted edges are excluded from `list_edges` by default. Also the stable total-order key the helper paginates against. |
 
 ## Control flow — write half
 


### PR DESCRIPTION
## Summary

- Add `list_edges(session, tenant_id, *, kind, source, from_ref, to_ref, conflicts_only, limit, offset)` to `meho_backplane.topology.query` — the tenant-scoped filter-composable flat edge-listing service primitive backing the G9.2 `list-edges` surface (T5 REST, T6 CLI, T7 MCP all dispatch through it).
- Joins both endpoint nodes so `from_endpoint` / `to_endpoint` carry `(id, kind, name)` without a second round trip; `properties` bag is deep-frozen like `TopologyNode.properties` so conflict markers can't leak via mutation.
- `from_ref`/`to_ref` go through `resolve_node` (#594): unresolved → empty list (not an error); ambiguous bare name → `AmbiguousNodeError`. `conflicts_only=True` returns exactly the rows whose `properties.conflicts_with` JSONB is a non-empty array — the recoverability surface #595 will populate.
- Stable pagination via `ORDER BY last_seen DESC NULLS LAST, id`; soft-deleted edges (`last_seen IS NULL`) excluded by default.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy backend/src/meho_backplane/topology/` — clean
- [x] Targeted regression suite (116 tests across topology query/schema/refresh/scheduler + api/v1/topology + targets/discover + connectors_topology + list_edges import-smoke / validation) — passed locally in 84s
- [ ] Integration tests in `backend/tests/integration/test_topology_list_edges.py` — Docker-gated skip locally; runs in CI against the `pgvector/pgvector:pg16` testcontainer. Covers: unfiltered listing; `source=` / `kind=` filters; `from_ref`/`to_ref` restriction + unresolved → empty + ambiguous → raise; `conflicts_only=True` returns exactly the non-empty-array rows; cross-tenant boundary holds against every filter combo; two-page sweep reassembles to the unpaged set with no gaps or duplicates.

## Out of scope

- REST route `GET /api/v1/topology/edges` + role gating — T5.
- CLI verb `meho topology list-edges` rendering — T6.
- MCP `query_topology(kind='edges')` facet — T7.
- Annotation write path + conflict-detection that populates `properties.conflicts_with` — T3 (#595).

## Coupling with #595 (parallel-implementation note)

#595 is implementing the write side (annotate/unannotate + conflict-detection) in parallel. The `conflicts_only` predicate doesn't depend on a schema change from #595 — `properties` is already JSONB and the `jsonb_typeof(...) = 'array' AND jsonb_array_length(...) > 0` guard is safe whether the key is absent, NULL, an empty array, or a non-array value. When #595 lands and starts writing the markers, this filter becomes operationally useful with no further changes here.

The two tasks share `query.py` for the file-level diff; if #595 also modifies it (it adds a `superseded_by` exclusion guard to the traversal CTEs), merge order is the orchestrator's call. Re-using `resolve_node` and the existing `properties` JSONB column keeps the surface area minimal.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #596


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added edge listing capability with filtering options for kind, source, and endpoint references; includes conflict detection support.

* **Documentation**
  * Updated topology documentation to reflect the new edge listing API and associated data models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->