### PR TITLE
fix(ci): restore main CI green — Go gofmt/revive (G9.2 CLI) + k8s e2e meta-tool target contract (#580)

### DIFF
--- a/backend/tests/integration/test_connectors_k8s_e2e.py
+++ b/backend/tests/integration/test_connectors_k8s_e2e.py
@@ -69,6 +69,7 @@ import contextlib
 import os
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
@@ -76,7 +77,7 @@ from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 import meho_backplane.operations._handler_resolve as _handler_resolve_module
 from meho_backplane.connectors.kubernetes import (
@@ -92,6 +93,7 @@ from meho_backplane.connectors.registry import (
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.meta_tools import call_operation, search_operations
@@ -111,6 +113,20 @@ DOCKER_AVAILABLE: bool = _docker_socket_present()
 SKIP_REASON: str = (
     "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
 )
+
+#: Tenant the test operators run under. Must equal the
+#: ``_make_operator`` default tenant_id so the seeded ``Target`` ORM
+#: row and the operator built by every ``call_operation`` test are
+#: tenant-consistent — :func:`resolve_target` is tenant-scoped
+#: (``WHERE tenant_id = ? AND name = ?``) and is the meta-tool's
+#: tenant-isolation boundary, so a mismatch surfaces as
+#: ``TargetNotFoundError`` (404), not a silent cross-tenant read.
+_OPERATOR_TENANT_ID: UUID = UUID("00000000-0000-0000-0000-00000000a0a0")
+
+#: Name the meta-tool ``call_operation`` test resolves via
+#: ``{"target": {"name": _TARGET_NAME}}`` → :func:`resolve_target`.
+#: Matches the ``_K3sTarget`` stub the direct-``dispatch`` tests pass.
+_TARGET_NAME: str = "k3s-e2e"
 
 #: Every op id this harness exercises. Pinned here (rather than
 #: re-derived from ``KUBERNETES_OPS``) so a registration regression
@@ -261,6 +277,24 @@ async def k8s_e2e(
     5. Set the pass-through reducer so set-shaped op results land
        verbatim in ``OperationResult.result`` (v0.2 default; G3.3-T4's
        JSONFlux reducer is a separate test concern).
+    6. Insert a tenant-scoped :class:`~meho_backplane.db.models.Target`
+       ORM row (``name="k3s-e2e"``, ``tenant_id=_OPERATOR_TENANT_ID``,
+       ``product="k8s"``, ``fingerprint={"version": "1.32.0"}``) so the
+       ``call_operation`` meta-tool path — which resolves
+       ``arguments["target"]={"name": ...}`` through the tenant-scoped
+       :func:`~meho_backplane.targets.resolver.resolve_target` (the
+       meta-tool's tenant-isolation boundary) — exercises the real
+       contract instead of being handed an already-resolved object.
+       host/port/secret_ref mirror the ``_K3sTarget`` stub; they never
+       reach a real cluster because phase 3 preseeded the connector
+       instance cache (the dispatcher resolves the class, the seeded
+       instance's injected loader returns the k3s kubeconfig directly).
+       The ``targets`` table is a soft-FK column the ``pg_engine``
+       fixture does not truncate, so the row is deleted on teardown to
+       keep per-test isolation (a leftover ``k3s-e2e`` row would make a
+       subsequent resolve raise ``AmbiguousTargetError`` only if a
+       duplicate alias existed, but the explicit delete keeps the
+       ``targets`` table empty between tests regardless).
     """
     kubeconfig, target = k3s_kubeconfig_and_target
 
@@ -282,6 +316,41 @@ async def k8s_e2e(
 
     await register_kubernetes_typed_operations(embedding_service=stub_embedding_service)
 
+    # Phase 6: seed the tenant-scoped Target ORM row the meta-tool
+    # contract resolves by name. The ORM model structurally satisfies
+    # KubernetesTargetLike (name/host/port/secret_ref) and the resolver
+    # reads product + fingerprint["version"] + preferred_impl_id off it
+    # exactly as a production probed target. fingerprint is a JSON dict
+    # (the probe route persists FingerprintResult.model_dump(mode="json")
+    # to this column), so resolve_connector's _resolve_target_version
+    # reads it via .get("version"); the K8s connector advertises
+    # supported_version_range=None so the version is not filtered on,
+    # only echoed into the audit payload — same as the _K3sTarget stub.
+    now = datetime.now(UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            TargetORM(
+                id=uuid4(),
+                tenant_id=_OPERATOR_TENANT_ID,
+                name=_TARGET_NAME,
+                aliases=[],
+                product="k8s",
+                host=target.host,
+                port=target.port,
+                fqdn=None,
+                secret_ref=target.secret_ref,
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                notes=None,
+                fingerprint={"version": "1.32.0"},
+                preferred_impl_id=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
     try:
         yield target
     finally:
@@ -289,6 +358,17 @@ async def k8s_e2e(
         # mask the test's own assertion failures.
         with contextlib.suppress(Exception):
             await seeded_connector.aclose()
+        # Delete the seeded Target row — pg_engine does not truncate
+        # `targets` (soft-FK column), so without this a leftover row
+        # leaks across tests in the same container session.
+        with contextlib.suppress(Exception):
+            async with sessionmaker() as session, session.begin():
+                await session.execute(
+                    delete(TargetORM).where(
+                        TargetORM.tenant_id == _OPERATOR_TENANT_ID,
+                        TargetORM.name == _TARGET_NAME,
+                    )
+                )
         reset_dispatcher_caches()
         clear_registry()
 
@@ -393,14 +473,27 @@ async def test_search_operations_returns_hits_for_each_op(
 async def test_call_operation_about_dispatches_through_meta_tool(
     k8s_e2e: _K3sTarget,
 ) -> None:
-    """``call_operation(k8s.about)`` round-trips dispatcher -> handler -> k3s."""
-    operator = _make_operator(sub="op-meta-about")
+    """``call_operation(k8s.about)`` round-trips dispatcher -> handler -> k3s.
+
+    Exercises the real meta-tool target contract: ``call_operation``
+    requires ``arguments["target"]`` to be ``{"name": <str>}`` and runs
+    it through the tenant-scoped :func:`resolve_target` (the meta-tool's
+    tenant-isolation boundary, since #438 G0.6-T8) before dispatch — it
+    does NOT accept an already-resolved target object. The ``k8s_e2e``
+    fixture seeds the matching tenant-scoped ``Target`` ORM row; the
+    operator built here uses the same default tenant
+    (``_OPERATOR_TENANT_ID``) so resolution succeeds. The other suites
+    call :func:`dispatch` directly with the duck-typed ``_K3sTarget``;
+    that low-level path legitimately accepts the object — only the
+    meta-tool enforces the name→resolve_target contract.
+    """
+    operator = _make_operator(sub="op-meta-about", tenant_id=_OPERATOR_TENANT_ID)
     result = await call_operation(
         operator,
         {
             "connector_id": "k8s-1.x",
             "op_id": "k8s.about",
-            "target": k8s_e2e,
+            "target": {"name": _TARGET_NAME},
             "params": {},
         },
     )

--- a/cli/internal/cmd/topology/bulk_import.go
+++ b/cli/internal/cmd/topology/bulk_import.go
@@ -86,7 +86,7 @@ func (e *bulkImportEndpoint) UnmarshalYAML(node *yaml.Node) error {
 
 // bulkImportRequest is the wire shape for
 // POST /api/v1/topology/edges/bulk: `{edges: [...], dry_run: bool}`.
-// The route accepts both ``dry_run=true/false`` in the body and a
+// The route accepts both “dry_run=true/false“ in the body and a
 // canonical 200 response.
 type bulkImportRequest struct {
 	Edges  []bulkImportEdgeYAML `json:"edges"`
@@ -117,7 +117,7 @@ type bulkImportResponse struct {
 
 // bulkImportError mirrors the 422 invalid_bulk envelope.
 type bulkImportErrorEnvelope struct {
-	Error  string                `json:"error"`
+	Error  string                 `json:"error"`
 	Errors []bulkImportRowErrJSON `json:"errors"`
 }
 

--- a/cli/internal/cmd/topology/e2e_test.go
+++ b/cli/internal/cmd/topology/e2e_test.go
@@ -400,7 +400,7 @@ func TestAnnotateRoundTripVisibleViaListEdgesThenUnannotate(t *testing.T) {
 	cmd, stdout, stderr := newRunCmd(t)
 	if err := runAnnotate(cmd, annotateOptions{
 		From: "service-x", Kind: "depends-on", To: "database-y",
-		EvidenceURL: "https://docs/example",
+		EvidenceURL:       "https://docs/example",
 		BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runAnnotate: %v; stderr=%s", err, stderr.String())

--- a/cli/internal/cmd/topology/list_edges.go
+++ b/cli/internal/cmd/topology/list_edges.go
@@ -82,7 +82,7 @@ func newListEdgesCmd() *cobra.Command {
 			"emits the raw response array.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runListEdges(cmd, listEdgesOptions{
 				Kind:              kindFilter,
 				Source:            sourceFilter,


### PR DESCRIPTION
## Summary

`evoila/meho` `main` was red on two CI jobs, blocking a clean v0.2.1 tag. This is a direct, un-ticketed CI-unbreak: two deterministic regressions that landed on `main` (the DCO admin-bypass is what let them through — this PR ships a real `Signed-off-by` trailer so it passes DCO without a bypass, deliberately). Two separate commits, one per regression.

### Regression 1 — Go (`golangci-lint` job), trivial hygiene

The `Go (golangci-lint + go test)` job (golangci-lint **v1.64.8** / Go **1.23**, `run --path-prefix=cli`) failed on three findings introduced by **#656 (G9.2-T6)** and **#667 (G9.2-T8)**:

- `cli/internal/cmd/topology/list_edges.go:85` — `revive` `unused-parameter`: the cobra `RunE` closure declared `args` but never used it. Renamed `args` → `_` (matches the package convention: siblings that don't consume positional args use `_`; the ones that do use `args[0]`).
- `cli/internal/cmd/topology/bulk_import.go:89` — `gofmt`: doc-comment + struct-tag alignment.
- `cli/internal/cmd/topology/e2e_test.go:403` — `gofmt`: struct-literal field alignment.

Formatting + the one parameter rename only — **no behavioral change**.

### Regression 2 — Python (`Python (integration testcontainers)` job): k8s e2e meta-tool target contract (#580)

`backend/tests/integration/test_connectors_k8s_e2e.py::test_call_operation_about_dispatches_through_meta_tool` failed deterministically:

```
AttributeError: '_K3sTarget' object has no attribute 'get'
  at backend/src/meho_backplane/operations/meta_tools.py:455
```

**Root cause:** since **#438 (G0.6-T8)** the `call_operation` meta-tool requires `arguments["target"]` to be a dict `{"name": <str>}` and resolves it through the tenant-scoped `resolve_target()` (`backend/src/meho_backplane/targets/resolver.py`) before dispatch. That name→`resolve_target` step is the meta-tool's tenant-isolation boundary. The test (last touched by **#580, G3.2-T6**) passed the raw duck-typed `_K3sTarget` **object** as `"target"`; `meta_tools.py:455` does `target_arg.get("name")` on it → `AttributeError`. The `k8s_e2e` fixture preseeded the dispatcher's connector-instance cache but never inserted a `Target` ORM row.

**Fix (option A — test/fixture only):** the `k8s_e2e` fixture now seeds a tenant-scoped `Target` ORM row (`name="k3s-e2e"`, `tenant_id` = the `_make_operator` default tenant, `product="k8s"`, `fingerprint={"version":"1.32.0"}`, host/port/secret_ref mirroring the `_K3sTarget` stub) and deletes it on teardown (`pg_engine` does not truncate the soft-FK `targets` table). The meta-tool test now passes `"target": {"name": "k3s-e2e"}` and pins its operator to the same tenant so `resolve_target` succeeds; the dispatcher still resolves `KubernetesConnector` via the preseeded instance cache, so host/port never reach a real cluster. The other suites keep calling `dispatch()` directly with the duck-typed object — that low-level path legitimately accepts it; only the meta-tool enforces the name→`resolve_target` contract.

**Option B was NOT used.** `meta_tools.py` was not weakened to accept an already-resolved object or `getattr` off non-dicts — that would bypass the tenant-isolation boundary and is a security regression. The handler contract is correct; the test was wrong.

## Test plan

- **Go** — verified with the **CI-exact** golangci-lint **v1.64.8** built on Go 1.23, `run --path-prefix=cli`: clean (exit 0) with the fix; reproduces exactly the three reported findings on clean `main`. `gofmt -l` empty. `go build ./...` clean. `go test ./...` all green (incl. the `topology` package).
- **Python** — `uv run ruff check src/ tests/`, `uv run ruff format --check src/ tests/`, `uv run mypy src/` all clean (no `src/` changes — confirming option B was not taken).
- **k3d integration test** — needs Docker + k3d; CI runs it in the `Python (integration testcontainers)` job. This is the accepted verification path for that test (not locally runnable in the sandbox by design). This environment happened to have Docker available, so the full round-trip (fixture seed → `resolve_target` → dispatcher → live k3s) was exercised end-to-end and **passes**; on clean `main` the full file is `2 failed`, with the fix it is `1 failed` and the previously-targeted test now passes.

### Note: a separate pre-existing flake (out of scope)

`test_dispatch_logs_against_running_pod` (a `k8s.logs` / pod-log timing race on the **direct-`dispatch`** path, unrelated to the meta-tool target contract) is **also red on clean `main`** in the full-file run and is **not** caused by this change (it passes in isolation; it's a freshly-booted-k3s log-availability race). It is not one of the two assigned CI regressions and is intentionally not touched here (surgical-changes discipline). Flagging it for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Kubernetes integration testing infrastructure with improved test fixtures to more thoroughly exercise target resolution and verify proper tenant isolation behavior.

* **Refactor**
  * Removed unused code parameters from command handlers.
  * Improved code formatting and field alignment for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->