### PR TITLE
fix(connectors): cast K8s resolve_* return to typed V1Pod/V1Deployment — unblock mypy unit lane

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
@@ -86,7 +86,7 @@ References
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from kubernetes_asyncio import client
 
@@ -594,7 +594,7 @@ async def resolve_pod_name(v1: client.CoreV1Api, namespace: str, pod_name: str) 
     docstring's prefix-resolution note).
     """
     pod_list = await v1.list_namespaced_pod(namespace=namespace)
-    return _resolve_from_items(list(pod_list.items or []), pod_name, "pod")
+    return cast("V1Pod", _resolve_from_items(list(pod_list.items or []), pod_name, "pod"))
 
 
 async def resolve_deployment_name(
@@ -602,7 +602,10 @@ async def resolve_deployment_name(
 ) -> V1Deployment:
     """Resolve a deployment name + namespace pair to a :class:`V1Deployment`."""
     deployment_list = await apps_v1.list_namespaced_deployment(namespace=namespace)
-    return _resolve_from_items(list(deployment_list.items or []), deployment_name, "deployment")
+    return cast(
+        "V1Deployment",
+        _resolve_from_items(list(deployment_list.items or []), deployment_name, "deployment"),
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The unit lane (`Python (ruff + mypy + pytest)`) on `main` is failing the
`uv run mypy src/` step, which blocks the **v0.2.1 release tag**. ruff
check and ruff format pass; only mypy fails. This is a direct,
un-ticketed CI-unbreak.

## Root cause

`backend/src/meho_backplane/connectors/kubernetes/ops_workload.py`
defines `_resolve_from_items(items, target_name, kind) -> Any` (line
557) — a deliberately-generic shared resolver. Its two typed callers
return that `Any` result directly across a typed boundary:

- `resolve_pod_name(...) -> V1Pod` (line 597)
- `resolve_deployment_name(...) -> V1Deployment` (line 605)

Under `mypy==2.1.0` strict, both trip `[no-any-return]`:

```
ops_workload.py:597: error: Returning Any from function declared to return "V1Pod"  [no-any-return]
ops_workload.py:605: error: Returning Any from function declared to return "V1Deployment"  [no-any-return]
```

Latent since **#562** (G3.2-T3) — not a new regression. It surfaced now
because prior `main` CI runs were cancelled by rapid back-to-back merges,
so the failing mypy step was never reached on a completed run.

## The fix (3 lines, behavior-preserving)

- add `cast` to the existing `from typing import ...`
- wrap both returns: `cast("V1Pod", _resolve_from_items(...))` /
  `cast("V1Deployment", _resolve_from_items(...))`

`V1Pod` / `V1Deployment` are `TYPE_CHECKING`-only imports, so the
forward-ref **string** form is used to avoid a runtime `NameError`.
`typing.cast` is the idiomatic mypy pattern for a generic helper
crossing into a typed API and changes **zero runtime behavior** —
`cast` is an identity function at runtime. Helper logic, return
annotations, and all other code are untouched.

## Verification (CI-exact gates, run from `backend/`)

- `uv run ruff check src/ tests/` → `All checks passed!`
- `uv run ruff format --check src/ tests/` → `366 files already formatted`
- `uv run mypy src/` → `Success: no issues found in 180 source files`
  (both `[no-any-return]` errors gone, no new errors)
- `uv run pytest -n auto --dist loadscope -q tests/test_connectors_k8s_workload.py`
  → `32 passed` (sanity; type-only change, unaffected)

Refs #562 (origin of the latent defect). No `Closes` — un-ticketed
CI-unbreak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type annotations for Kubernetes model object handling with no user-facing impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->