### PR TITLE
feat(topology): G9.2-T6 CLI verbs annotate/unannotate/list-edges + in-help vocab

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,16 +3,14 @@ module github.com/evoila/meho/cli
 go 1.23.0
 
 require (
+	github.com/google/uuid v1.5.0
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.27.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require (
-	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/google/uuid v1.5.0 // indirect
-)
+require github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 
 require (
 	github.com/danieljoos/wincred v1.2.3 // indirect

--- a/cli/internal/cmd/topology/annotate.go
+++ b/cli/internal/cmd/topology/annotate.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// edgeKindVocabulary mirrors the closed 10-kind GraphEdgeKind enum
+// (backend/src/meho_backplane/db/models.py). The order matches the
+// enum declaration order so the in-help table is stable across
+// releases — the four auto-discoverable kinds first, then the six
+// curated-only kinds. The vocabulary is closed; widening it is a
+// coordinated DB migration + enum + decision-row change per §12 of
+// Initiative #364. Keep this list in lock-step with the enum.
+var edgeKindVocabulary = []edgeKindEntry{
+	// Four auto-discoverable kinds — refresh writes these on every probe.
+	{"runs-on", "vm runs-on host, pod runs-on node (physical/scheduling host)"},
+	{"mounts", "vm mounts datastore, pod mounts volume (storage attachment)"},
+	{"routes-through", "ingress routes-through service, service routes-through pod (network)"},
+	{"belongs-to", "pod belongs-to namespace, vm belongs-to host (logical group membership)"},
+	// Six curated-only kinds — operator-asserted; cannot be derived from probes.
+	{"authenticates-via", "principal -> identity-provider (e.g. k8s-sa-foo -> vault-role-bar)"},
+	{"depends-on", "cross-system functional dependency (service-X -> database-Y)"},
+	{"replicates-to", "operator-asserted replication between storage / database nodes"},
+	{"backed-up-by", "operator-asserted backup relationship"},
+	{"routes-via", "operator-asserted network path through an intermediary (vm-A -> firewall-X -> vm-B)"},
+	{"policy-binds", "RBAC / policy attachment across connector boundaries (k8s-ns -> vault-policy)"},
+}
+
+type edgeKindEntry struct {
+	Name string
+	Desc string
+}
+
+// formatEdgeKindTable renders the 10-kind vocabulary as an aligned
+// table block. Used both for the cobra `Long` help (§12 of Initiative
+// #364 requires the table to be discoverable from `--help`) and for
+// the unit tests that assert every name + description is present.
+func formatEdgeKindTable() string {
+	var b strings.Builder
+	b.WriteString("Edge kind vocabulary (closed 10-kind enum, §12 of Initiative #364):\n\n")
+	for _, e := range edgeKindVocabulary {
+		fmt.Fprintf(&b, "  %-18s %s\n", e.Name, e.Desc)
+	}
+	return b.String()
+}
+
+// newAnnotateCmd returns the `meho topology annotate` command.
+//
+//	meho topology annotate <from> <kind> <to> [--note "..."]
+//	  [--evidence-url URL] [--from-kind K] [--to-kind K]
+//	  [--json] [--backplane <url>]
+//	# POST /api/v1/topology/edges
+//
+// Creates or upserts a curated edge. The server runs §6 conflict
+// detection on neighbouring auto edges so the resulting TopologyEdge
+// `properties` may carry `conflicts_with` / `supersedes` markers; the
+// CLI emits the raw response under --json so a consumer can react.
+// Requires `tenant_admin` — a 403 from the backend is surfaced with
+// the required-role hint.
+func newAnnotateCmd() *cobra.Command {
+	var (
+		note              string
+		evidenceURL       string
+		fromKind          string
+		toKind            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "annotate <from> <kind> <to>",
+		Short: "Assert a curated topology edge (operator-curated cross-system relationship)",
+		Long: "annotate calls POST /api/v1/topology/edges and asserts a " +
+			"curated edge between two topology nodes — the operator " +
+			"surface for the six cross-system relationships auto-" +
+			"discovery cannot infer (authenticates-via, depends-on, " +
+			"replicates-to, backed-up-by, routes-via, policy-binds), " +
+			"and the recoverability lever for an incorrectly auto-" +
+			"discovered edge (the §6 supersede flow). Idempotent — a " +
+			"repeat call upserts the same row. Requires tenant_admin.\n\n" +
+			"<kind> must be one of the closed 10-kind vocabulary " +
+			"below. <from> and <to> are node names; pass --from-kind " +
+			"/ --to-kind when a bare name is ambiguous across node " +
+			"kinds (the backend 409s otherwise).\n\n" +
+			formatEdgeKindTable(),
+		Args:          cobra.ExactArgs(3),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAnnotate(cmd, annotateOptions{
+				From:              args[0],
+				Kind:              args[1],
+				To:                args[2],
+				Note:              note,
+				EvidenceURL:       evidenceURL,
+				FromKind:          fromKind,
+				ToKind:            toKind,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&note, "note", "",
+		"free-form operator note (max 2000 chars) attached to the edge")
+	cmd.Flags().StringVar(&evidenceURL, "evidence-url", "",
+		"URL pointing at evidence for the asserted relationship (max 2000 chars)")
+	cmd.Flags().StringVar(&fromKind, "from-kind", "",
+		"pin the `from` endpoint to one node kind when its name is ambiguous")
+	cmd.Flags().StringVar(&toKind, "to-kind", "",
+		"pin the `to` endpoint to one node kind when its name is ambiguous")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the raw TopologyEdge response to stdout instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type annotateOptions struct {
+	From              string
+	Kind              string
+	To                string
+	Note              string
+	EvidenceURL       string
+	FromKind          string
+	ToKind            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// annotateRequestBody is the wire shape for POST /api/v1/topology/edges
+// — the issue body specifies `{from, kind, to, note?, evidence_url?}`.
+// `evidence_url` is snake_case on the wire (the JSON tag) even though
+// the CLI flag is kebab-case `--evidence-url` (Cobra convention).
+// Endpoints are nested objects carrying `name` + optional `kind` — the
+// route binds them via the `_EdgeEndpoint` Pydantic model and the
+// `_AnnotateEdgeRequest`'s `from` / `to` aliases.
+type annotateRequestBody struct {
+	From        annotateRequestEndpoint `json:"from"`
+	Kind        string                  `json:"kind"`
+	To          annotateRequestEndpoint `json:"to"`
+	Note        string                  `json:"note,omitempty"`
+	EvidenceURL string                  `json:"evidence_url,omitempty"`
+}
+
+type annotateRequestEndpoint struct {
+	Name string `json:"name"`
+	Kind string `json:"kind,omitempty"`
+}
+
+func runAnnotate(cmd *cobra.Command, opts annotateOptions) error {
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	body := annotateRequestBody{
+		From:        annotateRequestEndpoint{Name: opts.From, Kind: opts.FromKind},
+		Kind:        opts.Kind,
+		To:          annotateRequestEndpoint{Name: opts.To, Kind: opts.ToKind},
+		Note:        opts.Note,
+		EvidenceURL: opts.EvidenceURL,
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("encode annotate body: %v", err)),
+			opts.JSONOut)
+	}
+	edge, err := postAnnotate(cmd.Context(), backplaneURL, encoded)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), edge)
+	}
+	printAnnotateSummary(cmd.OutOrStdout(), edge)
+	return nil
+}
+
+func postAnnotate(ctx context.Context, backplaneURL string, body []byte) (*Edge, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/topology/edges", body)
+	if err != nil {
+		return nil, err
+	}
+	var out Edge
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode annotate response: %w", err)
+	}
+	return &out, nil
+}
+
+// printAnnotateSummary renders the resulting edge as a compact two-
+// line block: the relationship in `kind/from -> kind/to` form (the
+// same arrow notation the `path` verb uses) plus the edge id so the
+// operator can pipe it into a follow-up `unannotate <id>`.
+func printAnnotateSummary(w io.Writer, e *Edge) {
+	fmt.Fprintf(w, "annotated edge: %s/%s --[%s]--> %s/%s\n",
+		e.From.Kind, e.From.Name, e.Kind, e.To.Kind, e.To.Name)
+	fmt.Fprintf(w, "  edge_id: %s\n", e.ID)
+	fmt.Fprintf(w, "  source:  %s\n", e.Source)
+}

--- a/cli/internal/cmd/topology/e2e_test.go
+++ b/cli/internal/cmd/topology/e2e_test.go
@@ -331,6 +331,423 @@ func TestClosure403InsufficientRole(t *testing.T) {
 	}
 }
 
+// TestAnnotateRoundTripVisibleViaListEdgesThenUnannotate — the
+// acceptance criterion for #599: annotate → list-edges shows it →
+// unannotate removes it, against an httptest backplane that mirrors
+// the T5 wire shape (POST /edges → 201 TopologyEdge, GET /edges →
+// list of TopologyEdge, DELETE /edges/{id} → 204).
+func TestAnnotateRoundTripVisibleViaListEdgesThenUnannotate(t *testing.T) {
+	const edgeID = "11111111-2222-3333-4444-555555555555"
+	annotated := false
+	deleted := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			var body annotateRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode POST body: %v", err)
+			}
+			if body.From.Name != "service-x" || body.Kind != "depends-on" || body.To.Name != "database-y" {
+				t.Errorf("POST body mismatch: %+v", body)
+			}
+			if body.EvidenceURL != "https://docs/example" {
+				t.Errorf("evidence_url not propagated: %q", body.EvidenceURL)
+			}
+			annotated = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(Edge{
+				ID:     edgeID,
+				From:   EdgeEndpoint{ID: "a", Kind: "service", Name: "service-x"},
+				To:     EdgeEndpoint{ID: "b", Kind: "database", Name: "database-y"},
+				Kind:   "depends-on",
+				Source: "curated",
+			})
+		case http.MethodGet:
+			// Honour the source filter — annotate test issues
+			// source=curated when resolving the tuple form.
+			if got := r.URL.Query().Get("source"); got != "" && got != "curated" {
+				t.Errorf("unexpected source filter %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if !annotated || deleted {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]Edge{{
+				ID:     edgeID,
+				From:   EdgeEndpoint{ID: "a", Kind: "service", Name: "service-x"},
+				To:     EdgeEndpoint{ID: "b", Kind: "database", Name: "database-y"},
+				Kind:   "depends-on",
+				Source: "curated",
+			}})
+		default:
+			t.Errorf("unexpected method on /edges: %s", r.Method)
+		}
+	})
+	mux.HandleFunc("/api/v1/topology/edges/"+edgeID, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE; got %s", r.Method)
+		}
+		deleted = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	// 1. annotate
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runAnnotate(cmd, annotateOptions{
+		From: "service-x", Kind: "depends-on", To: "database-y",
+		EvidenceURL: "https://docs/example",
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runAnnotate: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "annotated edge") {
+		t.Errorf("annotate summary missing; got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), edgeID) {
+		t.Errorf("annotate summary missing edge_id; got %q", stdout.String())
+	}
+
+	// 2. list-edges — sees the new edge
+	cmd2, stdout2, stderr2 := newRunCmd(t)
+	if err := runListEdges(cmd2, listEdgesOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runListEdges: %v; stderr=%s", err, stderr2.String())
+	}
+	for _, want := range []string{"KIND", "depends-on", "service-x", "database-y"} {
+		if !strings.Contains(stdout2.String(), want) {
+			t.Errorf("list-edges missing %q in %q", want, stdout2.String())
+		}
+	}
+
+	// 3. unannotate (tuple form) — resolves client-side then DELETEs by id
+	cmd3, stdout3, stderr3 := newRunCmd(t)
+	if err := runUnannotate(cmd3, unannotateOptions{
+		From: "service-x", Kind: "depends-on", To: "database-y",
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runUnannotate tuple: %v; stderr=%s", err, stderr3.String())
+	}
+	if !strings.Contains(stdout3.String(), "deleted edge "+edgeID) {
+		t.Errorf("unannotate output wrong; got %q", stdout3.String())
+	}
+	if !deleted {
+		t.Errorf("DELETE never reached the server")
+	}
+
+	// 4. list-edges — now empty
+	cmd4, stdout4, _ := newRunCmd(t)
+	if err := runListEdges(cmd4, listEdgesOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("final list: %v", err)
+	}
+	if !strings.Contains(stdout4.String(), "no edges matched") {
+		t.Errorf("expected empty listing after delete; got %q", stdout4.String())
+	}
+}
+
+// TestAnnotateJSONPassesThroughRawEdge — --json emits the raw
+// TopologyEdge envelope unchanged so a consumer (jq, MCP shim, etc.)
+// can pipe the response into a follow-up call.
+func TestAnnotateJSONPassesThroughRawEdge(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Edge{
+			ID:   "edge-abc",
+			From: EdgeEndpoint{ID: "1", Kind: "vm", Name: "a"},
+			To:   EdgeEndpoint{ID: "2", Kind: "vm", Name: "b"},
+			Kind: "depends-on", Source: "curated",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runAnnotate(cmd, annotateOptions{
+		From: "a", Kind: "depends-on", To: "b",
+		JSONOut: true, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runAnnotate --json: %v; stderr=%s", err, stderr.String())
+	}
+	var decoded Edge
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
+	}
+	if decoded.ID != "edge-abc" || decoded.Kind != "depends-on" {
+		t.Errorf("--json decode produced %+v", decoded)
+	}
+}
+
+// TestAnnotate403TenantAdminRequired — a 403 from the route renders
+// the backend's role hint with exit class insufficient_role so the
+// operator sees "annotation requires tenant_admin", not a raw HTTP dump.
+func TestAnnotate403TenantAdminRequired(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runAnnotate(cmd, annotateOptions{
+		From: "a", Kind: "depends-on", To: "b", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error for 403")
+	}
+	for _, want := range []string{"insufficient_role", "tenant_admin"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("expected %q; got %q", want, stderr.String())
+		}
+	}
+}
+
+// TestUnannotateIDFormHappyPath — `unannotate <edge-id>` skips the
+// client-side resolve and DELETEs directly.
+func TestUnannotateIDFormHappyPath(t *testing.T) {
+	const edgeID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	deleted := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges/"+edgeID, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE; got %s", r.Method)
+		}
+		deleted = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	// A GET handler exists so the test fails loud if the id-form
+	// accidentally resolves via the list helper.
+	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("id form should not list-edges")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runUnannotate(cmd, unannotateOptions{
+		EdgeID: edgeID, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runUnannotate id: %v; stderr=%s", err, stderr.String())
+	}
+	if !deleted {
+		t.Fatalf("DELETE never reached the server")
+	}
+	if !strings.Contains(stdout.String(), "deleted edge "+edgeID) {
+		t.Errorf("output wrong; got %q", stdout.String())
+	}
+}
+
+// TestUnannotateRejectsNonUUIDIDForm — single-arg form requires a
+// valid UUID; a misshapen id fails fast client-side (no DELETE round-
+// trip).
+func TestUnannotateRejectsNonUUIDIDForm(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("network call not expected; got %s %s", r.Method, r.URL)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runUnannotate(cmd, unannotateOptions{
+		EdgeID: "not-a-uuid", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID edge-id")
+	}
+	if !strings.Contains(stderr.String(), "not a UUID") {
+		t.Errorf("expected UUID-shape hint; got %q", stderr.String())
+	}
+}
+
+// TestUnannotateAutoEdge409RendersServerDetail — DELETE on an auto-row
+// returns the route's typed 409 envelope; the CLI surfaces the
+// server's `detail.message` verbatim (the annotate-over-auto guidance)
+// instead of dumping the raw HTTP body.
+func TestUnannotateAutoEdge409RendersServerDetail(t *testing.T) {
+	const edgeID = "11111111-1111-1111-1111-111111111111"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges/"+edgeID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"detail":{"error":"auto_edge_deletion","edge_id":"`+edgeID+`",`+
+			`"message":"graph_edge has source='auto'; auto edges resurrect on the next refresh, `+
+			`so manual deletion is a no-op. Annotate over the auto edge first, then unannotate the curated row."}}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runUnannotate(cmd, unannotateOptions{
+		EdgeID: edgeID, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error for 409")
+	}
+	for _, want := range []string{"auto edges resurrect", "Annotate over"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("expected server detail %q in stderr; got %q", want, stderr.String())
+		}
+	}
+	if strings.Contains(stderr.String(), "HTTP 409") {
+		t.Errorf("expected the auto-row message, not a raw HTTP 409 dump; got %q", stderr.String())
+	}
+}
+
+// TestUnannotateTupleAmbiguous — two curated edges match the same
+// tuple → the CLI surfaces an ambiguous-tuple error with the candidate
+// ids so the operator can re-run with `unannotate <edge-id>`.
+func TestUnannotateTupleAmbiguous(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Edge{
+			{ID: "id-1", From: EdgeEndpoint{Kind: "vm", Name: "a"}, To: EdgeEndpoint{Kind: "host", Name: "b"}, Kind: "runs-on"},
+			{ID: "id-2", From: EdgeEndpoint{Kind: "vm", Name: "a"}, To: EdgeEndpoint{Kind: "host", Name: "b"}, Kind: "runs-on"},
+		})
+	})
+	mux.HandleFunc("/api/v1/topology/edges/", func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("DELETE must not fire on ambiguous tuple")
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runUnannotate(cmd, unannotateOptions{
+		From: "a", Kind: "runs-on", To: "b", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error for ambiguous tuple")
+	}
+	for _, want := range []string{"matches 2 curated edges", "id-1", "id-2"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("ambiguous render missing %q in %q", want, stderr.String())
+		}
+	}
+}
+
+// TestUnannotateTupleNotFound — empty list → the CLI surfaces a
+// not-found line that names the queried triple (and never another
+// tenant's row, since the list helper is server-side tenant-scoped).
+func TestUnannotateTupleNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runUnannotate(cmd, unannotateOptions{
+		From: "ghost", Kind: "depends-on", To: "phantom", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error for not-found tuple")
+	}
+	if !strings.Contains(stderr.String(), "no curated edge matches") {
+		t.Errorf("expected not-found hint; got %q", stderr.String())
+	}
+}
+
+// TestListEdgesJSONRoundTrip — --json emits the raw []Edge envelope so
+// a consumer can pipe the response into the unannotate id form.
+func TestListEdgesJSONRoundTrip(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Edge{{
+			ID:   "edge-1",
+			From: EdgeEndpoint{ID: "n1", Kind: "vm", Name: "web"},
+			To:   EdgeEndpoint{ID: "n2", Kind: "host", Name: "esxi-1"},
+			Kind: "runs-on", Source: "auto",
+		}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runListEdges(cmd, listEdgesOptions{JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runListEdges --json: %v; stderr=%s", err, stderr.String())
+	}
+	var decoded []Edge
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
+	}
+	if len(decoded) != 1 || decoded[0].ID != "edge-1" {
+		t.Errorf("--json decode produced %+v", decoded)
+	}
+}
+
+// TestListEdgesFlagsMapToQueryString — --kind / --source / --from /
+// --to / --conflicts / --limit / --offset land on the wire under the
+// names the route documents (no kebab→snake mismatch).
+func TestListEdgesFlagsMapToQueryString(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		want := map[string]string{
+			"kind":      "depends-on",
+			"source":    "curated",
+			"from":      "svc-x",
+			"to":        "db-y",
+			"conflicts": "true",
+			"limit":     "50",
+			"offset":    "10",
+		}
+		for k, v := range want {
+			if got := q.Get(k); got != v {
+				t.Errorf("query %s: got %q; want %q", k, got, v)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runListEdges(cmd, listEdgesOptions{
+		Kind: "depends-on", Source: "curated",
+		From: "svc-x", To: "db-y",
+		Conflicts: true, Limit: 50, Offset: 10,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runListEdges: %v; stderr=%s", err, stderr.String())
+	}
+}
+
+// TestListEdgesRejectsInvalidSource — --source must be curated or
+// auto; anything else fails fast client-side.
+func TestListEdgesRejectsInvalidSource(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runListEdges(cmd, listEdgesOptions{Source: "manual"})
+	if err == nil {
+		t.Fatalf("expected error for invalid --source")
+	}
+	if !strings.Contains(stderr.String(), "curated") || !strings.Contains(stderr.String(), "auto") {
+		t.Errorf("expected source hint; got %q", stderr.String())
+	}
+}
+
 // TestRefresh401AuthExpired — exhausting the refresh budget renders
 // auth_expired with the `meho login` hint.
 func TestRefresh401AuthExpired(t *testing.T) {

--- a/cli/internal/cmd/topology/list_edges.go
+++ b/cli/internal/cmd/topology/list_edges.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// Edge mirrors the backend TopologyEdge Pydantic model
+// (backend/src/meho_backplane/topology/schemas.py). The wire shape uses
+// `from` / `to` keys (`serialization_alias` on the Python side); the
+// Go struct names the fields `From` / `To` and uses the same JSON tag
+// so the response decodes cleanly. `Properties` is a free-form bag the
+// service writes (conflict markers, supersede UUIDs, operator notes);
+// rendered only in --json mode to keep the table view scannable.
+// Hand-written rather than aliased to a generated client type for the
+// same generated-client-decoupling reason the other verb trees document.
+type Edge struct {
+	ID         string         `json:"id"`
+	From       EdgeEndpoint   `json:"from"`
+	To         EdgeEndpoint   `json:"to"`
+	Kind       string         `json:"kind"`
+	Source     string         `json:"source"`
+	Properties map[string]any `json:"properties"`
+	LastSeen   *string        `json:"last_seen"`
+}
+
+// EdgeEndpoint mirrors backend TopologyEdgeEndpoint. Carries the three
+// fields a human-readable edge summary needs: the node id, the kind,
+// and the name. The full node properties bag is not included — an
+// edge listing is a survey of relationships, not a node dump.
+type EdgeEndpoint struct {
+	ID   string `json:"id"`
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+// newListEdgesCmd returns the `meho topology list-edges` command.
+//
+//	meho topology list-edges [--kind <type>] [--source curated|auto]
+//	  [--from <node>] [--to <node>] [--conflicts] [--limit N]
+//	  [--offset N] [--json] [--backplane <url>]
+//	# GET /api/v1/topology/edges?kind=&source=&from=&to=&conflicts=&limit=&offset=
+//
+// Tenant-scoped flat listing of curated + auto edges. The tenant
+// boundary is server-side (the JWT) — no flag accepts a tenant id, and
+// cross-tenant queries return the same empty list a missing node would.
+func newListEdgesCmd() *cobra.Command {
+	var (
+		kindFilter        string
+		sourceFilter      string
+		fromFilter        string
+		toFilter          string
+		conflictsOnly     bool
+		limit             int
+		offset            int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list-edges",
+		Short: "List curated + auto topology edges (filterable, tenant-scoped)",
+		Long: "list-edges calls GET /api/v1/topology/edges and renders " +
+			"a flat tenant-scoped edge listing. All filters are " +
+			"optional and combine with AND: --kind narrows to one " +
+			"edge kind, --source picks curated-only or auto-only, " +
+			"--from / --to filter by endpoint name, --conflicts " +
+			"surfaces only edges flagged by the §6 conflict detector " +
+			"(usually an auto edge that an annotation supersedes — " +
+			"the recoverability listing). Default output is an " +
+			"aligned table sorted newest-first by last_seen; --json " +
+			"emits the raw response array.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runListEdges(cmd, listEdgesOptions{
+				Kind:              kindFilter,
+				Source:            sourceFilter,
+				From:              fromFilter,
+				To:                toFilter,
+				Conflicts:         conflictsOnly,
+				Limit:             limit,
+				Offset:            offset,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&kindFilter, "kind", "",
+		"restrict to one edge kind (run `meho topology annotate --help` for the closed 10-kind vocabulary)")
+	cmd.Flags().StringVar(&sourceFilter, "source", "",
+		"restrict by source: `curated` (operator-asserted) or `auto` (probe-derived)")
+	cmd.Flags().StringVar(&fromFilter, "from", "",
+		"filter to edges whose `from` endpoint matches this node name")
+	cmd.Flags().StringVar(&toFilter, "to", "",
+		"filter to edges whose `to` endpoint matches this node name")
+	cmd.Flags().BoolVar(&conflictsOnly, "conflicts", false,
+		"surface only edges flagged by the §6 conflict detector (recoverability listing)")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max edges to return (1..1000, server default 200 when omitted)")
+	cmd.Flags().IntVar(&offset, "offset", 0,
+		"pagination offset (default 0)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type listEdgesOptions struct {
+	Kind              string
+	Source            string
+	From              string
+	To                string
+	Conflicts         bool
+	Limit             int
+	Offset            int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runListEdges(cmd *cobra.Command, opts listEdgesOptions) error {
+	if opts.Source != "" && opts.Source != "curated" && opts.Source != "auto" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--source must be `curated` or `auto`; got %q", opts.Source)),
+			opts.JSONOut,
+		)
+	}
+	if opts.Limit < 0 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be >= 0; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	if opts.Offset < 0 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--offset must be >= 0; got %d", opts.Offset)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	edges, err := getEdges(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), edges)
+	}
+	printEdgeListing(cmd.OutOrStdout(), edges)
+	return nil
+}
+
+// buildListEdgesPath assembles the GET path + query string. Every
+// filter is omitted from the wire when unset so the server applies
+// its defaults (no kind / source filter, limit=200, offset=0). The
+// `--source` flag maps directly to the `?source=` query param (the
+// `graph_edge.source` column literal — `auto` or `curated`); the
+// route's regex pattern enforces the same closed pair. Exposed for
+// unit tests.
+func buildListEdgesPath(opts listEdgesOptions) string {
+	q := url.Values{}
+	if opts.Kind != "" {
+		q.Set("kind", opts.Kind)
+	}
+	if opts.Source != "" {
+		q.Set("source", opts.Source)
+	}
+	if opts.From != "" {
+		q.Set("from", opts.From)
+	}
+	if opts.To != "" {
+		q.Set("to", opts.To)
+	}
+	if opts.Conflicts {
+		q.Set("conflicts", "true")
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Offset > 0 {
+		q.Set("offset", strconv.Itoa(opts.Offset))
+	}
+	path := "/api/v1/topology/edges"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path
+}
+
+func getEdges(ctx context.Context, backplaneURL string, opts listEdgesOptions) ([]Edge, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListEdgesPath(opts), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out []Edge
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode list-edges response: %w", err)
+	}
+	return out, nil
+}
+
+// printEdgeListing renders edges as an aligned table. Columns: KIND,
+// SOURCE, FROM (kind/name), TO (kind/name), LAST_SEEN. The id column
+// is omitted from the default view to keep rows scannable; --json
+// emits the full envelope including ids for piping into `unannotate
+// <edge-id>`. Empty listing → an explanatory line so an operator can
+// tell "tenant has no curated edges yet" from "filter matched nothing".
+func printEdgeListing(w io.Writer, edges []Edge) {
+	if len(edges) == 0 {
+		fmt.Fprintln(w, "no edges matched")
+		return
+	}
+	fmt.Fprintf(w, "%-18s %-8s %-30s %-30s %s\n",
+		"KIND", "SOURCE", "FROM", "TO", "LAST_SEEN")
+	for _, e := range edges {
+		lastSeen := "-"
+		if e.LastSeen != nil && *e.LastSeen != "" {
+			lastSeen = *e.LastSeen
+		}
+		from := fmt.Sprintf("%s/%s", e.From.Kind, e.From.Name)
+		to := fmt.Sprintf("%s/%s", e.To.Kind, e.To.Name)
+		fmt.Fprintf(w, "%-18s %-8s %-30s %-30s %s\n",
+			truncate(e.Kind, 18),
+			truncate(e.Source, 8),
+			truncate(from, 30),
+			truncate(to, 30),
+			lastSeen,
+		)
+	}
+}

--- a/cli/internal/cmd/topology/topology.go
+++ b/cli/internal/cmd/topology/topology.go
@@ -2,8 +2,10 @@
 // Copyright (c) 2026 evoila Group
 
 // Package topology hosts the cobra commands under `meho topology ...`
-// for G9.1-T6 (#454) of Initiative #363. v0.2 ships four operator-
-// facing verbs that wrap the T5 REST surface (#453) shipped by
+// for G9.1-T6 (#454) of Initiative #363 (read/traversal verbs) and
+// G9.2-T6 (#599) of Initiative #364 (curated-edge write + listing
+// verbs). v0.2 ships seven operator-facing verbs over the T5 REST
+// surface (#453, #597) shipped by
 // `backend/src/meho_backplane/api/v1/topology.py`:
 //
 //   - `meho topology refresh <target> [--json]` —
@@ -23,6 +25,19 @@
 //     GET /api/v1/topology/path?from=A&to=B. Shortest unweighted
 //     path between two named nodes, or the no-path line when
 //     unreachable. Role: operator.
+//   - `meho topology annotate <from> <kind> <to> [--note "..."]
+//     [--evidence-url URL] [--json]` — POST /api/v1/topology/edges.
+//     Operator-curated cross-system edge assertion. Idempotent.
+//     Role: tenant_admin.
+//   - `meho topology unannotate <edge-id> | <from> <kind> <to>` —
+//     DELETE /api/v1/topology/edges/{edge_id}. The tuple form is
+//     client-side: a GET resolves the unique curated edge id, then
+//     DELETE removes it. Auto rows refuse with 409 + remediation
+//     hint. Role: tenant_admin.
+//   - `meho topology list-edges [--kind K] [--source curated|auto]
+//     [--from N] [--to N] [--conflicts] [--json]` — GET
+//     /api/v1/topology/edges. Flat filterable listing of the
+//     tenant's edges. Role: operator.
 //
 // The fifth G9.1-T6 verb, `meho targets discover <product>`, lives
 // under `cli/internal/cmd/targets/discover.go` because it sits under
@@ -80,21 +95,27 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "topology",
-		Short: "Query and refresh the MEHO topology graph (refresh / dependents / dependencies / path)",
-		Long: "Operate the tenant-scoped topology graph wired by G9.1. " +
-			"Refresh a target's discovered topology, walk what depends " +
-			"on a node (dependents), walk what a node depends on " +
-			"(dependencies), or find the shortest path between two " +
-			"nodes. All verbs are operator-level. Tenant scoping is " +
-			"enforced server-side via the JWT — no surface accepts a " +
-			"tenant id, and cross-tenant traversal returns the same " +
-			"empty/404 shape as a node that does not exist.",
+		Short: "Query and refresh the MEHO topology graph (refresh / dependents / dependencies / path / annotate / unannotate / list-edges)",
+		Long: "Operate the tenant-scoped topology graph wired by G9.1 + " +
+			"G9.2. Refresh a target's discovered topology, walk what " +
+			"depends on a node (dependents), walk what a node depends " +
+			"on (dependencies), find the shortest path between two " +
+			"nodes, assert a curated cross-system edge (annotate), " +
+			"delete a curated edge (unannotate), or list the tenant's " +
+			"edges (list-edges). Read verbs are operator-level; " +
+			"annotate / unannotate require tenant_admin. Tenant " +
+			"scoping is enforced server-side via the JWT — no surface " +
+			"accepts a tenant id, and cross-tenant queries return the " +
+			"same empty/404 shape as a node that does not exist.",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newRefreshCmd())
 	cmd.AddCommand(newDependentsCmd())
 	cmd.AddCommand(newDependenciesCmd())
 	cmd.AddCommand(newPathCmd())
+	cmd.AddCommand(newAnnotateCmd())
+	cmd.AddCommand(newUnannotateCmd())
+	cmd.AddCommand(newListEdgesCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/topology/topology_test.go
+++ b/cli/internal/cmd/topology/topology_test.go
@@ -61,14 +61,20 @@ func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
 	return cmd, &stdout, &stderr
 }
 
-// TestNewRootCmdWiresFourVerbs — the parent must expose exactly the
-// four topology verbs (the fifth T6 verb, `targets discover`, lives
-// on the targets parent, not here).
-func TestNewRootCmdWiresFourVerbs(t *testing.T) {
+// TestNewRootCmdWiresAllVerbs — the parent must expose every topology
+// verb: the four G9.1 read/traversal verbs plus the three G9.2 write
+// + listing verbs. The fifth G9.1-T6 verb, `targets discover`, lives
+// on the targets parent (not here).
+func TestNewRootCmdWiresAllVerbs(t *testing.T) {
 	root := NewRootCmd()
 	want := map[string]bool{
-		"refresh": false, "dependents": false,
-		"dependencies": false, "path": false,
+		"refresh":      false,
+		"dependents":   false,
+		"dependencies": false,
+		"path":         false,
+		"annotate":     false,
+		"unannotate":   false,
+		"list-edges":   false,
 	}
 	for _, c := range root.Commands() {
 		name := strings.Fields(c.Use)[0]
@@ -231,6 +237,96 @@ func TestFormatAmbiguousNode(t *testing.T) {
 	}
 	if strings.Contains(strings.ReplaceAll(got, "--node-kind", ""), "--kind") {
 		t.Errorf("formatAmbiguousNode must not point at --kind (edge filter); got %q", got)
+	}
+}
+
+// TestAnnotateHelpEmitsTenKindVocabulary — §12 acceptance criterion
+// for #599: `meho topology annotate --help` must surface every one of
+// the closed 10 GraphEdgeKind values with a one-line description so
+// operators discover the vocabulary without leaving the CLI.
+func TestAnnotateHelpEmitsTenKindVocabulary(t *testing.T) {
+	cmd := newAnnotateCmd()
+	long := cmd.Long
+	// Every kind name must be present.
+	want := []string{
+		"runs-on", "mounts", "routes-through", "belongs-to",
+		"authenticates-via", "depends-on", "replicates-to",
+		"backed-up-by", "routes-via", "policy-binds",
+	}
+	for _, kind := range want {
+		if !strings.Contains(long, kind) {
+			t.Errorf("annotate --help missing kind %q", kind)
+		}
+	}
+	// Sanity: the help block names the table explicitly so the table
+	// header is searchable in shell scrollback.
+	if !strings.Contains(long, "Edge kind vocabulary") {
+		t.Errorf("annotate --help should label the table; got %q", long)
+	}
+}
+
+// TestEdgeKindVocabularyMatchesEnum — the in-help table must stay in
+// lock-step with the closed enum on the backend side. Both lists are
+// declared in source; this test fails noisily when the count drifts
+// (the actual enum lives in backend/src/meho_backplane/db/models.py
+// and is asserted from the Python side; here we lock the CLI mirror).
+func TestEdgeKindVocabularyMatchesEnum(t *testing.T) {
+	if got := len(edgeKindVocabulary); got != 10 {
+		t.Fatalf("edgeKindVocabulary count = %d; want 10 (closed v0.2 enum)", got)
+	}
+	seen := make(map[string]bool, 10)
+	for _, e := range edgeKindVocabulary {
+		if e.Name == "" || e.Desc == "" {
+			t.Errorf("incomplete vocab entry: %+v", e)
+		}
+		if seen[e.Name] {
+			t.Errorf("duplicate vocab kind %q", e.Name)
+		}
+		seen[e.Name] = true
+	}
+}
+
+// TestBuildListEdgesPathOmitsDefaults — empty options send no query
+// string so the server applies its defaults.
+func TestBuildListEdgesPathOmitsDefaults(t *testing.T) {
+	got := buildListEdgesPath(listEdgesOptions{})
+	if got != "/api/v1/topology/edges" {
+		t.Fatalf("default path: got %q", got)
+	}
+}
+
+// TestBuildListEdgesPathMapsFilters — every flag maps to the route's
+// documented query-param name; --conflicts only rides when true.
+func TestBuildListEdgesPathMapsFilters(t *testing.T) {
+	got := buildListEdgesPath(listEdgesOptions{
+		Kind: "depends-on", Source: "curated",
+		From: "svc", To: "db",
+		Conflicts: true, Limit: 25, Offset: 5,
+	})
+	if !strings.HasPrefix(got, "/api/v1/topology/edges?") {
+		t.Fatalf("prefix wrong: %q", got)
+	}
+	for _, want := range []string{"kind=depends-on", "source=curated", "from=svc", "to=db", "conflicts=true", "limit=25", "offset=5"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildListEdgesPath missing %q in %q", want, got)
+		}
+	}
+}
+
+// TestFormatAutoEdgeConflictPullsServerMessage — the 409 envelope
+// renders into a line that prefixes the server's `detail.message`
+// (the annotate-over-auto remediation guidance) with the edge id.
+func TestFormatAutoEdgeConflictPullsServerMessage(t *testing.T) {
+	body := `{"detail":{"error":"auto_edge_deletion","edge_id":"abc","message":"go fix it"}}`
+	got := formatAutoEdgeConflict(body)
+	if !strings.Contains(got, "abc") || !strings.Contains(got, "go fix it") {
+		t.Errorf("formatAutoEdgeConflict missing edge_id/message; got %q", got)
+	}
+	// A wrong-error body must return the empty string so the caller
+	// falls back to the generic renderer rather than masking a real
+	// 409 from elsewhere.
+	if got := formatAutoEdgeConflict(`{"detail":{"error":"ambiguous_node"}}`); got != "" {
+		t.Errorf("expected empty fallback for wrong-error body; got %q", got)
 	}
 }
 

--- a/cli/internal/cmd/topology/unannotate.go
+++ b/cli/internal/cmd/topology/unannotate.go
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newUnannotateCmd returns the `meho topology unannotate` command.
+//
+//	meho topology unannotate <edge-id>
+//	meho topology unannotate <from> <kind> <to> [--from-kind K] [--to-kind K]
+//	# DELETE /api/v1/topology/edges/<edge_id>
+//
+// The id form maps directly to the DELETE route. The tuple form is
+// **client-side**: a GET /api/v1/topology/edges?from=&kind=&to=&source=curated
+// resolves the unique curated edge and then a DELETE deletes by id.
+// T5's DELETE accepts only `{edge_id}` in the path (no tuple-form
+// DELETE route) so the resolution must happen here, not at the route.
+//
+// The auto-vs-curated rule (§3 of Initiative #364): a 409 from the
+// route indicates the targeted edge has `source='auto'` — auto edges
+// resurrect on the next refresh, so manual deletion is meaningless.
+// The CLI surfaces the server's `detail.message` verbatim so an
+// operator sees the annotate-over-auto remediation guidance.
+func newUnannotateCmd() *cobra.Command {
+	var (
+		fromKind          string
+		toKind            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "unannotate <edge-id> | <from> <kind> <to>",
+		Short: "Delete a curated topology edge (by id or by from/kind/to tuple)",
+		Long: "unannotate deletes a curated topology edge. Two forms:\n\n" +
+			"  meho topology unannotate <edge-id>\n" +
+			"  meho topology unannotate <from> <kind> <to>\n\n" +
+			"The id form maps to DELETE /api/v1/topology/edges/<edge_id> " +
+			"directly. The tuple form is resolved client-side: a GET " +
+			"locates the unique curated edge matching the triple, then " +
+			"a DELETE removes it by id. Requires tenant_admin.\n\n" +
+			"Auto edges (source='auto') cannot be deleted — they " +
+			"resurrect on the next refresh, so the server returns 409 " +
+			"with the annotate-over-auto remediation hint. The CLI " +
+			"surfaces that hint verbatim. A missing or cross-tenant " +
+			"edge returns 404 (the tenant boundary is opaque — a row " +
+			"in another tenant is indistinguishable from a missing row).",
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 1 && len(args) != 3 {
+				return errors.New(
+					"unannotate requires either <edge-id> or <from> <kind> <to> " +
+						"(got " + fmt.Sprintf("%d", len(args)) + " args)")
+			}
+			return nil
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := unannotateOptions{
+				FromKindPin:       fromKind,
+				ToKindPin:         toKind,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			}
+			switch len(args) {
+			case 1:
+				opts.EdgeID = args[0]
+			case 3:
+				opts.From = args[0]
+				opts.Kind = args[1]
+				opts.To = args[2]
+			}
+			return runUnannotate(cmd, opts)
+		},
+	}
+	cmd.Flags().StringVar(&fromKind, "from-kind", "",
+		"pin the `from` endpoint to one node kind when its name is ambiguous (tuple form only)")
+	cmd.Flags().StringVar(&toKind, "to-kind", "",
+		"pin the `to` endpoint to one node kind when its name is ambiguous (tuple form only)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON ({\"deleted\": \"<edge_id>\"}) instead of the human line")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type unannotateOptions struct {
+	// EdgeID is set when the operator passed a single argument (the id
+	// form). The CLI validates it as a UUID before issuing the DELETE.
+	EdgeID string
+	// From / Kind / To are set when the operator passed three arguments
+	// (the tuple form). The CLI runs a client-side GET to resolve the
+	// unique edge id before issuing the DELETE.
+	From string
+	Kind string
+	To   string
+	// FromKindPin / ToKindPin disambiguate an endpoint whose bare name
+	// resolves to multiple node kinds in the tenant — the same lever
+	// the list-edges / annotate / closure verbs expose.
+	FromKindPin       string
+	ToKindPin         string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runUnannotate(cmd *cobra.Command, opts unannotateOptions) error {
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+
+	edgeID := opts.EdgeID
+	if edgeID == "" {
+		// Tuple form — resolve client-side. The list helper applies the
+		// tenant scope server-side, so a cross-tenant tuple returns an
+		// empty list (rendered as "not found"), never another tenant's
+		// row. Pin source=curated because the auto-row deletion would
+		// 409 anyway, and an auto edge accidentally selected by a
+		// matching tuple would block the curated row that the operator
+		// actually wants to remove.
+		resolved, err := resolveCuratedEdgeID(cmd.Context(), backplaneURL, opts)
+		if err != nil {
+			return renderUnannotateResolveError(cmd, backplaneURL, err, opts)
+		}
+		edgeID = resolved
+	} else {
+		if _, perr := uuid.Parse(edgeID); perr != nil {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"invalid <edge-id> %q: not a UUID (%v)", edgeID, perr)),
+				opts.JSONOut)
+		}
+	}
+
+	if err := deleteEdge(cmd.Context(), backplaneURL, edgeID); err != nil {
+		return renderUnannotateDeleteError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(),
+			map[string]string{"deleted": edgeID})
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "deleted edge %s\n", edgeID)
+	return nil
+}
+
+// resolveCuratedEdgeID issues a GET /api/v1/topology/edges with the
+// from/kind/to triple + source=curated and returns the single matching
+// edge id. The route applies the tenant scope server-side, so a cross-
+// tenant tuple resolves to an empty result. Multiple matches are
+// possible when the operator didn't pass --from-kind / --to-kind on an
+// ambiguous endpoint; the helper surfaces an explanatory error rather
+// than silently picking one.
+func resolveCuratedEdgeID(
+	ctx context.Context,
+	backplaneURL string,
+	opts unannotateOptions,
+) (string, error) {
+	listOpts := listEdgesOptions{
+		Kind:   opts.Kind,
+		Source: "curated",
+		From:   opts.From,
+		To:     opts.To,
+		Limit:  2, // 2 is enough to detect ambiguity without dragging back the world.
+	}
+	edges, err := getEdges(ctx, backplaneURL, listOpts)
+	if err != nil {
+		return "", err
+	}
+	// Filter client-side by endpoint kind when the operator pinned one
+	// — the list route filters by name only.
+	if opts.FromKindPin != "" || opts.ToKindPin != "" {
+		filtered := edges[:0]
+		for _, e := range edges {
+			if opts.FromKindPin != "" && e.From.Kind != opts.FromKindPin {
+				continue
+			}
+			if opts.ToKindPin != "" && e.To.Kind != opts.ToKindPin {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		edges = filtered
+	}
+	switch len(edges) {
+	case 0:
+		return "", &unannotateResolveError{kind: "not_found"}
+	case 1:
+		return edges[0].ID, nil
+	default:
+		ids := make([]string, 0, len(edges))
+		for _, e := range edges {
+			ids = append(ids, fmt.Sprintf(
+				"%s (%s/%s --[%s]--> %s/%s)",
+				e.ID, e.From.Kind, e.From.Name, e.Kind, e.To.Kind, e.To.Name))
+		}
+		return "", &unannotateResolveError{
+			kind:    "ambiguous",
+			matches: ids,
+		}
+	}
+}
+
+// unannotateResolveError signals a tuple-form resolution failure so
+// the caller can surface a CLI-shaped diagnostic distinct from a
+// transport / HTTP error. `kind` is "not_found" or "ambiguous";
+// `matches` carries the rendered candidates for the ambiguous case.
+type unannotateResolveError struct {
+	kind    string
+	matches []string
+}
+
+func (e *unannotateResolveError) Error() string {
+	if e.kind == "ambiguous" {
+		return "ambiguous tuple matches multiple edges"
+	}
+	return "no matching curated edge"
+}
+
+func renderUnannotateResolveError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	opts unannotateOptions,
+) error {
+	var rerr *unannotateResolveError
+	if errors.As(err, &rerr) {
+		if rerr.kind == "ambiguous" {
+			msg := fmt.Sprintf(
+				"tuple %q --[%s]--> %q matches %d curated edges; "+
+					"re-run `meho topology unannotate <edge-id>` with one of:\n  - %s",
+				opts.From, opts.Kind, opts.To,
+				len(rerr.matches), strings.Join(rerr.matches, "\n  - "))
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(msg), opts.JSONOut)
+		}
+		// not_found
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"no curated edge matches %q --[%s]--> %q in this tenant",
+				opts.From, opts.Kind, opts.To)),
+			opts.JSONOut)
+	}
+	return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+}
+
+// renderUnannotateDeleteError intercepts the route's 409 auto-edge
+// envelope so the operator sees the server's `detail.message`
+// verbatim — the annotate-over-auto remediation guidance — instead of
+// the raw 409 body the generic renderHTTPError would surface.
+func renderUnannotateDeleteError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	var he *httpError
+	if errors.As(err, &he) && he.StatusCode == 409 {
+		if msg := formatAutoEdgeConflict(he.Body); msg != "" {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(msg), jsonOut)
+		}
+	}
+	return renderRequestError(cmd, backplaneURL, err, jsonOut)
+}
+
+// autoEdgeConflictDetail mirrors the 409 body the unannotate route
+// emits for an auto-row delete attempt:
+// `{"detail":{"error":"auto_edge_deletion","edge_id":"...","message":"..."}}`.
+type autoEdgeConflictDetail struct {
+	Error   string `json:"error"`
+	EdgeID  string `json:"edge_id"`
+	Message string `json:"message"`
+}
+
+// formatAutoEdgeConflict pulls the server's `detail.message` out of the
+// 409 envelope and prefixes it with the edge id. Returns the empty
+// string when the body doesn't match the auto_edge_deletion shape —
+// the caller then falls back to the generic 409 renderer.
+func formatAutoEdgeConflict(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		return ""
+	}
+	var detail autoEdgeConflictDetail
+	if err := json.Unmarshal(env.Detail, &detail); err != nil {
+		return ""
+	}
+	if detail.Error != "auto_edge_deletion" {
+		return ""
+	}
+	if detail.Message == "" {
+		return fmt.Sprintf("cannot delete auto edge %s", detail.EdgeID)
+	}
+	return fmt.Sprintf("cannot delete edge %s: %s", detail.EdgeID, detail.Message)
+}
+
+func deleteEdge(ctx context.Context, backplaneURL, edgeID string) error {
+	// edgeID is UUID-validated above; pathEscape is belt-and-braces.
+	_, err := doAuthedRequest(ctx, backplaneURL,
+		"DELETE", "/api/v1/topology/edges/"+pathEscape(edgeID), nil)
+	return err
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -137,8 +137,8 @@ cli/
     │   │   └── retire_checklist_test.go # surface-bucket + table-render + marshal tests.
     │   ├── vmware/            # G3.1-T7 #511 — `meho vmware …` alias verb tree (connector_id="vmware-rest-9.0" pre-baked).
     │   ├── vault/             # G3.3-T6 #550 — `meho vault …` alias verb tree (connector_id="vault-1.x" pre-baked).
-    │   └── topology/          # G9.1-T6 #454 — `meho topology refresh/dependents/dependencies/path` over the T5 REST surface (#453).
-    │                          #   (the 5th T6 verb, `meho targets discover`, lives in targets/discover.go.)
+    │   └── topology/          # G9.1-T6 #454 + G9.2-T6 #599 — `meho topology refresh/dependents/dependencies/path/annotate/unannotate/list-edges` over the T5 REST surface (#453, #597).
+    │                          #   (the 5th G9.1-T6 verb, `meho targets discover`, lives in targets/discover.go.)
     │       ├── vault.go          # NewRootCmd + shared HTTP/auth/render helpers + ConnectorID const.
     │       ├── dispatch.go       # CallResult/callRequestBody + dispatchOp + renderCallResult + generic renderer.
     │       ├── kv.go             # `meho vault kv read|list|put|versions|delete` (vault.kv.* ops, #545).
@@ -884,16 +884,16 @@ cycle cmd/root.go's graft would otherwise create). Exit codes: `0`
 status=ok, `1` status=error/denied (via the `errOpError` sentinel),
 `2` auth_expired, `3` unreachable, `4` unexpected_response.
 
-## Topology verbs (`meho topology`, G9.1-T6 #454)
+## Topology verbs (`meho topology`, G9.1-T6 #454 + G9.2-T6 #599)
 
-`cli/internal/cmd/topology/` registers the four operator-facing
-topology verbs that wrap the T5 REST surface (#453). The fifth
+`cli/internal/cmd/topology/` registers seven operator-facing topology
+verbs that wrap the T5 REST surface (#453 / #597). The eighth
 G9.1-T6 verb, `meho targets discover`, lives under the `meho targets`
 parent (`cli/internal/cmd/targets/discover.go`) because the backend
 registers `GET /api/v1/targets/discover` on the targets router, under
 the canonical `/api/v1/targets` prefix.
 
-### Subcommands
+### Subcommands (G9.1 read/traversal — #454)
 
 - `meho topology refresh <target>` — `POST
   /api/v1/topology/refresh/<target>`. Rediscovers one target's
@@ -919,6 +919,38 @@ the canonical `/api/v1/targets` prefix.
   the no-path line when unreachable / an endpoint is missing /
   cross-tenant (all the same `null` answer, exit 0, never an error).
 
+### Subcommands (G9.2 curated-edge write + listing — #599)
+
+- `meho topology annotate <from> <kind> <to> [--note "..."]
+  [--evidence-url URL] [--from-kind K] [--to-kind K]` — `POST
+  /api/v1/topology/edges`. Asserts a curated cross-system edge.
+  Idempotent (server-side upsert). `--help` inlines the closed
+  10-kind vocabulary table (§12 of Initiative #364) so operators
+  discover valid `<kind>` values without leaving the CLI.
+  `--evidence-url` is kebab-case on the CLI but maps to the wire
+  field `evidence_url` (snake_case per `_AnnotateEdgeRequest`).
+  Requires `tenant_admin`; a 403 renders the backend's role hint
+  with exit class `insufficient_role`.
+- `meho topology unannotate <edge-id> | <from> <kind> <to>
+  [--from-kind K] [--to-kind K]` — `DELETE
+  /api/v1/topology/edges/<edge_id>`. The tuple form is **client-
+  side**: a `GET /api/v1/topology/edges?from=&kind=&to=&source=
+  curated` resolves the unique curated edge, then `DELETE` removes
+  it by id. T5's DELETE is id-only (no tuple-form route), so the
+  resolution must happen here. The route's typed 409 (auto-row
+  deletion refused; §3 of Initiative #364) is rendered with the
+  server's `detail.message` verbatim — the annotate-over-auto
+  remediation guidance, not a raw HTTP dump. Requires `tenant_admin`.
+- `meho topology list-edges [--kind K] [--source curated|auto]
+  [--from N] [--to N] [--conflicts] [--limit N] [--offset N]` —
+  `GET /api/v1/topology/edges`. Flat filterable listing of the
+  tenant's edges. `--source` maps directly to the `graph_edge.source`
+  column literal; `--conflicts` surfaces the §6 conflict-detector
+  recoverability listing only. Default output is an aligned
+  `KIND / SOURCE / FROM / TO / LAST_SEEN` table; `--json` emits the
+  raw `[]Edge` envelope so consumers can pipe ids into the
+  `unannotate <edge-id>` form. Role: `operator`.
+
 ### Flag → query-param mapping
 
 The route exposes `kind` (anchor `(tenant_id, kind, name)` pin) and
@@ -938,7 +970,10 @@ discipline `meho targets list --limit` applies.
   render. Stable schemas: `refresh` → `RefreshResult`;
   `dependents`/`dependencies` → `[]Node`; `path` →
   `Path` or literal `null` (the unreachable answer, emitted
-  verbatim so jq consumers see one contract).
+  verbatim so jq consumers see one contract); `annotate` →
+  `TopologyEdge` (the 201 response shape); `unannotate` →
+  `{"deleted": "<edge_id>"}` on success; `list-edges` →
+  `[]TopologyEdge`.
 - `--backplane <url>` — override the backplane URL (defaults to the
   URL `meho login` recorded).
 


### PR DESCRIPTION
## Summary

- Add three operator-facing topology CLI verbs over the T5 REST surface (#597): `meho topology annotate` (POST), `meho topology unannotate` (DELETE, id-form + client-side-resolved tuple form), `meho topology list-edges` (GET) — completing the G9.2 operator surface for curated cross-system edges.
- `annotate --help` inlines the closed 10-kind `GraphEdgeKind` vocabulary table (§12 of Initiative #364) so operators discover valid kinds without leaving the CLI; the source-of-truth is locked to the enum by a drift-guard test.
- The 409 auto-edge-deletion envelope is rendered with the server's `detail.message` verbatim (the §3 annotate-over-auto remediation guidance), not a raw HTTP dump — and the tuple-form `unannotate` resolves client-side via `GET /edges?source=curated` because T5's DELETE is id-only.

## Test plan

- [x] `go vet ./...` — clean (CLI module).
- [x] `go test ./internal/cmd/topology/...` — 29 tests pass, including the full `annotate → list-edges → tuple unannotate` round-trip against an httptest backplane.
- [x] `go test ./...` (CLI module) — all packages pass; no regressions in the existing topology / targets / kb / etc. trees.
- [x] `go build ./...` — clean.
- [x] Acceptance: `annotate --help` output contains all 10 kind names with one-line descriptions — `TestAnnotateHelpEmitsTenKindVocabulary`.
- [x] Acceptance: `--json` emits machine-readable output for `list-edges` (raw `[]Edge`), `annotate` (raw `TopologyEdge`), `unannotate` (`{"deleted": "<id>"}`).
- [x] Acceptance: default `list-edges` emits an aligned table; `--conflicts` filters via the `conflicts=true` query param — `TestListEdgesFlagsMapToQueryString`.
- [x] Acceptance: a 409 from `unannotate` (auto row) is surfaced as the server's `detail.message`, not a raw HTTP error dump — `TestUnannotateAutoEdge409RendersServerDetail`.
- [x] Acceptance: 403 `tenant_admin` denial renders the role hint with exit class `insufficient_role` — `TestAnnotate403TenantAdminRequired`.

## Out of scope

- T8 `meho topology bulk-import` (optional stretch).
- T7 MCP parity — landed separately in #654 (`feat/598-mcp-annotate-tools`).
- Any backend logic (#595/#596/#597 own the service + REST layer).

## Notes

- New direct dependency: `github.com/google/uuid v1.5.0` (was indirect — used for client-side `<edge-id>` UUID validation in `unannotate`); `go mod tidy` promoted it.
- Sibling: #601 (integration tests for the same REST surface) ships in parallel; different packages, no overlap with this PR.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #599


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `meho topology annotate` command to annotate edges with notes and evidence URLs.
  * Added `meho topology unannotate` command to remove edge annotations.
  * Added `meho topology list-edges` command to list edges with filtering and pagination support.
  * All new commands support JSON output mode.

* **Documentation**
  * Updated topology command documentation to include new annotation and listing commands.

* **Tests**
  * Added comprehensive end-to-end test coverage for edge annotation, deletion, and listing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->