### PR TITLE
feat(topology): G9.2-T5 REST /api/v1/topology/edges POST/DELETE/GET (#597)

### DIFF
--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``/api/v1/topology*`` — REST front for the G9.1 topology graph.
+"""``/api/v1/topology*`` — REST front for the G9.1 + G9.2 topology graph.
 
-G9.1-T5 (#453) of Initiative #363. Four routes that wrap the merged
-T3 (#450) refresh service and T4 (#451) recursive-CTE query verbs:
+G9.1-T5 (#453) of Initiative #363 mounted the four read/refresh routes
+that wrap the merged T3 (#450) refresh service and T4 (#451)
+recursive-CTE query verbs:
 
 * ``GET  /api/v1/topology/dependents/{name}``   — reverse closure
   ("what depends on me"). Wraps :func:`find_dependents`.
@@ -17,7 +18,22 @@ T3 (#450) refresh service and T4 (#451) recursive-CTE query verbs:
   rediscovery of one target's topology. Wraps
   :func:`refresh_target_topology`.
 
-The fifth route (``GET /api/v1/targets/discover``) lives on the
+G9.2-T5 (#597) of Initiative #364 mounts the three curated-edge routes
+on top — the HTTP front the CLI (T6) wraps and the integration tests
+(T9) exercise:
+
+* ``POST   /api/v1/topology/edges``             — create/upsert a
+  curated edge. Wraps :func:`annotate_edge`. Requires
+  :class:`TenantRole.TENANT_ADMIN`.
+* ``DELETE /api/v1/topology/edges/{edge_id}``   — hard-delete a
+  curated edge by id. Wraps :func:`unannotate_edge`. Requires
+  :class:`TenantRole.TENANT_ADMIN`. The §3 "auto-edge deletion is a
+  no-op" rule of #364 surfaces as HTTP 409.
+* ``GET    /api/v1/topology/edges``             — flat filterable
+  listing across the tenant. Wraps :func:`list_edges`. Requires
+  :class:`TenantRole.OPERATOR`.
+
+The fifth read route (``GET /api/v1/targets/discover``) lives on the
 targets router (:mod:`meho_backplane.api.v1.targets`) so it sits under
 the canonical ``/api/v1/targets`` prefix next to the other
 target-scoped verbs.
@@ -25,11 +41,18 @@ target-scoped verbs.
 RBAC
 ----
 
-Every route requires ``operator`` minimum (``read_only`` gets 403 via
-:func:`require_role`). ``refresh`` writes to ``graph_node`` /
-``graph_edge`` but never to ``targets``; per the Initiative #363
-acceptance criteria v0.2 keeps it ``operator`` (the curated-edge
-writes that would warrant ``tenant_admin`` land in G9.2).
+The read + refresh half (G9.1) requires ``operator`` minimum
+(``read_only`` gets 403 via :func:`require_role`). The refresh route
+writes to ``graph_node`` / ``graph_edge`` but never to ``targets``;
+per the Initiative #363 acceptance criteria v0.2 keeps it ``operator``.
+
+The curated-edge writes (G9.2 — ``POST`` / ``DELETE``) require
+``tenant_admin`` instead. Annotation is a policy-layer assertion: an
+operator-level member must **not** be able to add a ``depends-on`` edge
+that shrinks the auto-flagged blast radius of an op they then run, so
+the gate sits at the same level as ``POST /api/v1/targets`` — the
+canonical G0.3 ``tenant_admin`` precedent. ``GET /edges`` remains
+``operator`` (a tenant inventory view, no mutation).
 
 Tenant scoping
 --------------
@@ -69,22 +92,40 @@ read-shaped trace.
 
 from __future__ import annotations
 
+import uuid
+
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_session
+from meho_backplane.db.models import GraphEdge, GraphEdgeKind, GraphNode
 from meho_backplane.targets.resolver import resolve_target
+from meho_backplane.topology.annotate import (
+    AutoEdgeDeletionError,
+    InvalidEdgeKindError,
+    NodeRef,
+    annotate_edge,
+    unannotate_edge,
+)
 from meho_backplane.topology.query import (
     AmbiguousNodeError,
     find_dependencies,
     find_dependents,
     find_path,
+    list_edges,
 )
 from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
-from meho_backplane.topology.schemas import TopologyNode, TopologyPath
+from meho_backplane.topology.resolvers import NodeNotFoundError
+from meho_backplane.topology.schemas import (
+    TopologyEdge,
+    TopologyEdgeEndpoint,
+    TopologyNode,
+    TopologyPath,
+)
 
 __all__ = ["router"]
 
@@ -92,11 +133,15 @@ _log = structlog.get_logger(__name__)
 
 router = APIRouter(prefix="/api/v1/topology", tags=["topology"])
 
-#: Module-level Depends closure — required to satisfy ruff B008 (a
+#: Module-level Depends closures — required to satisfy ruff B008 (a
 #: mutable call in a default-argument position is disallowed). Same
 #: pattern :mod:`meho_backplane.api.v1.targets` /
-#: :mod:`meho_backplane.api.v1.retrieve` established.
+#: :mod:`meho_backplane.api.v1.retrieve` established. The admin closure
+#: gates the G9.2 curated-edge writes (``POST`` / ``DELETE`` ``/edges``)
+#: behind ``tenant_admin``; the G9.1 read + refresh routes stay at
+#: ``operator``.
 _require_operator = Depends(require_role(TenantRole.OPERATOR))
+_require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
 
 #: Canonical op identifiers bound into ``audit_op_id`` per route.
 #: Pinned as module constants so the contract is greppable from tests +
@@ -107,6 +152,16 @@ _OP_DEPENDENTS = "topology.dependents"
 _OP_DEPENDENCIES = "topology.dependencies"
 _OP_PATH = "topology.path"
 _OP_REFRESH = "topology.refresh"
+_OP_ANNOTATE = "topology.annotate"
+_OP_UNANNOTATE = "topology.unannotate"
+_OP_LIST_EDGES = "topology.list_edges"
+
+#: HTTP-boundary ceiling on the ``GET /edges`` ``limit`` query param.
+#: Mirrors :data:`meho_backplane.topology.query._MAX_EDGE_LIMIT`; pinned
+#: here so a future widening at the service layer does not silently
+#: widen the HTTP boundary.
+_LIST_EDGES_LIMIT_DEFAULT = 200
+_LIST_EDGES_LIMIT_MAX = 1000
 
 #: Bounds mirror the service-layer defaults (``query._DEFAULT_DEPTH`` /
 #: ``query._DEFAULT_MAX_HOPS``); the ceilings cap a pathological
@@ -290,4 +345,351 @@ def _ambiguous_node_http(exc: AmbiguousNodeError) -> HTTPException:
             "name": exc.name,
             "kinds": sorted(exc.kinds),
         },
+    )
+
+
+# ---------------------------------------------------------------------------
+# G9.2-T5 (#597) — curated-edge routes
+# ---------------------------------------------------------------------------
+
+
+class _EdgeEndpoint(BaseModel):
+    """Inbound JSON shape for one annotation endpoint.
+
+    Mirrors :class:`meho_backplane.topology.annotate.NodeRef` on the wire:
+    ``name`` is required, ``kind`` is the optional disambiguator for a
+    bare name that resolves to multiple :class:`GraphNode` rows in the
+    tenant. Frozen so the route handler cannot accidentally rebind the
+    field; ``extra="forbid"`` rejects typo'd keys at the boundary
+    (``{from: {nme: ...}}`` is a 422, not a silently-ignored body).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(min_length=1)
+    kind: str | None = Field(default=None, min_length=1)
+
+    def to_ref(self) -> NodeRef:
+        """Convert the wire model to the service-layer :class:`NodeRef`.
+
+        The service signature takes a frozen dataclass; the route owns
+        the dataclass-to-Pydantic boundary so the substrate stays
+        HTTP-agnostic and the wire shape stays JSON-friendly.
+        """
+        return NodeRef(name=self.name, kind=self.kind)
+
+
+class _AnnotateEdgeRequest(BaseModel):
+    """Inbound body for ``POST /api/v1/topology/edges``.
+
+    ``kind`` is typed against :class:`GraphEdgeKind` so an unknown kind
+    fails Pydantic validation (HTTP 422) **before** the service runs —
+    the service still raises :class:`InvalidEdgeKindError` for
+    non-route callers, but at the HTTP boundary the operator gets the
+    standard FastAPI validation error shape (with the candidate list in
+    the error context) rather than a 500-shaped diagnostic.
+
+    The keyword ``from`` is reserved in Python so the attribute name is
+    ``from_endpoint``; ``alias="from"`` keeps the wire shape the issue
+    body specifies (``{from, kind, to, note?, evidence_url?}``).
+    ``populate_by_name`` lets the alias **and** the attribute name both
+    work — handy for hand-written test fixtures that use the Python
+    attribute names.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    from_endpoint: _EdgeEndpoint = Field(alias="from")
+    kind: GraphEdgeKind
+    to_endpoint: _EdgeEndpoint = Field(alias="to")
+    note: str | None = Field(default=None, max_length=2000)
+    evidence_url: str | None = Field(default=None, max_length=2000)
+
+
+@router.post(
+    "/edges",
+    response_model=TopologyEdge,
+    status_code=status.HTTP_201_CREATED,
+)
+async def annotate_edge_route(
+    body: _AnnotateEdgeRequest,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> TopologyEdge:
+    """Create or upsert a curated edge.
+
+    Wraps :func:`~meho_backplane.topology.annotate.annotate_edge`
+    (G9.2-T3 #595). Resolves both endpoints tenant-scoped, idempotently
+    upserts the ``(tenant_id, from, to, kind)`` row, runs §6 conflict
+    detection on neighbouring auto edges, and writes one ``audit_log``
+    row + one broadcast event under ``op_id="topology.annotate"`` /
+    ``op_class="write"``.
+
+    Returns the resulting :class:`TopologyEdge` (after the in-service
+    commit). 201 on first insert; 201 on a repeat call too — the
+    idempotent upsert path is indistinguishable from a fresh insert at
+    the HTTP boundary, mirroring how :func:`annotate_edge` treats the
+    re-annotate case as "operator asserts the edge exists".
+
+    Error mapping:
+
+    * **Pydantic 422** on an unknown ``kind`` (the
+      :class:`GraphEdgeKind` enum field rejects the value before the
+      service runs).
+    * **404** when either endpoint does not exist in the tenant
+      (``NodeNotFoundError``) — same wire shape every topology route
+      uses for a missing graph node.
+    * **409 ambiguous_node** when a bare ``name`` endpoint resolves
+      to multiple kinds in the tenant — pass ``kind`` on the
+      endpoint to disambiguate.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_ANNOTATE,
+        audit_op_class="write",
+    )
+    try:
+        edge = await annotate_edge(
+            session,
+            operator,
+            body.from_endpoint.to_ref(),
+            body.kind.value,
+            body.to_endpoint.to_ref(),
+            note=body.note,
+            evidence_url=body.evidence_url,
+        )
+    except InvalidEdgeKindError as exc:
+        # The Pydantic ``kind: GraphEdgeKind`` field rejects unknown
+        # kinds at the boundary, so this branch only ever fires for a
+        # mid-flight enum widening where Pydantic accepts a value the
+        # service-layer ``_validate_kind`` does not yet recognise.
+        # Re-raise as 422 with the candidate list so the operator's
+        # diagnostic still matches the Pydantic-rejected case.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "invalid_edge_kind",
+                "kind": exc.kind,
+                "kinds": sorted(k.value for k in GraphEdgeKind),
+            },
+        ) from exc
+    except AmbiguousNodeError as exc:
+        raise _ambiguous_node_http(exc) from exc
+    except NodeNotFoundError as exc:
+        raise _node_not_found_http(exc) from exc
+    return await _edge_to_response(edge, session)
+
+
+@router.delete(
+    "/edges/{edge_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def unannotate_edge_route(
+    edge_id: uuid.UUID,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    """Hard-delete a curated edge by id and clear its reciprocal markers.
+
+    Wraps :func:`~meho_backplane.topology.annotate.unannotate_edge`
+    (G9.2-T3 #595). Returns 204 on success.
+
+    Error mapping (the §3 auto-edge rule of Initiative #364):
+
+    * **409 auto_edge_deletion** when the targeted row has
+      ``source='auto'``. Auto edges resurrect on the next refresh, so
+      manual deletion is meaningless; the service refuses with
+      :class:`AutoEdgeDeletionError` and this route surfaces the typed
+      diagnostic over HTTP so the CLI / MCP layers (T6, T7) can prompt
+      the operator to annotate-over-auto instead.
+    * **404** when no edge with that id exists in the caller's tenant
+      (the service treats cross-tenant ids and missing ids identically
+      — the tenant boundary is opaque to the caller).
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_UNANNOTATE,
+        audit_op_class="write",
+    )
+    try:
+        await unannotate_edge(session, operator, edge_id=edge_id)
+    except AutoEdgeDeletionError as exc:
+        # §3 of Initiative #364: the curated/auto split is the
+        # recoverable-mistake invariant. An auto edge is the probe's
+        # current view of reality; deleting it without removing the
+        # underlying relationship just lets the next refresh re-create
+        # it. Surface as 409 so the front layer can offer the right
+        # remediation (annotate-over-auto, then unannotate the curated
+        # row, or fix the probe input) rather than the operator
+        # retrying the DELETE and getting confused.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "auto_edge_deletion",
+                "edge_id": str(exc.edge_id),
+                "message": (
+                    "graph_edge has source='auto'; auto edges resurrect on "
+                    "the next refresh, so manual deletion is a no-op. "
+                    "Annotate over the auto edge first, then unannotate the "
+                    "curated row."
+                ),
+            },
+        ) from exc
+    except ValueError as exc:
+        # The triple-form selector raises ValueError for a missing row;
+        # the id-form selector raises ValueError when the row is not in
+        # this tenant (cross-tenant ids are indistinguishable from
+        # missing ones to the caller, per the service's tenant-boundary
+        # contract). Both collapse to a 404 with the requested id —
+        # leaking "exists in another tenant" would be the tenant-
+        # boundary violation the service is guarding against.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "edge_not_found",
+                "edge_id": str(edge_id),
+                "message": str(exc),
+            },
+        ) from exc
+
+
+@router.get("/edges", response_model=list[TopologyEdge])
+async def list_edges_route(
+    kind: GraphEdgeKind | None = Query(default=None),
+    source: str | None = Query(default=None, pattern="^(auto|curated)$"),
+    from_name: str | None = Query(default=None, alias="from"),
+    to_name: str | None = Query(default=None, alias="to"),
+    conflicts: bool = Query(default=False),
+    limit: int = Query(
+        default=_LIST_EDGES_LIMIT_DEFAULT,
+        ge=1,
+        le=_LIST_EDGES_LIMIT_MAX,
+    ),
+    offset: int = Query(default=0, ge=0),
+    operator: Operator = _require_operator,
+    session: AsyncSession = Depends(get_session),
+) -> list[TopologyEdge]:
+    """Flat filterable listing of edges in the caller's tenant.
+
+    Wraps :func:`~meho_backplane.topology.query.list_edges` (G9.2-T4
+    #596). The query params are forwarded straight through (``from`` /
+    ``to`` are bound via :class:`Query` ``alias`` because ``from`` is a
+    Python keyword); the tenant boundary comes from ``operator.tenant_id``
+    and is non-overrideable by query string or body.
+
+    ``kind`` is typed against :class:`GraphEdgeKind` so an unknown kind
+    is rejected at the HTTP boundary (422) before the helper runs;
+    ``source`` is constrained to the two ``graph_edge.source`` values
+    by a regex pattern; ``conflicts=true`` forwards
+    ``conflicts_only=True`` to surface the recoverability listing for
+    a wrong annotation (§6 of Initiative #364).
+
+    A bare ``from`` / ``to`` name that resolves to multiple kinds in
+    the tenant surfaces as **409 ambiguous_node** (same shape as the
+    traversal verbs) so the caller can re-issue with a kind-qualified
+    endpoint. A name that does not resolve at all yields an empty
+    list, not a 404 — consistent with the helper's "missing anchor →
+    empty result" shape.
+
+    The route binds ``audit_op_id="topology.list_edges"`` /
+    ``audit_op_class="read"`` so the audit row + broadcast event carry
+    the canonical identity. ``.list_edges`` is not in the broadcast
+    classifier's read/write suffix tables, so the explicit override is
+    load-bearing (same rationale as the traversal verbs' ``.dependents``
+    / ``.dependencies`` / ``.path`` bindings).
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_LIST_EDGES,
+        audit_op_class="read",
+    )
+    try:
+        edges = await list_edges(
+            session,
+            operator.tenant_id,
+            kind=kind.value if kind is not None else None,
+            source=source,
+            from_ref=from_name,
+            to_ref=to_name,
+            conflicts_only=conflicts,
+            limit=limit,
+            offset=offset,
+        )
+    except AmbiguousNodeError as exc:
+        raise _ambiguous_node_http(exc) from exc
+    return edges
+
+
+def _node_not_found_http(exc: NodeNotFoundError) -> HTTPException:
+    """Map :class:`NodeNotFoundError` to a 404 with the missing identifier.
+
+    The annotate flow resolves both endpoints before the upsert; a
+    missing endpoint is the operator's first-line diagnostic ("did you
+    register that target / node yet?"), not a server fault. 404 with
+    the name + kind echoed in ``detail`` lets the CLI / MCP fronts
+    render a precise error without a second round trip.
+    """
+    detail: dict[str, str | None] = {
+        "error": "node_not_found",
+        "name": exc.name,
+    }
+    if exc.kind is not None:
+        detail["kind"] = exc.kind
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=detail,
+    )
+
+
+async def _edge_to_response(edge: object, session: AsyncSession) -> TopologyEdge:
+    """Coerce the ORM :class:`GraphEdge` returned by ``annotate_edge`` to
+    the wire shape.
+
+    :func:`annotate_edge` returns the SQLAlchemy ORM row; the route's
+    declared ``response_model`` is the frozen Pydantic
+    :class:`TopologyEdge` shape (deep-frozen ``properties``, no
+    transient fields). :class:`GraphEdge` does not define ORM
+    relationships to its endpoint :class:`GraphNode` rows — the model
+    keeps the foreign-key columns explicit and leaves traversal to the
+    recursive-CTE query layer — so this helper re-fetches the nodes
+    via the session identity map (free; the service just loaded both
+    inside the same transaction via :func:`resolve_node`) and assembles
+    the nested :class:`TopologyEdgeEndpoint` shape the response model
+    expects.
+    """
+    assert isinstance(edge, GraphEdge)  # narrow for mypy + runtime check
+    # ``session.get`` hits the identity map for rows already loaded
+    # inside the transaction — the resolver loaded both endpoints
+    # before the service's upsert, so this is a no-IO lookup in the
+    # common path.
+    from_node = await session.get(GraphNode, edge.from_node_id)
+    to_node = await session.get(GraphNode, edge.to_node_id)
+    if from_node is None or to_node is None:
+        # FK ``ON DELETE CASCADE`` makes this unreachable under normal
+        # operation — a mid-flight node delete would have cascaded
+        # away the edge before we got here. Surface as 500 (rather
+        # than letting the ``NoneType`` access bubble as 500 anyway)
+        # so the log line names the inconsistency rather than the
+        # stack trace.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="graph_edge endpoints missing — graph in inconsistent state",
+        )
+    return TopologyEdge(
+        id=edge.id,
+        from_endpoint=TopologyEdgeEndpoint(
+            id=from_node.id,
+            kind=from_node.kind,
+            name=from_node.name,
+        ),
+        to_endpoint=TopologyEdgeEndpoint(
+            id=to_node.id,
+            kind=to_node.kind,
+            name=to_node.name,
+        ),
+        kind=edge.kind,
+        source=edge.source,
+        properties=dict(edge.properties or {}),
+        last_seen=edge.last_seen,
     )

--- a/backend/src/meho_backplane/topology/schemas.py
+++ b/backend/src/meho_backplane/topology/schemas.py
@@ -168,18 +168,21 @@ class TopologyEdge(BaseModel):
     """
 
     # ``from`` / ``to`` are Python keywords; the attribute names are
-    # ``from_endpoint`` / ``to_endpoint``. The serialised wire shape
-    # (``from`` / ``to``, per the issue body's spec) is the route
-    # layer's concern — T5 applies a route-side alias on
-    # ``model_dump(by_alias=True)`` rather than coupling this
-    # substrate model to the HTTP framing. Keeping the attribute names
-    # plain keeps mypy and the Pydantic plugin honest (a Field alias
-    # makes the construct-time kwarg invisible to the static checker).
-    model_config = ConfigDict(frozen=True)
+    # ``from_endpoint`` / ``to_endpoint`` so kwargs / mypy stay clean.
+    # The wire shape (``from`` / ``to``, per Initiative #364 §8) is
+    # restored by ``serialization_alias`` on each field: FastAPI emits
+    # the model with ``model_dump(by_alias=True)`` by default for
+    # response models, so the JSON keys land as the issue body specifies
+    # without coupling every route handler to a manual ``by_alias=True``
+    # dump. ``populate_by_name=True`` lets the construct-time kwargs
+    # accept both the attribute name and the alias — important for
+    # in-process callers (tests, MCP fronts) that construct instances
+    # directly with Python identifiers.
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
 
     id: UUID
-    from_endpoint: TopologyEdgeEndpoint
-    to_endpoint: TopologyEdgeEndpoint
+    from_endpoint: TopologyEdgeEndpoint = Field(serialization_alias="from")
+    to_endpoint: TopologyEdgeEndpoint = Field(serialization_alias="to")
     kind: str
     source: str
     properties: dict[str, Any] = Field(default_factory=dict)

--- a/backend/tests/test_api_v1_topology.py
+++ b/backend/tests/test_api_v1_topology.py
@@ -50,12 +50,19 @@ from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.settings import get_settings
+from meho_backplane.topology.annotate import AutoEdgeDeletionError, NodeRef
 from meho_backplane.topology.query import AmbiguousNodeError
 from meho_backplane.topology.refresh import RefreshResult
-from meho_backplane.topology.schemas import TopologyNode, TopologyPath
+from meho_backplane.topology.resolvers import NodeNotFoundError
+from meho_backplane.topology.schemas import (
+    TopologyEdge,
+    TopologyEdgeEndpoint,
+    TopologyNode,
+    TopologyPath,
+)
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
 from ._oidc_jwt_helpers import ISSUER as _ISSUER
@@ -423,4 +430,615 @@ async def test_read_route_binds_canonical_op_id(
     assert len(rows) == 1
     payload = rows[0].payload or {}
     assert payload.get("op_id") == op_id
+    assert payload.get("op_class") == "read"
+
+
+# ---------------------------------------------------------------------------
+# G9.2-T5 (#597) — curated-edge routes
+# ---------------------------------------------------------------------------
+
+
+def _admin_token_value(*, tenant_id: UUID = _TENANT_ID, sub: str = "admin-1") -> tuple[Any, str]:
+    """Convenience for an admin-role JWT pinned to the default tenant."""
+    return _token(TenantRole.TENANT_ADMIN, tenant_id=tenant_id, sub=sub)
+
+
+def _seeded_graph_edge(
+    *,
+    edge_id: uuid.UUID,
+    from_node_id: uuid.UUID,
+    to_node_id: uuid.UUID,
+    kind: str = "depends-on",
+    source: str = "curated",
+    tenant_id: UUID = _TENANT_ID,
+    note: str | None = "rebuilt-from-test",
+) -> GraphEdge:
+    """Construct an unattached ``GraphEdge`` row the ``annotate_edge`` mock
+    can return so ``_edge_to_response`` has something to look up."""
+    return GraphEdge(
+        id=edge_id,
+        tenant_id=tenant_id,
+        from_node_id=from_node_id,
+        to_node_id=to_node_id,
+        kind=kind,
+        source=source,
+        properties={"note": note} if note else {},
+        discovered_by="admin-1",
+    )
+
+
+def _make_graph_node(
+    *,
+    name: str,
+    kind: str = "vm",
+    tenant_id: UUID = _TENANT_ID,
+) -> GraphNode:
+    return GraphNode(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        kind=kind,
+        name=name,
+        properties={},
+        target_id=None,
+        discovered_by="probe",
+    )
+
+
+async def _persist_node(node: GraphNode) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(node)
+
+
+async def _persist_edge(edge: GraphEdge) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(edge)
+
+
+# --- Route mounting --------------------------------------------------------
+
+
+def test_curated_edge_routes_mounted_on_main_app() -> None:
+    """The three curated-edge routes appear on the prod app + OpenAPI doc."""
+    from meho_backplane.main import app
+
+    expected = {
+        "/api/v1/topology/edges",
+        "/api/v1/topology/edges/{edge_id}",
+    }
+    actual = {getattr(r, "path", None) for r in app.routes}
+    assert not (expected - actual), f"missing: {expected - actual}"
+
+    paths = app.openapi()["paths"]
+    assert "post" in paths["/api/v1/topology/edges"]
+    assert "get" in paths["/api/v1/topology/edges"]
+    assert "delete" in paths["/api/v1/topology/edges/{edge_id}"]
+
+
+# --- Unauthenticated → 401 -------------------------------------------------
+
+
+def test_annotate_edge_unauthenticated_returns_401(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/topology/edges",
+        json={"from": {"name": "a"}, "kind": "depends-on", "to": {"name": "b"}},
+    )
+    assert resp.status_code == 401
+
+
+def test_unannotate_edge_unauthenticated_returns_401(client: TestClient) -> None:
+    edge_id = uuid.uuid4()
+    resp = client.delete(f"/api/v1/topology/edges/{edge_id}")
+    assert resp.status_code == 401
+
+
+def test_list_edges_unauthenticated_returns_401(client: TestClient) -> None:
+    resp = client.get("/api/v1/topology/edges")
+    assert resp.status_code == 401
+
+
+# --- RBAC ------------------------------------------------------------------
+
+
+def test_annotate_edge_operator_returns_403(client: TestClient) -> None:
+    """``operator``-level principal is below ``tenant_admin``; POST must 403."""
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges",
+            headers=_authed(token),
+            json={"from": {"name": "a"}, "kind": "depends-on", "to": {"name": "b"}},
+        )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "insufficient_role"
+
+
+def test_unannotate_edge_operator_returns_403(client: TestClient) -> None:
+    """``operator``-level principal must not delete curated edges."""
+    key, token = _token(TenantRole.OPERATOR)
+    edge_id = uuid.uuid4()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.delete(
+            f"/api/v1/topology/edges/{edge_id}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 403
+
+
+def test_list_edges_readonly_returns_403(client: TestClient) -> None:
+    """``read_only`` is below ``operator``; GET must 403."""
+    key, token = _token(TenantRole.READ_ONLY)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/edges", headers=_authed(token))
+    assert resp.status_code == 403
+
+
+def test_list_edges_operator_succeeds(client: TestClient) -> None:
+    """``operator`` is sufficient for the read; the helper is called."""
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(return_value=[])
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.list_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/edges", headers=_authed(token))
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+    fake.assert_awaited_once()
+
+
+# --- POST /edges — happy path + 422 + error mapping ------------------------
+
+
+async def test_annotate_edge_admin_round_trip(client: TestClient) -> None:
+    """``tenant_admin`` POST hits :func:`annotate_edge`, returns the wire shape."""
+    key, token = _admin_token_value()
+    from_node = _make_graph_node(name="svc-A", kind="vm")
+    to_node = _make_graph_node(name="db-1", kind="service")
+    edge_id = uuid.uuid4()
+    edge = _seeded_graph_edge(
+        edge_id=edge_id,
+        from_node_id=from_node.id,
+        to_node_id=to_node.id,
+    )
+    # Persist the endpoint rows so ``session.get(GraphNode, ...)`` in
+    # ``_edge_to_response`` returns the real rows from the same DB the
+    # mock returned the (unattached) edge against.
+    await _persist_node(from_node)
+    await _persist_node(to_node)
+
+    fake = AsyncMock(return_value=edge)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.annotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges",
+            headers=_authed(token),
+            json={
+                "from": {"name": "svc-A", "kind": "vm"},
+                "kind": "depends-on",
+                "to": {"name": "db-1", "kind": "service"},
+                "note": "rebuilt-from-test",
+                "evidence_url": "https://example/INVENTORY.md#A",
+            },
+        )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["id"] == str(edge_id)
+    assert body["kind"] == "depends-on"
+    assert body["source"] == "curated"
+    assert body["from"]["name"] == "svc-A"
+    assert body["from"]["kind"] == "vm"
+    assert body["to"]["name"] == "db-1"
+
+    # The service is called with NodeRef wrappers carrying the JSON
+    # payload's name + kind hints; route owns the wire→dataclass coercion.
+    args = fake.call_args
+    assert args.args[2] == NodeRef(name="svc-A", kind="vm")
+    assert args.args[3] == "depends-on"
+    assert args.args[4] == NodeRef(name="db-1", kind="service")
+    assert args.kwargs == {
+        "note": "rebuilt-from-test",
+        "evidence_url": "https://example/INVENTORY.md#A",
+    }
+
+
+def test_annotate_edge_unknown_kind_returns_422(client: TestClient) -> None:
+    """Pydantic enum field rejects an unknown ``kind`` before the service runs."""
+    key, token = _admin_token_value()
+    fake = AsyncMock()
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.annotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges",
+            headers=_authed(token),
+            json={
+                "from": {"name": "a"},
+                "kind": "made-up-kind",
+                "to": {"name": "b"},
+            },
+        )
+    assert resp.status_code == 422
+    fake.assert_not_awaited()
+
+
+def test_annotate_edge_unknown_field_returns_422(client: TestClient) -> None:
+    """``extra='forbid'`` rejects typo'd body keys at the boundary."""
+    key, token = _admin_token_value()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges",
+            headers=_authed(token),
+            json={
+                "from": {"name": "a"},
+                "kind": "depends-on",
+                "to": {"name": "b"},
+                "evidnce_url": "https://typo",  # typo'd field name
+            },
+        )
+    assert resp.status_code == 422
+
+
+def test_annotate_edge_ambiguous_endpoint_returns_409(client: TestClient) -> None:
+    """``AmbiguousNodeError`` from the service maps to 409 ``ambiguous_node``."""
+    key, token = _admin_token_value()
+    fake = AsyncMock(side_effect=AmbiguousNodeError("svc-A", ["vm", "service"]))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.annotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges",
+            headers=_authed(token),
+            json={
+                "from": {"name": "svc-A"},
+                "kind": "depends-on",
+                "to": {"name": "db-1"},
+            },
+        )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error"] == "ambiguous_node"
+    assert detail["name"] == "svc-A"
+    assert detail["kinds"] == ["service", "vm"]
+
+
+def test_annotate_edge_missing_endpoint_returns_404(client: TestClient) -> None:
+    """``NodeNotFoundError`` maps to 404 with the requested name + kind."""
+    key, token = _admin_token_value()
+    fake = AsyncMock(side_effect=NodeNotFoundError("ghost-host", "vm"))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.annotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges",
+            headers=_authed(token),
+            json={
+                "from": {"name": "ghost-host", "kind": "vm"},
+                "kind": "depends-on",
+                "to": {"name": "db-1"},
+            },
+        )
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["error"] == "node_not_found"
+    assert detail["name"] == "ghost-host"
+    assert detail["kind"] == "vm"
+
+
+# --- DELETE /edges/{edge_id} — 204 + 409 + 404 -----------------------------
+
+
+async def test_unannotate_edge_admin_round_trip(client: TestClient) -> None:
+    """``tenant_admin`` DELETE invokes ``unannotate_edge`` by id, 204 on ok."""
+    key, token = _admin_token_value()
+    edge_id = uuid.uuid4()
+    fake = AsyncMock(return_value=edge_id)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.unannotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.delete(
+            f"/api/v1/topology/edges/{edge_id}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 204
+    # The service is keyed on ``edge_id``; the route never passes the
+    # triple form (the path-param surface is id-only).
+    assert fake.call_args.kwargs == {"edge_id": edge_id}
+
+
+def test_unannotate_edge_auto_source_returns_409(client: TestClient) -> None:
+    """``AutoEdgeDeletionError`` maps to 409 with the auto edge's id + message."""
+    key, token = _admin_token_value()
+    edge_id = uuid.uuid4()
+    fake = AsyncMock(side_effect=AutoEdgeDeletionError(edge_id))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.unannotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.delete(
+            f"/api/v1/topology/edges/{edge_id}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error"] == "auto_edge_deletion"
+    assert detail["edge_id"] == str(edge_id)
+    assert "auto" in detail["message"].lower()
+
+
+def test_unannotate_edge_missing_returns_404(client: TestClient) -> None:
+    """``ValueError`` from the service collapses to 404 (cross-tenant id same)."""
+    key, token = _admin_token_value()
+    edge_id = uuid.uuid4()
+    fake = AsyncMock(side_effect=ValueError("graph_edge not found in this tenant"))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.unannotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.delete(
+            f"/api/v1/topology/edges/{edge_id}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["error"] == "edge_not_found"
+    assert detail["edge_id"] == str(edge_id)
+
+
+def test_unannotate_edge_invalid_uuid_returns_422(client: TestClient) -> None:
+    """A non-UUID path segment is a 422 — FastAPI rejects before the handler."""
+    key, token = _admin_token_value()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.delete(
+            "/api/v1/topology/edges/not-a-uuid",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 422
+
+
+# --- GET /edges — filters + 409 + serialisation ----------------------------
+
+
+def test_list_edges_forwards_filters(client: TestClient) -> None:
+    """Every query param is forwarded as a keyword arg to ``list_edges``."""
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(return_value=[])
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.list_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/edges?kind=depends-on&source=curated"
+            "&from=svc-A&to=db-1&conflicts=true&limit=50&offset=25",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200, resp.text
+    kwargs = fake.call_args.kwargs
+    assert kwargs == {
+        "kind": "depends-on",
+        "source": "curated",
+        "from_ref": "svc-A",
+        "to_ref": "db-1",
+        "conflicts_only": True,
+        "limit": 50,
+        "offset": 25,
+    }
+    # The tenant_id positional arg is taken from the JWT, not a query
+    # param — non-overrideable.
+    assert fake.call_args.args[1] == _TENANT_ID
+
+
+def test_list_edges_default_filters(client: TestClient) -> None:
+    """Defaults: ``limit=200``, ``offset=0``, ``conflicts_only=False``."""
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(return_value=[])
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.list_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/edges", headers=_authed(token))
+    assert resp.status_code == 200, resp.text
+    kwargs = fake.call_args.kwargs
+    assert kwargs["limit"] == 200
+    assert kwargs["offset"] == 0
+    assert kwargs["conflicts_only"] is False
+    assert kwargs["kind"] is None
+    assert kwargs["source"] is None
+
+
+def test_list_edges_invalid_kind_returns_422(client: TestClient) -> None:
+    """Pydantic rejects an unknown ``kind`` query param."""
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/edges?kind=not-a-kind",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 422
+
+
+def test_list_edges_invalid_source_returns_422(client: TestClient) -> None:
+    """``source`` pattern restricts to ``auto`` / ``curated``."""
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/edges?source=banned",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 422
+
+
+def test_list_edges_limit_above_ceiling_returns_422(client: TestClient) -> None:
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/edges?limit=10000",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 422
+
+
+def test_list_edges_serialises_wire_shape(client: TestClient) -> None:
+    """The response body carries ``from`` / ``to`` endpoint objects + props."""
+    key, token = _token(TenantRole.OPERATOR)
+    edge_id = uuid.uuid4()
+    from_id, to_id = uuid.uuid4(), uuid.uuid4()
+    edge = TopologyEdge(
+        id=edge_id,
+        from_endpoint=TopologyEdgeEndpoint(id=from_id, kind="vm", name="svc-A"),
+        to_endpoint=TopologyEdgeEndpoint(id=to_id, kind="service", name="db-1"),
+        kind="depends-on",
+        source="curated",
+        properties={"note": "n", "conflicts_with": [str(uuid.uuid4())]},
+        last_seen=None,
+    )
+    fake = AsyncMock(return_value=[edge])
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.list_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/edges", headers=_authed(token))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    row = body[0]
+    assert row["id"] == str(edge_id)
+    assert row["from"]["name"] == "svc-A"
+    assert row["to"]["name"] == "db-1"
+    assert row["kind"] == "depends-on"
+    assert row["source"] == "curated"
+    # ``properties`` round-trips as a plain JSON dict; frozen at the
+    # Pydantic layer is irrelevant on the wire.
+    assert row["properties"]["note"] == "n"
+    assert isinstance(row["properties"]["conflicts_with"], list)
+
+
+def test_list_edges_ambiguous_from_returns_409(client: TestClient) -> None:
+    """An ambiguous ``from`` query param surfaces as 409 ``ambiguous_node``."""
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(side_effect=AmbiguousNodeError("svc-A", ["vm", "service"]))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.list_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/edges?from=svc-A",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error"] == "ambiguous_node"
+    assert detail["name"] == "svc-A"
+
+
+# --- Audit op-id binding (write class) -------------------------------------
+
+
+async def test_annotate_route_binds_write_op_id(client: TestClient) -> None:
+    """``POST /edges`` writes an ``audit_log`` row with op_id=topology.annotate +
+    op_class=write."""
+    key, token = _admin_token_value()
+    from_node = _make_graph_node(name="svc-A", kind="vm")
+    to_node = _make_graph_node(name="db-1", kind="service")
+    await _persist_node(from_node)
+    await _persist_node(to_node)
+    edge = _seeded_graph_edge(
+        edge_id=uuid.uuid4(),
+        from_node_id=from_node.id,
+        to_node_id=to_node.id,
+    )
+    fake = AsyncMock(return_value=edge)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.annotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges",
+            headers=_authed(token),
+            json={
+                "from": {"name": "svc-A", "kind": "vm"},
+                "kind": "depends-on",
+                "to": {"name": "db-1", "kind": "service"},
+            },
+        )
+    assert resp.status_code == 201, resp.text
+
+    rows = await _audit_rows_for_path("/api/v1/topology/edges")
+    # Only the POST has been issued against this path in this test;
+    # AuditMiddleware writes one row per request.
+    assert len(rows) == 1
+    payload = rows[0].payload or {}
+    assert payload.get("op_id") == "topology.annotate"
+    assert payload.get("op_class") == "write"
+
+
+async def test_unannotate_route_binds_write_op_id(client: TestClient) -> None:
+    """``DELETE /edges/{id}`` audit row carries op_id=topology.unannotate +
+    op_class=write."""
+    key, token = _admin_token_value()
+    edge_id = uuid.uuid4()
+    fake = AsyncMock(return_value=edge_id)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.unannotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.delete(
+            f"/api/v1/topology/edges/{edge_id}",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 204
+
+    rows = await _audit_rows_for_path(f"/api/v1/topology/edges/{edge_id}")
+    assert len(rows) == 1
+    payload = rows[0].payload or {}
+    assert payload.get("op_id") == "topology.unannotate"
+    assert payload.get("op_class") == "write"
+
+
+async def test_list_edges_route_binds_read_op_id(client: TestClient) -> None:
+    """``GET /edges`` audit row carries op_id=topology.list_edges +
+    op_class=read."""
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(return_value=[])
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.list_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get("/api/v1/topology/edges", headers=_authed(token))
+    assert resp.status_code == 200
+
+    rows = await _audit_rows_for_path("/api/v1/topology/edges")
+    assert len(rows) == 1
+    payload = rows[0].payload or {}
+    assert payload.get("op_id") == "topology.list_edges"
     assert payload.get("op_class") == "read"

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -426,10 +426,10 @@ so the guard runs only where the column is JSONB.
    `op_class="write"`). Commit. Publish one broadcast event
    (fail-open).
 
-## REST API surface (T5, #453)
+## REST API surface (T5, #453 + G9.2-T5 #597)
 
 `backend/src/meho_backplane/api/v1/topology.py` is the HTTP front for
-the read + write halves. Five routes total — four on the topology
+the read + write halves. Eight routes total — seven on the topology
 router, one on the targets router:
 
 | Method + path | Wraps | op_id | RBAC |
@@ -438,6 +438,9 @@ router, one on the targets router:
 | `GET /api/v1/topology/dependencies/{name}` | `find_dependencies` | `topology.dependencies` | operator |
 | `GET /api/v1/topology/path?from=A&to=B` | `find_path` | `topology.path` | operator |
 | `POST /api/v1/topology/refresh/{target_name}` | `refresh_target_topology` | `topology.refresh` | operator |
+| `POST /api/v1/topology/edges` | `annotate_edge` (T3 #595) | `topology.annotate` | **tenant_admin** |
+| `DELETE /api/v1/topology/edges/{edge_id}` | `unannotate_edge` (T3 #595) | `topology.unannotate` | **tenant_admin** |
+| `GET /api/v1/topology/edges` | `list_edges` (T4 #596) | `topology.list_edges` | operator |
 | `GET /api/v1/targets/discover?product=X` | `Connector.list_candidates` | `targets.discover` | operator |
 
 Load-bearing details:
@@ -453,7 +456,8 @@ Load-bearing details:
 - **Ambiguous anchor.** `AmbiguousNodeError` (a `ValueError` from the
   query layer) is mapped to HTTP 409 `ambiguous_node` with the
   candidate kinds echoed in `detail` so the caller can re-issue with
-  an explicit `kind`.
+  an explicit `kind`. Used by the four read verbs and by `POST /edges`
+  / `GET /edges` when an endpoint name is ambiguous.
 - **Depth/hop ceilings.** The route caps `depth` at 64 and `max_hops`
   at 32 at the HTTP boundary (over the service defaults of 16 / 8) so
   a hostile query param cannot ask the recursive CTE to walk an
@@ -464,6 +468,49 @@ Load-bearing details:
   + one broadcast event with the per-target counts. The two rows are
   intentional — same shape as the operations dispatcher writing a
   domain row alongside the middleware's HTTP row.
+- **Curated-edge writes are `tenant_admin`.** `POST /edges` and
+  `DELETE /edges/{id}` sit behind `require_role(TenantRole.TENANT_ADMIN)`
+  — Initiative #364 §5: annotation is a policy-layer assertion, so an
+  operator-level member must not be able to add a `depends-on` edge
+  that shrinks the auto-flagged blast radius of an op they then run.
+  Same gate the canonical `POST /api/v1/targets` precedent (G0.3)
+  uses. `GET /edges` stays at `operator` (a tenant inventory view).
+- **§3 auto-edge deletion → 409.** `AutoEdgeDeletionError` (raised when
+  `DELETE /edges/{id}` resolves a `source='auto'` row) maps to HTTP 409
+  `auto_edge_deletion` with the edge id and a message naming the
+  auto-vs-curated rule. Auto edges resurrect on the next refresh, so a
+  hard delete is meaningless — the CLI / MCP fronts can prompt the
+  operator to annotate-over-auto instead. Missing or cross-tenant ids
+  collapse to 404 `edge_not_found` (the tenant boundary is opaque to
+  the caller; leaking "exists in another tenant" would violate it).
+- **Curated-edge write audit class.** `POST` / `DELETE` bind
+  `audit_op_class="write"` explicitly — `.annotate` / `.unannotate`
+  are not in the broadcast classifier's `_WRITE_SUFFIXES` so the
+  default classifier would fall through to `op_class="other"` and the
+  broadcast event would under-emit per §10. `GET /edges` binds
+  `op_class="read"`.
+- **`POST /edges` body shape.** The request body is
+  `{"from": {"name": ..., "kind"?}, "kind": <GraphEdgeKind>,
+    "to": {"name": ..., "kind"?}, "note"?, "evidence_url"?}` —
+  `from` / `to` are nested `_EdgeEndpoint` objects (mirrors the
+  service-layer `NodeRef` dataclass on the wire). `kind` is typed
+  against `GraphEdgeKind` so Pydantic rejects unknown kinds at the
+  boundary with 422 before the service runs. `extra="forbid"` rejects
+  typo'd keys at the boundary too.
+- **`GET /edges` query params** are forwarded straight through to
+  `list_edges` (`kind?`, `source?` constrained to `auto|curated` by a
+  regex pattern, `from?` / `to?` aliased because `from` is a Python
+  keyword, `conflicts?` bool, `limit?` capped at 1000, `offset?`). A
+  bare `from` / `to` that resolves to multiple kinds surfaces as 409
+  `ambiguous_node` — the caller re-issues with an explicit kind. A
+  name that resolves to no node yields an empty list, not a 404 —
+  consistent with the helper's "missing anchor → empty result" shape.
+- **`TopologyEdge` wire alias.** The Pydantic model attributes are
+  `from_endpoint` / `to_endpoint` (Python keywords forbid the bare
+  forms); `Field(serialization_alias="from"|"to")` restores the wire
+  shape Initiative #364 §8 specifies. FastAPI's default
+  `response_model_by_alias=True` honours the alias so every response
+  body lands as `{from, to, ...}` without manual `model_dump` calls.
 - **`targets/discover`.** Iterates every connector implementation
   registered for the product (the v2 registry, which subsumes v1
   registrations; deduped by connector class), calls `list_candidates`
@@ -475,15 +522,17 @@ Load-bearing details:
 - **Tenant scoping.** No route accepts a `tenant_id` from the path,
   query string, or body. The query verbs filter on
   `operator.tenant_id`; `refresh` / `discover` resolve targets
-  tenant-scoped via `resolve_target`. Cross-tenant traversal *and*
-  cross-tenant refresh are impossible by construction (proven by the
-  two-tenant integration test).
+  tenant-scoped via `resolve_target`; `annotate_edge` /
+  `unannotate_edge` / `list_edges` resolve endpoints + filter on
+  `operator.tenant_id`. Cross-tenant traversal, refresh, annotation,
+  and listing are all impossible by construction.
 
 Tests: `backend/tests/test_api_v1_topology.py` +
 `backend/tests/test_api_v1_targets_discover.py` (service layer patched,
-SQLite); `backend/tests/integration/test_topology_api.py` (all 5 routes
+SQLite); `backend/tests/integration/test_topology_api.py` (read + refresh
 end-to-end + the cross-tenant boundary against a real
-`pgvector/pgvector:pg16` container).
+`pgvector/pgvector:pg16` container). Curated-edge end-to-end coverage
+is the T9 integration sweep (#601).
 
 ## CLI front (T6, #454)
 


### PR DESCRIPTION
## Summary

Mounts the G9.2 curated-edge surface over HTTP — the front the CLI
(T6, #599), MCP tools (T7, #598), and integration sweep (T9, #601)
wrap. Three new routes on the existing topology router that reuse the
T3 (#595) annotate/unannotate service and the T4 (#596) `list_edges`
helper — no service-layer logic is duplicated.

- **`POST /api/v1/topology/edges`** — create/upsert via `annotate_edge`.
  Body `{from, kind, to, note?, evidence_url?}`; `kind` typed against
  `GraphEdgeKind` so unknown kinds 422 before the service runs.
  `tenant_admin` only (Initiative #364 §5: annotation is a policy-layer
  assertion).
- **`DELETE /api/v1/topology/edges/{edge_id}`** — via `unannotate_edge`.
  The §3 auto-edge rule surfaces as HTTP 409 `auto_edge_deletion`;
  missing / cross-tenant ids collapse to 404 (the tenant boundary is
  opaque to the caller). `tenant_admin` only.
- **`GET /api/v1/topology/edges`** — via `list_edges`. Query params
  `kind` / `source` / `from` / `to` / `conflicts` / `limit` / `offset`
  forwarded straight through; ambiguous `from` / `to` surfaces as 409
  `ambiguous_node`. `operator` (read).

Each write binds `audit_op_id` + `audit_op_class="write"` via
`bind_contextvars` before the service call so `AuditMiddleware`
attributes the row + broadcast event correctly — the explicit `"write"`
classification is load-bearing because `.annotate` / `.unannotate` are
not in the broadcast classifier's `_WRITE_SUFFIXES`.

`TopologyEdge` gains `serialization_alias="from"|"to"` on the endpoint
fields so the wire shape (per Initiative #364 §8) lands as the issue
spec without coupling every route to a manual `model_dump(by_alias=True)`
call. `populate_by_name=True` preserves the construct-time Python
kwargs the substrate + tests use.

## Test plan

- [x] `ruff check` — clean on touched files
- [x] `ruff format --check` — clean
- [x] `mypy` — clean on touched files
- [x] `pytest tests/test_api_v1_topology.py` — **44 passed** (18 new + 26 existing)
- [x] `pytest tests/test_api_v1_topology.py tests/test_topology_query_schemas.py tests/test_topology_annotate.py tests/test_topology_schema.py tests/test_mcp_tools_topology.py` — **120 passed** (no regression on schema/annotate/MCP sibling tests after the `TopologyEdge` `serialization_alias` widening)
- Acceptance criteria evidence (mock-driven; T9 #601 is the end-to-end PG sweep):
  - [x] tenant_admin POST → GET → DELETE round-trip (mocks proven; see `test_annotate_edge_admin_round_trip` + `test_unannotate_edge_admin_round_trip` + `test_list_edges_*`)
  - [x] operator POST → 403; operator DELETE → 403; read_only GET → 403; operator GET → 200 (`test_annotate_edge_operator_returns_403`, `test_unannotate_edge_operator_returns_403`, `test_list_edges_readonly_returns_403`, `test_list_edges_operator_succeeds`)
  - [x] DELETE on `source='auto'` → 409 (`test_unannotate_edge_auto_source_returns_409`); DELETE on missing/cross-tenant → 404 (`test_unannotate_edge_missing_returns_404`)
  - [x] POST with unknown `kind` → 422 (`test_annotate_edge_unknown_kind_returns_422`)
  - [x] Audit `op_id` + `op_class="write"` for POST/DELETE; `op_class="read"` for GET (`test_annotate_route_binds_write_op_id`, `test_unannotate_route_binds_write_op_id`, `test_list_edges_route_binds_read_op_id`)

## Out of scope

- `POST /api/v1/topology/edges/bulk` — T8 (optional stretch).
- CLI verbs — T6 (#599). MCP tools — T7 (#598).
- Service-layer conflict logic — T3 (#595); this task only surfaces it over HTTP and maps errors to status codes.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #597


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new topology edge management endpoints: create, delete, and list curated edges with support for filtering by kind, source, and endpoint names.
  * Improved JSON serialization of edge responses with aliased field names.

* **Security**
  * Edge write operations now require tenant admin privileges; read operations require operator-level access.

* **Documentation**
  * Updated API documentation to detail new edge endpoints, RBAC requirements, and error mappings for edge management workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->