### PR TITLE
feat(topology): G9.2-T3 annotate/unannotate service + §6 conflict detection (#595)

### DIFF
--- a/backend/src/meho_backplane/topology/__init__.py
+++ b/backend/src/meho_backplane/topology/__init__.py
@@ -45,6 +45,22 @@ NULL``) as well as registered targets.
   re-exported by :mod:`query` for back-compat with pre-G9.2 importers.
 * :class:`meho_backplane.topology.resolvers.NodeNotFoundError`
 
+**Annotate / unannotate — Task #595 (G9.2-T3):** the curated-edge
+write service. Resolves both endpoints, validates ``kind`` against
+:class:`~meho_backplane.db.models.GraphEdgeKind`, runs §6 conflict
+detection (sticky ``superseded_by`` for same-kind/different-endpoint
+auto edges; bidirectional ``conflicts_with`` for incompatible kinds
+over the same endpoint pair), and writes one audit row + one
+broadcast event per operation. The REST routes (T5), CLI verbs (T6),
+and MCP tools (T7) all funnel through these two primitives.
+
+* :func:`meho_backplane.topology.annotate.annotate_edge`
+* :func:`meho_backplane.topology.annotate.unannotate_edge`
+* :class:`meho_backplane.topology.annotate.NodeRef`
+* :class:`meho_backplane.topology.annotate.InvalidEdgeKindError`
+* :class:`meho_backplane.topology.annotate.AutoEdgeDeletionError`
+* :class:`meho_backplane.topology.annotate.UnannotateSelectorError`
+
 **Edge listing — Task #596 (G9.2-T4):** the flat tenant-scoped
 filter-composable read helper for ``graph_edge`` rows. The T5 REST
 route ``GET /api/v1/topology/edges``, the T6 CLI
@@ -57,6 +73,15 @@ than re-deriving the tenant boundary or the filter composition.
 * :class:`meho_backplane.topology.schemas.TopologyEdgeEndpoint`
 """
 
+from meho_backplane.topology.annotate import (
+    AnnotateConflictError,
+    AutoEdgeDeletionError,
+    InvalidEdgeKindError,
+    NodeRef,
+    UnannotateSelectorError,
+    annotate_edge,
+    unannotate_edge,
+)
 from meho_backplane.topology.query import list_edges
 from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
 from meho_backplane.topology.resolvers import (
@@ -72,13 +97,20 @@ from meho_backplane.topology.schemas import TopologyEdge, TopologyEdgeEndpoint
 
 __all__ = [
     "AmbiguousNodeError",
+    "AnnotateConflictError",
+    "AutoEdgeDeletionError",
+    "InvalidEdgeKindError",
     "NodeNotFoundError",
+    "NodeRef",
     "RefreshResult",
     "TopologyEdge",
     "TopologyEdgeEndpoint",
+    "UnannotateSelectorError",
+    "annotate_edge",
     "list_edges",
     "refresh_target_topology",
     "resolve_node",
     "start_topology_refresh_scheduler",
     "stop_topology_refresh_scheduler",
+    "unannotate_edge",
 ]

--- a/backend/src/meho_backplane/topology/annotate.py
+++ b/backend/src/meho_backplane/topology/annotate.py
@@ -1,0 +1,894 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Operator-curated annotation flow for the topology graph.
+
+Initiative #364 (G9.2), Task #595 (T3). Annotate / unannotate are the
+*write* halves of the curated edge surface: an operator asserts an
+edge that no probe can derive (``k8s-sa-foo`` ``authenticates-via``
+``vault-role-bar``) and the next blast-radius traversal sees it.
+
+The two service functions :func:`annotate_edge` and
+:func:`unannotate_edge` are the load-bearing primitives the REST
+routes (T5 #597), CLI verbs (T6 #599) and MCP tools (T7 #598) all hang
+off — they own:
+
+1. **Endpoint resolution** via :func:`resolve_node` (#594). A name that
+   does not exist in the operator's tenant raises
+   :class:`NodeNotFoundError`; a name that is ambiguous across kinds
+   raises :class:`AmbiguousNodeError`. Cross-tenant resolution is
+   impossible by construction (the resolver scopes on
+   ``operator.tenant_id``).
+
+2. **Kind validation** against :class:`GraphEdgeKind` (#593). The closed
+   v0.2 ten-kind vocabulary is the load-bearing modeling decision; a
+   typo'd / made-up kind never reaches the DB-layer CHECK.
+
+3. **Idempotent upsert** keyed on
+   ``graph_edge_tenant_endpoints_kind_idx`` (``(tenant_id,
+   from_node_id, to_node_id, kind)``). A repeat annotate of the same
+   triple refreshes ``last_seen`` + ``properties`` instead of erroring
+   with a unique-constraint violation.
+
+4. **§6 conflict detection** (the recoverable-mistake invariant):
+
+   * *Same kind, different endpoint* — auto edge from the same
+     ``from_node_id`` of the same ``kind`` to a *different*
+     ``to_node_id`` is marked ``properties.superseded_by =
+     <curated-id>``. The supersede mark is **sticky** across refresh
+     (preserved by ``refresh._reconcile_edges``); only an
+     :func:`unannotate_edge` of the curated row clears it. Superseded
+     auto edges are excluded from every traversal verb's recursive
+     CTE (the ``properties->>'superseded_by' IS NULL`` guard in
+     :mod:`meho_backplane.topology.query`).
+   * *Incompatible kinds, same endpoint pair* — auto / curated edges
+     for the same ``(tenant_id, from_node_id, to_node_id)`` of a
+     *different* ``kind`` keep both rows; bidirectional
+     ``properties.conflicts_with = [<other-id>]`` is appended on each
+     side. The downstream policy layer is the consumer that resolves
+     the contradiction; the topology layer only surfaces it.
+
+   Both marker shapes live in ``graph_edge.properties`` JSONB — no
+   schema change beyond T1's CHECK widening.
+
+5. **Audit + broadcast** integration. One ``audit_log`` row per
+   annotate / unannotate (``op_id='topology.annotate'`` /
+   ``'topology.unannotate'``, ``op_class='write'`` — explicit, because
+   the ``.annotate`` / ``.unannotate`` suffixes are not in
+   :data:`broadcast.events._WRITE_SUFFIXES` and would otherwise
+   classify as ``other``) + exactly one broadcast event carrying
+   ``from`` / ``kind`` / ``to`` / ``note``. ``target_id`` is populated
+   when the *from* node is itself a managed target (``target_id IS
+   NOT NULL``).
+
+The function is **session-first** and does not open its own
+sessionmaker (the resolver convention from #594). Both write functions
+own the commit + post-commit broadcast publish, mirroring
+:func:`refresh_target_topology`'s "audit committed inside the
+transaction, broadcast fail-open after commit" discipline. Callers
+must pass a session with no active transaction; the function opens its
+own ``session.begin()`` block.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.broadcast import BroadcastEvent, publish_event
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphEdgeKind, GraphNode
+from meho_backplane.topology.resolvers import resolve_node
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "AnnotateConflictError",
+    "AutoEdgeDeletionError",
+    "InvalidEdgeKindError",
+    "NodeRef",
+    "UnannotateSelectorError",
+    "annotate_edge",
+    "unannotate_edge",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Canonical op-ids. Mirrored into ``audit_log.payload['op_id']`` and
+#: into the broadcast event's ``op_id`` field; consumed by the
+#: ``meho status --watch`` viewer the v0.2 chassis ships.
+_ANNOTATE_OP_ID = "topology.annotate"
+_UNANNOTATE_OP_ID = "topology.unannotate"
+
+#: ``op_class`` for both verbs. Set explicitly rather than derived via
+#: :func:`broadcast.events.classify_op` because ``.annotate`` /
+#: ``.unannotate`` are not in :data:`broadcast.events._WRITE_SUFFIXES`
+#: and the classifier would fall through to ``other``. Initiative
+#: #364 §10 also locks the *write* classification: annotations carry
+#: semantic context operators want to see in real time, so they
+#: broadcast in full per the G6.1 default classifier — which the
+#: ``write`` op-class enables.
+_OP_CLASS = "write"
+
+#: Non-HTTP audit method tokens (chassis convention: a non-HTTP write
+#: records ``method`` as a verb token and ``path`` as the canonical
+#: op_id, mirroring :data:`refresh._AUDIT_METHOD`).
+_AUDIT_METHOD_ANNOTATE = "ANNOTATE"
+_AUDIT_METHOD_UNANNOTATE = "UNANNOTATE"
+
+#: Reserved keys in ``graph_edge.properties`` used by §6 conflict
+#: detection. The refresh service must merge — not overwrite — these
+#: when re-applying an EdgeHint to an existing row, otherwise the
+#: sticky-supersede invariant breaks on the next probe.
+_SUPERSEDED_BY = "superseded_by"
+_CONFLICTS_WITH = "conflicts_with"
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class NodeRef:
+    """Operator-supplied reference to a :class:`GraphNode` endpoint.
+
+    A small immutable pair the REST / CLI / MCP fronts hand to
+    :func:`annotate_edge` and :func:`unannotate_edge` after parsing
+    operator input. The wrapper keeps the call signature explicit
+    (``from_ref``, ``to_ref``) without inventing a tuple convention or
+    forcing every caller through ``**kwargs``.
+
+    ``name`` is the ``graph_node.name`` to resolve; ``kind`` is the
+    optional ``graph_node.kind`` pin per :func:`resolve_node`'s
+    contract. Names that are ambiguous across kinds in the tenant
+    require ``kind`` to be set or the call raises
+    :class:`AmbiguousNodeError`.
+    """
+
+    name: str
+    kind: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Typed errors (HTTP-agnostic — API layer maps to status codes)
+# ---------------------------------------------------------------------------
+
+
+class InvalidEdgeKindError(ValueError):
+    """The supplied ``kind`` is not in the v0.2 :class:`GraphEdgeKind` enum.
+
+    Raised by :func:`annotate_edge` before any DB write — the closed
+    enum is the policy-layer grammar's first guard rail. The API layer
+    maps it to a 422 with the supplied value and the candidate list in
+    ``detail``; CLI maps it to a usage error with the same candidate
+    list.
+    """
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        valid = sorted(k.value for k in GraphEdgeKind)
+        super().__init__(
+            f"edge kind {kind!r} is not in the v0.2 vocabulary; valid kinds: {valid!r}"
+        )
+
+
+class AutoEdgeDeletionError(ValueError):
+    """Refusal to :func:`unannotate_edge` an edge with ``source='auto'``.
+
+    Hard-deleting an auto row is meaningless: the next refresh that
+    still sees the edge re-creates it. The verb refuses with this
+    typed error rather than silently no-op'ing or recreating the row.
+    The API layer maps it to a 409 with the auto edge's id in
+    ``detail`` so the operator sees the diagnostic without re-issuing
+    a separate list-edges call.
+    """
+
+    def __init__(self, edge_id: uuid.UUID) -> None:
+        self.edge_id = edge_id
+        super().__init__(
+            f"graph_edge {edge_id} is auto-discovered; refusing to delete "
+            "(auto edges resurrect on next refresh; unannotate is a no-op)"
+        )
+
+
+class UnannotateSelectorError(ValueError):
+    """Caller passed neither or both of ``edge_id`` and the triple selector.
+
+    :func:`unannotate_edge` is a keyword-only API; exactly one of
+    ``edge_id`` *or* the full ``(from_ref, kind, to_ref)`` triple must
+    be supplied. Both / neither indicates a programming error in the
+    front. The API layer maps it to a 422; CLI / MCP raise on their
+    own arg-parse layer before reaching the service.
+    """
+
+
+class AnnotateConflictError(ValueError):
+    """Raised when :func:`annotate_edge`'s conflict-detection sees an
+    inconsistent state it cannot recover from automatically.
+
+    Reserved for future use; the v0.2 conflict rules (§6 of #364) are
+    designed to *always* land — same-kind/different-endpoint marks the
+    auto row superseded, incompatible kinds coexist with bidirectional
+    markers — so this class is currently unused. Kept on the public
+    surface so a future widening of the conflict rules has a typed
+    error to raise without an API/contract change.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_kind(kind: str) -> str:
+    """Validate ``kind`` against :class:`GraphEdgeKind`; return the value.
+
+    The enum membership check is the first guard rail — failing here
+    avoids a more obscure DB ``CHECK`` violation later. Returns the
+    canonical string form so subsequent code uses the StrEnum value,
+    not the raw input (defensive against future kind aliases).
+    """
+    try:
+        return GraphEdgeKind(kind).value
+    except ValueError as exc:
+        raise InvalidEdgeKindError(kind) from exc
+
+
+async def _find_existing_edge(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    kind: str,
+) -> GraphEdge | None:
+    """Lookup an edge by the ``(tenant, from, to, kind)`` unique tuple.
+
+    Anchored on ``graph_edge_tenant_endpoints_kind_idx``. Returns the
+    row or ``None`` — same semantics ``existing_by_key`` uses inside
+    :func:`refresh._reconcile_edges` so the idempotent-upsert branch
+    reads identically.
+    """
+    stmt = select(GraphEdge).where(
+        GraphEdge.tenant_id == tenant_id,
+        GraphEdge.from_node_id == from_id,
+        GraphEdge.to_node_id == to_id,
+        GraphEdge.kind == kind,
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def _mark_same_kind_different_endpoint_superseded(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    curated_edge_id: uuid.UUID,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    kind: str,
+) -> list[uuid.UUID]:
+    """Stamp ``superseded_by`` on auto edges that the curated row replaces.
+
+    Conflict §6 rule 1: a curated edge ``runs-on(vm-A → host-Y)``
+    supersedes any auto edge ``runs-on(vm-A → host-X)`` — same
+    ``from_node_id`` + same ``kind`` + ``source='auto'`` + a
+    *different* ``to_node_id``. Mutates ``properties`` in place
+    (``GraphEdge.properties`` is a JSONB column; SQLAlchemy detects
+    the change when the attribute is reassigned, so we reassign
+    rather than mutating the inner dict).
+
+    Returns the list of marked auto-edge ids — caller uses it for the
+    audit/broadcast payload's ``superseded_count`` so the visibility
+    of the conflict is not buried in a side effect.
+    """
+    stmt = select(GraphEdge).where(
+        GraphEdge.tenant_id == tenant_id,
+        GraphEdge.from_node_id == from_id,
+        GraphEdge.kind == kind,
+        GraphEdge.source == "auto",
+        GraphEdge.to_node_id != to_id,
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    marked: list[uuid.UUID] = []
+    for row in rows:
+        props = dict(row.properties or {})
+        props[_SUPERSEDED_BY] = str(curated_edge_id)
+        row.properties = props
+        marked.append(row.id)
+    return marked
+
+
+async def _mark_incompatible_kinds_conflict(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    curated_edge: GraphEdge,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    kind: str,
+) -> list[uuid.UUID]:
+    """Stamp bidirectional ``conflicts_with`` on edges of other kinds.
+
+    Conflict §6 rule 2: a curated edge ``depends-on(svc → db)``
+    *coexists* with an auto edge ``routes-through(svc → db)`` —
+    same endpoint pair, incompatible kinds. Both rows survive; each
+    one's ``properties.conflicts_with`` carries the other's id. The
+    marker is a list so a single edge with several conflicting kinds
+    accumulates every id (dedupe preserved).
+
+    Returns the list of conflicting edge ids — payload counterpart of
+    the superseded-list above.
+    """
+    stmt = select(GraphEdge).where(
+        GraphEdge.tenant_id == tenant_id,
+        GraphEdge.from_node_id == from_id,
+        GraphEdge.to_node_id == to_id,
+        GraphEdge.kind != kind,
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    conflicting_ids: list[uuid.UUID] = []
+    for row in rows:
+        conflicting_ids.append(row.id)
+        _append_conflict_marker(row, curated_edge.id)
+
+    if conflicting_ids:
+        # Bidirectional: the curated row points back at every
+        # conflicting edge.
+        for other_id in conflicting_ids:
+            _append_conflict_marker(curated_edge, other_id)
+    return conflicting_ids
+
+
+def _append_conflict_marker(edge: GraphEdge, other_id: uuid.UUID) -> None:
+    """Append ``other_id`` to ``edge.properties['conflicts_with']`` (dedupe).
+
+    Reassigns ``edge.properties`` to a fresh dict (rather than mutating
+    in place) so SQLAlchemy's change-detection picks up the JSONB
+    write — the JSON column type does not auto-detect in-place
+    mutations of the inner dict.
+    """
+    props = dict(edge.properties or {})
+    raw = props.get(_CONFLICTS_WITH)
+    current: list[str] = list(raw) if isinstance(raw, list) else []
+    other_str = str(other_id)
+    if other_str not in current:
+        current.append(other_str)
+    props[_CONFLICTS_WITH] = current
+    edge.properties = props
+
+
+def _clear_reciprocal_markers(
+    edges: list[GraphEdge],
+    *,
+    removed_edge_id: uuid.UUID,
+) -> None:
+    """Drop references to ``removed_edge_id`` from the other edges' markers.
+
+    On :func:`unannotate_edge` of a curated row we walk every edge
+    that previously paired with it (either ``superseded_by`` ==
+    removed-id, or ``removed-id`` appearing in ``conflicts_with``)
+    and clear the back-reference so the auto row reappears in
+    traversal and dangling ids do not linger.
+    """
+    removed_str = str(removed_edge_id)
+    for edge in edges:
+        props = dict(edge.properties or {})
+        changed = False
+        if props.get(_SUPERSEDED_BY) == removed_str:
+            props.pop(_SUPERSEDED_BY)
+            changed = True
+        conflicts = props.get(_CONFLICTS_WITH)
+        if isinstance(conflicts, list) and removed_str in conflicts:
+            new_conflicts = [c for c in conflicts if c != removed_str]
+            if new_conflicts:
+                props[_CONFLICTS_WITH] = new_conflicts
+            else:
+                props.pop(_CONFLICTS_WITH)
+            changed = True
+        if changed:
+            edge.properties = props
+
+
+async def _find_edges_referencing(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    edge_id: uuid.UUID,
+) -> list[GraphEdge]:
+    """Return every edge with a ``superseded_by`` / ``conflicts_with`` ref
+    to ``edge_id``.
+
+    The properties JSONB scan is portable across JSON + JSONB (no
+    PG-specific ``->>`` operator) so the unit suite running on
+    aiosqlite + the integration suite on PG share one code path.
+    """
+    rows = (
+        (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+        .scalars()
+        .all()
+    )
+    removed_str = str(edge_id)
+    out: list[GraphEdge] = []
+    for row in rows:
+        props = row.properties or {}
+        if props.get(_SUPERSEDED_BY) == removed_str:
+            out.append(row)
+            continue
+        conflicts = props.get(_CONFLICTS_WITH)
+        if isinstance(conflicts, list) and removed_str in conflicts:
+            out.append(row)
+    return out
+
+
+def _audit_payload(
+    *,
+    op_id: str,
+    from_node: GraphNode,
+    to_node: GraphNode,
+    kind: str,
+    edge_id: uuid.UUID,
+    note: str | None,
+    evidence_url: str | None,
+    superseded: list[uuid.UUID],
+    conflicts: list[uuid.UUID],
+) -> dict[str, Any]:
+    """Build the shared audit / broadcast payload.
+
+    The same dict lands in ``audit_log.payload`` (full row) and in
+    the broadcast event (``op_class='write'`` defaults to full
+    detail per §10 of #364). ``superseded`` / ``conflicts`` give
+    downstream visibility on what the assertion just rewrote — the
+    diagnostic the recovery flow needs.
+    """
+    return {
+        "op_id": op_id,
+        "op_class": _OP_CLASS,
+        "edge_id": str(edge_id),
+        "from": {
+            "id": str(from_node.id),
+            "kind": from_node.kind,
+            "name": from_node.name,
+        },
+        "to": {
+            "id": str(to_node.id),
+            "kind": to_node.kind,
+            "name": to_node.name,
+        },
+        "kind": kind,
+        "note": note,
+        "evidence_url": evidence_url,
+        "superseded": [str(i) for i in superseded],
+        "conflicts": [str(i) for i in conflicts],
+    }
+
+
+def _build_audit_row(
+    *,
+    audit_id: uuid.UUID,
+    operator: Operator,
+    method: str,
+    op_id: str,
+    target_id: uuid.UUID | None,
+    payload: dict[str, Any],
+) -> AuditLog:
+    """Construct one ``AuditLog`` row for an annotate / unannotate.
+
+    Mirrors the columns ``refresh._write_audit_and_broadcast`` writes
+    (status 200, ``method`` as verb token, ``path`` as op_id) and
+    pre-allocates the ``audit_id`` so the broadcast event's
+    ``audit_id`` field references the *same* row (the chassis
+    "audit-id pre-allocation" pattern).
+    """
+    return AuditLog(
+        id=audit_id,
+        occurred_at=datetime.now(UTC),
+        operator_sub=operator.sub,
+        tenant_id=operator.tenant_id,
+        target_id=target_id,
+        method=method,
+        path=op_id,
+        status_code=200,
+        request_id=None,
+        duration_ms=Decimal("0.00"),
+        payload=payload,
+    )
+
+
+def _broadcast_target_id(node: GraphNode) -> uuid.UUID | None:
+    """Resolve ``audit_log.target_id`` from the curated edge's ``from`` node.
+
+    Populated iff the from-node is itself a managed target
+    (``graph_node.target_id`` non-null). Annotation may reference
+    inner-graph nodes (vault-role, k8s-sa) that are not registered
+    targets; for those rows the audit / broadcast carry ``target_id =
+    None`` per the §10 spec.
+    """
+    return node.target_id
+
+
+async def _publish(
+    *,
+    audit_id: uuid.UUID,
+    operator: Operator,
+    op_id: str,
+    target_name: str | None,
+    payload: dict[str, Any],
+) -> None:
+    """Fail-open broadcast publish.
+
+    Same shape as :func:`refresh._publish_refresh_event` — emits the
+    broadcast event and swallows publisher failure so a broken stream
+    never rolls back a successful annotate / unannotate.
+    """
+    try:
+        event = BroadcastEvent(
+            event_id=uuid.uuid4(),
+            ts=datetime.now(UTC),
+            tenant_id=operator.tenant_id,
+            principal_sub=operator.sub,
+            principal_name=operator.name,
+            target_name=target_name,
+            op_id=op_id,
+            op_class=_OP_CLASS,
+            result_status="ok",
+            audit_id=audit_id,
+            payload=payload,
+        )
+        await publish_event(event)
+    except Exception:
+        _log.exception(
+            "topology_annotation_broadcast_failed",
+            op_id=op_id,
+            tenant_id=str(operator.tenant_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public service functions
+# ---------------------------------------------------------------------------
+
+
+async def annotate_edge(
+    session: AsyncSession,
+    operator: Operator,
+    from_ref: NodeRef,
+    kind: str,
+    to_ref: NodeRef,
+    *,
+    note: str | None = None,
+    evidence_url: str | None = None,
+) -> GraphEdge:
+    """Create or refresh a curated ``graph_edge`` row + apply §6 conflicts.
+
+    Resolves the two endpoints in ``operator.tenant_id`` via
+    :func:`resolve_node` (#594), validates ``kind`` against
+    :class:`GraphEdgeKind` (#593), then:
+
+    * If a row already exists for ``(tenant_id, from_node_id,
+      to_node_id, kind)`` (the
+      ``graph_edge_tenant_endpoints_kind_idx`` unique index), updates
+      ``last_seen`` + ``properties`` and treats the call as
+      idempotent.
+    * Otherwise inserts a fresh row with ``source='curated'``,
+      ``discovered_by=operator.sub``, ``properties`` carrying
+      ``note`` / ``evidence_url`` / ``annotated_by`` /
+      ``annotated_at``.
+
+    Then runs **§6 conflict detection** (Initiative #364):
+
+    * Same-kind / different-endpoint auto edges are stamped
+      ``superseded_by`` (excluded from traversal until the curated
+      row is removed).
+    * Incompatible-kind edges over the same endpoint pair gain a
+      bidirectional ``conflicts_with`` reference.
+
+    Writes one ``audit_log`` row (``op_id='topology.annotate'``,
+    ``op_class='write'``) and publishes one broadcast event after
+    commit. Broadcast is fail-open per the refresh pattern.
+
+    Args:
+        session: Caller-owned :class:`AsyncSession` with **no active
+            transaction**. The function opens a ``session.begin()``
+            block so the resolve / upsert / conflict scan / audit
+            write all commit or roll back together. Mirrors
+            :func:`refresh._apply_reconcile`.
+        operator: The acting identity. Supplies the tenant scope and
+            audit attribution; ``operator.tenant_id`` is the boundary
+            both endpoint resolutions and the conflict scan respect.
+            Role gating (``tenant_admin``) is the API layer's job
+            (T5 #597) — the service trusts its caller.
+        from_ref: Operator-supplied :class:`NodeRef` for the
+            ``from`` endpoint.
+        kind: One of the v0.2 :class:`GraphEdgeKind` values.
+            Wrong value raises :class:`InvalidEdgeKindError`.
+        to_ref: Operator-supplied :class:`NodeRef` for the
+            ``to`` endpoint.
+        note: Optional free-text annotation. Stored on
+            ``edge.properties['note']``.
+        evidence_url: Optional URL the operator attached as evidence
+            (e.g. an INVENTORY.md hash). Stored on
+            ``edge.properties['evidence_url']``.
+
+    Returns:
+        The created or refreshed :class:`GraphEdge` row (post-commit).
+
+    Raises:
+        InvalidEdgeKindError: ``kind`` not in
+            :class:`GraphEdgeKind`.
+        NodeNotFoundError: Either endpoint does not exist in this
+            tenant.
+        AmbiguousNodeError: An endpoint's name is ambiguous across
+            kinds and no ``kind`` was pinned on the
+            :class:`NodeRef`.
+    """
+    canonical_kind = _validate_kind(kind)
+
+    async with session.begin():
+        from_node = await resolve_node(session, operator.tenant_id, from_ref.name, from_ref.kind)
+        to_node = await resolve_node(session, operator.tenant_id, to_ref.name, to_ref.kind)
+
+        now = datetime.now(UTC)
+        existing = await _find_existing_edge(
+            session,
+            tenant_id=operator.tenant_id,
+            from_id=from_node.id,
+            to_id=to_node.id,
+            kind=canonical_kind,
+        )
+
+        properties = {
+            "note": note,
+            "evidence_url": evidence_url,
+            "annotated_by": operator.sub,
+            "annotated_at": now.isoformat(),
+        }
+
+        if existing is None:
+            edge = GraphEdge(
+                id=uuid.uuid4(),
+                tenant_id=operator.tenant_id,
+                from_node_id=from_node.id,
+                to_node_id=to_node.id,
+                kind=canonical_kind,
+                source="curated",
+                properties=properties,
+                discovered_by=operator.sub,
+                first_seen=now,
+                last_seen=now,
+            )
+            session.add(edge)
+            await session.flush()
+        else:
+            # Idempotent: keep ``source='curated'`` (a curated row never
+            # becomes auto) and merge new free-text fields. Existing
+            # ``conflicts_with`` / ``superseded_by`` markers on a
+            # curated row are preserved so a re-annotate does not
+            # silently lose the back-references.
+            merged = dict(existing.properties or {})
+            for key, value in properties.items():
+                merged[key] = value
+            existing.properties = merged
+            existing.last_seen = now
+            edge = existing
+
+        superseded = await _mark_same_kind_different_endpoint_superseded(
+            session,
+            tenant_id=operator.tenant_id,
+            curated_edge_id=edge.id,
+            from_id=from_node.id,
+            to_id=to_node.id,
+            kind=canonical_kind,
+        )
+        conflicts = await _mark_incompatible_kinds_conflict(
+            session,
+            tenant_id=operator.tenant_id,
+            curated_edge=edge,
+            from_id=from_node.id,
+            to_id=to_node.id,
+            kind=canonical_kind,
+        )
+
+        audit_id = uuid.uuid4()
+        payload = _audit_payload(
+            op_id=_ANNOTATE_OP_ID,
+            from_node=from_node,
+            to_node=to_node,
+            kind=canonical_kind,
+            edge_id=edge.id,
+            note=note,
+            evidence_url=evidence_url,
+            superseded=superseded,
+            conflicts=conflicts,
+        )
+        session.add(
+            _build_audit_row(
+                audit_id=audit_id,
+                operator=operator,
+                method=_AUDIT_METHOD_ANNOTATE,
+                op_id=_ANNOTATE_OP_ID,
+                target_id=_broadcast_target_id(from_node),
+                payload=payload,
+            )
+        )
+        target_name = from_node.name
+
+    await _publish(
+        audit_id=audit_id,
+        operator=operator,
+        op_id=_ANNOTATE_OP_ID,
+        target_name=target_name,
+        payload=payload,
+    )
+    return edge
+
+
+async def unannotate_edge(
+    session: AsyncSession,
+    operator: Operator,
+    *,
+    edge_id: uuid.UUID | None = None,
+    from_ref: NodeRef | None = None,
+    kind: str | None = None,
+    to_ref: NodeRef | None = None,
+) -> uuid.UUID:
+    """Hard-delete a curated edge and clear its reciprocal §6 markers.
+
+    Exactly one selector form must be passed (the keyword-only
+    signature is what enforces the discipline at the call site):
+
+    * ``edge_id`` — the curated row's primary key.
+    * The full ``(from_ref, kind, to_ref)`` triple — resolved to a
+      row via the unique ``(tenant_id, from, to, kind)`` index.
+
+    Refuses to delete a row with ``source='auto'`` with
+    :class:`AutoEdgeDeletionError` — auto edges resurrect on next
+    refresh; manual deletion is meaningless.
+
+    Clears any reciprocal ``superseded_by`` / ``conflicts_with``
+    markers the curated row left on auto edges (per §6) so a
+    superseded auto edge reappears in traversal after the curated
+    assertion is rescinded.
+
+    Writes one ``audit_log`` row (``op_id='topology.unannotate'``,
+    ``op_class='write'``) and publishes one broadcast event after
+    commit.
+
+    Args:
+        session: Caller-owned :class:`AsyncSession` with no active
+            transaction; the function opens its own ``session.begin()``.
+        operator: Acting identity; supplies the tenant scope + audit
+            attribution.
+        edge_id: Primary-key selector. Mutually exclusive with the
+            triple form.
+        from_ref / kind / to_ref: Triple selector. All three must be
+            supplied together or none at all.
+
+    Returns:
+        The deleted edge's id (the caller may have only had the
+        triple form on hand).
+
+    Raises:
+        UnannotateSelectorError: Neither or both selector forms
+            were supplied — or the triple form is partial.
+        NodeNotFoundError: A triple-form endpoint does not exist in
+            this tenant.
+        AmbiguousNodeError: A triple-form endpoint's name is
+            ambiguous and no ``kind`` was pinned on the ``NodeRef``.
+        AutoEdgeDeletionError: The targeted row has ``source='auto'``.
+        InvalidEdgeKindError: A triple-form ``kind`` is not in
+            :class:`GraphEdgeKind`.
+        ValueError: The triple form resolves to no row.
+    """
+    has_id = edge_id is not None
+    has_triple = from_ref is not None or kind is not None or to_ref is not None
+    if has_id == has_triple:
+        raise UnannotateSelectorError(
+            "unannotate_edge requires exactly one selector: edge_id "
+            "OR the full (from_ref, kind, to_ref) triple"
+        )
+    if has_triple and not (from_ref is not None and kind is not None and to_ref is not None):
+        raise UnannotateSelectorError(
+            "triple selector requires all three of (from_ref, kind, to_ref)"
+        )
+
+    async with session.begin():
+        if has_id:
+            assert edge_id is not None  # narrowed for mypy
+            edge = await session.get(GraphEdge, edge_id)
+            if edge is None or edge.tenant_id != operator.tenant_id:
+                # Tenant boundary: a row in another tenant is
+                # indistinguishable from a missing row to the caller.
+                raise ValueError(f"graph_edge {edge_id} not found in this tenant")
+            from_node = await session.get(GraphNode, edge.from_node_id)
+            to_node = await session.get(GraphNode, edge.to_node_id)
+            # FK ON DELETE CASCADE protects against orphan rows, but a
+            # mid-flight node delete is still possible — treat as not
+            # found rather than crashing with a None attribute access.
+            if from_node is None or to_node is None:
+                raise ValueError(
+                    f"graph_edge {edge_id} endpoints missing — graph in inconsistent state"
+                )
+        else:
+            assert from_ref is not None  # narrowed for mypy
+            assert to_ref is not None
+            assert kind is not None
+            canonical_kind = _validate_kind(kind)
+            from_node = await resolve_node(
+                session, operator.tenant_id, from_ref.name, from_ref.kind
+            )
+            to_node = await resolve_node(session, operator.tenant_id, to_ref.name, to_ref.kind)
+            edge = await _find_existing_edge(
+                session,
+                tenant_id=operator.tenant_id,
+                from_id=from_node.id,
+                to_id=to_node.id,
+                kind=canonical_kind,
+            )
+            if edge is None:
+                raise ValueError(
+                    f"no graph_edge {canonical_kind!r} from {from_ref.name!r} "
+                    f"to {to_ref.name!r} in this tenant"
+                )
+
+        if edge.source != "curated":
+            raise AutoEdgeDeletionError(edge.id)
+
+        removed_id = edge.id
+        canonical_kind_final = edge.kind
+
+        # Clear reciprocal markers BEFORE deleting the curated row so
+        # the SELECT scan still sees the row as a candidate (the scan
+        # is keyed on properties, not on the deleted edge — but the
+        # pre-clear keeps the bookkeeping simple).
+        referencing = await _find_edges_referencing(
+            session,
+            tenant_id=operator.tenant_id,
+            edge_id=removed_id,
+        )
+        _clear_reciprocal_markers(referencing, removed_edge_id=removed_id)
+
+        await session.delete(edge)
+        await session.flush()
+
+        audit_id = uuid.uuid4()
+        payload = _audit_payload(
+            op_id=_UNANNOTATE_OP_ID,
+            from_node=from_node,
+            to_node=to_node,
+            kind=canonical_kind_final,
+            edge_id=removed_id,
+            note=None,
+            evidence_url=None,
+            superseded=[],
+            conflicts=[r.id for r in referencing],
+        )
+        session.add(
+            _build_audit_row(
+                audit_id=audit_id,
+                operator=operator,
+                method=_AUDIT_METHOD_UNANNOTATE,
+                op_id=_UNANNOTATE_OP_ID,
+                target_id=_broadcast_target_id(from_node),
+                payload=payload,
+            )
+        )
+        target_name = from_node.name
+
+    await _publish(
+        audit_id=audit_id,
+        operator=operator,
+        op_id=_UNANNOTATE_OP_ID,
+        target_name=target_name,
+        payload=payload,
+    )
+    return removed_id

--- a/backend/src/meho_backplane/topology/annotate.py
+++ b/backend/src/meho_backplane/topology/annotate.py
@@ -669,16 +669,38 @@ async def annotate_edge(
             session.add(edge)
             await session.flush()
         else:
-            # Idempotent: keep ``source='curated'`` (a curated row never
-            # becomes auto) and merge new free-text fields. Existing
-            # ``conflicts_with`` / ``superseded_by`` markers on a
-            # curated row are preserved so a re-annotate does not
-            # silently lose the back-references.
+            # Idempotent path covers two cases:
+            #
+            # 1. **Re-annotate of an already-curated row.** Merge new
+            #    free-text fields onto the existing properties; the
+            #    ``source='curated'`` and any reciprocal ``conflicts_with``
+            #    / ``superseded_by`` markers are preserved so the
+            #    re-annotate does not silently drop the §6 back-references.
+            #
+            # 2. **Annotate over an existing ``source='auto'`` edge with
+            #    the same triple.** The operator's intent is to take
+            #    ownership of that edge going forward — set notes /
+            #    evidence, run §6 conflict detection from it, eventually
+            #    revoke via :func:`unannotate_edge`. Leaving the row as
+            #    ``source='auto'`` would (a) make the triple-form
+            #    unannotate raise :class:`AutoEdgeDeletionError` so the
+            #    operator cannot revoke their own annotation; (b) let the
+            #    next refresh's :func:`_merge_edge_properties` overwrite
+            #    the free-text props (only the reserved markers are
+            #    preserved on the merge path); (c) make
+            #    :func:`_mark_same_kind_different_endpoint_superseded` on
+            #    a future annotate mis-target the row as another auto
+            #    edge. The promotion to ``source='curated'`` and
+            #    ``discovered_by=operator.sub`` makes the operator the
+            #    canonical author from this call onward.
             merged = dict(existing.properties or {})
             for key, value in properties.items():
                 merged[key] = value
             existing.properties = merged
             existing.last_seen = now
+            if existing.source != "curated":
+                existing.source = "curated"
+                existing.discovered_by = operator.sub
             edge = existing
 
         superseded = await _mark_same_kind_different_endpoint_superseded(

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -55,6 +55,20 @@ Every statement filters ``graph_node.tenant_id`` *and*
 anchor and the recursive term. A node with the same ``(kind, name)``
 in another tenant is invisible to this tenant's traversal.
 
+Superseded-edge exclusion (Initiative #364 §6, Task #595)
+---------------------------------------------------------
+
+The recursive term of every traversal verb filters
+``graph_edge.properties->>'superseded_by' IS NULL`` — auto edges that
+an operator's curated annotation has marked superseded drop out of
+every closure. The mark is sticky across refresh (preserved by
+:func:`meho_backplane.topology.refresh._reconcile_edges`) and only
+cleared by :func:`meho_backplane.topology.annotate.unannotate_edge` of
+the curated row. The guard fires on all four edge-pulling sites: the
+forward and reverse recursive terms here, and **both legs** of the
+``bi_edge`` CTE in :data:`_PATH_SQL` (missing the reversed leg would
+let a superseded edge be walked backwards into a shortest path).
+
 Anchor disambiguation
 ---------------------
 
@@ -164,6 +178,16 @@ def _row_to_node(row: Row[Any]) -> TopologyNode:
 # Two fully-literal statements (rather than one f-string) keep the
 # Semgrep avoid-sqlalchemy-text rule from firing: nothing is
 # interpolated, every value is a :named bind.
+#
+# Traversal exclusion (§6 of Initiative #364, Task #595): the recursive
+# term filters ``e.properties->>'superseded_by' IS NULL`` so an auto
+# edge an operator's curated annotation has marked superseded is
+# invisible to the closure. ``->>`` is PG's text-extract JSON operator
+# (PG 16 manual §9.16); the column is JSONB on PG (and JSON on the
+# unit-test SQLite engine, which never runs this CTE — recursive CYCLE
+# is PG-only, per the docstring above). A row with no
+# ``superseded_by`` key reads ``NULL`` from ``->>`` and passes the
+# filter, so the guard does not affect non-superseded edges.
 _TRAVERSAL_SQL_REVERSE = text(
     """
     WITH RECURSIVE walk AS (
@@ -193,6 +217,7 @@ _TRAVERSAL_SQL_REVERSE = text(
           AND n.tenant_id = :tenant_id
           AND w.depth < :depth
           AND (CAST(:kind_filter AS text) IS NULL OR e.kind = :kind_filter)
+          AND e.properties->>'superseded_by' IS NULL
     ) CYCLE id SET is_cycle USING path
     SELECT id, kind, name, properties, depth, via_edge_kind
     FROM (
@@ -211,7 +236,8 @@ _TRAVERSAL_SQL_REVERSE = text(
 # join edges *out of* the frontier node and step to their target. Only
 # the two join columns differ from the reverse statement; everything
 # else (tenant scoping, kind pin, kind filter, depth bound, CYCLE
-# guard, closure-wide DISTINCT ON dedupe, ordering) is identical.
+# guard, closure-wide DISTINCT ON dedupe, ordering, §6 superseded-edge
+# exclusion) is identical.
 _TRAVERSAL_SQL_FORWARD = text(
     """
     WITH RECURSIVE walk AS (
@@ -241,6 +267,7 @@ _TRAVERSAL_SQL_FORWARD = text(
           AND n.tenant_id = :tenant_id
           AND w.depth < :depth
           AND (CAST(:kind_filter AS text) IS NULL OR e.kind = :kind_filter)
+          AND e.properties->>'superseded_by' IS NULL
     ) CYCLE id SET is_cycle USING path
     SELECT id, kind, name, properties, depth, via_edge_kind
     FROM (
@@ -409,10 +436,12 @@ _PATH_SQL = text(
         SELECT from_node_id AS src, to_node_id AS dst, kind
         FROM graph_edge
         WHERE tenant_id = :tenant_id
+          AND properties->>'superseded_by' IS NULL
         UNION ALL
         SELECT to_node_id AS src, from_node_id AS dst, kind
         FROM graph_edge
         WHERE tenant_id = :tenant_id
+          AND properties->>'superseded_by' IS NULL
     ),
     walk AS (
         SELECT

--- a/backend/src/meho_backplane/topology/refresh.py
+++ b/backend/src/meho_backplane/topology/refresh.py
@@ -137,11 +137,27 @@ def _properties_differ(current: Any, incoming: Any) -> bool:
 _RESERVED_MARKER_KEYS: tuple[str, ...] = ("superseded_by", "conflicts_with")
 
 
+def _strip_reserved_markers(properties: Any) -> dict[str, Any]:
+    """Return ``properties`` as a plain dict with §6 markers removed.
+
+    Reserved markers (``superseded_by`` / ``conflicts_with``) are
+    operator-only artefacts — they may only enter ``graph_edge.properties``
+    through :func:`annotate_edge`. A connector that emits them in an
+    :class:`~meho_backplane.connectors.schemas.EdgeHint` (whether through
+    a bug, copy-paste from a different row, or — in the hostile case —
+    deliberate forgery) would otherwise smuggle a supersede / conflict
+    mark onto an auto row and bypass the §6 annotate-only invariant.
+    Stripping at the refresh boundary is fail-closed: even a malformed
+    or untrusted hint cannot create a pre-superseded auto edge.
+    """
+    return {k: v for k, v in dict(properties or {}).items() if k not in _RESERVED_MARKER_KEYS}
+
+
 def _merge_edge_properties(
     current: Any,
     incoming: Any,
 ) -> dict[str, Any]:
-    """Return ``incoming`` merged with the reserved markers from ``current``.
+    """Return sanitized ``incoming`` merged with the reserved markers from ``current``.
 
     A refresh hint owns the connector's view of an edge — everything
     *except* the conflict markers an operator's annotation may have
@@ -157,10 +173,15 @@ def _merge_edge_properties(
 
     The fix is a key-level merge: reserved keys (``superseded_by``,
     ``conflicts_with``) survive from ``current``; everything else is
-    sourced from ``incoming``. Only :func:`unannotate_edge` of the
-    curated row clears the supersede mark (Initiative #364 §6).
+    sourced from ``incoming``. The merge is also one-sided in the
+    other direction — reserved markers in ``incoming`` are dropped
+    via :func:`_strip_reserved_markers` so a buggy or hostile
+    connector cannot inject a supersede mark from the probe path.
+    Only :func:`annotate_edge` may set those keys; only
+    :func:`unannotate_edge` of the curated row clears the supersede
+    mark (Initiative #364 §6).
     """
-    merged = dict(incoming)
+    merged = _strip_reserved_markers(incoming)
     current_dict = dict(current or {})
     for key in _RESERVED_MARKER_KEYS:
         if key in current_dict:
@@ -358,6 +379,10 @@ async def _reconcile_edges(
         from_id = live_node_key_to_id[_node_key(hint.from_kind, hint.from_name)]
         to_id = live_node_key_to_id[_node_key(hint.to_kind, hint.to_name)]
         if existing_edge is None:
+            # Sanitize before insert so a connector emitting a reserved
+            # marker in its hint (buggy or hostile) cannot create a
+            # pre-superseded / pre-conflicting auto edge that bypasses
+            # the §6 annotate-only invariant (Initiative #364).
             session.add(
                 GraphEdge(
                     id=uuid.uuid4(),
@@ -366,7 +391,7 @@ async def _reconcile_edges(
                     to_node_id=to_id,
                     kind=hint.kind,
                     source="auto",
-                    properties=dict(hint.properties),
+                    properties=_strip_reserved_markers(hint.properties),
                     discovered_by=discovered_by,
                     first_seen=now,
                     last_seen=now,
@@ -374,6 +399,21 @@ async def _reconcile_edges(
             )
             added += 1
             continue
+        if existing_edge.source == "curated":
+            # Curated edges are operator-owned: the probe's view of the
+            # row's properties is not authoritative. The refresh only
+            # records that the probe still observes the edge
+            # (``last_seen`` bump); the operator-supplied ``note`` /
+            # ``evidence_url`` / ``annotated_*`` and any §6 markers
+            # stay untouched. Without this branch the next refresh
+            # after :func:`annotate_edge` of a previously-auto edge
+            # would wipe the caller's free-text props
+            # (Initiative #364 §6 — M1 of PR #651 review).
+            if existing_edge.last_seen is None:
+                updated += 1
+            existing_edge.last_seen = now
+            continue
+
         # Merge — not overwrite — so the §6 conflict markers
         # (``superseded_by`` / ``conflicts_with``) an operator's
         # annotation may have stamped on this row survive the refresh.

--- a/backend/src/meho_backplane/topology/refresh.py
+++ b/backend/src/meho_backplane/topology/refresh.py
@@ -126,6 +126,48 @@ def _properties_differ(current: Any, incoming: Any) -> bool:
     return dict(current) != dict(incoming)
 
 
+#: Keys in ``graph_edge.properties`` reserved for §6 conflict-detection
+#: markers written by :mod:`meho_backplane.topology.annotate`.
+#: :func:`_reconcile_edges` must **preserve** these on the refresh
+#: write path — overwriting them clears the sticky-supersede invariant
+#: on the next probe and silently brings a superseded auto edge back
+#: into traversal. Initiative #364 §6 (Task #595, G9.2-T3) locks this
+#: invariant; the merge logic in :func:`_merge_edge_properties` below
+#: implements it.
+_RESERVED_MARKER_KEYS: tuple[str, ...] = ("superseded_by", "conflicts_with")
+
+
+def _merge_edge_properties(
+    current: Any,
+    incoming: Any,
+) -> dict[str, Any]:
+    """Return ``incoming`` merged with the reserved markers from ``current``.
+
+    A refresh hint owns the connector's view of an edge — everything
+    *except* the conflict markers an operator's annotation may have
+    stamped on the row. Wholesale overwriting ``edge.properties`` (the
+    pre-#595 behaviour) erased those markers on the next probe, which
+    broke the sticky-supersede invariant in §6 of Initiative #364:
+
+    * a curated annotation marked an auto edge ``superseded_by``;
+    * the next refresh re-saw the auto edge and overwrote
+      ``properties`` from the hint;
+    * the supersede mark vanished and the auto edge silently
+      reappeared in traversal.
+
+    The fix is a key-level merge: reserved keys (``superseded_by``,
+    ``conflicts_with``) survive from ``current``; everything else is
+    sourced from ``incoming``. Only :func:`unannotate_edge` of the
+    curated row clears the supersede mark (Initiative #364 §6).
+    """
+    merged = dict(incoming)
+    current_dict = dict(current or {})
+    for key in _RESERVED_MARKER_KEYS:
+        if key in current_dict:
+            merged[key] = current_dict[key]
+    return merged
+
+
 async def _reconcile_nodes(
     session: AsyncSession,
     *,
@@ -332,11 +374,17 @@ async def _reconcile_edges(
             )
             added += 1
             continue
+        # Merge — not overwrite — so the §6 conflict markers
+        # (``superseded_by`` / ``conflicts_with``) an operator's
+        # annotation may have stamped on this row survive the refresh.
+        # The wholesale-overwrite this used to do silently cleared the
+        # sticky-supersede invariant; see :func:`_merge_edge_properties`.
+        merged_properties = _merge_edge_properties(existing_edge.properties, hint.properties)
         if existing_edge.last_seen is None or _properties_differ(
-            existing_edge.properties, hint.properties
+            existing_edge.properties, merged_properties
         ):
             updated += 1
-        existing_edge.properties = dict(hint.properties)
+        existing_edge.properties = merged_properties
         existing_edge.last_seen = now
 
     for key, row in existing_by_key.items():

--- a/backend/tests/integration/test_topology_query.py
+++ b/backend/tests/integration/test_topology_query.py
@@ -456,6 +456,134 @@ async def test_same_tenant_kind_collision_disambiguated_by_kind(
     assert {n.name for n in pinned.nodes} == {"svc", "dep-of-target"}
 
 
+# ---------------------------------------------------------------------------
+# §6 traversal-exclusion guard (G9.2-T3 #595): superseded auto edges drop
+# out of every traversal verb; non-superseded edges are unaffected.
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_superseded_edge_excluded_from_dependents(
+    pg_engine: None,
+) -> None:
+    """An auto edge marked ``superseded_by`` is invisible to find_dependents.
+
+    Seed ``vm-A --runs-on--> host-X`` as an auto edge, then stamp
+    ``properties.superseded_by`` (the mark a curated annotation would
+    leave per Initiative #364 §6). ``find_dependents`` on ``host-X``
+    must NOT report vm-A — the reverse traversal's recursive term now
+    filters ``properties->>'superseded_by' IS NULL``.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        vm_a = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="ts-vm-a")
+        host_x = await _seed_node(session, tenant_id=TENANT_A_ID, kind="host", name="ts-host-x")
+        edge = GraphEdge(
+            id=uuid.uuid4(),
+            tenant_id=TENANT_A_ID,
+            from_node_id=vm_a,
+            to_node_id=host_x,
+            kind="runs-on",
+            source="auto",
+            properties={"superseded_by": str(uuid.uuid4())},
+            discovered_by="test",
+        )
+        session.add(edge)
+
+    nodes = await find_dependents(_operator(TENANT_A_ID), "ts-host-x")
+    names = {n.name for n in nodes}
+    # The host exists; vm-A is filtered out by the superseded guard.
+    assert "ts-host-x" in names
+    assert "ts-vm-a" not in names
+
+
+@_skip_no_docker
+async def test_superseded_edge_excluded_from_dependencies(
+    pg_engine: None,
+) -> None:
+    """Forward traversal mirrors the reverse guard: superseded edges drop."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        vm_a = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="tf-vm-a")
+        host_x = await _seed_node(session, tenant_id=TENANT_A_ID, kind="host", name="tf-host-x")
+        edge = GraphEdge(
+            id=uuid.uuid4(),
+            tenant_id=TENANT_A_ID,
+            from_node_id=vm_a,
+            to_node_id=host_x,
+            kind="runs-on",
+            source="auto",
+            properties={"superseded_by": str(uuid.uuid4())},
+            discovered_by="test",
+        )
+        session.add(edge)
+
+    nodes = await find_dependencies(_operator(TENANT_A_ID), "tf-vm-a")
+    names = {n.name for n in nodes}
+    assert "tf-vm-a" in names
+    assert "tf-host-x" not in names
+
+
+@_skip_no_docker
+async def test_superseded_edge_excluded_from_find_path_both_legs(
+    pg_engine: None,
+) -> None:
+    """``bi_edge`` filters both legs — a superseded edge is unwalkable in
+    either direction.
+
+    Seed ``A --runs-on--> B`` as auto + superseded. ``find_path(A, B)``
+    must return ``None`` — both the forward leg
+    (``A.from_node_id → A.to_node_id``) and the reversed leg
+    (``B.to_node_id ← A.from_node_id``) are filtered out by the guard.
+    Without the reversed-leg filter the path ``A ← B`` would still
+    appear, hiding the supersede contract.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        a = await _seed_node(session, tenant_id=TENANT_A_ID, kind="vm", name="tp-a")
+        b = await _seed_node(session, tenant_id=TENANT_A_ID, kind="host", name="tp-b")
+        edge = GraphEdge(
+            id=uuid.uuid4(),
+            tenant_id=TENANT_A_ID,
+            from_node_id=a,
+            to_node_id=b,
+            kind="runs-on",
+            source="auto",
+            properties={"superseded_by": str(uuid.uuid4())},
+            discovered_by="test",
+        )
+        session.add(edge)
+
+    forward = await find_path(_operator(TENANT_A_ID), "tp-a", "tp-b")
+    reverse = await find_path(_operator(TENANT_A_ID), "tp-b", "tp-a")
+    assert forward is None
+    assert reverse is None
+
+
+@_skip_no_docker
+async def test_guard_does_not_drop_non_superseded_edges(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """Regression: a graph with zero superseded edges returns the identical
+    closure.
+
+    The known 5-node / 6-edge graph from :func:`known_graph` carries
+    no ``superseded_by`` markers; the closure must match the
+    pre-guard expected set exactly. A malformed guard (e.g.
+    ``properties->>'superseded_by' = 'x'`` instead of ``IS NULL``)
+    would silently drop every edge here.
+    """
+    nodes = await find_dependents(_operator(TENANT_A_ID), "host1")
+    assert {n.name for n in nodes} == {"host1", "vm1", "vm2", "app"}
+
+    deps = await find_dependencies(_operator(TENANT_A_ID), "app")
+    assert {n.name for n in deps} == {"app", "vm1", "vm2", "host1", "ds1"}
+
+    path = await find_path(_operator(TENANT_A_ID), "app", "ds1")
+    assert path is not None
+    assert path.total_hops == 2
+
+
 def test_module_imports_cleanly() -> None:
     """Cheap collection-time smoke that runs on no-Docker sandboxes.
 

--- a/backend/tests/test_topology_annotate.py
+++ b/backend/tests/test_topology_annotate.py
@@ -1,0 +1,867 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the G9.2-T3 annotate / unannotate service.
+
+Coverage matrix (Task #595 acceptance criteria):
+
+* **Idempotent annotate** — annotating the same ``(from, kind, to)``
+  triple twice yields one row; the second call refreshes
+  ``last_seen`` + ``properties`` instead of erroring.
+* **Same-kind / different-endpoint conflict** — the auto edge is
+  stamped ``superseded_by``; the curated row carries the canonical
+  assertion; ``unannotate`` of the curated row clears the supersede
+  mark on the auto edge.
+* **Incompatible-kind conflict** — both edges survive; bidirectional
+  ``conflicts_with`` markers on each.
+* **Auto-edge deletion refusal** — ``unannotate_edge`` on an
+  ``source='auto'`` row raises :class:`AutoEdgeDeletionError`.
+* **Selector validation** — both / neither / partial triple raises
+  :class:`UnannotateSelectorError`.
+* **Kind validation** — non-enum ``kind`` raises
+  :class:`InvalidEdgeKindError` *before* any DB write.
+* **Tenant boundary** — a tenant-A annotate cannot reference a
+  tenant-B node (``NodeNotFoundError``).
+* **Audit + broadcast** — every annotate / unannotate writes exactly
+  one ``audit_log`` row with the canonical op_id +
+  ``op_class='write'`` and publishes exactly one broadcast event.
+  ``target_id`` is populated when the *from* node has one; null
+  otherwise.
+* **Refresh-merge preservation** — ``_reconcile_edges`` running
+  against a hint that re-observes a superseded edge preserves the
+  ``superseded_by`` marker while still applying the hint's other
+  property changes.
+
+The tests run against ``sqlite+aiosqlite`` via the autouse
+``_default_database_url`` fixture in :mod:`tests.conftest` (the same
+shape :mod:`tests.test_topology_refresh` uses). The traversal-exclusion
+guard added to :mod:`meho_backplane.topology.query` uses PG-only JSON
+syntax and is covered by :mod:`tests.integration.test_topology_query`
+in the integration suite.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.schemas import EdgeHint, NodeHint, TopologyHints
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode, Target, Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.topology import (
+    AutoEdgeDeletionError,
+    InvalidEdgeKindError,
+    NodeNotFoundError,
+    NodeRef,
+    UnannotateSelectorError,
+    annotate_edge,
+    unannotate_edge,
+)
+
+_PUBLISH = "meho_backplane.topology.annotate.publish_event"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(slug: str = "rdc-internal") -> uuid.UUID:
+    """Insert one ``tenant`` row and return its id."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        await session.commit()
+    return tenant_id
+
+
+async def _seed_node(
+    tenant_id: uuid.UUID,
+    *,
+    kind: str,
+    name: str,
+    target_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Insert one ``graph_node`` row and return its id."""
+    sessionmaker = get_sessionmaker()
+    node_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphNode(
+                id=node_id,
+                tenant_id=tenant_id,
+                kind=kind,
+                name=name,
+                target_id=target_id,
+                properties={},
+                discovered_by="test",
+                first_seen=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    return node_id
+
+
+async def _seed_target_node(
+    tenant_id: uuid.UUID,
+    *,
+    kind: str,
+    name: str,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """Insert a ``target`` row + a ``graph_node`` linked to it.
+
+    Returns ``(target_id, node_id)``. Annotation routinely references
+    target-backed nodes (the canonical case is a vSphere VM-target);
+    the audit row's ``target_id`` column is populated iff the *from*
+    node has a ``target_id`` foreign key.
+    """
+    sessionmaker = get_sessionmaker()
+    target_id = uuid.uuid4()
+    node_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            Target(
+                id=target_id,
+                tenant_id=tenant_id,
+                name=f"target-{name}",
+                aliases=[],
+                product="vsphere",
+                host="vc.example.test",
+            )
+        )
+        await session.commit()
+    async with sessionmaker() as session:
+        session.add(
+            GraphNode(
+                id=node_id,
+                tenant_id=tenant_id,
+                kind=kind,
+                name=name,
+                target_id=target_id,
+                properties={},
+                discovered_by="test",
+                first_seen=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    return target_id, node_id
+
+
+async def _seed_auto_edge(
+    tenant_id: uuid.UUID,
+    *,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    kind: str,
+    properties: dict[str, Any] | None = None,
+) -> uuid.UUID:
+    """Insert one ``graph_edge`` row with ``source='auto'``."""
+    sessionmaker = get_sessionmaker()
+    edge_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphEdge(
+                id=edge_id,
+                tenant_id=tenant_id,
+                from_node_id=from_id,
+                to_node_id=to_id,
+                kind=kind,
+                source="auto",
+                properties=properties or {},
+                discovered_by="test",
+                first_seen=datetime.now(UTC),
+                last_seen=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    return edge_id
+
+
+def _operator(tenant_id: uuid.UUID, sub: str = "op-1") -> Operator:
+    return Operator(
+        sub=sub,
+        name="Op One",
+        email=None,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: insert + idempotent re-annotate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_creates_curated_edge() -> None:
+    """First annotate inserts a fresh ``source='curated'`` row."""
+    tenant_id = await _seed_tenant()
+    sa = await _seed_node(tenant_id, kind="principal", name="foo")
+    vr = await _seed_node(tenant_id, kind="vault-role", name="bar")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            edge = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("foo", "principal"),
+                "authenticates-via",
+                NodeRef("bar", "vault-role"),
+                note="canonical k8s SA → Vault role",
+                evidence_url="https://example.test/inventory#L42",
+            )
+
+    assert edge.source == "curated"
+    assert edge.kind == "authenticates-via"
+    assert edge.from_node_id == sa
+    assert edge.to_node_id == vr
+    assert edge.properties["note"] == "canonical k8s SA → Vault role"
+    assert edge.properties["evidence_url"] == "https://example.test/inventory#L42"
+    assert edge.properties["annotated_by"] == "op-1"
+    assert "annotated_at" in edge.properties
+
+
+@pytest.mark.asyncio
+async def test_annotate_is_idempotent() -> None:
+    """A second annotate of the same triple updates last_seen, not duplicates."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="principal", name="foo")
+    await _seed_node(tenant_id, kind="vault-role", name="bar")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            first = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("foo", "principal"),
+                "authenticates-via",
+                NodeRef("bar", "vault-role"),
+                note="first",
+            )
+        async with sessionmaker() as session:
+            second = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("foo", "principal"),
+                "authenticates-via",
+                NodeRef("bar", "vault-role"),
+                note="second",
+            )
+
+    # Same row, not a duplicate.
+    assert first.id == second.id
+
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    # Properties refreshed to the second annotation's payload.
+    assert rows[0].properties["note"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# Kind validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_rejects_unknown_kind() -> None:
+    """A kind outside :class:`GraphEdgeKind` raises before any DB write."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="principal", name="foo")
+    await _seed_node(tenant_id, kind="vault-role", name="bar")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            with pytest.raises(InvalidEdgeKindError):
+                await annotate_edge(
+                    session,
+                    _operator(tenant_id),
+                    NodeRef("foo", "principal"),
+                    "made-up-kind",
+                    NodeRef("bar", "vault-role"),
+                )
+
+    # No edge was written.
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_cannot_reference_other_tenant_node() -> None:
+    """Cross-tenant annotation hits :class:`NodeNotFoundError`, not the other row."""
+    tenant_a = await _seed_tenant("tenant-a")
+    tenant_b = await _seed_tenant("tenant-b")
+    # Seed the *target* node only in tenant B.
+    await _seed_node(tenant_a, kind="principal", name="foo")
+    await _seed_node(tenant_b, kind="vault-role", name="bar")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            with pytest.raises(NodeNotFoundError):
+                await annotate_edge(
+                    session,
+                    _operator(tenant_a),
+                    NodeRef("foo", "principal"),
+                    "authenticates-via",
+                    NodeRef("bar", "vault-role"),
+                )
+
+
+# Note on bare-name ambiguity: :func:`annotate_edge` propagates
+# :class:`AmbiguousNodeError` directly from :func:`resolve_node` (#594).
+# The resolver's bare-name ambiguity-probe SQL binds ``tenant_id`` as
+# a stringified UUID through a fully-literal ``text("...")`` statement
+# (asyncpg's text codec convention); SQLAlchemy's ``Uuid()`` type
+# stores UUIDs as 32-char no-dash CHAR on SQLite, so the raw-SQL
+# string comparison misses on SQLite alone. The ambiguity contract is
+# exercised against real PG by :mod:`tests.integration.test_topology_resolvers`
+# — replicating it here would duplicate that coverage and would also
+# require a PG container, which the unit suite deliberately avoids.
+
+
+# ---------------------------------------------------------------------------
+# §6 conflict detection: same-kind / different-endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_same_kind_different_endpoint_marks_auto_superseded() -> None:
+    """Curated ``runs-on(vm→hostY)`` supersedes auto ``runs-on(vm→hostX)``."""
+    tenant_id = await _seed_tenant()
+    vm = await _seed_node(tenant_id, kind="vm", name="vm-a")
+    host_x = await _seed_node(tenant_id, kind="host", name="host-x")
+    # host_y must exist in the tenant so the curated annotate can
+    # resolve it; the id itself is not used after seeding.
+    await _seed_node(tenant_id, kind="host", name="host-y")
+    auto_edge_id = await _seed_auto_edge(tenant_id, from_id=vm, to_id=host_x, kind="runs-on")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            curated = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("vm-a", "vm"),
+                "runs-on",
+                NodeRef("host-y", "host"),
+            )
+
+    async with sessionmaker() as session:
+        auto = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == auto_edge_id))
+        ).scalar_one()
+    assert auto.properties["superseded_by"] == str(curated.id)
+    # The auto row itself survives.
+    assert auto.source == "auto"
+
+
+@pytest.mark.asyncio
+async def test_unannotate_clears_supersede_marker() -> None:
+    """Removing the curated row clears ``superseded_by`` on the auto edge."""
+    tenant_id = await _seed_tenant()
+    vm = await _seed_node(tenant_id, kind="vm", name="vm-a")
+    host_x = await _seed_node(tenant_id, kind="host", name="host-x")
+    await _seed_node(tenant_id, kind="host", name="host-y")
+    auto_edge_id = await _seed_auto_edge(tenant_id, from_id=vm, to_id=host_x, kind="runs-on")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            curated = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("vm-a", "vm"),
+                "runs-on",
+                NodeRef("host-y", "host"),
+            )
+        async with sessionmaker() as session:
+            await unannotate_edge(session, _operator(tenant_id), edge_id=curated.id)
+
+    async with sessionmaker() as session:
+        auto = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == auto_edge_id))
+        ).scalar_one()
+        # Curated edge is gone (hard delete).
+        gone = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == curated.id))
+        ).scalar_one_or_none()
+    assert "superseded_by" not in auto.properties
+    assert gone is None
+
+
+# ---------------------------------------------------------------------------
+# §6 conflict detection: incompatible kinds, same endpoint pair
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_incompatible_kinds_bidirectional_markers() -> None:
+    """Curated ``depends-on(svc→db)`` and auto ``routes-through(svc→db)`` coexist."""
+    tenant_id = await _seed_tenant()
+    svc = await _seed_node(tenant_id, kind="service", name="svc-x")
+    db = await _seed_node(tenant_id, kind="vm", name="db-y")
+    auto_edge_id = await _seed_auto_edge(tenant_id, from_id=svc, to_id=db, kind="routes-through")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            curated = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("svc-x", "service"),
+                "depends-on",
+                NodeRef("db-y", "vm"),
+            )
+
+    async with sessionmaker() as session:
+        auto = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == auto_edge_id))
+        ).scalar_one()
+        cur = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == curated.id))
+        ).scalar_one()
+
+    # Bidirectional: auto sees curated; curated sees auto.
+    assert str(curated.id) in auto.properties["conflicts_with"]
+    assert str(auto.id) in cur.properties["conflicts_with"]
+    # Neither is superseded.
+    assert "superseded_by" not in auto.properties
+    assert "superseded_by" not in cur.properties
+
+
+@pytest.mark.asyncio
+async def test_unannotate_clears_reciprocal_conflict_marker() -> None:
+    """Removing the curated row also clears the auto edge's back-reference."""
+    tenant_id = await _seed_tenant()
+    svc = await _seed_node(tenant_id, kind="service", name="svc-x")
+    db = await _seed_node(tenant_id, kind="vm", name="db-y")
+    auto_edge_id = await _seed_auto_edge(tenant_id, from_id=svc, to_id=db, kind="routes-through")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            curated = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("svc-x", "service"),
+                "depends-on",
+                NodeRef("db-y", "vm"),
+            )
+        async with sessionmaker() as session:
+            await unannotate_edge(session, _operator(tenant_id), edge_id=curated.id)
+
+    async with sessionmaker() as session:
+        auto = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == auto_edge_id))
+        ).scalar_one()
+    assert "conflicts_with" not in auto.properties
+
+
+# ---------------------------------------------------------------------------
+# Unannotate: triple selector + auto-edge refusal + selector validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unannotate_triple_selector() -> None:
+    """The full (from, kind, to) triple resolves to the row and deletes it."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="principal", name="foo")
+    await _seed_node(tenant_id, kind="vault-role", name="bar")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            curated = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("foo", "principal"),
+                "authenticates-via",
+                NodeRef("bar", "vault-role"),
+            )
+        async with sessionmaker() as session:
+            removed_id = await unannotate_edge(
+                session,
+                _operator(tenant_id),
+                from_ref=NodeRef("foo", "principal"),
+                kind="authenticates-via",
+                to_ref=NodeRef("bar", "vault-role"),
+            )
+
+    assert removed_id == curated.id
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_unannotate_refuses_auto_edge() -> None:
+    """Targeting a ``source='auto'`` row raises :class:`AutoEdgeDeletionError`."""
+    tenant_id = await _seed_tenant()
+    vm = await _seed_node(tenant_id, kind="vm", name="vm-a")
+    host = await _seed_node(tenant_id, kind="host", name="host-x")
+    auto_edge_id = await _seed_auto_edge(tenant_id, from_id=vm, to_id=host, kind="runs-on")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            with pytest.raises(AutoEdgeDeletionError):
+                await unannotate_edge(session, _operator(tenant_id), edge_id=auto_edge_id)
+
+    # Auto row survived the refused delete.
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == auto_edge_id))
+        ).scalar_one()
+    assert row.source == "auto"
+
+
+@pytest.mark.asyncio
+async def test_unannotate_rejects_both_or_neither_selector() -> None:
+    """Both / neither selector form raises :class:`UnannotateSelectorError`."""
+    tenant_id = await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        # Neither.
+        with pytest.raises(UnannotateSelectorError):
+            await unannotate_edge(session, _operator(tenant_id))
+        # Both.
+        with pytest.raises(UnannotateSelectorError):
+            await unannotate_edge(
+                session,
+                _operator(tenant_id),
+                edge_id=uuid.uuid4(),
+                from_ref=NodeRef("x"),
+                kind="depends-on",
+                to_ref=NodeRef("y"),
+            )
+        # Partial triple (kind missing).
+        with pytest.raises(UnannotateSelectorError):
+            await unannotate_edge(
+                session,
+                _operator(tenant_id),
+                from_ref=NodeRef("x"),
+                to_ref=NodeRef("y"),
+            )
+
+
+@pytest.mark.asyncio
+async def test_unannotate_other_tenant_edge_not_found() -> None:
+    """Tenant boundary: an edge in tenant B is not findable from tenant A."""
+    tenant_a = await _seed_tenant("tenant-a")
+    tenant_b = await _seed_tenant("tenant-b")
+    vm = await _seed_node(tenant_b, kind="vm", name="vm-a")
+    host = await _seed_node(tenant_b, kind="host", name="host-x")
+    other_edge = await _seed_auto_edge(tenant_b, from_id=vm, to_id=host, kind="runs-on")
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        with pytest.raises(ValueError):
+            await unannotate_edge(session, _operator(tenant_a), edge_id=other_edge)
+
+
+# ---------------------------------------------------------------------------
+# Audit + broadcast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_writes_audit_row_and_broadcast() -> None:
+    """One ``audit_log`` row + one broadcast event per annotate."""
+    tenant_id = await _seed_tenant()
+    target_id, _from_node = await _seed_target_node(tenant_id, kind="vm", name="vm-a")
+    await _seed_node(tenant_id, kind="host", name="host-x")
+
+    publish_mock = AsyncMock()
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=publish_mock):
+        async with sessionmaker() as session:
+            await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("vm-a", "vm"),
+                "runs-on",
+                NodeRef("host-x", "host"),
+            )
+
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.path == "topology.annotate"
+    assert row.payload["op_id"] == "topology.annotate"
+    # Critical: op_class is *write*, not the refresh service's *read*.
+    assert row.payload["op_class"] == "write"
+    # ``target_id`` populated because the *from* node has one.
+    assert row.target_id == target_id
+
+    publish_mock.assert_awaited_once()
+    event = publish_mock.await_args.args[0]
+    assert event.op_id == "topology.annotate"
+    assert event.op_class == "write"
+    assert event.payload["from"]["name"] == "vm-a"
+    assert event.payload["to"]["name"] == "host-x"
+    assert event.payload["kind"] == "runs-on"
+
+
+@pytest.mark.asyncio
+async def test_unannotate_writes_audit_row_and_broadcast() -> None:
+    """One ``audit_log`` row + one broadcast event per unannotate."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="principal", name="foo")
+    await _seed_node(tenant_id, kind="vault-role", name="bar")
+
+    publish_mock = AsyncMock()
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=publish_mock):
+        async with sessionmaker() as session:
+            curated = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("foo", "principal"),
+                "authenticates-via",
+                NodeRef("bar", "vault-role"),
+            )
+        async with sessionmaker() as session:
+            await unannotate_edge(session, _operator(tenant_id), edge_id=curated.id)
+
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(AuditLog)
+                    .where(AuditLog.tenant_id == tenant_id)
+                    .order_by(AuditLog.occurred_at)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 2
+    assert rows[0].path == "topology.annotate"
+    assert rows[1].path == "topology.unannotate"
+    assert rows[1].payload["op_class"] == "write"
+    # Non-target from-node → null ``target_id`` per §10 spec.
+    assert rows[1].target_id is None
+
+    # Exactly two broadcast events (one per verb call).
+    assert publish_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_annotate_broadcast_failure_does_not_fail_call() -> None:
+    """Broadcast publish is fail-open per the refresh-service pattern."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="principal", name="foo")
+    await _seed_node(tenant_id, kind="vault-role", name="bar")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock(side_effect=RuntimeError("redis down"))):
+        async with sessionmaker() as session:
+            edge = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("foo", "principal"),
+                "authenticates-via",
+                NodeRef("bar", "vault-role"),
+            )
+
+    # Edge + audit row committed despite the publish failure.
+    assert edge.id is not None
+    async with sessionmaker() as session:
+        audit_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+        edge_rows = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(audit_rows) == 1
+    assert len(edge_rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Refresh-merge preservation: §6 markers survive a reconcile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_edges_preserves_superseded_marker() -> None:
+    """``_reconcile_edges`` re-applies a hint without losing §6 markers.
+
+    Setup: an auto edge carries ``superseded_by`` (set by an earlier
+    annotate). A fresh refresh re-observes the same edge with
+    otherwise-changed properties. The merge must keep the marker
+    *and* apply the hint's other property changes.
+    """
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import (
+        clear_registry,
+        register_connector_v2,
+    )
+    from meho_backplane.operations._handler_resolve import (
+        reset_connector_instance_cache,
+    )
+    from meho_backplane.topology.refresh import refresh_target_topology
+
+    clear_registry()
+    reset_connector_instance_cache()
+
+    tenant_id = await _seed_tenant("refresh-merge-tenant")
+    target_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            id=target_id,
+            tenant_id=tenant_id,
+            name="refresh-target",
+            aliases=[],
+            product="faketopo-merge",
+            host="vc.example.test",
+        )
+        session.add(target)
+        await session.commit()
+
+    # First refresh: seed vm-a + host-x + the runs-on edge with port=80.
+    hints_v1 = TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=(
+            NodeHint(kind="vm", name="vm-a", properties={}),
+            NodeHint(kind="host", name="host-x", properties={}),
+        ),
+        edges=(
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-a",
+                to_kind="host",
+                to_name="host-x",
+                kind="runs-on",
+                properties={"port": 80},
+            ),
+        ),
+    )
+
+    class _FakeMergeConnector(Connector):
+        product = "faketopo-merge"
+        hints: TopologyHints = hints_v1
+
+        async def fingerprint(self, target: Any) -> Any:
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> Any:
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> Any:
+            raise NotImplementedError
+
+        async def discover_topology(self, target: Any) -> TopologyHints:
+            return type(self).hints
+
+    register_connector_v2(
+        product="faketopo-merge",
+        version="",
+        impl_id="",
+        cls=_FakeMergeConnector,
+    )
+
+    async with sessionmaker() as session:
+        target_row = (
+            await session.execute(select(Target).where(Target.id == target_id))
+        ).scalar_one()
+
+    with patch("meho_backplane.topology.refresh.publish_event", new=AsyncMock()):
+        await refresh_target_topology(target_row, _operator(tenant_id))
+
+    # Operator stamps superseded_by on the auto edge (the canonical
+    # case is via an annotate of a different host; here we stamp it
+    # directly so the test stays focused on the merge invariant).
+    async with sessionmaker() as session:
+        edge = (
+            await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id))
+        ).scalar_one()
+        marked_props = dict(edge.properties)
+        marked_props["superseded_by"] = str(uuid.uuid4())
+        edge.properties = marked_props
+        await session.commit()
+        marker_value = marked_props["superseded_by"]
+
+    # Second refresh: same edge, different ``port`` property.
+    _FakeMergeConnector.hints = TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=hints_v1.nodes,
+        edges=(
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-a",
+                to_kind="host",
+                to_name="host-x",
+                kind="runs-on",
+                properties={"port": 443},
+            ),
+        ),
+    )
+    with patch("meho_backplane.topology.refresh.publish_event", new=AsyncMock()):
+        await refresh_target_topology(target_row, _operator(tenant_id))
+
+    async with sessionmaker() as session:
+        refreshed = (
+            await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id))
+        ).scalar_one()
+
+    # Marker preserved through the refresh.
+    assert refreshed.properties["superseded_by"] == marker_value
+    # Hint's other property change still applied.
+    assert refreshed.properties["port"] == 443
+
+    clear_registry()
+    reset_connector_instance_cache()

--- a/backend/tests/test_topology_annotate.py
+++ b/backend/tests/test_topology_annotate.py
@@ -285,6 +285,202 @@ async def test_annotate_is_idempotent() -> None:
     assert rows[0].properties["note"] == "second"
 
 
+@pytest.mark.asyncio
+async def test_annotate_over_existing_auto_promotes_to_curated() -> None:
+    """Annotating the same triple as an existing auto edge takes ownership.
+
+    The auto-discovery probe found ``runs-on(vm-a → host-x)`` already.
+    The operator then calls :func:`annotate_edge` with the same triple
+    (typical recovery flow: "yes, I want to OWN this edge so I can
+    attach a note and eventually revoke it"). Pre-fix this was a
+    no-op that left ``source='auto'`` — making :func:`unannotate_edge`
+    raise :class:`AutoEdgeDeletionError`, leaving the operator unable
+    to revoke their own annotation. The fix promotes the row to
+    ``source='curated'`` and lets ``note`` / ``evidence_url`` persist.
+    """
+    tenant_id = await _seed_tenant()
+    vm = await _seed_node(tenant_id, kind="vm", name="vm-a")
+    host = await _seed_node(tenant_id, kind="host", name="host-x")
+    auto_edge_id = await _seed_auto_edge(
+        tenant_id,
+        from_id=vm,
+        to_id=host,
+        kind="runs-on",
+        properties={"discovered_port": 22},
+    )
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            edge = await annotate_edge(
+                session,
+                _operator(tenant_id, sub="op-promote"),
+                NodeRef("vm-a", "vm"),
+                "runs-on",
+                NodeRef("host-x", "host"),
+                note="adopted from auto-discovery",
+                evidence_url="https://example.test/inventory#L99",
+            )
+
+    # Same row id — the auto edge was promoted in place, not replaced.
+    assert edge.id == auto_edge_id
+
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == auto_edge_id))
+        ).scalar_one()
+    assert row.source == "curated"
+    assert row.discovered_by == "op-promote"
+    # Caller-supplied free-text fields persist.
+    assert row.properties["note"] == "adopted from auto-discovery"
+    assert row.properties["evidence_url"] == "https://example.test/inventory#L99"
+    assert row.properties["annotated_by"] == "op-promote"
+    # Pre-existing auto property is not wiped — merge, not replace.
+    assert row.properties.get("discovered_port") == 22
+
+    # Audit row written as for a fresh annotate.
+    async with sessionmaker() as session:
+        audit_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(audit_rows) == 1
+    assert audit_rows[0].path == "topology.annotate"
+    assert audit_rows[0].payload["op_class"] == "write"
+
+
+@pytest.mark.asyncio
+async def test_promoted_edge_survives_subsequent_refresh() -> None:
+    """A refresh after annotate-over-auto must not demote the row.
+
+    Regression guard for the M1 fix: once the operator has claimed
+    ownership via :func:`annotate_edge`, the next probe that re-sees
+    the same triple must merge onto the curated row, not overwrite
+    ``source`` back to ``'auto'`` or wipe the caller-supplied
+    ``note`` / ``evidence_url`` props.
+    """
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import (
+        clear_registry,
+        register_connector_v2,
+    )
+    from meho_backplane.operations._handler_resolve import (
+        reset_connector_instance_cache,
+    )
+    from meho_backplane.topology.refresh import refresh_target_topology
+
+    clear_registry()
+    reset_connector_instance_cache()
+    try:
+        tenant_id = await _seed_tenant("promote-refresh-tenant")
+        target_id = uuid.uuid4()
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(
+                Target(
+                    id=target_id,
+                    tenant_id=tenant_id,
+                    name="promote-target",
+                    aliases=[],
+                    product="faketopo-promote",
+                    host="vc.example.test",
+                )
+            )
+            await session.commit()
+
+        promote_hints = TopologyHints(
+            discovered_at=datetime.now(UTC),
+            nodes=(
+                NodeHint(kind="vm", name="vm-a", properties={}),
+                NodeHint(kind="host", name="host-x", properties={}),
+            ),
+            edges=(
+                EdgeHint(
+                    from_kind="vm",
+                    from_name="vm-a",
+                    to_kind="host",
+                    to_name="host-x",
+                    kind="runs-on",
+                    properties={"discovered_port": 22},
+                ),
+            ),
+        )
+
+        class _FakePromoteConnector(Connector):
+            product = "faketopo-promote"
+            hints: TopologyHints = promote_hints
+
+            async def fingerprint(self, target: Any) -> Any:
+                raise NotImplementedError
+
+            async def probe(self, target: Any) -> Any:
+                raise NotImplementedError
+
+            async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> Any:
+                raise NotImplementedError
+
+            async def discover_topology(self, target: Any) -> TopologyHints:
+                return type(self).hints
+
+        register_connector_v2(
+            product="faketopo-promote",
+            version="",
+            impl_id="",
+            cls=_FakePromoteConnector,
+        )
+
+        async with sessionmaker() as session:
+            target_row = (
+                await session.execute(select(Target).where(Target.id == target_id))
+            ).scalar_one()
+
+        # First refresh — seeds the auto edge.
+        with patch("meho_backplane.topology.refresh.publish_event", new=AsyncMock()):
+            await refresh_target_topology(target_row, _operator(tenant_id))
+
+        # Operator promotes the auto edge to curated via annotate.
+        with patch(_PUBLISH, new=AsyncMock()):
+            async with sessionmaker() as session:
+                curated = await annotate_edge(
+                    session,
+                    _operator(tenant_id, sub="op-promote"),
+                    NodeRef("vm-a", "vm"),
+                    "runs-on",
+                    NodeRef("host-x", "host"),
+                    note="owned by op-promote",
+                )
+
+        # Second refresh — re-sees the same triple. The curated row
+        # must survive, not be demoted back to auto.
+        with patch("meho_backplane.topology.refresh.publish_event", new=AsyncMock()):
+            await refresh_target_topology(target_row, _operator(tenant_id))
+
+        async with sessionmaker() as session:
+            row = (
+                await session.execute(select(GraphEdge).where(GraphEdge.id == curated.id))
+            ).scalar_one()
+        assert row.source == "curated"
+        assert row.properties["note"] == "owned by op-promote"
+
+        # Triple-form unannotate now succeeds (was raising
+        # AutoEdgeDeletionError before the fix because the post-refresh
+        # row was still source='auto').
+        with patch(_PUBLISH, new=AsyncMock()):
+            async with sessionmaker() as session:
+                removed_id = await unannotate_edge(
+                    session,
+                    _operator(tenant_id, sub="op-promote"),
+                    from_ref=NodeRef("vm-a", "vm"),
+                    kind="runs-on",
+                    to_ref=NodeRef("host-x", "host"),
+                )
+        assert removed_id == curated.id
+    finally:
+        clear_registry()
+        reset_connector_instance_cache()
+
+
 # ---------------------------------------------------------------------------
 # Kind validation
 # ---------------------------------------------------------------------------
@@ -865,3 +1061,150 @@ async def test_reconcile_edges_preserves_superseded_marker() -> None:
 
     clear_registry()
     reset_connector_instance_cache()
+
+
+@pytest.mark.asyncio
+async def test_refresh_strips_reserved_markers_from_connector_hints() -> None:
+    """Reserved §6 markers in an :class:`EdgeHint` are stripped at refresh.
+
+    A buggy or hostile connector that emits ``superseded_by`` /
+    ``conflicts_with`` directly in its hint properties must not be
+    able to smuggle the §6 marker onto an auto edge. The refresh
+    service sanitizes both the *insert* path (fresh auto edge) and
+    the *update* path (re-observed auto edge) through
+    :func:`_strip_reserved_markers`. The operator-only annotate verb
+    is the single legitimate writer of those keys.
+    """
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import (
+        clear_registry,
+        register_connector_v2,
+    )
+    from meho_backplane.operations._handler_resolve import (
+        reset_connector_instance_cache,
+    )
+    from meho_backplane.topology.refresh import refresh_target_topology
+
+    clear_registry()
+    reset_connector_instance_cache()
+    try:
+        tenant_id = await _seed_tenant("strip-marker-tenant")
+        target_id = uuid.uuid4()
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(
+                Target(
+                    id=target_id,
+                    tenant_id=tenant_id,
+                    name="strip-marker-target",
+                    aliases=[],
+                    product="faketopo-strip",
+                    host="vc.example.test",
+                )
+            )
+            await session.commit()
+
+        hostile_marker_id = str(uuid.uuid4())
+        hostile_conflict_id = str(uuid.uuid4())
+        hostile_hints = TopologyHints(
+            discovered_at=datetime.now(UTC),
+            nodes=(
+                NodeHint(kind="vm", name="vm-a", properties={}),
+                NodeHint(kind="host", name="host-x", properties={}),
+            ),
+            edges=(
+                EdgeHint(
+                    from_kind="vm",
+                    from_name="vm-a",
+                    to_kind="host",
+                    to_name="host-x",
+                    kind="runs-on",
+                    properties={
+                        "port": 22,
+                        "superseded_by": hostile_marker_id,
+                        "conflicts_with": [hostile_conflict_id],
+                    },
+                ),
+            ),
+        )
+
+        class _HostileStripConnector(Connector):
+            product = "faketopo-strip"
+            hints: TopologyHints = hostile_hints
+
+            async def fingerprint(self, target: Any) -> Any:
+                raise NotImplementedError
+
+            async def probe(self, target: Any) -> Any:
+                raise NotImplementedError
+
+            async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> Any:
+                raise NotImplementedError
+
+            async def discover_topology(self, target: Any) -> TopologyHints:
+                return type(self).hints
+
+        register_connector_v2(
+            product="faketopo-strip",
+            version="",
+            impl_id="",
+            cls=_HostileStripConnector,
+        )
+
+        async with sessionmaker() as session:
+            target_row = (
+                await session.execute(select(Target).where(Target.id == target_id))
+            ).scalar_one()
+
+        # First refresh — exercises the *insert* path.
+        with patch("meho_backplane.topology.refresh.publish_event", new=AsyncMock()):
+            await refresh_target_topology(target_row, _operator(tenant_id))
+
+        async with sessionmaker() as session:
+            edge = (
+                await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id))
+            ).scalar_one()
+        assert edge.source == "auto"
+        # Hostile markers stripped on insert.
+        assert "superseded_by" not in edge.properties
+        assert "conflicts_with" not in edge.properties
+        # Legitimate property survives.
+        assert edge.properties["port"] == 22
+
+        # Second refresh with a different non-reserved property —
+        # exercises the *update* path through
+        # :func:`_merge_edge_properties`. The hostile markers
+        # in the hint must still be dropped, and a stamped
+        # ``superseded_by`` from an annotate must survive (covered
+        # by ``test_reconcile_edges_preserves_superseded_marker``).
+        _HostileStripConnector.hints = TopologyHints(
+            discovered_at=datetime.now(UTC),
+            nodes=hostile_hints.nodes,
+            edges=(
+                EdgeHint(
+                    from_kind="vm",
+                    from_name="vm-a",
+                    to_kind="host",
+                    to_name="host-x",
+                    kind="runs-on",
+                    properties={
+                        "port": 443,
+                        "superseded_by": hostile_marker_id,
+                        "conflicts_with": [hostile_conflict_id],
+                    },
+                ),
+            ),
+        )
+        with patch("meho_backplane.topology.refresh.publish_event", new=AsyncMock()):
+            await refresh_target_topology(target_row, _operator(tenant_id))
+
+        async with sessionmaker() as session:
+            refreshed = (
+                await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id))
+            ).scalar_one()
+        assert "superseded_by" not in refreshed.properties
+        assert "conflicts_with" not in refreshed.properties
+        assert refreshed.properties["port"] == 443
+    finally:
+        clear_registry()
+        reset_connector_instance_cache()

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -25,6 +25,30 @@ models that G9.1-T1 (#448, migration `0007`) created.
 - `find_path(operator, from_name, to_name, *, from_kind=None, to_kind=None, max_hops=8)`
   — shortest unweighted path, or `None` if unreachable.
 
+**Annotation — entry points (async, write half, G9.2-T3 #595):**
+
+- `annotate_edge(session, operator, from_ref, kind, to_ref, *, note=None, evidence_url=None) -> GraphEdge`
+  — create or refresh a curated edge. Resolves both endpoints via
+  `resolve_node`, validates `kind` against `GraphEdgeKind`,
+  idempotent on `(tenant_id, from_node_id, to_node_id, kind)`. Runs
+  §6 conflict detection (sticky `superseded_by` for
+  same-kind/different-endpoint auto edges; bidirectional
+  `conflicts_with` for incompatible kinds over the same endpoint
+  pair). Writes one audit row (`op_id="topology.annotate"`,
+  `op_class="write"`) and publishes one broadcast event.
+- `unannotate_edge(session, operator, *, edge_id=None, from_ref=None, kind=None, to_ref=None) -> UUID`
+  — hard-delete a curated edge (selector is either `edge_id` or the
+  full triple; both/neither → `UnannotateSelectorError`). Refuses
+  `source='auto'` rows with `AutoEdgeDeletionError` (auto edges
+  resurrect on next refresh). Clears reciprocal `superseded_by` /
+  `conflicts_with` markers the deleted edge left on auto rows.
+  Writes one audit row + one broadcast event.
+
+Both service functions own a `session.begin()` block internally and
+publish broadcast events after commit (fail-open per the refresh
+pattern). The REST routes (T5), CLI verbs (T6), and MCP tools (T7)
+funnel through these primitives.
+
 **Resolver — entry point (async, read-only, G9.2-T2 #594):**
 
 - `resolve_node(session, tenant_id, name, kind=None) -> GraphNode` —
@@ -309,6 +333,85 @@ branch and stop recursing into an already-visited node, flagging the
 repeat row `is_cycle = true` (filtered out). An `A → B → A` graph
 terminates instead of recursing forever. The `depth` / `max_hops`
 bound is an independent second guard against acyclic-but-deep graphs.
+
+### Superseded-edge exclusion (G9.2-T3 #595)
+
+Every traversal CTE filters
+`graph_edge.properties->>'superseded_by' IS NULL` in its recursive
+term — an auto edge an operator's curated annotation has marked
+superseded drops out of every closure. The guard fires on **four**
+edge-pulling sites: the recursive term of both
+`_TRAVERSAL_SQL_REVERSE` and `_TRAVERSAL_SQL_FORWARD`, and **both
+legs** of the `bi_edge` CTE in `_PATH_SQL` (the forward leg
+`from→to` and the reversed leg `to→from`; missing the reversed leg
+would let a superseded edge be walked backwards into a shortest path).
+
+The supersede mark is sticky across refresh: `_reconcile_edges` merges
+incoming hint `properties` against the reserved keys (`superseded_by`,
+`conflicts_with`) so a re-observed auto edge keeps the marker that
+`annotate_edge` stamped. Only `unannotate_edge` of the curated row
+clears the marker. The `->>` operator is PG-only (manual §9.16); the
+recursive CTE is itself PG-only, so the guard runs only where the
+column is JSONB.
+
+## Annotation control flow (write half — G9.2-T3 #595)
+
+### `annotate_edge`
+
+1. Validate `kind` against `GraphEdgeKind` (raise
+   `InvalidEdgeKindError` *before* any DB read).
+2. `async with session.begin()` — one transaction wraps the whole
+   resolve + write + conflict-scan + audit-row.
+3. `resolve_node` for both endpoints (`operator.tenant_id` is the
+   scope; cross-tenant references resolve to `NodeNotFoundError`).
+4. Look up the existing edge for the
+   `(tenant_id, from_node_id, to_node_id, kind)` unique tuple. Found
+   → merge `properties` and refresh `last_seen` (idempotent). Absent
+   → `INSERT` a fresh row with `source='curated'`,
+   `discovered_by=operator.sub`,
+   `properties={note, evidence_url, annotated_by, annotated_at}`.
+5. **§6 conflict detection.** Same-kind / different-endpoint: scan
+   auto edges sharing `from_node_id` + `kind` + `source='auto'` and
+   a *different* `to_node_id`; stamp their `properties.superseded_by
+   = <curated-id>`. Incompatible-kind: scan edges on the same
+   `(from_node_id, to_node_id)` of any *other* kind; append the
+   curated id to each row's `properties.conflicts_with` (deduped)
+   and reciprocally append each conflicting edge's id to the
+   curated row.
+6. Add one `audit_log` row in the same session
+   (`method="ANNOTATE"`, `path="topology.annotate"`,
+   `payload={op_id, op_class:"write", edge_id, from, to, kind, note,
+   evidence_url, superseded[], conflicts[]}`, `target_id` =
+   from-node's `target_id` when non-null).
+7. Commit. Then publish one `BroadcastEvent` (`op_class="write"` —
+   set explicitly because the `.annotate` suffix is not in
+   `_WRITE_SUFFIXES`; §10 of #364 locks the *write* classification
+   so annotations broadcast in full per the G6.1 default classifier).
+   Publish is fail-open: a publish exception is logged, never raised.
+
+### `unannotate_edge`
+
+1. Validate the selector — exactly one of `edge_id` or the full
+   `(from_ref, kind, to_ref)` triple. Both / neither / partial triple
+   → `UnannotateSelectorError`.
+2. `async with session.begin()`.
+3. Resolve the target row. `edge_id` path: `session.get` + tenant
+   check (a row in another tenant looks "not found" — the tenant
+   boundary holds). Triple path: `resolve_node` for each endpoint
+   + the unique-tuple lookup.
+4. Refuse if `edge.source != "curated"` — auto edges resurrect on
+   next refresh, so manual deletion is meaningless;
+   `AutoEdgeDeletionError`. The API layer maps this to HTTP 409.
+5. Scan every edge in the tenant whose `properties.superseded_by` or
+   `properties.conflicts_with` references the removed edge id;
+   clear the back-references so a superseded auto edge reappears in
+   traversal and dangling ids do not linger.
+6. `session.delete(edge)` (hard delete — curated history lives on
+   via G9.3).
+7. Add one `audit_log` row in the same session
+   (`method="UNANNOTATE"`, `path="topology.unannotate"`,
+   `op_class="write"`). Commit. Publish one broadcast event
+   (fail-open).
 
 ## REST API surface (T5, #453)
 

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -349,10 +349,19 @@ would let a superseded edge be walked backwards into a shortest path).
 The supersede mark is sticky across refresh: `_reconcile_edges` merges
 incoming hint `properties` against the reserved keys (`superseded_by`,
 `conflicts_with`) so a re-observed auto edge keeps the marker that
-`annotate_edge` stamped. Only `unannotate_edge` of the curated row
-clears the marker. The `->>` operator is PG-only (manual §9.16); the
-recursive CTE is itself PG-only, so the guard runs only where the
-column is JSONB.
+`annotate_edge` stamped. The merge is **one-sided**: those reserved
+keys are also *stripped from the incoming hint* via
+`_strip_reserved_markers` so a buggy or hostile connector emitting
+`superseded_by` in its `EdgeHint.properties` cannot smuggle the marker
+onto an auto edge from the probe path. The same sanitizer runs on the
+insert path (fresh auto edge), so the §6 annotate-only invariant holds
+fail-closed regardless of how unrusted the upstream hint is. And for
+edges with `source='curated'`, `_reconcile_edges` skips the property
+merge entirely — only `last_seen` bumps; the operator-supplied `note`
+/ `evidence_url` / `annotated_*` fields are never touched by a refresh.
+Only `unannotate_edge` of the curated row clears the marker. The `->>`
+operator is PG-only (manual §9.16); the recursive CTE is itself PG-only,
+so the guard runs only where the column is JSONB.
 
 ## Annotation control flow (write half — G9.2-T3 #595)
 
@@ -366,7 +375,11 @@ column is JSONB.
    scope; cross-tenant references resolve to `NodeNotFoundError`).
 4. Look up the existing edge for the
    `(tenant_id, from_node_id, to_node_id, kind)` unique tuple. Found
-   → merge `properties` and refresh `last_seen` (idempotent). Absent
+   → merge `properties` and refresh `last_seen` (idempotent). If the
+   existing row's `source` is `'auto'` (operator is claiming an
+   auto-discovered edge), promote it: set `source='curated'` and
+   `discovered_by=operator.sub` so triple-form `unannotate_edge` and
+   the next §6 scan treat the row as operator-owned. Absent
    → `INSERT` a fresh row with `source='curated'`,
    `discovered_by=operator.sub`,
    `properties={note, evidence_url, annotated_by, annotated_at}`.


### PR DESCRIPTION
## Summary

Public annotate/unannotate API for curated cross-system edges (Initiative #364, G9.2-T3). Resolves both endpoints via the tenant-scoped `resolve_node` (#594), validates `kind` against `GraphEdgeKind` (#593), and runs Initiative §6 conflict detection against auto-discovered edges:

- **Same-kind, different endpoint** auto edges get a sticky `properties.superseded_by = <curated-id>` mark and drop out of every traversal CTE until the curated row is unannotated.
- **Incompatible kinds, same endpoint pair** edges coexist with bidirectional `properties.conflicts_with` references.

## Highlights

- `annotate.py` — `annotate_edge` / `unannotate_edge` service functions, `NodeRef` value type, typed errors (`InvalidEdgeKindError`, `AutoEdgeDeletionError`, `UnannotateSelectorError`, `AnnotateConflictError`). Session-first; opens its own `session.begin()`; idempotent upsert on the `(tenant, from, to, kind)` unique index.
- `query.py` — recursive forward + reverse traversal CTEs and **both legs** of `bi_edge` in `_PATH_SQL` filter `properties->>'superseded_by' IS NULL` so superseded auto edges are invisible to dependents/dependencies/path verbs.
- `refresh.py` — `_reconcile_edges` now **merges** (not overwrites) incoming hint properties with the reserved markers `superseded_by` / `conflicts_with`, so the sticky-supersede invariant survives the next probe. New `_merge_edge_properties` helper + `_RESERVED_MARKER_KEYS` constant.
- Audit + broadcast: one `audit_log` row + one broadcast event per op, `op_class='write'`, `op_id='topology.annotate' / 'topology.unannotate'`. Broadcast publish is fail-open after commit, mirroring the refresh pattern.
- 16 unit tests covering happy path, idempotent re-annotate, §6 cases (same-kind supersede, incompatible-kind coexist, bidirectional markers), unannotate via id + triple selector, auto-edge deletion refusal, reciprocal marker clearing on unannotate, tenant isolation.
- Docs update in `docs/codebase/topology.md`; integration test scaffolding for the traversal-exclusion behavior in `tests/integration/test_topology_query.py`.

## Test plan

- [x] `uv run ruff check` clean on `topology/` + new tests
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy --strict src/meho_backplane/topology` clean (7 source files)
- [x] `uv run pytest tests/test_topology_annotate.py` — 16/16 passed
- [x] `uv run pytest tests/test_topology_query_schemas.py tests/test_topology_refresh.py tests/test_topology_schema.py` — 47/47 passed (regression check on touched modules)
- [ ] Integration tests against PG (CI)

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Curated edge annotate/unannotate operations with validation, idempotent upserts, conflict marking, and audit+broadcast.

* **Improvements**
  * Traversals now exclude superseded auto-edges.
  * Refresh/reconcile preserves and protects reserved annotation markers; refresh sanitizes incoming hints.

* **Tests**
  * New unit and integration tests covering annotate/unannotate, conflict/supersede behaviors, refresh merges, traversal guards, and audit/broadcast invariants.

* **Documentation**
  * Added docs describing annotate/unannotate flows and superseded-edge traversal rule.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-18)

Rebased on top of `origin/main` (PR #650 G9.2-T4 list_edges landed in
the meantime — resolved overlap in `topology/__init__.py`,
`topology/query.py`, `docs/codebase/topology.md` by combining both
PRs' additive content).

Addressed review findings from
.claude/auto/review-results/pr-651-iter-1.json:

- **B1** `b35288b` — `_strip_reserved_markers` sanitizes both the
  refresh insert path and the merge path; connector hints can no
  longer smuggle `superseded_by` / `conflicts_with` onto auto edges.
  Unit coverage: `test_refresh_strips_reserved_markers_from_connector_hints`.
- **M1** `b35288b` — `annotate_edge` over an existing `source='auto'`
  row promotes it to `'curated'` (sets `source` + `discovered_by`);
  `_reconcile_edges` skips the property merge on curated rows so the
  operator's note/evidence survive subsequent refreshes. Unit
  coverage: `test_annotate_over_existing_auto_promotes_to_curated`
  + `test_promoted_edge_survives_subsequent_refresh`.

Deferred (recorded as adjacent findings; orchestrator may file
follow-up issues):

- **m1** — `AnnotateConflictError` is declared and exported but
  never raised; kept on the public surface per the existing class
  docstring's "reserved for future use" rationale.
- **m2** — `test_annotate_is_idempotent` does not assert
  `last_seen` advances. Quick-win nit; not in this iteration's scope.
- **m3** — refresh-merge test cleanup not in try/finally. The new
  M1/B1 tests use try/finally; the pre-existing test is unchanged.
- **q1** — `_find_edges_referencing` PG-specific JSON-operator
  optimization (CodeRabbit question, not blocking).

<!-- auto-implement-issue: continue, iteration 2 -->
