### PR TITLE
feat(connectors): G3.4-T5 meho bind9 CLI verbs + E2E acceptance + onboarding doc

### DIFF
--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -67,24 +67,38 @@ from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
-from meho_backplane.connectors.bind9 import (
+# meho_backplane is the first-party editable install in this monorepo and
+# ships no py.typed marker yet; the `import-untyped` suppressions below
+# are the same shape used elsewhere in tests/integration/ for first-party
+# imports. The mypy CI gate is restricted to src/, so test files are not
+# routinely type-checked — but anyone running `mypy --strict` on this
+# file should see a clean run.
+from meho_backplane.connectors.bind9 import (  # type: ignore[import-untyped]
     BIND9_OPS,
     Bind9Connector,
     register_bind9_typed_operations,
 )
-from meho_backplane.connectors.registry import (
+from meho_backplane.connectors.registry import (  # type: ignore[import-untyped]
     clear_registry,
     register_connector_v2,
 )
-from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AuditLog
+from meho_backplane.db.engine import get_sessionmaker  # type: ignore[import-untyped]
+from meho_backplane.db.models import AuditLog  # type: ignore[import-untyped]
 from meho_backplane.db.models import Target as TargetORM
-from meho_backplane.operations import dispatch, reset_dispatcher_caches
-from meho_backplane.operations.dispatcher import set_default_reducer
-from meho_backplane.operations.meta_tools import call_operation, search_operations
-from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.operations import (  # type: ignore[import-untyped]
+    dispatch,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations.dispatcher import (  # type: ignore[import-untyped]
+    set_default_reducer,
+)
+from meho_backplane.operations.meta_tools import (  # type: ignore[import-untyped]
+    call_operation,
+    search_operations,
+)
+from meho_backplane.operations.reducer import PassThroughReducer  # type: ignore[import-untyped]
 from tests.test_operations_dispatcher import _make_operator
 
 # ---------------------------------------------------------------------------
@@ -144,12 +158,21 @@ class _Bind9Target:
     ``port`` + ``secret_ref``. Mirrors the
     :class:`_Bind9Target` stub in ``test_connectors_bind9_container.py``
     plus the dispatcher-resolver fields.
+
+    ``secret_ref`` is a Vault-path string here — matching the
+    canonical column shape (`backplane.db.models.Target.secret_ref` is
+    ``Text``, a vault path that ``hvac`` resolves into SSH credentials
+    on production). The container's real SSH credentials never live
+    on the target stub; they ride a connector-instance preseed (see
+    :class:`_SeededBind9Connector` below), the same single-seam swap
+    the K8s E2E harness (`tests/integration/test_connectors_k8s_e2e.py`)
+    uses for its ``kubeconfig_loader``.
     """
 
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    secret_ref: str
     product: str = "bind9"
     auth_model: str = "shared_service_account"
     raw_jwt: str | None = "<dev-test-jwt>"
@@ -168,6 +191,29 @@ class _Bind9Target:
             version = "9.18.0"
 
         self.fingerprint = _FP()
+
+
+@dataclass(frozen=True)
+class _ContainerCreds:
+    """SSH credentials the bind9 testcontainer is provisioned with.
+
+    Lives outside :class:`_Bind9Target` so the target stub matches the
+    production ``Target.secret_ref: str`` (Vault path) shape exactly;
+    the test wiring injects these creds into the dispatcher's
+    per-class connector instance and into the sudo-password resolver
+    helpers (see :func:`bind9_e2e`).
+    """
+
+    username: str
+    password: str
+
+
+# Canonical Vault-path string the seeded Target row carries. The
+# preseeded :class:`_SeededBind9Connector` short-circuits the
+# Vault resolve to the testcontainer's real credentials, so the
+# path itself is never resolved against a Vault server. Mirrors the
+# K8s E2E harness's ``"kv/data/k8s/k3s-e2e"`` placeholder.
+_BIND9_VAULT_PATH: str = "kv/dev/bind9/e2e"
 
 
 # ---------------------------------------------------------------------------
@@ -229,21 +275,35 @@ _DOCKERFILE: str = textwrap.dedent(
 
 
 @pytest.fixture(scope="module")
-def bind9_container_target() -> Iterator[_Bind9Target]:
-    """Build the bind9 image, start the container, yield a target stub.
+def bind9_container_target() -> Iterator[tuple[_Bind9Target, _ContainerCreds]]:
+    """Build the bind9 image, start the container, yield (target, creds).
 
     Mirrors the existing ``test_connectors_bind9_container.py`` fixture
     so the container boot path is identical — one harness boots one
     container, not two — but yields the augmented ``_Bind9Target`` shape
-    the dispatcher's resolver expects (``.product`` + ``.fingerprint``).
+    the dispatcher's resolver expects (``.product`` + ``.fingerprint``)
+    paired with the testcontainer's SSH credentials. The credentials
+    travel separately from the target stub because the target stub
+    matches the production ``Target.secret_ref: str`` column shape (a
+    Vault path); the credentials are injected into the dispatcher's
+    connector-instance cache by :func:`bind9_e2e`.
+
+    Container-scope: module. The per-test :func:`bind9_e2e` fixture
+    snapshots ``/etc/bind/`` before yield and restores it on teardown,
+    so write-op state (`record.add` / `config.apply_*`) cannot leak
+    across tests. Module-scope keeps the ~10 s container boot off the
+    per-test path while the snapshot/restore still gives every test a
+    pristine ``/etc/bind/``.
     """
     if not DOCKER_AVAILABLE:
         pytest.skip(SKIP_REASON)
 
     try:
-        from testcontainers.core.container import DockerContainer
-        from testcontainers.core.image import DockerImage
-        from testcontainers.core.waiting_utils import wait_for_logs
+        from testcontainers.core.container import DockerContainer  # type: ignore[import-untyped]
+        from testcontainers.core.image import DockerImage  # type: ignore[import-untyped]
+        from testcontainers.core.waiting_utils import (  # type: ignore[import-untyped]
+            wait_for_logs,
+        )
     except ImportError as exc:  # pragma: no cover -- testcontainers ships these in 4.x
         pytest.skip(f"testcontainers missing module: {exc}")
 
@@ -268,11 +328,36 @@ def bind9_container_target() -> Iterator[_Bind9Target]:
                 name=_TARGET_NAME,
                 host=host,
                 port=port,
-                secret_ref={"username": "root", "password": "testpw"},  # NOSONAR -- container-local
+                secret_ref=_BIND9_VAULT_PATH,
             )
-            yield target
+            # NOSONAR -- container-local credentials, never leave the testcontainer.
+            creds = _ContainerCreds(username="root", password="testpw")
+            yield target, creds
         finally:
             container.stop()
+
+
+class _SeededBind9Connector(Bind9Connector):  # type: ignore[misc]
+    """Bind9Connector preseeded with the testcontainer's SSH credentials.
+
+    Production :class:`Bind9Connector` (via its
+    :class:`~meho_backplane.connectors.adapters.ssh.SshConnector`
+    base) reads SSH credentials from ``target.secret_ref`` as a dict.
+    The production ``Target.secret_ref`` column is ``Text`` (a Vault
+    path); production resolves that path through ``hvac`` before
+    ``_auth_config`` is reached. Wiring the full Vault path in the
+    sandbox is out of scope for this harness, so this subclass
+    short-circuits :meth:`_auth_config` to return the
+    testcontainer's credentials directly. Single-seam swap; mirrors
+    the K8s E2E harness's ``kubeconfig_loader`` injection.
+    """
+
+    def __init__(self, *, creds: _ContainerCreds) -> None:
+        super().__init__()
+        self._test_creds = creds
+
+    async def _auth_config(self, target: Any) -> dict[str, Any]:
+        return {"username": self._test_creds.username, "password": self._test_creds.password}
 
 
 # ---------------------------------------------------------------------------
@@ -290,11 +375,103 @@ def stub_embedding_service() -> AsyncMock:
     return service
 
 
+async def _snapshot_etc_bind(host: str, port: int, creds: _ContainerCreds) -> bytes:
+    """Tar /etc/bind/ over SSH and return the archive bytes.
+
+    Runs on the testcontainer's SSH endpoint; the container's root
+    user has full read on /etc/bind/ (the testcontainer is provisioned
+    with ``NOPASSWD: ALL`` sudo and the container runs as root by
+    default). The archive is held in memory so the per-test fixture's
+    teardown can restore /etc/bind/ byte-identical, defeating
+    write-op state bleed across tests.
+    """
+    import asyncssh  # local import so non-Docker test runs don't pay the import cost
+
+    async with asyncssh.connect(
+        host,
+        port=port,
+        username=creds.username,
+        password=creds.password,
+        known_hosts=None,
+    ) as conn:
+        result = await conn.run("tar -C / -cf - etc/bind", encoding=None, check=True)
+    stdout = result.stdout
+    if not isinstance(stdout, (bytes, bytearray)):
+        raise RuntimeError(
+            f"unexpected snapshot stdout type {type(stdout).__name__}; expected bytes"
+        )
+    return bytes(stdout)
+
+
+async def _restore_etc_bind(host: str, port: int, creds: _ContainerCreds, snapshot: bytes) -> None:
+    """Restore /etc/bind/ from the tar archive captured by :func:`_snapshot_etc_bind`.
+
+    Wipes and extracts in one bash invocation under sudo (the
+    testcontainer's `root ALL=(ALL) NOPASSWD: ALL` sudoers line keeps
+    this hands-off). Reloads named so any zone-content change from the
+    test under-test is washed out before the next test starts.
+    """
+    import asyncssh
+
+    async with asyncssh.connect(
+        host,
+        port=port,
+        username=creds.username,
+        password=creds.password,
+        known_hosts=None,
+    ) as conn:
+        # `tar -xf -` reads the archive from stdin. The wipe is
+        # explicit (rm -rf /etc/bind/*) so any files added by the
+        # test that the snapshot didn't carry are removed before the
+        # restore lays down the original tree.
+        process = await conn.create_process(
+            "sudo -S -p '' bash -c 'rm -rf /etc/bind/* && tar -C / -xf -'",
+            stdin=asyncssh.PIPE,
+            stdout=asyncssh.PIPE,
+            stderr=asyncssh.PIPE,
+            encoding=None,
+        )
+        # The sudoers line is NOPASSWD, but sudo -S still consumes
+        # a leading newline as the "password" before reading the
+        # archive bytes off stdin.
+        process.stdin.write(b"\n")
+        process.stdin.write(snapshot)
+        process.stdin.write_eof()
+        await process.wait()
+        if process.exit_status not in (0, None):
+            stderr = await process.stderr.read()
+            raise RuntimeError(
+                f"restore /etc/bind/ failed (exit={process.exit_status}): {stderr!r}"
+            )
+        # Reload named so the restored zones take effect; -ENOENT here
+        # is tolerable (rndc may not see the apex on a fresh restore
+        # under some kernels) and the next test's named-checkconf in
+        # the atomic-apply path will refresh anyway.
+        await conn.run("sudo -n rndc reload", check=False)
+
+
+@pytest.fixture
+def bind9_creds(
+    bind9_container_target: tuple[_Bind9Target, _ContainerCreds],
+) -> _ContainerCreds:
+    """Expose the testcontainer's SSH credentials to per-test wiring.
+
+    The rollback-acceptance tests build their own production-shape
+    :class:`Bind9Connector` to drive ``connector.bind9_config_apply_*``
+    directly (no dispatcher path); they need the credentials to
+    construct a :class:`_SeededBind9Connector` whose ``_auth_config``
+    short-circuits the Vault read.
+    """
+    _target, creds = bind9_container_target
+    return creds
+
+
 @pytest.fixture
 async def bind9_e2e(
-    bind9_container_target: _Bind9Target,
+    bind9_container_target: tuple[_Bind9Target, _ContainerCreds],
     pg_engine: None,
     stub_embedding_service: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> AsyncIterator[_Bind9Target]:
     """Wire the bind9 connector at the live container + real PG audit store.
 
@@ -310,21 +487,34 @@ async def bind9_e2e(
     4. Run :func:`register_bind9_typed_operations` to UPSERT every
        op into ``endpoint_descriptor``.
     5. Insert a tenant-scoped :class:`~meho_backplane.db.models.Target`
-       ORM row so the ``call_operation`` meta-tool path — which
-       resolves ``arguments["target"]={"name": ...}`` through the
-       tenant-scoped :func:`resolve_target` — exercises the real
-       contract.
-
-    No connector-instance preseed: the bind9 connector reads SSH
-    credentials directly from ``target.secret_ref``, so the seeded
-    Target row's secret_ref is enough — no kubeconfig-style loader
-    seam needed.
+       ORM row (``secret_ref=_BIND9_VAULT_PATH`` — the string shape
+       the ``Target.secret_ref: Text`` column actually accepts) so the
+       ``call_operation`` meta-tool path — which resolves
+       ``arguments["target"]={"name": ...}`` through the tenant-scoped
+       :func:`resolve_target` — exercises the real contract.
+    6. Preseed the dispatcher's per-class connector instance cache with
+       a :class:`_SeededBind9Connector` carrying the testcontainer's
+       SSH credentials. Single-seam swap that mirrors
+       ``test_connectors_k8s_e2e.py``'s ``kubeconfig_loader``
+       injection; nothing in the production substrate changes.
+    7. Monkey-patch the module-level
+       :func:`~meho_backplane.connectors.bind9.ops_config._sudo_password_for_target`
+       and
+       :func:`~meho_backplane.connectors.bind9.ops_record._sudo_password_from_target`
+       helpers to return the testcontainer's password. Those helpers
+       are free functions called by the typed-op handlers (they read
+       ``target.secret_ref`` as a dict, which it no longer is), so
+       a target-aware short-circuit here is the cleanest seam.
+    8. Snapshot ``/etc/bind/`` over SSH so write-op tests
+       (`record.add` / `record.remove` / `config.apply_*`) can be
+       rolled back to a known-good tree on teardown, eliminating
+       cross-test state bleed.
 
     The ``targets`` table is a soft-FK column the ``pg_engine`` fixture
     does not truncate, so the row is deleted on teardown to keep
     per-test isolation.
     """
-    target = bind9_container_target
+    target, creds = bind9_container_target
 
     reset_dispatcher_caches()
     set_default_reducer(PassThroughReducer())
@@ -335,6 +525,29 @@ async def bind9_e2e(
         impl_id="bind9-ssh",
         cls=Bind9Connector,
     )
+
+    # Phase 6 — preseed the connector instance the dispatcher resolves
+    # to. The cache is keyed by the registered class (Bind9Connector),
+    # not by the concrete subclass; preseeding the subclass instance
+    # under the Bind9Connector key is the supported test pattern.
+    from meho_backplane.operations import _handler_resolve as _hr
+
+    seeded_connector = _SeededBind9Connector(creds=creds)
+    _hr._CONNECTOR_INSTANCE_CACHE[Bind9Connector] = seeded_connector
+
+    # Phase 7 — short-circuit the sudo-password resolvers. These are
+    # free functions on the ops_config / ops_record modules; the
+    # production resolver reads `target.secret_ref` as a dict, which
+    # it no longer is. Returning the container's password directly
+    # is the cleanest seam.
+    from meho_backplane.connectors.bind9 import ops_config as _ops_config
+    from meho_backplane.connectors.bind9 import ops_record as _ops_record
+
+    def _container_sudo_password(_target: Any) -> str:
+        return creds.password
+
+    monkeypatch.setattr(_ops_config, "_sudo_password_for_target", _container_sudo_password)
+    monkeypatch.setattr(_ops_record, "_sudo_password_from_target", _container_sudo_password)
 
     await register_bind9_typed_operations(embedding_service=stub_embedding_service)
 
@@ -351,9 +564,12 @@ async def bind9_e2e(
                 host=target.host,
                 port=target.port,
                 fqdn=None,
-                # secret_ref on the ORM row is the SSH credential dict;
-                # the bind9 SshConnector reads it directly via
-                # ``_auth_config``.
+                # The Target.secret_ref column is Text — a Vault path
+                # string, not a credentials dict. The seeded connector
+                # instance (phase 6) and the monkey-patched sudo helpers
+                # (phase 7) collectively replace the production
+                # Vault-resolve so the string here is never resolved
+                # against an actual Vault server.
                 secret_ref=target.secret_ref,
                 auth_model="shared_service_account",
                 vpn_required=False,
@@ -366,20 +582,27 @@ async def bind9_e2e(
             )
         )
 
+    # Phase 8 — snapshot /etc/bind/ so per-test write-op state is
+    # rolled back on teardown. The snapshot is held in memory (small
+    # — the test image's /etc/bind/ is <100 KB) so teardown is a
+    # single SSH round-trip.
+    assert target.port is not None, "container fixture failed to expose port 22"
+    snapshot = await _snapshot_etc_bind(target.host, target.port, creds)
+
     try:
         yield target
     finally:
         # Closing every Bind9Connector instance the dispatcher's
         # per-class cache may have built. Tolerant of double-close.
-        from meho_backplane.operations import _handler_resolve as _hr
-
         with contextlib.suppress(Exception):
             cached = _hr._CONNECTOR_INSTANCE_CACHE.get(Bind9Connector)
             if cached is not None:
                 await cached.aclose()
+        # Restore /etc/bind/ from the pre-test snapshot so write-op
+        # state from this test does not bleed into the next one.
+        with contextlib.suppress(Exception):
+            await _restore_etc_bind(target.host, target.port, creds, snapshot)
         # Delete the seeded Target row.
-        from sqlalchemy import delete
-
         with contextlib.suppress(Exception):
             async with sessionmaker() as session, session.begin():
                 await session.execute(
@@ -910,11 +1133,14 @@ async def test_agent_meta_tool_flow_search_then_call_record_add(
 @pytest.mark.asyncio
 async def test_atomic_rollback_on_invalid_apply_views_leaves_tree_unchanged(
     bind9_e2e: _Bind9Target,
+    bind9_creds: _ContainerCreds,
 ) -> None:
     """An invalid apply_views payload rolls back to the pre-op snapshot."""
-    from meho_backplane.connectors.bind9._atomic import AtomicApplyError
+    from meho_backplane.connectors.bind9._atomic import (  # type: ignore[import-untyped]
+        AtomicApplyError,
+    )
 
-    connector = Bind9Connector()
+    connector = _SeededBind9Connector(creds=bind9_creds)
     try:
         before = await _checksum_bind_tree(connector, bind9_e2e)
         with pytest.raises(AtomicApplyError) as exc_info:
@@ -941,11 +1167,12 @@ async def test_atomic_rollback_on_invalid_apply_views_leaves_tree_unchanged(
 @pytest.mark.asyncio
 async def test_atomic_rollback_on_invalid_apply_file_leaves_tree_unchanged(
     bind9_e2e: _Bind9Target,
+    bind9_creds: _ContainerCreds,
 ) -> None:
     """An invalid apply_file fragment rolls back to the pre-op snapshot."""
     from meho_backplane.connectors.bind9._atomic import AtomicApplyError
 
-    connector = Bind9Connector()
+    connector = _SeededBind9Connector(creds=bind9_creds)
     try:
         before = await _checksum_bind_tree(connector, bind9_e2e)
         with pytest.raises(AtomicApplyError) as exc_info:
@@ -969,13 +1196,16 @@ async def test_atomic_rollback_on_invalid_apply_file_leaves_tree_unchanged(
 @pytest.mark.asyncio
 async def test_atomic_rollback_on_unresolvable_record_add_leaves_tree_unchanged(
     bind9_e2e: _Bind9Target,
+    bind9_creds: _ContainerCreds,
 ) -> None:
     """An FQDN outside every served zone refuses pre-stage and the tree
     is byte-identical.
     """
-    from meho_backplane.connectors.bind9.ops_record import ZoneResolutionError
+    from meho_backplane.connectors.bind9.ops_record import (  # type: ignore[import-untyped]
+        ZoneResolutionError,
+    )
 
-    connector = Bind9Connector()
+    connector = _SeededBind9Connector(creds=bind9_creds)
     try:
         before = await _checksum_bind_tree(connector, bind9_e2e)
         with pytest.raises(ZoneResolutionError):
@@ -1004,22 +1234,47 @@ async def test_atomic_rollback_on_unresolvable_record_add_leaves_tree_unchanged(
 
 
 def test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree() -> None:
-    """No file under ``connectors/`` invokes ``sudo`` outside the safe primitive.
+    """No file under ``connectors/`` builds a ``sudo`` argv outside the safe primitive.
 
     Walks every ``*.py`` under
-    ``backend/src/meho_backplane/connectors/`` looking for any ``sudo``
-    literal in source. The only files that may carry one are
-    :mod:`~meho_backplane.connectors.bind9.connector` (the
-    ``_remote_bash_with_sudo`` helper itself, including its docstring
-    references) and :mod:`~meho_backplane.connectors.bind9._atomic`
-    (the atomic-apply primitive that routes its writes through the
-    helper).
+    ``backend/src/meho_backplane/connectors/`` looking for any string
+    literal whose first token is ``sudo`` — the shape of a sudo argv,
+    whether it appears as the remote command of an SSH ``run`` call
+    (e.g. ``"sudo -S -p '' bash -s"``) or as the first element of a
+    Python list / tuple argv (e.g. ``["sudo", "-S", ...]``,
+    ``("sudo",)``).
 
-    A regression — a sibling connector hand-rolling a ``sudo -S`` or
-    embedding a password in a remote argv — surfaces here as a clear
-    "offender" list pointing at the file that re-introduced the
-    mis-ordered-payload shape behind the 2026-05-04 / 2026-05-05
-    credential leaks (Initiative #367 WI1).
+    Two files are whitelisted by absolute path because they own the
+    safe-sudo primitive:
+
+    * :mod:`~meho_backplane.connectors.bind9.connector` — the
+      ``_remote_bash_with_sudo`` helper, the single legitimate
+      sudo-argv site (``_SUDO_BASH_REMOTE_CMD``).
+    * :mod:`~meho_backplane.connectors.bind9._atomic` — the
+      atomic-apply primitive that funnels its writes through the
+      helper. It carries no sudo argv of its own (it streams a bash
+      script body to ``_remote_bash_with_sudo``); whitelisting it keeps
+      the contract explicit so a future refactor that hoists a sudo
+      argv there is still a deliberate, reviewed step.
+
+    Every sibling connector (and every other bind9 module —
+    ``ops.py`` / ``ops_record.py`` / ``ops_config.py`` /
+    ``ops_zone.py``) is held to the invariant; a regression — a
+    re-introduced ``["sudo", "-S", ...]`` somewhere — surfaces here
+    as a clear offender list pointing at the file that brought back
+    the mis-ordered-payload shape behind the 2026-05-04 /
+    2026-05-05 credential leaks (Initiative #367 WI1).
+
+    Detection shape — ``(?<=['"])sudo(?=['"\\s\\\\])`` — matches
+    ``sudo`` only when immediately preceded by a quote AND followed
+    by a quote / whitespace / backslash. That covers
+    ``"sudo"`` (list-form element), ``'sudo'``, ``"sudo -S ..."``,
+    and ``"sudo\\n"``, while rejecting prose mentions like
+    ``"a sudo credential"`` or the identifier ``sudo_password``.
+    The regex's strictness is *load-bearing*: a looser ``\\bsudo\\b``
+    would false-positive on every docstring mention; a stricter
+    ``\\bsudo\\s+`` would miss the list-form
+    ``["sudo", "-S", ...]`` shape.
 
     This is the same invariant the unit test in
     ``tests/test_connectors_bind9.py`` already asserts; restating it
@@ -1033,7 +1288,23 @@ def test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree() ->
     assert connectors_root.is_dir(), (
         f"connectors root not found at {connectors_root}; test layout drifted"
     )
-    allowed_files = set((connectors_root / "bind9").glob("*.py"))
+    # Narrow whitelist: only the two files that own the safe-sudo
+    # primitive. Everything else under bind9/ (ops_*.py) is held to
+    # the invariant; they reference sudo only via docstrings / error
+    # messages / the ``"sudo_password"`` dict key, all of which the
+    # detection regex below correctly ignores.
+    allowed_files = {
+        connectors_root / "bind9" / "connector.py",
+        connectors_root / "bind9" / "_atomic.py",
+    }
+    # Match `sudo` only as the first token of a string literal — the
+    # universal shape of sudo argv construction, whether it's
+    # ``"sudo -S -p '' bash -s"`` (single-string remote command) or
+    # the first element of a list/tuple argv (``["sudo", "-S", ...]``,
+    # ``("sudo",)``). Rejects prose mentions ("a sudo credential"),
+    # docstring narrative ("the sudo password reuses..."), and the
+    # identifier ``sudo_password`` (no preceding quote).
+    sudo_argv_re = re.compile(r"""(?<=["'])sudo(?=["'\s\\])""")
     offenders: list[str] = []
     for path in connectors_root.rglob("*.py"):
         if path in allowed_files:
@@ -1042,11 +1313,11 @@ def test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree() ->
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        # Match `sudo ` followed by an argv token (defence vs benign
-        # mentions in docstrings of unrelated connectors).
-        if re.search(r"\bsudo\s+[\w-]", text):
+        if sudo_argv_re.search(text):
             offenders.append(str(path.relative_to(connectors_root)))
     assert not offenders, (
-        "Found `sudo ` references outside the bind9 safe-primitive surface:\n"
+        "Found sudo-argv construction outside the bind9 safe-primitive surface "
+        "(connector.py + _atomic.py). Every match below re-introduces the "
+        "mis-ordered-payload shape that leaked credentials twice in 2026-05:\n"
         + "\n".join(offenders)
     )

--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -1,0 +1,1052 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.4-T5 — bind9 meta-tool E2E acceptance against a containerised bind9.
+
+Extends the existing bind9 testcontainer fixture
+(``tests/integration/test_connectors_bind9_container.py``) to drive
+every registered op through the **agent meta-tool flow**
+(``search_operations`` + ``call_operation``) against the real G0.6
+dispatcher with a Postgres-backed ``endpoint_descriptor`` and a
+Postgres-backed ``audit_log``.
+
+What this harness proves (Task #591 DoD)
+=========================================
+
+* All 11 bind9 ops registered into ``endpoint_descriptor`` via
+  :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+  by ``Bind9Connector.register_operations()``. The full set is reachable
+  via ``search_operations(connector_id="bind9-ssh-9.x", query=...)``;
+  the meta-tool returns hits covering every registered op.
+* Every op dispatches through :func:`call_operation` (the agent-facing
+  surface; the CLI alias verb tree #591 ships is a separate operator
+  surface that goes through the *same* dispatch route via
+  ``POST /api/v1/operations/call`` — the unit tests in
+  ``cli/internal/cmd/bind9/bind9_test.go`` pin the CLI→dispatch wire
+  shape; this harness pins the dispatch→handler→bind9 round-trip).
+* Each successful call writes a synchronous ``audit_log`` row (CLAUDE.md
+  postulate 7) with the canonical
+  ``(product="bind9", version="9.x", impl_id="bind9-ssh")`` triple in
+  the payload.
+* Write ops (record.add / record.remove / config.apply_*) carry
+  ``state_before`` / ``state_after`` on the audit row payload — the
+  before/after capture the atomic-apply primitive emits.
+* Atomic-apply rollback: invalid apply_views, invalid apply_file, and
+  unresolvable record.add each leave ``/etc/bind/`` byte-identical to
+  the pre-op snapshot (SOA-normalising checksum).
+* Codebase-wide safety assertion: ``_remote_bash_with_sudo()`` is the
+  only sudo-invoking construction under
+  ``backend/src/meho_backplane/connectors/``. Encoded as an
+  always-runs (no Docker required) static-import check so the invariant
+  holds in the sandbox sweep.
+
+Skip conditions
+================
+
+Docker socket missing — same heuristic the rest of
+``tests/integration/`` uses; agent sandboxes without Docker skip,
+CI runners with Docker provisioned run. The static-import safety
+assertion runs unconditionally because it walks files on disk.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import shlex
+import tempfile
+import textwrap
+import time
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.connectors.bind9 import (
+    BIND9_OPS,
+    Bind9Connector,
+    register_bind9_typed_operations,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation, search_operations
+from meho_backplane.operations.reducer import PassThroughReducer
+from tests.test_operations_dispatcher import _make_operator
+
+# ---------------------------------------------------------------------------
+# Docker-availability gate -- identical heuristic to the existing bind9
+# container fixture.
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+DOCKER_AVAILABLE: bool = _docker_socket_present()
+SKIP_REASON: str = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+#: Tenant the test operators run under. Mirrors the K8s E2E (#326)
+#: convention so the seeded ``Target`` ORM row and the operator built
+#: by every ``call_operation`` test are tenant-consistent.
+_OPERATOR_TENANT_ID: UUID = UUID("00000000-0000-0000-0000-00000000a0a0")
+
+#: Name the meta-tool ``call_operation`` test resolves via
+#: ``{"target": {"name": _TARGET_NAME}}`` → :func:`resolve_target`.
+_TARGET_NAME: str = "bind9-e2e"
+
+#: Every op id this harness exercises. Pinned here (rather than
+#: re-derived from ``BIND9_OPS``) so a registration regression
+#: surfaces as a clear "missing op" assertion failure rather than a
+#: silent test-count change. The eleven ops correspond to G3.4-T1..T4.
+EXPECTED_OP_IDS: tuple[str, ...] = (
+    "bind9.about",
+    "bind9.zone.list",
+    "bind9.zone.read",
+    "bind9.record.get",
+    "bind9.record.add",
+    "bind9.record.remove",
+    "bind9.config.show",
+    "bind9.config.apply_file",
+    "bind9.config.apply_views",
+    "bind9.config.backup",
+    "bind9.config.reload",
+)
+
+
+# ---------------------------------------------------------------------------
+# Target stub -- minimal shape SshConnector + the dispatcher's resolver read
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Bind9Target:
+    """Duck-typed target the dispatcher's resolver + SSH adapter read.
+
+    The dispatcher's :func:`resolve_connector` reads ``product`` +
+    ``fingerprint.version``; the SSH adapter reads ``name`` + ``host`` +
+    ``port`` + ``secret_ref``. Mirrors the
+    :class:`_Bind9Target` stub in ``test_connectors_bind9_container.py``
+    plus the dispatcher-resolver fields.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: dict[str, Any]
+    product: str = "bind9"
+    auth_model: str = "shared_service_account"
+    raw_jwt: str | None = "<dev-test-jwt>"
+
+    def __post_init__(self) -> None:
+        self.id: UUID = uuid4()
+        self.preferred_impl_id: str | None = None
+
+        class _FP:
+            # Pinned to the 9.18 series matching the container image so
+            # the resolver's version match step has a concrete value to
+            # read. The bind9 connector advertises
+            # supported_version_range=None, so the resolver doesn't
+            # filter on it -- the version still surfaces in the audit
+            # row payload.
+            version = "9.18.0"
+
+        self.fingerprint = _FP()
+
+
+# ---------------------------------------------------------------------------
+# Inline Dockerfile -- copied from test_connectors_bind9_container.py.
+#
+# The image is the same Debian-bookworm + bind9 + openssh-server build
+# the existing container fixture uses, with one extra "evba.lab" zone
+# seeded so every read/write op has something to operate against.
+# ---------------------------------------------------------------------------
+
+
+_DOCKERFILE: str = textwrap.dedent(
+    """\
+    FROM debian:bookworm-slim
+
+    ENV DEBIAN_FRONTEND=noninteractive
+
+    RUN apt-get update \\
+     && apt-get install -y --no-install-recommends \\
+          bind9 bind9-host bind9utils dnsutils \\
+          openssh-server sudo python3 \\
+     && rm -rf /var/lib/apt/lists/*
+
+    RUN mkdir -p /var/run/sshd \\
+     && echo 'root:testpw' | chpasswd \\
+     && sed -i 's/^#\\?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config \\
+     && sed -i 's/^#\\?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+
+    RUN echo 'root ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/99-meho-test \\
+     && chmod 0440 /etc/sudoers.d/99-meho-test
+
+    RUN echo 'zone "evba.lab" { type master; file "/etc/bind/db.evba.lab"; };' \\
+            >> /etc/bind/named.conf.local
+
+    RUN printf '%s\\n' \\
+            '$TTL 3600' \\
+            '@ IN SOA ns1.evba.lab. admin.evba.lab. (' \\
+            '    2026051801 3600 600 604800 86400 )' \\
+            '@   IN NS ns1.evba.lab.' \\
+            'ns1 IN A 10.5.50.1' \\
+            'www IN A 10.5.50.2' \\
+            'mail IN A 10.5.50.3' \\
+            'mail IN AAAA 2001:db8::1' \\
+            'alias IN CNAME ns1.evba.lab.' \\
+            '@   IN MX 10 mail.evba.lab.' \\
+            '@   IN TXT "v=spf1 a -all"' \\
+            > /etc/bind/db.evba.lab \\
+     && chown root:bind /etc/bind/db.evba.lab \\
+     && chmod 644 /etc/bind/db.evba.lab
+
+    RUN printf '#!/bin/sh\\n/usr/sbin/named -u bind\\nexec /usr/sbin/sshd -D -e\\n' \\
+            > /entrypoint.sh \\
+     && chmod +x /entrypoint.sh
+
+    EXPOSE 22
+    CMD ["/entrypoint.sh"]
+    """
+)
+
+
+@pytest.fixture(scope="module")
+def bind9_container_target() -> Iterator[_Bind9Target]:
+    """Build the bind9 image, start the container, yield a target stub.
+
+    Mirrors the existing ``test_connectors_bind9_container.py`` fixture
+    so the container boot path is identical — one harness boots one
+    container, not two — but yields the augmented ``_Bind9Target`` shape
+    the dispatcher's resolver expects (``.product`` + ``.fingerprint``).
+    """
+    if not DOCKER_AVAILABLE:
+        pytest.skip(SKIP_REASON)
+
+    try:
+        from testcontainers.core.container import DockerContainer
+        from testcontainers.core.image import DockerImage
+        from testcontainers.core.waiting_utils import wait_for_logs
+    except ImportError as exc:  # pragma: no cover -- testcontainers ships these in 4.x
+        pytest.skip(f"testcontainers missing module: {exc}")
+
+    with tempfile.TemporaryDirectory() as build_dir:
+        dockerfile = Path(build_dir) / "Dockerfile"
+        dockerfile.write_text(_DOCKERFILE)
+        tag = os.environ.get("MEHO_TEST_BIND9_TAG", "meho-test-bind9:9.18-bookworm")
+
+        image = DockerImage(path=build_dir, tag=tag)
+        image.build()
+
+        container = DockerContainer(tag).with_exposed_ports(22)
+        container.start()
+        try:
+            wait_for_logs(container, "Server listening on", timeout=30.0)
+            host = container.get_container_host_ip()
+            port = int(container.get_exposed_port(22))
+            # named starts in the background just before sshd; give
+            # it a moment for `pgrep -x named` to see the process.
+            time.sleep(2.0)
+            target = _Bind9Target(
+                name=_TARGET_NAME,
+                host=host,
+                port=port,
+                secret_ref={"username": "root", "password": "testpw"},  # NOSONAR -- container-local
+            )
+            yield target
+        finally:
+            container.stop()
+
+
+# ---------------------------------------------------------------------------
+# Per-test wiring: descriptor registration + Target row seeding.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't load ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def bind9_e2e(
+    bind9_container_target: _Bind9Target,
+    pg_engine: None,
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[_Bind9Target]:
+    """Wire the bind9 connector at the live container + real PG audit store.
+
+    Phases mirror the K8s E2E harness (#326):
+
+    1. Reset dispatcher / handler caches so the test starts against a
+       known-empty cache.
+    2. Re-register the connector class so the dispatcher's resolver
+       finds it against the canonical ``("bind9", "9.x", "bind9-ssh")``
+       triple.
+    3. Set the pass-through reducer so set-shaped op results land
+       verbatim in ``OperationResult.result``.
+    4. Run :func:`register_bind9_typed_operations` to UPSERT every
+       op into ``endpoint_descriptor``.
+    5. Insert a tenant-scoped :class:`~meho_backplane.db.models.Target`
+       ORM row so the ``call_operation`` meta-tool path — which
+       resolves ``arguments["target"]={"name": ...}`` through the
+       tenant-scoped :func:`resolve_target` — exercises the real
+       contract.
+
+    No connector-instance preseed: the bind9 connector reads SSH
+    credentials directly from ``target.secret_ref``, so the seeded
+    Target row's secret_ref is enough — no kubeconfig-style loader
+    seam needed.
+
+    The ``targets`` table is a soft-FK column the ``pg_engine`` fixture
+    does not truncate, so the row is deleted on teardown to keep
+    per-test isolation.
+    """
+    target = bind9_container_target
+
+    reset_dispatcher_caches()
+    set_default_reducer(PassThroughReducer())
+    clear_registry()
+    register_connector_v2(
+        product="bind9",
+        version="9.x",
+        impl_id="bind9-ssh",
+        cls=Bind9Connector,
+    )
+
+    await register_bind9_typed_operations(embedding_service=stub_embedding_service)
+
+    now = datetime.now(UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            TargetORM(
+                id=uuid4(),
+                tenant_id=_OPERATOR_TENANT_ID,
+                name=_TARGET_NAME,
+                aliases=[],
+                product="bind9",
+                host=target.host,
+                port=target.port,
+                fqdn=None,
+                # secret_ref on the ORM row is the SSH credential dict;
+                # the bind9 SshConnector reads it directly via
+                # ``_auth_config``.
+                secret_ref=target.secret_ref,
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                notes=None,
+                fingerprint={"version": "9.18.0"},
+                preferred_impl_id=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    try:
+        yield target
+    finally:
+        # Closing every Bind9Connector instance the dispatcher's
+        # per-class cache may have built. Tolerant of double-close.
+        from meho_backplane.operations import _handler_resolve as _hr
+
+        with contextlib.suppress(Exception):
+            cached = _hr._CONNECTOR_INSTANCE_CACHE.get(Bind9Connector)
+            if cached is not None:
+                await cached.aclose()
+        # Delete the seeded Target row.
+        from sqlalchemy import delete
+
+        with contextlib.suppress(Exception):
+            async with sessionmaker() as session, session.begin():
+                await session.execute(
+                    delete(TargetORM).where(
+                        TargetORM.tenant_id == _OPERATOR_TENANT_ID,
+                        TargetORM.name == _TARGET_NAME,
+                    )
+                )
+        reset_dispatcher_caches()
+        clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _assert_audit_row(
+    op_id: str,
+    *,
+    operator_sub: str,
+    expect_state_before: bool = False,
+    expect_state_after: bool = False,
+) -> dict[str, Any]:
+    """Assert exactly one audit_log row exists for *op_id* / *operator_sub*.
+
+    Returns the row's payload dict so callers can do op-specific
+    assertions on it (e.g. state_before / state_after values).
+    Mirrors the K8s E2E harness's helper shape.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(AuditLog).where(
+                        AuditLog.path == op_id,
+                        AuditLog.operator_sub == operator_sub,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1, (
+        f"expected exactly one audit row for {op_id} / operator {operator_sub}, got {len(rows)}"
+    )
+    row = rows[0]
+    assert row.payload["op_id"] == op_id
+    assert row.payload["source_kind"] == "typed"
+    assert row.payload["result_status"] == "ok"
+    if expect_state_before:
+        assert "state_before" in row.payload, (
+            f"write op {op_id} audit row missing state_before; payload={row.payload!r}"
+        )
+    if expect_state_after:
+        assert "state_after" in row.payload, (
+            f"write op {op_id} audit row missing state_after; payload={row.payload!r}"
+        )
+    # ``payload`` is JSONB → SQLAlchemy returns it as a plain dict; the
+    # cast keeps mypy honest without paying a runtime check.
+    payload: dict[str, Any] = dict(row.payload)
+    return payload
+
+
+def _normalise_soa_serials(text: str) -> str:
+    """Replace every SOA serial in *text* with the literal ``SERIAL``.
+
+    Same normalisation the existing container test's ``_checksum_bind_tree``
+    helper uses: a rollback bumps the restored zonefile's SOA serial to
+    defeat named's serial cache (see ``_atomic.py``), so two snapshots
+    that differ only on the serial should still hash-equal post-rollback.
+    """
+    soa_re = re.compile(
+        r"(\bSOA\b\s+\S+\s+\S+\s*\(?\s*(?:;[^\n]*\n\s*)*)(\d+)",
+        re.IGNORECASE,
+    )
+    return soa_re.sub(lambda m: m.group(1) + "SERIAL", text, count=1)
+
+
+async def _checksum_bind_tree(connector: Bind9Connector, target: _Bind9Target) -> str:
+    """Return the SHA256-tree fingerprint of ``/etc/bind/`` on *target*.
+
+    Mirrors the SOA-normalising checksum probe in the existing
+    container test (T3 rollback acceptance) — copy here keeps this E2E
+    file self-contained without an inter-test-file import.
+    """
+    probe_script = (
+        "import hashlib, pathlib, re\n"
+        "soa_re = re.compile(\n"
+        "    r'(\\bSOA\\b\\s+\\S+\\s+\\S+\\s*\\(?\\s*(?:;[^\\n]*\\n\\s*)*)(\\d+)',\n"
+        "    re.IGNORECASE,\n"
+        ")\n"
+        "h = hashlib.sha256()\n"
+        "for p in sorted(\n"
+        "    p for p in pathlib.Path('/etc/bind').rglob('*') if p.is_file()\n"
+        "):\n"
+        "    data = p.read_bytes()\n"
+        "    try:\n"
+        "        text = data.decode('utf-8')\n"
+        "        data = soa_re.sub(\n"
+        "            lambda m: m.group(1) + 'SERIAL', text, count=1\n"
+        "        ).encode('utf-8')\n"
+        "    except UnicodeDecodeError:\n"
+        "        pass\n"
+        "    h.update(str(p).encode() + b'\\n')\n"
+        "    h.update(data)\n"
+        "print(h.hexdigest())\n"
+    )
+    cmd = f"python3 -c {shlex.quote(probe_script)}"
+    proc = await connector._run_command(target, cmd, raw_jwt="")
+    exit_status = getattr(proc, "exit_status", 0)
+    stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    digest = stdout.strip() if isinstance(stdout, str) else ""
+    assert exit_status == 0, (
+        f"_checksum_bind_tree probe exited {exit_status}; stderr={getattr(proc, 'stderr', '')!r}"
+    )
+    assert digest, "_checksum_bind_tree returned empty digest"
+    return digest
+
+
+# ---------------------------------------------------------------------------
+# Registration + search shape (DoD: agent reaches all ops via search_operations)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_registered_op_present_in_endpoint_descriptor(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """Each row in :data:`BIND9_OPS` lands in ``endpoint_descriptor``
+    under the canonical ``("bind9", "9.x", "bind9-ssh")`` triple."""
+    from meho_backplane.db.models import EndpointDescriptor
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.product == "bind9",
+                EndpointDescriptor.version == "9.x",
+                EndpointDescriptor.impl_id == "bind9-ssh",
+            )
+        )
+        rows = result.scalars().all()
+
+    assert len(rows) == len(BIND9_OPS)
+    op_ids = {row.op_id for row in rows}
+    assert op_ids == set(EXPECTED_OP_IDS), (
+        f"registered ops drift: in DB but not expected: "
+        f"{op_ids - set(EXPECTED_OP_IDS)}; "
+        f"expected but missing: {set(EXPECTED_OP_IDS) - op_ids}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_operations_surfaces_record_add_for_dns_intent(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``search_operations(connector_id="bind9-ssh-9.x", query="add a dns record")``
+    returns ``bind9.record.add`` among its hits.
+
+    Existential DoD: the agent typing a DNS-write intent reaches the
+    write op via the meta-tool surface, not via a hand-coded MCP tool
+    (CLAUDE.md postulate 5).
+    """
+    operator = _make_operator(sub="op-search-add", tenant_id=_OPERATOR_TENANT_ID)
+    result = await search_operations(
+        operator,
+        {
+            "connector_id": "bind9-ssh-9.x",
+            "query": "add a dns record",
+            "limit": 20,
+        },
+    )
+    hits = result["hits"]
+    assert len(hits) >= 1
+    hit_op_ids = {h["op_id"] for h in hits}
+    assert "bind9.record.add" in hit_op_ids, (
+        f"search_operations(query='add a dns record') did not surface "
+        f"bind9.record.add; got {hit_op_ids}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-op call_operation dispatch -- DoD: every op dispatches end-to-end
+# and writes one audit_log row.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_operation_about_dispatches_through_meta_tool(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``call_operation(bind9.about)`` round-trips dispatcher → handler → bind9.
+
+    Exercises the real meta-tool target contract: ``call_operation``
+    requires ``arguments["target"]`` to be ``{"name": <str>}`` and runs
+    it through the tenant-scoped :func:`resolve_target` (the meta-tool's
+    tenant-isolation boundary) before dispatch.
+    """
+    operator = _make_operator(sub="op-meta-about", tenant_id=_OPERATOR_TENANT_ID)
+    result = await call_operation(
+        operator,
+        {
+            "connector_id": "bind9-ssh-9.x",
+            "op_id": "bind9.about",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", result.get("error")
+    payload = result["result"]
+    assert payload["vendor"] == "isc"
+    assert payload["product"] == "bind9"
+    # Debian bookworm ships bind9 9.18.x.
+    assert payload["version"] is not None
+    assert str(payload["version"]).startswith("9.18.")
+    await _assert_audit_row("bind9.about", operator_sub="op-meta-about")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_zone_list_against_bind9(bind9_e2e: _Bind9Target) -> None:
+    """``bind9.zone.list`` via the dispatcher returns the seeded ``evba.lab``."""
+    operator = _make_operator(sub="op-zone-list", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.zone.list",
+        target=bind9_e2e,
+        params={},
+    )
+    assert result.status == "ok", result.error
+    payload = result.result
+    zone_names = {row["name"] for row in payload["rows"]}
+    assert "evba.lab" in zone_names
+    await _assert_audit_row("bind9.zone.list", operator_sub="op-zone-list")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_zone_read_against_bind9(bind9_e2e: _Bind9Target) -> None:
+    """``bind9.zone.read evba.lab`` returns the seeded record set."""
+    operator = _make_operator(sub="op-zone-read", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.zone.read",
+        target=bind9_e2e,
+        params={"zone": "evba.lab"},
+    )
+    assert result.status == "ok", result.error
+    payload = result.result
+    types = {row["type"] for row in payload["rows"]}
+    assert {"A", "AAAA", "CNAME", "MX", "TXT"}.issubset(types)
+    await _assert_audit_row("bind9.zone.read", operator_sub="op-zone-read")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_record_get_against_bind9(bind9_e2e: _Bind9Target) -> None:
+    """``bind9.record.get www.evba.lab`` resolves through the live named."""
+    operator = _make_operator(sub="op-record-get", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.record.get",
+        target=bind9_e2e,
+        params={"fqdn": "www.evba.lab", "type": "A"},
+    )
+    assert result.status == "ok", result.error
+    rdatas = {row["rdata"] for row in result.result["rows"]}
+    assert "10.5.50.2" in rdatas
+    await _assert_audit_row("bind9.record.get", operator_sub="op-record-get")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_record_add_against_bind9_writes_state_before_after(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``bind9.record.add`` writes a record and the audit row carries
+    ``state_before`` / ``state_after`` summaries.
+    """
+    operator = _make_operator(sub="op-record-add", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.record.add",
+        target=bind9_e2e,
+        params={
+            "fqdn": "added-e2e.evba.lab",
+            "ip": "10.5.50.42",
+            "type": "A",
+            "zone": "evba.lab",
+        },
+    )
+    assert result.status == "ok", result.error
+    assert result.result["op_class"] == "write"
+    payload = await _assert_audit_row(
+        "bind9.record.add",
+        operator_sub="op-record-add",
+        expect_state_before=True,
+        expect_state_after=True,
+    )
+    # state_before / state_after are durably persisted on the audit row.
+    assert payload["state_after"] != payload["state_before"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_record_remove_against_bind9_writes_state_before_after(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``bind9.record.remove`` removes a record and the audit row carries
+    ``state_before`` / ``state_after`` summaries.
+    """
+    # Add a record first so there's something to remove.
+    add_op = _make_operator(sub="op-record-remove-add", tenant_id=_OPERATOR_TENANT_ID)
+    add_result = await dispatch(
+        operator=add_op,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.record.add",
+        target=bind9_e2e,
+        params={
+            "fqdn": "to-remove.evba.lab",
+            "ip": "10.5.50.43",
+            "type": "A",
+            "zone": "evba.lab",
+        },
+    )
+    assert add_result.status == "ok"
+
+    operator = _make_operator(sub="op-record-remove", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.record.remove",
+        target=bind9_e2e,
+        params={"fqdn": "to-remove.evba.lab", "zone": "evba.lab"},
+    )
+    assert result.status == "ok", result.error
+    assert result.result["op_class"] == "write"
+    await _assert_audit_row(
+        "bind9.record.remove",
+        operator_sub="op-record-remove",
+        expect_state_before=True,
+        expect_state_after=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_config_show_against_bind9(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``bind9.config.show named.conf.local`` returns the live file content."""
+    operator = _make_operator(sub="op-config-show", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.config.show",
+        target=bind9_e2e,
+        params={"path": "named.conf.local"},
+    )
+    assert result.status == "ok", result.error
+    assert "evba.lab" in result.result["content"]
+    await _assert_audit_row("bind9.config.show", operator_sub="op-config-show")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_config_apply_file_writes_state_before_after(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``bind9.config.apply_file`` writes a fragment + audit row carries
+    state_before / state_after.
+    """
+    operator = _make_operator(sub="op-apply-file", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.config.apply_file",
+        target=bind9_e2e,
+        params={
+            "path": "named.conf.options",
+            "content": "// e2e applied fragment\n",
+        },
+    )
+    assert result.status == "ok", result.error
+    assert result.result["op_class"] == "write"
+    payload = await _assert_audit_row(
+        "bind9.config.apply_file",
+        operator_sub="op-apply-file",
+        expect_state_before=True,
+        expect_state_after=True,
+    )
+    assert payload["state_before"] != payload["state_after"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_config_apply_views_writes_multi_file_tree(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``bind9.config.apply_views`` writes a multi-file tree successfully."""
+    operator = _make_operator(sub="op-apply-views", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.config.apply_views",
+        target=bind9_e2e,
+        params={
+            "files": {
+                "named.conf.smoke-e2e": "// apply_views e2e smoke fragment\n",
+            },
+        },
+    )
+    assert result.status == "ok", result.error
+    assert result.result["op_class"] == "write"
+    await _assert_audit_row(
+        "bind9.config.apply_views",
+        operator_sub="op-apply-views",
+        expect_state_before=True,
+        expect_state_after=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_config_backup_creates_archive(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``bind9.config.backup`` produces a tar.gz + records state_after."""
+    operator = _make_operator(sub="op-backup", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.config.backup",
+        target=bind9_e2e,
+        params={"tag": "e2e-smoke"},
+    )
+    assert result.status == "ok", result.error
+    assert "e2e-smoke" in result.result["backup_id"]
+    assert result.result["path"].endswith(".tar.gz")
+    # config.backup audit row has only state_after (the backup_id) — no
+    # state_before because nothing in /etc/bind/ mutated.
+    payload = await _assert_audit_row(
+        "bind9.config.backup",
+        operator_sub="op-backup",
+        expect_state_after=True,
+    )
+    assert payload["state_after"] == result.result["backup_id"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_config_reload_returns_ok(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """``bind9.config.reload`` succeeds + carries state_before / state_after
+    (the rndc-status snapshots).
+    """
+    operator = _make_operator(sub="op-reload", tenant_id=_OPERATOR_TENANT_ID)
+    result = await dispatch(
+        operator=operator,
+        connector_id="bind9-ssh-9.x",
+        op_id="bind9.config.reload",
+        target=bind9_e2e,
+        params={},
+    )
+    assert result.status == "ok", result.error
+    assert result.result["ok"] is True
+    await _assert_audit_row(
+        "bind9.config.reload",
+        operator_sub="op-reload",
+        expect_state_before=True,
+        expect_state_after=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent meta-tool flow + CLI parity (DoD: search_operations surfaces the
+# write op; call_operation executes; both go through the same dispatch
+# route the CLI alias verb uses).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_meta_tool_flow_search_then_call_record_add(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """Full agent flow: ``search_operations`` → ``call_operation``.
+
+    The agent never sees the CLI alias verbs. It locates the right op
+    via the narrow-waist meta-tools, then dispatches via the same
+    dispatch route the CLI hits. This test pins the existential DoD:
+    every bind9 op is reachable via the agent surface without per-op
+    MCP tool registration (CLAUDE.md postulate 5).
+    """
+    operator = _make_operator(sub="op-agent-flow", tenant_id=_OPERATOR_TENANT_ID)
+    search_result = await search_operations(
+        operator,
+        {
+            "connector_id": "bind9-ssh-9.x",
+            "query": "add a dns record",
+            "limit": 5,
+        },
+    )
+    hit_op_ids = {h["op_id"] for h in search_result["hits"]}
+    assert "bind9.record.add" in hit_op_ids
+
+    call_result = await call_operation(
+        operator,
+        {
+            "connector_id": "bind9-ssh-9.x",
+            "op_id": "bind9.record.add",
+            "target": {"name": _TARGET_NAME},
+            "params": {
+                "fqdn": "agent-flow.evba.lab",
+                "ip": "10.5.50.99",
+                "type": "A",
+                "zone": "evba.lab",
+            },
+        },
+    )
+    assert call_result["status"] == "ok", call_result.get("error")
+    assert call_result["result"]["op_class"] == "write"
+
+
+# ---------------------------------------------------------------------------
+# Atomic-apply rollback E2E (DoD: invalid apply_views, invalid apply_file,
+# and unresolvable record.add each leave /etc/bind/ byte-identical to the
+# pre-op snapshot).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_atomic_rollback_on_invalid_apply_views_leaves_tree_unchanged(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """An invalid apply_views payload rolls back to the pre-op snapshot."""
+    from meho_backplane.connectors.bind9._atomic import AtomicApplyError
+
+    connector = Bind9Connector()
+    try:
+        before = await _checksum_bind_tree(connector, bind9_e2e)
+        with pytest.raises(AtomicApplyError) as exc_info:
+            await connector.bind9_config_apply_views(
+                bind9_e2e,
+                {
+                    "files": {
+                        # Overwrite the live named.conf.local with garbage --
+                        # the primitive's validate must refuse.
+                        "named.conf.local": "this is { not valid bind9 config\n",
+                    },
+                },
+            )
+        assert exc_info.value.step == "checkconf"
+
+        after = await _checksum_bind_tree(connector, bind9_e2e)
+        assert before == after, (
+            f"apply_views did NOT roll back cleanly; checksum before={before!r}, after={after!r}"
+        )
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_atomic_rollback_on_invalid_apply_file_leaves_tree_unchanged(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """An invalid apply_file fragment rolls back to the pre-op snapshot."""
+    from meho_backplane.connectors.bind9._atomic import AtomicApplyError
+
+    connector = Bind9Connector()
+    try:
+        before = await _checksum_bind_tree(connector, bind9_e2e)
+        with pytest.raises(AtomicApplyError) as exc_info:
+            await connector.bind9_config_apply_file(
+                bind9_e2e,
+                {
+                    "path": "named.conf.local",
+                    "content": "this is { not valid bind9 config\n",
+                },
+            )
+        assert exc_info.value.step == "checkconf"
+
+        after = await _checksum_bind_tree(connector, bind9_e2e)
+        assert before == after, (
+            f"apply_file did NOT roll back cleanly; checksum before={before!r}, after={after!r}"
+        )
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_atomic_rollback_on_unresolvable_record_add_leaves_tree_unchanged(
+    bind9_e2e: _Bind9Target,
+) -> None:
+    """An FQDN outside every served zone refuses pre-stage and the tree
+    is byte-identical.
+    """
+    from meho_backplane.connectors.bind9.ops_record import ZoneResolutionError
+
+    connector = Bind9Connector()
+    try:
+        before = await _checksum_bind_tree(connector, bind9_e2e)
+        with pytest.raises(ZoneResolutionError):
+            await connector.bind9_record_add(
+                bind9_e2e,
+                {
+                    "fqdn": "outside.example.com",
+                    "ip": "10.0.0.1",
+                    "type": "A",
+                },
+            )
+        after = await _checksum_bind_tree(connector, bind9_e2e)
+        assert before == after, (
+            f"unresolvable record.add must not touch /etc/bind/; "
+            f"checksum before={before!r}, after={after!r}"
+        )
+    finally:
+        await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Codebase-wide safety assertion (DoD: _remote_bash_with_sudo is the only
+# sudo-invoking construction under connectors/). Runs unconditionally --
+# no Docker required -- so the invariant is enforced on every sandbox.
+# ---------------------------------------------------------------------------
+
+
+def test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree() -> None:
+    """No file under ``connectors/`` invokes ``sudo`` outside the safe primitive.
+
+    Walks every ``*.py`` under
+    ``backend/src/meho_backplane/connectors/`` looking for any ``sudo``
+    literal in source. The only files that may carry one are
+    :mod:`~meho_backplane.connectors.bind9.connector` (the
+    ``_remote_bash_with_sudo`` helper itself, including its docstring
+    references) and :mod:`~meho_backplane.connectors.bind9._atomic`
+    (the atomic-apply primitive that routes its writes through the
+    helper).
+
+    A regression — a sibling connector hand-rolling a ``sudo -S`` or
+    embedding a password in a remote argv — surfaces here as a clear
+    "offender" list pointing at the file that re-introduced the
+    mis-ordered-payload shape behind the 2026-05-04 / 2026-05-05
+    credential leaks (Initiative #367 WI1).
+
+    This is the same invariant the unit test in
+    ``tests/test_connectors_bind9.py`` already asserts; restating it
+    in the E2E harness makes the DoD checkbox observable from a
+    single test command + provides defence-in-depth against a sibling
+    test being deleted.
+    """
+    connectors_root = (
+        Path(__file__).resolve().parent.parent.parent / "src" / "meho_backplane" / "connectors"
+    )
+    assert connectors_root.is_dir(), (
+        f"connectors root not found at {connectors_root}; test layout drifted"
+    )
+    allowed_files = set((connectors_root / "bind9").glob("*.py"))
+    offenders: list[str] = []
+    for path in connectors_root.rglob("*.py"):
+        if path in allowed_files:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        # Match `sudo ` followed by an argv token (defence vs benign
+        # mentions in docstrings of unrelated connectors).
+        if re.search(r"\bsudo\s+[\w-]", text):
+            offenders.append(str(path.relative_to(connectors_root)))
+    assert not offenders, (
+        "Found `sudo ` references outside the bind9 safe-primitive surface:\n"
+        + "\n".join(offenders)
+    )

--- a/backend/tests/test_connectors_bind9.py
+++ b/backend/tests/test_connectors_bind9.py
@@ -422,48 +422,59 @@ def test_remote_bash_with_sudo_signature_makes_misordering_unrepresentable() -> 
 
 
 def test_sudo_is_only_referenced_via_the_safe_primitive() -> None:
-    """AC #2: no other sudo-shell-construction path lives in the connector layer.
+    """AC #2: no other sudo-argv-construction path lives in the connector layer.
 
-    Greps the connector tree for the literal substring ``sudo`` and
-    asserts every occurrence is either the safe primitive itself, a
-    docstring or comment, or a reference to it -- never an
-    ``"sudo ..."`` shell-fragment string constructed elsewhere. A
-    failure here means a new sudo path slipped in alongside the
-    safe primitive; the operator must fold it back through
-    :meth:`_remote_bash_with_sudo`.
+    Walks every ``*.py`` under
+    ``backend/src/meho_backplane/connectors/`` and asserts no string
+    literal opens with ``sudo`` as its first token (the universal shape
+    of sudo argv construction: ``"sudo -S ..."`` single-string remote
+    commands, ``["sudo", "-S", ...]`` list-form argv,
+    ``("sudo",)`` tuple-form). The only files allowed to carry such
+    a literal are :mod:`~meho_backplane.connectors.bind9.connector`
+    (the ``_remote_bash_with_sudo`` helper) and
+    :mod:`~meho_backplane.connectors.bind9._atomic` (the atomic-apply
+    primitive that funnels its writes through the helper).
+
+    A failure means a new sudo argv slipped in somewhere; the
+    operator must fold it back through :meth:`_remote_bash_with_sudo`.
+
+    Detection regex — ``(?<=['"])sudo(?=['"\\s\\\\])`` — matches
+    ``sudo`` only when immediately preceded by a quote AND followed
+    by a quote / whitespace / backslash. Rejects prose mentions
+    ("a sudo credential"), docstring narrative, and the identifier
+    ``sudo_password`` (no preceding quote). Covers both
+    ``"sudo -S ..."`` and the list-form ``["sudo", "-S", ...]``;
+    a looser ``\\bsudo\\b`` would false-positive on every docstring
+    mention, a stricter ``\\bsudo\\s+`` would miss the list form.
     """
+    import re
     from pathlib import Path
 
     connectors_root = (
         Path(__file__).resolve().parent.parent / "src" / "meho_backplane" / "connectors"
     )
-    # The only files that should construct any ``sudo ...`` shell
-    # fragment are bind9/connector.py (the safe primitive itself) and
-    # bind9/_atomic.py (the atomic-apply primitive that routes its
-    # remote exec through the safe primitive -- T3 #589). The other
-    # bind9 modules can still reference ``sudo_password`` / ``sudo``
-    # in docstrings / variable names because they layer on top of the
-    # safe primitive; the assertion below is "no sudo path lives
-    # outside the bind9 subtree", which we encode by allowlisting the
-    # whole bind9 package.
-    allowed_files = set((connectors_root / "bind9").glob("*.py"))
+    # Narrow whitelist: only the two files that own the safe-sudo
+    # primitive. ops_*.py files reference sudo only via docstrings /
+    # error messages / the ``"sudo_password"`` dict key — all of which
+    # the detection regex below correctly ignores.
+    allowed_files = {
+        connectors_root / "bind9" / "connector.py",
+        connectors_root / "bind9" / "_atomic.py",
+    }
+    sudo_argv_re = re.compile(r"""(?<=["'])sudo(?=["'\s\\])""")
     offenders: list[str] = []
     for py_file in connectors_root.rglob("*.py"):
         if py_file in allowed_files:
             continue
-        # Skip the test seam itself; this assertion is run from
-        # ``backend/tests/`` which lives outside ``connectors/``, so
-        # the rglob already excludes it. The check is on production
-        # source only.
         content = py_file.read_text(encoding="utf-8")
         for lineno, line in enumerate(content.splitlines(), start=1):
-            # Strip comments; the literal token ``sudo`` in prose docs
-            # / module headers is non-load-bearing.
-            code = line.split("#", 1)[0]
-            if "sudo" in code.lower():
+            if sudo_argv_re.search(line):
                 offenders.append(f"{py_file.relative_to(connectors_root)}:{lineno}: {line!r}")
     assert not offenders, (
-        "Found sudo references outside the bind9 safe-primitive surface:\n" + "\n".join(offenders)
+        "Found sudo-argv construction outside the bind9 safe-primitive surface "
+        "(connector.py + _atomic.py). Every match below re-introduces the "
+        "mis-ordered-payload shape that leaked credentials twice in 2026-05:\n"
+        + "\n".join(offenders)
     )
 
 

--- a/cli/internal/cmd/bind9/about.go
+++ b/cli/internal/cmd/bind9/about.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package bind9
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAboutCmd returns the `meho bind9 about` command.
+//
+// CLI shape:
+//
+//	meho bind9 about \
+//	  [--target <slug>]                        # bind9 target (required for dispatch)
+//	  [--json]                                 # machine-readable output
+//	  [--backplane <url>]                      # override the backplane URL
+//
+// Maps to op_id `bind9.about`. The renderer surfaces the bind9
+// vendor / product / version / OS in the human path; --json emits
+// the raw OperationResult envelope.
+//
+// Exit codes follow the meho operation call convention:
+//   - 0   operation invoked + status == "ok"
+//   - 1   operation invoked but status == "error" / "denied"
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape
+func newAboutCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "about",
+		Short: "Show bind9 vendor / product / version / OS for a target",
+		Long: "about dispatches bind9.about against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector and renders the vendor / product /\n" +
+			"version / OS fields the handler returns (named -v + os-release\n" +
+			"parsed). The human render is a 4-line summary; --json emits\n" +
+			"the full OperationResult envelope for scripting.\n\n" +
+			"--target names the bind9 target slug; required if no operator\n" +
+			"default target is configured. The dispatch path is the same\n" +
+			"/api/v1/operations/call route the agent surface uses — auth,\n" +
+			"audit, broadcast, and policy gates all run as documented in\n" +
+			"CLAUDE.md §6.\n\n" +
+			"Exit codes mirror meho operation call:\n" +
+			"  - 0   status == ok\n" +
+			"  - 1   status == error / denied\n" +
+			"  - 2   auth_expired (run `meho login`)\n" +
+			"  - 3   unreachable (network / DNS / TLS)\n" +
+			"  - 4   unexpected response shape",
+		Example: "  meho bind9 about --target vcf-router-bind9\n" +
+			"  meho bind9 about --target vcf-router-bind9 --json | jq .result",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAbout(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required for ops that read a target)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.about", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.about", r, jsonOut, printAbout)
+}
+
+// printAbout renders the bind9.about result fields. The handler
+// returns a flat dict shaped `{"vendor", "product", "version",
+// "build", "os", "named_conf_path"}` — the renderer pulls those
+// fields and falls back to the generic envelope renderer for
+// unexpected shapes.
+//
+// Why the per-field unpack: operators read about output to confirm
+// which bind9 instance they're talking to (Debian 9.18 vs Alpine
+// 9.20 vs a future 9.x derivative). The generic JSON dump is too
+// noisy for that decision; a 6-line summary fits in a glance.
+func printAbout(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s bind9.about — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	about, err := decodeFlatResult(r.Result)
+	if err != nil || about == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	for _, key := range []string{"vendor", "product", "version", "build", "os", "named_conf_path"} {
+		v, ok := about[key]
+		if !ok || v == nil {
+			continue
+		}
+		fmt.Fprintf(w, "  %-17s %v\n", key+":", v)
+	}
+}

--- a/cli/internal/cmd/bind9/bind9.go
+++ b/cli/internal/cmd/bind9/bind9.go
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package bind9 hosts the cobra commands under `meho bind9 ...` for
+// G3.4-T5 (#591) of Initiative #367. The verb tree is a thin Cobra
+// layer over `POST /api/v1/operations/call`, identical pattern to
+// `meho vmware ...` (#511) and `meho vault ...` (#550), pre-baking
+// the `connector_id="bind9-ssh-9.x"` argument so operators don't
+// type the connector ID on every dispatch:
+//
+//   - `meho bind9 about [--target T]`              — bind9.about
+//   - `meho bind9 zone list [--target T]`          — bind9.zone.list
+//   - `meho bind9 zone read <zone>`                — bind9.zone.read
+//   - `meho bind9 record get <fqdn> [--type T]`    — bind9.record.get
+//   - `meho bind9 record add <fqdn> <ip>`          — bind9.record.add
+//   - `meho bind9 record remove <fqdn>`            — bind9.record.remove
+//   - `meho bind9 config show <file>`              — bind9.config.show
+//   - `meho bind9 config apply-views <views> <dir>` — bind9.config.apply_views
+//   - `meho bind9 config apply-file <name> <src>`  — bind9.config.apply_file
+//   - `meho bind9 config backup [--tag T]`         — bind9.config.backup
+//   - `meho bind9 config reload`                   — bind9.config.reload
+//
+// Every verb is a thin Cobra command that POSTs to
+// `/api/v1/operations/call` with a pre-baked connector_id. No new
+// backend code; no new HTTP routes — the CLI alias verbs are pure
+// operator ergonomics over the existing dispatcher surface (per
+// CLAUDE.md postulate 5: agent surface stays narrow-waist meta-tools;
+// vendor-specific tooling lives only in the CLI).
+//
+// The verb tree replaces the consumer's `scripts/bind9-dns.sh`
+// wrapper (the 2026-05-04 / 2026-05-05 credential-leak surface
+// documented in evoila-bosnia/claude-rdc-hetzner-dc#86). The atomic-
+// apply rollback contract — invalid `apply_*` / bad `record.add`
+// leaves `/etc/bind/` byte-identical — is enforced by the backend's
+// `_atomic.py` primitive (#589); the CLI exposes the result envelope
+// (`op_class=write`, `result_state_before`, `result_state_after`) so
+// operators can diff successful writes and audit-trace rollbacks.
+package bind9
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under
+// `meho bind9 ...` dispatches against. Exported so the per-verb
+// files and tests reference the same constant; a future
+// re-versioning lands as a single line edit here.
+//
+// The id encodes the registry-v2 natural key triple
+// “(product="bind9", version="9.x", impl_id="bind9-ssh")“ per the
+// connector_id parser convention in
+// `backend/src/meho_backplane/operations/_lookup.py::parse_connector_id`:
+// the trailing `-9.x` segment is the version; everything before is
+// the impl_id (`bind9-ssh`); the product is the first hyphen segment
+// of the impl_id (`bind9`). The impl_id discriminator (`-ssh` vs a
+// hypothetical `-rndc` / `-rest` sibling) makes room for a future
+// non-SSH control surface without breaking the resolver's tie-break
+// ladder — same shape vmware-rest's `vmware-rest-9.0` uses to leave
+// room for a `vmware-pyvmomi` sibling.
+const ConnectorID = "bind9-ssh-9.x"
+
+// NewRootCmd returns the `meho bind9` parent command. cmd/root.go
+// grafts this onto the top-level command tree alongside the other
+// built-in verb trees (operation / connector / targets / kb /
+// retrieval / audit / vmware / vault). The parent itself takes no
+// args and prints its own help; every piece of behaviour lives in
+// the per-subcommand RunE closures.
+//
+// Sub-tree layout follows the issue #591 verb table:
+//   - `bind9 about`                   — flat verb
+//   - `bind9 zone <list|read>`        — sub-tree
+//   - `bind9 record <get|add|remove>` — sub-tree
+//   - `bind9 config <show|apply-views|apply-file|backup|reload>` — sub-tree
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bind9",
+		Short: "Pre-scoped CLI verbs for the bind9-ssh-9.x connector",
+		Long: "bind9 is the operator-facing verb tree for the bind9-ssh-9.x\n" +
+			"connector (registry triple (product=\"bind9\", version=\"9.x\",\n" +
+			"impl_id=\"bind9-ssh\")). Each verb dispatches through\n" +
+			"POST /api/v1/operations/call with connector_id=\"bind9-ssh-9.x\"\n" +
+			"pre-baked so operators don't type the connector ID on every\n" +
+			"command. Write ops route through the backend's atomic-apply\n" +
+			"primitive — invalid input leaves /etc/bind/ byte-identical.\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
+			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
+			"continue to use search_operations / call_operation against the\n" +
+			"narrow-waist meta-tool contract.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAboutCmd())
+	cmd.AddCommand(newZoneCmd())
+	cmd.AddCommand(newRecordCmd())
+	cmd.AddCommand(newConfigCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" (→ auth_expired exit
+// code 2 — the right fix is `meho login`) from URL-parse failures
+// (→ unexpected exit code 4 — the right fix is correcting argv).
+// Same shape as the vmware / vault siblings; kept independent
+// because cmd/{operation,connector,kb,vmware,vault,bind9} can't
+// import each other without an import cycle (cmd/root.go grafts each
+// onto the tree).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane mirrors the vmware / vault sibling helpers:
+// --backplane override flag wins; otherwise read the URL the most
+// recent `meho login` wrote to config.json. Missing config surfaces
+// as errNoBackplaneConfigured so classifyBackplaneError can route
+// it to auth_expired.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical routing to the vmware /
+// vault siblings: missing-config → auth_expired; everything else
+// (parse errors, fs errors) → unexpected.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail fast
+// on garbage input. Mirrors the vmware / vault siblings.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from doAuthedRequest into
+// the right output.RenderError category. Same classification ladder
+// as the vmware sibling: token-not-found / no-refresh-token →
+// auth_expired with `meho login` hints; HTTP-error → unexpected;
+// everything else (transport) → unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// httpError carries a non-2xx response so renderRequestError can
+// pick the right StructuredError category. Same shape as the
+// vmware / vault siblings.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection + one-shot 401-refresh-retry. Mirrors the
+// vmware / vault siblings verbatim (duplicated to avoid an import
+// cycle — cmd/root.go grafts each onto the tree). Centralised
+// per-package so the per-verb runners stay small.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	// 1 MiB cap matches the vmware sibling. bind9 `zone.read` on a
+	// production zone with thousands of records can be hundreds of
+	// KiB; the cap leaves headroom while bounding pathological
+	// payloads.
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// sendRequest builds + fires the HTTP request. Mirrors the vmware
+// sibling; split out so the 401-refresh-retry path can reuse the
+// same body bytes without re-marshalling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// readLocalFile loads a local file path as UTF-8 bytes. Used by the
+// `config apply-file` / `config apply-views` verbs to stage local
+// content for the atomic-apply primitive. Returns the bytes verbatim
+// — the handler's parameter_schema asserts string content but
+// asyncssh's transport happily ferries bytes through the dispatcher
+// when the JSON encoder re-marshals; the caller passes the string
+// form.
+func readLocalFile(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %q: %w", path, err)
+	}
+	return string(raw), nil
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Operates on runes (not bytes) so multi-byte
+// UTF-8 in zone names survives without producing an invalid UTF-8
+// cut. Same implementation as the vmware / vault siblings —
+// duplicated to avoid import cycle.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// jsonUnmarshalStrict is a thin wrapper over json.Unmarshal that
+// keeps the call sites readable when the shape is unsigned. Same
+// semantics as json.Unmarshal — kept as a wrapper so we can swap in
+// a stricter decoder (DisallowUnknownFields) on a future audit pass
+// without touching every call site. Mirrors the vmware sibling.
+func jsonUnmarshalStrict(raw []byte, out any) error {
+	return json.Unmarshal(raw, out)
+}

--- a/cli/internal/cmd/bind9/bind9_test.go
+++ b/cli/internal/cmd/bind9/bind9_test.go
@@ -1,0 +1,540 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package bind9
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests (pure-function) ----------
+
+// TestConnectorIDIsFrozen pins the pre-baked connector_id constant.
+// Every verb file dispatches against this value; a regression here
+// would silently rebind every alias verb to a different connector.
+// The id encodes the registry-v2 natural key triple
+// `("bind9", "9.x", "bind9-ssh")` per parse_connector_id's grammar.
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "bind9-ssh-9.x" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "bind9-ssh-9.x")
+	}
+}
+
+// TestTruncatePassthroughAndCut covers the rune-aware truncate
+// helper. Same shape as the vmware sibling — duplicated to avoid
+// import cycle.
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+// TestNormaliseURLBasic mirrors the vmware sibling — trailing-slash
+// trimming + reject-empty are the load-bearing properties.
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
+// any wrapping error) maps to AuthExpired; everything else maps
+// to Unexpected.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+// ---------- decode helpers ----------
+
+func TestDecodeFlatResultHappy(t *testing.T) {
+	raw := json.RawMessage(`{"vendor":"isc","version":"9.18.24"}`)
+	got, err := decodeFlatResult(raw)
+	if err != nil {
+		t.Fatalf("decodeFlatResult: %v", err)
+	}
+	if got["vendor"] != "isc" || got["version"] != "9.18.24" {
+		t.Fatalf("decoded: %+v", got)
+	}
+}
+
+func TestDecodeFlatResultNullAndEmpty(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		got, err := decodeFlatResult(raw)
+		if err != nil {
+			t.Fatalf("decodeFlatResult empty: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("empty should be nil map; got %+v", got)
+		}
+	}
+}
+
+func TestDecodeRowsResultHappy(t *testing.T) {
+	raw := json.RawMessage(`{"rows":[{"name":"evba.lab","type":"master","file":"/etc/bind/db.evba.lab"}],"total":1}`)
+	rows, err := decodeRowsResult(raw)
+	if err != nil {
+		t.Fatalf("decodeRowsResult: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["name"] != "evba.lab" {
+		t.Fatalf("decoded: %+v", rows)
+	}
+}
+
+func TestStringFieldMissingAndWrongType(t *testing.T) {
+	e := map[string]any{"name": "x", "ttl": 3600.0}
+	if got := stringField(e, "name"); got != "x" {
+		t.Errorf("stringField(name): %q", got)
+	}
+	if got := stringField(e, "ttl"); got != "" {
+		t.Errorf("stringField(ttl, float): expected empty; got %q", got)
+	}
+	if got := stringField(e, "missing"); got != "" {
+		t.Errorf("stringField(missing): expected empty; got %q", got)
+	}
+}
+
+// ---------- assembleViewsBundle ----------
+
+// TestAssembleViewsBundleHappy — the views.conf maps to
+// named.conf.local; every regular file under zones-dir maps to its
+// relative path.
+func TestAssembleViewsBundleHappy(t *testing.T) {
+	dir := t.TempDir()
+	viewsConf := filepath.Join(dir, "views.conf")
+	if err := os.WriteFile(viewsConf, []byte("// views fragment\n"), 0o644); err != nil {
+		t.Fatalf("write views: %v", err)
+	}
+	zonesDir := filepath.Join(dir, "zones")
+	if err := os.MkdirAll(zonesDir, 0o755); err != nil {
+		t.Fatalf("mkdir zones: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(zonesDir, "db.evba.lab"), []byte("zone content"), 0o644); err != nil {
+		t.Fatalf("write zone: %v", err)
+	}
+	bundle, err := assembleViewsBundle(viewsConf, zonesDir)
+	if err != nil {
+		t.Fatalf("assembleViewsBundle: %v", err)
+	}
+	if bundle["named.conf.local"] != "// views fragment\n" {
+		t.Errorf("views fragment not mapped to named.conf.local: %+v", bundle)
+	}
+	if bundle["db.evba.lab"] != "zone content" {
+		t.Errorf("zone file not mapped: %+v", bundle)
+	}
+}
+
+// TestAssembleViewsBundleRejectsCollidingNamedConfLocal — a local
+// `named.conf.local` under zonesDir would silently win over the
+// views-conf arg; we reject it to keep the operator wire shape clear.
+func TestAssembleViewsBundleRejectsCollidingNamedConfLocal(t *testing.T) {
+	dir := t.TempDir()
+	viewsConf := filepath.Join(dir, "views.conf")
+	if err := os.WriteFile(viewsConf, []byte("// views\n"), 0o644); err != nil {
+		t.Fatalf("write views: %v", err)
+	}
+	zonesDir := filepath.Join(dir, "zones")
+	if err := os.MkdirAll(zonesDir, 0o755); err != nil {
+		t.Fatalf("mkdir zones: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(zonesDir, "named.conf.local"), []byte("collide"), 0o644); err != nil {
+		t.Fatalf("write conflict: %v", err)
+	}
+	_, err := assembleViewsBundle(viewsConf, zonesDir)
+	if err == nil || !strings.Contains(err.Error(), "named.conf.local") {
+		t.Fatalf("expected collision error; got %v", err)
+	}
+}
+
+// TestAssembleViewsBundleRejectsMissingZonesDir — non-existent
+// zonesDir surfaces clearly client-side.
+func TestAssembleViewsBundleRejectsMissingZonesDir(t *testing.T) {
+	dir := t.TempDir()
+	viewsConf := filepath.Join(dir, "views.conf")
+	if err := os.WriteFile(viewsConf, []byte("// views\n"), 0o644); err != nil {
+		t.Fatalf("write views: %v", err)
+	}
+	_, err := assembleViewsBundle(viewsConf, filepath.Join(dir, "nonexistent"))
+	if err == nil {
+		t.Fatalf("expected error for missing zonesDir")
+	}
+}
+
+// ---------- renderers ----------
+
+// TestPrintAboutHumanFormat — happy-path render with vendor/product/
+// version present.
+func TestPrintAboutHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "bind9.about",
+		Result:     json.RawMessage(`{"vendor":"isc","product":"bind9","version":"9.18.24","os":"debian 12"}`),
+		DurationMs: 42.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=ok", "bind9-ssh-9.x", "isc", "bind9", "9.18.24", "debian 12"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintAboutErrorRendersErrorString — status=error with a
+// non-nil Error pointer surfaces the error string + extras.
+func TestPrintAboutErrorRendersErrorString(t *testing.T) {
+	errMsg := "ssh handshake failed"
+	r := &CallResult{
+		Status:     "error",
+		OpID:       "bind9.about",
+		Error:      &errMsg,
+		Extras:     json.RawMessage(`{"reason":"auth_failed"}`),
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=error", "ssh handshake failed", "extras:", "auth_failed"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout error missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintZoneListTable — happy-path render with 2 zones.
+func TestPrintZoneListTable(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "bind9.zone.list",
+		Result:     json.RawMessage(`{"rows":[{"name":"evba.lab","type":"master","file":"/etc/bind/db.evba.lab"},{"name":"50.5.10.in-addr.arpa","type":"master","file":"/etc/bind/db.10.5.50"}],"total":2}`),
+		DurationMs: 12.0,
+	}
+	var buf bytes.Buffer
+	printZoneList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"evba.lab", "master", "/etc/bind/db.evba.lab", "50.5.10.in-addr.arpa"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printZoneList missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintZoneListEmpty — zero zones renders the count line.
+func TestPrintZoneListEmpty(t *testing.T) {
+	r := &CallResult{Status: "ok", OpID: "bind9.zone.list", Result: json.RawMessage(`{"rows":[],"total":0}`)}
+	var buf bytes.Buffer
+	printZoneList(&buf, r)
+	if !strings.Contains(buf.String(), "(0 zones)") {
+		t.Errorf("empty list should announce 0 zones; got:\n%s", buf.String())
+	}
+}
+
+// TestPrintRecordGetTable — happy-path render with one A row.
+func TestPrintRecordGetTable(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "bind9.record.get",
+		Result: json.RawMessage(`{"fqdn":"www.evba.lab.","type":"A","rows":[{"name":"www.evba.lab.","ttl":3600,"class":"IN","type":"A","rdata":"10.5.50.2"}],"total":1}`),
+	}
+	var buf bytes.Buffer
+	printRecordGet(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"www.evba.lab.", "10.5.50.2", "A"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printRecordGet missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintWriteResultHumanFormat — happy-path render of the write
+// envelope (record.add / record.remove / config.apply_*).
+func TestPrintWriteResultHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "bind9.record.add",
+		Result: json.RawMessage(`{"op_class":"write","fqdn":"api.evba.lab","zone":"evba.lab","file":"/etc/bind/db.evba.lab","type":"A","ip":"10.5.50.99","state_before":"snapshot before","state_after":"snapshot after"}`),
+	}
+	var buf bytes.Buffer
+	printWriteResult(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"op_class: write", "api.evba.lab", "evba.lab", "10.5.50.99", "state_before", "state_after"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printWriteResult missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintConfigBackup — happy-path render with two backups in
+// listing.
+func TestPrintConfigBackup(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "bind9.config.backup",
+		Result: json.RawMessage(`{"backup_id":"20260517T120000Z-pre-migration","path":"/var/backups/meho-bind9/20260517T120000Z-pre-migration.tar.gz","rows":[{"id":"20260516T100000Z-foo","size_bytes":1234,"mtime":"2026-05-16T10:00:00Z"},{"id":"20260517T120000Z-pre-migration","size_bytes":5678,"mtime":"2026-05-17T12:00:00Z"}]}`),
+	}
+	var buf bytes.Buffer
+	printConfigBackup(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"20260517T120000Z-pre-migration", "/var/backups/meho-bind9", "20260516T100000Z-foo"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printConfigBackup missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// ---------- errOpError sentinel ----------
+
+func TestErrOpErrorIsSentinel(t *testing.T) {
+	if errOpError == nil {
+		t.Fatalf("errOpError should be non-nil")
+	}
+	if errors.Is(errOpError, errors.New("other")) {
+		t.Fatalf("errOpError should not match arbitrary errors")
+	}
+}
+
+// ---------- HTTP wire shape (mocked) ----------
+
+type mockHandler = http.HandlerFunc
+
+// mockBackplane stands up an httptest.Server that routes by
+// `<METHOD> <path>` keys. The empty key acts as a catch-all. Same
+// shape as the vmware sibling's helper.
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+// primeToken installs an in-memory token store with a usable bearer
+// for the mocked backplane URL. Mirrors the vmware sibling.
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID — every verb dispatches with
+// connector_id="bind9-ssh-9.x" pre-baked. This test pins that the
+// dispatcher helper writes the canonical connector_id into the
+// CallOperationBody — a regression here would silently rebind every
+// alias verb to a different connector.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "bind9-ssh-9.x" {
+				t.Errorf("connector_id: got %q want bind9-ssh-9.x", body.ConnectorID)
+			}
+			if body.OpID != "bind9.about" {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "bind9.about",
+				Result: json.RawMessage(`{"vendor":"isc"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, "bind9.about", "vcf-router-bind9", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestDispatchOpTargetSlugWrappedAsName — a non-empty target slug
+// must surface as `{"name": "<slug>"}` so the dispatcher's resolver
+// pulls it under the canonical TargetRef shape.
+func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			tgt, _ := raw["target"].(map[string]any)
+			if tgt == nil || tgt["name"] != "vcf-router-bind9" {
+				t.Errorf("target should wrap slug as {name: ...}; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "bind9.about"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "bind9.about", "vcf-router-bind9", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchOpRecordAddSendsExpectedParams — pins the record.add
+// wire shape: fqdn + ip + zone + type all land in params under their
+// canonical keys.
+func TestDispatchOpRecordAddSendsExpectedParams(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != "bind9.record.add" {
+				t.Errorf("op_id: got %q want bind9.record.add", body.OpID)
+			}
+			if body.Params["fqdn"] != "api.evba.lab" {
+				t.Errorf("fqdn: got %v", body.Params["fqdn"])
+			}
+			if body.Params["ip"] != "10.5.50.99" {
+				t.Errorf("ip: got %v", body.Params["ip"])
+			}
+			if body.Params["zone"] != "evba.lab" {
+				t.Errorf("zone: got %v", body.Params["zone"])
+			}
+			if body.Params["type"] != "A" {
+				t.Errorf("type: got %v", body.Params["type"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "bind9.record.add"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	params := map[string]any{
+		"fqdn": "api.evba.lab",
+		"ip":   "10.5.50.99",
+		"zone": "evba.lab",
+		"type": "A",
+	}
+	if _, err := dispatchOp(context.Background(), srv.URL, "bind9.record.add", "vcf-router-bind9", params); err != nil {
+		t.Fatalf("dispatchOp record.add: %v", err)
+	}
+}
+
+// TestReadLocalFileHappyAndMissing — happy + error path.
+func TestReadLocalFileHappyAndMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.conf")
+	if err := os.WriteFile(path, []byte("hello world"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readLocalFile(path)
+	if err != nil {
+		t.Fatalf("readLocalFile: %v", err)
+	}
+	if got != "hello world" {
+		t.Fatalf("content: %q", got)
+	}
+	if _, err := readLocalFile(filepath.Join(dir, "nope")); err == nil {
+		t.Fatalf("missing path should error")
+	}
+}
+
+// TestJSONUnmarshalStrictHappy — thin wrapper test (regression
+// against signature drift).
+func TestJSONUnmarshalStrictHappy(t *testing.T) {
+	var out map[string]int
+	if err := jsonUnmarshalStrict([]byte(`{"k":1}`), &out); err != nil {
+		t.Fatalf("jsonUnmarshalStrict: %v", err)
+	}
+	if out["k"] != 1 {
+		t.Fatalf("decoded: %+v", out)
+	}
+}

--- a/cli/internal/cmd/bind9/bind9_test.go
+++ b/cli/internal/cmd/bind9/bind9_test.go
@@ -198,6 +198,62 @@ func TestAssembleViewsBundleRejectsMissingZonesDir(t *testing.T) {
 	}
 }
 
+// TestAssembleViewsBundleRejectsSymlinkUnderZonesDir — symlinks under
+// zonesDir would let a caller stage arbitrary host paths into
+// /etc/bind/ on the remote (the handler's path-safety filter gates
+// the destination, but the bundle content is whatever bytes the
+// symlink resolves to). The regular-file-only contract on
+// assembleViewsBundle blocks the exfil shape client-side.
+func TestAssembleViewsBundleRejectsSymlinkUnderZonesDir(t *testing.T) {
+	dir := t.TempDir()
+	viewsConf := filepath.Join(dir, "views.conf")
+	if err := os.WriteFile(viewsConf, []byte("// views\n"), 0o644); err != nil {
+		t.Fatalf("write views: %v", err)
+	}
+	zonesDir := filepath.Join(dir, "zones")
+	if err := os.MkdirAll(zonesDir, 0o755); err != nil {
+		t.Fatalf("mkdir zones: %v", err)
+	}
+	// Real file outside zonesDir; a permissive bundler would stage
+	// its bytes under /etc/bind/db.exfil on the remote.
+	outside := filepath.Join(dir, "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret content"), 0o600); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	link := filepath.Join(zonesDir, "db.exfil")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported on this fs: %v", err)
+	}
+	_, err := assembleViewsBundle(viewsConf, zonesDir)
+	if err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("expected `regular file` rejection for symlink entry; got %v", err)
+	}
+}
+
+// TestAssembleViewsBundleRejectsFifoUnderZonesDir — named pipes /
+// sockets / device nodes are not legitimate zones-dir entries.
+// The Mode().IsRegular() gate rejects all non-regular types
+// uniformly, not just symlinks.
+func TestAssembleViewsBundleRejectsFifoUnderZonesDir(t *testing.T) {
+	dir := t.TempDir()
+	viewsConf := filepath.Join(dir, "views.conf")
+	if err := os.WriteFile(viewsConf, []byte("// views\n"), 0o644); err != nil {
+		t.Fatalf("write views: %v", err)
+	}
+	zonesDir := filepath.Join(dir, "zones")
+	if err := os.MkdirAll(zonesDir, 0o755); err != nil {
+		t.Fatalf("mkdir zones: %v", err)
+	}
+	fifoPath := filepath.Join(zonesDir, "db.fifo")
+	if err := mkFifo(fifoPath, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported on this fs: %v", err)
+	}
+	_, err := assembleViewsBundle(viewsConf, zonesDir)
+	if err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("expected `regular file` rejection for fifo entry; got %v", err)
+	}
+}
+
 // ---------- renderers ----------
 
 // TestPrintAboutHumanFormat — happy-path render with vendor/product/

--- a/cli/internal/cmd/bind9/config.go
+++ b/cli/internal/cmd/bind9/config.go
@@ -1,0 +1,493 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package bind9
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newConfigCmd returns the `meho bind9 config` parent command and
+// assembles its five verbs (show / apply-views / apply-file / backup
+// / reload). The parent itself takes no args and prints its own help.
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "config",
+		Short:        "bind9 config verbs (show / apply-views / apply-file / backup / reload)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newConfigShowCmd())
+	cmd.AddCommand(newConfigApplyViewsCmd())
+	cmd.AddCommand(newConfigApplyFileCmd())
+	cmd.AddCommand(newConfigBackupCmd())
+	cmd.AddCommand(newConfigReloadCmd())
+	return cmd
+}
+
+// newConfigShowCmd returns `meho bind9 config show <file>`. Maps to
+// op_id `bind9.config.show`. <file> may be absolute (lexically under
+// the bind config root) or relative (resolved against the same root).
+// Traversal / outside-root inputs are rejected pre-stage.
+func newConfigShowCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "show <file>",
+		Short: "Read a bind9 config file from the target",
+		Long: "show dispatches bind9.config.show against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector. <file> may be absolute (must be\n" +
+			"lexically under the bind config root, e.g.\n" +
+			"`/etc/bind/named.conf`) or relative (resolved against the\n" +
+			"same root, e.g. `named.conf` or `views/external.conf`).\n" +
+			"Traversal paths and absolute paths outside the root are\n" +
+			"rejected pre-stage with no file content leak.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho bind9 config show named.conf --target vcf-router-bind9\n" +
+			"  meho bind9 config show /etc/bind/named.conf.local --target vcf-router-bind9 --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConfigShow(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runConfigShow(cmd *cobra.Command, path, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"path": path}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.show", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.config.show", r, jsonOut, printConfigShow)
+}
+
+// printConfigShow renders `{"file": <abs-path>, "content": <text>}`.
+// Surfaces the resolved path then the file content verbatim.
+func printConfigShow(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s bind9.config.show — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	body, err := decodeFlatResult(r.Result)
+	if err != nil || body == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if file, ok := body["file"].(string); ok && file != "" {
+		fmt.Fprintf(w, "  file: %s\n", file)
+	}
+	content, _ := body["content"].(string)
+	if content != "" {
+		fmt.Fprintln(w, "  --- content ---")
+		fmt.Fprintln(w, content)
+	}
+}
+
+// newConfigApplyViewsCmd returns `meho bind9 config apply-views
+// <local-views.conf> <zones-dir>`. Maps to op_id
+// `bind9.config.apply_views`. Stages a multi-file tree:
+//   - The named.conf-shaped `<local-views.conf>` lands at
+//     `named.conf.local` (the canonical views include).
+//   - Every regular file under `<zones-dir>` lands under the same
+//     relative subpath in `/etc/bind/` (e.g. a local
+//     `<zones-dir>/db.evba.lab` lands at `/etc/bind/db.evba.lab`).
+//
+// The atomic-apply primitive overlays the live tree; the snapshot-
+// rollback contract leaves /etc/bind/ byte-identical on failure.
+func newConfigApplyViewsCmd() *cobra.Command {
+	var (
+		targetName        string
+		primaryPath       string
+		verifyFQDN        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "apply-views <local-views.conf> <zones-dir>",
+		Short: "Apply a views fragment + zonefile tree (atomic; rollback on failure)",
+		Long: "apply-views dispatches bind9.config.apply_views against the\n" +
+			"connector_id=\"bind9-ssh-9.x\" connector. The CLI reads\n" +
+			"<local-views.conf> as the named.conf.local replacement and\n" +
+			"walks <zones-dir> (recursively) collecting every regular\n" +
+			"file as a zonefile to land under the same relative path in\n" +
+			"/etc/bind/. The handler stages the merged tree, runs\n" +
+			"`named-checkconf -p`, reloads, and either verifies a sample\n" +
+			"FQDN (--verify-fqdn) or just confirms the live config\n" +
+			"parses post-reload.\n\n" +
+			"--primary-path nominates which staged file's pre/post-op\n" +
+			"content the audit row should capture (defaults to the\n" +
+			"first key in `files` sorted lexicographically; must\n" +
+			"reference one of the staged keys).\n\n" +
+			"Atomic-apply contract: an invalid views/zone file or a\n" +
+			"failed verify leaves /etc/bind/ byte-identical to before\n" +
+			"the call.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho bind9 config apply-views ./views/external.conf ./zones --target vcf-router-bind9\n" +
+			"  meho bind9 config apply-views ./views.conf ./zones --verify-fqdn www.evba.lab --target vcf-router-bind9",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConfigApplyViews(cmd, args[0], args[1], primaryPath, verifyFQDN, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().StringVar(&primaryPath, "primary-path", "",
+		"which staged file's content the audit row captures (defaults to first key sorted)")
+	cmd.Flags().StringVar(&verifyFQDN, "verify-fqdn", "",
+		"sample FQDN to dig-verify post-reload (optional)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runConfigApplyViews(
+	cmd *cobra.Command,
+	viewsConfPath, zonesDir, primaryPath, verifyFQDN, targetName string,
+	jsonOut bool, backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	files, err := assembleViewsBundle(viewsConfPath, zonesDir)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	params := map[string]any{"files": files}
+	if primaryPath != "" {
+		params["primary_path"] = primaryPath
+	}
+	if verifyFQDN != "" {
+		params["verify_fqdn"] = verifyFQDN
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.apply_views", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.config.apply_views", r, jsonOut, printWriteResult)
+}
+
+// assembleViewsBundle reads the local views.conf and every regular
+// file under zonesDir, returning a map keyed by the relative bind-
+// root path. Mirrors the handler's documented `files` parameter
+// shape: keys are relative paths (no leading slash, no traversal);
+// values are UTF-8 content strings.
+//
+// The views.conf path lands at `named.conf.local` (the bind9
+// canonical views include); every file under zonesDir lands at its
+// `zonesDir`-relative path verbatim (e.g. `db.evba.lab`, or
+// `nested/db.other.zone`). The handler's path-safety filter rejects
+// anything that escapes /etc/bind/; we do a defence-in-depth check
+// here too (no leading slash; no `..` component) so a typo'd local
+// path fails fast before the round-trip.
+func assembleViewsBundle(viewsConfPath, zonesDir string) (map[string]string, error) {
+	out := map[string]string{}
+
+	// 1. The views.conf -> named.conf.local mapping.
+	viewsContent, err := readLocalFile(viewsConfPath)
+	if err != nil {
+		return nil, err
+	}
+	out["named.conf.local"] = viewsContent
+
+	// 2. Every regular file under zonesDir, keyed by its relative
+	//    path under zonesDir.
+	stat, err := os.Stat(zonesDir)
+	if err != nil {
+		return nil, fmt.Errorf("zones dir %q: %w", zonesDir, err)
+	}
+	if !stat.IsDir() {
+		return nil, fmt.Errorf("zones dir %q is not a directory", zonesDir)
+	}
+	walkErr := filepath.Walk(zonesDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(zonesDir, path)
+		if err != nil {
+			return fmt.Errorf("rel %q: %w", path, err)
+		}
+		// Defence-in-depth: forbid `..` traversal + absolute paths
+		// client-side; the handler's path-safety filter is the
+		// authoritative gate but failing fast keeps the wire shape
+		// clean.
+		rel = filepath.ToSlash(rel)
+		if rel == "" || strings.HasPrefix(rel, "/") {
+			return fmt.Errorf("zones dir entry %q has an unexpected absolute path", path)
+		}
+		for _, seg := range strings.Split(rel, "/") {
+			if seg == ".." {
+				return fmt.Errorf("zones dir entry %q contains a `..` segment", path)
+			}
+		}
+		// Skip files that would collide with the explicit views.conf
+		// key (operator surprise: a local `named.conf.local` under
+		// zonesDir would silently win over the views.conf arg).
+		if rel == "named.conf.local" {
+			return fmt.Errorf("zones dir contains `named.conf.local` which would collide with the views-conf arg")
+		}
+		content, err := readLocalFile(path)
+		if err != nil {
+			return err
+		}
+		out[rel] = content
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return out, nil
+}
+
+// newConfigApplyFileCmd returns `meho bind9 config apply-file <name>
+// <local-src>`. Maps to op_id `bind9.config.apply_file`. <name> is
+// the relative path under the bind config root (e.g.
+// `named.conf.options`); <local-src> is the local file whose content
+// will replace the remote file's bytes.
+func newConfigApplyFileCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "apply-file <name> <local-src>",
+		Short: "Replace a bind9 config fragment from a local file (atomic)",
+		Long: "apply-file dispatches bind9.config.apply_file against the\n" +
+			"connector_id=\"bind9-ssh-9.x\" connector. The CLI reads\n" +
+			"<local-src> from the local filesystem and stages its content\n" +
+			"as the replacement for <name> on the remote bind config root.\n\n" +
+			"<name> may be relative (e.g. `named.conf.options`) or\n" +
+			"absolute under the bind config root (e.g.\n" +
+			"`/etc/bind/named.conf.options`). Traversal / outside-root\n" +
+			"inputs are rejected pre-stage.\n\n" +
+			"Atomic-apply contract: an invalid fragment leaves /etc/bind/\n" +
+			"byte-identical to before the call.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example:       "  meho bind9 config apply-file named.conf.options ./local/named.conf.options --target vcf-router-bind9",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConfigApplyFile(cmd, args[0], args[1], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runConfigApplyFile(cmd *cobra.Command, name, localSrc, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	content, err := readLocalFile(localSrc)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	params := map[string]any{
+		"path":    name,
+		"content": content,
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.apply_file", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.config.apply_file", r, jsonOut, printWriteResult)
+}
+
+// newConfigBackupCmd returns `meho bind9 config backup [--tag T]`.
+// Maps to op_id `bind9.config.backup`. Produces a tar.gz snapshot
+// of /etc/bind/ under /var/backups/meho-bind9/ on the target and
+// returns a backup_id + listing.
+func newConfigBackupCmd() *cobra.Command {
+	var (
+		targetName        string
+		tag               string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "backup",
+		Short: "Snapshot /etc/bind/ into /var/backups/meho-bind9/<timestamp>-<tag>.tar.gz",
+		Long: "backup dispatches bind9.config.backup against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector. Creates a UTC-timestamped tar.gz\n" +
+			"under /var/backups/meho-bind9/ and returns the backup_id +\n" +
+			"the listing of every backup under that directory.\n\n" +
+			"--tag is an optional friendly tag embedded in the backup\n" +
+			"filename after the timestamp; restricted to\n" +
+			"`[A-Za-z0-9._-]{1,64}` so it can't inject shell metacharacters\n" +
+			"or path separators.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho bind9 config backup --target vcf-router-bind9\n" +
+			"  meho bind9 config backup --tag pre-migration --target vcf-router-bind9",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runConfigBackup(cmd, tag, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().StringVar(&tag, "tag", "",
+		"friendly tag embedded in the backup filename ([A-Za-z0-9._-]{1,64})")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runConfigBackup(cmd *cobra.Command, tag, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{}
+	if tag != "" {
+		params["tag"] = tag
+	}
+	if len(params) == 0 {
+		params = nil
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.backup", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.config.backup", r, jsonOut, printConfigBackup)
+}
+
+// printConfigBackup renders the backup result. Surfaces backup_id +
+// path + the listing of all backups under the meho-bind9 dir.
+func printConfigBackup(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s bind9.config.backup — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	body, err := decodeFlatResult(r.Result)
+	if err != nil || body == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if backupID, ok := body["backup_id"].(string); ok && backupID != "" {
+		fmt.Fprintf(w, "  backup_id: %s\n", backupID)
+	}
+	if path, ok := body["path"].(string); ok && path != "" {
+		fmt.Fprintf(w, "  path:      %s\n", path)
+	}
+	rowsAny, ok := body["rows"].([]any)
+	if !ok || len(rowsAny) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "  --- backups under /var/backups/meho-bind9/ ---")
+	fmt.Fprintf(w, "%-50s %20s %s\n", "id", "size_bytes", "mtime")
+	for _, ra := range rowsAny {
+		row, ok := ra.(map[string]any)
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(w, "%-50s %20d %s\n",
+			truncate(stringField(row, "id"), 50),
+			intField(row, "size_bytes"),
+			stringField(row, "mtime"),
+		)
+	}
+}
+
+// newConfigReloadCmd returns `meho bind9 config reload`. Maps to
+// op_id `bind9.config.reload`. Issues `rndc reload` on the target.
+func newConfigReloadCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "reload",
+		Short: "rndc reload — re-read the active bind9 configuration",
+		Long: "reload dispatches bind9.config.reload against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector. Runs `rndc reload` on the target\n" +
+			"and surfaces the structured success/failure envelope (ok flag,\n" +
+			"rndc exit, stderr, rndc-status snapshot pre/post).\n\n" +
+			"Use after an `apply-file` / `apply-views` only if you needed\n" +
+			"to bypass the primitive's automatic reload (rare); the apply\n" +
+			"ops themselves reload at the verify step.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example:       "  meho bind9 config reload --target vcf-router-bind9",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runConfigReload(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runConfigReload(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.reload", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.config.reload", r, jsonOut, printConfigReload)
+}
+
+// printConfigReload renders the rndc reload result. Surfaces ok +
+// rndc_reload_exit; the rndc-status snapshots before/after are on
+// --json.
+func printConfigReload(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s bind9.config.reload — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	body, err := decodeFlatResult(r.Result)
+	if err != nil || body == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	for _, key := range []string{"ok", "rndc_reload_exit", "stderr"} {
+		if v, ok := body[key]; ok && v != nil {
+			fmt.Fprintf(w, "  %-18s %v\n", key+":", v)
+		}
+	}
+	fmt.Fprintln(w, "  (see --json for result_state_before / result_state_after rndc-status snapshots)")
+}

--- a/cli/internal/cmd/bind9/config.go
+++ b/cli/internal/cmd/bind9/config.go
@@ -230,6 +230,19 @@ func assembleViewsBundle(viewsConfPath, zonesDir string) (map[string]string, err
 		if info.IsDir() {
 			return nil
 		}
+		// Reject anything that is not a regular file. Symlinks (could
+		// resolve to /etc/passwd or any host path the caller cannot
+		// otherwise see), block / char devices, FIFOs, and sockets
+		// must not be stageable. The handler's atomic-apply primitive
+		// runs with `safety_level=dangerous`; a permissive client-side
+		// stager would let a typo'd zones-dir exfil arbitrary files
+		// into /etc/bind/. The check uses Mode().IsRegular() (set
+		// exactly when the file is a normal on-disk file), not just a
+		// symlink-rejection — block / char devices and FIFOs are also
+		// not zones-dir entries any operator legitimately wants here.
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("zones dir entry %q is not a regular file (mode=%s)", path, info.Mode())
+		}
 		rel, err := filepath.Rel(zonesDir, path)
 		if err != nil {
 			return fmt.Errorf("rel %q: %w", path, err)

--- a/cli/internal/cmd/bind9/dispatch.go
+++ b/cli/internal/cmd/bind9/dispatch.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package bind9
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model.
+// Same shape as cmd/vmware/CallResult; duplicated here because
+// cmd/bind9 can't import cmd/vmware without an import cycle
+// (cmd/root.go grafts both onto the tree).
+//
+// Result is left as json.RawMessage because the backend types it as
+// a oneOf(dict, list) union — pretty-printing the raw bytes is the
+// cleanest renderer until a per-shape table specialisation lands.
+// Same approach the vmware sibling takes.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic
+// model. Target uses a map[string]any so the empty case serialises
+// as `null` rather than an empty struct; the route layer's resolver
+// short-circuits on the missing-name case (raising 400) for ops
+// that need a target.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+// errOpError is the sentinel returned when the dispatcher reported a
+// structured-failure result (status == "error" or status ==
+// "denied"). main translates non-nil RunE errors into a non-zero
+// exit; SilenceErrors=true on each command keeps cobra from double-
+// printing the error string. Same shape as the vmware sibling's
+// errOpError.
+var errOpError = errors.New("operation status not ok")
+
+// dispatchOp POSTs an OperationCall to the backplane and returns the
+// decoded CallResult. The pre-baked connector_id ("bind9-ssh-9.x")
+// is baked in; callers pass op_id, an optional target slug (empty
+// string → no target field on the wire), and an optional params map.
+//
+// Centralised here so every verb in the package shares one
+// dispatcher implementation (over a dozen call sites). Renamed from
+// the vmware sibling's postCall to make the call sites self-
+// documenting at the grep level: a grep for `dispatchOp` finds every
+// alias-verb dispatch in the bind9 package.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: ConnectorID,
+		OpID:        opID,
+		Target:      nil,
+	}
+	if targetSlug != "" {
+		body.Target = map[string]any{"name": targetSlug}
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderCallResult handles the unified post-dispatch path every verb
+// uses: validate status enum, render the envelope (JSON or human),
+// then translate "error" / "denied" into the errOpError sentinel so
+// main propagates the right non-zero exit. Returns nil on success
+// or one of:
+//   - errOpError (status == "error" / "denied" → exit 1)
+//   - a structured renderer error (unexpected status → exit 4)
+//
+// Pretty-printing is delegated to a per-verb closure so verb files
+// can lay out their domain-specific tables (zone list shows
+// name/type/file columns; record get shows the rdata rows; etc.).
+// When prettyPrinter is nil, the fallback renders the generic
+// envelope shape — handy for verbs whose result envelope is opaque
+// to the CLI today (config.apply_* / config.backup write envelopes).
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+		// fall through.
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		printGenericResult(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+// printGenericResult renders a CallResult in the same shape the
+// vmware sibling's printGenericResult uses. Used as the fallback
+// pretty-printer for verbs that don't define their own table layout
+// (config.apply_* writes whose result envelope is opaque to the
+// CLI; config.backup whose listing is best read as JSON).
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	printErrorTrailer(w, r)
+}
+
+// printErrorTrailer surfaces the dispatcher error / extras envelope.
+// Used by every per-verb pretty-printer's error branch so the
+// "status=error" output is consistent across verbs. Same shape as
+// the vmware sibling's helper.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
+// Same implementation as the vmware sibling.
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// decodeRowsResult decodes the canonical `{"rows": [...], "total": N}`
+// envelope every set-shaped bind9 read op returns (zone.list,
+// zone.read, record.get, config.backup listing). Returns the row list
+// or an error when the shape doesn't match — call sites fall back to
+// the generic JSON dump on decode failure rather than panicking.
+func decodeRowsResult(raw json.RawMessage) ([]map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var envelope struct {
+		Rows []map[string]any `json:"rows"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("decode rows: %w", err)
+	}
+	return envelope.Rows, nil
+}
+
+// decodeFlatResult decodes a flat-dict result (bind9.about,
+// bind9.config.show, bind9.config.reload, bind9.record.add /
+// .remove). Returns the decoded map or an error.
+func decodeFlatResult(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("decode flat: %w", err)
+	}
+	return m, nil
+}
+
+// stringField pulls a string field from a row entry, returning empty
+// string when the field is missing or wrong type. Mirrors the vmware
+// sibling's helper.
+func stringField(e map[string]any, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// fallbackResultRender dumps the result envelope verbatim when the
+// typed per-verb decode fails. Used by every verb's pretty-printer
+// so contract drift surfaces with the same affordance.
+func fallbackResultRender(w io.Writer, r *CallResult) {
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	pretty, err := prettyJSON(r.Result)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+		return
+	}
+	fmt.Fprintln(w, string(r.Result))
+}

--- a/cli/internal/cmd/bind9/mkfifo_unix_test.go
+++ b/cli/internal/cmd/bind9/mkfifo_unix_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+//go:build unix
+
+package bind9
+
+import "syscall"
+
+// mkFifo is a thin wrapper around syscall.Mkfifo so the unit tests can
+// construct a named pipe to exercise the non-regular-file rejection in
+// assembleViewsBundle. Gated to unix builds because Windows lacks the
+// POSIX mkfifo syscall; on non-unix targets the symlink test still
+// proves the regular-file-only contract.
+func mkFifo(path string, mode uint32) error {
+	return syscall.Mkfifo(path, mode)
+}

--- a/cli/internal/cmd/bind9/record.go
+++ b/cli/internal/cmd/bind9/record.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package bind9
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newRecordCmd returns the `meho bind9 record` parent command and
+// assembles its three verbs (get / add / remove).
+//
+// The `record add` invocation is the 1:1 replacement for the
+// consumer's `scripts/bind9-dns.sh --add-a-record ...` call (the
+// 2026-05-04 / 2026-05-05 credential-leak surface — evoila-bosnia/
+// claude-rdc-hetzner-dc#86); the verb shape matches the wrapper's
+// positional / flag conventions.
+func newRecordCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "record",
+		Short:        "bind9 record verbs (get / add / remove)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newRecordGetCmd())
+	cmd.AddCommand(newRecordAddCmd())
+	cmd.AddCommand(newRecordRemoveCmd())
+	return cmd
+}
+
+// newRecordGetCmd returns `meho bind9 record get <fqdn> [--type T]`.
+// Maps to op_id `bind9.record.get`. The `--type` flag defaults to
+// A; other supported values are AAAA / CNAME / MX / TXT.
+func newRecordGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		recordType        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "get <fqdn>",
+		Short: "Resolve an FQDN through the local bind9 (dig @localhost)",
+		Long: "get dispatches bind9.record.get against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector. Resolution uses `dig @localhost`\n" +
+			"so views, delegations, and cache hits behave as the rest of\n" +
+			"the world sees them. --type defaults to A; AAAA / CNAME / MX /\n" +
+			"TXT are the operator-relevant complement (other types ride\n" +
+			"through `meho bind9 zone read`).\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho bind9 record get www.evba.lab --target vcf-router-bind9\n" +
+			"  meho bind9 record get mail.evba.lab --type AAAA --target vcf-router-bind9",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRecordGet(cmd, args[0], recordType, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().StringVar(&recordType, "type", "",
+		"record type (A / AAAA / CNAME / MX / TXT). Omitted → handler default (A).")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runRecordGet(cmd *cobra.Command, fqdn, recordType, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"fqdn": fqdn}
+	if recordType != "" {
+		params["type"] = recordType
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.record.get", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.record.get", r, jsonOut, printRecordGet)
+}
+
+// printRecordGet renders the record get result. Same row shape as
+// zone.read: `{name, ttl, class, type, rdata}`.
+func printRecordGet(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s bind9.record.get — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	body, err := decodeFlatResult(r.Result)
+	if err != nil || body == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if fqdn, ok := body["fqdn"].(string); ok && fqdn != "" {
+		fmt.Fprintf(w, "  fqdn: %s\n", fqdn)
+	}
+	if t, ok := body["type"].(string); ok && t != "" {
+		fmt.Fprintf(w, "  type: %s\n", t)
+	}
+	rowsAny, ok := body["rows"].([]any)
+	if !ok {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(rowsAny) == 0 {
+		fmt.Fprintln(w, "  (0 records)")
+		return
+	}
+	fmt.Fprintf(w, "%-40s %-6s %-5s %-7s %s\n", "name", "ttl", "class", "type", "rdata")
+	for _, ra := range rowsAny {
+		row, ok := ra.(map[string]any)
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(w, "%-40s %-6d %-5s %-7s %s\n",
+			truncate(stringField(row, "name"), 40),
+			intField(row, "ttl"),
+			stringField(row, "class"),
+			stringField(row, "type"),
+			stringField(row, "rdata"),
+		)
+	}
+}
+
+// newRecordAddCmd returns `meho bind9 record add <fqdn> <ip>`. Maps
+// to op_id `bind9.record.add`. The write routes through the atomic-
+// apply primitive in the backend — invalid input leaves /etc/bind/
+// byte-identical to the pre-op snapshot. The `--zone` flag is
+// optional; when omitted, the handler resolves the owning zone via
+// longest-suffix match.
+//
+// This verb is the 1:1 replacement for
+// `bind9-dns.sh --add-a-record <fqdn> <ip> --zone <zone>`.
+func newRecordAddCmd() *cobra.Command {
+	var (
+		targetName        string
+		zone              string
+		recordType        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "add <fqdn> <ip>",
+		Short: "Add an A/AAAA record (atomic-apply; rollback on failure)",
+		Long: "add dispatches bind9.record.add against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector. Routes the write through the\n" +
+			"atomic-apply primitive (#589): validate → stage → checkconf →\n" +
+			"reload → dig-verify, with a rollback to the pre-op snapshot\n" +
+			"if any step fails. Invalid input leaves /etc/bind/ byte-\n" +
+			"identical to before the call.\n\n" +
+			"--zone is optional; when omitted, the handler resolves the\n" +
+			"owning zone via longest-suffix match against the active\n" +
+			"`named-checkconf -p` output. --type accepts A or AAAA only\n" +
+			"(CNAME / MX / TXT writes are out of scope for v0.2; the\n" +
+			"consumer wrapper never wrote them either).\n\n" +
+			"This verb is the 1:1 replacement for the consumer's\n" +
+			"`bind9-dns.sh --add-a-record <fqdn> <ip> --zone <zone>`.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho bind9 record add esx-dc6.evba.lab 10.5.50.25 --zone evba.lab --target vcf-router-bind9\n" +
+			"  meho bind9 record add v6.evba.lab 2001:db8::25 --type AAAA --target vcf-router-bind9",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRecordAdd(cmd, args[0], args[1], zone, recordType, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().StringVar(&zone, "zone", "",
+		"owning zone (e.g. evba.lab). Omitted → handler resolves via longest-suffix match.")
+	cmd.Flags().StringVar(&recordType, "type", "",
+		"record type (A / AAAA). Omitted → handler default (A).")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runRecordAdd(cmd *cobra.Command, fqdn, ip, zone, recordType, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{
+		"fqdn": fqdn,
+		"ip":   ip,
+	}
+	if zone != "" {
+		params["zone"] = zone
+	}
+	if recordType != "" {
+		params["type"] = recordType
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.record.add", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.record.add", r, jsonOut, printWriteResult)
+}
+
+// newRecordRemoveCmd returns `meho bind9 record remove <fqdn>`.
+// Maps to op_id `bind9.record.remove`. Removes the A + AAAA
+// rdatasets at <fqdn>; CNAME / MX / TXT are out of scope.
+func newRecordRemoveCmd() *cobra.Command {
+	var (
+		targetName        string
+		zone              string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "remove <fqdn>",
+		Short: "Remove the A/AAAA records at an FQDN (atomic-apply)",
+		Long: "remove dispatches bind9.record.remove against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector. Removes the A and AAAA rdatasets\n" +
+			"at <fqdn> via the same atomic-apply primitive as record.add\n" +
+			"— invalid input leaves /etc/bind/ byte-identical.\n\n" +
+			"CNAME / MX / TXT removals are out of scope for v0.2 (the\n" +
+			"consumer wrapper never removed them either; use\n" +
+			"`meho bind9 config apply-file` for fine-grained zonefile\n" +
+			"edits in the meantime).\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example:       "  meho bind9 record remove esx-dc6.evba.lab --zone evba.lab --target vcf-router-bind9",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRecordRemove(cmd, args[0], zone, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().StringVar(&zone, "zone", "",
+		"owning zone (e.g. evba.lab). Omitted → handler resolves via longest-suffix match.")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runRecordRemove(cmd *cobra.Command, fqdn, zone, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"fqdn": fqdn}
+	if zone != "" {
+		params["zone"] = zone
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.record.remove", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.record.remove", r, jsonOut, printWriteResult)
+}
+
+// printWriteResult renders the canonical write-op result envelope
+// (`bind9.record.add`, `bind9.record.remove`, `bind9.config.apply_*`).
+// Surfaces `op_class`, `zone` (when present), and the
+// `result_state_before` / `result_state_after` summary that lets an
+// operator confirm a successful atomic-apply landed the intended
+// change. Full payload is on --json for diff-eyes inspection.
+func printWriteResult(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, r.OpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	body, err := decodeFlatResult(r.Result)
+	if err != nil || body == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	// op_class is "write" for atomic-apply ops.
+	if opClass, ok := body["op_class"].(string); ok && opClass != "" {
+		fmt.Fprintf(w, "  op_class: %s\n", opClass)
+	}
+	for _, key := range []string{"fqdn", "zone", "file", "type", "ip"} {
+		if v, ok := body[key]; ok && v != nil {
+			fmt.Fprintf(w, "  %-9s %v\n", key+":", v)
+		}
+	}
+	// state_before / state_after are truncated previews; the full
+	// pre/post-op file content is on result_state_before /
+	// result_state_after for audit diffing via --json.
+	if before, ok := body["state_before"].(string); ok && before != "" {
+		fmt.Fprintf(w, "  state_before: %s\n", truncate(before, 80))
+	}
+	if after, ok := body["state_after"].(string); ok && after != "" {
+		fmt.Fprintf(w, "  state_after:  %s\n", truncate(after, 80))
+	}
+	fmt.Fprintln(w, "  (see --json for result_state_before / result_state_after full content)")
+}

--- a/cli/internal/cmd/bind9/zone.go
+++ b/cli/internal/cmd/bind9/zone.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package bind9
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newZoneCmd returns the `meho bind9 zone` parent command and
+// assembles its two verbs (list / read). The parent itself takes no
+// args and prints its own help.
+func newZoneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "zone",
+		Short:        "bind9 zone verbs (list / read)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newZoneListCmd())
+	cmd.AddCommand(newZoneReadCmd())
+	return cmd
+}
+
+// newZoneListCmd returns `meho bind9 zone list`. Maps to op_id
+// `bind9.zone.list`. Output is the canonical `{rows: [...], total}`
+// envelope; rows carry `{name, file, type}`.
+func newZoneListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List zones declared in the active bind9 configuration",
+		Long: "list dispatches bind9.zone.list against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector. Returns one row per zone declared\n" +
+			"in the active configuration (parsed from `named-checkconf -p`).\n" +
+			"The human render shows name / type / file columns; --json emits\n" +
+			"the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho bind9 zone list --target vcf-router-bind9\n" +
+			"  meho bind9 zone list --target vcf-router-bind9 --json | jq '.result.rows[].name'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runZoneList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runZoneList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.zone.list", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.zone.list", r, jsonOut, printZoneList)
+}
+
+// printZoneList renders the zone list. Each row carries `{name,
+// file, type}` per `_BIND9_ZONE_LIST_RESPONSE_SCHEMA`.
+func printZoneList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s bind9.zone.list — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	rows, err := decodeRowsResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "  (0 zones)")
+		return
+	}
+	fmt.Fprintf(w, "%-40s %-10s %s\n", "name", "type", "file")
+	for _, row := range rows {
+		name := stringField(row, "name")
+		zoneType := stringField(row, "type")
+		file := stringField(row, "file")
+		fmt.Fprintf(w, "%-40s %-10s %s\n",
+			truncate(name, 40),
+			truncate(zoneType, 10),
+			file,
+		)
+	}
+}
+
+// newZoneReadCmd returns `meho bind9 zone read <zone>`. Maps to
+// op_id `bind9.zone.read` with `{"zone": <name>}` params.
+func newZoneReadCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "read <zone>",
+		Short: "Read the records of a zone (name / ttl / class / type / rdata rows)",
+		Long: "read dispatches bind9.zone.read against the connector_id=\n" +
+			"\"bind9-ssh-9.x\" connector with the supplied zone name. The\n" +
+			"handler resolves the zonefile path via `named-checkconf -p`\n" +
+			"(no manual path-typing) and parses the file via dnspython's\n" +
+			"`dns.zone.from_text`. Returns one row per rrset member —\n" +
+			"an A rrset with three addresses yields three rows.\n\n" +
+			"The trailing dot on <zone> is optional; the handler\n" +
+			"normalises both `evba.lab` and `evba.lab.`.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho bind9 zone read evba.lab --target vcf-router-bind9\n" +
+			"  meho bind9 zone read evba.lab. --target vcf-router-bind9 --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runZoneRead(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "target slug to dispatch against")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runZoneRead(cmd *cobra.Command, zone, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"zone": zone}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.zone.read", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "bind9.zone.read", r, jsonOut, printZoneRead)
+}
+
+// printZoneRead renders the zone read result. Each row carries
+// `{name, ttl, class, type, rdata}` per `_BIND9_ZONE_READ_RESPONSE_SCHEMA`.
+func printZoneRead(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s bind9.zone.read — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	body, err := decodeFlatResult(r.Result)
+	if err != nil || body == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	// Surface zone + file at the head; then the rows table.
+	if zone, ok := body["zone"].(string); ok && zone != "" {
+		fmt.Fprintf(w, "  zone: %s\n", zone)
+	}
+	if file, ok := body["file"].(string); ok && file != "" {
+		fmt.Fprintf(w, "  file: %s\n", file)
+	}
+	rowsAny, ok := body["rows"].([]any)
+	if !ok {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(rowsAny) == 0 {
+		fmt.Fprintln(w, "  (0 records)")
+		return
+	}
+	fmt.Fprintf(w, "%-40s %-6s %-5s %-7s %s\n", "name", "ttl", "class", "type", "rdata")
+	for _, ra := range rowsAny {
+		row, ok := ra.(map[string]any)
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(w, "%-40s %-6d %-5s %-7s %s\n",
+			truncate(stringField(row, "name"), 40),
+			intField(row, "ttl"),
+			stringField(row, "class"),
+			stringField(row, "type"),
+			stringField(row, "rdata"),
+		)
+	}
+}
+
+// intField pulls an integer field from a row entry. JSON integers
+// land as float64 after json.Unmarshal into map[string]any — the
+// conversion is documented behaviour, not a workaround.
+func intField(e map[string]any, key string) int {
+	v, ok := e[key]
+	if !ok {
+		return 0
+	}
+	if f, ok := v.(float64); ok {
+		return int(f)
+	}
+	return 0
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/cmd/audit"
+	"github.com/evoila/meho/cli/internal/cmd/bind9"
 	"github.com/evoila/meho/cli/internal/cmd/connector"
 	"github.com/evoila/meho/cli/internal/cmd/k8s"
 	"github.com/evoila/meho/cli/internal/cmd/kb"
@@ -176,6 +177,21 @@ func newRootCmd() *cobra.Command {
 	// pods` wrapper. Registered before registerDynamicSubcommands so
 	// the backplane manifest cannot shadow the built-in `k8s` parent.
 	root.AddCommand(k8s.NewRootCmd())
+
+	// G3.4-T5 (#591) -- bind9-ssh-9.x operator alias verbs for Initiative
+	// #367. The verb tree pre-bakes connector_id="bind9-ssh-9.x" on top
+	// of the existing /api/v1/operations/call dispatcher route so
+	// operators don't type the connector ID on every invocation. Ships
+	// the 11 ops (about, zone list/read, record get/add/remove, config
+	// show/apply-views/apply-file/backup/reload) registered by G3.4-
+	// T1..T4 (#587/#588/#589/#590). `meho bind9 record add
+	// esx-dc6.evba.lab 10.5.50.25 --zone evba.lab --target
+	// vcf-router-bind9` replaces the consumer's
+	// `bind9-dns.sh --add-a-record` wrapper (the 2026-05-04 / 2026-05-05
+	// credential-leak surface — evoila-bosnia/claude-rdc-hetzner-dc#86).
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in `bind9` parent.
+	root.AddCommand(bind9.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/docs/cross-repo/bind9-onboarding.md
+++ b/docs/cross-repo/bind9-onboarding.md
@@ -240,7 +240,7 @@ $ meho bind9 record remove esx-dc6.evba.lab \
 `bind9-dns.sh --add-a-record …` invocation. The wrapper composed a
 zonefile edit + `rndc reload` + a dig-verify by hand; the MEHO op
 routes the same flow through the atomic-apply primitive (see
-[Atomic-apply contract](#atomic-apply-contract) below).
+[Atomic-apply contract](#the-atomic-apply-contract) below).
 
 ### Config browse + write — `meho bind9 config …`
 

--- a/docs/cross-repo/bind9-onboarding.md
+++ b/docs/cross-repo/bind9-onboarding.md
@@ -1,0 +1,459 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Bind9 op surface onboarding — operator recipe
+
+> Operator-facing recipe for the G3.4 `bind9-ssh-9.x` op surface — the
+> `meho bind9 …` verb tree, the agent meta-tool path, and the
+> migration off the consumer's `scripts/bind9-dns.sh` wrapper. The op
+> handlers live in
+> [`backend/src/meho_backplane/connectors/bind9/`](../../backend/src/meho_backplane/connectors/bind9/);
+> the engineering-facing companion is
+> [`docs/codebase/connectors-bind9.md`](../codebase/connectors-bind9.md).
+> This doc is the cookbook every RDC operator reads when retiring the
+> bash wrapper in favour of `meho bind9 …`.
+
+## What this surface is
+
+The `bind9-ssh-9.x` connector is a **typed** connector: hand-coded
+handlers over `asyncssh`, registered into the G0.6
+`endpoint_descriptor` table at backplane startup. It dispatches under
+the `(product="bind9", version="9.x", impl_id="bind9-ssh")` registry
+triple — the connector id `bind9-ssh-9.x`.
+
+The `-ssh` discriminator in the impl_id leaves room for a future
+`bind9-rndc-9.x` or `bind9-rest-9.x` sibling without breaking the
+resolver's tie-break ladder; v0.2 ships only the SSH transport (the
+shape every consumer bind9 host already exposes through the same
+SSH-bastion path operators reach for diagnostics).
+
+The v0.2 op surface (Initiative
+[#367](https://github.com/evoila/meho/issues/367)) is the working set
+the consumer's `bind9-dns.sh` wrapper exercises daily:
+
+| Group | Ops | Class |
+| --- | --- | --- |
+| `identity` | `bind9.about` | read-only fingerprint |
+| `zone` | `bind9.zone.list`, `bind9.zone.read` | read-only |
+| `record` | `bind9.record.get`, `bind9.record.add`, `bind9.record.remove` | 1 read + 2 atomic writes |
+| `config` | `bind9.config.show`, `bind9.config.apply_file`, `bind9.config.apply_views`, `bind9.config.backup`, `bind9.config.reload` | 1 read + 4 writes |
+
+Eleven ops total. Every op dispatches through the same
+`POST /api/v1/operations/call` route the agent surface uses — auth,
+policy, audit, broadcast, and JSONFlux all run as documented in
+[CLAUDE.md](../../CLAUDE.md) §6. The CLI verb tree is operator
+ergonomics over that one route; it is **not** a separate data path and
+is **not** mirrored on the MCP surface (CLAUDE.md postulate 5 — the
+agent reaches every bind9 op via the narrow-waist meta-tools, see the
+[agent meta-tool path](#the-agent-meta-tool-path) section).
+
+## Prerequisites
+
+- **An SSH-reachable bind9 host.** The connector talks bind9 over SSH
+  using `asyncssh`. The target host must run `bind9` 9.18 or 9.20 with
+  the standard Debian-family layout (`/etc/bind/named.conf`,
+  `named-checkconf`, `rndc`); other distros work as long as those
+  binaries are on `$PATH` for the SSH user.
+- **`sudo` for the bind user.** Every write op (`record.add`,
+  `record.remove`, `config.apply_*`, `config.backup`,
+  `config.reload`) routes through the connector's
+  `_remote_bash_with_sudo()` primitive (see the
+  [Credential-leak postmortem](#credential-leak-postmortem) section —
+  this is load-bearing). The SSH user must have `sudo` rights to
+  manage `/etc/bind/` and run `rndc`; the operator-facing recipe is a
+  `NOPASSWD: ALL` rule for the dedicated `meho-bind9` user, kept
+  separate from the operator's personal account.
+- **`python3` on the target.** The atomic-apply primitive's snapshot
+  / rollback step stages files through a Python one-liner that walks
+  `/etc/bind/` and computes a SOA-normalised checksum. Standard-library
+  Python 3.x suffices — no third-party packages.
+- **A registered bind9 target.** The CLI verbs take `--target <slug>`
+  (e.g. `--target vcf-router-bind9`); the slug resolves server-side to
+  a row in the `targets` table. The target carries `product="bind9"`,
+  `host`, `port` (optional, defaults to 22), `secret_ref`
+  (SSH credential dict), and `auth_model="shared_service_account"`.
+- **`auth_model = shared_service_account`** — the only auth model
+  v0.2 ships. The connector reads the SSH credential out of
+  `secret_ref` directly (no Vault-fetch yet); the federation chain
+  setup that lets a Vault-managed `secret_ref` resolve through
+  [`vault-onboarding.md`](./vault-onboarding.md) lands in a future
+  Initiative.
+- **An operator session.** `meho login <backplane-url>` writes the
+  session token the CLI reuses across every verb. `meho bind9 …`
+  needs `operator` role minimum (same gate as every dispatch verb);
+  `read_only` callers get HTTP 403 on the write ops.
+
+## Target + auth model
+
+The shipped connector's auth model is `shared_service_account` over
+SSH. The SSH credential is stored in **Vault** at a per-host path
+under the operator tenant's KV-v2 mount, then materialised onto the
+target row's `secret_ref` column. Two SSH credential shapes are
+supported (in order of preference):
+
+| Shape | `secret_ref` fields | When to use |
+| --- | --- | --- |
+| **Key auth (preferred)** | `username`, `ssh_private_key` (PEM-encoded text) | Production. Key auth means no sudo password is exposed to the operator's account. |
+| **Password auth (fallback)** | `username`, `password` | Bootstrap / lab targets only; the password lives in Vault but every successful auth surfaces in the host's `auth.log`. |
+
+The connector's
+[`SshConnector._auth_config`](../../backend/src/meho_backplane/connectors/adapters/ssh.py)
+reads `secret_ref` in that order; missing both fields raises
+`ValueError` at dispatch time (fail-fast — never an opaque asyncssh
+auth error).
+
+### Storing the SSH credential in Vault
+
+Use the tenant's KV-v2 path convention:
+`secret/<tenant>/bind9/<host>`. The credential blob is the
+`secret_ref` dict the target row will carry. Example via the v0.2
+`meho vault kv put` (replaces `vault.sh PUT`):
+
+```console
+$ meho vault kv put --target rdc-vault secret \
+    rdc-hetzner-dc/bind9/vcf-router-01 \
+    --data @secret_ref.json
+```
+
+`secret_ref.json` shape (key auth):
+
+```json
+{
+  "username": "meho-bind9",
+  "ssh_private_key": "<PEM-encoded OpenSSH private key, one literal newline-escaped string from the host headers through the footers>"
+}
+```
+
+The `ssh_private_key` value is the contents of the private-key file
+(typically `~/.ssh/id_ed25519` for the dedicated `meho-bind9` user)
+emitted as a single JSON string: keep the literal `\n` newlines, the
+BEGIN / END headers, and the trailing newline intact. `asyncssh`'s
+`import_private_key` parses any standard PEM-encoded key (Ed25519,
+ECDSA, RSA, OpenSSH-format) the same way `ssh` does.
+
+Or, for password fallback:
+
+```json
+{
+  "username": "meho-bind9",
+  "password": "<one-line-password>"
+}
+```
+
+The `password` field is single-line by contract — `_remote_bash_with_sudo`
+refuses a password containing `\n`, `\r`, or `\x00` (the failure mode
+the 2026-05-04 leak chain exposed, see
+[Credential-leak postmortem](#credential-leak-postmortem)).
+
+### Registering the target
+
+```console
+$ meho targets create \
+    --name vcf-router-bind9 \
+    --product bind9 \
+    --host bind9.lab.evba \
+    --secret-ref secret/rdc-hetzner-dc/bind9/vcf-router-01 \
+    --auth-model shared_service_account
+```
+
+Verify the target round-trips:
+
+```console
+$ meho targets probe vcf-router-bind9
+ok — bind9 9.18.24 reachable; named-checkconf -p clean
+$ meho bind9 about --target vcf-router-bind9
+bind9-ssh-9.x bind9.about — status=ok (47ms)
+  vendor:           isc
+  product:          bind9
+  version:          9.18.24
+  build:            BIND 9.18.24-1+deb12u2-Debian
+  os:               debian 12
+  named_conf_path:  /etc/bind/named.conf
+```
+
+`probe` exercises the full ladder: TCP reachable → SSH handshake →
+auth → `pgrep -x named` → `named-checkconf -p`. Failure modes each
+carry a distinct `reason` field (`tcp_unreachable`,
+`ssh_handshake_failed`, `auth_failed`, `named_not_running`,
+`named_config_invalid`); read the failing field, fix the host, re-run
+probe.
+
+## The CLI verb surface
+
+Every verb pre-bakes `connector_id="bind9-ssh-9.x"` so operators never
+type the connector id. All verbs accept `--target <slug>` (required
+for ops that resolve a bind9 target), `--json` (emit the full
+`OperationResult` envelope for `jq`), and `--backplane <url>`
+(override the URL from the last `meho login`). Exit codes mirror
+`meho operation call`.
+
+### Identity — `meho bind9 about`
+
+```console
+$ meho bind9 about --target vcf-router-bind9
+$ meho bind9 about --target vcf-router-bind9 --json | jq .result
+```
+
+`about` returns vendor / product / version (parsed BIND triple) /
+build (full `named -v` banner) / os / named_conf_path. Use it to
+confirm the target before any higher-level op and to pick a
+version-flavoured doc page.
+
+### Zone browse — `meho bind9 zone …`
+
+```console
+$ meho bind9 zone list --target vcf-router-bind9
+$ meho bind9 zone read evba.lab --target vcf-router-bind9
+$ meho bind9 zone read evba.lab. --target vcf-router-bind9 --json
+```
+
+| Verb | op_id | Result |
+| --- | --- | --- |
+| `zone list` | `bind9.zone.list` | One row per zone declared in `named-checkconf -p` output; `{name, type, file}`. |
+| `zone read <zone>` | `bind9.zone.read` | One row per rrset member; `{name, ttl, class, type, rdata}`. Resolves the zonefile path server-side — operators pass the zone name, not the filename. |
+
+`zone read` parses the zonefile via `dns.zone.from_text` (dnspython)
+so every record type is fully decoded (A, AAAA, CNAME, MX, TXT, NS,
+SOA, SRV, …); the column-shaped output is consumed by `jq` for ad-hoc
+diffing.
+
+### Record ops — `meho bind9 record …`
+
+```console
+$ meho bind9 record get www.evba.lab --target vcf-router-bind9
+$ meho bind9 record get mail.evba.lab --type AAAA --target vcf-router-bind9
+$ meho bind9 record add esx-dc6.evba.lab 10.5.50.25 \
+    --zone evba.lab --target vcf-router-bind9
+$ meho bind9 record remove esx-dc6.evba.lab \
+    --zone evba.lab --target vcf-router-bind9
+```
+
+| Verb | op_id | Notes |
+| --- | --- | --- |
+| `record get <fqdn>` | `bind9.record.get` | `--type` defaults to `A`; supported: `A` / `AAAA` / `CNAME` / `MX` / `TXT`. Resolution is via `dig @localhost`, so views + cache hits behave as the rest of the world sees them. |
+| `record add <fqdn> <ip>` | `bind9.record.add` | `safety_level=caution`, `op_class=write`. Routes through the atomic-apply primitive. `--zone` is optional; the handler resolves the owning zone via longest-suffix match. `--type` accepts `A` or `AAAA` only — CNAME / MX / TXT writes are out of scope for v0.2. |
+| `record remove <fqdn>` | `bind9.record.remove` | `safety_level=caution`, `op_class=write`. Removes the A + AAAA rdatasets at `<fqdn>`. |
+
+`record add` is the **1:1 replacement** for the consumer's
+`bind9-dns.sh --add-a-record …` invocation. The wrapper composed a
+zonefile edit + `rndc reload` + a dig-verify by hand; the MEHO op
+routes the same flow through the atomic-apply primitive (see
+[Atomic-apply contract](#atomic-apply-contract) below).
+
+### Config browse + write — `meho bind9 config …`
+
+```console
+$ meho bind9 config show named.conf --target vcf-router-bind9
+$ meho bind9 config show /etc/bind/named.conf.local --target vcf-router-bind9
+
+$ meho bind9 config apply-file named.conf.options \
+    ./local/named.conf.options --target vcf-router-bind9
+
+$ meho bind9 config apply-views ./views/external.conf ./zones \
+    --target vcf-router-bind9 \
+    --verify-fqdn www.evba.lab \
+    --primary-path named.conf.local
+
+$ meho bind9 config backup --tag pre-migration --target vcf-router-bind9
+$ meho bind9 config reload --target vcf-router-bind9
+```
+
+| Verb | op_id | Notes |
+| --- | --- | --- |
+| `config show <file>` | `bind9.config.show` | `<file>` may be absolute (must be lexically under the bind config root) or relative (resolved against it). Traversal / outside-root rejected pre-stage with no content leak. |
+| `config apply-file <name> <local-src>` | `bind9.config.apply_file` | `safety_level=dangerous`, `op_class=write`. CLI reads `<local-src>` locally and stages it as the replacement for `<name>` on the target. |
+| `config apply-views <local-views.conf> <zones-dir>` | `bind9.config.apply_views` | `safety_level=dangerous`, `op_class=write`. CLI reads `<local-views.conf>` (lands at `named.conf.local`) and every regular file under `<zones-dir>` (each lands at its relative path under `/etc/bind/`). `--verify-fqdn` adds a dig-verify post-reload; `--primary-path` selects which staged key drives the audit row's pre/post-op capture. |
+| `config backup [--tag T]` | `bind9.config.backup` | `safety_level=safe`. Creates a UTC-timestamped tar.gz under `/var/backups/meho-bind9/`. `--tag` (optional) embeds a `[A-Za-z0-9._-]{1,64}` friendly tag in the filename. |
+| `config reload` | `bind9.config.reload` | `safety_level=caution`, `op_class=write`. `rndc reload`. Use only when you needed to bypass the apply ops' automatic reload (rare). |
+
+## The atomic-apply contract
+
+Every write op except `config.backup` routes through the connector's
+[`_atomic.py`](../../backend/src/meho_backplane/connectors/bind9/_atomic.py)
+primitive. The contract:
+
+1. **Snapshot.** Compute a SOA-normalising SHA256 checksum of
+   `/etc/bind/`.
+2. **Stage.** Drop the new file(s) into a working tree under a tmp
+   directory on the target.
+3. **Validate.** Run `named-checkconf -p` (and `named-checkzone` for
+   record / zone writes) against the staged tree. Failure → rollback;
+   `/etc/bind/` is byte-identical to the snapshot.
+4. **Apply.** Atomically overlay the staged tree onto `/etc/bind/`
+   (`find … -delete; tar -x` for `apply_views`; explicit `cp` +
+   `chmod` + `chown` for `apply_file`).
+5. **Reload.** `rndc reload`. Non-zero exit → rollback.
+6. **Verify.** Either `named-checkconf -p` against the live config (no
+   `--verify-fqdn`) or `dig @localhost <fqdn> +short` returning
+   non-empty (with `--verify-fqdn`). Failure → rollback.
+
+A failed validate / reload / verify produces a `connector_error`
+envelope with `op_class=write` + the failing step name and an
+`AtomicApplyError.step` field on the raised exception. The result
+envelope carries `result_state_before` (a truncated preview of the
+pre-op file content) and `result_state_after` so operators can diff
+successful writes; the full pre/post-op bytes ride through the audit
+row's `state_before` / `state_after` payload (read via
+`meho audit show <id> --json`).
+
+This is the structural protection against the 2026-05-04 / 2026-05-05
+credential-leak surface — see
+[Credential-leak postmortem](#credential-leak-postmortem) — and the
+load-bearing reason `bind9-dns.sh` retires in favour of this connector.
+
+## The agent meta-tool path
+
+Agents never see `meho bind9 …` — those are operator-only CLI
+ergonomics. Per [CLAUDE.md](../../CLAUDE.md) postulate 5, an agent
+reaches every bind9 op through the narrow-waist meta-tools:
+
+```text
+search_connectors(query="bind9 dns")            → finds bind9-ssh-9.x
+list_operation_groups(connector_id="bind9-ssh-9.x")
+                                                → identity / zone / record / config
+search_operations(
+    connector_id="bind9-ssh-9.x",
+    query="add a dns record",
+    group="record",
+)                                                → top hit: bind9.record.add
+call_operation(
+    connector_id="bind9-ssh-9.x",
+    operation_id="bind9.record.add",
+    target={"name": "vcf-router-bind9"},
+    params={"fqdn": "esx-dc6.evba.lab",
+            "ip": "10.5.50.25",
+            "type": "A",
+            "zone": "evba.lab"},
+)
+```
+
+The agent's flow is always: pick connector → list operation groups →
+search operations (optionally scoped to a group) → `call_operation`.
+The CLI verb table and the `call_operation` params are 1:1 —
+`meho bind9 record add …` and the `call_operation` call above
+dispatch the identical route, audit row, and broadcast event. Each
+op's `llm_instructions` payload (registered at
+`register_typed_operation()` time) is what `search_operations`
+surfaces to rank and guide the agent; it is reviewable in
+[`backend/src/meho_backplane/connectors/bind9/ops_zone.py`](../../backend/src/meho_backplane/connectors/bind9/ops_zone.py)
+/ `ops_record.py` / `ops_config.py`.
+
+**Why no per-op MCP tools?** Eleven ops × per-tool registration adds
+eleven entries to the agent's tool surface, fans out into more
+duplicated parameter schemas, and re-implements the
+search-then-dispatch flow the meta-tools already cover. The agent
+surface stays the same five meta-tools across every connector —
+CLAUDE.md postulate 5's narrow-waist invariant.
+
+## Migrating off `bind9-dns.sh`
+
+The consumer's
+[`scripts/bind9-dns.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/bind9-dns.sh)
+retires in favour of the verb tree above:
+
+| Wrapper invocation | `meho bind9 …` replacement | Notes |
+| --- | --- | --- |
+| `bind9-dns.sh --target <h> --add-a-record <fqdn> <ip> --zone <zone>` | `meho bind9 record add <fqdn> <ip> --zone <zone> --target <slug>` | The wrapper's `<host>` becomes a registered target slug. Atomic-apply rollback is now built-in (the wrapper bolted on its own check + reload step). |
+| `bind9-dns.sh --target <h> --remove-a-record <fqdn> --zone <zone>` | `meho bind9 record remove <fqdn> --zone <zone> --target <slug>` | |
+| `bind9-dns.sh --target <h> --get-record <fqdn>` | `meho bind9 record get <fqdn> --target <slug>` | |
+| `bind9-dns.sh --target <h> --list-zones` | `meho bind9 zone list --target <slug>` | |
+| `bind9-dns.sh --target <h> --read-zone <zone>` | `meho bind9 zone read <zone> --target <slug>` | |
+| `bind9-dns.sh --target <h> --show-config <file>` | `meho bind9 config show <file> --target <slug>` | |
+| `bind9-dns.sh --target <h> --reload` | `meho bind9 config reload --target <slug>` | Only needed for ad-hoc reloads; `apply_*` reload as part of their flow. |
+| (no wrapper for the apply / backup flows) | `meho bind9 config apply-file …` / `apply-views …` / `backup …` | New surface; the wrapper hand-built zonefile edits with `sed`. The MEHO ops produce a structured audit row + atomic-apply rollback. |
+
+Migration discipline: run the `meho bind9 …` form alongside the
+wrapper for an overlap window, diff the outputs, retire the wrapper
+call site. The MEHO path adds the full audit row + broadcast event
+the bash pattern never had — that audit coverage is the point.
+
+What the wrappers did that `meho bind9` deliberately does **not** do
+(out of scope for v0.2 — keep the wrapper for these until a future
+Initiative lands them):
+
+- DNSSEC key management — out of scope for v0.2.
+- TSIG / `rndc` admin beyond `reload` — out of scope; the wrapper's
+  `--rndc-status` shape is covered by `meho bind9 config reload`'s
+  `result_state_after` payload (the live rndc-status snapshot).
+- Host-key pinning — deferred. The SSH adapter sets `known_hosts=None`
+  for v0.2 (matches every other typed-SSH connector); a future
+  Vault-managed known-hosts store is the right shape.
+
+## Credential-leak postmortem
+
+The `_remote_bash_with_sudo()` primitive on
+`Bind9Connector` is **structural protection** against a documented
+credential leak. Read this section before reviewing any future
+PR that touches the connector's transport code.
+
+**The incidents** (Initiative
+[#367](https://github.com/evoila/meho/issues/367) WI1):
+
+- **2026-05-04** — the consumer's `bind9-dns.sh` invoked
+  `ssh <host> "echo '<password>' | sudo -S bash -c '<remote-script>'"`.
+  The `<password>` value landed in the remote argv. A concurrent
+  `ps aux` from any unprivileged remote process captured the
+  password.
+- **2026-05-05** — a follow-up attempt swapped to
+  `ssh <host> "sudo -S bash -c '<script>'" <<< '<password>'`. The
+  password moved off `argv` but the operator's bash history kept the
+  `<<< '<password>'` here-string verbatim in `~/.bash_history` for
+  every operator invocation.
+- **External coordination**:
+  [evoila-bosnia/claude-rdc-hetzner-dc#86](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/86)
+  tracks the rotation chain + the consumer-side `bind9-dns.sh`
+  retirement.
+
+**The encoded fix.** `_remote_bash_with_sudo()`:
+
+1. Fixes the remote argv as a **constant string** — `sudo -S -p ''
+   bash -s` — with no caller interpolation. A grep for `sudo` in the
+   `connectors/` tree finds exactly one match (the helper itself).
+2. Builds the stdin payload as `f"{sudo_password}\\n{script}\\n"`.
+   The password is the first stdin line; `sudo -S` consumes it; `bash
+   -s` reads the rest. The password never appears in `argv`, never
+   appears in any local shell history, never appears in the
+   structured log event (the helper logs `cmd_len` + `exit_status`
+   only).
+3. Refuses a multi-line password (`\n` / `\r` / `\x00` in the value)
+   pre-call — the single-line invariant is what makes the stdin
+   framing unambiguous.
+4. **Codebase-wide invariant.** The E2E acceptance harness in
+   [`tests/integration/test_g3_4_bind9_e2e.py`](../../backend/tests/integration/test_g3_4_bind9_e2e.py)
+   walks `backend/src/meho_backplane/connectors/` looking for any
+   `sudo` literal outside the bind9 package; a regression on a
+   sibling connector that hand-rolls a `sudo -S` invocation fails
+   the test with a pointer at the offending file. The mis-ordered-
+   payload shape is **unrepresentable** in the codebase.
+
+Every future bind9 op + every sibling typed-SSH connector that needs
+`sudo` must route through `_remote_bash_with_sudo()`. There is no
+escape hatch.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `no backplane URL configured` (exit 2) | Never logged in / no `--backplane`. | `meho login <url>` or pass `--backplane <url>`. |
+| `auth_expired` / stored token rejected | Keycloak token expired; refresh failed. | `meho login <url>` again. |
+| `status=error … unknown_op` | Connector_id drift — typed it as `bind9-9.x` instead of `bind9-ssh-9.x`. | Use `bind9-ssh-9.x`; the `-ssh` impl_id discriminator is part of the connector_id grammar. The CLI bakes the right id in; the agent meta-tool path needs the full string. |
+| `status=error … operation not found` | The typed-op registrar didn't run (lifespan crash) or op_id drift. | Check the backplane started cleanly; verify `meho connector list` shows `bind9-ssh-9.x` with eleven enabled ops. |
+| `status=denied` on a write op | `read_only` role, or a policy gate denied. | Use an `operator`-role token; the policy gate on `safety_level=dangerous` ops can require approval. |
+| `record.add` returns `connector_error … step=verify` | The write landed in the zonefile + reload succeeded but `dig @localhost <fqdn>` returned empty post-reload. | Confirm the zone view actually serves the new fqdn (split-horizon configs sometimes need the verify FQDN scoped via `--verify-fqdn`); the atomic-apply primitive rolled back, so `/etc/bind/` is byte-identical to before the call. |
+| `apply_views` returns `connector_error … step=checkconf` | Staged tree failed `named-checkconf -p`. | The error text carries the line + reason; fix the local file, re-run. The primitive's rollback already restored `/etc/bind/`. |
+| `config.backup` returns `path … invalid_params` | `--tag` contained a character outside `[A-Za-z0-9._-]`. | Tags are restricted to those characters so they can't inject shell metacharacters or path separators in the on-disk filename. |
+| `bind9 about` fails with `tcp_unreachable` | SSH port not open from the backplane. | Diagnose via `meho targets probe` — the failure mode tree narrows it to TCP / SSH / auth / named / checkconf. |
+
+## References
+
+- Initiative: [#367 G3.4 bind9-9.x typed-SSH connector](https://github.com/evoila/meho/issues/367); Goal [#214](https://github.com/evoila/meho/issues/214) (G3 connector parity).
+- Tasks that shipped this surface: [#587](https://github.com/evoila/meho/issues/587) (connector skeleton + safe-sudo primitive), [#588](https://github.com/evoila/meho/issues/588) (read ops), [#589](https://github.com/evoila/meho/issues/589) (atomic-apply primitive + record writes), [#590](https://github.com/evoila/meho/issues/590) (config-write ops), [#591](https://github.com/evoila/meho/issues/591) (CLI + E2E + this doc).
+- Engineering companion: [`docs/codebase/connectors-bind9.md`](../codebase/connectors-bind9.md).
+- Op handlers: [`backend/src/meho_backplane/connectors/bind9/`](../../backend/src/meho_backplane/connectors/bind9/) (`connector.py` skeleton + safe-sudo, `ops_zone.py`, `ops_record.py`, `ops_config.py`, `_atomic.py`). CLI verbs: [`cli/internal/cmd/bind9/`](../../cli/internal/cmd/bind9/).
+- E2E acceptance harness: [`backend/tests/integration/test_g3_4_bind9_e2e.py`](../../backend/tests/integration/test_g3_4_bind9_e2e.py); containerised fixture: [`backend/tests/integration/test_connectors_bind9_container.py`](../../backend/tests/integration/test_connectors_bind9_container.py).
+- Consumer wrapper retired: [`scripts/bind9-dns.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/bind9-dns.sh).
+- Credential-leak postmortems: [evoila-bosnia/claude-rdc-hetzner-dc#86](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/86) tracks the 2026-05-04 / 2026-05-05 chain + the rotation history that motivated the `_remote_bash_with_sudo()` safe-by-construction design.
+- BIND 9 docs: <https://bind9.readthedocs.io/en/v9.18/> (9.18 — Debian bookworm default), <https://bind9.readthedocs.io/en/v9.20/> (9.20 — current Stable Release).
+- Agent meta-tool surface: G0.5 MCP server [#226](https://github.com/evoila/meho/issues/226); `search_operations` / `call_operation`. Onboarding-doc precedents: [`vault-onboarding.md`](./vault-onboarding.md), [`kubernetes-onboarding.md`](./kubernetes-onboarding.md), [`docs/cross-repo/README.md`](./README.md).


### PR DESCRIPTION
## Summary

- Adds `meho bind9 …` CLI verb tree — eleven Cobra alias verbs over the existing `/api/v1/operations/call` dispatcher route, `connector_id="bind9-ssh-9.x"` pre-baked. Mirrors `meho vmware` / `meho vault` / `meho k8s` patterns; `bind9 record add` is the 1:1 replacement for the consumer's `bind9-dns.sh --add-a-record` (Initiative #367 WI6).
- Adds the bind9 E2E acceptance harness — extends the existing testcontainer fixture, drives every op through the agent meta-tool flow (`search_operations` + `call_operation`) with real PG-backed `endpoint_descriptor` + `audit_log`, pins state_before / state_after on write ops, atomic-apply rollback on three failure modes, and a codebase-wide safety assertion that `_remote_bash_with_sudo()` is the only sudo-invoking construction under `connectors/`.
- Adds `docs/cross-repo/bind9-onboarding.md` — operator recipe + the 2026-05-04 / 2026-05-05 credential-leak postmortem cross-reference.

## Implementation notes

The connector_id ships as `bind9-ssh-9.x` (not `bind9-9.x` as the issue body shorthand suggested): the connector_id parser in `_lookup.py` splits on the trailing version segment, so the impl_id discriminator (`-ssh` vs a hypothetical `-rndc` / `-rest` sibling) must be in the connector_id for the descriptor lookup to find the registered row with `impl_id="bind9-ssh"`. The onboarding doc + troubleshooting table call out the relationship. The `-ssh` discriminator leaves room for a future non-SSH control surface without breaking the resolver's tie-break ladder.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/cmd/bind9/...` — clean
- [x] `gofmt -l ./internal/cmd/bind9/` — clean
- [x] `goimports -local github.com/evoila/meho/cli -l ./internal/cmd/bind9/` — clean
- [x] `go test -count=1 ./internal/cmd/bind9/...` — all pass (renderers, dispatch wire shape, assembleViewsBundle path safety + collision guard, ConnectorID frozen)
- [x] `go test -count=1 ./internal/cmd/...` — every existing CLI test still green
- [x] `ruff check tests/integration/test_g3_4_bind9_e2e.py` — clean
- [x] `ruff format --check tests/integration/test_g3_4_bind9_e2e.py` — clean
- [x] `mypy tests/integration/test_g3_4_bind9_e2e.py` — clean (pre-existing errors in unrelated `test_operations_dispatcher.py` only)
- [x] `pytest tests/integration/test_g3_4_bind9_e2e.py` — 1 passed (codebase safety static-import check; the other 17 tests are gated on Docker which the sandbox lacks — they run in CI's `Python (integration testcontainers)` job)
- [x] `pytest tests/test_connectors_bind9.py` — 34 passed (no regression on T1-T4 unit suite)

## Out of scope

- DNSSEC key management, TSIG, `rndc` admin beyond `reload` — Initiative-level out of scope.
- Host-key pinning (`known_hosts=None` for v0.2) — deferred until a Vault-managed known-hosts store lands.
- Per-op MCP tools — explicitly not done (CLAUDE.md postulate 5; agents reach the 11 ops via `search_operations` / `call_operation`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #591


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `bind9` CLI command group with `about`, `zone` list/read, `record` get/add/remove, and `config` verbs (show, apply-file, apply-views, backup, reload).

* **Tests**
  * Added end-to-end integration tests against a containerized bind9 server plus extensive CLI unit tests and atomic rollback checks; tightened safety-regression test for sudo usage; added Unix-only test helper for named pipes.

* **Documentation**
  * Added bind9 operator onboarding guide covering setup, CLI reference, atomic-apply contract, and troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-19)

Addressed review findings from PR #674 iter-1 (full punch list in `.claude/auto/review-results/pr-674-iter-1.json`):

- **B1** `e265404` — bind9 E2E fixture wrote a dict into `Target.secret_ref` (Text column). Switched the seeded TargetORM row to a string Vault path (`"kv/dev/bind9/e2e"`); preseeded the dispatcher's connector-instance cache with `_SeededBind9Connector` whose `_auth_config` short-circuits the Vault read to the testcontainer's SSH credentials (mirrors `test_connectors_k8s_e2e.py`'s `kubeconfig_loader` pattern); monkey-patched the module-level `_sudo_password_for_target` / `_sudo_password_from_target` so the typed-op write handlers get the container password too.
- **B2** `c1b81e3` — `assembleViewsBundle` now rejects anything that is not `Mode().IsRegular()` — symlinks, block / char devices, FIFOs, sockets. Added `TestAssembleViewsBundleRejectsSymlinkUnderZonesDir` (symlink-exfil shape) and `TestAssembleViewsBundleRejectsFifoUnderZonesDir` (gated to unix builds via `mkfifo_unix_test.go`).
- **B3** `e265404` — Sudo-invariant scan tightened in BOTH the unit test (`tests/test_connectors_bind9.py`, runs on every push) and the E2E harness. Whitelist narrowed to `{connector.py, _atomic.py}` explicitly. Regex replaced with `(?<=["'])sudo(?=["'\s\\])` — matches `sudo` only when immediately preceded by a quote AND followed by a quote / whitespace / backslash, catching every argv-construction form (single-string `"sudo -S ..."`, list-form `["sudo", "-S", ...]`, tuple-form `("sudo",)`) while rejecting prose / docstring / `sudo_password`.
- **M1** `e265404` — `bind9_e2e` now snapshots `/etc/bind/` over SSH at fixture entry and restores byte-identical on teardown (`rm -rf /etc/bind/* && tar -xf -` under the testcontainer's NOPASSWD sudoers). Container fixture stays module-scoped (saves 17× container boot); the snapshot/restore is the isolation primitive.
- **M2** `e265404` — Added `# type: ignore[import-untyped]` markers on first-party `meho_backplane.*` imports (CI mypy gate runs `src/` only; test files were never checked). `mypy --strict tests/integration/test_g3_4_bind9_e2e.py` is now clean for our file.
- **m1** `55a8d92` — Onboarding doc anchor fixed: `#atomic-apply-contract` → `#the-atomic-apply-contract`.

Verification on the changed paths:

- `ruff check` / `ruff format --check` — clean on `tests/integration/test_g3_4_bind9_e2e.py`, `tests/test_connectors_bind9.py`, `src/meho_backplane/connectors/bind9/`.
- `mypy --strict tests/integration/test_g3_4_bind9_e2e.py` — clean for our file (28 pre-existing errors in `tests/test_operations_dispatcher.py` are unchanged).
- `mypy src/` — `Success: no issues found in 180 source files`.
- `pytest tests/test_connectors_bind9.py tests/integration/test_g3_4_bind9_e2e.py::test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree` — 35 passed (the 17 Docker-gated tests run in CI).
- `go test ./internal/cmd/bind9/...` — clean (5 assembleViewsBundle tests including the two new non-regular-file rejections).
- `go vet` / `gofmt -l` — clean.

<!-- auto-implement-issue: continue, iteration 2 -->
