### PR TITLE
fix(test): deterministic running-pod selection in k8s e2e logs test (#580)

### DIFF
--- a/backend/tests/integration/test_connectors_k8s_e2e.py
+++ b/backend/tests/integration/test_connectors_k8s_e2e.py
@@ -65,8 +65,10 @@ in the ``Python (integration testcontainers)`` job.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import os
+import time
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -770,19 +772,61 @@ async def test_dispatch_event_list_against_k3s(k8s_e2e: _K3sTarget) -> None:
 
 @pytest.mark.asyncio
 async def test_dispatch_logs_against_running_pod(k8s_e2e: _K3sTarget) -> None:
-    """``k8s.logs`` against any kube-system pod returns a (possibly empty) lines list."""
+    """``k8s.logs`` against a Running kube-system pod with a Ready container
+    returns a (possibly empty) lines list.
+
+    Selecting ``rows[0]`` blindly is non-deterministic on a freshly-booted
+    k3s container: the first pod is frequently still Pending /
+    ContainerCreating, and ``k8s.logs`` then raises a generic kube
+    ``ApiException`` ("container ... is waiting to start: ContainerCreating")
+    which is neither the ok branch nor the structured
+    multi-container-ambiguity branch this test asserts. k3s always brings
+    up coredns / metrics-server / local-path-provisioner, but they take
+    time to become Ready after the container boots, so poll ``k8s.pod.list``
+    (through the same dispatch path, registered op only -- the row already
+    carries ``status`` (phase) and ``ready`` ("<ready>/<total>")) until a
+    pod is Running with every container Ready (and at least one container).
+    """
     operator = _make_operator(sub="op-logs-list")
-    listing = await dispatch(
-        operator=operator,
-        connector_id="k8s-1.x",
-        op_id="k8s.pod.list",
-        target=k8s_e2e,
-        params={"namespace": "kube-system"},
-    )
-    assert listing.status == "ok"
-    if not listing.result["rows"]:
-        pytest.skip("k3s shipped no kube-system pods to pull logs from")
-    pod_name = listing.result["rows"][0]["name"]
+
+    def _running_ready_pod(rows: list[dict[str, Any]]) -> str | None:
+        """First pod that is phase==Running with all containers Ready
+        (ready column ``X/Y`` where ``X == Y`` and ``X >= 1``)."""
+        for row in rows:
+            if row.get("status") != "Running":
+                continue
+            ready = row.get("ready")
+            if not isinstance(ready, str) or "/" not in ready:
+                continue
+            ready_n, _, total_n = ready.partition("/")
+            if not (ready_n.isdigit() and total_n.isdigit()):
+                continue
+            if int(ready_n) >= 1 and int(ready_n) == int(total_n):
+                name = row.get("name")
+                if isinstance(name, str) and name:
+                    return name
+        return None
+
+    pod_name: str | None = None
+    deadline = time.monotonic() + 90.0
+    while True:
+        listing = await dispatch(
+            operator=operator,
+            connector_id="k8s-1.x",
+            op_id="k8s.pod.list",
+            target=k8s_e2e,
+            params={"namespace": "kube-system"},
+        )
+        assert listing.status == "ok", listing.error
+        pod_name = _running_ready_pod(listing.result["rows"])
+        if pod_name is not None:
+            break
+        if time.monotonic() >= deadline:
+            pytest.skip(
+                "no Running kube-system pod with a Ready container appeared "
+                "within 90s -- cannot deterministically exercise k8s.logs"
+            )
+        await asyncio.sleep(3.0)
 
     operator2 = _make_operator(sub="op-logs")
     result = await dispatch(


### PR DESCRIPTION
## Summary

`backend/tests/integration/test_connectors_k8s_e2e.py::test_dispatch_logs_against_running_pod` flakes (and now fails deterministically on `main` after #671) because it selects the **first** pod from `k8s.pod.list` against `kube-system` blindly and calls `k8s.logs` on it. On a freshly-booted k3s container that first pod is frequently still `Pending` / `ContainerCreating`, so `k8s.logs` raises a generic kube `ApiException` ("container … is waiting to start: ContainerCreating") wrapped by the handler as `connector_error: ApiException` — which is neither the `status=="ok"` branch nor the structured `MultiContainerAmbiguityError` (`"container"`/`"ambig"`) branch the test asserts. The assertion `assert "container" in result.error or "ambig" in result.error.lower()` then fails on `result.error == 'connector_error: ApiException'`.

This makes the test name ("against_running_pod") a lie — it never ensured the pod was actually running with a ready container.

## Root cause

- `backend/tests/integration/test_connectors_k8s_e2e.py:772` (`test_dispatch_logs_against_running_pod`) — `pod_name = listing.result["rows"][0]["name"]` picks the first pod with no readiness check.
- Latent since the test was introduced (G3.2 **#580**, same file). `pytest -x` short-circuited on an earlier failure until **#671** fixed the meta-tool target-contract regression and let CI reach this test, unmasking the flake.

## Fix approach

Poll `k8s.pod.list` through the **same `dispatch()` path** (registered op only — the row already carries `status` (phase string) and `ready` ("`<ready>/<total>`"), per `backend/src/meho_backplane/connectors/kubernetes/ops_workload.py:249` `pod_row`) until a `kube-system` pod is `phase == "Running"` with **every** container Ready and at least one container. Bounded to 90 s with a 3 s sleep between attempts; `pytest.skip` only if no ready pod appears in time, matching the existing skip style in this file. k3s always brings up coredns / metrics-server / local-path-provisioner, so a ready pod deterministically appears well within the budget. No new production op, no raw kube-client reach-around.

## FORBIDDEN alternative — explicitly NOT taken

The negative-path assertion was **not** weakened. A correctly-selected Running pod still lands in exactly one of the two pre-existing branches (ok payload + audit row, or the structured multi-container-ambiguity error), and a bare `ApiException` / `connector_error: ApiException` is still **not** accepted — the test still fails loudly if `k8s.logs` genuinely errors against a healthy running pod. Both post-`k8s.logs` branches are untouched.

No production code under `backend/src/meho_backplane/` was touched; the handler erroring on a not-ready pod is correct behavior. Diff is one test file (+56 / −12).

## Verification

- `ruff check` + `ruff format --check` on the touched test path: clean.
- CI's mypy gate is `uv run mypy src/` (`[tool.mypy] files = ["src"]`) — it does not analyze test files, and no `src/` file changed; `uv run mypy src/` is clean (`no issues found in 180 source files`).
- This sandbox happened to have Docker available, so the k3s testcontainer actually ran: the target test and all 17 tests in the file **pass**. The k3d integration job is still the authoritative CI-verified gate; the change is reasoned to be deterministic because k3s' default control-plane pods reliably reach Running+Ready well inside the 90 s budget, and the selection predicate only accepts `Running` + all-containers-Ready (`X/Y`, `X==Y`, `X>=1`).
- Scope is limited to this one test's pod-selection; the other tests in the file are unchanged and still pass.

Refs #580, #671. Un-ticketed CI-unbreak fix — no `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of Kubernetes integration tests by enhancing pod selection logic in E2E test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->