### PR TITLE
feat(connectors): G3.5-T3 NSX CLI verbs + E2E recorded-fixture test + operator onboarding doc (#615)

### DIFF
--- a/backend/tests/test_connectors_nsx_e2e.py
+++ b/backend/tests/test_connectors_nsx_e2e.py
@@ -1,0 +1,597 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""NSX E2E recorded-fixture integration test (G3.5-T3 #615).
+
+Covers all four acceptance criteria from Issue #615:
+
+(a) All 9 curated NSX read ops dispatch through the full
+    ``call_operation`` stack against a respx-mocked NSX manager
+    and return ``status='ok'``.
+(b) Session-establish + 401-retry path: the connector fires
+    ``POST /api/session/create`` on the first dispatch, and a
+    simulated 401 from the NSX manager side triggers one re-login +
+    one retry (no more, no less).
+(c) Audit rows: each dispatch inserts an ``AuditLog`` row carrying
+    ``method='DISPATCH'``, a non-null ``target_id``, and a
+    ``payload["params_hash"]`` key.
+(d) JSONFlux handle path: ``GET:/policy/api/v1/infra/segments``
+    dispatched with a ``ForceHandleReducer`` returns a populated
+    ``OperationResult.handle`` with at least one ``sample_rows``
+    entry.
+
+Database: SQLite via the autouse ``_default_database_url`` conftest
+fixture (no ``pg_engine`` required). Runs in the ``meho-runners``
+CI lane alongside the other ``backend/tests/test_connectors_*.py``
+files; no Docker dependency.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.nsx import (
+    NSX_CONNECTOR_ID,
+    NSX_CORE_OPS,
+    NSX_IMPL_ID,
+    NSX_PRODUCT,
+    NSX_VERSION,
+    NsxConnector,
+)
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+from tests.acceptance._nsx_canary_fixtures import (
+    NSX_CANARY_BASE_URL,
+    NSX_CANARY_FINGERPRINT,
+    NSX_CANARY_OPERATOR_TENANT,
+    NSX_CANARY_SEGMENTS,
+    NSX_FORCE_HANDLE_LIST_OP_ID,
+    _insert_nsx_descriptors,
+    _nsx_session_loader,
+    _register_nsx_routes,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+_OPERATOR = Operator(
+    sub="nsx-e2e-test",
+    name="NSX E2E Test Operator",
+    email=None,
+    raw_jwt="<nsx-e2e-raw-jwt>",
+    tenant_id=NSX_CANARY_OPERATOR_TENANT,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+_E2E_TARGET_NAME = "nsx-e2e-target"
+
+# Path-template params for the two firewall ops whose URLs carry
+# ``{domain-id}`` / ``{security-policy-id}`` placeholders. The
+# dispatcher's ``_substitute_path`` fills them at dispatch time;
+# the respx routes are registered against the substituted URLs.
+_FIREWALL_OP_PARAMS: dict[str, dict[str, object]] = {
+    "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies": {
+        "domain-id": "default",
+    },
+    "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules": {
+        "domain-id": "default",
+        "security-policy-id": "policy-app-tier",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Module-level autouse fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars that :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    from meho_backplane.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches around every test."""
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub out :func:`publish_event` so the broadcast bus doesn't fire.
+
+    Required for the same reason as every other DB-backed dispatcher
+    test: the real broadcast bus tries to write to a Redis stream that
+    doesn't exist in the unit-test environment.
+    """
+    events: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# ForceHandleReducer (acceptance criterion d)
+# ---------------------------------------------------------------------------
+
+
+class _ForceHandleReducer:
+    """Test-only reducer that always wraps an NSX list payload in a ResultHandle.
+
+    Installed for the JSONFlux handle-path test only; all other tests
+    use the v0.2 default :class:`PassThroughReducer`.
+    """
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        del schema, context
+        if isinstance(payload, dict) and "results" in payload:
+            rows = payload["results"]
+            total = len(rows) if isinstance(rows, list) else 1
+            sample: tuple[Any, ...] = tuple(rows[:5]) if isinstance(rows, list) and rows else ()
+        elif isinstance(payload, list):
+            total = len(payload)
+            sample = tuple(payload[:5]) if payload else ()
+        else:
+            total = 1
+            sample = ()
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"force-mode handle ({total} rows)",
+            schema_={"type": "array", "items": {"type": "object"}},
+            total_rows=total,
+            sample_rows=sample or None,
+            ttl_seconds=3600,
+        )
+        return {"row_count": total, "sample": list(sample)}, handle
+
+
+# ---------------------------------------------------------------------------
+# Setup helper
+# ---------------------------------------------------------------------------
+
+
+async def _seed_target() -> Any:
+    """Insert the E2E target row and return it (expunged from the session)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=NSX_CANARY_OPERATOR_TENANT,
+            name=_E2E_TARGET_NAME,
+            aliases=[],
+            product=NSX_PRODUCT,
+            host=NSX_CANARY_BASE_URL.removeprefix("https://"),
+            port=443,
+            fqdn=None,
+            secret_ref="kv/data/nsx/nsx-e2e",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=NSX_CANARY_FINGERPRINT,
+            notes="seeded by test_connectors_nsx_e2e._seed_target",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _resolve_connector() -> NsxConnector:
+    """Resolve + cache the NsxConnector instance with a stubbed session loader."""
+    registry = all_connectors_v2()
+    connector_cls = registry.get((NSX_PRODUCT, NSX_VERSION, NSX_IMPL_ID))
+    assert connector_cls is NsxConnector, (
+        f"NsxConnector not registered for ({NSX_PRODUCT}, {NSX_VERSION}, {NSX_IMPL_ID}); "
+        f"got {connector_cls!r}"
+    )
+    instance = get_or_create_connector_instance(connector_cls)
+    instance._session_loader = _nsx_session_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Primary E2E fixture (happy-path + audit rows)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _NsxE2EBundle:
+    target_name: str
+    connector_instance: NsxConnector
+
+
+@pytest.fixture
+async def nsx_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_NsxE2EBundle]:
+    """Dispatcher-ready NSX setup over a respx-mocked manager (standard happy-path).
+
+    Lifecycle:
+    1. Insert :data:`~meho_backplane.connectors.nsx.NSX_CORE_OPS`
+       descriptors + groups into the per-test SQLite DB.
+    2. Seed a :class:`Target` row carrying :data:`NSX_CANARY_FINGERPRINT`
+       so the resolver binds :class:`NsxConnector`.
+    3. Resolve + cache the connector instance; patch its
+       ``_session_loader`` to bypass Vault.
+    4. Activate a respx router for :data:`NSX_CANARY_BASE_URL` and
+       register the 9 read-op routes + session-create.
+    """
+    await _insert_nsx_descriptors()
+    await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=NSX_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_nsx_routes(mock)
+        try:
+            yield _NsxE2EBundle(
+                target_name=_E2E_TARGET_NAME,
+                connector_instance=instance,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# 401-retry fixture (acceptance criterion b)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Nsx401RetryBundle:
+    connector_instance: NsxConnector
+    db_target: Any
+    session_route: Any
+    node_route: Any
+
+
+@pytest.fixture
+async def nsx_e2e_401_canary(
+    captured_events: list[Any],
+) -> AsyncIterator[_Nsx401RetryBundle]:
+    """NSX setup with a respx mock that simulates a 401 on the first node GET.
+
+    The session-create route answers twice (initial establish + post-401
+    re-login). ``GET /api/v1/node`` returns 401 first then 200, exercising
+    :meth:`NsxConnector._get_json_with_session_retry`'s single-retry
+    contract.
+
+    The ``dispatch_ingested`` dispatcher branch calls ``_request_json``
+    directly (no 401-retry at the dispatch level — 4xx propagate as
+    ``connector_error`` per the ingested-dispatch contract). The 401-retry
+    path is tested here through the connector method directly against a
+    DB-seeded :class:`Target`, which is the real production call site
+    (``fingerprint`` / ``probe`` and any future typed ops that call
+    ``_get_json_with_session_retry``).
+    """
+    await _insert_nsx_descriptors()
+    target = await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=NSX_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        session_route = mock.post("/api/session/create")
+        session_route.side_effect = [
+            httpx.Response(
+                200,
+                headers={
+                    "X-XSRF-TOKEN": "xsrf-first",
+                    "Set-Cookie": "JSESSIONID=js-first; Path=/; HttpOnly",
+                },
+            ),
+            httpx.Response(
+                200,
+                headers={
+                    "X-XSRF-TOKEN": "xsrf-second",
+                    "Set-Cookie": "JSESSIONID=js-second; Path=/; HttpOnly",
+                },
+            ),
+        ]
+        node_route = mock.get("/api/v1/node")
+        node_route.side_effect = [
+            httpx.Response(401),
+            httpx.Response(
+                200,
+                json={
+                    "node_version": NSX_VERSION,
+                    "kernel_version": "4.2.1.0.0",
+                    "node_uuid": "deadbeef-retry-test",
+                    "hostname": "nsx-retry.test.invalid",
+                },
+            ),
+        ]
+        try:
+            yield _Nsx401RetryBundle(
+                connector_instance=instance,
+                db_target=target,
+                session_route=session_route,
+                node_route=node_route,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in NSX_CORE_OPS)
+
+
+@pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
+async def test_nsx_e2e_all_ops_dispatch_ok(
+    op_id: str,
+    nsx_e2e_canary: _NsxE2EBundle,
+) -> None:
+    """All 9 NSX core ops dispatch through the full dispatcher and return status='ok'.
+
+    Each op exercises session-establish (first call in the series) or
+    re-uses the cached XSRF token (subsequent calls). The parametrise
+    reports one CI case per op_id for granular failure attribution.
+    """
+    params = _FIREWALL_OP_PARAMS.get(op_id, {})
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": NSX_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": nsx_e2e_canary.target_name},
+            "params": params,
+        },
+    )
+    assert result["status"] == "ok", (
+        f"NSX op {op_id!r} did not return status='ok': "
+        f"error={result.get('error')!r} full={result!r}"
+    )
+
+
+async def test_nsx_e2e_session_establishes_on_first_dispatch(
+    nsx_e2e_canary: _NsxE2EBundle,
+) -> None:
+    """First dispatch to a fresh target fires POST /api/session/create.
+
+    Verifies the session-establish half of acceptance criterion (b) by
+    inspecting the connector's XSRF token cache before and after the
+    first ``call_operation`` call. The token key is ``target.name``,
+    the value is the ``X-XSRF-TOKEN`` the mock returns.
+    """
+    instance = nsx_e2e_canary.connector_instance
+    target_name = nsx_e2e_canary.target_name
+
+    assert target_name not in instance._session_tokens, (
+        "Expected empty token cache before first dispatch; "
+        f"got _session_tokens={instance._session_tokens!r}"
+    )
+
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": NSX_CONNECTOR_ID,
+            "op_id": "GET:/api/v1/node",
+            "target": {"name": target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+    assert instance._session_tokens.get(target_name) == "canary-xsrf-token", (
+        f"Expected XSRF token cached after first dispatch; "
+        f"got _session_tokens={instance._session_tokens!r}"
+    )
+
+
+async def test_nsx_e2e_401_retry_via_connector_method(
+    nsx_e2e_401_canary: _Nsx401RetryBundle,
+) -> None:
+    """A 401 on the first node GET triggers one re-login + one retry.
+
+    Exercises acceptance criterion (b) via
+    :meth:`NsxConnector._get_json_with_session_retry` against a
+    DB-seeded :class:`Target`.
+
+    The ``dispatch_ingested`` path calls ``_request_json`` directly (no
+    401-retry at that level; a 401 becomes ``connector_error``). The
+    retry contract lives on ``_get_json_with_session_retry``, which is
+    the call site for ``fingerprint()`` / ``probe()`` and any future
+    typed ops. Testing through the connector method (not ``call_operation``)
+    is the correct E2E surface for this path.
+
+    Assertions:
+    * The call returns the node JSON successfully (retry succeeded).
+    * ``POST /api/session/create`` called exactly twice: initial +
+      post-401 re-login.
+    * ``GET /api/v1/node`` called exactly twice: 401 + successful retry.
+    * Post-retry XSRF token (``xsrf-second``) replaces the stale one.
+    """
+    bundle = nsx_e2e_401_canary
+
+    result = await bundle.connector_instance._get_json_with_session_retry(
+        bundle.db_target,
+        "/api/v1/node",
+        raw_jwt="",
+    )
+
+    assert result.get("node_version") == NSX_VERSION, (
+        f"Expected node_version={NSX_VERSION!r} in retry result; got {result!r}"
+    )
+    assert bundle.session_route.call_count == 2, (
+        f"Expected session-create called twice (initial + post-401 relogin); "
+        f"got call_count={bundle.session_route.call_count}"
+    )
+    assert bundle.node_route.call_count == 2, (
+        f"Expected GET /api/v1/node called twice (401 + retry); "
+        f"got call_count={bundle.node_route.call_count}"
+    )
+    assert bundle.connector_instance._session_tokens.get(_E2E_TARGET_NAME) == "xsrf-second", (
+        f"Expected post-retry XSRF token to be 'xsrf-second'; "
+        f"got _session_tokens={bundle.connector_instance._session_tokens!r}"
+    )
+
+
+async def test_nsx_e2e_dispatch_writes_audit_row(
+    nsx_e2e_canary: _NsxE2EBundle,
+) -> None:
+    """Each dispatch inserts an AuditLog row with method='DISPATCH', target_id, params_hash.
+
+    Exercises acceptance criterion (c). Dispatches one op and asserts:
+
+    * Exactly one new ``AuditLog`` row with ``method='DISPATCH'`` and
+      ``path == op_id``.
+    * ``row.target_id`` is not None (the Target row was resolved and
+      its UUID was recorded).
+    * ``row.payload["op_id"]`` equals the dispatched ``op_id``.
+    * ``row.payload["params_hash"]`` is present (non-None string).
+    """
+    op_id = "GET:/api/v1/node"
+    sessionmaker = get_sessionmaker()
+
+    async def _count_dispatch_rows() -> int:
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AuditLog).where(
+                    AuditLog.method == "DISPATCH",
+                    AuditLog.path == op_id,
+                )
+            )
+            return len(list(result.scalars().all()))
+
+    baseline = await _count_dispatch_rows()
+
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": NSX_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": nsx_e2e_canary.target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+
+    final = await _count_dispatch_rows()
+    assert final - baseline == 1, (
+        f"Expected exactly one new DISPATCH row for {op_id!r}; baseline={baseline} final={final}"
+    )
+
+    async with sessionmaker() as session:
+        rows_result = await session.execute(
+            select(AuditLog).where(
+                AuditLog.method == "DISPATCH",
+                AuditLog.path == op_id,
+            )
+        )
+        rows = list(rows_result.scalars().all())
+
+    row = rows[-1]
+    assert row.target_id is not None, (
+        "AuditLog.target_id must not be None for a targeted dispatch; "
+        f"got target_id=None on row {row!r}"
+    )
+    assert row.payload.get("op_id") == op_id, (
+        f"AuditLog.payload['op_id'] must equal the dispatched op_id; got payload={row.payload!r}"
+    )
+    assert row.payload.get("params_hash"), (
+        f"AuditLog.payload must carry a non-empty 'params_hash'; got payload={row.payload!r}"
+    )
+
+
+async def test_nsx_e2e_jsonflux_handle_populated_for_segment_list(
+    nsx_e2e_canary: _NsxE2EBundle,
+) -> None:
+    """Segment list dispatched with ForceHandleReducer returns a populated handle.
+
+    Exercises acceptance criterion (d): the JSONFlux dispatcher seam
+    threads the reducer's :class:`ResultHandle` onto
+    :class:`OperationResult`.
+
+    Assertions mirror :mod:`tests.acceptance.test_g35_nsx_jsonflux_force_handle`:
+
+    * ``status == 'ok'``.
+    * ``handle`` is non-None and carries a valid UUID4 ``handle_id``.
+    * ``handle.total_rows`` matches the seeded segment count.
+    * ``handle.sample_rows`` is populated (≥1 row).
+    * ``result['row_count']`` equals ``handle.total_rows`` (the
+      reducer's summary inlined on the envelope).
+    """
+    expected_rows = len(NSX_CANARY_SEGMENTS["results"])  # type: ignore[arg-type]
+
+    set_default_reducer(_ForceHandleReducer())
+    try:
+        result_envelope = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": NSX_CONNECTOR_ID,
+                "op_id": NSX_FORCE_HANDLE_LIST_OP_ID,
+                "target": {"name": nsx_e2e_canary.target_name},
+                "params": {},
+            },
+        )
+    finally:
+        set_default_reducer(PassThroughReducer())
+
+    assert result_envelope["status"] == "ok", (
+        f"Expected JSONFlux dispatch to succeed; got {result_envelope!r}"
+    )
+
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        f"got handle=None on envelope={result_envelope!r}"
+    )
+
+    uuid.UUID(handle["handle_id"])
+
+    assert handle["total_rows"] == expected_rows, (
+        f"Expected {expected_rows} segment rows from NSX_CANARY_SEGMENTS; "
+        f"got handle.total_rows={handle['total_rows']}"
+    )
+
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        f"Expected ≥1 sample row from the seeded NSX segment list; got sample_rows={sample_rows!r}"
+    )
+
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == expected_rows, (
+        f"Expected reducer summary on result.row_count={expected_rows}; got result={payload!r}"
+    )

--- a/backend/tests/test_connectors_nsx_e2e.py
+++ b/backend/tests/test_connectors_nsx_e2e.py
@@ -357,6 +357,7 @@ async def nsx_e2e_401_canary(
 # ---------------------------------------------------------------------------
 
 _OP_IDS: tuple[str, ...] = tuple(op.op_id for op in NSX_CORE_OPS)
+assert len(_OP_IDS) == 9, f"Expected 9 curated NSX ops, got {len(_OP_IDS)}: {_OP_IDS}"
 
 
 @pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
@@ -514,15 +515,18 @@ async def test_nsx_e2e_dispatch_writes_audit_row(
     )
 
     async with sessionmaker() as session:
-        rows_result = await session.execute(
-            select(AuditLog).where(
+        row_result = await session.execute(
+            select(AuditLog)
+            .where(
                 AuditLog.method == "DISPATCH",
                 AuditLog.path == op_id,
             )
+            .order_by(AuditLog.id.desc())
+            .limit(1)
         )
-        rows = list(rows_result.scalars().all())
+        row = row_result.scalars().first()
 
-    row = rows[-1]
+    assert row is not None
     assert row.target_id is not None, (
         "AuditLog.target_id must not be None for a targeted dispatch; "
         f"got target_id=None on row {row!r}"

--- a/cli/internal/cmd/nsx/about.go
+++ b/cli/internal/cmd/nsx/about.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAboutCmd returns `meho nsx about` → GET:/api/v1/node.
+//
+// Renders the NSX Manager's node_version / hostname / node_uuid /
+// kernel_version identity fields; --json emits the raw envelope.
+func newAboutCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "about",
+		Short: "Show NSX Manager version, hostname, and node UUID",
+		Long: "about dispatches GET:/api/v1/node against connector_id=\"nsx-rest-4.2\"\n" +
+			"and renders the manager's node_version / hostname / node_uuid fields.\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call:\n" +
+			"  - 0   status == ok\n" +
+			"  - 1   status == error / denied\n" +
+			"  - 2   auth_expired\n" +
+			"  - 3   unreachable\n" +
+			"  - 4   unexpected response shape",
+		Example: "  meho nsx about --target rdc-nsx\n" +
+			"  meho nsx about --target rdc-nsx --json | jq .result",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAbout(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v1/node", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "GET:/api/v1/node", r, jsonOut, printAbout)
+}
+
+func printAbout(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/api/v1/node — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	var node struct {
+		NodeVersion   string `json:"node_version"`
+		KernelVersion string `json:"kernel_version"`
+		NodeUUID      string `json:"node_uuid"`
+		Hostname      string `json:"hostname"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &node); err != nil || node.NodeVersion == "" {
+		fallbackResultRender(w, r)
+		return
+	}
+	if node.NodeVersion != "" {
+		fmt.Fprintf(w, "  version:   %s\n", node.NodeVersion)
+	}
+	if node.KernelVersion != "" {
+		fmt.Fprintf(w, "  build:     %s\n", node.KernelVersion)
+	}
+	if node.Hostname != "" {
+		fmt.Fprintf(w, "  hostname:  %s\n", node.Hostname)
+	}
+	if node.NodeUUID != "" {
+		fmt.Fprintf(w, "  node_uuid: %s\n", node.NodeUUID)
+	}
+}

--- a/cli/internal/cmd/nsx/cluster.go
+++ b/cli/internal/cmd/nsx/cluster.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newClusterCmd returns the `meho nsx cluster` parent command (status sub-verb).
+func newClusterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "cluster",
+		Short:        "NSX management cluster verbs (status)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newClusterStatusCmd())
+	return cmd
+}
+
+// newClusterStatusCmd returns `meho nsx cluster status` → GET:/api/v1/cluster/status.
+func newClusterStatusCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show NSX management cluster health",
+		Long: "status dispatches GET:/api/v1/cluster/status against connector_id=\n" +
+			"\"nsx-rest-4.2\". Renders the overall mgmt_cluster_status and\n" +
+			"control_cluster_status fields; --json emits the full envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx cluster status --target rdc-nsx\n" +
+			"  meho nsx cluster status --target rdc-nsx --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runClusterStatus(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runClusterStatus(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v1/cluster/status", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "GET:/api/v1/cluster/status", r, jsonOut, printClusterStatus)
+}
+
+func printClusterStatus(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/api/v1/cluster/status — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	var cs struct {
+		MgmtClusterStatus struct {
+			Status string `json:"status"`
+		} `json:"mgmt_cluster_status"`
+		ControlClusterStatus struct {
+			Status string `json:"status"`
+		} `json:"control_cluster_status"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &cs); err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if s := cs.MgmtClusterStatus.Status; s != "" {
+		fmt.Fprintf(w, "  mgmt_cluster:    %s\n", s)
+	}
+	if s := cs.ControlClusterStatus.Status; s != "" {
+		fmt.Fprintf(w, "  control_cluster: %s\n", s)
+	}
+}

--- a/cli/internal/cmd/nsx/dispatch.go
+++ b/cli/internal/cmd/nsx/dispatch.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic model.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+var errOpError = errors.New("operation status not ok")
+
+// dispatchOp POSTs an OperationCall to the backplane and returns the
+// decoded CallResult with connector_id="nsx-rest-4.2" pre-baked.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: ConnectorID,
+		OpID:        opID,
+		Target:      nil,
+	}
+	if targetSlug != "" {
+		body.Target = map[string]any{"name": targetSlug}
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderCallResult handles the unified post-dispatch rendering path.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		printGenericResult(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+// printGenericResult renders a CallResult in the generic envelope shape.
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cli/internal/cmd/nsx/firewall.go
+++ b/cli/internal/cmd/nsx/firewall.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newFirewallCmd returns the `meho nsx firewall` parent command.
+// Sub-tree: `policy list [--scope]` and `rule list <policy> [--scope]`.
+func newFirewallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "firewall",
+		Short:        "NSX distributed-firewall verbs (policy list / rule list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newFirewallPolicyCmd())
+	cmd.AddCommand(newFirewallRuleCmd())
+	return cmd
+}
+
+// newFirewallPolicyCmd returns the `meho nsx firewall policy` sub-tree.
+func newFirewallPolicyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "policy",
+		Short:        "NSX distributed-firewall policy verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newFirewallPolicyListCmd())
+	return cmd
+}
+
+// newFirewallPolicyListCmd returns `meho nsx firewall policy list`.
+// Dispatches GET:/policy/api/v1/infra/domains/{domain-id}/security-policies
+// with the --scope flag mapped to the `domain-id` path parameter
+// (default "default" — the standard NSX policy domain).
+func newFirewallPolicyListCmd() *cobra.Command {
+	var (
+		scopeFlag         string
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List distributed-firewall security policies in a domain",
+		Long: "list dispatches GET:/policy/api/v1/infra/domains/{domain-id}/\n" +
+			"security-policies against connector_id=\"nsx-rest-4.2\".\n" +
+			"--scope sets the domain-id path parameter (default \"default\").\n" +
+			"Renders id / display_name / category for human eyes;\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx firewall policy list --target rdc-nsx\n" +
+			"  meho nsx firewall policy list --scope default --target rdc-nsx\n" +
+			"  meho nsx firewall policy list --target rdc-nsx --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runFirewallPolicyList(cmd, scopeFlag, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&scopeFlag, "scope", "default",
+		"NSX policy domain-id (default \"default\")")
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runFirewallPolicyList(cmd *cobra.Command, scope, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	if scope == "" {
+		scope = "default"
+	}
+	const opID = "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies"
+	params := map[string]any{"domain-id": scope}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printFirewallPolicyList)
+}
+
+func printFirewallPolicyList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s firewall policy list — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeNsxListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 security policies)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-30s %-16s\n", "id", "display_name", "category")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-30s %-16s\n",
+			truncate(nsxStringField(e, "id"), 38),
+			truncate(nsxStringField(e, "display_name"), 30),
+			truncate(nsxStringField(e, "category"), 16),
+		)
+	}
+}
+
+// newFirewallRuleCmd returns the `meho nsx firewall rule` sub-tree.
+func newFirewallRuleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "rule",
+		Short:        "NSX distributed-firewall rule verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newFirewallRuleListCmd())
+	return cmd
+}
+
+// newFirewallRuleListCmd returns `meho nsx firewall rule list <policy>`.
+// Dispatches GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules
+// with the <policy> positional arg mapped to `security-policy-id` and
+// --scope mapped to `domain-id` (default "default").
+func newFirewallRuleListCmd() *cobra.Command {
+	var (
+		scopeFlag         string
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list <policy-id>",
+		Short: "List rules in a distributed-firewall security policy",
+		Long: "list dispatches GET:/policy/api/v1/infra/domains/{domain-id}/\n" +
+			"security-policies/{security-policy-id}/rules against\n" +
+			"connector_id=\"nsx-rest-4.2\".\n" +
+			"<policy-id> is the security-policy-id path parameter.\n" +
+			"--scope sets the domain-id (default \"default\").\n" +
+			"Renders id / display_name / action for human eyes;\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx firewall rule list policy-app-tier --target rdc-nsx\n" +
+			"  meho nsx firewall rule list policy-app-tier --scope default --target rdc-nsx\n" +
+			"  meho nsx firewall rule list policy-app-tier --target rdc-nsx --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFirewallRuleList(cmd, args[0], scopeFlag, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&scopeFlag, "scope", "default",
+		"NSX policy domain-id (default \"default\")")
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runFirewallRuleList(cmd *cobra.Command, policyID, scope, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	if scope == "" {
+		scope = "default"
+	}
+	const opID = "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules"
+	params := map[string]any{
+		"domain-id":          scope,
+		"security-policy-id": policyID,
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printFirewallRuleList)
+}
+
+func printFirewallRuleList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s firewall rule list — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeNsxListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 rules)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-30s %-10s\n", "id", "display_name", "action")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-30s %-10s\n",
+			truncate(nsxStringField(e, "id"), 38),
+			truncate(nsxStringField(e, "display_name"), 30),
+			truncate(nsxStringField(e, "action"), 10),
+		)
+	}
+}

--- a/cli/internal/cmd/nsx/node.go
+++ b/cli/internal/cmd/nsx/node.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newNodeCmd returns the `meho nsx node` parent command (list sub-verb).
+func newNodeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "node",
+		Short:        "NSX transport-node verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newNodeListCmd())
+	return cmd
+}
+
+// newNodeListCmd returns `meho nsx node list` → GET:/api/v1/transport-nodes.
+func newNodeListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List NSX transport nodes (ESXi + edge)",
+		Long: "list dispatches GET:/api/v1/transport-nodes against connector_id=\n" +
+			"\"nsx-rest-4.2\". Renders id / display_name / type for human eyes;\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx node list --target rdc-nsx\n" +
+			"  meho nsx node list --target rdc-nsx --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runNodeList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runNodeList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v1/transport-nodes", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "GET:/api/v1/transport-nodes", r, jsonOut, printNodeList)
+}
+
+func printNodeList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/api/v1/transport-nodes — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeNsxListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 transport nodes)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-30s %-12s\n", "id", "display_name", "type")
+	for _, e := range entries {
+		nodeType := ""
+		if info, ok := e["node_deployment_info"].(map[string]any); ok {
+			nodeType = truncate(nsxStringField(info, "resource_type"), 12)
+		}
+		fmt.Fprintf(w, "%-38s %-30s %-12s\n",
+			truncate(nsxStringField(e, "id"), 38),
+			truncate(nsxStringField(e, "display_name"), 30),
+			nodeType,
+		)
+	}
+}

--- a/cli/internal/cmd/nsx/nsx.go
+++ b/cli/internal/cmd/nsx/nsx.go
@@ -263,9 +263,13 @@ func doAuthedRequest(
 		}
 	}
 	defer resp.Body.Close()
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	const maxBody = int64(1 << 20) // 1 MiB
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
 	if readErr != nil {
 		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if int64(len(raw)) > maxBody {
+		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
@@ -320,6 +324,17 @@ func loadParamsFlag(val string) (map[string]any, error) {
 
 func jsonUnmarshalStrict(raw []byte, out any) error {
 	return json.Unmarshal(raw, out)
+}
+
+// nsxPathBasename returns the last path segment (the part after the final "/").
+// NSX resource paths like /infra/sites/default/.../transport-zones/tz-1 encode
+// the human-readable name as the last segment; displaying just the basename
+// keeps list columns readable without truncating the identifier.
+func nsxPathBasename(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 && i < len(path)-1 {
+		return path[i+1:]
+	}
+	return path
 }
 
 func truncate(s string, maxLen int) string {

--- a/cli/internal/cmd/nsx/nsx.go
+++ b/cli/internal/cmd/nsx/nsx.go
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package nsx hosts the cobra commands under `meho nsx ...` for
+// G3.5-T3 (#615) of Initiative #368. v0.2 ships the operator-facing
+// alias verbs over the 9 enabled NSX read-only core ops, each
+// pre-baking connector_id="nsx-rest-4.2" so operators don't type
+// the connector ID on every dispatch:
+//
+//   - `meho nsx about [--target T]`                        — GET:/api/v1/node
+//   - `meho nsx node list [--target T]`                    — GET:/api/v1/transport-nodes
+//   - `meho nsx cluster status [--target T]`               — GET:/api/v1/cluster/status
+//   - `meho nsx segment list [--target T]`                 — GET:/policy/api/v1/infra/segments
+//   - `meho nsx transport-zone list [--target T]`          — GET:/policy/.../transport-zones
+//   - `meho nsx tier0 list [--target T]`                   — GET:/policy/api/v1/infra/tier-0s
+//   - `meho nsx tier1 list [--target T]`                   — GET:/policy/api/v1/infra/tier-1s
+//   - `meho nsx firewall policy list [--scope D] [--target T]`
+//   - `meho nsx firewall rule list <policy> [--scope D] [--target T]`
+//   - `meho nsx operation search/call`                     — meta-tool wrappers
+//
+// Every verb is a thin Cobra command that POSTs to
+// `/api/v1/operations/call` with connector_id="nsx-rest-4.2"
+// pre-baked. No NSX logic in the CLI; pure Cobra-over-HTTP following
+// the vmware precedent (CLAUDE.md postulate 5).
+package nsx
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under
+// `meho nsx ...` dispatches against.
+const ConnectorID = "nsx-rest-4.2"
+
+// NewRootCmd returns the `meho nsx` parent command.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "nsx",
+		Short: "Pre-scoped CLI verbs for the nsx-rest-4.2 connector",
+		Long: "nsx is the operator-facing verb tree for the nsx-rest-4.2\n" +
+			"connector. Each verb dispatches through POST /api/v1/operations/call\n" +
+			"with connector_id=\"nsx-rest-4.2\" pre-baked so operators don't\n" +
+			"type the connector ID on every command.\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
+			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
+			"continue to use search_operations / call_operation against the\n" +
+			"narrow-waist meta-tool contract.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAboutCmd())
+	cmd.AddCommand(newNodeCmd())
+	cmd.AddCommand(newClusterCmd())
+	cmd.AddCommand(newSegmentCmd())
+	cmd.AddCommand(newTransportZoneCmd())
+	cmd.AddCommand(newTier0Cmd())
+	cmd.AddCommand(newTier1Cmd())
+	cmd.AddCommand(newFirewallCmd())
+	cmd.AddCommand(newOperationCmd())
+	return cmd
+}
+
+// nsxEntry is a single row in an NSX list response. NSX uses
+// map[string]any because the fields differ per resource type.
+type nsxEntry = map[string]any
+
+// decodeNsxListResult unwraps NSX's `{"results": [...]}` envelope or
+// falls back to a bare array.
+func decodeNsxListResult(raw json.RawMessage) ([]nsxEntry, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var wrapped struct {
+		Results []nsxEntry `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && wrapped.Results != nil {
+		return wrapped.Results, nil
+	}
+	var arr []nsxEntry
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil, fmt.Errorf("decode NSX list result: %w", err)
+	}
+	return arr, nil
+}
+
+// nsxStringField extracts a string value from an NSX entry map.
+func nsxStringField(e nsxEntry, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// fallbackResultRender dumps raw result JSON when the typed decoder
+// doesn't match the actual response shape.
+func fallbackResultRender(w io.Writer, r *CallResult) {
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	pretty, err := prettyJSON(r.Result)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+		return
+	}
+	fmt.Fprintln(w, string(r.Result))
+}
+
+// printErrorTrailer surfaces the dispatcher error + extras envelope.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+func loadParamsFlag(val string) (map[string]any, error) {
+	if val == "" {
+		return nil, nil
+	}
+	var raw []byte
+	if strings.HasPrefix(val, "@") {
+		path := strings.TrimPrefix(val, "@")
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read params file %q: %w", path, err)
+		}
+	} else {
+		raw = []byte(val)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parse params JSON: %w", err)
+	}
+	return m, nil
+}
+
+func jsonUnmarshalStrict(raw []byte, out any) error {
+	return json.Unmarshal(raw, out)
+}
+
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/nsx/nsx_test.go
+++ b/cli/internal/cmd/nsx/nsx_test.go
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests ----------
+
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "nsx-rest-4.2" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "nsx-rest-4.2")
+	}
+}
+
+// ---------- loadParamsFlag ----------
+
+func TestLoadParamsFlagEmpty(t *testing.T) {
+	got, err := loadParamsFlag("")
+	if err != nil || got != nil {
+		t.Fatalf("loadParamsFlag(\"\"): err=%v got=%v", err, got)
+	}
+}
+
+func TestLoadParamsFlagInlineJSON(t *testing.T) {
+	got, err := loadParamsFlag(`{"domain-id":"default"}`)
+	if err != nil {
+		t.Fatalf("loadParamsFlag: %v", err)
+	}
+	if got["domain-id"] != "default" {
+		t.Fatalf("inline JSON params not parsed; got %v", got)
+	}
+}
+
+func TestLoadParamsFlagFileReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.json")
+	if err := os.WriteFile(path, []byte(`{"security-policy-id":"pol-1"}`), 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	got, err := loadParamsFlag("@" + path)
+	if err != nil || got["security-policy-id"] != "pol-1" {
+		t.Fatalf("loadParamsFlag @file: err=%v got=%v", err, got)
+	}
+}
+
+func TestLoadParamsFlagInvalidJSONReportsError(t *testing.T) {
+	_, err := loadParamsFlag(`{not json`)
+	if err == nil || !strings.Contains(err.Error(), "parse params JSON") {
+		t.Fatalf("expected parse error; got %v", err)
+	}
+}
+
+// ---------- decodeNsxListResult ----------
+
+func TestDecodeNsxListResultResultsWrapped(t *testing.T) {
+	raw := json.RawMessage(`{"results":[{"id":"seg-1","display_name":"web"},{"id":"seg-2","display_name":"db"}],"result_count":2}`)
+	entries, err := decodeNsxListResult(raw)
+	if err != nil {
+		t.Fatalf("decodeNsxListResult wrapped: %v", err)
+	}
+	if len(entries) != 2 || entries[0]["id"] != "seg-1" {
+		t.Fatalf("results-wrapped decode: got %+v", entries)
+	}
+}
+
+func TestDecodeNsxListResultBareArray(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"tz-1"},{"id":"tz-2"}]`)
+	entries, err := decodeNsxListResult(raw)
+	if err != nil {
+		t.Fatalf("decodeNsxListResult bare: %v", err)
+	}
+	if len(entries) != 2 || entries[1]["id"] != "tz-2" {
+		t.Fatalf("bare-array decode: got %+v", entries)
+	}
+}
+
+func TestDecodeNsxListResultEmpty(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		entries, err := decodeNsxListResult(raw)
+		if err != nil || entries != nil {
+			t.Fatalf("decodeNsxListResult empty: err=%v entries=%v", err, entries)
+		}
+	}
+}
+
+// ---------- renderers ----------
+
+func TestPrintAboutHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "GET:/api/v1/node",
+		Result:     json.RawMessage(`{"node_version":"4.2.1","kernel_version":"4.2.1.0.0","node_uuid":"deadbeef-1234","hostname":"nsxmgr-rdc"}`),
+		DurationMs: 42.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=ok", "nsx-rest-4.2", "4.2.1", "nsxmgr-rdc", "deadbeef-1234"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintAboutErrorRendersErrorString(t *testing.T) {
+	errMsg := "session expired"
+	r := &CallResult{
+		Status:     "error",
+		OpID:       "GET:/api/v1/node",
+		Error:      &errMsg,
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=error", "session expired"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout error missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintNodeList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"results":[{"id":"transport-node-1","display_name":"esx-01","node_deployment_info":{"resource_type":"EsxiNode"}}],"result_count":1}`),
+		DurationMs: 10.0,
+	}
+	var buf bytes.Buffer
+	printNodeList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"transport-node-1", "esx-01", "EsxiNode"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printNodeList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintNodeListEmpty(t *testing.T) {
+	r := &CallResult{Status: "ok", Result: json.RawMessage(`{"results":[],"result_count":0}`)}
+	var buf bytes.Buffer
+	printNodeList(&buf, r)
+	if !strings.Contains(buf.String(), "(0 transport nodes)") {
+		t.Errorf("empty list should announce 0 nodes; got:\n%s", buf.String())
+	}
+}
+
+func TestPrintSegmentList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"results":[{"id":"seg-1","display_name":"web-seg","transport_zone_path":"/infra/sites/default/enforcement-points/default/transport-zones/tz-1"}],"result_count":1}`),
+		DurationMs: 8.0,
+	}
+	var buf bytes.Buffer
+	printSegmentList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"seg-1", "web-seg", "tz-1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSegmentList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintClusterStatus(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"mgmt_cluster_status":{"status":"STABLE"},"control_cluster_status":{"status":"STABLE"}}`),
+		DurationMs: 3.0,
+	}
+	var buf bytes.Buffer
+	printClusterStatus(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"STABLE", "mgmt_cluster", "control_cluster"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printClusterStatus missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintFirewallPolicyList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"results":[{"id":"pol-app","display_name":"app-tier","category":"Application"}],"result_count":1}`),
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printFirewallPolicyList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"pol-app", "app-tier", "Application"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printFirewallPolicyList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintFirewallRuleList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"results":[{"id":"rule-1","display_name":"allow-http","action":"ALLOW"}],"result_count":1}`),
+		DurationMs: 4.0,
+	}
+	var buf bytes.Buffer
+	printFirewallRuleList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"rule-1", "allow-http", "ALLOW"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printFirewallRuleList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintSearchTable(t *testing.T) {
+	summary := "List NSX segments"
+	r := &searchResponse{
+		Hits: []searchHit{
+			{OpID: "GET:/policy/api/v1/infra/segments", Summary: &summary, FusedScore: 0.987},
+		},
+		QueryDurationMs: 12.0,
+	}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "list segments", r)
+	out := buf.String()
+	for _, want := range []string{"nsx-rest-4.2", "list segments", "1 hit(s)", "GET:/policy/api/v1/infra/segments", "List NSX segments"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSearchTable missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// ---------- HTTP wire shape ----------
+
+type mockHandler = http.HandlerFunc
+
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID — pins that connector_id="nsx-rest-4.2"
+// is sent on every alias-verb dispatch.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "nsx-rest-4.2" {
+				t.Errorf("connector_id: got %q want nsx-rest-4.2", body.ConnectorID)
+			}
+			if body.OpID != "GET:/api/v1/node" {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "GET:/api/v1/node",
+				Result: json.RawMessage(`{"node_version":"4.2.1","hostname":"nsx-test"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, "GET:/api/v1/node", "rdc-nsx", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestDispatchOpEmptyTargetSendsNullTarget — empty slug → null target on wire.
+func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if raw["target"] != nil {
+				t.Errorf("empty target should be null on wire; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "GET:/api/v1/node"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/api/v1/node", "", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchFirewallPolicySendsScope — firewall policy list passes
+// domain-id in params map so the backend can substitute the path template.
+func TestDispatchFirewallPolicySendsScope(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			domainID, _ := body.Params["domain-id"].(string)
+			if domainID != "my-domain" {
+				t.Errorf("domain-id: got %q want %q", domainID, "my-domain")
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	const opID = "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies"
+	params := map[string]any{"domain-id": "my-domain"}
+	if _, err := dispatchOp(context.Background(), srv.URL, opID, "rdc-nsx", params); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchFirewallRuleListSendsPolicyAndScope — firewall rule list
+// passes both domain-id and security-policy-id.
+func TestDispatchFirewallRuleListSendsPolicyAndScope(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			domainID, _ := body.Params["domain-id"].(string)
+			policyID, _ := body.Params["security-policy-id"].(string)
+			if domainID != "default" {
+				t.Errorf("domain-id: got %q", domainID)
+			}
+			if policyID != "policy-app-tier" {
+				t.Errorf("security-policy-id: got %q", policyID)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	const opID = "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules"
+	params := map[string]any{
+		"domain-id":          "default",
+		"security-policy-id": "policy-app-tier",
+	}
+	if _, err := dispatchOp(context.Background(), srv.URL, opID, "rdc-nsx", params); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestErrOpErrorIsSentinel — pins the exported sentinel.
+func TestErrOpErrorIsSentinel(t *testing.T) {
+	if errOpError == nil {
+		t.Fatal("errOpError should be non-nil")
+	}
+}

--- a/cli/internal/cmd/nsx/operation.go
+++ b/cli/internal/cmd/nsx/operation.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newOperationCmd returns `meho nsx operation` with search / call
+// meta-tool wrappers pre-scoped to nsx-rest-4.2.
+func newOperationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "operation",
+		Short:        "Pre-scoped meta-tool wrappers (search / call) for nsx-rest-4.2",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newOperationSearchCmd())
+	cmd.AddCommand(newOperationCallCmd())
+	return cmd
+}
+
+// searchHit mirrors the backend OperationSearchHit Pydantic model.
+type searchHit struct {
+	OpID             string   `json:"op_id"`
+	Summary          *string  `json:"summary"`
+	Description      *string  `json:"description"`
+	GroupKey         *string  `json:"group_key"`
+	SafetyLevel      string   `json:"safety_level"`
+	RequiresApproval bool     `json:"requires_approval"`
+	FusedScore       float64  `json:"fused_score"`
+	Bm25Score        *float64 `json:"bm25_score"`
+	CosineScore      *float64 `json:"cosine_score"`
+}
+
+type searchResponse struct {
+	Hits            []searchHit `json:"hits"`
+	QueryDurationMs float64     `json:"query_duration_ms"`
+}
+
+func newOperationSearchCmd() *cobra.Command {
+	var (
+		groupKey          string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Hybrid BM25 + cosine RRF search across nsx-rest-4.2 operations",
+		Long: "search wraps GET /api/v1/operations/search with connector_id=\n" +
+			"\"nsx-rest-4.2\" pre-baked.\n\n" +
+			"Exit codes mirror meho operation search.",
+		Example: "  meho nsx operation search \"list segments\"\n" +
+			"  meho nsx operation search \"firewall rules\" --group policy-firewall",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationSearch(cmd, args[0], groupKey, limit, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&groupKey, "group", "", "narrow the search to one group_key")
+	cmd.Flags().IntVar(&limit, "limit", 10, "max hits (1..50, clamped by the API)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, jsonOut bool, backplaneOverride string) error {
+	if limit < 1 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
+			jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printSearchTable(cmd.OutOrStdout(), query, result)
+	return nil
+}
+
+func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
+	q := url.Values{}
+	q.Set("connector_id", ConnectorID)
+	q.Set("query", query)
+	if groupKey != "" {
+		q.Set("group", groupKey)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/operations/search?" + q.Encode()
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out searchResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+	return &out, nil
+}
+
+func printSearchTable(w io.Writer, query string, r *searchResponse) {
+	fmt.Fprintf(w, "search %s %q — %d hit(s) in %.0fms\n",
+		ConnectorID, query, len(r.Hits), r.QueryDurationMs)
+	if len(r.Hits) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%-50s %6s  %s\n", "op_id", "score", "summary")
+	for _, h := range r.Hits {
+		fmt.Fprintf(w, "%-50s %6.3f  %s\n",
+			truncate(h.OpID, 50),
+			h.FusedScore,
+			truncate(strDeref(h.Summary), 80),
+		)
+	}
+}
+
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func newOperationCallCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "call <op_id>",
+		Short: "Dispatch any nsx-rest-4.2 op_id (escape hatch for ops without aliases)",
+		Long: "call wraps POST /api/v1/operations/call with connector_id=\n" +
+			"\"nsx-rest-4.2\" pre-baked. Use when an op doesn't have a\n" +
+			"dedicated alias yet.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx operation call GET:/api/v1/node --target rdc-nsx\n" +
+			"  meho nsx operation call GET:/policy/api/v1/infra/segments --target rdc-nsx --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationCall(cmd, args[0], targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, nil)
+}

--- a/cli/internal/cmd/nsx/segment.go
+++ b/cli/internal/cmd/nsx/segment.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newSegmentCmd returns the `meho nsx segment` parent command (list sub-verb).
+func newSegmentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "segment",
+		Short:        "NSX segment verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSegmentListCmd())
+	return cmd
+}
+
+// newSegmentListCmd returns `meho nsx segment list` → GET:/policy/api/v1/infra/segments.
+func newSegmentListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List NSX policy-API segments (logical + DVS-backed portgroups)",
+		Long: "list dispatches GET:/policy/api/v1/infra/segments against\n" +
+			"connector_id=\"nsx-rest-4.2\". Renders id / display_name /\n" +
+			"transport_zone_path for human eyes; --json emits the full envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx segment list --target rdc-nsx\n" +
+			"  meho nsx segment list --target rdc-nsx --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSegmentList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runSegmentList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	const opID = "GET:/policy/api/v1/infra/segments"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printSegmentList)
+}
+
+func printSegmentList(w io.Writer, r *CallResult) {
+	const opID = "GET:/policy/api/v1/infra/segments"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeNsxListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 segments)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-30s %-50s\n", "id", "display_name", "transport_zone_path")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-30s %-50s\n",
+			truncate(nsxStringField(e, "id"), 38),
+			truncate(nsxStringField(e, "display_name"), 30),
+			truncate(nsxStringField(e, "transport_zone_path"), 50),
+		)
+	}
+}

--- a/cli/internal/cmd/nsx/segment.go
+++ b/cli/internal/cmd/nsx/segment.go
@@ -82,12 +82,12 @@ func printSegmentList(w io.Writer, r *CallResult) {
 		fmt.Fprintln(w, "  (0 segments)")
 		return
 	}
-	fmt.Fprintf(w, "%-38s %-30s %-50s\n", "id", "display_name", "transport_zone_path")
+	fmt.Fprintf(w, "%-38s %-30s %-30s\n", "id", "display_name", "transport_zone")
 	for _, e := range entries {
-		fmt.Fprintf(w, "%-38s %-30s %-50s\n",
+		fmt.Fprintf(w, "%-38s %-30s %-30s\n",
 			truncate(nsxStringField(e, "id"), 38),
 			truncate(nsxStringField(e, "display_name"), 30),
-			truncate(nsxStringField(e, "transport_zone_path"), 50),
+			truncate(nsxPathBasename(nsxStringField(e, "transport_zone_path")), 30),
 		)
 	}
 }

--- a/cli/internal/cmd/nsx/tier0.go
+++ b/cli/internal/cmd/nsx/tier0.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newTier0Cmd returns the `meho nsx tier0` parent command (list sub-verb).
+func newTier0Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "tier0",
+		Short:        "NSX tier-0 gateway verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newTier0ListCmd())
+	return cmd
+}
+
+// newTier0ListCmd returns `meho nsx tier0 list` → GET:/policy/api/v1/infra/tier-0s.
+func newTier0ListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List NSX tier-0 (provider edge) gateways",
+		Long: "list dispatches GET:/policy/api/v1/infra/tier-0s against\n" +
+			"connector_id=\"nsx-rest-4.2\". Renders id / display_name / ha_mode\n" +
+			"for human eyes; --json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx tier0 list --target rdc-nsx\n" +
+			"  meho nsx tier0 list --target rdc-nsx --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTier0List(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runTier0List(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	const opID = "GET:/policy/api/v1/infra/tier-0s"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printTier0List)
+}
+
+func printTier0List(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/policy/api/v1/infra/tier-0s — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeNsxListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 tier-0 gateways)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-30s %-16s\n", "id", "display_name", "ha_mode")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-30s %-16s\n",
+			truncate(nsxStringField(e, "id"), 38),
+			truncate(nsxStringField(e, "display_name"), 30),
+			truncate(nsxStringField(e, "ha_mode"), 16),
+		)
+	}
+}

--- a/cli/internal/cmd/nsx/tier1.go
+++ b/cli/internal/cmd/nsx/tier1.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newTier1Cmd returns the `meho nsx tier1` parent command (list sub-verb).
+func newTier1Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "tier1",
+		Short:        "NSX tier-1 gateway verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newTier1ListCmd())
+	return cmd
+}
+
+// newTier1ListCmd returns `meho nsx tier1 list` → GET:/policy/api/v1/infra/tier-1s.
+func newTier1ListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List NSX tier-1 (per-tenant) gateways",
+		Long: "list dispatches GET:/policy/api/v1/infra/tier-1s against\n" +
+			"connector_id=\"nsx-rest-4.2\". Renders id / display_name / tier0_path\n" +
+			"for human eyes; --json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx tier1 list --target rdc-nsx\n" +
+			"  meho nsx tier1 list --target rdc-nsx --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTier1List(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runTier1List(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	const opID = "GET:/policy/api/v1/infra/tier-1s"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printTier1List)
+}
+
+func printTier1List(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/policy/api/v1/infra/tier-1s — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeNsxListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 tier-1 gateways)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-30s %-50s\n", "id", "display_name", "tier0_path")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-30s %-50s\n",
+			truncate(nsxStringField(e, "id"), 38),
+			truncate(nsxStringField(e, "display_name"), 30),
+			truncate(nsxStringField(e, "tier0_path"), 50),
+		)
+	}
+}

--- a/cli/internal/cmd/nsx/transportzone.go
+++ b/cli/internal/cmd/nsx/transportzone.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package nsx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+const tzOpID = "GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"
+
+// newTransportZoneCmd returns `meho nsx transport-zone` parent command.
+func newTransportZoneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "transport-zone",
+		Short:        "NSX transport-zone verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newTransportZoneListCmd())
+	return cmd
+}
+
+// newTransportZoneListCmd returns `meho nsx transport-zone list`.
+func newTransportZoneListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List NSX transport zones under the default enforcement point",
+		Long: "list dispatches GET:/policy/api/v1/infra/sites/default/enforcement-points/\n" +
+			"default/transport-zones against connector_id=\"nsx-rest-4.2\".\n" +
+			"Renders id / display_name / tz_type for human eyes; --json emits\n" +
+			"the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho nsx transport-zone list --target rdc-nsx\n" +
+			"  meho nsx transport-zone list --target rdc-nsx --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTransportZoneList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "NSX target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runTransportZoneList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, tzOpID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, tzOpID, r, jsonOut, printTransportZoneList)
+}
+
+func printTransportZoneList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s transport-zones — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeNsxListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 transport zones)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-30s %-10s\n", "id", "display_name", "tz_type")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-30s %-10s\n",
+			truncate(nsxStringField(e, "id"), 38),
+			truncate(nsxStringField(e, "display_name"), 30),
+			truncate(nsxStringField(e, "tz_type"), 10),
+		)
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/connector"
 	"github.com/evoila/meho/cli/internal/cmd/k8s"
 	"github.com/evoila/meho/cli/internal/cmd/kb"
+	"github.com/evoila/meho/cli/internal/cmd/nsx"
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
 	"github.com/evoila/meho/cli/internal/cmd/targets"
@@ -141,6 +142,17 @@ func newRootCmd() *cobra.Command {
 	// the backplane manifest cannot shadow the built-in `vmware`
 	// parent.
 	root.AddCommand(vmware.NewRootCmd())
+
+	// G3.5-T3 (#615) -- nsx-rest-4.2 operator alias verbs for
+	// Initiative #368. The verb tree pre-bakes connector_id=
+	// "nsx-rest-4.2" on top of the existing /api/v1/operations/call
+	// dispatcher route. Ships the 9 read-only NSX core verbs (about,
+	// node list, cluster status, segment list, transport-zone list,
+	// tier0 list, tier1 list, firewall policy list, firewall rule list)
+	// plus operation search/call meta-tool wrappers.
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in `nsx` parent.
+	root.AddCommand(nsx.NewRootCmd())
 
 	// G3.3-T6 (#550) -- vault-1.x operator alias verbs for Initiative
 	// #366. The verb tree pre-bakes connector_id="vault-1.x" on top of

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -244,13 +244,24 @@ posture `edit_group` takes for `when_to_use`).
 
 - Issues: [G3.5-T1 #613](https://github.com/evoila/meho/issues/613)
   (skeleton); [G3.5-T2 #614](https://github.com/evoila/meho/issues/614)
-  (core-ops curation + `edit_op(llm_instructions=)` substrate).
+  (core-ops curation + `edit_op(llm_instructions=)` substrate);
+  [G3.5-T3 #615](https://github.com/evoila/meho/issues/615)
+  (CLI verbs + E2E recorded-fixture tests + operator onboarding doc).
 - Parent Initiative: [G3.5 #368](https://github.com/evoila/meho/issues/368).
 - Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
-- Sibling tasks: #615 (CLI + MCP review + E2E).
-- Operator runbook: `docs/cross-repo/g35-nsx-canary.md` — ingest +
-  curate + enable + smoke procedure for an operator standing up
-  NSX against a fresh deploy.
+- CLI verbs: `cli/internal/cmd/nsx/` — thin Cobra layer over
+  `POST /api/v1/operations/call` for the 9 core ops + `operation
+  search/call` meta-tools; mirrors `cli/internal/cmd/vmware/`.
+- Operator runbooks:
+  - `docs/cross-repo/g35-nsx-canary.md` — ingest + curate + enable +
+    smoke procedure for an operator standing up NSX against a fresh
+    deploy.
+  - `docs/cross-repo/nsx-onboarding.md` — `meho nsx …` verb reference
+    + `scripts/nsx.sh` → `meho nsx` per-ticket wrapper-flip recipe.
+- Integration test: `backend/tests/test_connectors_nsx_e2e.py` —
+  combined E2E covering all 9 ops, session-establish, 401-retry,
+  audit rows, and JSONFlux handle path; runs in the `meho-runners` CI
+  lane with no Docker dependency.
 - Acceptance tests:
   - `backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py` —
     dispatch the 9 NSX core ops against a respx-mocked NSX REST

--- a/docs/cross-repo/nsx-onboarding.md
+++ b/docs/cross-repo/nsx-onboarding.md
@@ -1,0 +1,376 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# NSX op surface onboarding — operator recipe
+
+> Operator-facing recipe for the G3.5 `nsx-rest-4.2` op surface — the
+> `meho nsx …` verb tree, the agent meta-tool path, and the migration
+> off the consumer's `scripts/nsx.sh` wrapper. The op handlers live in
+> [`backend/src/meho_backplane/connectors/nsx/`](../../backend/src/meho_backplane/connectors/nsx/);
+> the engineering-facing companion is
+> [`docs/codebase/connectors-nsx.md`](../codebase/connectors-nsx.md).
+> This doc is the cookbook every RDC operator reads when retiring
+> `scripts/nsx.sh` in favour of `meho nsx …`.
+
+## What this surface is
+
+The `nsx-rest-4.2` connector is an **ingested** connector: the 9 curated
+read-only ops are stored as `EndpointDescriptor` rows seeded from
+[`NSX_CORE_OPS`](../../backend/src/meho_backplane/connectors/nsx/core_ops.py)
+and dispatched through `HttpConnector._request_json` by the G0.6
+`dispatch_ingested` branch. The connector registers under the
+`(product="nsx", version="4.2", impl_id="nsx-rest")` registry triple —
+the connector id `nsx-rest-4.2`. Auth is session-cookie + `X-XSRF-TOKEN`
+(not HTTP Basic); the connector handles this transparently via
+`NsxConnector.auth_headers`.
+
+NSX has no public CI simulator (#536 proved simulators cannot serve
+vendor REST). Integration coverage uses a recorded-fixture record/replay
+pattern against captured NSX responses. This is a known, documented
+limitation per Initiative #368's DoD.
+
+The v0.2 op surface (Initiative
+[#368](https://github.com/evoila/meho/issues/368)) is the **read**
+working set the consumer's `scripts/nsx.sh` exercises daily — write
+ops stay in the wrapper until v0.2.next ships policy + approval flow:
+
+| Group | CLI verb | `op_id` | Path |
+| --- | --- | --- | --- |
+| nsx-identity | `meho nsx about` | `GET:/api/v1/node` | Manager identity + version |
+| nsx-inventory | `meho nsx node list` | `GET:/api/v1/transport-nodes` | Transport-node inventory |
+| nsx-cluster | `meho nsx cluster status` | `GET:/api/v1/cluster/status` | Management + control cluster health |
+| nsx-segments | `meho nsx segment list` | `GET:/policy/api/v1/infra/segments` | Policy-API overlay/VLAN segment listing |
+| nsx-transport-zones | `meho nsx transport-zone list` | `GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones` | Transport-zone listing |
+| nsx-routing | `meho nsx tier0 list` | `GET:/policy/api/v1/infra/tier-0s` | Provider-edge Tier-0 router listing |
+| nsx-routing | `meho nsx tier1 list` | `GET:/policy/api/v1/infra/tier-1s` | Tenant Tier-1 router listing |
+| nsx-policy-firewall | `meho nsx firewall policy list [--scope <domain>]` | `GET:/policy/api/v1/infra/domains/{domain-id}/security-policies` | Security policy listing per domain |
+| nsx-policy-firewall | `meho nsx firewall rule list <policy-id> [--scope <domain>]` | `GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules` | Per-policy rule listing |
+
+Every op dispatches through the same `POST /api/v1/operations/call`
+route the agent surface uses — auth, policy, audit, broadcast, and
+JSONFlux all run as documented in [CLAUDE.md](../../CLAUDE.md) §6. The
+CLI verb tree is operator ergonomics over that one route; it is **not**
+a separate data path and is **not** mirrored on the MCP surface
+(CLAUDE.md postulate 5).
+
+## Prerequisites
+
+- **A reachable NSX Manager** (standalone NSX-T or behind the VCF 9
+  envoy proxy). The connector derives the base URL from `target.host` +
+  `target.port`; both plain NSX-T and VCF-proxied addresses work.
+- **Service-account credentials in Vault.** The connector reads
+  `{"username": ..., "password": ...}` from Vault at `target.secret_ref`.
+  The username/password pair is form-encoded to `POST /api/session/create`
+  at the start of every new per-target session; the resulting
+  `JSESSIONID` cookie + `X-XSRF-TOKEN` are cached per-target and
+  re-used until a 401 forces a re-login.
+- **A registered NSX target.** The CLI verbs take `--target <slug>`
+  (e.g. `--target rdc-nsx`). The target carries `product="nsx"`,
+  `host` (the NSX Manager FQDN — no `https://`), `port` (default 443),
+  `secret_ref` (the Vault path to the credentials), and
+  `auth_model="shared_service_account"`.
+- **The 9 curated ops registered + enabled.** Run the G3.5-T2 curation
+  step (`apply_nsx_core_curation`) once per NSX target after the G0.7
+  spec ingest. See [`docs/cross-repo/g35-nsx-canary.md`](./g35-nsx-canary.md)
+  for the end-to-end canary procedure.
+- **An operator session.** `meho login <backplane-url>` writes the
+  session token the CLI reuses. `meho nsx …` requires `operator` role
+  minimum (same gate as every dispatch verb).
+
+## Target + auth model
+
+The shipped connector's auth model is **`shared_service_account`** —
+the Vault-sourced credentials are used regardless of which operator
+invokes the verb. Per-operator impersonation is out of scope for v0.2.
+
+What this means for the credentials in Vault:
+
+- Vault path: `target.secret_ref` (e.g. `kv/data/nsx/<slug>`).
+- Required fields: `username` (string), `password` (string).
+- The backplane reads them lazily on first op invocation per target; the
+  session cookie + XSRF token are then cached in the connector's
+  per-target httpx client until a 401 triggers one re-login.
+- **Session expiry**: NSX 4.x default session idle timeout is 30 minutes.
+  The connector handles expiry transparently: a 401 on any downstream
+  GET invalidates the cached token, re-POSTs to `/api/session/create`,
+  and retries the request once. A second consecutive 401 raises
+  `RuntimeError` (bad credentials) — operator action required.
+- **Credential rotation**: update the Vault secret, then restart the
+  backplane (or wait for the next session expiry) so the connector
+  reloads. The in-process session cache is the only persistent state;
+  there is no per-target credential refresh hook in v0.2.
+
+To register a new target via the CLI:
+
+```bash
+meho targets import \
+  --name rdc-nsx \
+  --product nsx \
+  --host nsx-manager.rdc.evoila.io \
+  --port 443 \
+  --secret-ref kv/data/nsx/rdc-nsx \
+  --auth-model shared_service_account
+```
+
+Verify the fingerprint resolved correctly:
+
+```bash
+meho targets probe --name rdc-nsx --json | jq '{product, version, reachable}'
+# expected: {"product": "nsx", "version": "4.2", "reachable": true}
+```
+
+## Quick-start
+
+```bash
+# Identity + version
+meho nsx about --target rdc-nsx
+
+# Transport-node inventory
+meho nsx node list --target rdc-nsx
+
+# Cluster health
+meho nsx cluster status --target rdc-nsx
+
+# Overlay segments
+meho nsx segment list --target rdc-nsx
+
+# Transport zones
+meho nsx transport-zone list --target rdc-nsx
+
+# Routing topology
+meho nsx tier0 list --target rdc-nsx
+meho nsx tier1 list --target rdc-nsx
+
+# Distributed firewall — policies + rules
+meho nsx firewall policy list --target rdc-nsx
+meho nsx firewall rule list policy-app-tier --target rdc-nsx
+
+# Firewall in a non-default domain
+meho nsx firewall policy list --scope my-domain --target rdc-nsx
+
+# Machine-readable output for any verb
+meho nsx segment list --target rdc-nsx --json | jq '.result.results[] | .id'
+
+# Escape hatch: run any nsx-rest-4.2 op by op_id
+meho nsx operation call GET:/api/v1/node --target rdc-nsx
+meho nsx operation search "firewall rules" --target rdc-nsx
+```
+
+## Verb reference
+
+### `meho nsx about`
+
+Dispatches `GET:/api/v1/node` against `connector_id="nsx-rest-4.2"`.
+Human output: `node_version`, `kernel_version`, `hostname`, `node_uuid`.
+
+```
+$ meho nsx about --target rdc-nsx
+nsx-rest-4.2 — node_version=4.2.1.0.0 (kernel 4.2.1.0.0 build) @ nsxmgr-rdc
+  node_uuid: deadbeef-1111-2222-3333-cafebabecafe
+  hostname:  nsxmgr-rdc.evoila.io
+```
+
+### `meho nsx node list`
+
+Dispatches `GET:/api/v1/transport-nodes`. Renders `id` / `display_name`
+and `resource_type` from `node_deployment_info`. The list covers all
+transport nodes registered on the manager (ESXi hosts, bare-metal
+endpoints, edge nodes).
+
+### `meho nsx cluster status`
+
+Dispatches `GET:/api/v1/cluster/status`. Renders management-cluster
+and control-cluster aggregate status. A healthy deployment shows
+`STABLE` / `STABLE`; a degraded member shows the member UUID in the
+detail list.
+
+### `meho nsx segment list`
+
+Dispatches `GET:/policy/api/v1/infra/segments`. Renders `id` /
+`display_name` / `transport_zone_path`. This is the broadest list op —
+production deployments often have hundreds of segments. Use `--json |
+jq` to filter by transport zone path or subnet CIDR.
+
+### `meho nsx transport-zone list`
+
+Dispatches the long enforcement-point-qualified path. Renders `id` /
+`display_name` / `tz_type` (`OVERLAY` or `VLAN`).
+
+### `meho nsx tier0 list` / `meho nsx tier1 list`
+
+Dispatch `GET:/policy/api/v1/infra/tier-0s` and
+`GET:/policy/api/v1/infra/tier-1s` respectively. Render `id` /
+`display_name` / `ha_mode` (Tier-0) or `tier0_path` (Tier-1). Tier-0s
+are provider-owned; Tier-1s are tenant-owned and attach to a Tier-0.
+
+### `meho nsx firewall policy list`
+
+Dispatches `GET:/policy/api/v1/infra/domains/{domain-id}/security-policies`
+with `--scope` (default `"default"`) substituted as `domain-id`. Renders
+`id` / `display_name` / `category`. Most environments use the `default`
+domain; multi-domain setups pass `--scope <domain-id>`.
+
+### `meho nsx firewall rule list <policy-id>`
+
+Dispatches the per-policy rules path with `<policy-id>` substituted as
+`security-policy-id` and `--scope` (default `"default"`) as `domain-id`.
+Renders `id` / `display_name` / `action` (`ALLOW` / `DROP` / `REJECT`).
+
+### `meho nsx operation search` / `meho nsx operation call`
+
+Meta-tool wrappers pre-scoped to `nsx-rest-4.2`. `search` runs the
+hybrid BM25+cosine search across nsx-rest-4.2 op descriptors; `call`
+dispatches any op_id directly. Use these for ops not yet promoted to
+dedicated CLI aliases.
+
+```bash
+meho nsx operation search "cluster status" --group nsx-cluster
+meho nsx operation call GET:/api/v1/node --target rdc-nsx
+```
+
+## Audit and broadcast classification
+
+Every NSX v0.2 op is `safety_level=safe`, `requires_approval=false` —
+the read-only surface never mutates state. The audit row carries:
+`method='DISPATCH'`, `path=<op_id>`, `target_id=<uuid>`,
+`payload={"op_id": ..., "params_hash": ..., "source_kind": "ingested",
+"connector_product": "nsx", "connector_version": "4.2",
+"connector_impl_id": "nsx-rest", "result_status": "ok"|"error"}`.
+
+Broadcast events publish per-tenant on every successful dispatch.
+`meho audit query --connector nsx-rest-4.2` retrieves the full
+dispatch history; see [`audit-query.md`](./audit-query.md) for filter
+syntax.
+
+## Migrating off `scripts/nsx.sh`
+
+The consumer's
+[`scripts/nsx.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/nsx.sh)
+drives NSX REST via a `curl` + session-cookie wrapper. The `meho nsx`
+verbs replace it for the read-only workflows; write workflows stay in
+the wrapper.
+
+Active tickets using `nsx.sh` (from consumer-needs.md L85):
+
+| Consumer workflow | `nsx.sh` invocation | `meho nsx …` replacement | Notes |
+| --- | --- | --- | --- |
+| Node identity + version | `nsx.sh about` | `meho nsx about --target rdc-nsx` | |
+| Transport-node inventory | `nsx.sh nodes` | `meho nsx node list --target rdc-nsx` | |
+| Cluster health check | `nsx.sh cluster status` | `meho nsx cluster status --target rdc-nsx` | |
+| Segment listing | `nsx.sh segments` | `meho nsx segment list --target rdc-nsx` | JSON output: `--json \| jq '.result.results[] \| .id'` |
+| Transport-zone listing | `nsx.sh transport-zones` | `meho nsx transport-zone list --target rdc-nsx` | |
+| Tier-0 edge listing | `nsx.sh tier0s` | `meho nsx tier0 list --target rdc-nsx` | |
+| Tenant router listing | `nsx.sh tier1s` | `meho nsx tier1 list --target rdc-nsx` | |
+| FW policy listing | `nsx.sh fw-policies [domain]` | `meho nsx firewall policy list --target rdc-nsx [--scope <domain>]` | Default domain `"default"` if `--scope` omitted |
+| FW rule listing | `nsx.sh fw-rules <policy>` | `meho nsx firewall rule list <policy-id> --target rdc-nsx` | |
+
+What `scripts/nsx.sh` did that `meho nsx` deliberately does **not** do
+(out of scope for v0.2 — keep the wrapper for these until a future
+Initiative lands them):
+
+- **Write / mutate ops** — segment create/update/delete, FW rule create,
+  transport-node configuration. v0.2 is read-only; write ops land in
+  v0.2.next pending policy + approval workflow.
+- **Custom query parameters** — `nsx.sh` passes raw query strings;
+  the v0.2 CLI exposes only the parameters each op formally declares
+  in its descriptor. Use `meho nsx operation call <op_id> --params
+  '{"cursor": "...", "page_size": 100}'` for custom pagination.
+- **Non-policy API paths** — `nsx.sh` can hit arbitrary `/api/v1/…`
+  paths; `meho nsx` exposes only the 9 curated core ops. Use
+  `meho nsx operation call GET:<path>` as an escape hatch for one-off
+  queries.
+
+Migration discipline: run the `meho nsx` form alongside `nsx.sh` for
+an overlap window, diff the outputs, then retire the wrapper call site.
+The MEHO path adds the full audit row + broadcast event the bash
+pattern never had — that audit coverage is the point of migrating.
+
+### Per-ticket wrapper-flip recipe
+
+For each active NSX consumer ticket, apply this pattern:
+
+1. **Identify the wrapper invocation** in the ticket's reproduction
+   steps (usually `bash scripts/nsx.sh <command>`).
+2. **Find the `meho nsx` equivalent** from the table above.
+3. **Validate output parity**: run both side-by-side against `rdc-nsx`.
+   Use `--json | jq` on the `meho nsx` side to pull the same fields
+   the bash script was parsing.
+4. **Update the ticket steps**: replace the `nsx.sh` invocation with
+   the `meho nsx` form. Capture the `--json` output for the ticket's
+   evidence block.
+5. **Retire the wrapper call site** in the ticket's automation scripts
+   once the MEHO form is validated.
+
+Example — segment listing ticket:
+
+```bash
+# Before (wrapper):
+bash scripts/nsx.sh segments rdc-nsx | jq '.[].id'
+
+# After (meho nsx):
+meho nsx segment list --target rdc-nsx --json | jq '.result.results[].id'
+
+# Verify parity:
+diff \
+  <(bash scripts/nsx.sh segments rdc-nsx | jq -S '.[].id') \
+  <(meho nsx segment list --target rdc-nsx --json | jq -S '.result.results[].id')
+# expected: empty diff
+```
+
+Example — firewall rules:
+
+```bash
+# Before:
+bash scripts/nsx.sh fw-rules policy-app-tier rdc-nsx
+
+# After:
+meho nsx firewall rule list policy-app-tier --target rdc-nsx
+
+# With --scope for non-default domain:
+meho nsx firewall rule list policy-app-tier --target rdc-nsx --scope my-domain
+```
+
+## Goal #214 G3.5 NSX checklist
+
+| Checklist item | Status |
+| --- | --- |
+| G3.5-T1 #613 — `NsxConnector` skeleton + session/XSRF auth | ✅ merged |
+| G3.5-T2 #614 — 9 core ops + `apply_nsx_core_curation` + acceptance tests | ✅ merged |
+| G3.5-T3 #615 — CLI verbs + E2E recorded-fixture tests + this doc | ✅ merged |
+| MCP `llm_instructions` / `when_to_use` reviewed for agent legibility | ✅ done (part of T2 curation blobs) |
+| All 9 core ops dispatch → `status='ok'` in CI | ✅ `test_connectors_nsx_e2e.py` |
+| Audit rows carry `op_id` + `target_id` + `params_hash` | ✅ `test_connectors_nsx_e2e.py` |
+| 401-retry path tested in CI | ✅ `test_connectors_nsx_e2e.py` |
+| JSONFlux handle path tested in CI | ✅ `test_connectors_nsx_e2e.py` |
+| `docs/cross-repo/nsx-onboarding.md` with wrapper-flip recipe | ✅ this document |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `no backplane URL configured` (exit 2) | Never logged in / no `--backplane`. | `meho login <url>` or pass `--backplane <url>`. |
+| `auth_expired` / stored token rejected | Keycloak token expired. | `meho login <url>` again. |
+| `status=error connector_error: RuntimeError … returned HTTP 401` | NSX credentials invalid or account locked. | Verify the Vault secret at `target.secret_ref`; check NSX audit log for the service account. |
+| `status=error connector_error: RuntimeError … 401 after refresh` | Re-login also 401'd — credentials consistently rejected. | Update the Vault secret; restart the backplane to flush the in-process session cache. |
+| `status=error … unknown_op` | The 9 core ops are not registered/enabled. | Re-run `apply_nsx_core_curation` against the NSX connector; see [`g35-nsx-canary.md`](./g35-nsx-canary.md). |
+| `status=denied` | `read_only` role, or a tenant policy denied the dispatch. | Use an `operator`-role token. |
+| `about` / any verb times out | NSX Manager unreachable from the backplane host. | Verify the FQDN/IP in `target.host` resolves from the backplane; check firewall rules (port 443 from backplane → NSX Manager). |
+| `probe` fails with TLS error | Self-signed or expired certificate, or wrong CA bundle. | Mount the correct CA bundle in the backplane container and set `MEHO_TLS_CA_BUNDLE`; or configure NSX Manager with a CA-signed cert. |
+| Firewall policy/rule list returns 404 | `--scope` value doesn't match an existing NSX policy domain. | List available domains via `meho nsx operation call GET:/policy/api/v1/infra/domains --target rdc-nsx`. Default domain is always `"default"`. |
+| `meho nsx segment list` returns empty `results` | No segments in the default policy domain, or the policy API mount isn't reachable. | Verify segments exist via NSX Manager UI; confirm the NSX Manager version is 4.x (policy API is 4.0+). |
+
+## References
+
+- Initiative: [#368 G3.5 NSX REST 4.2 op surface](https://github.com/evoila/meho/issues/368); Goal [#214](https://github.com/evoila/meho/issues/214) (G3 connector parity).
+- Tasks that shipped this surface: [#613](https://github.com/evoila/meho/issues/613) (T1 skeleton + auth), [#614](https://github.com/evoila/meho/issues/614) (T2 core ops + curation), [#615](https://github.com/evoila/meho/issues/615) (T3 CLI verbs + E2E + this doc).
+- Engineering companion: [`docs/codebase/connectors-nsx.md`](../codebase/connectors-nsx.md).
+- Canary procedure (G0.7 spec ingest → curation): [`docs/cross-repo/g35-nsx-canary.md`](./g35-nsx-canary.md).
+- Connector source: [`backend/src/meho_backplane/connectors/nsx/`](../../backend/src/meho_backplane/connectors/nsx/).
+- CLI verbs: [`cli/internal/cmd/nsx/`](../../cli/internal/cmd/nsx/).
+- E2E integration test: [`backend/tests/test_connectors_nsx_e2e.py`](../../backend/tests/test_connectors_nsx_e2e.py).
+- Acceptance tests: [`backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py`](../../backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py), [`backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py`](../../backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py).
+- Consumer wrapper retiring: [`scripts/nsx.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/nsx.sh).
+- NSX REST API reference: <https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/>.
+- Related onboarding docs: [`vault-onboarding.md`](./vault-onboarding.md), [`audit-query.md`](./audit-query.md), [`broadcast-onboarding.md`](./broadcast-onboarding.md).

--- a/docs/cross-repo/nsx-onboarding.md
+++ b/docs/cross-repo/nsx-onboarding.md
@@ -165,7 +165,7 @@ meho nsx operation search "firewall rules" --target rdc-nsx
 Dispatches `GET:/api/v1/node` against `connector_id="nsx-rest-4.2"`.
 Human output: `node_version`, `kernel_version`, `hostname`, `node_uuid`.
 
-```
+```text
 $ meho nsx about --target rdc-nsx
 nsx-rest-4.2 — node_version=4.2.1.0.0 (kernel 4.2.1.0.0 build) @ nsxmgr-rdc
   node_uuid: deadbeef-1111-2222-3333-cafebabecafe


### PR DESCRIPTION
## Summary

- Add `cli/internal/cmd/nsx/` Cobra verb package: 9 noun sub-commands (`about`, `node`, `cluster`, `segment`, `transport-zone`, `tier0`, `tier1`, `firewall`) + `operation search/call` meta-tools, all pre-scoped to `connector_id="nsx-rest-4.2"`. Mirrors the vmware CLI verb package; NSX-specific delta is `{"results": [...]}` list decoding and firewall path template params (`--scope`/`<policy-id>`).
- Add `backend/tests/test_connectors_nsx_e2e.py`: recorded-fixture E2E covering all 4 acceptance criteria — all 9 ops dispatch `status='ok'`, session-establish + 401-retry path, audit rows (`method='DISPATCH'`/`target_id`/`params_hash`), JSONFlux handle path via `ForceHandleReducer`. Runs against SQLite, no Docker dependency.
- Add `docs/cross-repo/nsx-onboarding.md`: verb reference, Target+auth model, Vault creds, per-ticket `scripts/nsx.sh → meho nsx` wrapper-flip recipe, Goal #214 G3.5 NSX checklist.
- Wire `nsx.NewRootCmd()` into `cli/internal/cmd/root.go`. Update `docs/codebase/connectors-nsx.md` references to include T3 deliverables.

## Test plan

- [x] `ruff check` — clean
- [x] `mypy backend/src/meho_backplane/connectors/nsx/` — clean
- [x] `pytest backend/tests/test_connectors_nsx_e2e.py -v` — 13 passed (all 9 op dispatch, session-establish, 401-retry, audit row, JSONFlux handle)
- [x] `pytest backend/tests/test_connectors_nsx_auth.py backend/tests/test_connectors_nsx_core_ops.py -v` — 36 passed (no regressions)
- [x] Go tests (`cli/internal/cmd/nsx/nsx_test.go`): truncate/normalise helpers, classifier, params flag, decoder, renderer, wire-shape + dispatch assertions — validated at compile + test time by CI (Go 1.23 via `actions/setup-go`; Go not in local dev env)
- [x] AC(a): `test_nsx_e2e_all_ops_dispatch_ok` — 9 parametrised cases, all green
- [x] AC(b): `test_nsx_e2e_session_establishes_on_first_dispatch` + `test_nsx_e2e_401_retry_via_connector_method` — session token cached on first dispatch; 401 triggers re-login + retry via `_get_json_with_session_retry`
- [x] AC(c): `test_nsx_e2e_dispatch_writes_audit_row` — AuditLog row with `method='DISPATCH'`, non-null `target_id`, `payload["params_hash"]`
- [x] AC(d): `test_nsx_e2e_jsonflux_handle_populated_for_segment_list` — `OperationResult.handle` populated with ≥1 sample row from NSX_CANARY_SEGMENTS

## Out of scope

- NSX write verbs — read-only in v0.2 per #368
- Live NSX CI environment — recorded-fixture is the accepted v0.2 approach (#536)
- MCP `llm_instructions`/`when_to_use` review — landed in G3.5-T2 (#614)

Closes #615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full NSX CLI suite (nsx) with commands to query about, cluster, node, segment, tier-0, tier-1, transport-zone, firewall policies/rules, and perform operation search/call.

* **Tests**
  * Added NSX end-to-end integration tests validating operation dispatches, session establishment and single-retry on 401, audit logging, and result handling.

* **Documentation**
  * Added NSX onboarding guide and updated connector reference docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->