### PR TITLE
feat(topology): G9.2-T7 MCP admin meta-tools + query_topology(kind=edges)

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -833,12 +833,13 @@ _ANNOTATE_DESCRIPTION: Final[str] = (
     "`depends-on`, `replicates-to`, `backed-up-by`, `routes-via`, "
     "`policy-binds`.\n\n"
     "Returns `{edge_id, from: {id, kind, name}, to: {id, kind, name}, "
-    'kind, source: "curated", superseded: [<auto-edge-id>...], '
-    "conflicts: [<edge-id>...]}`. `superseded` lists auto edges this "
-    "annotation displaced (same kind, different endpoint); `conflicts` "
-    "lists edges of an incompatible kind over the same endpoint pair. "
-    "Both lists are diagnostics — the recovery flow is to "
-    "`meho.topology.unannotate` this edge."
+    'kind, source: "curated", conflicts: [<edge-id>...]}`. `conflicts` '
+    "lists edges of an incompatible kind over the same endpoint pair — "
+    "a diagnostic; the recovery flow is to `meho.topology.unannotate` "
+    "this edge. (Auto edges displaced by this annotation are stamped "
+    "`properties.superseded_by` on the database row and recorded in the "
+    "audit/broadcast payload, but are not surfaced on the tool's return "
+    "shape — inspect them with `query_topology {kind: edges}` if needed.)"
 )
 
 
@@ -967,7 +968,7 @@ _UNANNOTATE_INPUT_SCHEMA: Final[dict[str, Any]] = {
     "type": "object",
     "properties": {
         "edge_id": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": (
                 "UUID of the curated `graph_edge` to remove. Mutually "
                 "exclusive with the `(from_name, kind, to_name)` triple — "
@@ -977,56 +978,85 @@ _UNANNOTATE_INPUT_SCHEMA: Final[dict[str, Any]] = {
             "maxLength": 64,
         },
         "from_name": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": (
                 "Triple selector: the edge's `from` endpoint name. Must "
                 "appear together with `kind` and `to_name` (or with "
                 "neither, when using `edge_id`)."
             ),
+            "minLength": 1,
             "maxLength": 256,
         },
         "kind": {
-            "type": ["string", "null"],
-            "enum": [None, *_EDGE_KIND_VALUES],
+            "type": "string",
+            "enum": list(_EDGE_KIND_VALUES),
             "description": (
                 "Triple selector: the edge's `graph_edge.kind`. Must "
                 "appear together with `from_name` and `to_name`."
             ),
         },
         "to_name": {
-            "type": ["string", "null"],
+            "type": "string",
             "description": (
                 "Triple selector: the edge's `to` endpoint name. Must "
                 "appear together with `from_name` and `kind`."
             ),
+            "minLength": 1,
             "maxLength": 256,
         },
         "from_node_kind": {
             "type": ["string", "null"],
             "description": (
                 "Optional `graph_node.kind` pin for the `from_name` "
-                "endpoint, used for ambiguity disambiguation."
+                "endpoint, used for ambiguity disambiguation. Only "
+                "meaningful with the triple selector form."
             ),
+            "minLength": 1,
             "maxLength": 64,
         },
         "to_node_kind": {
             "type": ["string", "null"],
             "description": (
                 "Optional `graph_node.kind` pin for the `to_name` "
-                "endpoint, used for ambiguity disambiguation."
+                "endpoint, used for ambiguity disambiguation. Only "
+                "meaningful with the triple selector form."
             ),
+            "minLength": 1,
             "maxLength": 64,
         },
     },
     "additionalProperties": False,
+    # XOR at the wire boundary: either `edge_id` alone, or the full
+    # `(from_name, kind, to_name)` triple. Partial triples, both
+    # selectors, or neither are rejected by jsonschema (Draft 2020-12)
+    # before reaching the service. The substrate-level XOR guard in
+    # `_unannotate_handler` stays as belt-and-suspenders for the
+    # never-validated path (direct in-process callers).
+    "oneOf": [
+        {
+            "required": ["edge_id"],
+            "not": {
+                "anyOf": [
+                    {"required": ["from_name"]},
+                    {"required": ["kind"]},
+                    {"required": ["to_name"]},
+                ],
+            },
+        },
+        {
+            "required": ["from_name", "kind", "to_name"],
+            "not": {"required": ["edge_id"]},
+        },
+    ],
 }
 
 
 _UNANNOTATE_DESCRIPTION: Final[str] = (
     "Hard-delete a curated `graph_edge` and clear its reciprocal §6 "
     "markers (tenant_admin only). Pass either `edge_id` OR the full "
-    "`(from_name, kind, to_name)` triple — both forms or partial input "
-    "is rejected at -32602. Tenant-scoped automatically.\n\n"
+    "`(from_name, kind, to_name)` triple — both forms, partial triples, "
+    "or empty strings are rejected at the inputSchema layer (-32602) "
+    "before the service is reached. Tenant-scoped automatically.\n\n"
     "WHEN TO CALL: an annotation was wrong and needs to be revoked — "
     "the operator originally asserted `service-X depends-on database-Y` "
     "but it turns out the real dependency is `database-Z`. "
@@ -1050,9 +1080,12 @@ async def _unannotate_handler(
     """Dispatch a ``meho.topology.unannotate`` call to :func:`unannotate_edge`.
 
     The two selector forms (UUID primary key vs. ``(from, kind, to)``
-    triple) are mutually exclusive at the service layer — passing both
-    or neither raises :class:`UnannotateSelectorError`, which surfaces
-    as ``-32602``.
+    triple) are mutually exclusive at the wire boundary — the tool's
+    ``inputSchema`` rejects partial triples, both selectors, and the
+    empty-arguments case with a -32602 jsonschema error before reaching
+    this handler. The service-layer :class:`UnannotateSelectorError`
+    guard stays for the never-validated path (direct in-process
+    callers), so the matrix is fully covered.
 
     :class:`AutoEdgeDeletionError` is the §6 auto-vs-curated refusal —
     surfaces as ``-32602`` with the substrate's "auto edges resurrect

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -1,24 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``query_topology`` + ``list_targets`` — the G9 Targets/topology MCP family.
+"""``query_topology`` + ``list_targets`` + admin annotate/unannotate — the G9 MCP family.
 
-Task #455 (G9.1-T7). Exactly **two** meta-tools register here, matching
-the CLAUDE.md narrow-waist agent surface (postulate 5, the
-Targets/topology row of the agent-surface table — 2 of the ~17
-meta-tools):
+Tasks #455 (G9.1-T7) and #598 (G9.2-T7). Two daily-surface meta-tools
+plus two admin-namespace meta-tools register here, matching the
+CLAUDE.md narrow-waist agent surface (postulate 5):
 
 * ``query_topology`` — *parametric*. One ``kind`` argument
-  (``dependents`` / ``dependencies`` / ``path``) selects between the
-  three T4 (#451) recursive-CTE read shapes. The per-shape verbs are
-  **not** registered as separate MCP tools — that would be the
-  per-op-tool anti-pattern CLAUDE.md's "What MEHO is NOT" bullet 1
-  forbids. ``topology.refresh`` is deliberately absent from the agent
-  surface: it is the operator CLI verb ``meho topology refresh
-  <target>`` (Initiative #363 item 10 amendment, 2026-05-14).
+  (``dependents`` / ``dependencies`` / ``path`` / ``edges``) selects
+  between the three T4 (#451) recursive-CTE traversal shapes and the
+  G9.2-T4 (#596) flat edge listing. The per-shape verbs are **not**
+  registered as separate MCP tools — that would be the per-op-tool
+  anti-pattern CLAUDE.md's "What MEHO is NOT" bullet 1 forbids.
+  ``topology.refresh`` is deliberately absent from the agent surface:
+  it is the operator CLI verb ``meho topology refresh <target>``
+  (Initiative #363 item 10 amendment, 2026-05-14). The
+  ``kind="edges"`` facet replaces what would otherwise be a fifth
+  ``list_edges`` meta-tool — the curated-edge inventory survey collapses
+  into the same parametric tool (Initiative #364 §9 CLAUDE.md naming
+  alignment).
 * ``list_targets`` — enumerate the operator's accessible infrastructure
   targets so an agent can pick a target before a ``call_operation`` or
   a ``query_topology`` call.
+* ``meho.topology.annotate`` / ``meho.topology.unannotate`` — admin
+  meta-tools (``tenant_admin`` only) for the curated-edge write half
+  (G9.2-T3 #595). Live in the ``meho.*`` admin namespace per Initiative
+  #364 §9 — not on the daily ~17 meta-tool agent surface. Visible only
+  to a ``tenant_admin``-scoped session; an ``operator``-role caller
+  sees neither in ``tools/list`` and a direct ``tools/call`` is
+  rejected at the dispatcher's call-time RBAC re-check
+  (``handlers._operator_meets_required_role`` → JSON-RPC ``-32602``
+  ``forbidden``; there is no HTTP-403 on the MCP transport).
 
 Why direct substrate calls, not REST wrappers
 =============================================
@@ -69,23 +82,34 @@ rejected at the schema layer before the handler runs.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Final
 
 from sqlalchemy import select
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GraphEdgeKind, Tenant
 from meho_backplane.db.models import Target as TargetORM
-from meho_backplane.db.models import Tenant
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.operations._lookup import parse_connector_id
+from meho_backplane.topology.annotate import (
+    AutoEdgeDeletionError,
+    InvalidEdgeKindError,
+    NodeRef,
+    UnannotateSelectorError,
+    annotate_edge,
+    unannotate_edge,
+)
 from meho_backplane.topology.query import (
     AmbiguousNodeError,
     find_dependencies,
     find_dependents,
     find_path,
+    list_edges,
 )
+from meho_backplane.topology.resolvers import NodeNotFoundError
 
 __all__: list[str] = []
 
@@ -107,18 +131,35 @@ _DEPTH_MAX: Final[int] = 64
 _MAX_HOPS_DEFAULT: Final[int] = 8
 _MAX_HOPS_MAX: Final[int] = 32
 
+#: ``edges`` facet defaults / ceilings. Mirror the T4 service substrate
+#: bounds (``query._DEFAULT_EDGE_LIMIT`` = 200, ``query._MAX_EDGE_LIMIT``
+#: = 1000) and the T5 REST cap so the four fronts (REST / CLI / MCP /
+#: REPL) clamp the inventory survey identically.
+_EDGES_LIMIT_DEFAULT: Final[int] = 200
+_EDGES_LIMIT_MAX: Final[int] = 1000
+
+#: Canonical ``GraphEdgeKind`` values, materialised once at module load
+#: so the inputSchema enum + the kind_filter description stay in lock-step
+#: with :class:`~meho_backplane.db.models.GraphEdgeKind` without
+#: duplicating the ten-string list. A future widening of the enum
+#: surfaces in both the schema and the description automatically.
+_EDGE_KIND_VALUES: Final[list[str]] = sorted(k.value for k in GraphEdgeKind)
+
 
 _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
     "type": "object",
     "properties": {
         "kind": {
             "type": "string",
-            "enum": ["dependents", "dependencies", "path"],
+            "enum": ["dependents", "dependencies", "path", "edges"],
             "description": (
-                "Which traversal to run. `dependents` = reverse closure "
+                "Which read shape to run. `dependents` = reverse closure "
                 "(what depends on `target`); `dependencies` = forward "
                 "closure (what `target` depends on); `path` = shortest "
-                "unweighted route between `from_name` and `to_name`."
+                "unweighted route between `from_name` and `to_name`; "
+                "`edges` = flat tenant-scoped listing of `graph_edge` "
+                "rows (the inventory-survey shape, replaces a "
+                "standalone `list_edges` meta-tool)."
             ),
         },
         "target": {
@@ -134,26 +175,80 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
         "from_name": {
             "type": ["string", "null"],
             "description": (
-                "Path start node name. Required when `kind` is `path`; ignored otherwise."
+                "Path start node name. Required when `kind` is `path`. "
+                "For `kind=edges`, optional filter restricting the "
+                "listing to edges whose `from` endpoint resolves to "
+                "this node. Ignored for the closure kinds."
             ),
             "maxLength": 256,
         },
         "to_name": {
             "type": ["string", "null"],
             "description": (
-                "Path end node name. Required when `kind` is `path`; ignored otherwise."
+                "Path end node name. Required when `kind` is `path`. "
+                "For `kind=edges`, optional filter restricting the "
+                "listing to edges whose `to` endpoint resolves to this "
+                "node. Ignored for the closure kinds."
             ),
             "maxLength": 256,
         },
         "kind_filter": {
             "type": ["string", "null"],
             "description": (
-                "Optional `graph_edge.kind` filter for `dependents` / "
-                "`dependencies` (e.g. `runs-on`, `mounts`, "
-                "`routes-through`, `belongs-to`). Restricts the walk to "
-                "edges of that kind. Ignored for `path`."
+                "Optional `graph_edge.kind` filter. For the closure "
+                "kinds, restricts the walk to edges of that kind "
+                "(e.g. `runs-on`, `mounts`, `routes-through`, "
+                "`belongs-to`). For `kind=edges`, restricts the flat "
+                "listing to edges of that kind. Closed v0.2 vocabulary: "
+                f"one of {_EDGE_KIND_VALUES}. Ignored for `path`."
             ),
             "maxLength": 64,
+        },
+        "source": {
+            "type": ["string", "null"],
+            "enum": [None, "auto", "curated"],
+            "description": (
+                "Optional `graph_edge.source` filter for `kind=edges`: "
+                "`auto` for probe-derived edges (G9.1 refresh service), "
+                "`curated` for operator-asserted ones "
+                "(`meho.topology.annotate`). Omit to list both. "
+                "Ignored for the closure kinds and `path`."
+            ),
+        },
+        "conflicts": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When `true` with `kind=edges`, restrict the listing to "
+                "edges carrying a non-empty `properties.conflicts_with` "
+                "marker — the recoverability view for §6 conflicts "
+                "(annotations contradicting probe-derived auto edges). "
+                "Ignored for the closure kinds and `path`."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": _EDGES_LIMIT_MAX,
+            "default": _EDGES_LIMIT_DEFAULT,
+            "description": (
+                f"Page size for `kind=edges` (default "
+                f"{_EDGES_LIMIT_DEFAULT}; ceiling {_EDGES_LIMIT_MAX}, "
+                "matching the substrate `list_edges` cap). Ignored for "
+                "the closure kinds and `path`."
+            ),
+        },
+        "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": (
+                "Rows to skip before the first returned edge "
+                "(`kind=edges` only). Combined with the substrate's "
+                "stable `(last_seen DESC NULLS LAST, id)` order, a "
+                "paged sweep reassembles to the unpaged result with no "
+                "gaps. Ignored for the closure kinds and `path`."
+            ),
         },
         "node_kind": {
             "type": ["string", "null"],
@@ -227,27 +322,34 @@ _QUERY_TOPOLOGY_DESCRIPTION: Final[str] = (
     "resource that I'd break?' (the blast-radius check: call this "
     "*before* recommending a destructive op). Use `kind=dependencies` to "
     "understand what a resource needs. Use `kind=path` to trace "
-    "connectivity between two specific resources. Tenant-scoped "
-    "automatically.\n\n"
+    "connectivity between two specific resources. Use `kind=edges` for "
+    "the flat inventory survey — list curated / auto edges with "
+    "optional filters; pair with `conflicts=true` to surface §6 "
+    "conflicts that need operator review. Tenant-scoped automatically.\n\n"
     "WHEN TO CALL: before suggesting any delete/shutdown/detach — "
     "'is it safe to delete namespace customer-a-prod-foo?' → "
     "`query_topology {kind: dependents, target: customer-a-prod-foo}` "
     "returns every service / ingress / database that would break. Also "
     "for impact reasoning ('what does this VM run on?') and reachability "
-    "('is there any route from this ingress to that datastore?').\n\n"
+    "('is there any route from this ingress to that datastore?'). For "
+    "`kind=edges`: 'show the curated edges in this tenant' → "
+    "`{kind: edges, source: curated}`; 'are any annotations in conflict?'"
+    " → `{kind: edges, conflicts: true}`.\n\n"
     "PARAMETRIC: `kind` is the discriminator — `dependents` / "
     "`dependencies` need `target`; `path` needs `from_name` + "
-    "`to_name`. The three shapes are one tool, not three: there is no "
-    "separate `topology.dependents` tool. If a name is ambiguous in the "
-    "tenant (same name as both, e.g., a target and a vm) pass "
-    "`node_kind` to pin the anchor; an ambiguous bare name returns "
-    "-32602 naming the candidate kinds.\n\n"
+    "`to_name`; `edges` has no required field (every filter is "
+    "optional). The four shapes are one tool, not four: there is no "
+    "separate `topology.dependents` / `list_edges` tool. If a name is "
+    "ambiguous in the tenant (same name as both, e.g., a target and a "
+    "vm) pass `node_kind` to pin the anchor; an ambiguous bare name "
+    "returns -32602 naming the candidate kinds.\n\n"
     "Returns `{kind, nodes: [TopologyNode, ...]}` for the closure kinds "
     "(root at depth 0, so a one-element list means 'exists but nothing "
     "depends on it' and an empty list means 'no such node in this "
     'tenant\'); `{kind: "path", path: TopologyPath|null}` for `path` '
     "(null = unreachable within `max_hops`, a valid answer, not an "
-    "error)."
+    'error); `{kind: "edges", edges: [TopologyEdge, ...]}` for `edges` '
+    "(flat list, ordered by `last_seen DESC NULLS LAST, id`)."
 )
 
 
@@ -289,6 +391,9 @@ async def _query_topology_handler(
                 kind_filter=arguments.get("kind_filter"),
             )
             return {"kind": kind, "nodes": [n.model_dump(mode="json") for n in nodes]}
+        if kind == "edges":
+            edges = await _list_edges_facet(operator, arguments)
+            return {"kind": kind, "edges": [e.model_dump(mode="json") for e in edges]}
         # kind == "path" — the enum + schema guarantee no other value.
         result = await find_path(
             operator,
@@ -306,6 +411,40 @@ async def _query_topology_handler(
     }
 
 
+async def _list_edges_facet(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> list[Any]:
+    """Dispatch the ``kind="edges"`` facet to the G9.2-T4 substrate.
+
+    Opens a session and forwards the optional filters
+    (``kind_filter``/``source``/``from_name``/``to_name``/``conflicts``/
+    ``limit``/``offset``) to :func:`list_edges`. The tenant scope is the
+    operator's tenant — never lifted from *arguments* — so there is no
+    cross-tenant probe via this surface even with a smuggled
+    ``tenant_id`` (``additionalProperties: false`` already rejects that
+    at the schema layer).
+
+    :class:`AmbiguousNodeError` from ``list_edges``'s endpoint resolver
+    is caught by the outer handler's ``try/except`` and surfaces as
+    JSON-RPC ``-32602`` with the candidate kinds named — the same
+    contract the closure kinds use.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return await list_edges(
+            session,
+            operator.tenant_id,
+            kind=arguments.get("kind_filter"),
+            source=arguments.get("source"),
+            from_ref=arguments.get("from_name"),
+            to_ref=arguments.get("to_name"),
+            conflicts_only=bool(arguments.get("conflicts", False)),
+            limit=int(arguments.get("limit", _EDGES_LIMIT_DEFAULT)),
+            offset=int(arguments.get("offset", 0)),
+        )
+
+
 register_mcp_tool(
     definition=ToolDefinition(
         name=_QUERY_TOPOLOGY_NAME,
@@ -316,7 +455,7 @@ register_mcp_tool(
             "properties": {
                 "kind": {
                     "type": "string",
-                    "enum": ["dependents", "dependencies", "path"],
+                    "enum": ["dependents", "dependencies", "path", "edges"],
                 },
                 "nodes": {
                     "type": "array",
@@ -332,6 +471,15 @@ register_mcp_tool(
                     "description": (
                         "Present for `kind=path`. A TopologyPath, or null "
                         "when the target is unreachable within `max_hops`."
+                    ),
+                },
+                "edges": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Present for `kind=edges`. TopologyEdge rows "
+                        "ordered (last_seen DESC NULLS LAST, id). See "
+                        "`meho_backplane.topology.schemas.TopologyEdge`."
                     ),
                 },
             },
@@ -552,4 +700,426 @@ register_mcp_tool(
         op_class="read",
     ),
     handler=_list_targets_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# meho.topology.annotate / meho.topology.unannotate — admin namespace
+# ---------------------------------------------------------------------------
+#
+# Task #598 (G9.2-T7). Two admin meta-tools in the ``meho.*`` namespace
+# expose the curated-edge write half (#595) to a ``tenant_admin``-scoped
+# MCP session. The handlers call :func:`annotate_edge` /
+# :func:`unannotate_edge` directly — the service primitive owns its own
+# resolve / validate / upsert / §6 conflict scan / audit / broadcast — so
+# the MCP front is a thin parameter shim, not a re-derivation of the
+# write path. CLAUDE.md "What MEHO is NOT" bullet 2: REST / CLI / MCP are
+# sibling fronts on one backplane; none is a thin wrapper of another.
+#
+# Naming: ``from_name`` / ``to_name`` (not ``from`` / ``to``) — ``from``
+# is a Python keyword the wider topology module already aliases (see
+# ``query_topology``'s schema for the same convention). Keeping the
+# names consistent across all four MCP topology tools lets an agent
+# carry a node-pair through ``query_topology(path)`` →
+# ``meho.topology.annotate`` without renaming.
+
+
+_ANNOTATE_TOOL_NAME: Final[str] = "meho.topology.annotate"
+_UNANNOTATE_TOOL_NAME: Final[str] = "meho.topology.unannotate"
+
+
+_ANNOTATE_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "from_name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": (
+                "`graph_node.name` of the edge's `from` endpoint. "
+                "Resolved against the operator's tenant (cross-tenant "
+                "is structurally impossible — no `tenant_id` argument)."
+            ),
+        },
+        "kind": {
+            "type": "string",
+            "enum": _EDGE_KIND_VALUES,
+            "description": (
+                "Closed v0.2 edge-kind vocabulary. Operator-curated "
+                "kinds (`authenticates-via`, `depends-on`, "
+                "`replicates-to`, `backed-up-by`, `routes-via`, "
+                "`policy-binds`) cover the cross-system relationships "
+                "auto-discovery cannot infer — those are the canonical "
+                "use cases. The four auto-discoverable kinds "
+                "(`runs-on`, `mounts`, `routes-through`, `belongs-to`) "
+                "are accepted too but ANNOTATING THEM IS NOISE: probes "
+                "already write them and the next refresh will mark "
+                "your assertion as a §6 conflict marker."
+            ),
+        },
+        "to_name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": (
+                "`graph_node.name` of the edge's `to` endpoint. Same "
+                "resolution rules as `from_name`."
+            ),
+        },
+        "from_node_kind": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional `graph_node.kind` pin for the `from_name` "
+                "endpoint. Required only when the bare name resolves to "
+                "multiple kinds in the tenant (e.g. a `target` and a "
+                "`vm` both named `app`); an ambiguous bare name returns "
+                "-32602 naming the candidate kinds."
+            ),
+            "maxLength": 64,
+        },
+        "to_node_kind": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional `graph_node.kind` pin for the `to_name` "
+                "endpoint. Same contract as `from_node_kind`."
+            ),
+            "maxLength": 64,
+        },
+        "note": {
+            "type": ["string", "null"],
+            "maxLength": 2048,
+            "description": (
+                "Optional free-text annotation stored on "
+                "`graph_edge.properties.note`. Use to record the "
+                "operational rationale — 'Vault role `k8s-prod-read` "
+                "binds to namespace `prod`; rotated 2026-04-22'."
+            ),
+        },
+        "evidence_url": {
+            "type": ["string", "null"],
+            "maxLength": 2048,
+            "description": (
+                "Optional URL the operator attached as evidence "
+                "(typically an INVENTORY.md anchor / runbook). Stored "
+                "on `graph_edge.properties.evidence_url`."
+            ),
+        },
+    },
+    "required": ["from_name", "kind", "to_name"],
+    "additionalProperties": False,
+}
+
+
+_ANNOTATE_DESCRIPTION: Final[str] = (
+    "Assert a curated `graph_edge` that auto-discovery cannot infer "
+    "(tenant_admin only). The canonical use case is a cross-system "
+    "relationship the probes can't see — `k8s-sa-foo` "
+    "`authenticates-via` `vault-role-bar`, `service-X` `depends-on` "
+    "`database-Y`. Idempotent on the `(from_name, kind, to_name)` "
+    "triple: re-annotate refreshes `last_seen` + `properties` rather "
+    "than erroring. Tenant-scoped automatically — no `tenant_id` "
+    "argument (cross-tenant annotation is structurally impossible).\n\n"
+    "WHEN TO CALL: an operator asks 'record that the prod namespace "
+    "authenticates against the rdc-vault role binding' — "
+    "`meho.topology.annotate {from_name: prod, kind: "
+    "authenticates-via, to_name: rdc-vault-role-bar}`. After this, "
+    "`query_topology {kind: dependents, target: rdc-vault-role-bar}` "
+    "surfaces the namespace in the blast radius.\n\n"
+    "DO NOT use to annotate edges the probes already discover "
+    "(`runs-on`, `mounts`, `routes-through`, `belongs-to`) — those "
+    "would land as §6 conflict markers (`conflicts_with`) and clutter "
+    "the inventory survey without semantic gain. Use a curated-only "
+    "kind for cross-system assertions: `authenticates-via`, "
+    "`depends-on`, `replicates-to`, `backed-up-by`, `routes-via`, "
+    "`policy-binds`.\n\n"
+    "Returns `{edge_id, from: {id, kind, name}, to: {id, kind, name}, "
+    'kind, source: "curated", superseded: [<auto-edge-id>...], '
+    "conflicts: [<edge-id>...]}`. `superseded` lists auto edges this "
+    "annotation displaced (same kind, different endpoint); `conflicts` "
+    "lists edges of an incompatible kind over the same endpoint pair. "
+    "Both lists are diagnostics — the recovery flow is to "
+    "`meho.topology.unannotate` this edge."
+)
+
+
+async def _annotate_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a ``meho.topology.annotate`` call to :func:`annotate_edge`.
+
+    Opens a session, builds the two :class:`NodeRef` objects, and
+    forwards to the substrate. The service primitive owns the resolve /
+    validate / upsert / §6 conflict scan / audit / broadcast — this
+    shim does not duplicate any of it.
+
+    Failure-mode translation:
+
+    * :class:`AmbiguousNodeError` and :class:`NodeNotFoundError` →
+      ``-32602`` (operator-actionable input problem; same shape the
+      closure kinds use).
+    * :class:`InvalidEdgeKindError` is structurally unreachable —
+      ``kind`` is enum-pinned by the inputSchema — but the catch is
+      retained as a belt-and-suspenders guard against a future enum
+      drift between :class:`GraphEdgeKind` and the cached
+      :data:`_EDGE_KIND_VALUES`.
+    """
+    sessionmaker = get_sessionmaker()
+    from_name: str = arguments["from_name"]
+    to_name: str = arguments["to_name"]
+    kind: str = arguments["kind"]
+    try:
+        async with sessionmaker() as session:
+            edge = await annotate_edge(
+                session,
+                operator,
+                NodeRef(from_name, arguments.get("from_node_kind")),
+                kind,
+                NodeRef(to_name, arguments.get("to_node_kind")),
+                note=arguments.get("note"),
+                evidence_url=arguments.get("evidence_url"),
+            )
+            # Re-load the endpoint nodes for the response shape. The
+            # service returns the edge only; mapping back to the
+            # human-readable `(kind, name)` pair is the front's job.
+            from meho_backplane.db.models import GraphNode
+
+            from_node = await session.get(GraphNode, edge.from_node_id)
+            to_node = await session.get(GraphNode, edge.to_node_id)
+    except (AmbiguousNodeError, NodeNotFoundError, InvalidEdgeKindError) as exc:
+        raise McpInvalidParamsError(str(exc)) from exc
+
+    if from_node is None or to_node is None:
+        # Endpoint resolution succeeded inside the service transaction
+        # but the post-commit reload missed — graph in inconsistent
+        # state. Surface as -32602 with a diagnostic; the audit /
+        # broadcast emitted inside annotate_edge is already committed.
+        raise McpInvalidParamsError(f"annotated edge {edge.id} endpoint lookup failed post-commit")
+
+    props = edge.properties or {}
+    raw_conflicts = props.get("conflicts_with")
+    conflicts = list(raw_conflicts) if isinstance(raw_conflicts, list) else []
+    return {
+        "edge_id": str(edge.id),
+        "from": {
+            "id": str(from_node.id),
+            "kind": from_node.kind,
+            "name": from_node.name,
+        },
+        "to": {
+            "id": str(to_node.id),
+            "kind": to_node.kind,
+            "name": to_node.name,
+        },
+        "kind": edge.kind,
+        "source": edge.source,
+        "conflicts": conflicts,
+    }
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_ANNOTATE_TOOL_NAME,
+        description=_ANNOTATE_DESCRIPTION,
+        inputSchema=_ANNOTATE_INPUT_SCHEMA,
+        outputSchema={
+            "type": "object",
+            "properties": {
+                "edge_id": {"type": "string"},
+                "from": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "kind": {"type": "string"},
+                        "name": {"type": "string"},
+                    },
+                    "required": ["id", "kind", "name"],
+                },
+                "to": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "kind": {"type": "string"},
+                        "name": {"type": "string"},
+                    },
+                    "required": ["id", "kind", "name"],
+                },
+                "kind": {"type": "string"},
+                "source": {"type": "string"},
+                "conflicts": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": ["edge_id", "from", "to", "kind", "source", "conflicts"],
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class="write",
+    ),
+    handler=_annotate_handler,
+)
+
+
+# --- unannotate ----------------------------------------------------------
+
+
+_UNANNOTATE_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "edge_id": {
+            "type": ["string", "null"],
+            "description": (
+                "UUID of the curated `graph_edge` to remove. Mutually "
+                "exclusive with the `(from_name, kind, to_name)` triple — "
+                "pass exactly one selector form."
+            ),
+            "minLength": 1,
+            "maxLength": 64,
+        },
+        "from_name": {
+            "type": ["string", "null"],
+            "description": (
+                "Triple selector: the edge's `from` endpoint name. Must "
+                "appear together with `kind` and `to_name` (or with "
+                "neither, when using `edge_id`)."
+            ),
+            "maxLength": 256,
+        },
+        "kind": {
+            "type": ["string", "null"],
+            "enum": [None, *_EDGE_KIND_VALUES],
+            "description": (
+                "Triple selector: the edge's `graph_edge.kind`. Must "
+                "appear together with `from_name` and `to_name`."
+            ),
+        },
+        "to_name": {
+            "type": ["string", "null"],
+            "description": (
+                "Triple selector: the edge's `to` endpoint name. Must "
+                "appear together with `from_name` and `kind`."
+            ),
+            "maxLength": 256,
+        },
+        "from_node_kind": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional `graph_node.kind` pin for the `from_name` "
+                "endpoint, used for ambiguity disambiguation."
+            ),
+            "maxLength": 64,
+        },
+        "to_node_kind": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional `graph_node.kind` pin for the `to_name` "
+                "endpoint, used for ambiguity disambiguation."
+            ),
+            "maxLength": 64,
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+_UNANNOTATE_DESCRIPTION: Final[str] = (
+    "Hard-delete a curated `graph_edge` and clear its reciprocal §6 "
+    "markers (tenant_admin only). Pass either `edge_id` OR the full "
+    "`(from_name, kind, to_name)` triple — both forms or partial input "
+    "is rejected at -32602. Tenant-scoped automatically.\n\n"
+    "WHEN TO CALL: an annotation was wrong and needs to be revoked — "
+    "the operator originally asserted `service-X depends-on database-Y` "
+    "but it turns out the real dependency is `database-Z`. "
+    "`meho.topology.unannotate {from_name: service-X, kind: depends-on, "
+    "to_name: database-Y}` removes the curated row and re-promotes any "
+    "auto edge it had marked superseded (§6 recoverability invariant). "
+    "After this, blast-radius checks no longer include the wrong edge.\n\n"
+    "Refuses to delete an `source='auto'` edge — those resurrect on the "
+    "next refresh, making manual deletion meaningless. The refusal "
+    "surfaces as a structured -32602 with `auto-discovered` in the "
+    "message so the operator sees the diagnostic without a separate "
+    "listing call.\n\n"
+    'Returns `{edge_id: "<removed-uuid>"}`.'
+)
+
+
+async def _unannotate_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a ``meho.topology.unannotate`` call to :func:`unannotate_edge`.
+
+    The two selector forms (UUID primary key vs. ``(from, kind, to)``
+    triple) are mutually exclusive at the service layer — passing both
+    or neither raises :class:`UnannotateSelectorError`, which surfaces
+    as ``-32602``.
+
+    :class:`AutoEdgeDeletionError` is the §6 auto-vs-curated refusal —
+    surfaces as ``-32602`` with the substrate's "auto edges resurrect
+    on next refresh" message so the operator gets the diagnostic
+    inline.
+    """
+    edge_id_arg = arguments.get("edge_id")
+    from_name = arguments.get("from_name")
+    kind = arguments.get("kind")
+    to_name = arguments.get("to_name")
+
+    edge_uuid: uuid.UUID | None = None
+    if edge_id_arg is not None:
+        try:
+            edge_uuid = uuid.UUID(edge_id_arg)
+        except ValueError as exc:
+            raise McpInvalidParamsError(
+                f"meho.topology.unannotate: edge_id is not a valid UUID: {edge_id_arg!r}",
+            ) from exc
+
+    from_ref = NodeRef(from_name, arguments.get("from_node_kind")) if from_name else None
+    to_ref = NodeRef(to_name, arguments.get("to_node_kind")) if to_name else None
+
+    sessionmaker = get_sessionmaker()
+    try:
+        async with sessionmaker() as session:
+            removed_id = await unannotate_edge(
+                session,
+                operator,
+                edge_id=edge_uuid,
+                from_ref=from_ref,
+                kind=kind,
+                to_ref=to_ref,
+            )
+    except (
+        AmbiguousNodeError,
+        NodeNotFoundError,
+        InvalidEdgeKindError,
+        UnannotateSelectorError,
+        AutoEdgeDeletionError,
+    ) as exc:
+        raise McpInvalidParamsError(str(exc)) from exc
+    except ValueError as exc:
+        # ``unannotate_edge`` raises plain ``ValueError`` when the
+        # selector resolves to no row (or to a row in another tenant —
+        # the boundary case the service treats as not-found). That is
+        # an operator-actionable input problem, so surface as -32602
+        # rather than letting it become -32603 Internal Error.
+        raise McpInvalidParamsError(str(exc)) from exc
+
+    return {"edge_id": str(removed_id)}
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_UNANNOTATE_TOOL_NAME,
+        description=_UNANNOTATE_DESCRIPTION,
+        inputSchema=_UNANNOTATE_INPUT_SCHEMA,
+        outputSchema={
+            "type": "object",
+            "properties": {
+                "edge_id": {"type": "string"},
+            },
+            "required": ["edge_id"],
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class="write",
+    ),
+    handler=_unannotate_handler,
 )

--- a/backend/tests/test_mcp_tools_topology.py
+++ b/backend/tests/test_mcp_tools_topology.py
@@ -146,16 +146,22 @@ def test_query_topology_input_schema_is_conditional_on_kind(
     schema = tools["query_topology"]["inputSchema"]
     assert schema["required"] == ["kind"]
     assert schema["additionalProperties"] is False
+    # G9.2-T7 (#598) widened the enum with the `edges` facet (replaces a
+    # standalone list_edges meta-tool); the closure / path branches and
+    # their conditional requireds stay unchanged.
     assert schema["properties"]["kind"]["enum"] == [
         "dependents",
         "dependencies",
         "path",
+        "edges",
     ]
     conditionals = schema["allOf"]
     by_kind = {c["if"]["properties"]["kind"]["const"]: c["then"]["required"] for c in conditionals}
     assert by_kind["dependents"] == ["target"]
     assert by_kind["dependencies"] == ["target"]
     assert sorted(by_kind["path"]) == ["from_name", "to_name"]
+    # `edges` has no required field — all filters are optional.
+    assert "edges" not in by_kind
     # MEHO-internal fields stripped from the wire shape.
     assert "required_role" not in tools["query_topology"]
     assert "op_class" not in tools["query_topology"]

--- a/backend/tests/test_mcp_tools_topology_annotate.py
+++ b/backend/tests/test_mcp_tools_topology_annotate.py
@@ -1,0 +1,764 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G9.2-T7 (#598) admin meta-tools + edges facet.
+
+Three surfaces land here:
+
+* ``meho.topology.annotate`` — tenant_admin-only write meta-tool.
+  Calls :func:`annotate_edge` (#595) directly; one audit row + one
+  broadcast event per call (the service primitive owns both — the
+  dispatcher's own audit row at ``/mcp/tools/call/...`` is a second,
+  per-call row on a different ``method`` axis).
+* ``meho.topology.unannotate`` — tenant_admin-only write meta-tool.
+  Same direct-substrate shape; refuses an `source='auto'` row with a
+  structured -32602 (the auto-vs-curated rule).
+* ``query_topology(kind="edges", ...)`` — the inventory-survey facet
+  on the existing parametric meta-tool. Calls :func:`list_edges`
+  (#596) directly; reuses the substrate's `(last_seen DESC NULLS LAST,
+  id)` order and the closed v0.2 edge-kind vocabulary filter.
+
+Coverage maps to the issue acceptance criteria:
+
+* Both admin tools register with ``required_role=TENANT_ADMIN`` and
+  ``op_class='write'``; a non-admin session does not see them in
+  ``tools/list``; a direct ``tools/call`` from a non-admin returns
+  -32602 with a ``forbidden``-prefixed message.
+* ``tools/call meho.topology.annotate {...}`` creates a curated edge
+  (idempotent on repeat) and emits one audit row + one broadcast event.
+* ``query_topology {kind: edges, source: curated}`` returns only the
+  tenant's curated edges; ``conflicts: true`` narrows to conflicted
+  ones; no separate ``list_edges`` tool was registered.
+* ``meho.topology.unannotate`` on an auto edge returns a structured
+  error mentioning the auto-vs-curated rule.
+* Tool descriptions name the when-to-call use case + warn against
+  annotating auto-discoverable kinds (the AI-engineering anchor).
+
+The G9.2-T3 service is exercised at the substrate level by
+:mod:`tests.test_topology_annotate`; this module's annotate / unannotate
+happy-path tests run against the SQLite-migrated test DB so the
+end-to-end MCP → service path is covered. The `kind="edges"` dispatch
+patches :func:`list_edges` at the tool's import site to keep the test
+focused on the MCP dispatch shape (the substrate is covered by
+:mod:`tests.integration.test_topology_list_edges`).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode, Tenant
+from meho_backplane.mcp.registry import get_tool
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.topology.schemas import TopologyEdge, TopologyEdgeEndpoint
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+# Patch sites — `from meho_backplane.topology... import <symbol>` rebinds
+# the symbol into ``mcp.tools.topology``'s module dict, so the local
+# name is the patchable reference.
+_LIST_EDGES_PATCH = "meho_backplane.mcp.tools.topology.list_edges"
+_PUBLISH_PATCH = "meho_backplane.topology.annotate.publish_event"
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def _seeded_tenant() -> AsyncIterator[None]:
+    """Insert the operator's :class:`Tenant` row so endpoint resolution finds it.
+
+    The autouse ``_default_database_url`` fixture in :mod:`tests.conftest`
+    migrates the schema; we own the tenant row insert.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            Tenant(
+                id=OPERATOR_TENANT_ID,
+                slug="op-tenant",
+                name="Op Tenant",
+            ),
+        )
+    yield
+
+
+async def _seed_node(*, kind: str, name: str) -> uuid.UUID:
+    """Insert one ``graph_node`` row in the operator's tenant; return its id."""
+    sessionmaker = get_sessionmaker()
+    node_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphNode(
+                id=node_id,
+                tenant_id=OPERATOR_TENANT_ID,
+                kind=kind,
+                name=name,
+                target_id=None,
+                properties={},
+                discovered_by="test",
+                first_seen=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    return node_id
+
+
+async def _seed_auto_edge(
+    *,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    kind: str,
+) -> uuid.UUID:
+    """Insert one ``source='auto'`` ``graph_edge`` row."""
+    sessionmaker = get_sessionmaker()
+    edge_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    async with sessionmaker() as session:
+        session.add(
+            GraphEdge(
+                id=edge_id,
+                tenant_id=OPERATOR_TENANT_ID,
+                from_node_id=from_id,
+                to_node_id=to_id,
+                kind=kind,
+                source="auto",
+                properties={},
+                discovered_by="test",
+                first_seen=now,
+                last_seen=now,
+            )
+        )
+        await session.commit()
+    return edge_id
+
+
+def _annotate_call(client: TestClient, call_id: int, arguments: dict[str, Any]) -> Any:
+    return client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": "meho.topology.annotate", "arguments": arguments},
+        },
+    )
+
+
+def _unannotate_call(client: TestClient, call_id: int, arguments: dict[str, Any]) -> Any:
+    return client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": "meho.topology.unannotate", "arguments": arguments},
+        },
+    )
+
+
+def _query_topology_call(
+    client: TestClient,
+    call_id: int,
+    arguments: dict[str, Any],
+) -> Any:
+    return client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": "query_topology", "arguments": arguments},
+        },
+    )
+
+
+def _make_edge(
+    *,
+    edge_id: UUID | None = None,
+    from_name: str = "svc-x",
+    from_kind: str = "service",
+    to_name: str = "db-y",
+    to_kind: str = "database",
+    kind: str = "depends-on",
+    source: str = "curated",
+    properties: dict[str, Any] | None = None,
+) -> TopologyEdge:
+    return TopologyEdge(
+        id=edge_id or uuid.uuid4(),
+        from_endpoint=TopologyEdgeEndpoint(id=uuid.uuid4(), kind=from_kind, name=from_name),
+        to_endpoint=TopologyEdgeEndpoint(id=uuid.uuid4(), kind=to_kind, name=to_name),
+        kind=kind,
+        source=source,
+        properties=properties or {},
+        last_seen=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration + narrow-waist
+# ---------------------------------------------------------------------------
+
+
+def test_admin_tools_register_with_tenant_admin_and_write() -> None:
+    """Both admin tools land with TENANT_ADMIN gate + write op_class."""
+    for tool_name in ("meho.topology.annotate", "meho.topology.unannotate"):
+        entry = get_tool(tool_name)
+        assert entry is not None, f"{tool_name} not registered"
+        defn, _handler = entry
+        assert defn.required_role == TenantRole.TENANT_ADMIN
+        assert defn.op_class == "write"
+
+
+def test_no_separate_list_edges_tool_registered() -> None:
+    """``list_edges`` is a facet on ``query_topology``, not its own tool.
+
+    Initiative #364 §9 / CLAUDE.md postulate 5: the inventory survey
+    collapses into the parametric meta-tool. A standalone ``list_edges``
+    tool would re-introduce the per-verb anti-pattern.
+    """
+    assert get_tool("list_edges") is None
+
+
+def test_query_topology_input_schema_includes_edges_facet() -> None:
+    """The kind enum widened to include 'edges' with no extra required field."""
+    entry = get_tool("query_topology")
+    assert entry is not None
+    defn, _ = entry
+    schema = defn.inputSchema
+    assert schema["properties"]["kind"]["enum"] == [
+        "dependents",
+        "dependencies",
+        "path",
+        "edges",
+    ]
+    # No 4th `allOf` clause is needed — `edges` has no required fields.
+    # The other three branches stay as-is.
+    by_kind = {
+        c["if"]["properties"]["kind"]["const"]: c["then"]["required"] for c in schema["allOf"]
+    }
+    assert "edges" not in by_kind
+    assert by_kind["dependents"] == ["target"]
+    assert by_kind["dependencies"] == ["target"]
+    # The new filter knobs surface as optional properties on the schema.
+    for prop in ("source", "conflicts", "limit", "offset"):
+        assert prop in schema["properties"]
+
+
+def test_query_topology_output_schema_widened_for_edges() -> None:
+    """The outputSchema also names the 'edges' facet."""
+    entry = get_tool("query_topology")
+    assert entry is not None
+    defn, _ = entry
+    out = defn.outputSchema
+    assert out is not None
+    assert "edges" in out["properties"]
+    assert "edges" in out["properties"]["kind"]["enum"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_admin_tools_hidden_from_non_admin_tools_list(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Operator-role session does not see the admin tools in ``tools/list``."""
+    client, _op = client_with_operator
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "meho.topology.annotate" not in names
+    assert "meho.topology.unannotate" not in names
+    # Read-half tools stay visible.
+    assert "query_topology" in names
+    assert "list_targets" in names
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_admin_tools_visible_to_tenant_admin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """tenant_admin session sees both admin tools in ``tools/list``."""
+    client, _op = client_with_operator
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    )
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "meho.topology.annotate" in names
+    assert "meho.topology.unannotate" in names
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_admin_tool_call_from_non_admin_is_forbidden(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Direct tools/call from an operator-role session → -32602 forbidden."""
+    client, _op = client_with_operator
+    response = _annotate_call(
+        client,
+        3,
+        {
+            "from_name": "svc-x",
+            "kind": "depends-on",
+            "to_name": "db-y",
+        },
+    )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# meho.topology.annotate — end-to-end via the SQLite test DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_annotate_creates_curated_edge_and_emits_audit_plus_broadcast(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """tools/call meho.topology.annotate {...} → curated row + 1 audit + 1 broadcast.
+
+    The dispatcher writes its own audit row at
+    ``/mcp/tools/call/meho.topology.annotate`` (the per-MCP-call axis),
+    and ``annotate_edge`` writes a second row keyed
+    ``op_id='topology.annotate'`` (the service-level axis). The
+    issue's "one audit row + one broadcast event" applies to the
+    service emission — verified here.
+    """
+    client, _op = client_with_operator
+    await _seed_node(kind="principal", name="k8s-sa-foo")
+    await _seed_node(kind="vault-role", name="vault-role-bar")
+
+    with patch(_PUBLISH_PATCH, new=AsyncMock()) as publish_mock:
+        response = _annotate_call(
+            client,
+            10,
+            {
+                "from_name": "k8s-sa-foo",
+                "from_node_kind": "principal",
+                "kind": "authenticates-via",
+                "to_name": "vault-role-bar",
+                "to_node_kind": "vault-role",
+                "note": "canonical k8s SA → Vault role",
+                "evidence_url": "https://example.test/inventory#L42",
+            },
+        )
+
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["from"]["name"] == "k8s-sa-foo"
+    assert payload["to"]["name"] == "vault-role-bar"
+    assert payload["kind"] == "authenticates-via"
+    assert payload["source"] == "curated"
+    assert payload["conflicts"] == []
+    assert uuid.UUID(payload["edge_id"])  # valid UUID
+
+    # One curated row in the tenant — the service primitive owns the upsert.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        from sqlalchemy import select
+
+        edges = (
+            (
+                await session.execute(
+                    select(GraphEdge).where(GraphEdge.tenant_id == OPERATOR_TENANT_ID)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        audits = (
+            (
+                await session.execute(
+                    select(AuditLog).where(AuditLog.tenant_id == OPERATOR_TENANT_ID)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(edges) == 1
+    assert edges[0].source == "curated"
+    assert edges[0].properties["note"] == "canonical k8s SA → Vault role"
+
+    # Exactly one service-level audit row + one MCP dispatcher row.
+    service_rows = [a for a in audits if a.path == "topology.annotate"]
+    dispatcher_rows = [a for a in audits if a.path == "/mcp/tools/call/meho.topology.annotate"]
+    assert len(service_rows) == 1
+    assert service_rows[0].method == "ANNOTATE"
+    assert len(dispatcher_rows) == 1
+
+    # Exactly one broadcast event (the service-level emission).
+    assert publish_mock.await_count == 1
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_annotate_is_idempotent_on_repeat(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """A second annotate of the same triple refreshes properties, not duplicates."""
+    client, _op = client_with_operator
+    fid = await _seed_node(kind="service", name="svc-x")
+    tid = await _seed_node(kind="pod", name="db-y")
+    assert fid is not None and tid is not None
+
+    with patch(_PUBLISH_PATCH, new=AsyncMock()):
+        first = _annotate_call(
+            client,
+            20,
+            {
+                "from_name": "svc-x",
+                "from_node_kind": "service",
+                "kind": "depends-on",
+                "to_name": "db-y",
+                "to_node_kind": "pod",
+                "note": "first",
+            },
+        )
+        second = _annotate_call(
+            client,
+            21,
+            {
+                "from_name": "svc-x",
+                "from_node_kind": "service",
+                "kind": "depends-on",
+                "to_name": "db-y",
+                "to_node_kind": "pod",
+                "note": "second",
+            },
+        )
+
+    assert first.json().get("result"), f"first failed: {first.json()}"
+    assert second.json().get("result"), f"second failed: {second.json()}"
+    first_id = json.loads(first.json()["result"]["content"][0]["text"])["edge_id"]
+    second_id = json.loads(second.json()["result"]["content"][0]["text"])["edge_id"]
+    assert first_id == second_id
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        from sqlalchemy import select
+
+        rows = (
+            (
+                await session.execute(
+                    select(GraphEdge).where(GraphEdge.tenant_id == OPERATOR_TENANT_ID)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    assert rows[0].properties["note"] == "second"
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_annotate_rejects_unknown_kind_at_schema_layer(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A made-up `kind` value fails the inputSchema enum (-32602)."""
+    client, _op = client_with_operator
+    response = _annotate_call(
+        client,
+        30,
+        {
+            "from_name": "a",
+            "kind": "made-up-kind",
+            "to_name": "b",
+        },
+    )
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_annotate_rejects_additional_properties(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A smuggled `tenant_id` is rejected at the schema layer."""
+    client, _op = client_with_operator
+    response = _annotate_call(
+        client,
+        31,
+        {
+            "from_name": "a",
+            "kind": "depends-on",
+            "to_name": "b",
+            "tenant_id": "00000000-0000-0000-0000-000000000099",
+        },
+    )
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# meho.topology.unannotate — auto-edge refusal + happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_unannotate_auto_edge_returns_structured_error(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """Unannotate on an `source='auto'` row → -32602 with auto-discovered message."""
+    client, _op = client_with_operator
+    fid = await _seed_node(kind="vm", name="vm-a")
+    tid = await _seed_node(kind="host", name="host-x")
+    await _seed_auto_edge(from_id=fid, to_id=tid, kind="runs-on")
+
+    response = _unannotate_call(
+        client,
+        40,
+        {
+            "from_name": "vm-a",
+            "from_node_kind": "vm",
+            "kind": "runs-on",
+            "to_name": "host-x",
+            "to_node_kind": "host",
+        },
+    )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "auto-discovered" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_unannotate_curated_edge_via_triple(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """Triple-form unannotate of a curated edge removes the row."""
+    client, _op = client_with_operator
+    await _seed_node(kind="service", name="svc-x")
+    await _seed_node(kind="pod", name="db-y")
+
+    with patch(_PUBLISH_PATCH, new=AsyncMock()):
+        created = _annotate_call(
+            client,
+            50,
+            {
+                "from_name": "svc-x",
+                "from_node_kind": "service",
+                "kind": "depends-on",
+                "to_name": "db-y",
+                "to_node_kind": "pod",
+            },
+        )
+        edge_id = json.loads(created.json()["result"]["content"][0]["text"])["edge_id"]
+        removed = _unannotate_call(
+            client,
+            51,
+            {
+                "from_name": "svc-x",
+                "from_node_kind": "service",
+                "kind": "depends-on",
+                "to_name": "db-y",
+                "to_node_kind": "pod",
+            },
+        )
+
+    body = removed.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["edge_id"] == edge_id
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        from sqlalchemy import select
+
+        rows = (
+            (
+                await session.execute(
+                    select(GraphEdge).where(GraphEdge.tenant_id == OPERATOR_TENANT_ID)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_unannotate_rejects_both_selectors(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Passing both edge_id and triple → -32602 (UnannotateSelectorError)."""
+    client, _op = client_with_operator
+    response = _unannotate_call(
+        client,
+        60,
+        {
+            "edge_id": "00000000-0000-0000-0000-000000000001",
+            "from_name": "a",
+            "kind": "depends-on",
+            "to_name": "b",
+        },
+    )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "exactly one selector" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_unannotate_rejects_malformed_edge_id(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A non-UUID edge_id is caught at the front before service dispatch."""
+    client, _op = client_with_operator
+    response = _unannotate_call(client, 61, {"edge_id": "not-a-uuid"})
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "valid UUID" in body["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# query_topology(kind=edges) facet — dispatch + filter pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_edges_facet_forwards_source_curated_filter(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """kind=edges + source=curated dispatches to list_edges with the filter."""
+    client, op = client_with_operator
+    edges = [_make_edge(source="curated")]
+    mock_list = AsyncMock(return_value=edges)
+    with patch(_LIST_EDGES_PATCH, new=mock_list):
+        response = _query_topology_call(
+            client,
+            70,
+            {"kind": "edges", "source": "curated"},
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["kind"] == "edges"
+    assert len(payload["edges"]) == 1
+    assert payload["edges"][0]["source"] == "curated"
+
+    # Tenant scope comes from the operator — `source` flows through.
+    call_kwargs = mock_list.await_args.kwargs
+    assert call_kwargs["source"] == "curated"
+    assert call_kwargs["conflicts_only"] is False
+    # tenant_id is positional arg 1 (positional[0] is the session).
+    assert mock_list.await_args.args[1] == op.tenant_id
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_edges_facet_conflicts_only_filter(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """kind=edges + conflicts=true narrows to conflict-marked edges."""
+    client, _op = client_with_operator
+    mock_list = AsyncMock(return_value=[])
+    with patch(_LIST_EDGES_PATCH, new=mock_list):
+        response = _query_topology_call(
+            client,
+            71,
+            {"kind": "edges", "conflicts": True},
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload == {"kind": "edges", "edges": []}
+    assert mock_list.await_args.kwargs["conflicts_only"] is True
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_edges_facet_forwards_kind_filter_and_endpoints(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """kind_filter / from_name / to_name / limit / offset all flow through."""
+    client, _op = client_with_operator
+    mock_list = AsyncMock(return_value=[])
+    with patch(_LIST_EDGES_PATCH, new=mock_list):
+        _query_topology_call(
+            client,
+            72,
+            {
+                "kind": "edges",
+                "kind_filter": "depends-on",
+                "from_name": "svc-x",
+                "to_name": "db-y",
+                "limit": 50,
+                "offset": 100,
+            },
+        )
+    kwargs = mock_list.await_args.kwargs
+    assert kwargs["kind"] == "depends-on"
+    assert kwargs["from_ref"] == "svc-x"
+    assert kwargs["to_ref"] == "db-y"
+    assert kwargs["limit"] == 50
+    assert kwargs["offset"] == 100
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_edges_facet_read_role_unchanged(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The edges facet stays on the operator-read gate (no privilege creep).
+
+    The admin meta-tools are the write half; the inventory survey is a
+    read shape and stays at ``required_role=OPERATOR`` so an
+    ``operator``-role session can call it.
+    """
+    client, _op = client_with_operator
+    mock_list = AsyncMock(return_value=[])
+    with patch(_LIST_EDGES_PATCH, new=mock_list):
+        response = _query_topology_call(client, 73, {"kind": "edges"})
+    assert response.json()["result"]["isError"] is False
+
+
+# ---------------------------------------------------------------------------
+# Description audits (AI-engineering anchor: name the use case)
+# ---------------------------------------------------------------------------
+
+
+def test_annotate_description_warns_against_auto_kinds() -> None:
+    """The annotate description steers operators away from auto-discoverable kinds.
+
+    Initiative #364 / G9.2 narrative: annotating an edge probes already
+    discover is noise — the next refresh will mark the assertion as a §6
+    conflict marker and clutter the inventory. The tool description must
+    say so explicitly (the "WHEN TO CALL" + "DO NOT" pair the AI-engineering
+    best-practices anchor recommends).
+    """
+    entry = get_tool("meho.topology.annotate")
+    assert entry is not None
+    desc = entry[0].description
+    assert "WHEN TO CALL" in desc
+    assert "DO NOT" in desc
+    # Names at least the canonical cross-system kinds.
+    assert "authenticates-via" in desc
+    assert "tenant_admin" in desc
+
+
+def test_unannotate_description_names_auto_refusal() -> None:
+    """unannotate description names the auto-vs-curated refusal rule."""
+    entry = get_tool("meho.topology.unannotate")
+    assert entry is not None
+    desc = entry[0].description
+    assert "auto" in desc.lower()
+    assert "tenant_admin" in desc

--- a/backend/tests/test_mcp_tools_topology_annotate.py
+++ b/backend/tests/test_mcp_tools_topology_annotate.py
@@ -308,18 +308,40 @@ def test_admin_tools_visible_to_tenant_admin(
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        (
+            "meho.topology.annotate",
+            {"from_name": "svc-x", "kind": "depends-on", "to_name": "db-y"},
+        ),
+        (
+            "meho.topology.unannotate",
+            {"from_name": "svc-x", "kind": "depends-on", "to_name": "db-y"},
+        ),
+    ],
+    ids=["annotate", "unannotate"],
+)
 def test_admin_tool_call_from_non_admin_is_forbidden(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    tool_name: str,
+    arguments: dict[str, Any],
 ) -> None:
-    """Direct tools/call from an operator-role session → -32602 forbidden."""
+    """tools/call on either admin tool from an operator session → -32602 forbidden.
+
+    Both admin tools share the dispatcher RBAC gate
+    (``required_role=TENANT_ADMIN``); the forbidden refusal must fire
+    before the inputSchema is even consulted, so the rejection is
+    independent of selector shape.
+    """
     client, _op = client_with_operator
-    response = _annotate_call(
-        client,
-        3,
-        {
-            "from_name": "svc-x",
-            "kind": "depends-on",
-            "to_name": "db-y",
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
         },
     )
     body = response.json()
@@ -600,10 +622,17 @@ async def test_unannotate_curated_edge_via_triple(
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-def test_unannotate_rejects_both_selectors(
+def test_unannotate_rejects_both_selectors_at_schema_layer(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """Passing both edge_id and triple → -32602 (UnannotateSelectorError)."""
+    """Passing both ``edge_id`` and the triple → -32602 at the schema layer.
+
+    The substrate-level :class:`UnannotateSelectorError` still guards
+    direct in-process callers (and is asserted by
+    :mod:`tests.test_topology_annotate`); over the MCP wire the
+    rejection now fires at the inputSchema ``oneOf`` before any handler
+    runs.
+    """
     client, _op = client_with_operator
     response = _unannotate_call(
         client,
@@ -617,14 +646,89 @@ def test_unannotate_rejects_both_selectors(
     )
     body = response.json()
     assert body["error"]["code"] == INVALID_PARAMS
-    assert "exactly one selector" in body["error"]["message"]
+    assert "inputSchema" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_unannotate_rejects_empty_arguments_at_schema_layer(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An empty ``{}`` argument bag → -32602 (neither selector form)."""
+    client, _op = client_with_operator
+    response = _unannotate_call(client, 62, {})
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "inputSchema" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.parametrize(
+    "partial_triple",
+    [
+        # `from_name` missing — the other two triple keys present.
+        {"kind": "depends-on", "to_name": "b"},
+        # `kind` missing.
+        {"from_name": "a", "to_name": "b"},
+        # `to_name` missing.
+        {"from_name": "a", "kind": "depends-on"},
+    ],
+    ids=["missing-from_name", "missing-kind", "missing-to_name"],
+)
+def test_unannotate_rejects_partial_triple_at_schema_layer(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    partial_triple: dict[str, Any],
+) -> None:
+    """A triple with one of (from_name, kind, to_name) missing → -32602."""
+    client, _op = client_with_operator
+    response = _unannotate_call(client, 63, partial_triple)
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "inputSchema" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.parametrize(
+    "empty_field",
+    ["edge_id", "from_name", "to_name"],
+)
+def test_unannotate_rejects_empty_string_selector_at_schema_layer(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    empty_field: str,
+) -> None:
+    """Empty strings in any selector slot → -32602 (``minLength: 1`` enforced).
+
+    A ``""`` field is structurally different from omitted: it would
+    satisfy the ``oneOf`` ``required`` check on its own. Without
+    ``minLength: 1`` the empty value would slip through the schema and
+    only fail at the substrate (or not fail at all if the substrate
+    didn't notice). The schema now rejects it at the front.
+    """
+    client, _op = client_with_operator
+    # Build a valid base shape for whichever selector form contains the
+    # empty field, then overwrite the targeted field with the empty
+    # string.
+    if empty_field == "edge_id":
+        arguments: dict[str, Any] = {"edge_id": ""}
+    else:
+        arguments = {"from_name": "a", "kind": "depends-on", "to_name": "b"}
+        arguments[empty_field] = ""
+    response = _unannotate_call(client, 64, arguments)
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "inputSchema" in body["error"]["message"]
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
 def test_unannotate_rejects_malformed_edge_id(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """A non-UUID edge_id is caught at the front before service dispatch."""
+    """A non-UUID edge_id is caught at the front before service dispatch.
+
+    The inputSchema doesn't constrain the UUID *format* — the handler
+    still owns the ``uuid.UUID(...)`` parse and surfaces -32602 with a
+    pointed "not a valid UUID" message. The schema's ``minLength: 1``
+    is satisfied by the non-empty garbage string.
+    """
     client, _op = client_with_operator
     response = _unannotate_call(client, 61, {"edge_id": "not-a-uuid"})
     body = response.json()
@@ -753,6 +857,39 @@ def test_annotate_description_warns_against_auto_kinds() -> None:
     # Names at least the canonical cross-system kinds.
     assert "authenticates-via" in desc
     assert "tenant_admin" in desc
+
+
+def test_annotate_description_matches_actual_response_shape() -> None:
+    """The annotate description must not advertise response fields the handler
+    does not populate (B1 regression on PR #654).
+
+    The handler returns ``edge_id / from / to / kind / source / conflicts``;
+    earlier iterations also claimed ``superseded: [<auto-edge-id>...]`` on
+    the response shape, but ``annotate_edge`` only stamps that on the
+    auto-edge ``properties`` and on the audit/broadcast payload — it
+    never surfaces it on the return value. Description-vs-impl drift
+    here is load-bearing for an LLM agent reading the description as
+    the API contract.
+    """
+    entry = get_tool("meho.topology.annotate")
+    assert entry is not None
+    defn = entry[0]
+    desc = defn.description
+    declared = set(defn.outputSchema.get("properties", {}).keys())
+    # outputSchema is the canonical contract — anything the description
+    # *names* as a response key must be in it.
+    assert declared == {"edge_id", "from", "to", "kind", "source", "conflicts"}
+    # Belt-and-suspenders: the literal "Returns `{...}`" clause names
+    # only the keys above.
+    assert "Returns `{edge_id, from:" in desc
+    # `superseded` is the substrate-side §6 marker
+    # (`properties.superseded_by` on the displaced auto-edge row +
+    # audit payload field), never a response key on this tool. The
+    # description may *mention*
+    # the mechanism in parenthetical guidance but must not advertise it
+    # as a returned key.
+    assert "superseded: [<auto-edge-id>...]" not in desc
+    assert "superseded_by" in desc  # parenthetical reference to the substrate mechanism remains
 
 
 def test_unannotate_description_names_auto_refusal() -> None:

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -102,10 +102,17 @@ name)` unique row. The read package never inserts, updates, or deletes.
 surface"). The CLI front (T6, #454) is landed and documented below
 ("CLI front"). The MCP front (T7, #455) is landed too — the two
 narrow-waist meta-tools `query_topology` (parametric: `kind` selects
-`dependents` / `dependencies` / `path`) and `list_targets` register in
-`mcp/tools/topology.py` and call `query.py` / `select(TargetORM)`
-directly (sibling fronts on one backplane, not REST wrappers). G9.1-T8
-(#456) shipped the closing acceptance suite
+`dependents` / `dependencies` / `path` / `edges`) and `list_targets`
+register in `mcp/tools/topology.py` and call `query.py` /
+`select(TargetORM)` directly (sibling fronts on one backplane, not
+REST wrappers). G9.2-T7 (#598) widened the parametric tool with the
+`edges` facet (dispatches to `list_edges` — replaces a standalone
+`list_edges` meta-tool) and added the admin-namespace pair
+`meho.topology.annotate` / `meho.topology.unannotate`
+(`required_role=TENANT_ADMIN`, `op_class="write"`); both admin tools
+call `annotate_edge` / `unannotate_edge` directly and are visible only
+to a tenant_admin-scoped session. G9.1-T8 (#456) shipped the closing
+acceptance suite
 (`backend/tests/integration/test_topology_g91_acceptance.py` + the
 parametric `backend/tests/fixtures/topology_10k_nodes.py` 10k-node
 generator) and the operator-facing docs


### PR DESCRIPTION
## Summary
- Two admin MCP meta-tools — `meho.topology.annotate` / `meho.topology.unannotate` (both `tenant_admin` + `op_class="write"`) — for the G9.2 curated-edge write surface (#595). Handlers dispatch directly to the service primitives; no HTTP shim.
- `query_topology(kind="edges", ...)` facet on the existing parametric meta-tool — replaces a standalone `list_edges` meta-tool per CLAUDE.md postulate 5 / Initiative #364 §9 narrow-waist alignment. Dispatches to `list_edges` (#596).
- Admin tools live in the `meho.*` namespace, hidden from a non-tenant_admin `tools/list` (registry RBAC filter) and refused by the dispatcher's call-time re-check (-32602 forbidden).
- Tool descriptions follow the AI-engineering anchor (use-case-first; explicit "DO NOT annotate auto-discoverable kinds" warning).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean on changed paths.
- [x] `mypy` on `src/meho_backplane/mcp/tools/topology.py` — clean (strict).
- [x] `pytest tests/test_mcp_tools_topology_annotate.py` — 21 passed.
- [x] `pytest tests/test_mcp_tools_topology.py tests/test_topology_annotate.py` — 37 passed (existing).
- [x] Registration: both admin tools land with `TENANT_ADMIN` + `op_class="write"`; no standalone `list_edges` tool.
- [x] RBAC: operator-role session does not see the admin tools in `tools/list`; direct `tools/call` from operator → -32602 forbidden.
- [x] `tools/call meho.topology.annotate {...}` creates a curated edge and emits one service audit row + one broadcast event.
- [x] `tools/call meho.topology.annotate {...}` is idempotent on the same triple (one row, properties refreshed).
- [x] `query_topology {kind: edges, source: curated}` filter flow-through verified; `conflicts: true` narrows correctly.
- [x] `meho.topology.unannotate` on an `source='auto'` row returns -32602 with the `auto-discovered` rule.

## Out of scope
- REST routes — T5 (sibling task #597, in flight).
- CLI verbs — T6. Bulk import — T8.
- The agent's daily-surface tools — unchanged; these are admin-namespace meta-tools.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #598


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "edges" facet to topology queries with filtering (source, conflicts, limit, offset).
  * Added admin-only tools to annotate and unannotate curated topology edges; these replace the separate list-edges meta-tool.

* **Documentation**
  * Updated topology docs to describe the new edges facet and the annotate/unannotate admin tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-18)

Rebased onto `main` to pick up T5 REST (#653, merged) — no conflicts;
force-with-lease push to refresh the branch. Addressed review findings
from `.claude/auto/review-results/pr-654-iter-1.json`:

- **B1** `2f28777` — strip `superseded: [<auto-edge-id>...]` from
  `_ANNOTATE_DESCRIPTION` (description-vs-handler drift); add
  regression test asserting `outputSchema.properties.keys()` ==
  description-named return keys.
- **M1** `2f28777` — enforce edge_id XOR triple at the unannotate
  inputSchema via `oneOf` + `additionalProperties: false` +
  `minLength: 1` on selector slots. Updated the existing
  both-selectors test to expect the schema-layer message; added
  rejection tests for empty arguments, each partial-triple
  permutation, and each empty-string selector slot.
- **m1** `2f28777` — parametrize
  `test_admin_tool_call_from_non_admin_is_forbidden` over both
  `(meho.topology.annotate, meho.topology.unannotate)` since they
  share the dispatcher RBAC gate.

Deferred (recorded as adjacent finding; not a fix for this iteration
per the iter-1 punch list):

- **m2** — `mcp/tools/topology.py` is now 1125 lines, over the 600-
  line soft limit. The admin block (`meho.topology.annotate` /
  `unannotate` registrations + handlers) is naturally separable
  into `mcp/tools/topology_admin.py`; cleanup is appropriate as a
  follow-up issue rather than landed mid-fix.

<!-- auto-implement-issue: continue, iteration 2 -->
