### PR TITLE
feat(connectors): G3.4-T4 bind9 config-write op group — apply_file/apply_views/backup/reload (#590)

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/_atomic.py
+++ b/backend/src/meho_backplane/connectors/bind9/_atomic.py
@@ -426,11 +426,19 @@ tar -czf "$SNAPSHOT_PATH" -C / "$ROOT_NO_SLASH" >/dev/null
 # the Python side can split out the slice content from the rest of the
 # script's progress output. ``cat`` returns 1 on missing; treat that
 # as empty (the slice may be a new zonefile being created in a later
-# variant) by surfacing an empty marker block.
+# variant) by surfacing an empty marker block. The ``printf '\\n'``
+# after cat is a sentinel separator -- ``cat`` doesn't emit a trailing
+# newline if the file lacks one, so without this sentinel the line-
+# based parser would conflate the file's last line with the END marker
+# (for a no-trailing-newline file) or strip the file's real trailing
+# newline (for a file that has one). The Python-side parser's
+# strip-one-terminal-newline rule combined with this always-emitted
+# sentinel makes both cases round-trip byte-exact.
 echo "===STATE_BEFORE_BEGIN==="
 if [ -f "$AUDIT_SLICE_PATH" ]; then
     cat "$AUDIT_SLICE_PATH"
 fi
+printf '\n'
 echo "===STATE_BEFORE_END==="
 
 # Step 3: stage. Two mutually exclusive shapes share this step --
@@ -568,9 +576,12 @@ if ! VERIFY_OUT=$(eval "$BIND9_VERIFY_CMD" 2>&1); then
 fi
 
 # Step 7 (success): capture state_after and emit. Snapshot can be
-# discarded; the rollback path no longer needs it.
+# discarded; the rollback path no longer needs it. The ``printf '\\n'``
+# sentinel after cat parallels the state_before capture above -- see
+# that block's comment for the round-trip rationale.
 echo "===STATE_AFTER_BEGIN==="
 cat "$AUDIT_SLICE_PATH"
+printf '\n'
 echo "===STATE_AFTER_END==="
 
 rm -f "$SNAPSHOT_PATH" || true

--- a/backend/src/meho_backplane/connectors/bind9/_atomic.py
+++ b/backend/src/meho_backplane/connectors/bind9/_atomic.py
@@ -33,17 +33,28 @@ state -- either the whole script completed, or nothing about
    only -- the rollback always uses the full tar snapshot.
 3. **Stage.** Write the caller's proposed file content (passed as
    bytes) to the audit-slice path.
-4. **Validate.** Run ``named-checkzone <zone> <file>`` against the
-   staged file. Non-zero exit -> failure: restore from snapshot,
-   ``rndc reload``, return ``checkconf`` step.
+4. **Validate.** Run the caller-supplied ``BIND9_VALIDATE_CMD``
+   against the staged tree. Non-zero exit -> failure: restore from
+   snapshot, ``rndc reload``, return ``checkconf`` step.
 
-   Why ``named-checkzone`` rather than ``named-checkconf -p``: the
-   latter parses the *active* config tree (which already references
-   the new file, since step 3 wrote in place). A syntactically broken
-   zonefile would be caught either way, but ``named-checkzone`` runs
-   the per-zone integrity check at the granularity the operator's
-   change actually has -- a record-write only touches one zonefile,
-   so per-zone is the right blast-radius for the validation gate.
+   The default validate command is
+   ``named-checkzone "$ZONE_NAME" "$AUDIT_SLICE_PATH"`` (record-write
+   contract -- per-zone integrity check, the granularity a record
+   change actually has). T4 (#590) config-write callers
+   (``config.apply_file`` / ``config.apply_views``) override with
+   ``named-checkconf -p > /dev/null`` -- the whole-config parse is
+   the right blast-radius when the change may touch ``named.conf``
+   itself or a fragment file that ``named-checkzone`` cannot
+   evaluate in isolation.
+
+   Why default to ``named-checkzone`` rather than always
+   ``named-checkconf -p``: the latter parses the *active* config
+   tree (which already references the staged file, since step 3
+   wrote in place). For a single-zonefile record-write, the per-zone
+   check fails faster and surfaces the bind9 diagnostic (offending
+   record + reason); for a config-fragment write where the structural
+   shape may have changed, the whole-config parse is the correct
+   gate.
 5. **Reload.** ``rndc reload`` -- bind9 picks up the staged file.
    Non-zero exit -> restore from snapshot, ``rndc reload`` again to
    come back to the known-good config, return ``reload`` step.
@@ -255,12 +266,19 @@ class AtomicApplyResult:
 # ``shlex.quote`` wraps every interpolation regardless -- defence in
 # depth.
 #
-# ``BIND9_VERIFY_CMD`` and ``BIND9_STAGED_B64`` are exported as
-# environment variables in the script body (not interpolated into the
-# script text) so a verify command containing single quotes or a
-# multiline staged-bytes payload cannot break the shell quoting -- the
-# script reads them via ``$VAR`` after the bash interpreter has parsed
-# the literal script body.
+# ``BIND9_VERIFY_CMD``, ``BIND9_VALIDATE_CMD``, ``BIND9_STAGED_B64``,
+# and ``BIND9_STAGED_TAR_B64`` are exported as environment variables
+# in the script body (not interpolated into the script text) so a
+# verify command containing single quotes or a multiline staged-bytes
+# payload cannot break the shell quoting -- the script reads them via
+# ``$VAR`` after the bash interpreter has parsed the literal script
+# body. Two staging shapes share the step 3 branch: single-file mode
+# (``BIND9_STAGED_B64``, the T3 record-write contract) and multi-file
+# tar mode (``BIND9_STAGED_TAR_B64``, T4 ``config.apply_views``);
+# step 4 always evaluates ``BIND9_VALIDATE_CMD`` so the same primitive
+# can run ``named-checkzone`` for record writes and ``named-checkconf``
+# for config writes without per-caller branching outside the env-var
+# slot.
 _PIPELINE_TEMPLATE: str = """\
 set -e -u -o pipefail
 SNAPSHOT_PATH={snapshot_path}
@@ -415,35 +433,81 @@ if [ -f "$AUDIT_SLICE_PATH" ]; then
 fi
 echo "===STATE_BEFORE_END==="
 
-# Step 3: stage. The staged bytes arrive base64-encoded in the
-# BIND9_STAGED_B64 env var so a payload containing arbitrary bytes
-# (including newlines and quoting that would clash with heredoc
-# delimiters) round-trips unchanged. Decoded inline. Wrapped in the
-# same explicit-check shape every other step uses so a write failure
-# (ENOSPC / EACCES / read-only fs / base64 decode failure on a corrupt
-# payload) routes through rollback and surfaces step=``stage`` rather
-# than exiting under ``set -e`` with no rollback and no FAILED_STEP
-# marker (which would degrade to the snapshot-step fallback even
-# though the snapshot succeeded and the audit slice may be partially
-# truncated).
-if ! STAGE_OUT=$(printf '%s' "$BIND9_STAGED_B64" | base64 -d > "$AUDIT_SLICE_PATH" 2>&1); then
-    rollback
-    echo "===FAILED_STEP===stage"
-    echo "===FAILED_DETAIL_BEGIN==="
-    printf '%s' "$STAGE_OUT"
-    echo
-    echo "===FAILED_DETAIL_END==="
-    exit 9
+# Step 3: stage. Two mutually exclusive shapes share this step --
+# the contract is "either write one file, or extract a tar archive
+# of multiple files under $BIND_ROOT". Both arrive base64-encoded so
+# arbitrary bytes (including newlines and quoting that would clash
+# with heredoc delimiters) round-trip unchanged.
+#
+# * Single-file mode (T3 record writes / T4 ``config.apply_file``):
+#   ``BIND9_STAGED_B64`` carries the file content; the step writes
+#   it to ``$AUDIT_SLICE_PATH`` and preserves the ``root:bind`` mode
+#   bits the daemon expects on a zonefile.
+# * Multi-file mode (T4 ``config.apply_views``):
+#   ``BIND9_STAGED_TAR_B64`` carries a tar.gz archive whose member
+#   paths are absolute (rooted at ``/``). The step extracts it with
+#   ``tar -xzf - -C /`` so the archive overlays the live bind tree.
+#   Members outside ``$BIND_ROOT`` are refused at the Python-side
+#   archive build (see ``_pack_views_directory``), so the extraction
+#   target stays scoped.
+#
+# Both shapes route a write failure (ENOSPC / EACCES / read-only fs /
+# corrupt base64 / tar member outside expected path) through
+# ``rollback`` and emit ``===FAILED_STEP===stage``. Without this
+# guard ``set -e`` would exit the script under ``-e -o pipefail``
+# with no rollback and no FAILED_STEP marker, degrading to the
+# snapshot-step fallback even though the snapshot succeeded.
+if [ -n "${{BIND9_STAGED_TAR_B64:-}}" ]; then
+    # Multi-file mode: extract the staged tar over $BIND_ROOT.
+    # ``--no-same-owner`` lets us run inside the container fixture
+    # without honouring uid/gid baked into the archive (which would
+    # come from the orchestrator's tmpdir build); the daemon's
+    # ``chown root:bind`` is applied by the snapshot-restore path
+    # on rollback and by named's own file-create logic on success.
+    # Pipeline split across lines (bash command substitution
+    # accepts newlines inside ``$(...)``) so the rendered script
+    # stays under the linter's column cap.
+    if ! STAGE_OUT=$(
+        printf '%s' "$BIND9_STAGED_TAR_B64" | base64 -d \
+            | tar -xzf - -C / --no-same-owner 2>&1
+    ); then
+        rollback
+        echo "===FAILED_STEP===stage"
+        echo "===FAILED_DETAIL_BEGIN==="
+        printf '%s' "$STAGE_OUT"
+        echo
+        echo "===FAILED_DETAIL_END==="
+        exit 9
+    fi
+else
+    # Single-file mode: write the staged bytes to the audit slice.
+    if ! STAGE_OUT=$(printf '%s' "$BIND9_STAGED_B64" | base64 -d > "$AUDIT_SLICE_PATH" 2>&1); then
+        rollback
+        echo "===FAILED_STEP===stage"
+        echo "===FAILED_DETAIL_BEGIN==="
+        printf '%s' "$STAGE_OUT"
+        echo
+        echo "===FAILED_DETAIL_END==="
+        exit 9
+    fi
+    # Preserve the bind:bind ownership the daemon expects on a zonefile.
+    chown root:bind "$AUDIT_SLICE_PATH" 2>/dev/null || true
+    chmod 644 "$AUDIT_SLICE_PATH" 2>/dev/null || true
 fi
-# Preserve the bind:bind ownership the daemon expects.
-chown root:bind "$AUDIT_SLICE_PATH" 2>/dev/null || true
-chmod 644 "$AUDIT_SLICE_PATH" 2>/dev/null || true
 
-# Step 4: validate against the staged file. named-checkzone validates
-# the zonefile against the zone name; any non-zero exit triggers
-# rollback. Stderr is captured so the failure surface carries the
-# real diagnostic (bind9 prints the offending line + reason).
-if ! CHECKZONE_OUT=$(named-checkzone "$ZONE_NAME" "$AUDIT_SLICE_PATH" 2>&1); then
+# Step 4: validate the staged tree. The validate command is
+# caller-supplied via ``$BIND9_VALIDATE_CMD`` so the primitive serves
+# both shapes:
+#   * T3 record writes: ``named-checkzone "$ZONE_NAME" "$AUDIT_SLICE_PATH"``
+#     (per-zone integrity check, the granularity the change has).
+#   * T4 config writes: ``named-checkconf -p > /dev/null``
+#     (whole-config parse check; the change may touch ``named.conf``
+#     itself or a fragment file that ``named-checkzone`` cannot
+#     evaluate in isolation).
+# Any non-zero exit triggers rollback; stderr is captured so the
+# failure surface carries the real bind9 diagnostic (offending line +
+# reason).
+if ! CHECKZONE_OUT=$(eval "$BIND9_VALIDATE_CMD" 2>&1); then
     rollback
     echo "===FAILED_STEP===checkconf"
     echo "===FAILED_DETAIL_BEGIN==="
@@ -602,7 +666,9 @@ def _parse_pipeline_output(
 
 def _compose_full_script(
     *,
-    staged_bytes: bytes,
+    staged_bytes: bytes | None,
+    staged_tar_bytes: bytes | None,
+    validate_command: str,
     verify_command: str,
     pipeline_script: str,
 ) -> str:
@@ -610,19 +676,33 @@ def _compose_full_script(
 
     base64-encoding the staged bytes keeps the value safe to splice
     into an env-var assignment regardless of the bytes' shape (control
-    characters, embedded NULs, etc.). ``BIND9_VERIFY_CMD`` is
-    single-quoted; any single quote in the caller's command is escaped
-    via the standard ``'\\''`` rewrite. Pulled out of
-    :func:`atomic_apply` to keep the parent function within the
-    code-quality block limit and to make the env-var quoting logic
-    independently testable.
+    characters, embedded NULs, etc.). ``BIND9_VERIFY_CMD`` and
+    ``BIND9_VALIDATE_CMD`` are single-quoted; any single quote in the
+    caller's command is escaped via the standard ``'\\''`` rewrite.
+    Pulled out of :func:`atomic_apply` to keep the parent function
+    within the code-quality block limit and to make the env-var
+    quoting logic independently testable.
+
+    Exactly one of ``staged_bytes`` / ``staged_tar_bytes`` must be set.
+    The pipeline script branches on whether ``BIND9_STAGED_TAR_B64`` is
+    non-empty; the other env var is exported as the empty string so
+    ``set -u`` does not fire on the unused branch.
     """
     import base64
 
-    staged_b64 = base64.b64encode(staged_bytes).decode("ascii")
+    if (staged_bytes is None) == (staged_tar_bytes is None):
+        raise ValueError("exactly one of staged_bytes / staged_tar_bytes must be provided")
+
+    file_b64 = base64.b64encode(staged_bytes).decode("ascii") if staged_bytes is not None else ""
+    tar_b64 = (
+        base64.b64encode(staged_tar_bytes).decode("ascii") if staged_tar_bytes is not None else ""
+    )
+    validate_quoted = "'" + validate_command.replace("'", "'\\''") + "'"
     verify_quoted = "'" + verify_command.replace("'", "'\\''") + "'"
     return (
-        f"export BIND9_STAGED_B64='{staged_b64}'\n"
+        f"export BIND9_STAGED_B64='{file_b64}'\n"
+        f"export BIND9_STAGED_TAR_B64='{tar_b64}'\n"
+        f"export BIND9_VALIDATE_CMD={validate_quoted}\n"
         f"export BIND9_VERIFY_CMD={verify_quoted}\n"
         f"{pipeline_script}"
     )
@@ -685,19 +765,32 @@ async def atomic_apply(
     raw_jwt: str,
     sudo_password: str,
     audit_slice_path: str,
-    zone_name: str,
-    staged_bytes: bytes,
+    zone_name: str = "",
+    staged_bytes: bytes | None = None,
+    staged_tar_bytes: bytes | None = None,
+    validate_command: str | None = None,
     verify_command: str,
     bind_root: str = "/etc/bind",
 ) -> AtomicApplyResult:
-    """Stage *staged_bytes* at *audit_slice_path* with full snapshot rollback.
+    """Stage proposed content under *audit_slice_path* with full snapshot rollback.
 
     Returns :class:`AtomicApplyResult` on success; raises
     :class:`AtomicApplyError` with the failed step on any failure.
     By the time this returns (success or raise), the remote
     ``/etc/bind/`` tree is in a single coherent state: either the
-    staged file is live + reload succeeded + verify succeeded, OR the
-    pre-op tree is restored byte-identical via the snapshot tar.
+    staged content is live + reload succeeded + verify succeeded, OR
+    the pre-op tree is restored byte-identical via the snapshot tar.
+
+    Two staging shapes are supported. Exactly one of *staged_bytes* /
+    *staged_tar_bytes* must be set:
+
+    * **Single-file** (``staged_bytes``) -- the bytes are written to
+      ``audit_slice_path``; ``root:bind`` ownership + mode 644 are
+      applied. Used by record writes and ``config.apply_file``.
+    * **Multi-file** (``staged_tar_bytes``) -- a tar.gz archive whose
+      members carry absolute paths rooted at ``/`` is extracted in
+      place; the staged tree overlays the live bind root. Used by
+      ``config.apply_views``.
 
     Parameters
     ----------
@@ -711,20 +804,41 @@ async def atomic_apply(
         invariants (no newlines / NUL) apply.
     audit_slice_path
         The file the operation semantically edits (the affected
-        zonefile, typically). Used for ``state_before`` /
-        ``state_after`` capture and as the staging write target.
+        zonefile, the primary config fragment, etc.). Used for
+        ``state_before`` / ``state_after`` capture; in single-file
+        mode this is also the staging write target. In multi-file
+        mode the caller picks the most representative slice for
+        audit replay.
     zone_name
-        Zone name passed to ``named-checkzone`` for validation.
+        Zone name passed to the default ``named-checkzone``
+        validate command and to the rollback SOA-bump logic. Pass
+        ``""`` (the default) for config-write ops that don't have
+        a zone-scope -- the SOA-bump branch is guarded against an
+        empty zone name and becomes a no-op, and the caller must
+        supply a non-zone validate via *validate_command*.
     staged_bytes
-        The proposed file content. Streamed via a base64 env var so
+        Single-file mode payload. Mutually exclusive with
+        *staged_tar_bytes*. Streamed via a base64 env var so
         arbitrary bytes (incl. newlines) round-trip unchanged.
+    staged_tar_bytes
+        Multi-file mode payload -- a tar.gz archive. Mutually
+        exclusive with *staged_bytes*. Members must carry absolute
+        paths under *bind_root* (enforced by the caller's archive
+        build helper).
+    validate_command
+        Shell command run under sudo to validate the staged tree
+        before ``rndc reload``. When ``None``, the primitive renders
+        the default ``named-checkzone "$ZONE_NAME" "$AUDIT_SLICE_PATH"``
+        (the T3 record-write contract). Config-write callers pass an
+        explicit value -- typically ``named-checkconf -p > /dev/null``.
     verify_command
         Shell command that exits 0 iff the post-reload state matches
         the operation's intent. Commonly
-        ``dig @localhost <fqdn> +short A | grep -qx <expected-ip>``.
-        Run under sudo (the same shell as the rest of the pipeline);
-        callers needing to drop privileges should do so inside the
-        command.
+        ``dig @localhost <fqdn> +short A | grep -qx <expected-ip>`` for
+        record writes, ``named-checkconf > /dev/null`` for config writes
+        (a "config still parses after the live reload" sanity check),
+        or a `dig` that resolves a representative record under the new
+        views file.
     bind_root
         Root directory snapshotted by tar. Defaults to ``/etc/bind``;
         the only escape hatch is for tests using a temporary tree.
@@ -734,6 +848,8 @@ async def atomic_apply(
     AtomicApplyError
         On any failure at any step. ``error.step`` carries the
         failing step verb; the pre-op tree is restored.
+    ValueError
+        Neither or both of *staged_bytes* / *staged_tar_bytes* set.
     """
     # Per-call snapshot path. ``secrets.token_hex`` gives 32 hex chars
     # of CSPRNG entropy -- collision-resistant across concurrent
@@ -747,8 +863,19 @@ async def atomic_apply(
         zone_name=zone_name,
         bind_root=bind_root,
     )
+    effective_validate = (
+        validate_command
+        if validate_command is not None
+        # T3 default: per-zone checkzone against the staged zonefile.
+        # Quoted via the bash-side expansion of $ZONE_NAME and
+        # $AUDIT_SLICE_PATH (already shlex-quoted into the template
+        # by _build_pipeline_script).
+        else ('named-checkzone "$ZONE_NAME" "$AUDIT_SLICE_PATH"')
+    )
     full_script = _compose_full_script(
         staged_bytes=staged_bytes,
+        staged_tar_bytes=staged_tar_bytes,
+        validate_command=effective_validate,
         verify_command=verify_command,
         pipeline_script=pipeline_script,
     )

--- a/backend/src/meho_backplane/connectors/bind9/_atomic.py
+++ b/backend/src/meho_backplane/connectors/bind9/_atomic.py
@@ -481,7 +481,24 @@ if [ -n "${{BIND9_STAGED_TAR_B64:-}}" ]; then
     fi
 else
     # Single-file mode: write the staged bytes to the audit slice.
-    if ! STAGE_OUT=$(printf '%s' "$BIND9_STAGED_B64" | base64 -d > "$AUDIT_SLICE_PATH" 2>&1); then
+    # Redirection order matters: ``2>&1 > "$AUDIT_SLICE_PATH"`` dupes
+    # stderr to the still-current stdout (the command-substitution
+    # pipe captured by ``STAGE_OUT``) FIRST, then swaps stdout to the
+    # target file. Net effect: the decoded bytes land in the file
+    # (where they belong), and any decoder diagnostic (corrupt base64,
+    # ENOSPC, EACCES, read-only fs) lands in ``STAGE_OUT`` so the
+    # ``FAILED_DETAIL`` section carries the real reason. The earlier
+    # shape ``> "$AUDIT_SLICE_PATH" 2>&1`` is the inverse: stdout points
+    # at the file first, then stderr is duped to where stdout now
+    # points -- so a base64 error message would be appended into the
+    # (already-truncated) target file and ``FAILED_DETAIL`` would
+    # arrive empty. The pipeline splits across lines (bash command
+    # substitution accepts newlines inside ``$(...)``) so the rendered
+    # script stays under the linter's column cap.
+    if ! STAGE_OUT=$(
+        printf '%s' "$BIND9_STAGED_B64" | base64 -d \
+            2>&1 > "$AUDIT_SLICE_PATH"
+    ); then
         rollback
         echo "===FAILED_STEP===stage"
         echo "===FAILED_DETAIL_BEGIN==="

--- a/backend/src/meho_backplane/connectors/bind9/connector.py
+++ b/backend/src/meho_backplane/connectors/bind9/connector.py
@@ -47,7 +47,10 @@ This module ships:
 
 The remaining 10 ops (zone / record / config reads + writes) land
 under G3.4-T2..T4 by extending :data:`BIND9_OPS` from their own
-modules; the dispatcher shim does not change.
+modules; the dispatcher shim does not change. T4 (#590) completes
+the 11-op surface with ``bind9.config.apply_file``,
+``bind9.config.apply_views`` (atomic-apply reuse),
+``bind9.config.backup``, and ``bind9.config.reload``.
 """
 
 from __future__ import annotations
@@ -545,6 +548,76 @@ class Bind9Connector(SshConnector):
         )
 
         return await _bind9_config_show(self, target, params)
+
+    async def bind9_config_apply_file(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``bind9.config.apply_file`` (G3.4-T4 #590).
+
+        Atomic single-fragment write via the T3 atomic-apply primitive
+        (single-file staging mode). Routes sudo through
+        :meth:`_remote_bash_with_sudo`.
+        """
+        from meho_backplane.connectors.bind9.ops_config import (
+            bind9_config_apply_file as _bind9_config_apply_file,
+        )
+
+        return await _bind9_config_apply_file(self, target, params)
+
+    async def bind9_config_apply_views(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``bind9.config.apply_views`` (G3.4-T4 #590).
+
+        Atomic multi-file tree write via the T3 atomic-apply primitive
+        (multi-file tar mode). Routes sudo through
+        :meth:`_remote_bash_with_sudo`.
+        """
+        from meho_backplane.connectors.bind9.ops_config import (
+            bind9_config_apply_views as _bind9_config_apply_views,
+        )
+
+        return await _bind9_config_apply_views(self, target, params)
+
+    async def bind9_config_backup(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``bind9.config.backup`` (G3.4-T4 #590).
+
+        ``tar -czf`` of ``/etc/bind/`` into a timestamped backup file,
+        plus a listing of existing backups. Does NOT route through
+        atomic-apply (additive, no rollback contract). Routes sudo
+        through :meth:`_remote_bash_with_sudo`.
+        """
+        from meho_backplane.connectors.bind9.ops_config import (
+            bind9_config_backup as _bind9_config_backup,
+        )
+
+        return await _bind9_config_backup(self, target, params)
+
+    async def bind9_config_reload(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``bind9.config.reload`` (G3.4-T4 #590).
+
+        ``rndc reload`` with a structured success/failure envelope.
+        Does NOT route through atomic-apply (single command, no staging,
+        no rollback contract). Routes sudo through
+        :meth:`_remote_bash_with_sudo`.
+        """
+        from meho_backplane.connectors.bind9.ops_config import (
+            bind9_config_reload as _bind9_config_reload,
+        )
+
+        return await _bind9_config_reload(self, target, params)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/bind9/ops.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops.py
@@ -19,10 +19,13 @@ G3.4-T3 (#589) extends ``ops_record`` with the two record-write ops
 (``bind9.record.add`` / ``bind9.record.remove``), atomic-applied via
 :mod:`~meho_backplane.connectors.bind9._atomic`.
 
-The remaining write ops (``bind9.config.apply_*``,
-``bind9.config.backup``, ``bind9.config.reload``) land under T4 (#590)
-by extending :data:`BIND9_OPS` from their own module; the registration
-walk in :meth:`Bind9Connector.register_operations` does not change.
+G3.4-T4 (#590) extends ``ops_config`` with the four config-write ops
+(``bind9.config.apply_file``, ``bind9.config.apply_views``,
+``bind9.config.backup``, ``bind9.config.reload``). ``apply_file`` and
+``apply_views`` route through the atomic-apply primitive (single-file
+and multi-file tar modes respectively); ``backup`` and ``reload`` do
+not (additive / single-command respectively). The registration walk
+in :meth:`Bind9Connector.register_operations` does not change.
 
 The dataclass + tuple shape mirrors the Kubernetes connector
 (:mod:`~meho_backplane.connectors.kubernetes.ops`) so the registration
@@ -141,10 +144,11 @@ def _bind9_ops() -> tuple[Bind9Op, ...]:
     Composition: ``bind9.about`` (T1 canary) + ``ZONE_OPS`` (T2 read:
     ``bind9.zone.list`` / ``bind9.zone.read``) + ``RECORD_OPS`` (T2
     read ``bind9.record.get`` + T3 writes ``bind9.record.add`` /
-    ``bind9.record.remove``) + ``CONFIG_OPS`` (T2 read:
-    ``bind9.config.show``). T4 (#590) will append the config-write
-    group (``bind9.config.apply_views`` / ``bind9.config.apply_file``
-    / ``bind9.config.backup`` / ``bind9.config.reload``).
+    ``bind9.record.remove``) + ``CONFIG_OPS`` (T2 read
+    ``bind9.config.show`` + T4 writes ``bind9.config.apply_file``,
+    ``bind9.config.apply_views``, ``bind9.config.backup``,
+    ``bind9.config.reload``). Eleven ops total -- the full Initiative
+    #367 §4 op surface.
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
@@ -167,10 +171,11 @@ def _bind9_ops() -> tuple[Bind9Op, ...]:
 #: T1 shipped ``bind9.about``; T2 (#588) adds the read op group
 #: (``bind9.zone.list/read``, ``bind9.record.get``,
 #: ``bind9.config.show``); T3 (#589) adds the record-write group
-#: (``bind9.record.add/remove``); T4 (#590) will add the config-write
-#: group (``bind9.config.apply_views``, ``bind9.config.apply_file``,
-#: ``bind9.config.backup``, ``bind9.config.reload``). The shape of
-#: each follow-on PR is "import a new module-level tuple and splat it
+#: (``bind9.record.add/remove``); T4 (#590) adds the config-write
+#: group (``bind9.config.apply_file``, ``bind9.config.apply_views``,
+#: ``bind9.config.backup``, ``bind9.config.reload``) -- 11 ops in
+#: total, the full Initiative #367 §4 surface. The shape of each
+#: follow-on PR is "import a new module-level tuple and splat it
 #: into :data:`BIND9_OPS` via :func:`_bind9_ops`" -- the registration
 #: walk in :meth:`Bind9Connector.register_operations` does not need to
 #: change.

--- a/backend/src/meho_backplane/connectors/bind9/ops_config.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_config.py
@@ -94,6 +94,7 @@ from __future__ import annotations
 
 import io
 import posixpath
+import secrets
 import shlex
 import tarfile
 import time
@@ -638,7 +639,11 @@ async def bind9_config_apply_views(
     via ``primary_path`` (defaults to the first key in *files* sorted
     lexicographically) -- the audit row gets the pre/post-op content
     of that one file, the rest are reconstructable from the staged
-    tar if needed for replay.
+    tar if needed for replay. ``primary_path`` **must** resolve to one
+    of the staged files; an out-of-set value is rejected before any
+    remote write so a successful reload cannot be followed by a
+    cat-the-missing-slice failure that would force the caller to
+    retry an already-applied change.
 
     Returns ``{primary_path, files, op_class, result_state_before,
     result_state_after}``; ``files`` is the sorted list of resolved
@@ -660,11 +665,30 @@ async def bind9_config_apply_views(
     # Compute the resolved absolute paths for the audit row -- the
     # archive's member names are derived from the same filter.
     resolved_paths: list[str] = sorted(ensure_path_under_root(p, bind_root) for p in files)
-    primary_path = (
-        ensure_path_under_root(primary_param, bind_root)
-        if primary_param is not None
-        else resolved_paths[0]
-    )
+    if primary_param is not None:
+        primary_path = ensure_path_under_root(primary_param, bind_root)
+        # Guard against the double-apply trap: the atomic-apply primitive
+        # captures ``state_after`` by ``cat``-ing the audit-slice path on
+        # the success path (step 7). If the operator points
+        # ``primary_path`` at a file NOT in the staged ``files`` mapping,
+        # the post-reload ``cat`` either hits a file the staged tar
+        # didn't touch (informational mismatch -- the audit row reports
+        # an unrelated file) or hits a missing path (cat fails, the
+        # primitive raises after the live reload already succeeded, the
+        # caller retries, and the change is applied twice). Either case
+        # is broken; the only safe contract is "primary_path must
+        # reference one of the staged files". Rejecting at the handler
+        # boundary is cheaper than defending the primitive's success
+        # path and keeps the audit-replay invariant intact (the slice
+        # bytes are always one of the bytes the op shipped).
+        if primary_path not in set(resolved_paths):
+            raise ValueError(
+                f"bind9.config.apply_views: primary_path {primary_param!r} must reference "
+                f"one of the staged files; got resolved={primary_path!r}, "
+                f"staged={resolved_paths!r}"
+            )
+    else:
+        primary_path = resolved_paths[0]
 
     sudo_password = _sudo_password_for_target(target)
 
@@ -727,7 +751,10 @@ BIND9_CONFIG_APPLY_VIEWS_PARAMETER_SCHEMA: dict[str, Any] = {
             "description": (
                 "Optional. The fragment whose pre/post-op content the "
                 "audit row should capture. Defaults to the first key "
-                "in ``files`` sorted lexicographically."
+                "in ``files`` sorted lexicographically. **Must** "
+                "reference one of the keys in ``files`` -- a value "
+                "outside the staged set is rejected before any remote "
+                "write to keep the audit-replay invariant intact."
             ),
         },
         "verify_fqdn": {
@@ -860,12 +887,26 @@ async def bind9_config_backup(
 
     # Compose the filename. ``time.strftime`` returns a localtime-zoned
     # timestamp -- but we want UTC so backups across timezones sort
-    # deterministically; ``time.gmtime()`` is the right basis.
+    # deterministically; ``time.gmtime()`` is the right basis. A short
+    # CSPRNG suffix breaks ties when two backups land in the same
+    # second with the same tag (concurrent orchestrator calls, a
+    # tight retry loop, two operators racing): ``secrets.token_hex(3)``
+    # gives 6 hex chars / 24 bits of entropy -- birthday-collision
+    # probability under any realistic same-second burst is negligible,
+    # and the suffix is short enough that the backup ID stays readable.
+    # The ID schema is opaque to callers (the only test assertion is
+    # ``startswith("bind9-")``), so appending the suffix is a backward-
+    # compatible refinement.
     timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
-    filename = f"bind9-{timestamp}-{tag}.tar.gz" if tag is not None else f"bind9-{timestamp}.tar.gz"
+    suffix = secrets.token_hex(3)
+    filename = (
+        f"bind9-{timestamp}-{tag}-{suffix}.tar.gz"
+        if tag is not None
+        else f"bind9-{timestamp}-{suffix}.tar.gz"
+    )
     # Backup ID is the bare filename without the extension -- shorter
     # to type, unambiguous against future backups (timestamp is
-    # second-granular and includes the tag if set).
+    # second-granular; the random suffix breaks same-second ties).
     backup_id = filename.removesuffix(".tar.gz")
     backup_path = f"{_BACKUP_DIR}/{filename}"
 

--- a/backend/src/meho_backplane/connectors/bind9/ops_config.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_config.py
@@ -1,77 +1,130 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""bind9 config-read op -- ``bind9.config.show``.
+"""bind9 config-read + config-write op group.
 
-G3.4-T2 (#588) of Initiative #367. Read ``named.conf`` or any included
-fragment, behind a path-safety filter that refuses paths outside the
-bind config root.
+G3.4-T2 (#588) shipped ``bind9.config.show`` -- the read op behind a
+path-safety filter that refuses paths outside the bind config root.
 
-T4 (#590) will append the config-write ops (``bind9.config.apply_views``
-/ ``bind9.config.apply_file`` / ``bind9.config.backup`` /
-``bind9.config.reload``) to this module against the same registration
-shape.
+G3.4-T4 (#590) layers the four config-write ops onto the same module:
+
+* ``bind9.config.apply_views`` -- replace the entire views subtree (a
+  set of per-view fragment files plus the zonefiles they reference)
+  with the caller's proposed tree, atomically.
+* ``bind9.config.apply_file`` -- replace one config fragment (e.g.
+  ``named.conf.local``, ``named.conf.options``) with the caller's
+  proposed content, atomically.
+* ``bind9.config.backup`` -- archive ``/etc/bind/`` to a timestamped
+  ``.tar.gz`` under ``/var/backups/meho-bind9/`` and return the
+  backup ID + a listing of existing backups (the JSONFlux reducer
+  handles the > 20-entry threshold, not this handler -- the K8s
+  ``ops_core.py`` decision per Issue #322 is the precedent T2's
+  ``ops_zone`` adopted and this op extends).
+* ``bind9.config.reload`` -- ``rndc reload``; reports the structured
+  success/failure envelope with the named status before and after.
+
+Atomic-apply reuse (T3 #589 ``_atomic.py``)
+-------------------------------------------
+
+``apply_views`` and ``apply_file`` route every wire-modifying step
+through :func:`~meho_backplane.connectors.bind9._atomic.atomic_apply`
+unchanged. The handlers supply:
+
+* The **staged payload** -- either a single file (``apply_file``,
+  via ``staged_bytes``) or a tar.gz archive (``apply_views``, via
+  ``staged_tar_bytes``).
+* The **validate command** -- ``named-checkconf -p > /dev/null`` for
+  both ops (the whole-config parse is the correct gate when the
+  change may touch ``named.conf`` itself or a fragment file that
+  ``named-checkzone`` cannot evaluate in isolation).
+* The **verify predicate** -- a post-reload sanity check tailored to
+  what the change is supposed to make resolvable (a representative
+  ``dig`` for ``apply_views``, ``named-checkconf > /dev/null`` for
+  ``apply_file``).
+
+No new rollback logic lives in this module. The primitive's
+snapshot-tar restore handles the byte-identical rollback contract
+for both shapes -- including the multi-file ``apply_views`` case
+(which would otherwise leave orphan files behind a naive
+``tar -xzf``; the primitive's ``find $BIND_ROOT -mindepth 1 -delete``
+clear-before-extract sequence covers it).
+
+``backup`` and ``reload`` do NOT route through atomic-apply. ``backup``
+is additive (it writes a new archive under ``/var/backups/`` and
+does not mutate ``/etc/bind/``), so a rollback contract is moot;
+``reload`` is a single ``rndc reload`` invocation with no staging,
+no validate-before-commit window, and a structured exit code as
+its only failure surface.
 
 Path-safety -- the load-bearing primitive
 -----------------------------------------
 
-The op exposes ``cat <file>`` on a remote nameserver. Without a filter
-the agent could ask for ``/etc/passwd``, ``/etc/shadow``, or any other
-file the SSH user can read; that's a clear regression on the consumer's
-``scripts/bind9-dns.sh`` wrapper which at least scoped its reads to the
-bind subtree by construction. The replacement encodes the same scoping
-at the connector boundary:
+The read op exposes ``cat <file>`` on a remote nameserver; without a
+filter the agent could ask for ``/etc/passwd``. The same filter
+(``ensure_path_under_root``) is reused by ``apply_file`` to gate the
+target-path argument so an operator-typed value cannot deposit a
+file outside the bind config root.
 
-1. ``allowed_root`` -- the directory of the bind config root, taken
-   from the fingerprint's ``extras["named_conf_path"]`` (Debian default
-   ``/etc/bind/``, RHEL default ``/etc/named/``, chrooted bind
-   ``/var/cache/bind/``). The handler reads the fingerprint once per
-   call -- the value is cached on the SSH adapter's connection so the
-   per-call cost is one TCP round-trip in steady state.
-2. ``ensure_path_under_root`` -- the pure filter. Accepts an absolute
-   path that is **lexically** under ``allowed_root`` (no ``..``
-   segments, no symlinks-out-of-root walk), and a relative path that
-   resolves under ``allowed_root`` via :func:`posixpath.normpath`.
-   Rejects everything else with a structured error that carries the
-   sanitised attempt (the agent gets to know the value was refused
-   without ever seeing the file's contents).
-
-Why lexical, not realpath: a realpath check would require a second SSH
-round-trip to resolve symlinks server-side, doubling the wire cost.
-The threat model is operator-typed paths in agent prompts, not a
-hostile operator carefully placing a symlink to ``/etc/shadow`` inside
-``/etc/bind/`` -- if the latter exists, the operator already owns the
-server. The lexical check rejects ``../`` ladders and absolute paths
-outside the root, which is the right granularity for the agent-typed
-risk.
+Why lexical, not realpath: a realpath check would require a second
+SSH round-trip to resolve symlinks server-side, doubling the wire
+cost. The threat model is operator-typed paths in agent prompts,
+not a hostile operator carefully placing a symlink to ``/etc/shadow``
+inside ``/etc/bind/`` -- if the latter exists, the operator already
+owns the server. The lexical check rejects ``../`` ladders and
+absolute paths outside the root, which is the right granularity
+for the agent-typed risk.
 
 References
 ----------
 
-* Parent task: G3.4-T2 (#588).
-* Parent Initiative: G3.4 (#367) (WI4 read ops; the path-safety filter
-  is the canonical example of the connector encoding a safety
-  invariant at the API boundary).
+* Parent task (read op): G3.4-T2 (#588).
+* Parent task (config-write op group): G3.4-T4 (#590).
+* Parent Initiative: G3.4 (#367) (WI4 read+write ops; WI5
+  atomic-apply reuse; WI7 agent-warning; WI8 audit envelope).
+* Atomic-apply primitive: G3.4-T3 (#589) ``_atomic.py``.
+* JSONFlux substrate for the backup listing:
+  :mod:`meho_backplane.operations.reducer`. The K8s precedent is
+  documented in ``connectors/kubernetes/ops_core.py``.
+* ISC bind9 9.18 reference docs:
+  https://bind9.readthedocs.io/en/v9.18/manpages.html#named-checkconf,
+  https://bind9.readthedocs.io/en/v9.18/manpages.html#rndc.
 """
 
 from __future__ import annotations
 
+import io
 import posixpath
 import shlex
+import tarfile
+import time
 from typing import TYPE_CHECKING, Any
 
+from meho_backplane.connectors.bind9._atomic import atomic_apply
 from meho_backplane.connectors.bind9.ops import Bind9Op
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.bind9.connector import Bind9Connector
 
 __all__ = [
+    "BIND9_CONFIG_APPLY_FILE_LLM_INSTRUCTIONS",
+    "BIND9_CONFIG_APPLY_FILE_PARAMETER_SCHEMA",
+    "BIND9_CONFIG_APPLY_VIEWS_LLM_INSTRUCTIONS",
+    "BIND9_CONFIG_APPLY_VIEWS_PARAMETER_SCHEMA",
+    "BIND9_CONFIG_BACKUP_LLM_INSTRUCTIONS",
+    "BIND9_CONFIG_BACKUP_PARAMETER_SCHEMA",
+    "BIND9_CONFIG_RELOAD_LLM_INSTRUCTIONS",
+    "BIND9_CONFIG_RELOAD_PARAMETER_SCHEMA",
     "BIND9_CONFIG_SHOW_LLM_INSTRUCTIONS",
     "BIND9_CONFIG_SHOW_PARAMETER_SCHEMA",
     "CONFIG_OPS",
     "ConfigPathRejectedError",
+    "bind9_config_apply_file",
+    "bind9_config_apply_views",
+    "bind9_config_backup",
+    "bind9_config_reload",
     "bind9_config_show",
     "ensure_path_under_root",
+    "pack_views_tar",
 ]
 
 
@@ -281,6 +334,910 @@ BIND9_CONFIG_SHOW_LLM_INSTRUCTIONS: dict[str, Any] = {
 
 
 # ---------------------------------------------------------------------------
+# Tar-packing helper for apply_views (pure, unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def pack_views_tar(
+    files: dict[str, str],
+    *,
+    bind_root: str = "/etc/bind",
+) -> bytes:
+    """Pack *files* into a tar.gz archive whose members live under *bind_root*.
+
+    *files* maps **relative** paths under ``bind_root`` to their UTF-8
+    content strings. Every relative path is sanitised via
+    :func:`ensure_path_under_root` so an operator-typed
+    ``../../etc/passwd`` cannot smuggle a member outside the bind
+    config root.
+
+    The returned bytes are a gzip-compressed POSIX tar archive whose
+    member names are **absolute** (rooted at ``/``); the atomic-apply
+    primitive's stage step extracts with ``tar -xzf - -C /`` so an
+    absolute archive overlays the live bind tree exactly. Empty
+    *files* returns an empty (but valid) archive.
+
+    Uses :mod:`tarfile` rather than shelling out to system ``tar`` so
+    the archive build is exercised by the unit suite without an SSH
+    target.
+
+    Raises :class:`ConfigPathRejectedError` if any input path fails
+    the lexical filter; the agent gets a structured rejection with
+    the sanitised attempt and no archive is produced.
+    """
+    buf = io.BytesIO()
+    # ``gzip`` mode compresses on the fly; the resulting bytes are
+    # ready to feed into ``tar -xzf -`` on the remote side.
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for relative_path, content in files.items():
+            # The lexical filter handles ``../`` traversal, absolute
+            # paths outside the root, control characters, and empty
+            # inputs. ``allowed_root`` matches the primitive's
+            # ``bind_root`` exactly so the validation lines up with
+            # where the archive will actually extract.
+            absolute_path = ensure_path_under_root(relative_path, bind_root)
+            # Strip the leading "/" because tarfile's member names are
+            # conventionally relative to the archive root; ``tar -xzf
+            # -C /`` is the matching extract flag. A leading-"/"
+            # member triggers tar's "removing leading '/' from member
+            # names" warning otherwise, which under ``set -e -o
+            # pipefail`` does NOT fail the pipeline (tar exits 0) but
+            # pollutes the stderr stream the FAILED_DETAIL capture
+            # surfaces.
+            archive_member = absolute_path.lstrip("/")
+            payload = content.encode("utf-8")
+            info = tarfile.TarInfo(name=archive_member)
+            info.size = len(payload)
+            # Pin the mode bits at 0o644 so a future operator-typed
+            # archive cannot smuggle a setuid bit through this op.
+            info.mode = 0o644
+            tar.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for write handlers
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_bind_root(connector: Bind9Connector, target: Any) -> str:
+    """Return the absolute bind config root for *target*.
+
+    Mirrors :func:`bind9_config_show`'s fingerprint-driven lookup.
+    Pulled into a helper so every write handler resolves the root
+    the same way: read the fingerprint, take the directory part of
+    ``extras["named_conf_path"]``, fall back to ``/etc/bind``.
+    """
+    fingerprint = await connector.fingerprint(target)
+    named_conf_path = fingerprint.extras.get("named_conf_path") or "/etc/bind/named.conf"
+    if not isinstance(named_conf_path, str):
+        raise ConfigPathRejectedError(
+            f"fingerprint extras.named_conf_path is not a string: {named_conf_path!r}"
+        )
+    return posixpath.dirname(named_conf_path) or "/etc/bind"
+
+
+def _sudo_password_for_target(target: Any) -> str:
+    """Read the sudo password from the target's ``secret_ref``.
+
+    Re-uses the contract from
+    :mod:`meho_backplane.connectors.bind9.ops_record` -- the secret
+    keys (``sudo_password`` then ``password``) and the
+    :class:`ValueError` on missing-credential surface are identical.
+    Hoisted here as well so the config-write handlers don't take a
+    cross-module import dependency on a private helper.
+    """
+    secret_ref = getattr(target, "secret_ref", None) or {}
+    if not isinstance(secret_ref, dict):
+        raise ValueError(f"target.secret_ref must be a dict; got {type(secret_ref).__name__}")
+    password = secret_ref.get("sudo_password") or secret_ref.get("password")
+    if not password:
+        raise ValueError(
+            "target.secret_ref carries no sudo_password / password; "
+            "bind9 config-write ops require a sudo credential"
+        )
+    return str(password)
+
+
+# Global-atomic-apply warning every write op surfaces in its description
+# and ``llm_instructions``. The exact tokens "global" and "atomic" are
+# the load-bearing signals an agent reads before contemplating a DNS-
+# layer change; the registration-shape tests assert their presence.
+_WRITE_WARNING = (
+    "WARNING: this change is global and atomic. The atomic-apply "
+    "primitive snapshots ``/etc/bind/`` to a per-call tar, stages the "
+    "proposed content, runs ``named-checkconf``, ``rndc reload``, and a "
+    "post-reload verify predicate; on any failure the pre-op tree is "
+    "restored byte-identical. On success the change is live for every "
+    "consumer of this nameserver -- DNS has no per-caller scoping. "
+    "``safety_level`` is ``dangerous`` (a bad views file can dark the "
+    "whole resolver); the production-path gate is G7/G10 policy "
+    "territory keyed on this value."
+)
+
+
+# ---------------------------------------------------------------------------
+# bind9.config.apply_file
+# ---------------------------------------------------------------------------
+
+
+async def bind9_config_apply_file(
+    connector: Bind9Connector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``bind9.config.apply_file`` -- atomic single-fragment write.
+
+    Sequence:
+
+    1. Resolve the bind root from the target's fingerprint.
+    2. Path-filter the requested target path -- traversal / outside-root
+       inputs are rejected pre-stage with no remote IO past the
+       fingerprint call.
+    3. :func:`atomic_apply` stages the new content (single-file mode),
+       runs ``named-checkconf -p > /dev/null``, ``rndc reload``, and the
+       verify predicate; rolls back on any failure.
+
+    The verify predicate is ``named-checkconf > /dev/null`` -- after the
+    live reload the config tree must still parse cleanly. This is the
+    "live-loaded-and-still-coherent" sanity check; rolling back on a
+    failed verify guards against a fragment that parses in isolation
+    but breaks the global config (e.g. a duplicate-zone declaration
+    only visible after include-stitching).
+
+    Returns ``{file, op_class, result_state_before, result_state_after}``.
+    """
+    requested: str = params["path"]
+    content: str = params["content"]
+
+    bind_root = await _resolve_bind_root(connector, target)
+    resolved_path = ensure_path_under_root(requested, bind_root)
+    sudo_password = _sudo_password_for_target(target)
+
+    # Verify predicate: the live-loaded config must still parse. A
+    # bad fragment that passes the staged-tree parse but breaks the
+    # live tree (e.g. a duplicate-zone declaration only visible
+    # after include-stitching with sibling fragments) trips this.
+    verify_cmd = "named-checkconf > /dev/null"
+
+    apply_result = await atomic_apply(
+        connector,
+        target,
+        raw_jwt="",
+        sudo_password=sudo_password,
+        audit_slice_path=resolved_path,
+        # zone_name="" -- this is a config write, not a zonefile write.
+        # The SOA-bump rollback path is guarded against an empty zone
+        # name and stays inert.
+        zone_name="",
+        staged_bytes=content.encode("utf-8"),
+        validate_command="named-checkconf -p > /dev/null",
+        verify_command=verify_cmd,
+        bind_root=bind_root,
+    )
+
+    return {
+        "file": resolved_path,
+        "op_class": "write",
+        "result_state_before": apply_result.state_before,
+        "result_state_after": apply_result.state_after,
+    }
+
+
+BIND9_CONFIG_APPLY_FILE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Target path of the fragment to replace. May be absolute "
+                "(must be lexically under the bind config root from the "
+                "fingerprint) or relative (resolved against the same "
+                "root). Traversal / outside-root inputs are rejected "
+                "pre-stage with ``ConfigPathRejectedError``. Examples: "
+                "``named.conf.local``, ``named.conf.options``, "
+                "``views/external.conf``."
+            ),
+        },
+        "content": {
+            "type": "string",
+            "description": (
+                "Proposed file content as UTF-8 text. Replaces the "
+                "target file's bytes verbatim. The atomic-apply "
+                "primitive's snapshot covers the pre-op shape so a "
+                "bad payload rolls back to byte-identical."
+            ),
+        },
+    },
+    "required": ["path", "content"],
+    "additionalProperties": False,
+}
+
+
+_BIND9_CONFIG_APPLY_FILE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "file": {"type": "string"},
+        "op_class": {"type": "string", "enum": ["write"]},
+        "result_state_before": {"type": "string"},
+        "result_state_after": {"type": "string"},
+    },
+    "required": ["file", "op_class", "result_state_before", "result_state_after"],
+    "additionalProperties": False,
+}
+
+
+BIND9_CONFIG_APPLY_FILE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Replace one bind9 config fragment (``named.conf.local``, "
+        "``named.conf.options``, ``views/external.conf``, etc.) "
+        "atomically. " + _WRITE_WARNING + " Use ``bind9.config.show`` "
+        "first to capture the current content (an agent doing an "
+        "iterative edit should compute the new content from the old, "
+        "not blind-write)."
+    ),
+    "parameter_hints": {
+        "path": (
+            "Required. Target fragment path. Absolute (under the bind "
+            "config root) or relative (resolved against it). Traversal "
+            "inputs are rejected pre-stage."
+        ),
+        "content": (
+            "Required. Proposed file content as UTF-8 text. Replaces "
+            "the target file's bytes verbatim."
+        ),
+    },
+    "output_shape": (
+        "{'file': <resolved abs path>, 'op_class': 'write', "
+        "'result_state_before': <prior file text>, "
+        "'result_state_after': <post-write file text>}."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# bind9.config.apply_views
+# ---------------------------------------------------------------------------
+
+
+async def bind9_config_apply_views(
+    connector: Bind9Connector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``bind9.config.apply_views`` -- atomic multi-file tree write.
+
+    Replaces the views subtree (plus any zonefile fragments those
+    views reference) atomically. The caller supplies a mapping of
+    **relative** paths (under the bind config root) to their content
+    strings; the handler packs them into a tar.gz archive client-side
+    and ships it through the atomic-apply primitive's multi-file
+    staging shape.
+
+    Sequence:
+
+    1. Resolve the bind root from the target's fingerprint.
+    2. Pack *files* into a tar archive via :func:`pack_views_tar`.
+       Each relative path passes through :func:`ensure_path_under_root`
+       so an operator-typed traversal is rejected pre-stage.
+    3. :func:`atomic_apply` extracts the archive over the live bind
+       tree, runs ``named-checkconf -p > /dev/null``, ``rndc reload``,
+       and the verify predicate; rolls back on any failure.
+
+    The verify predicate is caller-supplied as ``verify_fqdn`` (the
+    representative FQDN that must resolve through one of the new views).
+    Omitting it falls back to ``named-checkconf > /dev/null`` (the
+    same predicate ``apply_file`` uses); a deployed views change that
+    parses but doesn't actually resolve is then a config-correctness
+    bug for the caller to catch on their side, but the rollback shape
+    stays sound either way.
+
+    ``audit_slice_path`` is the **primary** path the caller flagged
+    via ``primary_path`` (defaults to the first key in *files* sorted
+    lexicographically) -- the audit row gets the pre/post-op content
+    of that one file, the rest are reconstructable from the staged
+    tar if needed for replay.
+
+    Returns ``{primary_path, files, op_class, result_state_before,
+    result_state_after}``; ``files`` is the sorted list of resolved
+    absolute paths the archive deposited.
+    """
+    files: dict[str, str] = params["files"]
+    verify_fqdn: str | None = params.get("verify_fqdn")
+    primary_param: str | None = params.get("primary_path")
+
+    if not files:
+        raise ValueError("bind9.config.apply_views requires a non-empty 'files' mapping")
+
+    bind_root = await _resolve_bind_root(connector, target)
+    # Pack first so a traversal input fails the op pre-stage with the
+    # structured ConfigPathRejectedError -- no remote IO past the
+    # fingerprint call.
+    tar_bytes = pack_views_tar(files, bind_root=bind_root)
+
+    # Compute the resolved absolute paths for the audit row -- the
+    # archive's member names are derived from the same filter.
+    resolved_paths: list[str] = sorted(ensure_path_under_root(p, bind_root) for p in files)
+    primary_path = (
+        ensure_path_under_root(primary_param, bind_root)
+        if primary_param is not None
+        else resolved_paths[0]
+    )
+
+    sudo_password = _sudo_password_for_target(target)
+
+    # Verify predicate: prefer a representative dig if the caller named
+    # one; otherwise fall back to the "config still parses live" check.
+    # A `+short` dig that resolves anything (the actual rdata is the
+    # caller's call to assert post-hoc) is a stronger signal than the
+    # parse check alone -- it proves the views are wired through to a
+    # resolver answer for the new tree, not just syntactically intact.
+    if verify_fqdn is not None:
+        quoted_fqdn = shlex.quote(verify_fqdn)
+        verify_cmd = f'[ -n "$(dig @localhost {quoted_fqdn} +short 2>/dev/null)" ]'
+    else:
+        verify_cmd = "named-checkconf > /dev/null"
+
+    apply_result = await atomic_apply(
+        connector,
+        target,
+        raw_jwt="",
+        sudo_password=sudo_password,
+        audit_slice_path=primary_path,
+        zone_name="",  # multi-file config-write; no SOA-bump rollback.
+        staged_tar_bytes=tar_bytes,
+        validate_command="named-checkconf -p > /dev/null",
+        verify_command=verify_cmd,
+        bind_root=bind_root,
+    )
+
+    return {
+        "primary_path": primary_path,
+        "files": resolved_paths,
+        "op_class": "write",
+        "result_state_before": apply_result.state_before,
+        "result_state_after": apply_result.state_after,
+    }
+
+
+BIND9_CONFIG_APPLY_VIEWS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "files": {
+            "type": "object",
+            "description": (
+                "Mapping of **relative** paths (under the bind config "
+                "root) to their UTF-8 content. Every key is passed "
+                "through the path-safety filter; traversal / "
+                "outside-root inputs are rejected pre-stage. The "
+                "archive overlays the live tree atomically; files "
+                "absent from the mapping but present on the target are "
+                "preserved (the primitive extracts over the existing "
+                "tree, it does not clear it first)."
+            ),
+            "additionalProperties": {"type": "string"},
+            "minProperties": 1,
+        },
+        "primary_path": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Optional. The fragment whose pre/post-op content the "
+                "audit row should capture. Defaults to the first key "
+                "in ``files`` sorted lexicographically."
+            ),
+        },
+        "verify_fqdn": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Optional. A representative FQDN that must resolve "
+                "through one of the new views post-reload. The verify "
+                "predicate is ``dig @localhost <fqdn> +short`` returning "
+                "non-empty. Omit to fall back to ``named-checkconf > "
+                "/dev/null`` (the live-loaded config still parses)."
+            ),
+        },
+    },
+    "required": ["files"],
+    "additionalProperties": False,
+}
+
+
+_BIND9_CONFIG_APPLY_VIEWS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "primary_path": {"type": "string"},
+        "files": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "op_class": {"type": "string", "enum": ["write"]},
+        "result_state_before": {"type": "string"},
+        "result_state_after": {"type": "string"},
+    },
+    "required": [
+        "primary_path",
+        "files",
+        "op_class",
+        "result_state_before",
+        "result_state_after",
+    ],
+    "additionalProperties": False,
+}
+
+
+BIND9_CONFIG_APPLY_VIEWS_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Replace a multi-file views subtree (per-view fragment files "
+        "plus the zonefiles they reference) atomically. "
+        + _WRITE_WARNING
+        + " The archive overlays the live tree -- absent files are "
+        "preserved, present files are replaced byte-for-byte. Pair with "
+        "a ``verify_fqdn`` for the strongest verify (a dig that resolves "
+        "through one of the new views proves the deployment landed; "
+        "without it the verify falls back to the static parse check)."
+    ),
+    "parameter_hints": {
+        "files": (
+            "Required. Mapping of relative paths (under the bind config "
+            "root) to UTF-8 content strings. Traversal inputs are "
+            "rejected pre-stage."
+        ),
+        "primary_path": (
+            "Optional. Which file the audit row should capture pre/post. "
+            "Defaults to the first sorted key in ``files``."
+        ),
+        "verify_fqdn": (
+            "Optional. A FQDN that must resolve through one of the new "
+            "views post-reload. Strengthens the verify gate."
+        ),
+    },
+    "output_shape": (
+        "{'primary_path', 'files': [<resolved abs paths>], "
+        "'op_class': 'write', 'result_state_before', "
+        "'result_state_after'}. ``result_state_*`` captures the "
+        "primary file's bytes; the rest of the tree is reconstructable "
+        "from the staged tar if needed for replay."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# bind9.config.backup
+# ---------------------------------------------------------------------------
+
+
+# Directory under which timestamped backups live. ``/var/backups`` is
+# the Debian-family convention; the connector creates the meho-scoped
+# subdir on first use. ``rndc`` does not write here; only the connector
+# does, so a tenant-side backup never conflicts with bind9's own log
+# rotation.
+_BACKUP_DIR: str = "/var/backups/meho-bind9"
+
+# Tag-name filter -- the operator may set a friendly tag on a backup;
+# the filename embeds it. Restrict the character class so a tag cannot
+# inject shell metacharacters into the filename (the path lands inside
+# ``shlex.quote`` regardless, but the typed-op JSON schema enforces
+# the shape at the API boundary too).
+_BACKUP_TAG_PATTERN: str = r"^[A-Za-z0-9._-]{1,64}$"
+
+
+async def bind9_config_backup(
+    connector: Bind9Connector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``bind9.config.backup``.
+
+    ``tar -czf /var/backups/meho-bind9/<timestamp>[-<tag>].tar.gz
+    /etc/bind/`` and return a structured envelope with the backup ID
+    plus a listing of existing backups (so the operator can see what's
+    on disk in one round-trip).
+
+    Returns ``{backup_id, path, rows, total, op_class, state_after}``;
+    ``rows`` is the listing (one row per existing ``.tar.gz`` file
+    with ``{id, path, size, modified}``); ``total`` is the un-truncated
+    count. A future JSONFlux reducer reads ``rows`` + ``total`` and
+    swaps the row list for a result handle when ``total > 20`` -- the
+    K8s precedent (``ops_core.py``) is what this op extends.
+
+    ``op_class="write"`` because the op creates an artifact, but the
+    artifact lives outside ``/etc/bind/`` so the audit row carries
+    ``state_after`` (the backup ID) and no ``state_before`` -- nothing
+    in the bind tree mutated.
+
+    ``safety_level=caution`` (additive write; recoverable trivially via
+    ``rm`` if the backup is unwanted).
+    """
+    tag: str | None = params.get("tag")
+    sudo_password = _sudo_password_for_target(target)
+    bind_root = await _resolve_bind_root(connector, target)
+
+    # Compose the filename. ``time.strftime`` returns a localtime-zoned
+    # timestamp -- but we want UTC so backups across timezones sort
+    # deterministically; ``time.gmtime()`` is the right basis.
+    timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    filename = f"bind9-{timestamp}-{tag}.tar.gz" if tag is not None else f"bind9-{timestamp}.tar.gz"
+    # Backup ID is the bare filename without the extension -- shorter
+    # to type, unambiguous against future backups (timestamp is
+    # second-granular and includes the tag if set).
+    backup_id = filename.removesuffix(".tar.gz")
+    backup_path = f"{_BACKUP_DIR}/{filename}"
+
+    # Build the create + list script. ``set -e -o pipefail`` so any
+    # failure surfaces a non-zero exit; the dispatcher wraps it into
+    # a connector_error envelope. The listing is sorted by mtime
+    # newest-first so the most recent backup is the head row.
+    script = (
+        "set -e -o pipefail\n"
+        f"BACKUP_DIR={shlex.quote(_BACKUP_DIR)}\n"
+        f"BACKUP_PATH={shlex.quote(backup_path)}\n"
+        f"BIND_ROOT={shlex.quote(bind_root)}\n"
+        # ``mkdir -p`` is idempotent; ``chmod 700`` keeps the backup
+        # tree readable only by root since the tar contains the live
+        # named config (which may carry view-secret keys / DNSSEC
+        # material in future iterations).
+        'mkdir -p "$BACKUP_DIR"\n'
+        'chmod 700 "$BACKUP_DIR"\n'
+        # ``-C /`` so absolute paths in the archive round-trip; the
+        # rollback shape this matches is the atomic-apply primitive's
+        # snapshot grammar, deliberately consistent.
+        'ROOT_NO_SLASH="${BIND_ROOT#/}"\n'
+        'tar -czf "$BACKUP_PATH" -C / "$ROOT_NO_SLASH"\n'
+        # Emit the listing as JSONL so the parser is unambiguous --
+        # ``ls -l`` output varies between coreutils versions and locales.
+        # Python is the only tool we are guaranteed to have under
+        # ``python3-minimal`` (the testcontainer fixture from T3
+        # already pulls it in); stat-via-python keeps the parser pinned.
+        "python3 - \"$BACKUP_DIR\" <<'PYEOF'\n"
+        "import json, os, sys\n"
+        "backup_dir = sys.argv[1]\n"
+        "rows = []\n"
+        "for name in os.listdir(backup_dir):\n"
+        "    if not name.endswith('.tar.gz'):\n"
+        "        continue\n"
+        "    path = os.path.join(backup_dir, name)\n"
+        "    try:\n"
+        "        st = os.stat(path)\n"
+        "    except OSError:\n"
+        "        continue\n"
+        "    rows.append({\n"
+        "        'id': name.removesuffix('.tar.gz'),\n"
+        "        'path': path,\n"
+        "        'size': st.st_size,\n"
+        "        'modified': st.st_mtime,\n"
+        "    })\n"
+        # Sort newest-first; the operator's mental model is "the most\n"
+        # recent backup is the head of the list".\n"
+        "rows.sort(key=lambda r: -r['modified'])\n"
+        "print(json.dumps(rows))\n"
+        "PYEOF\n"
+    )
+
+    proc = await connector._remote_bash_with_sudo(
+        target,
+        script,
+        raw_jwt="",
+        sudo_password=sudo_password,
+        timeout=120.0,
+    )
+    exit_status = getattr(proc, "exit_status", 0)
+    if exit_status != 0:
+        stderr_raw = getattr(proc, "stderr", "")
+        stderr_text = stderr_raw if isinstance(stderr_raw, str) else ""
+        raise RuntimeError(
+            f"bind9.config.backup failed (exit={exit_status}): "
+            f"{stderr_text.strip() or '<no stderr>'}"
+        )
+    stdout_raw = getattr(proc, "stdout", "")
+    stdout_text = stdout_raw if isinstance(stdout_raw, str) else ""
+
+    # The Python listing prints exactly one JSON line; defensively
+    # take the last non-empty line in case bash echoed extra
+    # progress data ahead of it.
+    import json
+
+    rows: list[dict[str, Any]] = []
+    for line in reversed(stdout_text.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        else:
+            break
+
+    return {
+        "backup_id": backup_id,
+        "path": backup_path,
+        "rows": rows,
+        "total": len(rows),
+        "op_class": "write",
+        # No state_before: nothing in /etc/bind/ mutated. state_after
+        # is the backup ID -- the audit row's view of "the artifact
+        # this write produced".
+        "state_after": backup_id,
+    }
+
+
+BIND9_CONFIG_BACKUP_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "tag": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "pattern": _BACKUP_TAG_PATTERN,
+            "description": (
+                "Optional friendly tag embedded in the backup filename "
+                "after the UTC timestamp. Restricted to "
+                "``[A-Za-z0-9._-]{1,64}`` so a tag value cannot inject "
+                "shell metacharacters or path separators."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+_BIND9_CONFIG_BACKUP_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "backup_id": {"type": "string"},
+        "path": {"type": "string"},
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "path": {"type": "string"},
+                    "size": {"type": "integer"},
+                    "modified": {"type": "number"},
+                },
+                "required": ["id", "path", "size", "modified"],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+        "op_class": {"type": "string", "enum": ["write"]},
+        "state_after": {"type": "string"},
+    },
+    "required": ["backup_id", "path", "rows", "total", "op_class", "state_after"],
+    "additionalProperties": False,
+}
+
+
+BIND9_CONFIG_BACKUP_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Archive ``/etc/bind/`` to a timestamped ``.tar.gz`` under "
+        "``/var/backups/meho-bind9/`` before a risky change; the "
+        "operator can manually ``tar -xzf`` the result if a future "
+        "rollback is needed beyond the atomic-apply primitive's "
+        "per-call snapshot. Additive (non-destructive); "
+        "``safety_level=caution``."
+    ),
+    "parameter_hints": {
+        "tag": ("Optional friendly tag. Limit: ``[A-Za-z0-9._-]{1,64}``."),
+    },
+    "output_shape": (
+        "{'backup_id': <timestamp[-tag]>, 'path': <abs tar.gz path>, "
+        "'rows': [{id, path, size, modified}, ...] newest-first, "
+        "'total': <int>, 'op_class': 'write', 'state_after': "
+        "<backup_id>}. The future JSONFlux reducer swaps ``rows`` for "
+        "a result handle when ``total > 20``."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# bind9.config.reload
+# ---------------------------------------------------------------------------
+
+
+async def bind9_config_reload(
+    connector: Bind9Connector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``bind9.config.reload``.
+
+    ``rndc reload`` -- tells the running named to re-read its config
+    files and reload changed zones. Returns a structured envelope
+    distinguishing success from failure: a non-zero ``rndc reload`` exit
+    is **not** an exception, it's a structured ``ok: false`` row carrying
+    the stderr verbatim (the operator can diagnose without parsing the
+    exception class).
+
+    Captures ``rndc status`` before and after as ``state_before`` /
+    ``state_after`` so the audit row records the named instance's
+    health snapshot around the reload (uptime, query count, server is
+    up).
+
+    Does **not** route through atomic-apply -- there is no staging, no
+    validate-before-commit window, and no rollback contract. ``reload``
+    is a single ``rndc`` invocation; the failure mode is "rndc itself
+    refused" (control channel down, named mid-shutdown), not a
+    rollback-able partial state.
+
+    ``safety_level=caution`` (the live in-memory config is reloaded; if
+    a sibling write op already staged a bad fragment, the reload
+    surfaces it as a named-startup failure -- but the prior staged
+    state was already on disk by then, so this op is the messenger,
+    not the cause).
+    """
+    del params  # declared empty in schema; intentionally ignored
+    sudo_password = _sudo_password_for_target(target)
+
+    # ``rndc reload`` is one positional command; the wrapper captures
+    # stdout + stderr + exit so the result envelope can carry whichever
+    # surface the operator needs. ``set +e`` because we want the
+    # non-zero rndc exit to flow through to the structured shape, not
+    # bail out under ``set -e``.
+    script = (
+        "set +e\n"
+        "STATE_BEFORE=$(rndc status 2>&1)\n"
+        "RNDC_STATUS_BEFORE=$?\n"
+        "RELOAD_OUT=$(rndc reload 2>&1)\n"
+        "RELOAD_RC=$?\n"
+        "STATE_AFTER=$(rndc status 2>&1)\n"
+        "RNDC_STATUS_AFTER=$?\n"
+        "echo '===STATE_BEFORE_BEGIN==='\n"
+        'echo "$STATE_BEFORE"\n'
+        "echo '===STATE_BEFORE_END==='\n"
+        "echo '===RELOAD_OUT_BEGIN==='\n"
+        'echo "$RELOAD_OUT"\n'
+        "echo '===RELOAD_OUT_END==='\n"
+        "echo '===STATE_AFTER_BEGIN==='\n"
+        'echo "$STATE_AFTER"\n'
+        "echo '===STATE_AFTER_END==='\n"
+        'echo "===RELOAD_RC===$RELOAD_RC"\n'
+        # rndc's status exit codes are captured so the audit row can
+        # show whether the status probe itself failed (named down)
+        # vs the reload itself failed (named up but rndc refused).
+        'echo "===STATUS_BEFORE_RC===$RNDC_STATUS_BEFORE"\n'
+        'echo "===STATUS_AFTER_RC===$RNDC_STATUS_AFTER"\n'
+    )
+
+    proc = await connector._remote_bash_with_sudo(
+        target,
+        script,
+        raw_jwt="",
+        sudo_password=sudo_password,
+        timeout=60.0,
+    )
+    # ``_remote_bash_with_sudo`` exits 0 if the script ran (we suppressed
+    # rndc's own exit via ``set +e``); a non-zero here means the wrapper
+    # itself blew up (sudo refused, ssh dropped, etc.) -- that's a
+    # connector-error, raise it.
+    exit_status = getattr(proc, "exit_status", 0)
+    if exit_status != 0:
+        stderr_raw = getattr(proc, "stderr", "")
+        stderr_text = stderr_raw if isinstance(stderr_raw, str) else ""
+        raise RuntimeError(
+            f"bind9.config.reload wrapper failed (exit={exit_status}): "
+            f"{stderr_text.strip() or '<no stderr>'}"
+        )
+    stdout_raw = getattr(proc, "stdout", "")
+    stdout_text = stdout_raw if isinstance(stdout_raw, str) else ""
+
+    sections = _parse_reload_output(stdout_text)
+    reload_rc = int(sections.get("RELOAD_RC", "1"))
+    return {
+        "ok": reload_rc == 0,
+        "rndc_reload_exit": reload_rc,
+        "stderr": sections.get("RELOAD_OUT", "") if reload_rc != 0 else "",
+        "stdout": sections.get("RELOAD_OUT", "") if reload_rc == 0 else "",
+        "result_state_before": sections.get("STATE_BEFORE", ""),
+        "result_state_after": sections.get("STATE_AFTER", ""),
+        "op_class": "write",
+    }
+
+
+def _parse_reload_output(text: str) -> dict[str, str]:
+    """Parse the sentinel-delimited output of the reload script.
+
+    Same parser shape as :func:`_atomic._parse_pipeline_output` but
+    tailored to the reload script's section names. Pulled out so the
+    unit suite can exercise it directly against fixture text.
+    """
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    scalars: dict[str, str] = {}
+    scalar_names = ("RELOAD_RC", "STATUS_BEFORE_RC", "STATUS_AFTER_RC")
+    for raw in text.splitlines(keepends=True):
+        stripped = raw.rstrip("\r\n")
+        matched_scalar = False
+        for name in scalar_names:
+            prefix = f"==={name}==="
+            if stripped.startswith(prefix):
+                scalars[name] = stripped[len(prefix) :].strip()
+                matched_scalar = True
+                break
+        if matched_scalar:
+            continue
+        if stripped.startswith("===") and stripped.endswith("_BEGIN==="):
+            current = stripped[3 : -len("_BEGIN===")]
+            sections[current] = []
+            continue
+        if stripped.startswith("===") and stripped.endswith("_END==="):
+            current = None
+            continue
+        if current is not None:
+            sections[current].append(raw)
+    result: dict[str, str] = {name: "".join(lines) for name, lines in sections.items()}
+    # Bash's ``echo`` appends one newline of its own; strip exactly
+    # one terminal newline per captured section so the slice
+    # round-trips byte-for-byte.
+    for name in list(result):
+        if result[name].endswith("\n"):
+            result[name] = result[name][:-1]
+    result.update(scalars)
+    return result
+
+
+BIND9_CONFIG_RELOAD_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+_BIND9_CONFIG_RELOAD_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "ok": {"type": "boolean"},
+        "rndc_reload_exit": {"type": "integer"},
+        "stderr": {"type": "string"},
+        "stdout": {"type": "string"},
+        "result_state_before": {"type": "string"},
+        "result_state_after": {"type": "string"},
+        "op_class": {"type": "string", "enum": ["write"]},
+    },
+    "required": [
+        "ok",
+        "rndc_reload_exit",
+        "stderr",
+        "stdout",
+        "result_state_before",
+        "result_state_after",
+        "op_class",
+    ],
+    "additionalProperties": False,
+}
+
+
+BIND9_CONFIG_RELOAD_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Tell the running named to re-read its config and reload "
+        "changed zones. Use after a manual edit on the target (not "
+        "needed after ``config.apply_*`` ops -- those reload as part "
+        "of the atomic-apply pipeline). Returns a structured envelope "
+        "distinguishing success from failure; a non-zero ``rndc reload`` "
+        "exit is reported as ``ok: false`` with the stderr verbatim, "
+        "not raised as an exception. ``safety_level=caution`` (the "
+        "live config is reloaded; a prior staged-bad fragment surfaces "
+        "as a named-startup failure here)."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'ok': <bool>, 'rndc_reload_exit': <int>, 'stderr': <str>, "
+        "'stdout': <str>, 'result_state_before': <rndc status pre-reload>, "
+        "'result_state_after': <rndc status post-reload>, "
+        "'op_class': 'write'}."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
 # Op metadata table
 # ---------------------------------------------------------------------------
 
@@ -311,5 +1268,86 @@ CONFIG_OPS: tuple[Bind9Op, ...] = (
         safety_level="safe",
         requires_approval=False,
         llm_instructions=BIND9_CONFIG_SHOW_LLM_INSTRUCTIONS,
+    ),
+    Bind9Op(
+        op_id="bind9.config.apply_file",
+        handler_attr="bind9_config_apply_file",
+        summary="Atomically replace one bind9 config fragment with rollback on failure.",
+        description=(
+            "Atomic single-fragment write via the T3 atomic-apply "
+            "primitive. Replaces the target fragment with the proposed "
+            "content; validates via ``named-checkconf -p``, reloads "
+            "via ``rndc reload``, verifies the live config still parses "
+            "post-reload. " + _WRITE_WARNING
+        ),
+        parameter_schema=BIND9_CONFIG_APPLY_FILE_PARAMETER_SCHEMA,
+        response_schema=_BIND9_CONFIG_APPLY_FILE_RESPONSE_SCHEMA,
+        group_key="config",
+        tags=("write", "config", "atomic-apply"),
+        safety_level="dangerous",
+        requires_approval=False,
+        llm_instructions=BIND9_CONFIG_APPLY_FILE_LLM_INSTRUCTIONS,
+    ),
+    Bind9Op(
+        op_id="bind9.config.apply_views",
+        handler_attr="bind9_config_apply_views",
+        summary="Atomically replace a bind9 views subtree with rollback on failure.",
+        description=(
+            "Atomic multi-file tree write via the T3 atomic-apply "
+            "primitive (multi-file tar mode). Packs the caller's "
+            "``files`` mapping into a tar.gz archive, extracts it over "
+            "the live bind tree, validates via ``named-checkconf -p``, "
+            "reloads via ``rndc reload``, optionally verifies via a "
+            "representative ``dig`` against ``verify_fqdn``. " + _WRITE_WARNING
+        ),
+        parameter_schema=BIND9_CONFIG_APPLY_VIEWS_PARAMETER_SCHEMA,
+        response_schema=_BIND9_CONFIG_APPLY_VIEWS_RESPONSE_SCHEMA,
+        group_key="config",
+        tags=("write", "config", "atomic-apply"),
+        safety_level="dangerous",
+        requires_approval=False,
+        llm_instructions=BIND9_CONFIG_APPLY_VIEWS_LLM_INSTRUCTIONS,
+    ),
+    Bind9Op(
+        op_id="bind9.config.backup",
+        handler_attr="bind9_config_backup",
+        summary="Archive /etc/bind/ to a timestamped .tar.gz and list existing backups.",
+        description=(
+            "Creates a ``tar.gz`` archive of ``/etc/bind/`` under "
+            "``/var/backups/meho-bind9/`` and returns the backup ID + "
+            "a listing of existing backups (newest-first). Additive "
+            "(non-destructive); does NOT route through atomic-apply "
+            "because nothing in ``/etc/bind/`` mutates. The future "
+            "JSONFlux reducer swaps the ``rows`` list for a result "
+            "handle when ``total > 20``."
+        ),
+        parameter_schema=BIND9_CONFIG_BACKUP_PARAMETER_SCHEMA,
+        response_schema=_BIND9_CONFIG_BACKUP_RESPONSE_SCHEMA,
+        group_key="config",
+        tags=("write", "config", "backup"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions=BIND9_CONFIG_BACKUP_LLM_INSTRUCTIONS,
+    ),
+    Bind9Op(
+        op_id="bind9.config.reload",
+        handler_attr="bind9_config_reload",
+        summary="rndc reload -- tell the running named to re-read its config.",
+        description=(
+            "Wraps ``rndc reload`` with a structured success/failure "
+            "envelope. Captures ``rndc status`` before and after the "
+            "reload for the audit row. Does NOT route through "
+            "atomic-apply -- no staging, no validate-before-commit "
+            "window, no rollback contract. A non-zero ``rndc reload`` "
+            "exit is reported as ``ok: false`` with the stderr "
+            "verbatim, not raised as an exception."
+        ),
+        parameter_schema=BIND9_CONFIG_RELOAD_PARAMETER_SCHEMA,
+        response_schema=_BIND9_CONFIG_RELOAD_RESPONSE_SCHEMA,
+        group_key="config",
+        tags=("write", "config", "reload"),
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions=BIND9_CONFIG_RELOAD_LLM_INSTRUCTIONS,
     ),
 )

--- a/backend/tests/integration/test_connectors_bind9_container.py
+++ b/backend/tests/integration/test_connectors_bind9_container.py
@@ -93,7 +93,7 @@ _DOCKERFILE: str = textwrap.dedent(
     RUN apt-get update \\
      && apt-get install -y --no-install-recommends \\
           bind9 bind9-host bind9utils dnsutils \\
-          openssh-server sudo python3-minimal \\
+          openssh-server sudo python3 \\
      && rm -rf /var/lib/apt/lists/*
 
     # Allow root SSH login with password for the test fixture only;

--- a/backend/tests/integration/test_connectors_bind9_container.py
+++ b/backend/tests/integration/test_connectors_bind9_container.py
@@ -763,8 +763,13 @@ async def test_config_backup_against_real_bind9_creates_archive(
         # The listing must contain at least this backup we just made.
         ids = {row["id"] for row in result["rows"]}
         assert result["backup_id"] in ids
-        # Verify the artifact actually exists on disk.
-        cmd = f"ls -1 {result['path']}"
+        # Verify the artifact actually exists on disk. ``shlex.quote``
+        # is defence-in-depth -- the backup path is currently composed
+        # from a tag pattern + timestamp + hex suffix, none of which
+        # carries shell metacharacters, but quoting keeps the test
+        # robust if the path schema ever picks up a wider character
+        # class (e.g. tag pattern relaxed in a future op).
+        cmd = f"ls -1 {shlex.quote(result['path'])}"
         proc = await connector._run_command(bind9_container_target, cmd, raw_jwt="")
         ls_stderr = getattr(proc, "stderr", "")
         assert proc.exit_status == 0, (

--- a/backend/tests/integration/test_connectors_bind9_container.py
+++ b/backend/tests/integration/test_connectors_bind9_container.py
@@ -705,3 +705,208 @@ async def test_atomic_apply_rollback_on_checkzone_failure_leaves_tree_unchanged(
         )
     finally:
         await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# T4 config-write group -- bind9.config.apply_file / apply_views / backup /
+# reload against the seeded container. Acceptance criteria:
+#
+# * ``apply_views`` applies a valid multi-file tree; an invalid views file
+#   rolls back to a byte-identical /etc/bind/ (checksum assertion).
+# * ``apply_file`` applies a valid fragment; an invalid fragment rolls back
+#   identically.
+# * Both ``apply_*`` ops invoke T3's ``_atomic.py`` primitive (the
+#   ``op_class=write`` envelope + ``result_state_*`` capture come from the
+#   primitive directly -- a non-primitive implementation would not emit
+#   them).
+# * ``config.backup`` produces a restorable tar.gz and returns a backup
+#   ID + listing.
+# * ``config.reload`` returns a structured success/failure envelope.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_reload_against_real_bind9_returns_ok(
+    bind9_container_target: _Bind9Target,
+) -> None:
+    """``bind9.config.reload`` succeeds against the live named."""
+    connector = Bind9Connector()
+    try:
+        result = await connector.bind9_config_reload(bind9_container_target, {})
+        assert result["ok"] is True, f"reload failed: {result!r}"
+        assert result["rndc_reload_exit"] == 0
+        assert result["op_class"] == "write"
+        # rndc status output -- the live named's snapshot before/after.
+        # Carries the BIND version and the per-zone status; the exact
+        # text varies by version but the word "server" / "version"
+        # always shows up.
+        assert (
+            "version" in result["result_state_after"].lower()
+            or "server" in result["result_state_after"].lower()
+        )
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_config_backup_against_real_bind9_creates_archive(
+    bind9_container_target: _Bind9Target,
+) -> None:
+    """``bind9.config.backup`` creates a tar.gz under /var/backups/meho-bind9/."""
+    connector = Bind9Connector()
+    try:
+        result = await connector.bind9_config_backup(bind9_container_target, {"tag": "ci-smoke"})
+        assert result["op_class"] == "write"
+        assert "ci-smoke" in result["backup_id"]
+        assert result["path"].startswith("/var/backups/meho-bind9/")
+        assert result["path"].endswith(".tar.gz")
+        # The listing must contain at least this backup we just made.
+        ids = {row["id"] for row in result["rows"]}
+        assert result["backup_id"] in ids
+        # Verify the artifact actually exists on disk.
+        cmd = f"ls -1 {result['path']}"
+        proc = await connector._run_command(bind9_container_target, cmd, raw_jwt="")
+        ls_stderr = getattr(proc, "stderr", "")
+        assert proc.exit_status == 0, (
+            f"backup file missing: ls exit={proc.exit_status} stderr={ls_stderr!r}"
+        )
+        # The state_after carries the backup ID (the audit row's "what
+        # artifact this write produced" signal).
+        assert result["state_after"] == result["backup_id"]
+        # No state_before -- nothing in /etc/bind/ mutated.
+        assert "state_before" not in result
+        assert "result_state_before" not in result
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_config_apply_file_against_real_bind9_lands_and_reloads(
+    bind9_container_target: _Bind9Target,
+) -> None:
+    """``apply_file`` writes a valid fragment; named-checkconf + reload pass."""
+    connector = Bind9Connector()
+    try:
+        # Append a comment-only fragment via apply_file -- safe to
+        # write because it's not parsed by any other include. The
+        # primitive's validate (named-checkconf -p) must accept it.
+        content = "// meho integration test fragment\n"
+        result = await connector.bind9_config_apply_file(
+            bind9_container_target,
+            {"path": "named.conf.options", "content": content},
+        )
+        assert result["op_class"] == "write"
+        assert result["file"] == "/etc/bind/named.conf.options"
+        # state_after must equal the staged bytes (the primitive
+        # captures it post-write).
+        assert result["result_state_after"] == content
+        # The before / after must differ -- the seeded options file
+        # is not the comment-only version we just wrote.
+        assert result["result_state_after"] != result["result_state_before"]
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_config_apply_file_rollback_on_invalid_fragment_leaves_tree_unchanged(
+    bind9_container_target: _Bind9Target,
+) -> None:
+    """An invalid fragment -> rollback; /etc/bind/ byte-identical post-op."""
+    from meho_backplane.connectors.bind9._atomic import AtomicApplyError
+
+    connector = Bind9Connector()
+    try:
+        before = await _checksum_bind_tree(connector, bind9_container_target)
+        # Garbage fragment -- named-checkconf -p refuses to parse it.
+        garbage = "this is { not valid bind9 config\n"
+        with pytest.raises(AtomicApplyError) as exc_info:
+            await connector.bind9_config_apply_file(
+                bind9_container_target,
+                {"path": "named.conf.local", "content": garbage},
+            )
+        # Failure must happen at the checkconf step -- the primitive's
+        # validate ran and refused.
+        assert exc_info.value.step == "checkconf"
+
+        after = await _checksum_bind_tree(connector, bind9_container_target)
+        assert before == after, (
+            f"apply_file did NOT roll back cleanly on invalid fragment; "
+            f"checksum before={before!r}, after={after!r}"
+        )
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_config_apply_views_against_real_bind9_lands_multi_file_tree(
+    bind9_container_target: _Bind9Target,
+) -> None:
+    """``apply_views`` writes a multi-file tree; the tree shows up on disk."""
+    connector = Bind9Connector()
+    try:
+        # Stage a new fragment + the existing options file (keep that
+        # one identical so we don't break the live config). The
+        # archive overlays the live tree -- the fragment lands, the
+        # options stay byte-identical.
+        new_fragment = "// apply_views integration smoke fragment\n"
+        result = await connector.bind9_config_apply_views(
+            bind9_container_target,
+            {
+                "files": {
+                    "named.conf.smoke": new_fragment,
+                },
+            },
+        )
+        assert result["op_class"] == "write"
+        assert "/etc/bind/named.conf.smoke" in result["files"]
+        # The fragment we deposited must be on disk -- cat it back.
+        cat_proc = await connector._run_command(
+            bind9_container_target, "cat /etc/bind/named.conf.smoke", raw_jwt=""
+        )
+        assert cat_proc.exit_status == 0
+        assert "smoke fragment" in (cat_proc.stdout or "")
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_config_apply_views_rollback_on_invalid_tree_leaves_tree_unchanged(
+    bind9_container_target: _Bind9Target,
+) -> None:
+    """An invalid views file -> rollback; /etc/bind/ byte-identical post-op.
+
+    The load-bearing T4 acceptance criterion: ``apply_views`` reuses
+    the primitive's snapshot-rollback contract for multi-file trees.
+    A bad fragment in the staged archive must NOT leave the bind tree
+    in a half-applied state -- the primitive's
+    ``find $BIND_ROOT -mindepth 1 -delete`` clear-then-extract sequence
+    must clear the orphan fragment introduced by the failed stage.
+    """
+    from meho_backplane.connectors.bind9._atomic import AtomicApplyError
+
+    connector = Bind9Connector()
+    try:
+        before = await _checksum_bind_tree(connector, bind9_container_target)
+        # The staged archive overlays /etc/bind/named.conf.local with
+        # garbage -- the existing valid file is byte-replaced. The
+        # primitive's validate (named-checkconf -p) must refuse it.
+        with pytest.raises(AtomicApplyError) as exc_info:
+            await connector.bind9_config_apply_views(
+                bind9_container_target,
+                {
+                    "files": {
+                        # Overwrite the live named.conf.local with garbage --
+                        # bind9 must refuse to parse this on validate.
+                        "named.conf.local": "this is { not valid bind9 config\n",
+                    },
+                },
+            )
+        assert exc_info.value.step == "checkconf"
+
+        after = await _checksum_bind_tree(connector, bind9_container_target)
+        assert before == after, (
+            f"apply_views did NOT roll back cleanly on invalid tree; "
+            f"checksum before={before!r}, after={after!r}"
+        )
+    finally:
+        await connector.aclose()

--- a/backend/tests/test_connectors_bind9_atomic.py
+++ b/backend/tests/test_connectors_bind9_atomic.py
@@ -735,13 +735,57 @@ class TestPipelineScriptStageShape:
         )
         # The shape: a single ``if ! STAGE_OUT=$(...)`` guard around
         # the base64 pipe.
-        assert "if ! STAGE_OUT=$(printf" in script
-        # Rollback must be called from the stage branch.
+        assert "if ! STAGE_OUT=$(" in script
+        # Rollback must be called from the stage branch. Find the
+        # first stage branch in the script (the multi-file tar
+        # branch); the single-file branch follows. Pin rollback +
+        # FAILED_STEP within each.
         stage_branch_start = script.find("if ! STAGE_OUT=")
         stage_branch_end = script.find("fi", stage_branch_start)
         stage_branch = script[stage_branch_start:stage_branch_end]
         assert "rollback" in stage_branch
         assert "===FAILED_STEP===stage" in stage_branch
+
+    def test_single_file_stage_redirects_stderr_to_stage_out_not_target(self) -> None:
+        """The single-file base64 pipe must dupe stderr to STAGE_OUT, not the target file.
+
+        Regression for iter-1 M1 / T3 pre-existing bug: the prior
+        shape ``base64 -d > "$AUDIT_SLICE_PATH" 2>&1`` redirected
+        stdout to the target file FIRST, then duped stderr to the
+        same destination. Net effect: any decode diagnostic
+        (corrupt base64, ENOSPC, EACCES, read-only fs) landed
+        appended into the (already-truncated) audit-slice file and
+        ``FAILED_DETAIL`` arrived empty.
+
+        The fix order is ``2>&1 > "$AUDIT_SLICE_PATH"``: stderr is
+        duped to the command-substitution pipe (captured by
+        ``STAGE_OUT``) before stdout is swapped to the file. The
+        decoded bytes still land in the file; the diagnostic goes
+        to ``FAILED_DETAIL``.
+        """
+        script = _build_pipeline_script(
+            snapshot_path="/tmp/s",
+            audit_slice_path="/etc/bind/db.x",
+            zone_name="x",
+            bind_root="/etc/bind",
+        )
+        # Locate the single-file branch (the second ``if ! STAGE_OUT``
+        # in the script -- the first is the multi-file tar branch).
+        first_idx = script.find("if ! STAGE_OUT=")
+        single_branch_start = script.find("if ! STAGE_OUT=", first_idx + 1)
+        single_branch_end = script.find("fi", single_branch_start)
+        single_branch = script[single_branch_start:single_branch_end]
+        # ``2>&1`` must precede the stdout-to-file redirect; otherwise
+        # the diagnostic ends up in the file. The two forms are
+        # easily confused, so pin the exact ordering tokens.
+        twoone_idx = single_branch.find("2>&1")
+        stdout_redirect_idx = single_branch.find('> "$AUDIT_SLICE_PATH"')
+        assert twoone_idx != -1, "single-file stage branch must dupe stderr"
+        assert stdout_redirect_idx != -1, "single-file stage branch must redirect stdout to file"
+        assert twoone_idx < stdout_redirect_idx, (
+            "stderr dup (2>&1) must precede the stdout-to-file redirect; "
+            "otherwise the decode diagnostic lands in the audit slice file"
+        )
 
 
 class TestAtomicApplyStageFailureBranch:

--- a/backend/tests/test_connectors_bind9_atomic.py
+++ b/backend/tests/test_connectors_bind9_atomic.py
@@ -259,18 +259,36 @@ class TestPipelineScript:
         assert "'/tmp/snap;evil'" in script
         assert "'/etc/bind/foo;evil'" in script
 
-    def test_script_uses_named_checkzone_not_checkconf(self) -> None:
-        """Step 4 must invoke ``named-checkzone`` (per-zone) not ``named-checkconf -p``."""
+    def test_script_uses_caller_supplied_validate_command(self) -> None:
+        """Step 4 evaluates ``$BIND9_VALIDATE_CMD`` -- caller picks the validator.
+
+        T4 (#590) made the validate command caller-supplied so the
+        primitive serves both record writes (``named-checkzone
+        <zone> <file>``) and config writes (``named-checkconf -p >
+        /dev/null``). The template's step-4 line was previously
+        hardcoded to ``named-checkzone``; now it routes through the
+        env var. The default value is still ``named-checkzone "$ZONE_NAME"
+        "$AUDIT_SLICE_PATH"`` (composed by :func:`atomic_apply` when
+        the caller doesn't override it -- T3 record-write contract
+        stays intact).
+        """
         script = _build_pipeline_script(
             snapshot_path="/tmp/s",
             audit_slice_path="/etc/bind/f",
             zone_name="z",
             bind_root="/etc/bind",
         )
-        assert "named-checkzone" in script
-        # ``named-checkconf -p`` would parse the live config tree --
-        # not what step 4 needs. Pin the negative.
-        assert "named-checkconf -p" not in script
+        # The step-4 evaluation must reference the validate env var.
+        assert "BIND9_VALIDATE_CMD" in script
+        # The executable step-4 line is ``if ! CHECKZONE_OUT=$(eval
+        # "$BIND9_VALIDATE_CMD"...`` -- pin that exact shape so a
+        # refactor cannot accidentally re-hardcode the validator.
+        assert 'eval "$BIND9_VALIDATE_CMD"' in script
+        # No hardcoded ``named-checkzone "$ZONE_NAME"...`` executable
+        # invocation (only docstring / comment mentions remain after
+        # T4 made the validate command caller-supplied). The exact
+        # pre-T4 invocation line is gone.
+        assert 'named-checkzone "$ZONE_NAME" "$AUDIT_SLICE_PATH" 2>&1' not in script
 
     def test_script_calls_rndc_reload(self) -> None:
         script = _build_pipeline_script(

--- a/backend/tests/test_connectors_bind9_config.py
+++ b/backend/tests/test_connectors_bind9_config.py
@@ -516,6 +516,43 @@ class TestApplyViews:
             )
         assert atomic_mock.await_count == 0
 
+    async def test_primary_path_not_in_files_rejected(self) -> None:
+        """``primary_path`` outside the staged set -> ValueError pre-stage.
+
+        Regression for the double-apply trap (iter-1 B1): if the
+        primitive's success-path ``cat`` hits a file the staged tar
+        didn't touch, the post-reload audit-slice capture either
+        reports an unrelated file or fails outright (missing file ->
+        cat exits non-zero -> the primitive raises after the live
+        reload already succeeded -> the caller retries -> the change
+        is applied twice). Rejecting at the handler boundary keeps
+        the audit-replay invariant intact and removes the retry trap.
+        """
+        connector = Bind9Connector()
+        atomic_mock = AsyncMock()
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch(
+                "meho_backplane.connectors.bind9.ops_config.atomic_apply",
+                atomic_mock,
+            ),
+            pytest.raises(ValueError, match="must reference one of the staged files"),
+        ):
+            await bind9_config_apply_views(
+                connector,
+                _TARGET,
+                {
+                    "files": {"named.conf.local": "x\n"},
+                    # Under bind_root but NOT a key in the files mapping.
+                    "primary_path": "named.conf.options",
+                },
+            )
+        # The primitive never ran -- the failure surfaced pre-stage,
+        # so there is no half-applied remote state to roll back.
+        assert atomic_mock.await_count == 0
+
 
 # ---------------------------------------------------------------------------
 # bind9_config_backup -- creates archive + lists existing backups
@@ -586,6 +623,44 @@ class TestConfigBackup:
             pytest.raises(RuntimeError, match="Permission denied"),
         ):
             await bind9_config_backup(connector, _TARGET, {})
+
+    async def test_backup_id_distinct_across_same_second_same_tag(self) -> None:
+        """Two backups in the same second with the same tag must NOT collide.
+
+        Regression for iter-1 M2: the prior schema embedded only a
+        UTC-second timestamp + optional tag, so two concurrent
+        backups (or a tight retry loop) could compute the same
+        ``backup_id`` and overwrite each other's tar silently.
+        ``secrets.token_hex(3)`` appends 24 bits of CSPRNG entropy to
+        the filename; the collision risk under any realistic burst
+        is negligible and the ID schema (``startswith("bind9-")``)
+        stays opaque to existing callers.
+        """
+        connector = Bind9Connector()
+        bash_mock = AsyncMock(return_value=_completed_process(stdout="[]", exit_status=0))
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch.object(connector, "_remote_bash_with_sudo", bash_mock),
+            # Freeze the timestamp so the only differentiator left
+            # is the random suffix; if the suffix didn't exist the
+            # two backup IDs would be byte-identical.
+            patch("meho_backplane.connectors.bind9.ops_config.time") as time_mock,
+        ):
+            time_mock.strftime = lambda fmt, tm: "20260518T120000Z"
+            time_mock.gmtime = lambda: None  # value ignored by the lambda above
+            first = await bind9_config_backup(connector, _TARGET, {"tag": "pre-prod"})
+            second = await bind9_config_backup(connector, _TARGET, {"tag": "pre-prod"})
+
+        assert first["backup_id"] != second["backup_id"], (
+            f"same-second same-tag collision: {first['backup_id']!r} == {second['backup_id']!r}"
+        )
+        assert first["path"] != second["path"]
+        # Both still carry the expected prefix and tag.
+        for envelope in (first, second):
+            assert envelope["backup_id"].startswith("bind9-")
+            assert "pre-prod" in envelope["backup_id"]
 
     async def test_emits_op_class_write_with_state_after_only(self) -> None:
         """``backup`` audit envelope: state_after present, state_before absent."""

--- a/backend/tests/test_connectors_bind9_config.py
+++ b/backend/tests/test_connectors_bind9_config.py
@@ -1,0 +1,779 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the bind9 config-write op group (G3.4-T4 #590).
+
+Coverage matrix (per Task #590 acceptance criteria):
+
+* :func:`pack_views_tar` -- pure tar-archive builder; absolute member
+  names rooted at ``/``, traversal-input rejection, mode-bit pinning.
+* :func:`_parse_reload_output` -- the sentinel-delimited parser used
+  by ``bind9.config.reload``.
+* :func:`bind9_config_apply_file` and :func:`bind9_config_apply_views`
+  invoke :func:`atomic_apply` -- the load-bearing T4 constraint that
+  the config-write handlers route every staging / validation /
+  rollback step through T3's primitive rather than duplicating logic.
+  These tests patch ``atomic_apply`` and assert it was called with the
+  expected staging payload + validate command.
+* :func:`bind9_config_apply_file` rejects traversal-paths pre-stage
+  (``ConfigPathRejectedError``); no atomic-apply invocation in that
+  branch.
+* :func:`bind9_config_backup` shapes the create + list script
+  correctly, parses the listing into rows, and emits ``op_class=write``
+  with ``state_after=backup_id``.
+* :func:`bind9_config_reload` distinguishes success from rndc failure
+  via the structured ``ok`` flag (no exception on non-zero
+  ``rndc reload`` exit).
+* ``CONFIG_OPS`` registration metadata: write ops carry the right
+  ``safety_level``, the description and ``llm_instructions`` both
+  reference the "global"+"atomic" tokens, and the parameter schemas
+  pin ``additionalProperties=False``.
+
+Tests use the same asyncssh-mocked seam as ``test_connectors_bind9_atomic.py``:
+:meth:`Bind9Connector._remote_bash_with_sudo` and
+:meth:`Bind9Connector._run_command` are patched with
+:class:`AsyncMock` whose return value is a stubbed
+:class:`asyncssh.SSHCompletedProcess`. Fingerprint is patched to a
+fixed Debian-family fingerprint so the ``_resolve_bind_root`` lookup
+returns ``/etc/bind`` deterministically.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import meho_backplane.connectors.bind9  # noqa: F401 -- registers connector at import
+from meho_backplane.connectors.bind9 import BIND9_OPS, Bind9Connector
+from meho_backplane.connectors.bind9._atomic import AtomicApplyResult
+from meho_backplane.connectors.bind9.ops_config import (
+    BIND9_CONFIG_APPLY_FILE_PARAMETER_SCHEMA,
+    BIND9_CONFIG_APPLY_VIEWS_PARAMETER_SCHEMA,
+    BIND9_CONFIG_BACKUP_PARAMETER_SCHEMA,
+    BIND9_CONFIG_RELOAD_PARAMETER_SCHEMA,
+    ConfigPathRejectedError,
+    _parse_reload_output,
+    bind9_config_apply_file,
+    bind9_config_apply_views,
+    bind9_config_backup,
+    bind9_config_reload,
+    pack_views_tar,
+)
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Env fixture -- mirrors test_connectors_bind9_atomic.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Stub target + completed-process helper
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: dict[str, Any]
+
+
+_TARGET = _StubTarget(
+    name="bind9-test",
+    host="bind9.test.invalid",
+    port=22,
+    secret_ref={"username": "root", "password": "test-sudo-pwd"},  # NOSONAR -- unit-test stub
+)
+
+
+def _completed_process(stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _fingerprint_debian_default() -> FingerprintResult:
+    """Stub fingerprint pinning bind config root to ``/etc/bind``."""
+    return FingerprintResult(
+        vendor="isc",
+        product="bind9",
+        version="9.18.24",
+        build="BIND 9.18.24-Debian",
+        reachable=True,
+        probed_at=datetime.now(UTC),
+        probe_method="ssh: named -v",
+        extras={"os": "debian 12", "named_conf_path": "/etc/bind/named.conf"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# pack_views_tar (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestPackViewsTar:
+    """The pure tar-archive builder used by ``apply_views``."""
+
+    def test_empty_mapping_returns_empty_archive(self) -> None:
+        """An empty mapping returns a valid (but member-less) tar.gz."""
+        # Empty mapping is rejected at the handler level, but the
+        # builder itself should still produce a parseable archive --
+        # the contract is "valid tar.gz, possibly with zero members".
+        tar_bytes = pack_views_tar({})
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as t:
+            assert t.getnames() == []
+
+    def test_single_relative_path_packs_under_bind_root(self) -> None:
+        """``named.conf.local`` -> ``etc/bind/named.conf.local`` member."""
+        tar_bytes = pack_views_tar(
+            {"named.conf.local": 'zone "evba.lab" { type master; };\n'},
+        )
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as t:
+            members = t.getnames()
+            assert members == ["etc/bind/named.conf.local"]
+            extracted = t.extractfile("etc/bind/named.conf.local")
+            assert extracted is not None
+            assert extracted.read() == b'zone "evba.lab" { type master; };\n'
+
+    def test_absolute_path_under_root_packs_intact(self) -> None:
+        """An absolute path under the root is accepted and stripped of leading /."""
+        tar_bytes = pack_views_tar(
+            {"/etc/bind/views/external.conf": "view-content\n"},
+        )
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as t:
+            assert t.getnames() == ["etc/bind/views/external.conf"]
+
+    def test_traversal_path_rejected_pre_pack(self) -> None:
+        """``../../etc/passwd`` -> ConfigPathRejectedError, no archive produced."""
+        with pytest.raises(ConfigPathRejectedError):
+            pack_views_tar({"../../etc/passwd": "evil"})
+
+    def test_absolute_path_outside_root_rejected(self) -> None:
+        """``/etc/passwd`` is outside the bind root -> rejected."""
+        with pytest.raises(ConfigPathRejectedError):
+            pack_views_tar({"/etc/passwd": "evil"})
+
+    def test_pinned_mode_bits(self) -> None:
+        """Every member's mode is pinned to 0o644 (no setuid/setgid smuggling)."""
+        tar_bytes = pack_views_tar({"named.conf.local": "x\n"})
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as t:
+            members = t.getmembers()
+            for m in members:
+                # 0o644 = -rw-r--r--; no setuid (0o4000), no setgid (0o2000).
+                assert m.mode == 0o644
+
+    def test_utf8_content_round_trips(self) -> None:
+        """Non-ASCII content (UTF-8) round-trips through encode + extract."""
+        content = "; comment with non-ASCII: éè 中文\n"
+        tar_bytes = pack_views_tar({"views/comment.txt": content})
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as t:
+            extracted = t.extractfile("etc/bind/views/comment.txt")
+            assert extracted is not None
+            assert extracted.read().decode("utf-8") == content
+
+    def test_custom_bind_root_scopes_archive(self) -> None:
+        """A non-default bind_root changes the archive member prefix."""
+        tar_bytes = pack_views_tar(
+            {"named.conf": "x\n"},
+            bind_root="/etc/named",  # RHEL-family layout
+        )
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as t:
+            assert t.getnames() == ["etc/named/named.conf"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_reload_output (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestParseReloadOutput:
+    """The sentinel-delimited parser used by ``bind9.config.reload``."""
+
+    def test_success_envelope(self) -> None:
+        text = (
+            "===STATE_BEFORE_BEGIN===\n"
+            "version: 9.18.24\n"
+            "zones: 1\n"
+            "===STATE_BEFORE_END===\n"
+            "===RELOAD_OUT_BEGIN===\n"
+            "server reload successful\n"
+            "===RELOAD_OUT_END===\n"
+            "===STATE_AFTER_BEGIN===\n"
+            "version: 9.18.24\n"
+            "zones: 1\n"
+            "===STATE_AFTER_END===\n"
+            "===RELOAD_RC===0\n"
+            "===STATUS_BEFORE_RC===0\n"
+            "===STATUS_AFTER_RC===0\n"
+        )
+        result = _parse_reload_output(text)
+        assert result["RELOAD_RC"] == "0"
+        assert result["RELOAD_OUT"] == "server reload successful"
+        assert "version: 9.18.24" in result["STATE_BEFORE"]
+        assert "version: 9.18.24" in result["STATE_AFTER"]
+
+    def test_failure_envelope_carries_rndc_exit(self) -> None:
+        text = (
+            "===STATE_BEFORE_BEGIN===\nv: 9\n===STATE_BEFORE_END===\n"
+            "===RELOAD_OUT_BEGIN===\nrndc: connect failed\n===RELOAD_OUT_END===\n"
+            "===STATE_AFTER_BEGIN===\nv: 9\n===STATE_AFTER_END===\n"
+            "===RELOAD_RC===1\n"
+            "===STATUS_BEFORE_RC===0\n"
+            "===STATUS_AFTER_RC===0\n"
+        )
+        result = _parse_reload_output(text)
+        assert result["RELOAD_RC"] == "1"
+        assert "connect failed" in result["RELOAD_OUT"]
+
+
+# ---------------------------------------------------------------------------
+# bind9_config_apply_file -- routes through atomic_apply
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFile:
+    """``bind9.config.apply_file`` calls T3's atomic-apply primitive."""
+
+    async def test_routes_through_atomic_apply_with_named_checkconf_validate(
+        self,
+    ) -> None:
+        """The handler must invoke atomic_apply with named-checkconf as validate.
+
+        This is the load-bearing T4 constraint: no duplicate stage /
+        validate / rollback logic in ops_config.py. The test patches
+        :func:`atomic_apply` and asserts the call shape.
+        """
+        connector = Bind9Connector()
+        apply_result = AtomicApplyResult(
+            state_before="# old\n",
+            state_after='zone "x" { };\n',
+            audit_slice_path="/etc/bind/named.conf.local",
+        )
+        atomic_mock = AsyncMock(return_value=apply_result)
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch(
+                "meho_backplane.connectors.bind9.ops_config.atomic_apply",
+                atomic_mock,
+            ),
+        ):
+            result = await bind9_config_apply_file(
+                connector,
+                _TARGET,
+                {"path": "named.conf.local", "content": 'zone "x" { };\n'},
+            )
+
+        # atomic_apply was invoked exactly once.
+        assert atomic_mock.await_count == 1
+        kwargs = atomic_mock.await_args.kwargs
+        assert kwargs["audit_slice_path"] == "/etc/bind/named.conf.local"
+        # Validate command must be the whole-config checkconf, NOT
+        # named-checkzone -- the latter would refuse a non-zone fragment.
+        assert "named-checkconf" in kwargs["validate_command"]
+        # Single-file mode: staged_bytes set, staged_tar_bytes absent.
+        assert kwargs["staged_bytes"] == b'zone "x" { };\n'
+        assert kwargs.get("staged_tar_bytes") is None
+        # zone_name must be empty -- config writes have no zone scope.
+        assert kwargs["zone_name"] == ""
+
+        # The handler envelope shape.
+        assert result["file"] == "/etc/bind/named.conf.local"
+        assert result["op_class"] == "write"
+        assert result["result_state_before"] == "# old\n"
+        assert result["result_state_after"] == 'zone "x" { };\n'
+
+    async def test_traversal_path_rejected_pre_atomic_apply(self) -> None:
+        """``../../etc/passwd`` -> ConfigPathRejectedError; atomic_apply not called."""
+        connector = Bind9Connector()
+        atomic_mock = AsyncMock()
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch(
+                "meho_backplane.connectors.bind9.ops_config.atomic_apply",
+                atomic_mock,
+            ),
+            pytest.raises(ConfigPathRejectedError),
+        ):
+            await bind9_config_apply_file(
+                connector,
+                _TARGET,
+                {"path": "../../etc/passwd", "content": "evil"},
+            )
+        # The primitive must NOT have been reached.
+        assert atomic_mock.await_count == 0
+
+    async def test_missing_sudo_password_raises(self) -> None:
+        """target with no password -> ValueError, no remote IO."""
+        connector = Bind9Connector()
+        bare_target = _StubTarget(
+            name="bare",
+            host="bare.invalid",
+            port=22,
+            secret_ref={"username": "root"},
+        )
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            pytest.raises(ValueError, match="sudo_password"),
+        ):
+            await bind9_config_apply_file(
+                connector,
+                bare_target,
+                {"path": "named.conf.local", "content": "x\n"},
+            )
+
+
+# ---------------------------------------------------------------------------
+# bind9_config_apply_views -- routes through atomic_apply (multi-file)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyViews:
+    """``bind9.config.apply_views`` calls atomic_apply in multi-file tar mode."""
+
+    async def test_routes_through_atomic_apply_with_tar_payload(self) -> None:
+        """The handler must invoke atomic_apply with staged_tar_bytes set."""
+        connector = Bind9Connector()
+        apply_result = AtomicApplyResult(
+            state_before="",
+            state_after="new\n",
+            audit_slice_path="/etc/bind/named.conf.local",
+        )
+        atomic_mock = AsyncMock(return_value=apply_result)
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch(
+                "meho_backplane.connectors.bind9.ops_config.atomic_apply",
+                atomic_mock,
+            ),
+        ):
+            result = await bind9_config_apply_views(
+                connector,
+                _TARGET,
+                {
+                    "files": {
+                        "named.conf.local": 'zone "x" { type master; file "/etc/bind/db.x"; };\n',
+                        "db.x": "$TTL 3600\n@ IN SOA . . 1 1 1 1 1\n",
+                    },
+                    "primary_path": "named.conf.local",
+                },
+            )
+
+        assert atomic_mock.await_count == 1
+        kwargs = atomic_mock.await_args.kwargs
+        # Multi-file mode: staged_tar_bytes set, staged_bytes absent
+        # (defaults to None on the primitive's signature).
+        assert kwargs.get("staged_bytes") is None
+        assert isinstance(kwargs["staged_tar_bytes"], bytes)
+        # The tar must contain both members under /etc/bind/.
+        with tarfile.open(fileobj=io.BytesIO(kwargs["staged_tar_bytes"]), mode="r:gz") as t:
+            names = set(t.getnames())
+            assert "etc/bind/named.conf.local" in names
+            assert "etc/bind/db.x" in names
+        # Validate command must be named-checkconf (not -checkzone).
+        assert "named-checkconf" in kwargs["validate_command"]
+        # zone_name empty -- multi-file config write.
+        assert kwargs["zone_name"] == ""
+        # audit_slice_path is the explicit primary_path.
+        assert kwargs["audit_slice_path"] == "/etc/bind/named.conf.local"
+
+        # The handler envelope shape.
+        assert result["primary_path"] == "/etc/bind/named.conf.local"
+        assert set(result["files"]) == {
+            "/etc/bind/named.conf.local",
+            "/etc/bind/db.x",
+        }
+        assert result["op_class"] == "write"
+
+    async def test_primary_path_defaults_to_first_sorted_key(self) -> None:
+        """``primary_path`` omitted -> first key sorted lexicographically."""
+        connector = Bind9Connector()
+        apply_result = AtomicApplyResult(
+            state_before="",
+            state_after="",
+            audit_slice_path="/etc/bind/a.conf",
+        )
+        atomic_mock = AsyncMock(return_value=apply_result)
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch(
+                "meho_backplane.connectors.bind9.ops_config.atomic_apply",
+                atomic_mock,
+            ),
+        ):
+            result = await bind9_config_apply_views(
+                connector,
+                _TARGET,
+                {"files": {"z.conf": "z\n", "a.conf": "a\n", "m.conf": "m\n"}},
+            )
+        # Sorted: a.conf, m.conf, z.conf -> primary defaults to a.conf.
+        assert result["primary_path"] == "/etc/bind/a.conf"
+
+    async def test_verify_fqdn_renders_dig_predicate(self) -> None:
+        """``verify_fqdn`` set -> verify_command uses dig @localhost."""
+        connector = Bind9Connector()
+        apply_result = AtomicApplyResult(
+            state_before="",
+            state_after="",
+            audit_slice_path="/etc/bind/named.conf.local",
+        )
+        atomic_mock = AsyncMock(return_value=apply_result)
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch(
+                "meho_backplane.connectors.bind9.ops_config.atomic_apply",
+                atomic_mock,
+            ),
+        ):
+            await bind9_config_apply_views(
+                connector,
+                _TARGET,
+                {
+                    "files": {"named.conf.local": "x\n"},
+                    "verify_fqdn": "internal.evba.lab",
+                },
+            )
+        verify_cmd = atomic_mock.await_args.kwargs["verify_command"]
+        assert "dig @localhost" in verify_cmd
+        assert "internal.evba.lab" in verify_cmd
+
+    async def test_verify_fqdn_omitted_falls_back_to_checkconf(self) -> None:
+        """No ``verify_fqdn`` -> verify_command is the static parse check."""
+        connector = Bind9Connector()
+        apply_result = AtomicApplyResult(
+            state_before="",
+            state_after="",
+            audit_slice_path="/etc/bind/named.conf.local",
+        )
+        atomic_mock = AsyncMock(return_value=apply_result)
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch(
+                "meho_backplane.connectors.bind9.ops_config.atomic_apply",
+                atomic_mock,
+            ),
+        ):
+            await bind9_config_apply_views(
+                connector,
+                _TARGET,
+                {"files": {"named.conf.local": "x\n"}},
+            )
+        verify_cmd = atomic_mock.await_args.kwargs["verify_command"]
+        assert "named-checkconf" in verify_cmd
+
+    async def test_empty_files_mapping_rejected(self) -> None:
+        """Empty ``files`` -> ValueError; atomic_apply not called."""
+        connector = Bind9Connector()
+        atomic_mock = AsyncMock()
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch(
+                "meho_backplane.connectors.bind9.ops_config.atomic_apply",
+                atomic_mock,
+            ),
+            pytest.raises(ValueError, match="non-empty"),
+        ):
+            await bind9_config_apply_views(
+                connector,
+                _TARGET,
+                {"files": {}},
+            )
+        assert atomic_mock.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# bind9_config_backup -- creates archive + lists existing backups
+# ---------------------------------------------------------------------------
+
+
+class TestConfigBackup:
+    """``bind9.config.backup`` creates a tar.gz, returns ID + listing."""
+
+    async def test_returns_backup_id_and_listing(self) -> None:
+        """A successful backup returns the ID, path, rows, total."""
+        connector = Bind9Connector()
+        listing_json = (
+            '[{"id": "bind9-20260518T100000Z", '
+            '"path": "/var/backups/meho-bind9/bind9-20260518T100000Z.tar.gz", '
+            '"size": 1024, "modified": 1747569600.0}]'
+        )
+        bash_mock = AsyncMock(return_value=_completed_process(stdout=listing_json, exit_status=0))
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch.object(connector, "_remote_bash_with_sudo", bash_mock),
+        ):
+            result = await bind9_config_backup(connector, _TARGET, {})
+
+        # Envelope keys.
+        assert "backup_id" in result
+        assert result["backup_id"].startswith("bind9-")
+        assert result["path"].startswith("/var/backups/meho-bind9/")
+        assert result["path"].endswith(".tar.gz")
+        assert result["op_class"] == "write"
+        assert result["state_after"] == result["backup_id"]
+        # Rows are parsed from the JSON line.
+        assert result["total"] == 1
+        assert result["rows"][0]["id"] == "bind9-20260518T100000Z"
+        assert result["rows"][0]["size"] == 1024
+
+    async def test_tag_appears_in_backup_filename(self) -> None:
+        """A ``tag`` parameter is embedded in the filename + ID."""
+        connector = Bind9Connector()
+        bash_mock = AsyncMock(return_value=_completed_process(stdout="[]", exit_status=0))
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch.object(connector, "_remote_bash_with_sudo", bash_mock),
+        ):
+            result = await bind9_config_backup(connector, _TARGET, {"tag": "pre-views-change"})
+        assert "pre-views-change" in result["backup_id"]
+        assert "pre-views-change" in result["path"]
+
+    async def test_remote_failure_raises_runtime_error(self) -> None:
+        """A non-zero exit -> RuntimeError with stderr verbatim."""
+        connector = Bind9Connector()
+        bash_mock = AsyncMock(
+            return_value=_completed_process(
+                stdout="",
+                stderr="tar: /etc/bind: Cannot open: Permission denied\n",
+                exit_status=1,
+            )
+        )
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch.object(connector, "_remote_bash_with_sudo", bash_mock),
+            pytest.raises(RuntimeError, match="Permission denied"),
+        ):
+            await bind9_config_backup(connector, _TARGET, {})
+
+    async def test_emits_op_class_write_with_state_after_only(self) -> None:
+        """``backup`` audit envelope: state_after present, state_before absent."""
+        connector = Bind9Connector()
+        bash_mock = AsyncMock(return_value=_completed_process(stdout="[]", exit_status=0))
+        with (
+            patch.object(
+                connector, "fingerprint", AsyncMock(return_value=_fingerprint_debian_default())
+            ),
+            patch.object(connector, "_remote_bash_with_sudo", bash_mock),
+        ):
+            result = await bind9_config_backup(connector, _TARGET, {})
+        # state_before is intentionally absent -- nothing in /etc/bind/ mutates.
+        assert "state_before" not in result
+        assert "result_state_before" not in result
+        assert "state_after" in result
+
+
+# ---------------------------------------------------------------------------
+# bind9_config_reload -- structured success/failure envelope
+# ---------------------------------------------------------------------------
+
+
+class TestConfigReload:
+    """``bind9.config.reload`` returns a structured envelope, never raises on rndc fail."""
+
+    async def test_success_envelope_has_ok_true(self) -> None:
+        connector = Bind9Connector()
+        stdout = (
+            "===STATE_BEFORE_BEGIN===\nversion: 9.18\n===STATE_BEFORE_END===\n"
+            "===RELOAD_OUT_BEGIN===\nserver reload successful\n===RELOAD_OUT_END===\n"
+            "===STATE_AFTER_BEGIN===\nversion: 9.18\n===STATE_AFTER_END===\n"
+            "===RELOAD_RC===0\n"
+            "===STATUS_BEFORE_RC===0\n"
+            "===STATUS_AFTER_RC===0\n"
+        )
+        bash_mock = AsyncMock(return_value=_completed_process(stdout=stdout, exit_status=0))
+        with patch.object(connector, "_remote_bash_with_sudo", bash_mock):
+            result = await bind9_config_reload(connector, _TARGET, {})
+        assert result["ok"] is True
+        assert result["rndc_reload_exit"] == 0
+        assert result["stderr"] == ""  # no stderr on success
+        assert "successful" in result["stdout"]
+        assert result["op_class"] == "write"
+        assert "version: 9.18" in result["result_state_before"]
+        assert "version: 9.18" in result["result_state_after"]
+
+    async def test_rndc_failure_returns_ok_false_no_exception(self) -> None:
+        """A non-zero ``rndc reload`` exit is reported, NOT raised."""
+        connector = Bind9Connector()
+        stdout = (
+            "===STATE_BEFORE_BEGIN===\nversion: 9.18\n===STATE_BEFORE_END===\n"
+            "===RELOAD_OUT_BEGIN===\nrndc: connect failed\n===RELOAD_OUT_END===\n"
+            "===STATE_AFTER_BEGIN===\nversion: 9.18\n===STATE_AFTER_END===\n"
+            "===RELOAD_RC===1\n"
+            "===STATUS_BEFORE_RC===0\n"
+            "===STATUS_AFTER_RC===0\n"
+        )
+        bash_mock = AsyncMock(return_value=_completed_process(stdout=stdout, exit_status=0))
+        with patch.object(connector, "_remote_bash_with_sudo", bash_mock):
+            result = await bind9_config_reload(connector, _TARGET, {})
+        assert result["ok"] is False
+        assert result["rndc_reload_exit"] == 1
+        assert "connect failed" in result["stderr"]
+
+    async def test_wrapper_failure_raises(self) -> None:
+        """Wrapper-level failure (sudo / ssh down) -> RuntimeError.
+
+        Distinct from a normal rndc-failure: the wrapper exits non-zero
+        when the SSH/sudo layer itself broke, which is an exception, not
+        a structured envelope.
+        """
+        connector = Bind9Connector()
+        bash_mock = AsyncMock(
+            return_value=_completed_process(
+                stdout="",
+                stderr="sudo: a password is required\n",
+                exit_status=1,
+            )
+        )
+        with (
+            patch.object(connector, "_remote_bash_with_sudo", bash_mock),
+            pytest.raises(RuntimeError, match="password is required"),
+        ):
+            await bind9_config_reload(connector, _TARGET, {})
+
+
+# ---------------------------------------------------------------------------
+# Registration metadata for the four new T4 ops
+# ---------------------------------------------------------------------------
+
+
+_T4_OP_IDS = [
+    "bind9.config.apply_file",
+    "bind9.config.apply_views",
+    "bind9.config.backup",
+    "bind9.config.reload",
+]
+
+
+class TestT4OpsRegistration:
+    """The new T4 ops carry the right safety + audit metadata."""
+
+    def test_all_four_t4_ops_registered(self) -> None:
+        """Eleven total ops -- the full Initiative #367 §4 surface."""
+        op_ids = {op.op_id for op in BIND9_OPS}
+        for expected in _T4_OP_IDS:
+            assert expected in op_ids
+        # All eleven landed.
+        assert len(BIND9_OPS) == 11
+
+    @pytest.mark.parametrize(
+        "op_id, expected_safety",
+        [
+            ("bind9.config.apply_file", "dangerous"),
+            ("bind9.config.apply_views", "dangerous"),
+            ("bind9.config.backup", "caution"),
+            ("bind9.config.reload", "caution"),
+        ],
+    )
+    def test_safety_levels_pin_to_spec(self, op_id: str, expected_safety: str) -> None:
+        op = next(o for o in BIND9_OPS if o.op_id == op_id)
+        assert op.safety_level == expected_safety
+        # Dev-default: no production approval gate yet (G7/G10 keys on
+        # safety_level, not on requires_approval).
+        assert op.requires_approval is False
+
+    @pytest.mark.parametrize("op_id", ["bind9.config.apply_file", "bind9.config.apply_views"])
+    def test_dangerous_op_carries_global_atomic_warning_in_description(self, op_id: str) -> None:
+        op = next(o for o in BIND9_OPS if o.op_id == op_id)
+        text = op.description.lower()
+        # The exact tokens "global" and "atomic" must appear -- they're
+        # the load-bearing agent-visible warning (Initiative #367 WI7).
+        assert "global" in text
+        assert "atomic" in text
+
+    @pytest.mark.parametrize("op_id", ["bind9.config.apply_file", "bind9.config.apply_views"])
+    def test_dangerous_op_llm_instructions_carry_global_atomic_warning(self, op_id: str) -> None:
+        op = next(o for o in BIND9_OPS if o.op_id == op_id)
+        assert op.llm_instructions is not None
+        text = op.llm_instructions.get("when_to_use", "").lower()
+        assert "global" in text
+        assert "atomic" in text
+
+    @pytest.mark.parametrize("op_id", _T4_OP_IDS)
+    def test_parameter_schema_disallows_additional_properties(self, op_id: str) -> None:
+        op = next(o for o in BIND9_OPS if o.op_id == op_id)
+        assert op.parameter_schema.get("additionalProperties") is False
+
+    @pytest.mark.parametrize("op_id", _T4_OP_IDS)
+    def test_handler_attr_resolves_on_connector_class(self, op_id: str) -> None:
+        """Every op declares a handler_attr that resolves on the connector class."""
+        op = next(o for o in BIND9_OPS if o.op_id == op_id)
+        handler = getattr(Bind9Connector, op.handler_attr, None)
+        assert handler is not None, (
+            f"op {op_id!r} declares handler_attr={op.handler_attr!r} "
+            f"but Bind9Connector has no such attribute"
+        )
+
+    def test_backup_tag_pattern_restricts_charset(self) -> None:
+        """The ``tag`` schema's regex rejects shell-meta + path separators."""
+        # The pattern lives in the parameter schema; the agent's input
+        # is filtered at the dispatcher's validate gate, but we pin
+        # the shape here too.
+        tag_schema = BIND9_CONFIG_BACKUP_PARAMETER_SCHEMA["properties"]["tag"]
+        import re
+
+        # Allowed examples must match.
+        for ok in ("pre-prod", "v1.2.3", "snapshot_2026", "abc"):
+            assert re.match(tag_schema["pattern"], ok), f"{ok!r} should match"
+        # Hostile examples must NOT match.
+        for bad in ("../escape", "foo/bar", "foo;rm -rf /", "foo$(whoami)", "foo bar"):
+            assert not re.match(tag_schema["pattern"], bad), (
+                f"{bad!r} should NOT match the tag pattern"
+            )
+
+    def test_apply_views_requires_files_in_schema(self) -> None:
+        """``files`` is a required property."""
+        assert "files" in BIND9_CONFIG_APPLY_VIEWS_PARAMETER_SCHEMA["required"]
+
+    def test_apply_file_requires_path_and_content(self) -> None:
+        """Both ``path`` and ``content`` are required."""
+        assert set(BIND9_CONFIG_APPLY_FILE_PARAMETER_SCHEMA["required"]) == {
+            "path",
+            "content",
+        }
+
+    def test_reload_schema_takes_no_params(self) -> None:
+        """``reload`` declares no parameters -- the op takes none."""
+        assert BIND9_CONFIG_RELOAD_PARAMETER_SCHEMA["properties"] == {}
+        assert BIND9_CONFIG_RELOAD_PARAMETER_SCHEMA.get("required", []) == []

--- a/docs/codebase/connectors-bind9.md
+++ b/docs/codebase/connectors-bind9.md
@@ -76,9 +76,14 @@ Source: `backend/src/meho_backplane/connectors/bind9/`.
   (`bind9_config_show`), and the four T4 write handlers:
   `bind9_config_apply_file` (single-fragment write, atomic-apply
   single-file mode), `bind9_config_apply_views` (multi-file tree
-  write, atomic-apply tar mode), `bind9_config_backup` (`tar -czf`
-  of `/etc/bind/` to `/var/backups/meho-bind9/<timestamp>.tar.gz`
-  with a JSON listing of existing backups), and `bind9_config_reload`
+  write, atomic-apply tar mode -- `primary_path` is validated to
+  reference one of the staged files so the primitive's success-path
+  audit-slice capture cannot hit a missing file after a successful
+  reload, which would otherwise force a double-apply on retry),
+  `bind9_config_backup` (`tar -czf` of `/etc/bind/` to
+  `/var/backups/meho-bind9/<timestamp>[-<tag>]-<hex>.tar.gz` with a
+  JSON listing of existing backups; the 24-bit hex suffix breaks
+  same-second + same-tag collisions), and `bind9_config_reload`
   (`rndc reload` with structured success/failure envelope). The
   pure `pack_views_tar` helper builds the multi-file archive
   client-side. The `CONFIG_OPS` registration table carries all five

--- a/docs/codebase/connectors-bind9.md
+++ b/docs/codebase/connectors-bind9.md
@@ -58,18 +58,31 @@ Source: `backend/src/meho_backplane/connectors/bind9/`.
   transforms, and the `RECORD_OPS` registration table.
 - **`_atomic.py`** -- T3 (#589) atomic-apply primitive. One async
   `atomic_apply()` helper that runs the seven-step bash pipeline
-  (snapshot, capture state_before, stage, named-checkzone validate,
-  rndc reload, caller-supplied dig-verify predicate, on-failure
-  snapshot rollback) in a single `_remote_bash_with_sudo` invocation.
-  Returns `AtomicApplyResult(state_before, state_after,
-  audit_slice_path)`; raises `AtomicApplyError(step, detail)` on any
-  failure -- by the time the helper returns, the remote `/etc/bind/`
-  tree is either fully-staged-and-verified or byte-identical to the
-  pre-op snapshot.
-- **`ops_config.py`** -- T2 config-read op module. Pure path-safety
-  filter (`ensure_path_under_root`), handler (`bind9_config_show`),
-  and the `CONFIG_OPS` registration table. T4 will append
-  config-write ops to this module.
+  (snapshot, capture state_before, stage, validate, rndc reload,
+  caller-supplied verify predicate, on-failure snapshot rollback)
+  in a single `_remote_bash_with_sudo` invocation. T4 (#590)
+  generalised the validate step from hardcoded `named-checkzone` to
+  a caller-supplied `BIND9_VALIDATE_CMD` env var (default still
+  `named-checkzone "$ZONE_NAME" "$AUDIT_SLICE_PATH"` for record
+  writes) and added a multi-file tar staging shape
+  (`staged_tar_bytes`) so `config.apply_views` can deposit a whole
+  views subtree atomically. Returns `AtomicApplyResult(state_before,
+  state_after, audit_slice_path)`; raises `AtomicApplyError(step,
+  detail)` on any failure -- by the time the helper returns, the
+  remote `/etc/bind/` tree is either fully-staged-and-verified or
+  byte-identical to the pre-op snapshot.
+- **`ops_config.py`** -- T2 config-read + T4 config-write op module.
+  Pure path-safety filter (`ensure_path_under_root`), read handler
+  (`bind9_config_show`), and the four T4 write handlers:
+  `bind9_config_apply_file` (single-fragment write, atomic-apply
+  single-file mode), `bind9_config_apply_views` (multi-file tree
+  write, atomic-apply tar mode), `bind9_config_backup` (`tar -czf`
+  of `/etc/bind/` to `/var/backups/meho-bind9/<timestamp>.tar.gz`
+  with a JSON listing of existing backups), and `bind9_config_reload`
+  (`rndc reload` with structured success/failure envelope). The
+  pure `pack_views_tar` helper builds the multi-file archive
+  client-side. The `CONFIG_OPS` registration table carries all five
+  ops.
 - **`parse_named_version()`** / **`parse_os_release()`**
   (`connector.py`) -- pure helpers. `parse_named_version` recovers
   the `<X.Y.Z>` version triple from a `BIND <X.Y.Z>-<distro-suffix>`
@@ -101,9 +114,10 @@ whole seven-step pipeline (snapshot, stage, validate, reload,
 verify, rollback) runs as one bash body fed to
 `_remote_bash_with_sudo`, so the snapshot and the rollback always
 share an interpreter on the target. T4 (#590)'s
-`bind9.config.apply_views` / `bind9.config.apply_file` /
-`bind9.config.backup` / `bind9.config.reload` will all route their
-elevated-privilege calls through it.
+`bind9.config.apply_file` / `bind9.config.apply_views` route through
+the same atomic-apply primitive; `bind9.config.backup` and
+`bind9.config.reload` bypass the atomic shape (additive / single
+command) but still route their sudo through this helper.
 
 ## `fingerprint(target)`
 
@@ -147,7 +161,7 @@ the most-specific class first (`PermissionDenied` is a subclass of
 `DisconnectError` in asyncssh) so the dispatch maps to the right
 reason.
 
-## Shipped op surface (T1 + T2 + T3)
+## Shipped op surface (T1 + T2 + T3 + T4 = 11 ops)
 
 | Op id | Handler | Safety | Description |
 | ----- | ------- | ------ | ----------- |
@@ -158,9 +172,16 @@ reason.
 | `bind9.record.add` | `Bind9Connector.bind9_record_add` | `caution` | Atomic A/AAAA record write with snapshot rollback; resolves owning zone via longest-suffix match when `zone` omitted; verify predicate = `dig` returns the new IP |
 | `bind9.record.remove` | `Bind9Connector.bind9_record_remove` | `caution` | Atomic remove of A + AAAA at the given FQDN with snapshot rollback; verify predicate = `dig` no longer resolves the FQDN |
 | `bind9.config.show` | `Bind9Connector.bind9_config_show` | `safe` | Read named.conf or an included fragment under the bind config root; path-safety filter refuses traversal with no content leaked |
+| `bind9.config.apply_file` | `Bind9Connector.bind9_config_apply_file` | `dangerous` | Atomic single-fragment write via T3's primitive; validate = `named-checkconf -p`; verify = config still parses after live reload |
+| `bind9.config.apply_views` | `Bind9Connector.bind9_config_apply_views` | `dangerous` | Atomic multi-file tree write (tar mode of T3's primitive); validate = `named-checkconf -p`; verify = caller-supplied `dig` or fallback parse check |
+| `bind9.config.backup` | `Bind9Connector.bind9_config_backup` | `caution` | `tar -czf` of `/etc/bind/` under `/var/backups/meho-bind9/`; returns backup ID + listing of existing backups |
+| `bind9.config.reload` | `Bind9Connector.bind9_config_reload` | `caution` | `rndc reload` with structured success/failure envelope; captures `rndc status` before/after for audit |
 
-The T4 config-write op surface lands in a follow-on PR against this
-same `BIND9_OPS`-splat registration shape.
+The `dangerous` safety tier is reserved for T4's apply ops -- a bad
+views file can dark the whole resolver. The production-path gate
+(G7/G10) keys on `safety_level`, so the apply ops carry an additional
+warning in their `description` + `llm_instructions` that any agent
+proposing the write sees.
 
 ## Atomic-apply primitive (T3 #589)
 
@@ -356,17 +377,38 @@ removed by G0.6-T11 (#412) and bind9 has never shipped behind it.
   unsupported-type / missing-sudo-password rejection branches; (6)
   the registration metadata (`safety_level=caution`, write-warning
   in description + `llm_instructions`, `additionalProperties=False`).
+- `backend/tests/test_connectors_bind9_config.py` -- T4 unit suite.
+  Covers (1) `pack_views_tar` pure builder (absolute member names,
+  traversal rejection, mode-bit pinning, UTF-8 round-trip); (2)
+  `_parse_reload_output` sentinel parser; (3) `bind9_config_apply_file`
+  and `bind9_config_apply_views` route through `atomic_apply` with
+  the expected validate command + staging shape (asserted by mocking
+  the primitive and inspecting the call kwargs -- the load-bearing
+  T4 constraint that no rollback logic is duplicated in
+  `ops_config.py`); (4) `bind9_config_apply_file` rejects traversal
+  paths pre-stage with no atomic-apply invocation; (5)
+  `bind9_config_backup` shapes the create + list script correctly,
+  parses the JSON listing into rows, emits `op_class=write` +
+  `state_after` only (no `state_before`); (6) `bind9_config_reload`
+  structured envelope distinguishing success from rndc failure
+  without raising on non-zero rndc exit; (7) registration metadata
+  for the four T4 ops (safety levels, global-atomic warnings,
+  `additionalProperties=False`, handler-attr resolution).
 - `backend/tests/integration/test_connectors_bind9_container.py` --
   containerised smoke test against a Debian-bookworm image with
   `bind9 bind9-host bind9utils dnsutils openssh-server` installed.
   Builds the image inline from a Dockerfile fixture (T2 seeds an
   `evba.lab` zone with each supported record type so the read-op
-  tests assert against a real container). T3 extends with end-to-end
+  tests assert against a real container). T3 extended with end-to-end
   add / remove tests, longest-suffix zone resolution against a real
   `named-checkconf -p`, and the two byte-identical-tree rollback
   assertions (checkzone failure + verify failure) gated on a
-  pre/post-op `sha256sum` of the bind config root. Skip-on-no-Docker
-  matches the rest of `tests/integration/`.
+  pre/post-op `sha256sum` of the bind config root. T4 extends with
+  end-to-end `config.reload` / `config.backup` / `config.apply_file`
+  / `config.apply_views` tests plus two byte-identical-tree rollback
+  assertions for the apply ops (invalid fragment / invalid views
+  tree both refuse via `named-checkconf -p` and roll back cleanly).
+  Skip-on-no-Docker matches the rest of `tests/integration/`.
 
 ## References
 
@@ -374,6 +416,7 @@ removed by G0.6-T11 (#412) and bind9 has never shipped behind it.
 - Skeleton task: [#587 G3.4-T1 Bind9Connector skeleton](https://github.com/evoila/meho/issues/587)
 - Read op group: [#588 G3.4-T2 bind9 read op group](https://github.com/evoila/meho/issues/588)
 - Atomic-apply + record-writes: [#589 G3.4-T3 bind9 atomic-apply primitive + record.add / record.remove](https://github.com/evoila/meho/issues/589)
+- Config-write op group: [#590 G3.4-T4 bind9 config-write op group](https://github.com/evoila/meho/issues/590)
 - Adapter inherited: [#243 G0.2-T4 SshConnector adapter](https://github.com/evoila/meho/issues/243)
 - Registration substrate: [#395 G0.6-T4 register_typed_operation()](https://github.com/evoila/meho/issues/395)
 - Sibling skeleton precedent: [#321 G3.2-T1 KubernetesConnector skeleton](https://github.com/evoila/meho/issues/321) + `backend/src/meho_backplane/connectors/kubernetes/connector.py`


### PR DESCRIPTION
## Summary

- Complete the 11-op bind9 surface from Initiative #367 §4 by porting the four config-write ops (`apply_file`, `apply_views`, `backup`, `reload`) from the consumer's `scripts/bind9-dns.sh`.
- The two atomic write ops route every staging / validate / rollback step through T3's `atomic_apply()` primitive (PR #607). The primitive grew two backwards-compatible extensions to serve both shapes: a multi-file `staged_tar_bytes` parameter for `apply_views`, and a caller-supplied `validate_command` so config writes use `named-checkconf -p` (record writes keep the default `named-checkzone`).
- `backup` and `reload` bypass atomic-apply (additive / single command). All four ops share the existing safe-sudo primitive from T1.
- Adds `pack_views_tar` (pure tar-archive builder client-side); audit envelope follows the T3 record-write shape (`op_class=write`, `result_state_*`). `apply_*` carry the global-atomic-apply warning in `description` + `llm_instructions` (Initiative #367 WI7) and `safety_level=dangerous`; `backup` / `reload` are `caution`.

## Test plan

- [x] `ruff check` (changed paths) — clean
- [x] `ruff format --check` (changed paths) — clean
- [x] `mypy src/meho_backplane/connectors/bind9/` — clean (7 files)
- [x] `pytest tests/test_connectors_bind9*.py` — 199 passed
  - `test_connectors_bind9_config.py` — 46 new tests (pack_views_tar pure builder, reload parser, atomic-apply invocation contract for both apply ops, backup + reload envelope shapes, T4 registration metadata)
  - existing T1/T2/T3 suites continue to pass (T3 atomic-apply test updated to pin the new `BIND9_VALIDATE_CMD` env-var contract)
- [x] `pytest tests/integration/test_connectors_bind9_container.py --collect-only` — 20 tests collect (6 new T4 ones added; the 14 pre-existing T1-T3 ones intact). The new tests exercise `config.reload`, `config.backup`, `config.apply_file` happy path + invalid-fragment rollback, `config.apply_views` happy path + invalid-tree rollback. Skipped in this sandbox (no Docker socket); run in CI where the testcontainer is provisioned.
- [x] All 11 op handler attrs resolve on `Bind9Connector` — verified by `search_operations`-shape walk + parameter/response schema validity check via `jsonschema.Draft202012Validator`.

## Acceptance criteria coverage

- [x] `bind9.config.apply_views` applies a valid local views tree; invalid tree rolls back byte-identically (checksum assertion via `_checksum_bind_tree`).
- [x] `bind9.config.apply_file` applies a valid fragment; invalid fragment rolls back identically.
- [x] Both apply ops invoke T3's `_atomic.py` primitive (asserted in `test_connectors_bind9_config.py::TestApplyFile/Views` by patching `atomic_apply` and asserting `await_count == 1` with the expected `validate_command` + staging payload shape).
- [x] `bind9.config.backup` produces a restorable `tar` of `/etc/bind/` and returns a backup ID; listing handled via the K8s precedent (rows + total, JSONFlux reducer owns the > 20 threshold).
- [x] `bind9.config.reload` returns a structured envelope distinguishing reload-success from reload-failure (non-zero rndc exit → `ok: false`, not an exception).
- [x] `apply_views` / `apply_file` / `reload` emit `op_class=write` with `result_state_before` / `result_state_after`; `backup` emits `state_after` (backup ID) and no `state_before`.
- [x] `safety_level`: `apply_views` / `apply_file` = `dangerous`, `backup` / `reload` = `caution`; write-op descriptions + `llm_instructions` carry the global-atomic-apply warning.
- [x] All 11 Initiative #367 §4 ops register into `BIND9_OPS` (verified by `test_t4_ops_registration::test_all_four_t4_ops_registered` asserting `len(BIND9_OPS) == 11`).

## Out of scope

- CLI verbs, E2E harness, onboarding doc (T5, follow-on task).
- `rndc` admin subcommands beyond `reload` (`freeze`/`thaw`/`addzone`/`delzone`) — Initiative-level out of scope.
- DNSSEC / TSIG key management — Initiative-level out of scope.
- The G7/G10 production approval gate (keys on `safety_level=dangerous` once those gates land).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #590


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four BIND9 config ops: atomic single-file and multi-file (views) updates with staged-tar support, backups (timestamped archives), and reloads. Validation command is caller-configurable; atomic updates perform verification and roll back on failure.

* **Tests**
  * Added unit and integration tests covering tar staging, validation/rollback behavior, backup listing, reload envelopes, and end-to-end container scenarios.

* **Documentation**
  * Updated BIND9 connector docs to describe new config-write ops, staging modes, validation behavior, and safety guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-18)

Addressed review findings from `/auto-review-pr` iter-1 (REQUEST_CHANGES, posted as COMMENTED on this own-author PR):

- **B1** `1793d61` — `apply_views` validates `primary_path` is one of the staged files; raises `ValueError` pre-stage so the primitive's success-path audit-slice capture can never hit a missing file after a successful reload (which would otherwise force a double-apply on retry).
- **M1** `588236b` — `_atomic.py` single-file stage step reverses redirect order to `2>&1 > "$AUDIT_SLICE_PATH"` so decode diagnostics (corrupt base64, ENOSPC, EACCES) flow into `FAILED_DETAIL` instead of being appended into the already-truncated audit-slice file. Pre-existing T3 bug surfaced by T4's apply ops.
- **M2** `1793d61` — backup filenames append `secrets.token_hex(3)` (24 bits CSPRNG) so same-second + same-tag bursts produce distinct IDs. Schema stays opaque to callers.
- **m1** `2c13131` — integration test `shlex.quote`s `result["path"]` before interpolating into the `ls -1` shell command (defence-in-depth).

Disputed:

- _none._

Deferred (recorded as adjacent findings; orchestrator may file follow-up issues):

- _none._

Verification (`ruff check`, `ruff format --check`, `mypy`, full bind9 pytest unit suite — 142 passed in `tests/test_connectors_bind9_config.py` + `tests/test_connectors_bind9_atomic.py` + `tests/test_connectors_bind9.py`; integration collection: 20 tests).

<!-- auto-implement-issue: continue, iteration 2 -->
