### PR TITLE
feat(topology): G9.2-T8 bulk-import — meho topology bulk-import + POST /topology/edges/bulk

### DIFF
--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -111,6 +111,11 @@ from meho_backplane.topology.annotate import (
     annotate_edge,
     unannotate_edge,
 )
+from meho_backplane.topology.bulk_import import (
+    BulkImportRow,
+    BulkImportValidationError,
+    bulk_import_edges,
+)
 from meho_backplane.topology.query import (
     AmbiguousNodeError,
     find_dependencies,
@@ -155,6 +160,17 @@ _OP_REFRESH = "topology.refresh"
 _OP_ANNOTATE = "topology.annotate"
 _OP_UNANNOTATE = "topology.unannotate"
 _OP_LIST_EDGES = "topology.list_edges"
+_OP_BULK_IMPORT = "topology.bulk_import"
+
+#: HTTP-boundary ceiling on the number of edges accepted in one
+#: ``POST /edges/bulk`` body. The consumer's INVENTORY.md
+#: (https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/rdc-hetzner-dc/INVENTORY.md)
+#: lists ~30 curated cross-system edges at v0.2; the ceiling is sized
+#: well above that so onboarding does not need to chunk the file, but
+#: low enough that a stray hostile body cannot hold a single transaction
+#: open for an unbounded scan. The service layer is unbounded by
+#: design — the HTTP boundary is where the size guard belongs.
+_BULK_IMPORT_MAX_EDGES = 1000
 
 #: HTTP-boundary ceiling on the ``GET /edges`` ``limit`` query param.
 #: Mirrors :data:`meho_backplane.topology.query._MAX_EDGE_LIMIT`; pinned
@@ -619,6 +635,197 @@ async def list_edges_route(
     except AmbiguousNodeError as exc:
         raise _ambiguous_node_http(exc) from exc
     return edges
+
+
+# ---------------------------------------------------------------------------
+# G9.2-T8 (#600) — bulk import
+# ---------------------------------------------------------------------------
+
+
+class _BulkImportEdge(BaseModel):
+    """One edge in the ``POST /api/v1/topology/edges/bulk`` body.
+
+    Same wire shape as :class:`_AnnotateEdgeRequest` (``{from, kind, to,
+    note?, evidence_url?}``) — ``from`` is bound via ``alias`` because
+    it is a Python keyword. ``kind`` is typed against
+    :class:`GraphEdgeKind` so an unknown kind fails at the boundary
+    (HTTP 422) before any service call runs, and the per-row error
+    surfaces inside the standard FastAPI validation envelope with the
+    row index in ``loc``. ``extra="forbid"`` rejects typo'd keys so a
+    misspelled ``evidnce_url`` is caught at the boundary rather than
+    silently dropped.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    from_endpoint: _EdgeEndpoint = Field(alias="from")
+    kind: GraphEdgeKind
+    to_endpoint: _EdgeEndpoint = Field(alias="to")
+    note: str | None = Field(default=None, max_length=2000)
+    evidence_url: str | None = Field(default=None, max_length=2000)
+
+
+class _BulkImportRequest(BaseModel):
+    """Inbound body for ``POST /api/v1/topology/edges/bulk``.
+
+    ``edges`` is a non-empty list bounded at the HTTP boundary by
+    :data:`_BULK_IMPORT_MAX_EDGES`. Zero rows are rejected at 422
+    rather than silently no-op'ing — an empty body is almost always a
+    mistake in the operator's YAML / JSON file, and 422 surfaces it
+    immediately. ``dry_run`` defaults to ``False`` per the issue
+    body's "the CLI calls --dry-run explicitly" convention.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    edges: list[_BulkImportEdge] = Field(
+        min_length=1,
+        max_length=_BULK_IMPORT_MAX_EDGES,
+    )
+    dry_run: bool = Field(default=False)
+
+
+class _BulkImportRowResponse(BaseModel):
+    """One row's outcome in the ``POST /edges/bulk`` response.
+
+    Mirrors :class:`~meho_backplane.topology.bulk_import.BulkEdgeResult`
+    on the wire. ``edge_id`` is null in dry-run mode (no row exists)
+    and on the apply-pass ``create`` rows where the service hasn't
+    been called yet at validation time — the apply path always
+    populates it.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    index: int
+    action: str
+    edge_id: str | None
+    from_name: str
+    from_kind: str
+    to_name: str
+    to_kind: str
+    kind: str
+    superseded: list[str]
+    conflicts: list[str]
+
+
+class _BulkImportResponse(BaseModel):
+    """Response body for ``POST /api/v1/topology/edges/bulk``.
+
+    ``dry_run`` echoes the call-site flag so a CLI rendering the JSON
+    response can branch on it; ``created`` / ``updated`` / ``conflicts``
+    are the aggregate counts the service computed; ``rows`` carries the
+    per-row outcome in source order.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    dry_run: bool
+    created: int
+    updated: int
+    conflicts: int
+    rows: list[_BulkImportRowResponse]
+
+
+@router.post(
+    "/edges/bulk",
+    response_model=_BulkImportResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def bulk_import_edges_route(
+    body: _BulkImportRequest,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_raw_session),
+) -> _BulkImportResponse:
+    """Batch-annotate edges from a single body in one transaction.
+
+    Wraps
+    :func:`~meho_backplane.topology.bulk_import.bulk_import_edges`
+    (G9.2-T8 #600). Validation runs first against every row; a single
+    invalid row rejects the entire batch (no partial apply). The
+    apply pass writes every row inside one transaction so the
+    "all-or-nothing per the issue body" criterion holds.
+
+    Per-row audit + broadcast events fire one per applied row,
+    mirroring the single-edge :func:`annotate_edge` flow; the
+    chassis HTTP-level audit row at this route binds
+    ``op_id="topology.bulk_import"`` / ``op_class="write"`` so the
+    batch lives alongside the per-row audit trail under a recognisable
+    parent identity.
+
+    Error mapping:
+
+    * **Pydantic 422** on body shape (unknown ``kind``, typo'd field,
+      empty ``edges``, more than 1000 rows) — fails at the boundary
+      before the service runs.
+    * **422 invalid_bulk** with a per-row error list on
+      :class:`BulkImportValidationError` — every row's failure is
+      surfaced together so the operator fixes the file in one pass.
+    * **200** on a successful apply or a successful dry-run.
+
+    Uses HTTP 200 (not 201) for both apply and dry-run paths: the
+    request is fundamentally a list mutation (create + update mix)
+    where 201 is misleading for the update / dry-run path.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_BULK_IMPORT,
+        audit_op_class="write",
+    )
+    rows = [
+        BulkImportRow(
+            from_ref=edge.from_endpoint.to_ref(),
+            kind=edge.kind.value,
+            to_ref=edge.to_endpoint.to_ref(),
+            note=edge.note,
+            evidence_url=edge.evidence_url,
+        )
+        for edge in body.edges
+    ]
+    try:
+        result = await bulk_import_edges(session, operator, rows, dry_run=body.dry_run)
+    except BulkImportValidationError as exc:
+        # Surface every row's failure together. The operator's source
+        # YAML / JSON is authoritative; a single 422 with the structured
+        # list lets them fix every row in one pass rather than the
+        # walk-the-file-N-times loop a per-row error would force.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "invalid_bulk",
+                "errors": [
+                    {
+                        "index": e.index,
+                        "error": e.error,
+                        "message": e.message,
+                        "name": e.name,
+                        "kind": e.kind,
+                        "kinds": e.kinds,
+                    }
+                    for e in exc.errors
+                ],
+            },
+        ) from exc
+    return _BulkImportResponse(
+        dry_run=result.dry_run,
+        created=result.created,
+        updated=result.updated,
+        conflicts=result.conflicts,
+        rows=[
+            _BulkImportRowResponse(
+                index=row.index,
+                action=row.action,
+                edge_id=row.edge_id,
+                from_name=row.from_name,
+                from_kind=row.from_kind,
+                to_name=row.to_name,
+                to_kind=row.to_kind,
+                kind=row.kind,
+                superseded=row.superseded,
+                conflicts=row.conflicts,
+            )
+            for row in result.rows
+        ],
+    )
 
 
 def _node_not_found_http(exc: NodeNotFoundError) -> HTTPException:

--- a/backend/src/meho_backplane/topology/__init__.py
+++ b/backend/src/meho_backplane/topology/__init__.py
@@ -71,6 +71,18 @@ than re-deriving the tenant boundary or the filter composition.
 * :func:`meho_backplane.topology.query.list_edges`
 * :class:`meho_backplane.topology.schemas.TopologyEdge`
 * :class:`meho_backplane.topology.schemas.TopologyEdgeEndpoint`
+
+**Bulk import — Task #600 (G9.2-T8, stretch):** the batch curated-
+edge writer. The CLI ``meho topology bulk-import <file>`` and the
+REST route ``POST /api/v1/topology/edges/bulk`` both call
+:func:`bulk_import_edges`, which runs an all-or-nothing transaction
+over a list of :class:`BulkImportRow` (per-row idempotent annotate
+calls in one transaction) plus a ``--dry-run`` plan-preview path.
+
+* :func:`meho_backplane.topology.bulk_import.bulk_import_edges`
+* :class:`meho_backplane.topology.bulk_import.BulkImportRow`
+* :class:`meho_backplane.topology.bulk_import.BulkImportResult`
+* :class:`meho_backplane.topology.bulk_import.BulkImportValidationError`
 """
 
 from meho_backplane.topology.annotate import (
@@ -80,7 +92,17 @@ from meho_backplane.topology.annotate import (
     NodeRef,
     UnannotateSelectorError,
     annotate_edge,
+    annotate_edge_in_txn,
     unannotate_edge,
+)
+from meho_backplane.topology.bulk_import import (
+    BulkEdgeAction,
+    BulkEdgeResult,
+    BulkImportResult,
+    BulkImportRow,
+    BulkImportRowError,
+    BulkImportValidationError,
+    bulk_import_edges,
 )
 from meho_backplane.topology.query import list_edges
 from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
@@ -99,6 +121,12 @@ __all__ = [
     "AmbiguousNodeError",
     "AnnotateConflictError",
     "AutoEdgeDeletionError",
+    "BulkEdgeAction",
+    "BulkEdgeResult",
+    "BulkImportResult",
+    "BulkImportRow",
+    "BulkImportRowError",
+    "BulkImportValidationError",
     "InvalidEdgeKindError",
     "NodeNotFoundError",
     "NodeRef",
@@ -107,6 +135,8 @@ __all__ = [
     "TopologyEdgeEndpoint",
     "UnannotateSelectorError",
     "annotate_edge",
+    "annotate_edge_in_txn",
+    "bulk_import_edges",
     "list_edges",
     "refresh_target_topology",
     "resolve_node",

--- a/backend/src/meho_backplane/topology/annotate.py
+++ b/backend/src/meho_backplane/topology/annotate.py
@@ -676,12 +676,22 @@ class AnnotatePlan:
       event both carry.
     * ``target_name`` — the from-node's name; surfaces in the broadcast
       event's ``target_name`` field per the chassis convention.
+    * ``was_created`` — ``True`` when this call inserted a fresh row,
+      ``False`` when it merged onto an existing row (idempotent
+      re-annotate or auto→curated promotion). The bulk-import helper
+      re-derives its per-row ``create`` / ``update`` / ``conflict``
+      classification from this flag plus the post-commit marker arrays
+      so intra-batch duplicates (two rows resolving to the same triple
+      in one batch) and inter-pass races between validation and apply
+      cannot leave the reported counts disagreeing with the committed
+      state.
     """
 
     edge: GraphEdge
     audit_id: uuid.UUID
     audit_payload: dict[str, Any]
     target_name: str
+    was_created: bool
 
 
 async def annotate_edge_in_txn(
@@ -754,6 +764,7 @@ async def annotate_edge_in_txn(
         )
         session.add(edge)
         await session.flush()
+        was_created = True
     else:
         # Idempotent path covers two cases:
         #
@@ -782,12 +793,33 @@ async def annotate_edge_in_txn(
         merged = dict(existing.properties or {})
         for key, value in properties.items():
             merged[key] = value
+        promoting = existing.source != "curated"
+        if promoting:
+            # §6 invariant: a curated edge must never carry an
+            # ``superseded_by`` marker — that marker is meaningful only
+            # on ``source='auto'`` rows that the conflict-detection
+            # scan stamped against a different-endpoint curated
+            # assertion. When the same triple gets re-annotated, the
+            # auto row's stale marker would otherwise persist onto the
+            # promoted curated row and hide it from
+            # :func:`find_dependents` / :func:`find_dependencies` —
+            # the traversal CTE filters
+            # ``properties->>'superseded_by' IS NULL``. Drop the key
+            # here so the promoted curated edge is immediately visible.
+            #
+            # ``conflicts_with`` (bidirectional, list-shaped) is kept:
+            # the entries point at *other-kind* edges over the same
+            # endpoint pair, which still exist and still conflict; the
+            # incompatible-kinds scan below re-stamps the curated side
+            # without dropping the legitimate back-references.
+            merged.pop(_SUPERSEDED_BY, None)
         existing.properties = merged
         existing.last_seen = now
-        if existing.source != "curated":
+        if promoting:
             existing.source = "curated"
             existing.discovered_by = operator.sub
         edge = existing
+        was_created = False
 
     superseded = await _mark_same_kind_different_endpoint_superseded(
         session,
@@ -834,6 +866,7 @@ async def annotate_edge_in_txn(
         audit_id=audit_id,
         audit_payload=payload,
         target_name=from_node.name,
+        was_created=was_created,
     )
 
 

--- a/backend/src/meho_backplane/topology/annotate.py
+++ b/backend/src/meho_backplane/topology/annotate.py
@@ -92,11 +92,13 @@ if TYPE_CHECKING:
 
 __all__ = [
     "AnnotateConflictError",
+    "AnnotatePlan",
     "AutoEdgeDeletionError",
     "InvalidEdgeKindError",
     "NodeRef",
     "UnannotateSelectorError",
     "annotate_edge",
+    "annotate_edge_in_txn",
     "unannotate_edge",
 ]
 
@@ -631,127 +633,208 @@ async def annotate_edge(
             kinds and no ``kind`` was pinned on the
             :class:`NodeRef`.
     """
-    canonical_kind = _validate_kind(kind)
-
     async with session.begin():
-        from_node = await resolve_node(session, operator.tenant_id, from_ref.name, from_ref.kind)
-        to_node = await resolve_node(session, operator.tenant_id, to_ref.name, to_ref.kind)
-
-        now = datetime.now(UTC)
-        existing = await _find_existing_edge(
+        plan = await annotate_edge_in_txn(
             session,
-            tenant_id=operator.tenant_id,
-            from_id=from_node.id,
-            to_id=to_node.id,
-            kind=canonical_kind,
-        )
-
-        properties = {
-            "note": note,
-            "evidence_url": evidence_url,
-            "annotated_by": operator.sub,
-            "annotated_at": now.isoformat(),
-        }
-
-        if existing is None:
-            edge = GraphEdge(
-                id=uuid.uuid4(),
-                tenant_id=operator.tenant_id,
-                from_node_id=from_node.id,
-                to_node_id=to_node.id,
-                kind=canonical_kind,
-                source="curated",
-                properties=properties,
-                discovered_by=operator.sub,
-                first_seen=now,
-                last_seen=now,
-            )
-            session.add(edge)
-            await session.flush()
-        else:
-            # Idempotent path covers two cases:
-            #
-            # 1. **Re-annotate of an already-curated row.** Merge new
-            #    free-text fields onto the existing properties; the
-            #    ``source='curated'`` and any reciprocal ``conflicts_with``
-            #    / ``superseded_by`` markers are preserved so the
-            #    re-annotate does not silently drop the §6 back-references.
-            #
-            # 2. **Annotate over an existing ``source='auto'`` edge with
-            #    the same triple.** The operator's intent is to take
-            #    ownership of that edge going forward — set notes /
-            #    evidence, run §6 conflict detection from it, eventually
-            #    revoke via :func:`unannotate_edge`. Leaving the row as
-            #    ``source='auto'`` would (a) make the triple-form
-            #    unannotate raise :class:`AutoEdgeDeletionError` so the
-            #    operator cannot revoke their own annotation; (b) let the
-            #    next refresh's :func:`_merge_edge_properties` overwrite
-            #    the free-text props (only the reserved markers are
-            #    preserved on the merge path); (c) make
-            #    :func:`_mark_same_kind_different_endpoint_superseded` on
-            #    a future annotate mis-target the row as another auto
-            #    edge. The promotion to ``source='curated'`` and
-            #    ``discovered_by=operator.sub`` makes the operator the
-            #    canonical author from this call onward.
-            merged = dict(existing.properties or {})
-            for key, value in properties.items():
-                merged[key] = value
-            existing.properties = merged
-            existing.last_seen = now
-            if existing.source != "curated":
-                existing.source = "curated"
-                existing.discovered_by = operator.sub
-            edge = existing
-
-        superseded = await _mark_same_kind_different_endpoint_superseded(
-            session,
-            tenant_id=operator.tenant_id,
-            curated_edge_id=edge.id,
-            from_id=from_node.id,
-            to_id=to_node.id,
-            kind=canonical_kind,
-        )
-        conflicts = await _mark_incompatible_kinds_conflict(
-            session,
-            tenant_id=operator.tenant_id,
-            curated_edge=edge,
-            from_id=from_node.id,
-            to_id=to_node.id,
-            kind=canonical_kind,
-        )
-
-        audit_id = uuid.uuid4()
-        payload = _audit_payload(
-            op_id=_ANNOTATE_OP_ID,
-            from_node=from_node,
-            to_node=to_node,
-            kind=canonical_kind,
-            edge_id=edge.id,
+            operator,
+            from_ref,
+            kind,
+            to_ref,
             note=note,
             evidence_url=evidence_url,
-            superseded=superseded,
-            conflicts=conflicts,
         )
-        session.add(
-            _build_audit_row(
-                audit_id=audit_id,
-                operator=operator,
-                method=_AUDIT_METHOD_ANNOTATE,
-                op_id=_ANNOTATE_OP_ID,
-                target_id=_broadcast_target_id(from_node),
-                payload=payload,
-            )
-        )
-        target_name = from_node.name
 
     await _publish(
-        audit_id=audit_id,
+        audit_id=plan.audit_id,
         operator=operator,
         op_id=_ANNOTATE_OP_ID,
-        target_name=target_name,
-        payload=payload,
+        target_name=plan.target_name,
+        payload=plan.audit_payload,
     )
-    return edge
+    return plan.edge
+
+
+@dataclass(frozen=True, slots=True)
+class AnnotatePlan:
+    """Result of one :func:`annotate_edge_in_txn` call.
+
+    Carries the row + every post-commit broadcast input the caller needs
+    to publish the broadcast event(s) outside the SQL transaction. The
+    single-edge wrapper :func:`annotate_edge` publishes one event per
+    call; the bulk helper publishes one per row after the batch
+    transaction commits, mirroring the same broadcast-after-commit
+    discipline.
+
+    Fields:
+
+    * ``edge`` — the upserted :class:`GraphEdge` row (flushed inside the
+      caller-owned transaction).
+    * ``audit_id`` — pre-allocated id of the ``audit_log`` row written
+      for this annotation; broadcast events reference it under
+      ``audit_id``.
+    * ``audit_payload`` — the shared dict the audit row + the broadcast
+      event both carry.
+    * ``target_name`` — the from-node's name; surfaces in the broadcast
+      event's ``target_name`` field per the chassis convention.
+    """
+
+    edge: GraphEdge
+    audit_id: uuid.UUID
+    audit_payload: dict[str, Any]
+    target_name: str
+
+
+async def annotate_edge_in_txn(
+    session: AsyncSession,
+    operator: Operator,
+    from_ref: NodeRef,
+    kind: str,
+    to_ref: NodeRef,
+    *,
+    note: str | None = None,
+    evidence_url: str | None = None,
+) -> AnnotatePlan:
+    """In-transaction body of :func:`annotate_edge` — caller owns the txn.
+
+    The single-edge wrapper :func:`annotate_edge` opens its own
+    ``session.begin()`` block around this call and then publishes the
+    broadcast event after commit. The bulk-import helper
+    :func:`bulk_import_edges` (G9.2-T8 #600) calls this function N times
+    inside one shared transaction so the batch is all-or-nothing per
+    the issue body's atomicity criterion, then publishes one broadcast
+    event per row after the batch commits.
+
+    The function performs the four side effects ``annotate_edge``
+    documents (resolve endpoints, idempotent upsert, §6 conflict
+    detection, write the audit row) but **does not commit and does not
+    publish**. It returns an :class:`AnnotatePlan` so the caller can
+    drive the broadcast after its own commit.
+
+    The function expects ``session`` to be inside an active
+    transaction. Calling outside a transaction is an error — the
+    upsert + conflict-mark sequence must be atomic per row, and the
+    function does not open its own ``session.begin()``.
+
+    Args, return shape, and raised errors otherwise match
+    :func:`annotate_edge` verbatim.
+    """
+    canonical_kind = _validate_kind(kind)
+
+    from_node = await resolve_node(session, operator.tenant_id, from_ref.name, from_ref.kind)
+    to_node = await resolve_node(session, operator.tenant_id, to_ref.name, to_ref.kind)
+
+    now = datetime.now(UTC)
+    existing = await _find_existing_edge(
+        session,
+        tenant_id=operator.tenant_id,
+        from_id=from_node.id,
+        to_id=to_node.id,
+        kind=canonical_kind,
+    )
+
+    properties = {
+        "note": note,
+        "evidence_url": evidence_url,
+        "annotated_by": operator.sub,
+        "annotated_at": now.isoformat(),
+    }
+
+    if existing is None:
+        edge = GraphEdge(
+            id=uuid.uuid4(),
+            tenant_id=operator.tenant_id,
+            from_node_id=from_node.id,
+            to_node_id=to_node.id,
+            kind=canonical_kind,
+            source="curated",
+            properties=properties,
+            discovered_by=operator.sub,
+            first_seen=now,
+            last_seen=now,
+        )
+        session.add(edge)
+        await session.flush()
+    else:
+        # Idempotent path covers two cases:
+        #
+        # 1. **Re-annotate of an already-curated row.** Merge new
+        #    free-text fields onto the existing properties; the
+        #    ``source='curated'`` and any reciprocal ``conflicts_with``
+        #    / ``superseded_by`` markers are preserved so the
+        #    re-annotate does not silently drop the §6 back-references.
+        #
+        # 2. **Annotate over an existing ``source='auto'`` edge with
+        #    the same triple.** The operator's intent is to take
+        #    ownership of that edge going forward — set notes /
+        #    evidence, run §6 conflict detection from it, eventually
+        #    revoke via :func:`unannotate_edge`. Leaving the row as
+        #    ``source='auto'`` would (a) make the triple-form
+        #    unannotate raise :class:`AutoEdgeDeletionError` so the
+        #    operator cannot revoke their own annotation; (b) let the
+        #    next refresh's :func:`_merge_edge_properties` overwrite
+        #    the free-text props (only the reserved markers are
+        #    preserved on the merge path); (c) make
+        #    :func:`_mark_same_kind_different_endpoint_superseded` on
+        #    a future annotate mis-target the row as another auto
+        #    edge. The promotion to ``source='curated'`` and
+        #    ``discovered_by=operator.sub`` makes the operator the
+        #    canonical author from this call onward.
+        merged = dict(existing.properties or {})
+        for key, value in properties.items():
+            merged[key] = value
+        existing.properties = merged
+        existing.last_seen = now
+        if existing.source != "curated":
+            existing.source = "curated"
+            existing.discovered_by = operator.sub
+        edge = existing
+
+    superseded = await _mark_same_kind_different_endpoint_superseded(
+        session,
+        tenant_id=operator.tenant_id,
+        curated_edge_id=edge.id,
+        from_id=from_node.id,
+        to_id=to_node.id,
+        kind=canonical_kind,
+    )
+    conflicts = await _mark_incompatible_kinds_conflict(
+        session,
+        tenant_id=operator.tenant_id,
+        curated_edge=edge,
+        from_id=from_node.id,
+        to_id=to_node.id,
+        kind=canonical_kind,
+    )
+
+    audit_id = uuid.uuid4()
+    payload = _audit_payload(
+        op_id=_ANNOTATE_OP_ID,
+        from_node=from_node,
+        to_node=to_node,
+        kind=canonical_kind,
+        edge_id=edge.id,
+        note=note,
+        evidence_url=evidence_url,
+        superseded=superseded,
+        conflicts=conflicts,
+    )
+    session.add(
+        _build_audit_row(
+            audit_id=audit_id,
+            operator=operator,
+            method=_AUDIT_METHOD_ANNOTATE,
+            op_id=_ANNOTATE_OP_ID,
+            target_id=_broadcast_target_id(from_node),
+            payload=payload,
+        )
+    )
+
+    return AnnotatePlan(
+        edge=edge,
+        audit_id=audit_id,
+        audit_payload=payload,
+        target_name=from_node.name,
+    )
 
 
 async def unannotate_edge(

--- a/backend/src/meho_backplane/topology/bulk_import.py
+++ b/backend/src/meho_backplane/topology/bulk_import.py
@@ -553,6 +553,21 @@ async def _classify_row(
             # listing flags it pre-apply.
             action = "conflict"
 
+    # Incompatible-kind / same-endpoint scan: §6 class 2. The apply
+    # pass's :func:`annotate._mark_incompatible_kinds_conflict` will
+    # stamp bidirectional ``conflicts_with`` markers; pre-apply we
+    # surface the row as ``conflict`` so the dry-run plan exposes
+    # the recoverability listing for *both* §6 classes (the
+    # same-kind / different-endpoint case above and the
+    # incompatible-kind / same-endpoint case here). Reads only;
+    # marker writes happen in the apply transaction.
+    incoming_conflict_kinds = await _scan_would_conflict_kinds(
+        session, operator, from_node.id, to_node.id, canonical_kind
+    )
+    if incoming_conflict_kinds:
+        conflicts = list({*conflicts, *incoming_conflict_kinds})
+        action = "conflict"
+
     return action, _EdgeSummary(
         edge_id=edge_id,
         from_name=from_node.name,
@@ -590,6 +605,37 @@ async def _scan_would_supersede(
     return [str(r.id) for r in rows]
 
 
+async def _scan_would_conflict_kinds(
+    session: AsyncSession,
+    operator: Operator,
+    from_id: object,
+    to_id: object,
+    kind: str,
+) -> list[str]:
+    """Read-only counterpart of
+    :func:`annotate._mark_incompatible_kinds_conflict`.
+
+    Returns the ids of edges that already exist over the same endpoint
+    pair with a *different* ``kind`` — the §6 class-2 (incompatible-kind
+    / same-endpoint) conflict signal. Reads only; the apply pass's
+    bidirectional ``conflicts_with`` marker write is what makes the
+    conflict effective in the audit / broadcast payloads.
+
+    The query mirrors :func:`annotate._mark_incompatible_kinds_conflict`'s
+    SELECT verbatim so the plan-pass classification and the apply-pass
+    marker write target the same row set; a divergence between the two
+    would let dry-run plans hide §6 conflicts the apply would surface.
+    """
+    stmt = select(GraphEdge).where(
+        GraphEdge.tenant_id == operator.tenant_id,
+        GraphEdge.from_node_id == from_id,
+        GraphEdge.to_node_id == to_id,
+        GraphEdge.kind != kind,
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    return [str(r.id) for r in rows]
+
+
 def _materialise_apply_rows(
     plans: list[AnnotatePlan],
     plan_rows: list[BulkEdgeResult],
@@ -602,23 +648,59 @@ def _materialise_apply_rows(
     rows, and the audit payload carries the final ``superseded`` /
     ``conflicts`` lists post-marker-write — so we re-pack the result
     using those authoritative numbers.
+
+    The per-row ``action`` is re-derived from the apply pass's actual
+    insert-vs-merge outcome (:attr:`AnnotatePlan.was_created`) plus the
+    post-commit marker arrays, **not** carried forward from the pass-1
+    plan. The pass-1 ``action`` is a *prediction* that two situations
+    can invalidate:
+
+    1. **Intra-batch duplicates.** Two rows in the same batch resolving
+       to the same ``(from, to, kind)`` triple — pass-1 saw the row as
+       missing for both rows (the first row was not yet flushed); pass-2
+       inserts on row N and merges on row N+1. Carrying pass-1's action
+       forward would count both as ``create`` and report 2 created
+       edges when the DB only holds 1.
+
+    2. **Inter-pass races.** A concurrent transaction inserted the row
+       between pass-1 and pass-2. Pass-1 planned ``create``; pass-2 got
+       a unique-constraint hit on flush, then the second annotate
+       merged onto the racing row. Pass-1's action no longer reflects
+       what actually happened.
+
+    Re-deriving from the apply outcome makes the reported counts match
+    the committed DB state by construction. Any post-commit marker
+    array — ``superseded`` (§6 class 1, same-kind/different-endpoint)
+    or ``conflicts`` (§6 class 2, incompatible-kind/same-endpoint) —
+    forces ``action='conflict'`` so the recoverability listing
+    surfaces; otherwise ``was_created`` distinguishes ``create``
+    (fresh insert) from ``update`` (idempotent merge).
     """
     out: list[BulkEdgeResult] = []
     for plan_row, applied in zip(plan_rows, plans, strict=True):
         payload = applied.audit_payload
         edge = applied.edge
+        superseded = [str(s) for s in payload.get("superseded", [])]
+        conflicts = [str(c) for c in payload.get("conflicts", [])]
+        action: BulkEdgeAction
+        if superseded or conflicts:
+            action = "conflict"
+        elif applied.was_created:
+            action = "create"
+        else:
+            action = "update"
         out.append(
             BulkEdgeResult(
                 index=plan_row.index,
-                action=plan_row.action,
+                action=action,
                 edge_id=str(edge.id),
                 from_name=plan_row.from_name,
                 from_kind=plan_row.from_kind,
                 to_name=plan_row.to_name,
                 to_kind=plan_row.to_kind,
                 kind=plan_row.kind,
-                superseded=[str(s) for s in payload.get("superseded", [])],
-                conflicts=[str(c) for c in payload.get("conflicts", [])],
+                superseded=superseded,
+                conflicts=conflicts,
             )
         )
     return out

--- a/backend/src/meho_backplane/topology/bulk_import.py
+++ b/backend/src/meho_backplane/topology/bulk_import.py
@@ -1,0 +1,624 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Batch curated-edge import service (Initiative #364, G9.2-T8 #600).
+
+The single-edge :func:`annotate_edge` flow is the ergonomics floor for
+asserting one cross-system relationship; bulk import is what makes
+seeding the consumer's prose ``INVENTORY.md`` at onboarding a
+single declarative pass rather than a 30-verb shell loop.
+
+**Atomicity contract.** The whole batch lives in **one transaction**.
+A validation failure (unknown ``kind``, unresolvable endpoint,
+ambiguous endpoint) on any row rolls back the entire transaction —
+no partial apply. Re-running the same file is a per-row no-op because
+each row's idempotent upsert path matches the underlying
+:func:`annotate_edge_in_txn` contract. The chosen semantics (the
+issue body offers two options — atomic OR partial with explicit
+failure reporting) are atomic-only in v0.2 because:
+
+* The consumer's INVENTORY.md is the source of truth: a partially-
+  applied batch leaves the operator with no clean re-run path other
+  than "diff what landed vs the file, fix the file, rerun"; an atomic
+  failure surfaces the bad row and lets the operator fix-and-retry.
+* Bulk import is a v0.2 stretch (Initiative #364 §7); a future widening
+  to a ``--continue-on-error`` mode is back-compat and can ship in a
+  follow-up.
+* The per-row audit + broadcast events still fire — one per applied
+  row, fail-open broadcast publish after commit — so a successful
+  batch is indistinguishable from N single annotates at the audit /
+  event level.
+
+**Dry-run.** Returns the per-row plan (``create`` / ``update`` /
+``conflict``) without opening any write transaction. The validation
+pass still runs (resolves endpoints, runs ``_find_existing_edge``)
+inside a single ``session.begin()`` block that the caller's bulk
+import contract makes read-only — no row is added, no row is mutated,
+and the transaction always rolls back at the end of the dry-run
+block. Acceptance criterion: ``--dry-run`` produces the per-edge plan
+and performs zero writes (asserted: row count unchanged, no audit
+rows).
+
+**Broadcast.** Per the annotate convention, one event per row, fired
+after the batch commits. The fail-open semantics live in the
+:func:`annotate._publish` helper — a broken broadcaster never rolls
+back a successful batch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.db.models import GraphEdge, GraphEdgeKind
+from meho_backplane.topology.annotate import (
+    _ANNOTATE_OP_ID,
+    AnnotatePlan,
+    InvalidEdgeKindError,
+    NodeRef,
+    _find_existing_edge,
+    _publish,
+    _validate_kind,
+    annotate_edge_in_txn,
+)
+from meho_backplane.topology.resolvers import (
+    AmbiguousNodeError,
+    NodeNotFoundError,
+    resolve_node,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "BulkEdgeAction",
+    "BulkEdgeResult",
+    "BulkImportResult",
+    "BulkImportRow",
+    "BulkImportRowError",
+    "BulkImportValidationError",
+    "bulk_import_edges",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class BulkImportRow:
+    """One edge to import.
+
+    ``from_ref`` / ``to_ref`` mirror the single-edge :class:`NodeRef`
+    pair the :func:`annotate_edge` service takes. ``note`` /
+    ``evidence_url`` are the same optional free-text fields. Plain
+    immutable dataclass so the REST + CLI fronts have a stable shape
+    to coerce their input rows into.
+    """
+
+    from_ref: NodeRef
+    kind: str
+    to_ref: NodeRef
+    note: str | None = None
+    evidence_url: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+
+#: Per-row outcome on a successful (or dry-run) batch. ``create`` is a
+#: fresh row insert; ``update`` is the idempotent upsert path (the
+#: ``(tenant_id, from, to, kind)`` row already existed); ``conflict``
+#: surfaces a row that landed with §6 markers attached so the operator
+#: sees the recoverability listing the conflict-detection produced.
+BulkEdgeAction = Literal["create", "update", "conflict"]
+
+
+@dataclass(frozen=True, slots=True)
+class BulkEdgeResult:
+    """Per-row outcome surfaced in :class:`BulkImportResult`.
+
+    ``index`` is the source-order position (zero-based) so a caller
+    rendering a YAML file can point at the offending row. ``edge_id``
+    is populated post-commit (apply path) and pre-flush (dry-run path
+    returns ``None`` — no edge exists yet to point at). ``superseded``
+    / ``conflicts`` echo the §6 marker arrays the underlying
+    :func:`annotate_edge_in_txn` writes, so a consumer can detect that
+    a "successful" import nonetheless rewrote the auto-edge landscape.
+    """
+
+    index: int
+    action: BulkEdgeAction
+    edge_id: str | None
+    from_name: str
+    from_kind: str
+    to_name: str
+    to_kind: str
+    kind: str
+    superseded: list[str]
+    conflicts: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class BulkImportResult:
+    """Aggregate outcome of one batch.
+
+    ``dry_run`` echoes the call-site flag so callers (REST handler,
+    CLI renderer) can branch on it without reading the request side.
+    Counts are derived but pre-computed so the JSON shape is stable
+    for the operator's eye (the consumer's onboarding doc renders
+    them).
+    """
+
+    dry_run: bool
+    created: int
+    updated: int
+    conflicts: int
+    rows: list[BulkEdgeResult]
+
+
+# ---------------------------------------------------------------------------
+# Errors (HTTP-agnostic; API layer maps to status codes)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class BulkImportRowError:
+    """One row's validation failure, attached to a
+    :class:`BulkImportValidationError`.
+
+    ``index`` is the source-order position; ``error`` is a short
+    machine-readable token (``invalid_kind`` / ``node_not_found`` /
+    ``ambiguous_node``); ``message`` is the human-readable diagnostic
+    the front layer renders. The shape mirrors the per-row error
+    envelopes the REST layer surfaces — one struct per failure rather
+    than a free-form string blob, so the CLI / MCP fronts can render
+    a structured "row 3: invalid_kind 'made-up'" list.
+    """
+
+    index: int
+    error: str
+    message: str
+    name: str | None = None
+    kind: str | None = None
+    kinds: list[str] | None = None
+
+
+class BulkImportValidationError(ValueError):
+    """Aggregate validation failure for one or more rows.
+
+    Raised after the validation pass collects every row's error — the
+    batch is rejected atomically, but the operator sees **all** the
+    problems in one shot rather than fixing one and rediscovering the
+    next on the rerun. The REST layer maps this to a 422 with the
+    structured ``errors`` array in ``detail``.
+    """
+
+    def __init__(self, errors: list[BulkImportRowError]) -> None:
+        self.errors = errors
+        super().__init__(f"bulk import rejected: {len(errors)} row(s) failed validation")
+
+
+# ---------------------------------------------------------------------------
+# Public service
+# ---------------------------------------------------------------------------
+
+
+async def bulk_import_edges(
+    session: AsyncSession,
+    operator: Operator,
+    rows: list[BulkImportRow],
+    *,
+    dry_run: bool = False,
+) -> BulkImportResult:
+    """Annotate every row in ``rows`` in one transaction (or plan only).
+
+    The function performs two passes:
+
+    1. **Validation pass.** Resolves both endpoints of every row,
+       canonicalises the ``kind`` against :class:`GraphEdgeKind`, and
+       records what the apply pass would do (``create`` for a row that
+       does not yet exist; ``update`` for a row that matches an
+       existing ``(tenant, from, to, kind)``; ``conflict`` for a row
+       whose endpoint pair already carries a §6 conflict marker).
+       Failure on any row aggregates into a single
+       :class:`BulkImportValidationError` carrying every row's
+       per-row :class:`BulkImportRowError`.
+
+       The pass runs inside a transaction so the
+       :func:`resolve_node` lookups + :func:`_find_existing_edge`
+       reads see a consistent snapshot. In dry-run mode the
+       transaction is always rolled back at the end of the block
+       — no row is mutated, no audit row is inserted.
+
+    2. **Apply pass.** Skipped under ``dry_run=True``. Otherwise opens
+       a single ``session.begin()`` block, calls
+       :func:`annotate_edge_in_txn` for each row inside it, and
+       commits. Post-commit publishes one broadcast event per row
+       via the shared fail-open helper. Per-row audit rows are
+       written inside the transaction by ``annotate_edge_in_txn``,
+       so the audit + broadcast count matches the issue criterion:
+       one audit row per edge + one broadcast event per edge.
+
+    Args:
+        session: Caller-owned :class:`AsyncSession` with **no active
+            transaction**. The function opens its own
+            ``session.begin()`` block (twice — once for validation,
+            once for apply); reusing a session that already has a
+            txn-in-flight is a programming error.
+        operator: The acting principal. Supplies the tenant scope
+            (every endpoint resolution + every edge upsert respects
+            ``operator.tenant_id``) and the audit attribution.
+        rows: Source-ordered list of :class:`BulkImportRow`. Empty
+            list is a no-op (returns a zero-row result; no
+            validation error). The caller is free to dedupe inputs;
+            this function does not.
+        dry_run: When true, the apply pass is skipped. The returned
+            :class:`BulkImportResult` echoes the plan with
+            ``edge_id=None`` on every row; no audit row is written,
+            no broadcast event is published.
+
+    Returns:
+        A :class:`BulkImportResult` carrying the per-row outcomes +
+        the aggregate counts.
+
+    Raises:
+        BulkImportValidationError: One or more rows failed validation
+            (invalid ``kind``, missing endpoint, ambiguous endpoint).
+            The error carries every row's failure; partial rejection
+            is the deliberate semantics — a malformed batch is never
+            partially applied.
+    """
+    if not rows:
+        return BulkImportResult(dry_run=dry_run, created=0, updated=0, conflicts=0, rows=[])
+
+    # ----- Pass 1: validation in a read-only transaction --------------------
+    #
+    # We open a single ``session.begin()`` block so every resolver
+    # lookup + every existing-edge probe sees a consistent snapshot.
+    # The pass either succeeds (apply pass is allowed to proceed) or
+    # fails atomically — no partial annotate ever leaks past this
+    # check. The dry-run path also exits through this branch (with
+    # the transaction rolled back via the ``raise`` path on the
+    # else-clause when ``dry_run`` is true; see below).
+
+    errors: list[BulkImportRowError] = []
+    plan_rows: list[BulkEdgeResult] = []
+
+    async with session.begin():
+        for index, row in enumerate(rows):
+            try:
+                action, edge_summary = await _classify_row(session, operator, index, row)
+            except _RowValidationError as exc:
+                errors.append(exc.error)
+                continue
+            plan_rows.append(
+                BulkEdgeResult(
+                    index=index,
+                    action=action,
+                    edge_id=edge_summary.edge_id,
+                    from_name=edge_summary.from_name,
+                    from_kind=edge_summary.from_kind,
+                    to_name=edge_summary.to_name,
+                    to_kind=edge_summary.to_kind,
+                    kind=edge_summary.kind,
+                    superseded=edge_summary.superseded,
+                    conflicts=edge_summary.conflicts,
+                )
+            )
+
+    if errors:
+        raise BulkImportValidationError(errors)
+
+    counts = _aggregate_counts(plan_rows)
+    if dry_run:
+        return BulkImportResult(
+            dry_run=True,
+            created=counts.created,
+            updated=counts.updated,
+            conflicts=counts.conflicts,
+            rows=plan_rows,
+        )
+
+    # ----- Pass 2: apply — one transaction wrapping every annotate ----------
+
+    plans: list[AnnotatePlan] = []
+    async with session.begin():
+        for row in rows:
+            plan = await annotate_edge_in_txn(
+                session,
+                operator,
+                row.from_ref,
+                row.kind,
+                row.to_ref,
+                note=row.note,
+                evidence_url=row.evidence_url,
+            )
+            plans.append(plan)
+
+    # Publish one broadcast event per row after commit. The helper is
+    # fail-open per the refresh pattern — a broken broadcaster never
+    # rolls back the successful batch.
+    for plan in plans:
+        await _publish(
+            audit_id=plan.audit_id,
+            operator=operator,
+            op_id=_ANNOTATE_OP_ID,
+            target_name=plan.target_name,
+            payload=plan.audit_payload,
+        )
+
+    # Re-build the row list with post-commit edge ids so the response
+    # can carry the actually-applied row state (the validation-pass
+    # plan_rows have stale ids — the upsert path on update may have
+    # mutated the existing row, the create path adds a new id we now
+    # know).
+    applied_rows = _materialise_apply_rows(plans, plan_rows)
+    apply_counts = _aggregate_counts(applied_rows)
+    _log.info(
+        "topology_bulk_import_committed",
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+        created=apply_counts.created,
+        updated=apply_counts.updated,
+        conflicts=apply_counts.conflicts,
+        total=len(applied_rows),
+    )
+    return BulkImportResult(
+        dry_run=False,
+        created=apply_counts.created,
+        updated=apply_counts.updated,
+        conflicts=apply_counts.conflicts,
+        rows=applied_rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _Counts:
+    created: int
+    updated: int
+    conflicts: int
+
+
+def _aggregate_counts(rows: list[BulkEdgeResult]) -> _Counts:
+    """Tally action buckets for the result envelope."""
+    created = sum(1 for r in rows if r.action == "create")
+    updated = sum(1 for r in rows if r.action == "update")
+    conflicts = sum(1 for r in rows if r.action == "conflict")
+    return _Counts(created=created, updated=updated, conflicts=conflicts)
+
+
+@dataclass(frozen=True, slots=True)
+class _EdgeSummary:
+    """Mid-classify holder so the per-row record stays a single struct."""
+
+    edge_id: str | None
+    from_name: str
+    from_kind: str
+    to_name: str
+    to_kind: str
+    kind: str
+    superseded: list[str]
+    conflicts: list[str]
+
+
+class _RowValidationError(Exception):
+    """Internal sentinel: the row failed validation; carries the error."""
+
+    def __init__(self, error: BulkImportRowError) -> None:
+        self.error = error
+        super().__init__(error.message)
+
+
+async def _classify_row(
+    session: AsyncSession,
+    operator: Operator,
+    index: int,
+    row: BulkImportRow,
+) -> tuple[BulkEdgeAction, _EdgeSummary]:
+    """Resolve endpoints + kind + existing-row state for one input row.
+
+    Returns the planned action (``create`` / ``update`` / ``conflict``)
+    + a summary the result envelope renders. The ``conflict``
+    classification is conservative: a pre-existing edge over the same
+    endpoint pair that already carries §6 markers (``conflicts_with``
+    or ``superseded_by``) routes through ``conflict`` so the operator
+    sees the recoverability listing alongside the apply plan. A row
+    that fires *new* §6 markers via the conflict-detection scan still
+    classifies as ``create``/``update`` here — the marker arrays carry
+    the diagnostic the operator needs.
+
+    Raises:
+        _RowValidationError: Any of the three validation surfaces
+            failed for this row.
+    """
+    # Validate kind first — fail-fast on a typo before doing any
+    # node-resolution IO.
+    try:
+        canonical_kind = _validate_kind(row.kind)
+    except InvalidEdgeKindError as exc:
+        valid = sorted(k.value for k in GraphEdgeKind)
+        raise _RowValidationError(
+            BulkImportRowError(
+                index=index,
+                error="invalid_kind",
+                message=str(exc),
+                kind=exc.kind,
+                kinds=valid,
+            )
+        ) from exc
+
+    try:
+        from_node = await resolve_node(
+            session, operator.tenant_id, row.from_ref.name, row.from_ref.kind
+        )
+    except NodeNotFoundError as exc:
+        raise _RowValidationError(
+            BulkImportRowError(
+                index=index,
+                error="node_not_found",
+                message=str(exc),
+                name=exc.name,
+                kind=exc.kind,
+            )
+        ) from exc
+    except AmbiguousNodeError as exc:
+        raise _RowValidationError(
+            BulkImportRowError(
+                index=index,
+                error="ambiguous_node",
+                message=str(exc),
+                name=exc.name,
+                kinds=sorted(exc.kinds),
+            )
+        ) from exc
+
+    try:
+        to_node = await resolve_node(session, operator.tenant_id, row.to_ref.name, row.to_ref.kind)
+    except NodeNotFoundError as exc:
+        raise _RowValidationError(
+            BulkImportRowError(
+                index=index,
+                error="node_not_found",
+                message=str(exc),
+                name=exc.name,
+                kind=exc.kind,
+            )
+        ) from exc
+    except AmbiguousNodeError as exc:
+        raise _RowValidationError(
+            BulkImportRowError(
+                index=index,
+                error="ambiguous_node",
+                message=str(exc),
+                name=exc.name,
+                kinds=sorted(exc.kinds),
+            )
+        ) from exc
+
+    existing = await _find_existing_edge(
+        session,
+        tenant_id=operator.tenant_id,
+        from_id=from_node.id,
+        to_id=to_node.id,
+        kind=canonical_kind,
+    )
+
+    action: BulkEdgeAction
+    edge_id: str | None
+    superseded: list[str] = []
+    conflicts: list[str] = []
+    if existing is None:
+        action = "create"
+        edge_id = None
+    else:
+        edge_id = str(existing.id)
+        existing_props = existing.properties or {}
+        raw_conflicts = existing_props.get("conflicts_with")
+        if isinstance(raw_conflicts, list):
+            conflicts = [str(c) for c in raw_conflicts]
+        if existing_props.get("superseded_by"):
+            superseded = [str(existing_props["superseded_by"])]
+        # A pre-existing edge that already carries §6 markers gets the
+        # ``conflict`` classification so the operator sees it in the
+        # plan; a clean re-annotate gets ``update``.
+        action = "conflict" if (conflicts or superseded) else "update"
+
+    # Same-kind / different-endpoint scan: are there auto edges this
+    # apply would supersede? Reads only; the actual marker write
+    # happens inside the apply pass.
+    incoming_supersedes = await _scan_would_supersede(
+        session, operator, from_node.id, to_node.id, canonical_kind
+    )
+    if incoming_supersedes:
+        superseded = list({*superseded, *incoming_supersedes})
+        if action == "create":
+            # A row that creates a curated edge AND supersedes an auto
+            # edge surfaces as ``conflict`` so the recoverability
+            # listing flags it pre-apply.
+            action = "conflict"
+
+    return action, _EdgeSummary(
+        edge_id=edge_id,
+        from_name=from_node.name,
+        from_kind=from_node.kind,
+        to_name=to_node.name,
+        to_kind=to_node.kind,
+        kind=canonical_kind,
+        superseded=superseded,
+        conflicts=conflicts,
+    )
+
+
+async def _scan_would_supersede(
+    session: AsyncSession,
+    operator: Operator,
+    from_id: object,
+    to_id: object,
+    kind: str,
+) -> list[str]:
+    """Read-only counterpart of
+    :func:`annotate._mark_same_kind_different_endpoint_superseded`.
+
+    Returns the ids of auto edges the apply pass would stamp
+    ``superseded_by`` for this row. Reads only; the apply pass's
+    marker write is what makes the supersede effective.
+    """
+    stmt = select(GraphEdge).where(
+        GraphEdge.tenant_id == operator.tenant_id,
+        GraphEdge.from_node_id == from_id,
+        GraphEdge.kind == kind,
+        GraphEdge.source == "auto",
+        GraphEdge.to_node_id != to_id,
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    return [str(r.id) for r in rows]
+
+
+def _materialise_apply_rows(
+    plans: list[AnnotatePlan],
+    plan_rows: list[BulkEdgeResult],
+) -> list[BulkEdgeResult]:
+    """Rebuild per-row results with post-commit edge ids + final markers.
+
+    The validation pass produced ``plan_rows`` keyed by source index;
+    the apply pass produced :class:`AnnotatePlan` objects in the same
+    order. The plan ids point at the freshly-flushed (or refreshed)
+    rows, and the audit payload carries the final ``superseded`` /
+    ``conflicts`` lists post-marker-write — so we re-pack the result
+    using those authoritative numbers.
+    """
+    out: list[BulkEdgeResult] = []
+    for plan_row, applied in zip(plan_rows, plans, strict=True):
+        payload = applied.audit_payload
+        edge = applied.edge
+        out.append(
+            BulkEdgeResult(
+                index=plan_row.index,
+                action=plan_row.action,
+                edge_id=str(edge.id),
+                from_name=plan_row.from_name,
+                from_kind=plan_row.from_kind,
+                to_name=plan_row.to_name,
+                to_kind=plan_row.to_kind,
+                kind=plan_row.kind,
+                superseded=[str(s) for s in payload.get("superseded", [])],
+                conflicts=[str(c) for c in payload.get("conflicts", [])],
+            )
+        )
+    return out

--- a/backend/tests/test_api_v1_topology.py
+++ b/backend/tests/test_api_v1_topology.py
@@ -1042,3 +1042,260 @@ async def test_list_edges_route_binds_read_op_id(client: TestClient) -> None:
     payload = rows[0].payload or {}
     assert payload.get("op_id") == "topology.list_edges"
     assert payload.get("op_class") == "read"
+
+
+# ---------------------------------------------------------------------------
+# G9.2-T8 (#600) — bulk import
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_import_route_mounted_on_main_app() -> None:
+    """``POST /api/v1/topology/edges/bulk`` appears in the OpenAPI document."""
+    from meho_backplane.main import app as main_app
+
+    paths = main_app.openapi()["paths"]
+    assert "/api/v1/topology/edges/bulk" in paths
+    assert "post" in paths["/api/v1/topology/edges/bulk"]
+
+
+def test_bulk_import_unauthenticated_returns_401(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/topology/edges/bulk",
+        json={"edges": [{"from": {"name": "a"}, "kind": "depends-on", "to": {"name": "b"}}]},
+    )
+    assert resp.status_code == 401
+
+
+def test_bulk_import_operator_returns_403(client: TestClient) -> None:
+    """``operator`` is below ``tenant_admin``; bulk must 403."""
+    key, token = _token(TenantRole.OPERATOR)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges/bulk",
+            headers=_authed(token),
+            json={
+                "edges": [
+                    {"from": {"name": "a"}, "kind": "depends-on", "to": {"name": "b"}},
+                ]
+            },
+        )
+    assert resp.status_code == 403
+
+
+def test_bulk_import_empty_edges_returns_422(client: TestClient) -> None:
+    """``edges`` is non-empty (``min_length=1``)."""
+    key, token = _admin_token_value()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges/bulk",
+            headers=_authed(token),
+            json={"edges": []},
+        )
+    assert resp.status_code == 422
+
+
+def test_bulk_import_too_many_edges_returns_422(client: TestClient) -> None:
+    """The route caps the batch size at 1000 rows."""
+    key, token = _admin_token_value()
+    edges = [
+        {"from": {"name": f"a-{i}"}, "kind": "depends-on", "to": {"name": f"b-{i}"}}
+        for i in range(1001)
+    ]
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges/bulk",
+            headers=_authed(token),
+            json={"edges": edges},
+        )
+    assert resp.status_code == 422
+
+
+def test_bulk_import_unknown_kind_returns_422(client: TestClient) -> None:
+    """A typo'd ``kind`` is caught at the Pydantic boundary."""
+    key, token = _admin_token_value()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges/bulk",
+            headers=_authed(token),
+            json={
+                "edges": [
+                    {"from": {"name": "a"}, "kind": "made-up", "to": {"name": "b"}},
+                ]
+            },
+        )
+    assert resp.status_code == 422
+
+
+def test_bulk_import_unknown_field_returns_422(client: TestClient) -> None:
+    """``extra='forbid'`` rejects typo'd field names at the boundary."""
+    key, token = _admin_token_value()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges/bulk",
+            headers=_authed(token),
+            json={
+                "edges": [
+                    {
+                        "from": {"name": "a"},
+                        "kind": "depends-on",
+                        "to": {"name": "b"},
+                        "evidnce_url": "https://typo",
+                    }
+                ]
+            },
+        )
+    assert resp.status_code == 422
+
+
+def test_bulk_import_admin_round_trip(client: TestClient) -> None:
+    """``tenant_admin`` POST calls ``bulk_import_edges`` and renders the response.
+
+    The service helper is stubbed out — the surface under test is the
+    route's coercion of the JSON body into :class:`BulkImportRow`
+    instances plus the response model shape. The integration suite
+    (T9-style) exercises the real service against a live DB; here we
+    only verify that the route's wire-shape contract holds.
+    """
+    from meho_backplane.topology.bulk_import import BulkEdgeResult, BulkImportResult
+
+    key, token = _admin_token_value()
+    fake_result = BulkImportResult(
+        dry_run=False,
+        created=1,
+        updated=1,
+        conflicts=0,
+        rows=[
+            BulkEdgeResult(
+                index=0,
+                action="create",
+                edge_id=str(uuid.uuid4()),
+                from_name="sa-a",
+                from_kind="principal",
+                to_name="vr-a",
+                to_kind="vault-role",
+                kind="authenticates-via",
+                superseded=[],
+                conflicts=[],
+            ),
+            BulkEdgeResult(
+                index=1,
+                action="update",
+                edge_id=str(uuid.uuid4()),
+                from_name="svc-orders",
+                from_kind="service",
+                to_name="db-orders",
+                to_kind="service",
+                kind="depends-on",
+                superseded=[],
+                conflicts=[],
+            ),
+        ],
+    )
+    fake = AsyncMock(return_value=fake_result)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.bulk_import_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges/bulk",
+            headers=_authed(token),
+            json={
+                "edges": [
+                    {
+                        "from": {"name": "sa-a", "kind": "principal"},
+                        "kind": "authenticates-via",
+                        "to": {"name": "vr-a", "kind": "vault-role"},
+                    },
+                    {
+                        "from": {"name": "svc-orders", "kind": "service"},
+                        "kind": "depends-on",
+                        "to": {"name": "db-orders", "kind": "service"},
+                    },
+                ]
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["dry_run"] is False
+    assert body["created"] == 1
+    assert body["updated"] == 1
+    assert len(body["rows"]) == 2
+    assert body["rows"][0]["action"] == "create"
+    fake.assert_awaited_once()
+
+
+def test_bulk_import_dry_run_forwards_flag(client: TestClient) -> None:
+    """``dry_run=true`` is forwarded to the service kwarg."""
+    from meho_backplane.topology.bulk_import import BulkImportResult
+
+    key, token = _admin_token_value()
+    fake_result = BulkImportResult(dry_run=True, created=0, updated=0, conflicts=0, rows=[])
+    fake = AsyncMock(return_value=fake_result)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.bulk_import_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges/bulk",
+            headers=_authed(token),
+            json={
+                "edges": [
+                    {"from": {"name": "a"}, "kind": "depends-on", "to": {"name": "b"}},
+                ],
+                "dry_run": True,
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["dry_run"] is True
+    assert fake.call_args.kwargs == {"dry_run": True}
+
+
+def test_bulk_import_validation_error_returns_422(client: TestClient) -> None:
+    """``BulkImportValidationError`` maps to 422 with the per-row error list."""
+    from meho_backplane.topology.bulk_import import (
+        BulkImportRowError,
+        BulkImportValidationError,
+    )
+
+    key, token = _admin_token_value()
+    fake = AsyncMock(
+        side_effect=BulkImportValidationError(
+            [
+                BulkImportRowError(
+                    index=1,
+                    error="node_not_found",
+                    message="node 'ghost' not found",
+                    name="ghost",
+                    kind="vm",
+                ),
+            ]
+        )
+    )
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.bulk_import_edges", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post(
+            "/api/v1/topology/edges/bulk",
+            headers=_authed(token),
+            json={
+                "edges": [
+                    {"from": {"name": "a"}, "kind": "depends-on", "to": {"name": "b"}},
+                    {"from": {"name": "ghost"}, "kind": "depends-on", "to": {"name": "z"}},
+                ]
+            },
+        )
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["error"] == "invalid_bulk"
+    assert len(detail["errors"]) == 1
+    assert detail["errors"][0]["index"] == 1
+    assert detail["errors"][0]["error"] == "node_not_found"

--- a/backend/tests/test_topology_annotate.py
+++ b/backend/tests/test_topology_annotate.py
@@ -1208,3 +1208,80 @@ async def test_refresh_strips_reserved_markers_from_connector_hints() -> None:
     finally:
         clear_registry()
         reset_connector_instance_cache()
+
+
+@pytest.mark.asyncio
+async def test_promotion_clears_stale_superseded_by_marker() -> None:
+    """Re-annotating a superseded auto edge must clear ``superseded_by``.
+
+    Regression guard for PR #667 B1: an earlier curated assertion of
+    ``runs-on(vm-a → host-y)`` stamped ``superseded_by`` on a prior
+    auto edge ``runs-on(vm-a → host-x)``. The operator then asserts the
+    auto edge's own triple as canonical (``runs-on(vm-a → host-x)``) —
+    typical recovery flow after realising the first curated assertion
+    pointed at the wrong host. The auto→curated promotion must drop the
+    stale ``superseded_by`` key so the new curated edge is *visible* to
+    :func:`find_dependents` / :func:`find_dependencies` (their CTE
+    filters out edges with ``properties->>'superseded_by' IS NOT NULL``).
+    Leaving the marker in place would leave the curated assertion
+    silently absent from every traversal — §6's sticky-supersede semantics
+    apply only to ``source='auto'`` rows.
+    """
+    tenant_id = await _seed_tenant("b1-promotion-tenant")
+    vm = await _seed_node(tenant_id, kind="vm", name="vm-a")
+    host = await _seed_node(tenant_id, kind="host", name="host-x")
+    # Seed the auto edge already-superseded — pointing at a synthetic
+    # curated id we never actually inserted; the marker is the load-
+    # bearing state for the regression.
+    stale_curated_id = uuid.uuid4()
+    auto_edge_id = await _seed_auto_edge(
+        tenant_id,
+        from_id=vm,
+        to_id=host,
+        kind="runs-on",
+        properties={
+            "superseded_by": str(stale_curated_id),
+            "discovered_port": 22,
+        },
+    )
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            edge = await annotate_edge(
+                session,
+                _operator(tenant_id, sub="op-reclaim"),
+                NodeRef("vm-a", "vm"),
+                "runs-on",
+                NodeRef("host-x", "host"),
+                note="reclaiming after wrong supersede",
+            )
+
+    # Same row id — auto→curated promotion is in-place.
+    assert edge.id == auto_edge_id
+
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == auto_edge_id))
+        ).scalar_one()
+    assert row.source == "curated"
+    # B1 fix: the stale superseded_by marker is gone.
+    assert "superseded_by" not in row.properties
+    # The operator-supplied note and the unrelated auto-discovery
+    # property both persist — the clear is targeted, not a wipe.
+    assert row.properties["note"] == "reclaiming after wrong supersede"
+    assert row.properties.get("discovered_port") == 22
+
+    # Traversal-visibility check that does not depend on PG JSON
+    # operators: the curated row is the sole edge in this tenant, and
+    # its ``superseded_by`` is unset — so a SELECT mirroring the CTE's
+    # filter shape (in portable form) returns it.
+    async with sessionmaker() as session:
+        visible_rows = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    visible = [r for r in visible_rows if (r.properties or {}).get("superseded_by") is None]
+    assert len(visible) == 1
+    assert visible[0].id == auto_edge_id

--- a/backend/tests/test_topology_bulk_import.py
+++ b/backend/tests/test_topology_bulk_import.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the G9.2-T8 bulk-import service (#600).
+
+Coverage matrix (Task #600 acceptance criteria):
+
+* **Happy-path batch** — a 3-row file lands all 3 edges in one
+  transaction; one audit row per edge; one broadcast event per edge.
+* **Idempotency** — re-running the same batch is a per-row no-op
+  (row count unchanged, no new edge ids, ``update`` action).
+* **Dry-run** — no edge row is created, no audit row is written, no
+  broadcast event is published; the per-row plan still surfaces
+  create / update / conflict classifications.
+* **Validation failure (kind)** — one bad ``kind`` rejects the
+  entire batch (no partial apply); the error envelope carries every
+  row's failure.
+* **Validation failure (missing endpoint)** — same atomicity.
+* **Conflict classification** — a row whose endpoint pair already has
+  an auto edge of a different ``to`` (same kind / different endpoint)
+  routes through ``conflict`` so the operator sees the §6
+  recoverability marker pre-apply.
+
+The tests run against ``sqlite+aiosqlite`` via the autouse
+``_default_database_url`` fixture in :mod:`tests.conftest` (same
+shape :mod:`tests.test_topology_annotate` uses).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode, Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.topology import (
+    BulkImportRow,
+    BulkImportValidationError,
+    NodeRef,
+    bulk_import_edges,
+)
+
+_PUBLISH = "meho_backplane.topology.bulk_import._publish"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(slug: str = "rdc-internal") -> uuid.UUID:
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        await session.commit()
+    return tenant_id
+
+
+async def _seed_node(
+    tenant_id: uuid.UUID,
+    *,
+    kind: str,
+    name: str,
+) -> uuid.UUID:
+    sessionmaker = get_sessionmaker()
+    node_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphNode(
+                id=node_id,
+                tenant_id=tenant_id,
+                kind=kind,
+                name=name,
+                target_id=None,
+                properties={},
+                discovered_by="test",
+                first_seen=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    return node_id
+
+
+async def _seed_auto_edge(
+    tenant_id: uuid.UUID,
+    *,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    kind: str,
+    properties: dict[str, Any] | None = None,
+) -> uuid.UUID:
+    sessionmaker = get_sessionmaker()
+    edge_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphEdge(
+                id=edge_id,
+                tenant_id=tenant_id,
+                from_node_id=from_id,
+                to_node_id=to_id,
+                kind=kind,
+                source="auto",
+                properties=properties or {},
+                discovered_by="test",
+                first_seen=datetime.now(UTC),
+                last_seen=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    return edge_id
+
+
+def _operator(tenant_id: uuid.UUID, sub: str = "op-bulk") -> Operator:
+    return Operator(
+        sub=sub,
+        name="Bulk Op",
+        email=None,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_creates_all_rows_in_one_transaction() -> None:
+    """A 3-row batch creates 3 edges + 3 audit rows + 3 broadcast events."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="principal", name="sa-a")
+    await _seed_node(tenant_id, kind="vault-role", name="vr-a")
+    await _seed_node(tenant_id, kind="service", name="svc-orders")
+    await _seed_node(tenant_id, kind="service", name="db-orders")
+    await _seed_node(tenant_id, kind="vm", name="vm-1")
+    await _seed_node(tenant_id, kind="host", name="host-1")
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("sa-a", "principal"),
+            kind="authenticates-via",
+            to_ref=NodeRef("vr-a", "vault-role"),
+            note="SA → VR",
+        ),
+        BulkImportRow(
+            from_ref=NodeRef("svc-orders", "service"),
+            kind="depends-on",
+            to_ref=NodeRef("db-orders", "service"),
+            evidence_url="https://inv/L1",
+        ),
+        BulkImportRow(
+            from_ref=NodeRef("vm-1", "vm"),
+            kind="runs-on",
+            to_ref=NodeRef("host-1", "host"),
+        ),
+    ]
+
+    sessionmaker = get_sessionmaker()
+    publish = AsyncMock()
+    with patch(_PUBLISH, new=publish):
+        async with sessionmaker() as session:
+            result = await bulk_import_edges(session, _operator(tenant_id), rows)
+
+    assert result.dry_run is False
+    assert result.created == 3
+    assert result.updated == 0
+    assert result.conflicts == 0
+    assert {r.index for r in result.rows} == {0, 1, 2}
+    assert all(r.action == "create" for r in result.rows)
+    assert all(r.edge_id is not None for r in result.rows)
+
+    async with sessionmaker() as session:
+        edges = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+        audits = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(edges) == 3
+    assert {e.source for e in edges} == {"curated"}
+    assert len(audits) == 3
+    assert {a.path for a in audits} == {"topology.annotate"}
+    # One broadcast event per row.
+    assert publish.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_is_idempotent() -> None:
+    """Re-running the same batch is a per-row no-op (row count unchanged)."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="vm", name="vm-1")
+    await _seed_node(tenant_id, kind="host", name="host-1")
+    await _seed_node(tenant_id, kind="service", name="svc-1")
+    await _seed_node(tenant_id, kind="service", name="db-1")
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("vm-1", "vm"),
+            kind="runs-on",
+            to_ref=NodeRef("host-1", "host"),
+        ),
+        BulkImportRow(
+            from_ref=NodeRef("svc-1", "service"),
+            kind="depends-on",
+            to_ref=NodeRef("db-1", "service"),
+        ),
+    ]
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            first = await bulk_import_edges(session, _operator(tenant_id), rows)
+        async with sessionmaker() as session:
+            second = await bulk_import_edges(session, _operator(tenant_id), rows)
+
+    assert first.created == 2
+    assert second.created == 0
+    assert second.updated == 2
+    assert all(r.action == "update" for r in second.rows)
+
+    async with sessionmaker() as session:
+        edges = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(edges) == 2
+    # The second run reused the same edge ids (idempotent upsert path).
+    first_ids = {r.edge_id for r in first.rows}
+    second_ids = {r.edge_id for r in second.rows}
+    assert first_ids == second_ids
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_dry_run_writes_nothing() -> None:
+    """``--dry-run`` produces the plan and performs zero writes."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="principal", name="sa-a")
+    await _seed_node(tenant_id, kind="vault-role", name="vr-a")
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("sa-a", "principal"),
+            kind="authenticates-via",
+            to_ref=NodeRef("vr-a", "vault-role"),
+        ),
+    ]
+
+    sessionmaker = get_sessionmaker()
+    publish = AsyncMock()
+    with patch(_PUBLISH, new=publish):
+        async with sessionmaker() as session:
+            result = await bulk_import_edges(session, _operator(tenant_id), rows, dry_run=True)
+
+    assert result.dry_run is True
+    assert result.created == 1
+    assert result.rows[0].action == "create"
+    assert result.rows[0].edge_id is None  # No row created yet in dry-run.
+
+    async with sessionmaker() as session:
+        edges = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+        audits = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert edges == []
+    assert audits == []
+    publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_rejects_whole_batch_on_invalid_kind() -> None:
+    """One bad ``kind`` aborts the entire batch — no partial apply."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="vm", name="vm-1")
+    await _seed_node(tenant_id, kind="host", name="host-1")
+    await _seed_node(tenant_id, kind="service", name="svc-1")
+    await _seed_node(tenant_id, kind="service", name="db-1")
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("vm-1", "vm"),
+            kind="runs-on",
+            to_ref=NodeRef("host-1", "host"),
+        ),
+        BulkImportRow(
+            from_ref=NodeRef("svc-1", "service"),
+            kind="not-a-real-kind",
+            to_ref=NodeRef("db-1", "service"),
+        ),
+    ]
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            with pytest.raises(BulkImportValidationError) as exc_info:
+                await bulk_import_edges(session, _operator(tenant_id), rows)
+
+    assert len(exc_info.value.errors) == 1
+    err = exc_info.value.errors[0]
+    assert err.index == 1
+    assert err.error == "invalid_kind"
+    assert err.kind == "not-a-real-kind"
+
+    async with sessionmaker() as session:
+        edges = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert edges == []  # Row 0 didn't apply either — atomicity contract.
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_rejects_missing_endpoint() -> None:
+    """A row whose endpoint doesn't exist in the tenant fails the batch."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="vm", name="vm-1")
+    # No host-1.
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("vm-1", "vm"),
+            kind="runs-on",
+            to_ref=NodeRef("host-missing", "host"),
+        ),
+    ]
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            with pytest.raises(BulkImportValidationError) as exc_info:
+                await bulk_import_edges(session, _operator(tenant_id), rows)
+
+    err = exc_info.value.errors[0]
+    assert err.error == "node_not_found"
+    assert err.name == "host-missing"
+    assert err.kind == "host"
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_collects_every_row_failure() -> None:
+    """Validation failures are aggregated — operator sees all rows at once."""
+    tenant_id = await _seed_tenant()
+    # No nodes seeded — every row fails endpoint resolution.
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("a", "vm"),
+            kind="runs-on",
+            to_ref=NodeRef("b", "host"),
+        ),
+        BulkImportRow(
+            from_ref=NodeRef("c", "vm"),
+            kind="bad-kind",
+            to_ref=NodeRef("d", "host"),
+        ),
+    ]
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            with pytest.raises(BulkImportValidationError) as exc_info:
+                await bulk_import_edges(session, _operator(tenant_id), rows)
+    # Both rows surface in the error envelope.
+    assert {e.index for e in exc_info.value.errors} == {0, 1}
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_empty_rows_is_noop() -> None:
+    """An empty rows list returns a zero-row result; no error."""
+    tenant_id = await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            result = await bulk_import_edges(session, _operator(tenant_id), [])
+    assert result.created == 0
+    assert result.rows == []
+
+
+# ---------------------------------------------------------------------------
+# Conflict classification (§6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_flags_supersede_as_conflict() -> None:
+    """A row that would supersede an existing auto edge classifies ``conflict``.
+
+    The auto-discovery probe found ``runs-on(vm-1 → host-old)``; the
+    operator's curated batch asserts ``runs-on(vm-1 → host-new)``.
+    The §6 same-kind / different-endpoint rule fires: the auto edge
+    gets ``superseded_by`` stamped, and the bulk-import plan
+    classifies the asserting row as ``conflict`` so the operator sees
+    the recoverability listing in the response.
+    """
+    tenant_id = await _seed_tenant()
+    vm = await _seed_node(tenant_id, kind="vm", name="vm-1")
+    host_old = await _seed_node(tenant_id, kind="host", name="host-old")
+    await _seed_node(tenant_id, kind="host", name="host-new")
+    auto_edge_id = await _seed_auto_edge(tenant_id, from_id=vm, to_id=host_old, kind="runs-on")
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("vm-1", "vm"),
+            kind="runs-on",
+            to_ref=NodeRef("host-new", "host"),
+        ),
+    ]
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            result = await bulk_import_edges(session, _operator(tenant_id), rows)
+
+    assert result.rows[0].action == "conflict"
+    assert str(auto_edge_id) in result.rows[0].superseded

--- a/backend/tests/test_topology_bulk_import.py
+++ b/backend/tests/test_topology_bulk_import.py
@@ -454,3 +454,131 @@ async def test_bulk_import_flags_supersede_as_conflict() -> None:
 
     assert result.rows[0].action == "conflict"
     assert str(auto_edge_id) in result.rows[0].superseded
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_flags_incompatible_kind_as_conflict_in_dry_run() -> None:
+    """A row whose endpoint pair already has a *different-kind* edge classifies ``conflict``.
+
+    Regression guard for PR #667 B2: ``_classify_row`` originally only
+    detected same-kind / different-endpoint supersedes (§6 class 1)
+    and missed the incompatible-kind / same-endpoint class (§6 class 2).
+    A dry-run plan over a pair that already has ``depends-on(svc → db)``
+    auto + a new ``routes-through(svc → db)`` curated row must surface
+    as ``conflict`` so the apply pass's bidirectional ``conflicts_with``
+    marker write is visible pre-apply.
+    """
+    tenant_id = await _seed_tenant()
+    svc = await _seed_node(tenant_id, kind="service", name="svc")
+    db = await _seed_node(tenant_id, kind="service", name="db")
+    auto_depends = await _seed_auto_edge(tenant_id, from_id=svc, to_id=db, kind="depends-on")
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("svc", "service"),
+            kind="routes-through",
+            to_ref=NodeRef("db", "service"),
+        ),
+    ]
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            plan = await bulk_import_edges(session, _operator(tenant_id), rows, dry_run=True)
+
+    assert plan.dry_run is True
+    assert plan.conflicts == 1
+    assert plan.rows[0].action == "conflict"
+    assert str(auto_depends) in plan.rows[0].conflicts
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_flags_incompatible_kind_as_conflict_on_apply() -> None:
+    """The apply pass also reports incompatible-kind conflicts in the post-commit counts.
+
+    Companion to the dry-run test above — confirms that the apply
+    pass's re-derived counts (M1 fix) honour the §6 class-2 conflict
+    classification the same way the dry-run plan does.
+    """
+    tenant_id = await _seed_tenant()
+    svc = await _seed_node(tenant_id, kind="service", name="svc")
+    db = await _seed_node(tenant_id, kind="service", name="db")
+    await _seed_auto_edge(tenant_id, from_id=svc, to_id=db, kind="depends-on")
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("svc", "service"),
+            kind="routes-through",
+            to_ref=NodeRef("db", "service"),
+        ),
+    ]
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            result = await bulk_import_edges(session, _operator(tenant_id), rows)
+
+    assert result.dry_run is False
+    assert result.conflicts == 1
+    assert result.created == 0  # M1: bidirectional conflict promotes to ``conflict``.
+    assert result.rows[0].action == "conflict"
+    assert len(result.rows[0].conflicts) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Action re-derivation from post-commit state (M1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_intra_batch_duplicate_counts_match_db_state() -> None:
+    """Two rows in one batch resolving to the same triple report 1 created + 1 update.
+
+    Regression guard for PR #667 M1: ``_materialise_apply_rows``
+    originally carried forward pass-1's action verbatim. Pass-1 saw
+    *both* duplicate rows as missing (the first row was not yet
+    flushed at the time pass-1 ran), so the count came out as
+    ``created=2`` while the DB only held one edge — the second annotate
+    inside the apply transaction merged onto the first row instead of
+    inserting a new one. The fix re-derives action from the apply
+    pass's actual insert-vs-merge outcome
+    (:attr:`AnnotatePlan.was_created`).
+    """
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="vm", name="vm-1")
+    await _seed_node(tenant_id, kind="host", name="host-1")
+
+    rows = [
+        BulkImportRow(
+            from_ref=NodeRef("vm-1", "vm"),
+            kind="runs-on",
+            to_ref=NodeRef("host-1", "host"),
+            note="first",
+        ),
+        BulkImportRow(
+            from_ref=NodeRef("vm-1", "vm"),
+            kind="runs-on",
+            to_ref=NodeRef("host-1", "host"),
+            note="second — same triple as row 0",
+        ),
+    ]
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            result = await bulk_import_edges(session, _operator(tenant_id), rows)
+
+    # Exactly one edge was committed — the second row was an in-batch
+    # merge onto the first.
+    async with sessionmaker() as session:
+        edges = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    assert len(edges) == 1
+    # Reported counts match the committed state: 1 created + 1 updated,
+    # not 2 created. Both row records point at the same edge id.
+    assert result.created == 1
+    assert result.updated == 1
+    assert result.conflicts == 0
+    actions = sorted(r.action for r in result.rows)
+    assert actions == ["create", "update"]
+    assert {r.edge_id for r in result.rows} == {str(edges[0].id)}

--- a/cli/internal/cmd/topology/bulk_import.go
+++ b/cli/internal/cmd/topology/bulk_import.go
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// bulkImportDoc is the on-disk root: a single `edges:` list. Decode
+// into a typed struct rather than a generic map because every supported
+// field maps 1:1 to the wire shape — there is no extras-spill contract
+// for bulk-import the way targets/import.go has. yaml.v3's strict mode
+// (KnownFields) would reject typo'd field names; we leave that off so
+// the server-side validation surfaces every problem in one round trip
+// rather than the CLI failing fast on the first typo.
+type bulkImportDoc struct {
+	Edges []bulkImportEdgeYAML `yaml:"edges" json:"edges"`
+}
+
+// bulkImportEdgeYAML mirrors the issue body's file shape:
+// `{from, kind, to, note?, evidence_url?}`. `from` and `to` accept
+// either a bare string (the common case — a name with no kind pin) or
+// a nested `{name, kind}` map (when an endpoint is ambiguous and the
+// operator wants to pin the kind). YAML nodes are decoded into
+// `bulkImportEndpoint` via the custom UnmarshalYAML.
+type bulkImportEdgeYAML struct {
+	From        bulkImportEndpoint `yaml:"from" json:"from"`
+	Kind        string             `yaml:"kind" json:"kind"`
+	To          bulkImportEndpoint `yaml:"to" json:"to"`
+	Note        string             `yaml:"note,omitempty" json:"note,omitempty"`
+	EvidenceURL string             `yaml:"evidence_url,omitempty" json:"evidence_url,omitempty"`
+}
+
+// bulkImportEndpoint is the wire shape for one annotate endpoint.
+// `Name` is required; `Kind` is the optional disambiguator for an
+// ambiguous bare name. The YAML can spell each endpoint two ways:
+//
+//	from: svc-orders                 # bare string -> Name="svc-orders"
+//	from: { name: svc-orders, kind: service }
+type bulkImportEndpoint struct {
+	Name string `json:"name" yaml:"name"`
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+}
+
+// UnmarshalYAML accepts either a scalar (bare name) or a mapping
+// node so the file format stays terse for the common case and explicit
+// for the ambiguous case.
+func (e *bulkImportEndpoint) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		e.Name = node.Value
+		return nil
+	case yaml.MappingNode:
+		// Decode into an alias struct to avoid infinite recursion via
+		// this UnmarshalYAML method.
+		type endpointMap struct {
+			Name string `yaml:"name"`
+			Kind string `yaml:"kind"`
+		}
+		var m endpointMap
+		if err := node.Decode(&m); err != nil {
+			return err
+		}
+		if m.Name == "" {
+			return fmt.Errorf("endpoint missing required `name` field")
+		}
+		e.Name = m.Name
+		e.Kind = m.Kind
+		return nil
+	default:
+		return fmt.Errorf("endpoint must be a string or a {name, kind} map")
+	}
+}
+
+// bulkImportRequest is the wire shape for
+// POST /api/v1/topology/edges/bulk: `{edges: [...], dry_run: bool}`.
+// The route accepts both ``dry_run=true/false`` in the body and a
+// canonical 200 response.
+type bulkImportRequest struct {
+	Edges  []bulkImportEdgeYAML `json:"edges"`
+	DryRun bool                 `json:"dry_run,omitempty"`
+}
+
+// bulkImportResponseRow mirrors the per-row outcome from the service.
+type bulkImportResponseRow struct {
+	Index      int      `json:"index"`
+	Action     string   `json:"action"`
+	EdgeID     *string  `json:"edge_id"`
+	FromName   string   `json:"from_name"`
+	FromKind   string   `json:"from_kind"`
+	ToName     string   `json:"to_name"`
+	ToKind     string   `json:"to_kind"`
+	Kind       string   `json:"kind"`
+	Superseded []string `json:"superseded"`
+	Conflicts  []string `json:"conflicts"`
+}
+
+type bulkImportResponse struct {
+	DryRun    bool                    `json:"dry_run"`
+	Created   int                     `json:"created"`
+	Updated   int                     `json:"updated"`
+	Conflicts int                     `json:"conflicts"`
+	Rows      []bulkImportResponseRow `json:"rows"`
+}
+
+// bulkImportError mirrors the 422 invalid_bulk envelope.
+type bulkImportErrorEnvelope struct {
+	Error  string                `json:"error"`
+	Errors []bulkImportRowErrJSON `json:"errors"`
+}
+
+type bulkImportRowErrJSON struct {
+	Index   int      `json:"index"`
+	Error   string   `json:"error"`
+	Message string   `json:"message"`
+	Name    *string  `json:"name"`
+	Kind    *string  `json:"kind"`
+	Kinds   []string `json:"kinds"`
+}
+
+// newBulkImportCmd returns the `meho topology bulk-import` command.
+//
+//	meho topology bulk-import <file>
+//	  [--dry-run]  # plan-only; no writes; no audit / broadcast events
+//	  [--json]     # emit the raw response JSON instead of the human table
+//	  [--backplane <url>]  # override the recorded backplane URL
+//	# POST /api/v1/topology/edges/bulk
+//
+// Reads a YAML or JSON file matching `{edges: [{from, kind, to,
+// note?, evidence_url?}]}` and posts the whole batch to the backplane
+// in one transaction. The server runs validation (kind enum, endpoint
+// resolution, §6 conflict detection) before any write; a single
+// failing row aborts the entire batch (no partial apply). Requires
+// `tenant_admin` — a 403 from the backplane is surfaced with the
+// required-role hint.
+//
+// Dry-run shape. `--dry-run` returns the per-row plan (create /
+// update / conflict classification) without writing any row, audit
+// entry, or broadcast event. The plan is the operator's "what would
+// land" preview before committing to the file.
+func newBulkImportCmd() *cobra.Command {
+	var (
+		dryRun            bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "bulk-import <file>",
+		Short: "Annotate a list of curated topology edges from one file in a single transaction",
+		Long: "bulk-import reads a YAML or JSON file shaped as " +
+			"`edges: [{from, kind, to, note?, evidence_url?}]` and posts " +
+			"the whole batch to POST /api/v1/topology/edges/bulk. The " +
+			"server runs validation (kind enum, endpoint resolution, §6 " +
+			"conflict detection) before any write; a single failing row " +
+			"rejects the entire batch (no partial apply). Re-running the " +
+			"same file is a per-row no-op — the idempotent annotate " +
+			"upsert path matches the single-edge contract. Requires " +
+			"tenant_admin.\n\n" +
+			"`from` and `to` accept either a bare string (the common " +
+			"case) or a `{name, kind}` map when an endpoint is " +
+			"ambiguous and the operator wants to pin the kind. `kind` " +
+			"must be one of the closed 10-kind GraphEdgeKind vocabulary " +
+			"(`meho topology annotate --help` lists every kind).\n\n" +
+			"--dry-run returns the per-row plan (create / update / " +
+			"conflict) and writes nothing; --json emits the raw response " +
+			"JSON for piping into a downstream consumer.\n\n" +
+			formatEdgeKindTable(),
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runBulkImport(cmd, bulkImportOptions{
+				File:              args[0],
+				DryRun:            dryRun,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"compute the plan without applying any annotation (no writes, no audit, no broadcast events)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the raw POST /edges/bulk response JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to import into (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type bulkImportOptions struct {
+	File              string
+	DryRun            bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runBulkImport(cmd *cobra.Command, opts bulkImportOptions) error {
+	data, err := os.ReadFile(opts.File)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("read %s: %v", opts.File, err)),
+			opts.JSONOut)
+	}
+	doc, err := parseBulkImportDoc(data)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	if len(doc.Edges) == 0 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("file contains no edges (the `edges:` list is missing or empty)"),
+			opts.JSONOut)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			classifyBackplaneError(err), opts.JSONOut)
+	}
+	body, err := json.Marshal(bulkImportRequest{
+		Edges:  doc.Edges,
+		DryRun: opts.DryRun,
+	})
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("encode bulk-import body: %v", err)),
+			opts.JSONOut)
+	}
+	resp, err := postBulkImport(cmd.Context(), backplaneURL, body)
+	if err != nil {
+		return renderBulkImportError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	}
+	printBulkImportSummary(cmd.OutOrStdout(), resp)
+	return nil
+}
+
+// parseBulkImportDoc accepts YAML *or* JSON. yaml.v3's parser is a
+// JSON superset for the input shape we accept (mappings + scalars), so
+// the single yaml.Unmarshal call handles both — operators with a JSON
+// file don't need a separate code path. Returns the validated document
+// or a parse error.
+func parseBulkImportDoc(data []byte) (*bulkImportDoc, error) {
+	var doc bulkImportDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse bulk-import file: %w", err)
+	}
+	// Source-order validation: surface missing required fields with
+	// the row index so the operator can pinpoint the broken edge in
+	// the source file without scanning every row.
+	for i, e := range doc.Edges {
+		if e.From.Name == "" {
+			return nil, fmt.Errorf("entry %d: missing or empty `from` endpoint name", i)
+		}
+		if e.To.Name == "" {
+			return nil, fmt.Errorf("entry %d: missing or empty `to` endpoint name", i)
+		}
+		if e.Kind == "" {
+			return nil, fmt.Errorf("entry %d: missing or empty `kind` field", i)
+		}
+	}
+	return &doc, nil
+}
+
+func postBulkImport(ctx context.Context, backplaneURL string, body []byte) (*bulkImportResponse, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "POST",
+		"/api/v1/topology/edges/bulk", body)
+	if err != nil {
+		return nil, err
+	}
+	var out bulkImportResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode bulk-import response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderBulkImportError intercepts the 422 `invalid_bulk` envelope so
+// the per-row error list is rendered as a structured operator-readable
+// block — one line per bad row pointing at the file index. Other
+// errors fall back to the generic renderer.
+func renderBulkImportError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	var he *httpError
+	if errors.As(err, &he) && he.StatusCode == 422 {
+		if msg := formatInvalidBulkEnvelope(he.Body); msg != "" {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(msg), jsonOut)
+		}
+	}
+	return renderRequestError(cmd, backplaneURL, err, jsonOut)
+}
+
+// formatInvalidBulkEnvelope renders the 422 `invalid_bulk` body into
+// one operator-readable block. Returns the empty string when the body
+// doesn't match the envelope so the caller falls back to the generic
+// 422 renderer (Pydantic's standard validation shape).
+func formatInvalidBulkEnvelope(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		return ""
+	}
+	var inner bulkImportErrorEnvelope
+	if err := json.Unmarshal(env.Detail, &inner); err != nil {
+		return ""
+	}
+	if inner.Error != "invalid_bulk" {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "bulk-import rejected: %d row(s) failed validation\n",
+		len(inner.Errors))
+	for _, e := range inner.Errors {
+		fmt.Fprintf(&b, "  row %d: %s — %s\n", e.Index, e.Error, e.Message)
+	}
+	return b.String()
+}
+
+// printBulkImportSummary renders the apply / dry-run response. The
+// summary header names the action counts; the per-row block surfaces
+// the §6 conflict classifications + the edge ids so the operator can
+// pipe a follow-up unannotate by id.
+func printBulkImportSummary(w io.Writer, resp *bulkImportResponse) {
+	mode := "applied"
+	if resp.DryRun {
+		mode = "planned (dry-run)"
+	}
+	fmt.Fprintf(w, "Bulk-import %s: %d to create, %d to update, %d with conflicts (%d rows total)\n",
+		mode, resp.Created, resp.Updated, resp.Conflicts, len(resp.Rows))
+	if len(resp.Rows) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\n%-3s %-9s %-18s %-30s %-30s\n",
+		"#", "ACTION", "KIND", "FROM", "TO")
+	for _, r := range resp.Rows {
+		from := fmt.Sprintf("%s/%s", r.FromKind, r.FromName)
+		to := fmt.Sprintf("%s/%s", r.ToKind, r.ToName)
+		fmt.Fprintf(w, "%-3d %-9s %-18s %-30s %-30s\n",
+			r.Index, r.Action, truncate(r.Kind, 18),
+			truncate(from, 30), truncate(to, 30))
+		if len(r.Superseded) > 0 {
+			fmt.Fprintf(w, "        supersedes auto edge(s): %s\n",
+				strings.Join(r.Superseded, ", "))
+		}
+		if len(r.Conflicts) > 0 {
+			fmt.Fprintf(w, "        conflicts with edge(s): %s\n",
+				strings.Join(r.Conflicts, ", "))
+		}
+	}
+	if resp.DryRun {
+		fmt.Fprintln(w, "\nRun without --dry-run to apply.")
+	}
+}

--- a/cli/internal/cmd/topology/bulk_import_test.go
+++ b/cli/internal/cmd/topology/bulk_import_test.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package topology
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- parseBulkImportDoc ----------------------------------------------------
+
+func TestParseBulkImportDocYAMLBareEndpoint(t *testing.T) {
+	data := []byte(`edges:
+  - from: sa-a
+    kind: authenticates-via
+    to: vr-a
+`)
+	doc, err := parseBulkImportDoc(data)
+	if err != nil {
+		t.Fatalf("parseBulkImportDoc: %v", err)
+	}
+	if len(doc.Edges) != 1 {
+		t.Fatalf("want 1 edge, got %d", len(doc.Edges))
+	}
+	e := doc.Edges[0]
+	if e.From.Name != "sa-a" || e.From.Kind != "" {
+		t.Errorf("bare from: got %+v", e.From)
+	}
+	if e.Kind != "authenticates-via" {
+		t.Errorf("kind: got %q", e.Kind)
+	}
+	if e.To.Name != "vr-a" || e.To.Kind != "" {
+		t.Errorf("bare to: got %+v", e.To)
+	}
+}
+
+func TestParseBulkImportDocYAMLNestedEndpoint(t *testing.T) {
+	data := []byte(`edges:
+  - from: { name: svc-orders, kind: service }
+    kind: depends-on
+    to: { name: db-orders, kind: service }
+    note: "rebuilt"
+    evidence_url: "https://x/y#L1"
+`)
+	doc, err := parseBulkImportDoc(data)
+	if err != nil {
+		t.Fatalf("parseBulkImportDoc: %v", err)
+	}
+	e := doc.Edges[0]
+	if e.From.Name != "svc-orders" || e.From.Kind != "service" {
+		t.Errorf("nested from: got %+v", e.From)
+	}
+	if e.To.Name != "db-orders" || e.To.Kind != "service" {
+		t.Errorf("nested to: got %+v", e.To)
+	}
+	if e.Note != "rebuilt" {
+		t.Errorf("note: got %q", e.Note)
+	}
+	if e.EvidenceURL != "https://x/y#L1" {
+		t.Errorf("evidence_url: got %q", e.EvidenceURL)
+	}
+}
+
+func TestParseBulkImportDocJSON(t *testing.T) {
+	// yaml.v3 parses JSON shapes — operators can feed either format.
+	data := []byte(`{"edges":[{"from":"a","kind":"depends-on","to":"b"}]}`)
+	doc, err := parseBulkImportDoc(data)
+	if err != nil {
+		t.Fatalf("parseBulkImportDoc JSON: %v", err)
+	}
+	if len(doc.Edges) != 1 || doc.Edges[0].From.Name != "a" {
+		t.Errorf("JSON parse: got %+v", doc.Edges)
+	}
+}
+
+func TestParseBulkImportDocMissingKindFails(t *testing.T) {
+	data := []byte(`edges:
+  - from: a
+    to: b
+`)
+	if _, err := parseBulkImportDoc(data); err == nil {
+		t.Fatal("expected error for missing kind")
+	} else if !strings.Contains(err.Error(), "kind") {
+		t.Errorf("error should mention kind: %v", err)
+	}
+}
+
+func TestParseBulkImportDocMissingFromFails(t *testing.T) {
+	data := []byte(`edges:
+  - kind: depends-on
+    to: b
+`)
+	if _, err := parseBulkImportDoc(data); err == nil {
+		t.Fatal("expected error for missing from")
+	}
+}
+
+func TestParseBulkImportDocMalformedYAML(t *testing.T) {
+	data := []byte("edges: [not a list of maps")
+	if _, err := parseBulkImportDoc(data); err == nil {
+		t.Fatal("expected parse error for malformed YAML")
+	}
+}
+
+// --- formatInvalidBulkEnvelope ---------------------------------------------
+
+func TestFormatInvalidBulkEnvelopeRendersRows(t *testing.T) {
+	body := `{"detail":{"error":"invalid_bulk","errors":[` +
+		`{"index":0,"error":"node_not_found","message":"node 'ghost' not found","name":"ghost","kind":"vm","kinds":null},` +
+		`{"index":2,"error":"invalid_kind","message":"edge kind 'bad' is not in the v0.2 vocabulary","name":null,"kind":"bad","kinds":["depends-on","runs-on"]}` +
+		`]}}`
+	msg := formatInvalidBulkEnvelope(body)
+	if !strings.Contains(msg, "2 row(s) failed") {
+		t.Errorf("missing count: %q", msg)
+	}
+	if !strings.Contains(msg, "row 0: node_not_found") {
+		t.Errorf("missing row 0: %q", msg)
+	}
+	if !strings.Contains(msg, "row 2: invalid_kind") {
+		t.Errorf("missing row 2: %q", msg)
+	}
+}
+
+func TestFormatInvalidBulkEnvelopeReturnsEmptyForGenericBody(t *testing.T) {
+	body := `{"detail":[{"loc":["body","edges"],"msg":"field required"}]}`
+	if msg := formatInvalidBulkEnvelope(body); msg != "" {
+		t.Errorf("expected empty for generic Pydantic body; got %q", msg)
+	}
+}
+
+// --- printBulkImportSummary ------------------------------------------------
+
+func TestPrintBulkImportSummaryDryRun(t *testing.T) {
+	resp := &bulkImportResponse{
+		DryRun:    true,
+		Created:   1,
+		Updated:   0,
+		Conflicts: 1,
+		Rows: []bulkImportResponseRow{
+			{Index: 0, Action: "create", Kind: "depends-on",
+				FromKind: "service", FromName: "svc-A",
+				ToKind: "service", ToName: "db-1"},
+			{Index: 1, Action: "conflict", Kind: "runs-on",
+				FromKind: "vm", FromName: "vm-1",
+				ToKind: "host", ToName: "host-new",
+				Superseded: []string{"00000000-0000-0000-0000-000000000001"}},
+		},
+	}
+	var buf bytes.Buffer
+	printBulkImportSummary(&buf, resp)
+	out := buf.String()
+	if !strings.Contains(out, "planned (dry-run)") {
+		t.Errorf("missing dry-run banner: %q", out)
+	}
+	if !strings.Contains(out, "Run without --dry-run") {
+		t.Errorf("missing dry-run footer: %q", out)
+	}
+	if !strings.Contains(out, "supersedes auto edge") {
+		t.Errorf("missing supersede line: %q", out)
+	}
+}
+
+func TestPrintBulkImportSummaryApply(t *testing.T) {
+	resp := &bulkImportResponse{Created: 3, Updated: 0, Conflicts: 0, Rows: []bulkImportResponseRow{}}
+	var buf bytes.Buffer
+	printBulkImportSummary(&buf, resp)
+	out := buf.String()
+	if !strings.Contains(out, "applied") {
+		t.Errorf("missing applied banner: %q", out)
+	}
+	if strings.Contains(out, "dry-run") {
+		t.Errorf("apply summary leaked dry-run text: %q", out)
+	}
+}
+
+// --- runBulkImport end-to-end with httptest --------------------------------
+
+func TestRunBulkImportPostsBatchAndRendersSummary(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "edges.yaml")
+	if err := os.WriteFile(file, []byte(`edges:
+  - from: sa-a
+    kind: authenticates-via
+    to: vr-a
+`), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var receivedBody bulkImportRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/topology/edges/bulk" {
+			http.Error(w, "wrong path", http.StatusNotFound)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &receivedBody); err != nil {
+			http.Error(w, "decode body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		edgeID := "11111111-2222-3333-4444-555555555555"
+		resp := bulkImportResponse{
+			DryRun: false, Created: 1, Updated: 0, Conflicts: 0,
+			Rows: []bulkImportResponseRow{{
+				Index: 0, Action: "create", EdgeID: &edgeID,
+				FromName: "sa-a", FromKind: "principal",
+				ToName: "vr-a", ToKind: "vault-role",
+				Kind: "authenticates-via",
+			}},
+		}
+		body, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	seedXDGAndToken(t, srv.URL)
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runBulkImport(cmd, bulkImportOptions{
+		File:              file,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runBulkImport: %v", err)
+	}
+
+	if len(receivedBody.Edges) != 1 || receivedBody.Edges[0].From.Name != "sa-a" {
+		t.Errorf("wrong body posted: %+v", receivedBody)
+	}
+	if receivedBody.DryRun {
+		t.Errorf("dry-run should default to false")
+	}
+	if !strings.Contains(stdout.String(), "Bulk-import applied: 1 to create") {
+		t.Errorf("missing summary in stdout: %q", stdout.String())
+	}
+}
+
+func TestRunBulkImportDryRunForwardsFlag(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "edges.yaml")
+	if err := os.WriteFile(file, []byte(`edges:
+  - from: a
+    kind: depends-on
+    to: b
+`), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var receivedBody bulkImportRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &receivedBody)
+		resp := bulkImportResponse{DryRun: true, Created: 1}
+		body, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	seedXDGAndToken(t, srv.URL)
+	cmd, _, _ := newRunCmd(t)
+	if err := runBulkImport(cmd, bulkImportOptions{
+		File:              file,
+		DryRun:            true,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runBulkImport: %v", err)
+	}
+	if !receivedBody.DryRun {
+		t.Errorf("dry_run not forwarded; got body %+v", receivedBody)
+	}
+}
+
+func TestRunBulkImportRendersInvalidBulkEnvelope(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "edges.yaml")
+	if err := os.WriteFile(file, []byte(`edges:
+  - from: a
+    kind: not-a-kind
+    to: b
+`), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":{"error":"invalid_bulk","errors":[` +
+			`{"index":0,"error":"invalid_kind","message":"kind 'not-a-kind' not in v0.2 vocabulary","name":null,"kind":"not-a-kind","kinds":["depends-on"]}` +
+			`]}}`))
+	}))
+	defer srv.Close()
+
+	seedXDGAndToken(t, srv.URL)
+	cmd, _, stderr := newRunCmd(t)
+	err := runBulkImport(cmd, bulkImportOptions{
+		File:              file,
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error from 422 envelope")
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "invalid_kind") {
+		t.Errorf("stderr missing invalid_kind detail: %q", out)
+	}
+	if !strings.Contains(out, "row 0") {
+		t.Errorf("stderr missing row index: %q", out)
+	}
+}
+
+func TestRunBulkImportNonexistentFileSurfacesUnexpected(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runBulkImport(cmd, bulkImportOptions{File: "/no/such/file.yaml"})
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(stderr.String(), "no/such/file") {
+		t.Errorf("stderr missing path: %q", stderr.String())
+	}
+}

--- a/cli/internal/cmd/topology/topology.go
+++ b/cli/internal/cmd/topology/topology.go
@@ -38,6 +38,12 @@
 //     [--from N] [--to N] [--conflicts] [--json]` — GET
 //     /api/v1/topology/edges. Flat filterable listing of the
 //     tenant's edges. Role: operator.
+//   - `meho topology bulk-import <file> [--dry-run] [--json]` —
+//     POST /api/v1/topology/edges/bulk. Reads a YAML/JSON file
+//     shaped as `{edges: [...]}` and posts the whole batch in one
+//     transaction. The server runs validation first; a single bad
+//     row aborts the entire batch (no partial apply). Re-running
+//     the same file is a per-row no-op. Role: tenant_admin.
 //
 // The fifth G9.1-T6 verb, `meho targets discover <product>`, lives
 // under `cli/internal/cmd/targets/discover.go` because it sits under
@@ -116,6 +122,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newAnnotateCmd())
 	cmd.AddCommand(newUnannotateCmd())
 	cmd.AddCommand(newListEdgesCmd())
+	cmd.AddCommand(newBulkImportCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/topology/topology_test.go
+++ b/cli/internal/cmd/topology/topology_test.go
@@ -75,6 +75,7 @@ func TestNewRootCmdWiresAllVerbs(t *testing.T) {
 		"annotate":     false,
 		"unannotate":   false,
 		"list-edges":   false,
+		"bulk-import":  false,
 	}
 	for _, c := range root.Commands() {
 		name := strings.Fields(c.Use)[0]

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -436,7 +436,7 @@ so the guard runs only where the column is JSONB.
 ## REST API surface (T5, #453 + G9.2-T5 #597)
 
 `backend/src/meho_backplane/api/v1/topology.py` is the HTTP front for
-the read + write halves. Eight routes total — seven on the topology
+the read + write halves. Nine routes total — eight on the topology
 router, one on the targets router:
 
 | Method + path | Wraps | op_id | RBAC |
@@ -448,6 +448,7 @@ router, one on the targets router:
 | `POST /api/v1/topology/edges` | `annotate_edge` (T3 #595) | `topology.annotate` | **tenant_admin** |
 | `DELETE /api/v1/topology/edges/{edge_id}` | `unannotate_edge` (T3 #595) | `topology.unannotate` | **tenant_admin** |
 | `GET /api/v1/topology/edges` | `list_edges` (T4 #596) | `topology.list_edges` | operator |
+| `POST /api/v1/topology/edges/bulk` | `bulk_import_edges` (T8 #600) | `topology.bulk_import` | **tenant_admin** |
 | `GET /api/v1/targets/discover?product=X` | `Connector.list_candidates` | `targets.discover` | operator |
 
 Load-bearing details:
@@ -541,6 +542,98 @@ end-to-end + the cross-tenant boundary against a real
 `pgvector/pgvector:pg16` container). Curated-edge end-to-end coverage
 is the T9 integration sweep (#601).
 
+## Bulk import (G9.2-T8 #600)
+
+`backend/src/meho_backplane/topology/bulk_import.py` is the batch
+annotation service the CLI verb `meho topology bulk-import <file>` and
+the REST endpoint `POST /api/v1/topology/edges/bulk` both call. It is
+the operator-facing lever for seeding the consumer's prose
+`INVENTORY.md` cross-system graph at onboarding without a 30-verb
+shell loop.
+
+**Service entry point (async, write half):**
+
+- `bulk_import_edges(session, operator, rows, *, dry_run=False) -> BulkImportResult`
+  — runs a two-pass batch annotation. Pass 1 (validation) resolves
+  every row's endpoints + kind inside one `session.begin()` block;
+  any row's failure aggregates into a single
+  `BulkImportValidationError` carrying every row's diagnostic. Pass 2
+  (apply) opens a fresh `session.begin()` block and calls
+  `annotate_edge_in_txn` for each row inside it, so the whole batch
+  commits or rolls back atomically — no partial apply. Dry-run skips
+  pass 2 and returns the per-row plan only. Post-commit publishes one
+  broadcast event per row via the shared fail-open `_publish` helper;
+  per-row audit rows are written inside the apply transaction by
+  `annotate_edge_in_txn`, so the audit + broadcast count matches the
+  issue criterion: one audit row per edge + one broadcast event per
+  edge.
+
+**Atomicity contract.** The whole batch lives in one transaction.
+A validation failure on any row rolls back the entire transaction —
+no partial apply. The chosen semantics (the issue body offered two
+options — atomic OR partial with explicit failure reporting) are
+atomic-only in v0.2 because:
+
+- The consumer's INVENTORY.md is the source of truth: a
+  partially-applied batch leaves the operator with no clean re-run
+  path other than "diff what landed vs the file, fix the file, rerun";
+  an atomic failure surfaces the bad row and lets the operator
+  fix-and-retry.
+- Bulk import is a v0.2 stretch (Initiative #364 §7); a future
+  widening to a `--continue-on-error` mode is back-compat and can ship
+  in a follow-up.
+- The per-row audit + broadcast events still fire — one per applied
+  row — so a successful batch is indistinguishable from N single
+  annotates at the audit / event level.
+
+**Refactor.** `annotate.py` was extracted into an in-transaction
+helper `annotate_edge_in_txn` that returns an `AnnotatePlan`; the
+single-edge `annotate_edge` is now a thin wrapper that opens
+`session.begin()`, calls the helper, then publishes one broadcast
+event after commit. `bulk_import_edges` calls the same helper N times
+inside one shared transaction. Backwards compat is preserved — every
+existing caller of `annotate_edge` sees the same shape, audit row,
+and broadcast event.
+
+**Wire shape.** The REST body is
+`{"edges": [{"from", "kind", "to", "note"?, "evidence_url"?}, ...], "dry_run"?: bool}`.
+`from` / `to` accept the same `_EdgeEndpoint` `{name, kind?}` shape
+the single-edge endpoint uses; `kind` is the closed `GraphEdgeKind`
+enum so an unknown kind is rejected at the Pydantic boundary (422)
+before any service runs. `extra="forbid"` rejects typo'd fields at
+the boundary. The response is
+`{dry_run, created, updated, conflicts, rows: [...]}` where each row
+carries `{index, action, edge_id?, from_name, from_kind, to_name,
+to_kind, kind, superseded, conflicts}` so the operator (or the CLI's
+human-table renderer) can see the §6 conflict markers attached to
+each applied edge.
+
+**HTTP boundary guards.** The route caps the batch size at 1000 rows
+(`_BULK_IMPORT_MAX_EDGES`); the consumer's INVENTORY.md lists ~30 v0.2
+curated edges, so the cap is well above realistic use but low enough
+that a stray hostile body cannot hold a single transaction open
+indefinitely. The service layer is unbounded by design — the size
+guard belongs at the HTTP boundary.
+
+**CLI verb.** `meho topology bulk-import <file> [--dry-run] [--json]`
+reads YAML or JSON (yaml.v3's parser is a JSON superset for the
+shapes we accept, so a single `yaml.Unmarshal` call handles both)
+and posts the whole batch. Endpoints accept either a bare scalar
+(common case) or a `{name, kind}` map (ambiguity disambiguator) via
+the custom `UnmarshalYAML`. The 422 `invalid_bulk` envelope is
+rendered as a structured per-row list so the operator can pinpoint
+each broken edge in the source file without scanning every row.
+
+**Tests:**
+- `backend/tests/test_topology_bulk_import.py` — unit suite on
+  `sqlite+aiosqlite` (happy-path, idempotency, dry-run, validation
+  failures, §6 conflict classification).
+- `backend/tests/test_api_v1_topology.py` (the `bulk_import` section)
+  — RBAC + 422 envelopes + apply / dry-run round-trip with the
+  service mocked.
+- `cli/internal/cmd/topology/bulk_import_test.go` — YAML/JSON parser
+  + invalid-bulk renderer + end-to-end against an httptest server.
+
 ## CLI front (T6, #454)
 
 `cli/internal/cmd/topology/` is the operator front for the four
@@ -556,6 +649,10 @@ sits under the `/api/v1/targets` prefix, so its verb sits under the
 | `meho topology dependents <name>` | `GET /topology/dependents/{n}` | `DEPTH / KIND / NAME / VIA` table |
 | `meho topology dependencies <name>` | `GET /topology/dependencies/{n}` | same table, mirror direction |
 | `meho topology path <from> <to>` | `GET /topology/path?from=&to=` | `kind/name -> … (N hops)` chain |
+| `meho topology annotate <from> <kind> <to>` | `POST /topology/edges` | `annotated edge: ...` summary |
+| `meho topology unannotate <edge-id>` (or tuple) | `DELETE /topology/edges/{id}` | `deleted edge ...` line |
+| `meho topology list-edges` | `GET /topology/edges` | `KIND / SOURCE / FROM / TO / LAST_SEEN` table |
+| `meho topology bulk-import <file>` | `POST /topology/edges/bulk` | applied/planned counts + per-row table |
 | `meho targets discover <product>` | `GET /targets/discover?product=` | candidates + skipped tables |
 
 Load-bearing details:


### PR DESCRIPTION
## Summary
- Ship the v0.2 stretch bulk-curated-edge import flow so an operator can seed the consumer's prose `INVENTORY.md` cross-system graph at onboarding in one declarative pass.
- Add `meho topology bulk-import <file> [--dry-run] [--json]` reading YAML / JSON and `POST /api/v1/topology/edges/bulk` posting the whole batch in one atomic transaction; `tenant_admin`-only.
- Extract `annotate_edge_in_txn` from `annotate_edge` so the bulk service can iterate the existing per-row annotate logic inside a single shared `session.begin()` block — backwards-compat preserved (every single-edge caller sees the same audit row + broadcast event).

## Atomicity decision

The issue body offered two valid semantics (atomic OR partial-with-failure-reporting). v0.2 ships atomic-only because:

- The consumer's `INVENTORY.md` is the source of truth; a partially-applied batch leaves the operator without a clean re-run path.
- An atomic failure surfaces the bad row with the structured 422 `invalid_bulk` envelope (one fix-and-rerun pass rather than the walk-the-file-N-times loop per-row 422s would force).
- A future `--continue-on-error` mode is back-compat and can ship in a follow-up.

The chosen semantics are documented in the bulk_import.py docstring and the `docs/codebase/topology.md` "Bulk import" section.

## Test plan
- [x] `ruff check` — clean on all changed paths
- [x] `ruff format --check` — clean
- [x] `mypy` — clean on `meho_backplane.topology` + `api/v1/topology.py`
- [x] `pytest tests/test_topology_bulk_import.py` — 8 passed
- [x] `pytest tests/test_api_v1_topology.py` — 54 passed (adds 10 new bulk-import tests)
- [x] `pytest tests/test_topology_annotate.py` — 19 passed (annotate refactor preserves single-edge behaviour)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/cmd/topology/...` — all passing including the 12 new bulk-import tests

## Acceptance criteria

- [x] Importing a 10-edge file creates/updates all in one transaction; re-running the same file is a no-op per edge; one audit + one broadcast event per edge — covered by `test_bulk_import_creates_all_rows_in_one_transaction` + `test_bulk_import_is_idempotent`.
- [x] `--dry-run` produces the per-edge plan with zero writes (row count unchanged, no audit rows, no broadcast publish) — covered by `test_bulk_import_dry_run_writes_nothing`.
- [x] A file with one invalid `kind` fails the whole batch atomically with a row-pointed error (atomic semantics chosen + documented + tested) — `test_bulk_import_rejects_whole_batch_on_invalid_kind`.
- [x] Conflicting edges are reported in the result with their conflict classification (§6) — `test_bulk_import_flags_supersede_as_conflict`.
- [x] `POST /topology/edges/bulk` requires `tenant_admin`; operator → 403 — `test_bulk_import_operator_returns_403`.
- [x] CI green; `ruff` + `mypy` clean; `go build ./...` clean.

## Out of scope
- Bulk **export** — `meho topology list-edges --source curated --json | jq` covers it (Initiative "Out of scope").
- MCP bulk tool — explicitly CLI-only in v0.2 (§9).
- Operator-facing docs / runbook — sibling Wave-4 task #602 (parallel agent).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #600


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk edge import via REST (POST /api/v1/topology/edges/bulk) and CLI (meho topology bulk-import) with atomic batches, per-row validation/conflict detection, dry-run preview, and structured per-row results plus aggregate counts.
* **Tests**
  * Added unit and integration tests covering REST/CLI behavior, validation failure envelopes, conflict classifications, dry-run semantics, and apply-pass outcomes.
* **Documentation**
  * Added docs for the bulk-import API/CLI, request/response shape, and usage notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->