### PR TITLE
feat(connectors): G3.5-T4 SddcManagerConnector skeleton — HTTP Basic (sso_realm=vsphere.local) + fingerprint + probe + registry v2

### DIFF
--- a/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.sddc_manager — SddcManagerConnector package.
+
+Importing this package registers :class:`SddcManagerConnector` against the
+v2 connector registry under
+``(product="sddc-manager", version="9.0", impl_id="sddc-rest")``. The
+chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+which walks every ``connectors/<product>/`` subpackage at startup, so the
+registration lands before any dispatch can occur.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
+point is deliberately **not** called. The connector advertises an explicit
+``(version="9.0", impl_id="sddc-rest")`` key; the v1 entry would land as
+``("sddc-manager", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s tie-break
+ladder. Same pattern :mod:`meho_backplane.connectors.nsx` established.
+
+Once G0.7-T8 (#408) lands its
+:func:`ensure_connector_class_registered` auto-shim in main, the idempotency
+check there will no-op on the
+``(product="sddc-manager", version="9.0", impl_id="sddc-rest")`` triple
+because this module has already registered the hand-rolled class. Until then,
+this module is the only registration path.
+
+Operations for this connector arrive in #617 via G0.7 spec ingestion of
+the SDDC Manager VCF API against the ``endpoint_descriptor`` table. This
+Task ships only the skeleton.
+"""
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.sddc_manager.connector import SddcManagerConnector
+from meho_backplane.connectors.sddc_manager.session import (
+    SddcCredentialsLoader,
+    SddcTargetLike,
+    SessionCredentials,
+    load_credentials_from_vault,
+)
+
+register_connector_v2(
+    product="sddc-manager",
+    version="9.0",
+    impl_id="sddc-rest",
+    cls=SddcManagerConnector,
+)
+
+__all__ = [
+    "SddcCredentialsLoader",
+    "SddcManagerConnector",
+    "SddcTargetLike",
+    "SessionCredentials",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""SddcManagerConnector — hand-rolled HttpConnector subclass for SDDC Manager 9.0.
+
+Skeleton-only — auth + fingerprint + probe + the G0.6 dispatch shim.
+Operations arrive in #617 via G0.7 spec ingestion against the VCF API
+spec for SDDC Manager.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.sddc_manager.__init__`. The G0.7 auto-shim's
+idempotency check (in
+:func:`~meho_backplane.operations.ingest.connector_registration.ensure_connector_class_registered`
+once #408's pipeline lands in main) no-ops on subsequent ingests against the
+same ``(product="sddc-manager", version="9.0", impl_id="sddc-rest")`` triple.
+
+Auth divergence from the NSX/vSphere precedents
+------------------------------------------------
+
+SDDC Manager uses HTTP Basic auth sent on every request — no session cookie
+or XSRF token is established. The connector caches the raw service-account
+credentials (loaded once from Vault via an injectable loader) and computes
+the ``Authorization: Basic`` header on each :meth:`auth_headers` call from
+the cached values. The username is formatted as ``username@sso_realm`` where
+``sso_realm`` defaults to ``"vsphere.local"`` per the consumer wrapper
+contract; operators managing a custom SSO domain override this via
+``target.sso_realm``.
+
+Because HTTP Basic credentials are stateless server-side (no session to
+revoke or expire), no 401-driven re-login loop is needed. A 401 from a
+downstream call propagates directly to the caller — it means wrong
+credentials, not an expired session.
+
+Auth model gating
+-----------------
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` (or
+``None`` for pre-G0.3 targets where the column hasn't been populated yet).
+:meth:`auth_headers` rejects any other ``target.auth_model`` value with a
+clear :exc:`NotImplementedError` naming both the target and the requested
+mode.
+
+Fingerprint
+-----------
+
+``GET /v1/sddc-managers`` returns a pagination envelope
+``{"elements": [{id, fqdn, version, domain: {id, name}, ...}], ...}``.
+:meth:`fingerprint` reads ``elements[0]`` (SDDC Manager is typically a
+singleton appliance). ``version`` carries the full version string (e.g.
+``"5.2.0.0-24276214"``); ``build`` is extracted from a separate ``build``
+field when present (VCF 9.x may surface it explicitly), otherwise ``None``.
+``extras["management_domain"]`` carries the management domain name.
+
+Operations
+----------
+
+This module ships zero operations — the G0.6 dispatch shim :meth:`execute`
+exists for ABC compatibility but operations land in the
+``endpoint_descriptor`` table via #617's spec ingestion. Until then, the
+connector is registered and discoverable but ``execute(target, op_id, ...)``
+against any ``op_id`` resolves to "unknown operation" at the dispatcher
+layer — which is the correct behaviour for a registered-but-empty connector
+at this Task's stage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.sddc_manager.session import (
+    SddcCredentialsLoader,
+    SddcTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = ["SddcManagerConnector"]
+
+_log = structlog.get_logger(__name__)
+
+_DEFAULT_SSO_REALM = "vsphere.local"
+
+
+def _is_acceptable_auth_model(value: Any) -> bool:
+    """Return ``True`` iff *value* is the SHARED_SERVICE_ACCOUNT mode or unset.
+
+    Accepts the enum member, the equivalent string, and ``None`` (the
+    "auth_model column not yet populated" sentinel for pre-G0.3 targets).
+    Any other value is rejected by the caller. Same predicate the NSX and
+    vSphere precedents use; lifted into this module to keep connectors
+    decoupled.
+    """
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+def _basic_auth_header(username: str, password: str) -> str:
+    """Compute the ``Authorization: Basic`` header value for *username*:*password*."""
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+class SddcManagerConnector(HttpConnector):
+    """SDDC Manager 9.0 REST connector with HTTP Basic auth.
+
+    Per-target credentials cached in :attr:`_creds_cache` (loaded once via
+    the injectable :class:`SddcCredentialsLoader`). HTTP Basic auth is sent
+    on every request via ``Authorization: Basic <base64>`` — no session
+    token is established and no 401-driven re-login is needed.
+
+    The :attr:`priority` is set to ``1`` so a future
+    ``GenericRestConnector`` auto-shim that somehow registers for the same
+    triple loses the registry's tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"sddc-rest-9.0"`` -> (``"sddc-manager"``, ``"9.0"``, ``"sddc-rest"``).
+    product = "sddc-manager"
+    version = "9.0"
+    impl_id = "sddc-rest"
+    supported_version_range = ">=9.0,<10.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: SddcCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._creds_cache: dict[str, dict[str, str]] = {}
+        self._creds_lock = asyncio.Lock()
+        self._credentials_loader: SddcCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+
+    async def auth_headers(self, target: SddcTargetLike, raw_jwt: str) -> dict[str, str]:
+        """Return ``{"Authorization": "Basic ..."}`` for the request.
+
+        Loads credentials from Vault on first call against *target*, caches
+        them, and reuses the cached values on subsequent calls. ``raw_jwt``
+        is accepted for ABC-signature compatibility but unused —
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
+        Vault-sourced service account, not the operator's OIDC token.
+
+        The Basic auth username is ``{creds['username']}@{target.sso_realm}``
+        where ``sso_realm`` defaults to ``"vsphere.local"`` when unset or
+        empty.
+
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is
+        anything other than ``shared_service_account`` or ``None``.
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT mode does not forward operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not _is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"SddcManagerConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        creds = await self._load_credentials(target)
+        sso_realm = getattr(target, "sso_realm", None) or _DEFAULT_SSO_REALM
+        auth_username = f"{creds['username']}@{sso_realm}"
+        return {"Authorization": _basic_auth_header(auth_username, creds["password"])}
+
+    async def _load_credentials(self, target: SddcTargetLike) -> dict[str, str]:
+        """Return the cached credentials for *target*, loading from Vault on first use.
+
+        The lock serialises concurrent first-use callers for the same target;
+        subsequent calls take the fast path under the same lock. The loaded
+        dict must contain ``"username"`` and ``"password"`` keys; missing
+        keys raise a :exc:`RuntimeError` naming the target and the missing
+        key so operators can identify a misconfigured Vault path.
+        """
+        async with self._creds_lock:
+            cached = self._creds_cache.get(target.name)
+            if cached is not None:
+                return cached
+            raw = await self._credentials_loader(target)
+            try:
+                _ = raw["username"]
+                _ = raw["password"]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"sddc-manager credentials loader for target {target.name!r} returned "
+                    f"a dict missing required key {exc.args[0]!r}; need "
+                    "{'username': str, 'password': str}"
+                ) from exc
+            self._creds_cache[target.name] = raw
+            _log.info(
+                "sddc_manager_credentials_loaded",
+                target=target.name,
+                host=target.host,
+            )
+            return raw
+
+    async def fingerprint(self, target: SddcTargetLike) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /v1/sddc-managers``.
+
+        Reads ``elements[0]`` from the pagination envelope. On transport or
+        status failure, returns a non-reachable :class:`FingerprintResult`
+        whose ``extras["error"]`` carries the exception class + message —
+        same pattern the NSX and vSphere connectors established.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            payload = await self._get_json(target, "/v1/sddc-managers", raw_jwt="")
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="sddc-manager",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="GET /v1/sddc-managers",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        elements = payload.get("elements") or []
+        sddc = elements[0] if elements else {}
+        domain = sddc.get("domain") or sddc.get("managementDomain") or {}
+        return FingerprintResult(
+            vendor="vmware",
+            product="sddc-manager",
+            version=sddc.get("version"),
+            build=sddc.get("build"),
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="GET /v1/sddc-managers",
+            extras={
+                "id": sddc.get("id"),
+                "fqdn": sddc.get("fqdn"),
+                "management_domain": domain.get("name"),
+                "management_domain_id": domain.get("id"),
+            },
+        )
+
+    async def probe(self, target: SddcTargetLike) -> ProbeResult:
+        """Lightweight reachability + auth-challenge check.
+
+        Delegates to :meth:`fingerprint` — one authenticated request covers
+        both reachability and auth-challenge, same posture the vSphere and
+        NSX precedents use.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: SddcTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`NsxConnector.execute`'s shape. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI verbs
+        once #618 lands) construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly — they don't
+        reach this method.
+
+        The connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``'s contract:
+        ``"sddc-rest-9.0"`` → (product=``"sddc-manager"``,
+        version=``"9.0"``, impl_id=``"sddc-rest"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:sddc-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached credentials, then tear down the httpx pool.
+
+        No server-side session to revoke — HTTP Basic is stateless.
+        The credential cache is cleared so a post-aclose reuse of the same
+        connector instance (e.g. a test that builds one connector across two
+        contexts) starts clean.
+        """
+        async with self._creds_lock:
+            self._creds_cache.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/sddc_manager/session.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/session.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading for the sddc-manager connector.
+
+The hand-rolled :class:`~meho_backplane.connectors.sddc_manager.connector.SddcManagerConnector`
+reads service-account credentials from the target's Vault path and sends
+them as HTTP Basic auth on every request — no session token is established;
+the ``Authorization: Basic`` header is recomputed from the cached credentials
+on each call.
+
+The credential fetch (Vault path → ``{"username": ..., "password": ...}``
+dict) is split out behind a narrow :class:`SddcCredentialsLoader` callable
+so:
+
+* Production deploys override the default loader at construction time once
+  G0.3 (#224) lands the operator-context Vault read path.
+* Unit tests inject their own (mock) loader returning a pre-built dict.
+* Integration tests pass a loader that yields the appropriate service-account
+  credentials.
+
+The default loader, :func:`load_credentials_from_vault`, raises
+:exc:`NotImplementedError` until G0.3 (#224) merges. Mirrors the shape
+:func:`~meho_backplane.connectors.vmware_rest.session.load_session_credentials_from_vault`
+established for :class:`VmwareRestConnector` — once the Target model +
+operator-context Vault reads land, all loaders pick up the concrete
+implementation in a single follow-up commit.
+
+The :class:`SddcTargetLike` Protocol captures the minimum target shape the
+connector reads: ``name`` (for the per-target credential cache key), ``host``,
+``port`` (forwarded to :meth:`HttpConnector._base_url`), ``secret_ref`` (the
+Vault path the loader resolves), ``auth_model`` (checked at the boundary),
+and ``sso_realm`` (the SSO domain appended to the username in the Basic auth
+header, defaulting to ``"vsphere.local"``). Once G0.3 ships its concrete
+``Target`` model in :mod:`meho_backplane.targets`, the model satisfies this
+Protocol structurally — no edits here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "SddcCredentialsLoader",
+    "SddcTargetLike",
+    "SessionCredentials",
+    "load_credentials_from_vault",
+]
+
+
+class SessionCredentials(Protocol):
+    """The dict shape :class:`SddcCredentialsLoader` returns.
+
+    Captured as a Protocol so the type checker can flag a loader that
+    forgets a key. The two values map to the Basic auth components the
+    connector sends on every SDDC Manager API request; nothing else is
+    read.
+    """
+
+    username: str
+    password: str
+
+
+@runtime_checkable
+class SddcTargetLike(Protocol):
+    """Minimum target shape :class:`SddcManagerConnector` reads.
+
+    Structural Protocol — once G0.3 (#224) lands the concrete ``Target``
+    model in :mod:`meho_backplane.targets`, that model satisfies this
+    Protocol unchanged. ``auth_model`` is checked at the boundary so a
+    target tagged ``per_user`` or ``impersonation`` raises a clear error
+    rather than silently authenticating as the shared service account.
+
+    ``secret_ref`` is the Vault path the loader resolves to a
+    :class:`SessionCredentials`-shaped dict. ``port`` is optional —
+    SDDC Manager defaults to 443 and :meth:`HttpConnector._base_url`
+    already handles the ``port is None or 443`` case correctly.
+
+    ``sso_realm`` is the vSphere SSO domain appended to ``username`` when
+    constructing the Basic auth header (``username@sso_realm``). Defaults
+    to ``"vsphere.local"`` per the consumer wrapper contract; operators
+    managing a custom domain override this at the target level.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+    sso_realm: str
+
+
+SddcCredentialsLoader = Callable[[SddcTargetLike], Awaitable[dict[str, str]]]
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+The connector's :meth:`SddcManagerConnector._load_credentials` invokes the
+loader exactly once per target (first-use), caching the resulting dict under
+``target.name``. The return type is the looser ``dict[str, str]`` (not
+:class:`SessionCredentials`) because Python :class:`Protocol` instances
+aren't runtime-constructible without a matching class — production code
+returns a plain dict and the connector reads ``creds["username"]`` /
+``creds["password"]`` by key.
+"""
+
+
+async def load_credentials_from_vault(
+    target: SddcTargetLike,
+) -> dict[str, str]:
+    """Default credential loader — Vault read by ``target.secret_ref``.
+
+    Stubbed until G0.3 (#224) lands the ``Target`` model and the
+    operator-context Vault read path. Mirrors
+    :func:`~meho_backplane.connectors.vmware_rest.session.load_session_credentials_from_vault`'s
+    ``NotImplementedError`` stub so the wiring shape is stable: a production
+    caller without an explicit loader override receives a clear error rather
+    than a silent fallback or a hallucinated credential pair.
+
+    Once G0.3 lands, this function becomes the live implementation that reads
+    the ``sddc-manager/<target.name>`` Vault path and returns the parsed
+    ``{"username": ..., "password": ...}`` dict. Until then, tests and any
+    acceptance harness inject a custom :class:`SddcCredentialsLoader` on
+    connector construction.
+    """
+    raise NotImplementedError(
+        "load_credentials_from_vault requires G0.3 Target model + "
+        f"operator-context Vault read; target={target.name!r} "
+        f"secret_ref={target.secret_ref!r}. Inject a custom credentials_loader "
+        "on SddcManagerConnector until G0.3 lands."
+    )

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -247,3 +247,30 @@ def test_all_connectors_v2_returns_copy() -> None:
     snapshot = all_connectors_v2()
     snapshot[("injected", "", "")] = _FakeConnector
     assert ("injected", "", "") not in all_connectors_v2()
+
+
+# ---------------------------------------------------------------------------
+# Shipped connector triples — assert each hand-rolled connector resolves
+# ---------------------------------------------------------------------------
+
+
+def test_sddc_manager_connector_registered_under_v2_triple() -> None:
+    """SddcManagerConnector package registers under (sddc-manager, 9.0, sddc-rest) at import.
+
+    The autouse _clean_registry fixture clears the registry before this test,
+    so we re-import the package (which is a no-op if already imported) and
+    then manually re-register to assert the triple resolves correctly. Mirrors
+    the pattern in test_connectors_nsx_auth.py.
+    """
+    from meho_backplane.connectors.sddc_manager import SddcManagerConnector
+
+    register_connector_v2(
+        product=SddcManagerConnector.product,
+        version=SddcManagerConnector.version,
+        impl_id=SddcManagerConnector.impl_id,
+        cls=SddcManagerConnector,
+    )
+    snapshot = all_connectors_v2()
+    key = ("sddc-manager", "9.0", "sddc-rest")
+    assert key in snapshot
+    assert snapshot[key] is SddcManagerConnector

--- a/backend/tests/test_connectors_sddc_manager_auth.py
+++ b/backend/tests/test_connectors_sddc_manager_auth.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`SddcManagerConnector` auth + fingerprint/probe (G3.5-T4 #616).
+
+Exercises HTTP Basic auth with sso_realm handling (default + override),
+per-target credential isolation, the auth_model boundary gate, and the
+fingerprint/probe shape against a mocked ``GET /v1/sddc-managers`` endpoint.
+
+Auth divergence from the NSX/vSphere precedents: no session token is
+established — HTTP Basic is sent on every request via
+``Authorization: Basic <base64(username@realm:password)>``. Credentials are
+cached per target so Vault is only queried once per target per connector
+instance lifetime.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+import pytest
+import respx
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.sddc_manager import (
+    SddcManagerConnector,
+    SddcTargetLike,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_sddc_registry() -> Iterator[None]:
+    """Re-register SddcManagerConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that
+    calls :func:`clear_registry` between tests. Re-register before every
+    test in this module and clear after — same pattern
+    :mod:`tests.test_connectors_nsx_auth` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=SddcManagerConnector.product,
+        version=SddcManagerConnector.version,
+        impl_id=SddcManagerConnector.impl_id,
+        cls=SddcManagerConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies SddcTargetLike Protocol structurally.
+# Replaced by the real Target model when G0.3 (#224) lands.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    sso_realm: str = field(default="vsphere.local")
+
+
+_TARGET_A = _StubTarget(
+    name="sddc-a",
+    host="sddc-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/sddc/sddc-a",
+)
+_TARGET_B = _StubTarget(
+    name="sddc-b",
+    host="sddc-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/sddc/sddc-b",
+)
+
+
+async def _stub_loader(_target: SddcTargetLike) -> dict[str, str]:
+    """Return canned credentials regardless of the target."""
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> SddcManagerConnector:
+    """Build a connector wired with the stub loader."""
+    return SddcManagerConnector(credentials_loader=_stub_loader)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_sddc_connector_subclasses_http_connector() -> None:
+    """Sanity check: the connector inherits from HttpConnector with the right metadata."""
+    assert issubclass(SddcManagerConnector, HttpConnector)
+    assert SddcManagerConnector.product == "sddc-manager"
+    assert SddcManagerConnector.version == "9.0"
+    assert SddcManagerConnector.impl_id == "sddc-rest"
+    assert SddcManagerConnector.supported_version_range == ">=9.0,<10.0"
+    assert SddcManagerConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    """The package's __init__ calls register_connector_v2 at import time."""
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("sddc-manager", "9.0", "sddc-rest")
+    assert key in registry
+    assert registry[key] is SddcManagerConnector
+
+
+def test_default_credentials_loader_raises_until_g03_lands() -> None:
+    """The default Vault loader stays unimplemented until G0.3."""
+    import asyncio
+
+    from meho_backplane.connectors.sddc_manager.session import load_credentials_from_vault
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"G0\.3"):
+            await load_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# HTTP Basic auth — happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_sends_basic_auth_with_default_sso_realm() -> None:
+    """auth_headers() produces Authorization: Basic with sso_realm=vsphere.local default.
+
+    The username in the Basic auth header must be ``svc-meho@vsphere.local``,
+    not bare ``svc-meho``. This is the load-bearing sso_realm contract.
+
+    auth_headers() does not make any HTTP calls — it computes the header from
+    cached credentials — so no respx mock is needed here.
+    """
+    connector = _make_connector()
+    headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "Authorization" in headers
+    assert headers["Authorization"].startswith("Basic ")
+    username, password = _decode_basic_auth(headers["Authorization"])
+    assert username == "svc-meho@vsphere.local"
+    assert password == "stub-password"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_honors_explicit_sso_realm_override() -> None:
+    """A target with a custom sso_realm has that realm reflected in the Basic auth header."""
+    target = _StubTarget(
+        name="sddc-custom",
+        host="sddc-custom.test.invalid",
+        port=443,
+        secret_ref="kv/data/sddc/custom",
+        sso_realm="corp.example.com",
+    )
+    connector = _make_connector()
+
+    headers = await connector.auth_headers(target, raw_jwt="")
+    username, _ = _decode_basic_auth(headers["Authorization"])
+    assert username == "svc-meho@corp.example.com"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-invoke the loader."""
+    call_count = 0
+
+    async def _counting_loader(_target: SddcTargetLike) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "svc-meho", "password": "stub-password"}
+
+    connector = SddcManagerConnector(credentials_loader=_counting_loader)
+    h1 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h2 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert h1 == h2
+    assert call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_credentials_separate() -> None:
+    """Two targets get two distinct credential cache entries; no cross-target leakage."""
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: SddcTargetLike) -> dict[str, str]:
+        call_log.append(target.name)
+        return {"username": f"svc-{target.name}", "password": "pass"}
+
+    connector = SddcManagerConnector(credentials_loader=_tracking_loader)
+    h_a = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h_b = await connector.auth_headers(_TARGET_B, raw_jwt="")
+
+    username_a, _ = _decode_basic_auth(h_a["Authorization"])
+    username_b, _ = _decode_basic_auth(h_b["Authorization"])
+    assert username_a == "svc-sddc-a@vsphere.local"
+    assert username_b == "svc-sddc-b@vsphere.local"
+    # Loader called exactly once per distinct target.
+    assert call_log == ["sddc-a", "sddc-b"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential loading failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
+    """A loader returning a dict without 'password' surfaces a clear RuntimeError."""
+
+    async def _bad_loader(_target: SddcTargetLike) -> dict[str, str]:
+        return {"username": "svc-meho"}  # type: ignore[return-value]
+
+    connector = SddcManagerConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"password") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "sddc-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_username_key_raises_runtime_error_naming_target() -> None:
+    """A loader returning a dict without 'username' surfaces a clear RuntimeError."""
+
+    async def _bad_loader(_target: SddcTargetLike) -> dict[str, str]:
+        return {"password": "stub-password"}  # type: ignore[return-value]
+
+    connector = SddcManagerConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"username") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "sddc-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="sddc-per-user",
+        host="sddc.test.invalid",
+        port=443,
+        secret_ref="kv/data/sddc/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="")
+
+    assert "sddc-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="sddc-pre-g03",
+        host="sddc.test.invalid",
+        port=443,
+        secret_ref="kv/data/sddc/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="sddc-enum",
+        host="sddc.test.invalid",
+        port=443,
+        secret_ref="kv/data/sddc/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() + probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against a respx-mocked GET /v1/sddc-managers returns canonical shape."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.get("/v1/sddc-managers").respond(
+            200,
+            json={
+                "elements": [
+                    {
+                        "id": "sddc-uuid-1",
+                        "fqdn": "sddc-a.test.invalid",
+                        "version": "9.0.0.0-24276214",
+                        "build": "24276214",
+                        "domain": {"id": "domain-uuid-1", "name": "MGMT"},
+                    }
+                ],
+                "pageMetadata": {"pageNumber": 1, "pageSize": 10, "totalElements": 1},
+            },
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "sddc-manager"
+    assert fp.version == "9.0.0.0-24276214"
+    assert fp.build == "24276214"
+    assert fp.reachable is True
+    assert fp.probe_method == "GET /v1/sddc-managers"
+    assert fp.extras["management_domain"] == "MGMT"
+    assert fp.extras["management_domain_id"] == "domain-uuid-1"
+    assert fp.extras["id"] == "sddc-uuid-1"
+    assert fp.extras["fqdn"] == "sddc-a.test.invalid"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_returns_reachable_false_with_structured_error() -> None:
+    """Transport/status failure returns reachable=False with extras['error']."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.get("/v1/sddc-managers").respond(401, json={"message": "Unauthorized"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "sddc-manager"
+    assert fp.reachable is False
+    assert fp.probe_method == "GET /v1/sddc-managers"
+    error = fp.extras["error"]
+    assert "HTTPStatusError" in error or "401" in error
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_empty_elements_returns_reachable_true_with_no_version() -> None:
+    """An empty elements list produces reachable=True with version=None (API responded)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.get("/v1/sddc-managers").respond(
+            200,
+            json={"elements": [], "pageMetadata": {"totalElements": 0}},
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is True
+    assert fp.version is None
+    assert fp.extras["management_domain"] is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_when_reachable() -> None:
+    """probe() returns ok=True on a reachable target (delegates to fingerprint)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.get("/v1/sddc-managers").respond(
+            200,
+            json={
+                "elements": [
+                    {
+                        "id": "u",
+                        "fqdn": "sddc-a.test.invalid",
+                        "version": "9.0.0.0",
+                        "domain": {"id": "d", "name": "MGMT"},
+                    }
+                ]
+            },
+        )
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_with_reason_when_unreachable() -> None:
+    """probe() returns ok=False + reason on an unreachable target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.get("/v1/sddc-managers").respond(401)
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose — credential cache clear + pool tear-down
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_credential_cache_and_pool() -> None:
+    """aclose() clears the in-memory credential cache and tears down the httpx pool."""
+    connector = _make_connector()
+    await connector.auth_headers(_TARGET_A, raw_jwt="")
+    assert "sddc-a" in connector._creds_cache
+    await connector.aclose()
+    assert connector._creds_cache == {}
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_with_no_cached_credentials_is_a_noop() -> None:
+    """A fresh connector with no credentials established closes cleanly."""
+    connector = _make_connector()
+    await connector.aclose()
+    assert connector._clients == {}
+    assert connector._creds_cache == {}

--- a/docs/codebase/connectors-sddc-manager.md
+++ b/docs/codebase/connectors-sddc-manager.md
@@ -1,0 +1,158 @@
+# Connector: sddc-manager (SDDC Manager 9.0)
+
+## Overview
+
+The `sddc-manager` connector is the hand-rolled `HttpConnector` subclass that
+dispatches SDDC Manager REST operations under the
+`(product="sddc-manager", version="9.0", impl_id="sddc-rest")` registry triple.
+G3.5-T4 (#616) shipped the skeleton — HTTP Basic auth, fingerprint, probe, and
+the G0.6 dispatch shim. G3.5-T5 (#617) adds spec ingestion + operator-review
+curation + ~8 read-only core ops. CLI verbs + MCP review + recorded-fixture E2E
+arrive in G3.5-T6 (#618).
+
+Source: `backend/src/meho_backplane/connectors/sddc_manager/`.
+
+## Key types
+
+- **`SddcManagerConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="sddc-manager"`, `version="9.0"`,
+  `impl_id="sddc-rest"`, `supported_version_range=">=9.0,<10.0"`,
+  `priority=1`. The priority outranks a future `GenericRestConnector`
+  auto-shim (priority=0) defensively if both somehow register for the same
+  triple.
+- **`SddcTargetLike`** (`session.py`) — runtime-checkable Protocol capturing
+  the minimum target shape the connector reads: `name`, `host`, `port`,
+  `secret_ref`, `auth_model`, and `sso_realm`. `sso_realm` defaults to
+  `"vsphere.local"` per the consumer wrapper contract; operators managing a
+  custom SSO domain override it at the target level. Replaced by the concrete
+  `Target` model once G0.3 (#224) lands; the model satisfies the Protocol
+  structurally without code edits here.
+- **`SddcCredentialsLoader`** (`session.py`) — async callable type resolving
+  a target to `{"username": ..., "password": ...}`. Injectable on connector
+  construction (`SddcManagerConnector(credentials_loader=...)`) so unit tests,
+  integration tests, and pre-G0.3 production deploys override the default
+  Vault loader.
+- **`load_credentials_from_vault`** (`session.py`) — default loader, stubbed
+  `NotImplementedError` until G0.3 lands the operator-context Vault read path.
+  Mirrors the `load_session_credentials_from_vault` / `load_credentials_from_vault`
+  shape in `connectors/vmware_rest/` and `connectors/nsx/`.
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()` in
+   `meho_backplane/connectors/registry.py`, which walks every
+   `connectors/<product>/` subpackage in name-sorted order.
+2. Importing `meho_backplane.connectors.sddc_manager` triggers the
+   module-level
+   `register_connector_v2(product="sddc-manager", version="9.0", impl_id="sddc-rest", cls=SddcManagerConnector)`
+   call.
+3. The registry's v2 table now resolves `("sddc-manager", "9.0", "sddc-rest")`
+   to `SddcManagerConnector`. The G0.7 auto-shim's idempotency check (in
+   `ensure_connector_class_registered`, once #408's pipeline lands in main)
+   no-ops on subsequent ingests against the same triple.
+
+### Per-target credentials + HTTP Basic auth
+
+SDDC Manager auth diverges from the NSX/vSphere precedents: no session cookie
+or XSRF token is established; HTTP Basic is sent on every request.
+
+1. `SddcManagerConnector.auth_headers(target)` is called for the first time
+   against `target`.
+2. `_load_credentials(target)` acquires the per-instance `asyncio.Lock`,
+   checks the `self._creds_cache` dict (keyed on `target.name`), misses,
+   calls the injected `credentials_loader(target)` → resolves to
+   `{"username": ..., "password": ...}`.
+3. Credentials are validated for the `"username"` and `"password"` keys; a
+   missing key raises `RuntimeError` naming the target and the missing key.
+4. The credentials are cached under `target.name` for the lifetime of the
+   connector instance.
+5. `auth_headers()` computes the username as `f"{creds['username']}@{sso_realm}"`
+   where `sso_realm = target.sso_realm or "vsphere.local"`, then returns
+   `{"Authorization": f"Basic {base64(username:password)}"}`.
+6. Subsequent calls reuse the cached credentials; the loader is never
+   called again for the same target.
+
+Because HTTP Basic credentials are stateless server-side (no session to expire
+or revoke), no 401-driven re-login is implemented. A 401 from a downstream
+call propagates directly to the caller — it signals wrong credentials, not an
+expired session.
+
+### Fingerprint + probe
+
+- `fingerprint(target)` issues `GET /v1/sddc-managers` through
+  `HttpConnector._get_json` (with tenacity's connection-error + 5xx retry
+  decorator). On success: reads `elements[0]` from the pagination envelope
+  and returns
+  `FingerprintResult(vendor="vmware", product="sddc-manager", version=...,
+  build=..., reachable=True, extras={"id", "fqdn", "management_domain",
+  "management_domain_id"})`. On transport, HTTP-status, or
+  credentials-load failure: returns `reachable=False` with
+  `extras["error"] = "<ExcType>: <message>"`.
+- `probe(target)` delegates to `fingerprint` — one authenticated request
+  covers both reachability and auth-challenge, same posture the vSphere and
+  NSX precedents use.
+
+### Dispatch shim
+
+`execute(target, op_id, params)` synthesises a minimal `Operator`
+(nil-UUID tenant_id + `sub="system:sddc-rest-connector-shim"`) and delegates
+to `meho_backplane.operations.dispatch` with `connector_id="sddc-rest-9.0"`.
+Pre-G0.6 chassis routes reach the dispatcher through this shim; post-G0.6
+callers (the `/api/v1/operations/call` route, MCP `call_operation`, the CLI
+verbs once #618 lands) construct a real `Operator` and call `dispatch`
+themselves.
+
+### Shutdown
+
+`aclose()` clears `self._creds_cache` (no server-side session to revoke) and
+delegates to `HttpConnector.aclose()` which closes every per-target httpx
+client.
+
+## Dependencies
+
+- **httpx 0.28.x** — per-target `AsyncClient` pool (inherited from
+  `HttpConnector`); `Authorization: Basic` header computed by the connector
+  using `base64.b64encode`.
+- **tenacity 9.x** — the inherited `@retry` decorator on
+  `HttpConnector._request_json` retries connection errors and 5xx responses
+  up to four attempts with exponential backoff; 4xx propagates cleanly to
+  the fingerprint/probe layer.
+- **pydantic 2.13.x** — `FingerprintResult` / `ProbeResult` /
+  `OperationResult` are frozen models; the connector constructs them by
+  keyword.
+- **respx 0.23.x (test-only)** — the unit-test module mocks every request
+  shape without a network call.
+- **structlog** — a single `sddc_manager_credentials_loaded` info event per
+  successful first-use credential load; no other emit points in this skeleton.
+
+## Known issues
+
+- Default credentials loader raises `NotImplementedError`. Production callers
+  must inject `credentials_loader=...` on construction until G0.3 (#224)
+  lands the operator-context Vault read path. Mirrors the `vmware_rest` and
+  `nsx` precedents; both connectors pick up the live implementation in a
+  single follow-up commit once G0.3 merges.
+- Operations are not yet available. `execute(target, op_id, ...)` resolves to
+  "unknown operation" at the dispatcher layer until #617 lands the spec
+  ingestion + endpoint_descriptor rows.
+- HTTP Basic auth for VCF 9.x: the consumer wrapper (`scripts/sddc-manager.sh`)
+  uses HTTP Basic with `username@sso_realm` format, and this connector mirrors
+  that shape. Broadcom deprecated Basic Auth in VCF 4.x in favour of Bearer
+  tokens (POST /v1/tokens); if a future VCF 9.x deployment rejects Basic auth,
+  an auth-scheme migration task should be filed under Initiative #368.
+
+## References
+
+- Issues: [G3.5-T4 #616](https://github.com/evoila/meho/issues/616)
+  (skeleton); [G3.5-T5 #617](https://github.com/evoila/meho/issues/617)
+  (spec ingestion + read ops); [G3.5-T6 #618](https://github.com/evoila/meho/issues/618)
+  (CLI + MCP review + E2E + onboarding doc).
+- Parent Initiative: [G3.5 #368](https://github.com/evoila/meho/issues/368).
+- Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
+- Precedent: `connectors/nsx/connector.py` (session auth + fingerprint +
+  probe + dispatch shim); `connectors/vmware_rest/connector.py` (session auth);
+  `connectors/adapters/http.py` (`HttpConnector`);
+  `connectors/registry.py:108` (`register_connector_v2`).
+- VCF API reference: https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/


### PR DESCRIPTION
## Summary

- Adds `SddcManagerConnector(HttpConnector)` skeleton for SDDC Manager 9.0 under `connectors/sddc_manager/` (skeleton-only; ops arrive in #617 via G0.7 spec ingestion)
- Auth: HTTP Basic with `Authorization: Basic base64(username@sso_realm:password)` sent per-request; credentials loaded once from Vault via injectable `SddcCredentialsLoader`, cached per target for the connector instance lifetime
- `fingerprint()` → `GET /v1/sddc-managers` → `FingerprintResult(vendor="vmware", product="sddc-manager", version, build, extras={management_domain, id, fqdn})`; `probe()` delegates to fingerprint; `execute()` is the G0.6 dispatch shim
- Registered via `register_connector_v2(product="sddc-manager", version="9.0", impl_id="sddc-rest")` at module-import time (eager-import lifespan walk, same as vmware_rest/nsx)

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/sddc_manager/` — clean (3 source files)
- [x] `pytest -n auto test_connectors_sddc_manager_auth.py test_connectors_registry_v2.py` — 35 passed
- [x] Basic auth with `sso_realm=vsphere.local` default produces correct `Authorization: Basic` header (`svc-meho@vsphere.local`)
- [x] Explicit `sso_realm` override honored (`corp.example.com`)
- [x] Vault loader missing required key → `RuntimeError` naming target and missing key
- [x] Per-target credential isolation — two targets → two distinct cache entries, loader called once each
- [x] `auth_model="impersonation"` → `NotImplementedError` naming target + mode
- [x] `fingerprint()` against mocked `GET /v1/sddc-managers` returns canonical shape (vendor/product/version/build/management_domain)
- [x] Unreachable target → `reachable=False` + structured `extras["error"]`
- [x] `probe()` returns `ok=True/False` + reason
- [x] `("sddc-manager", "9.0", "sddc-rest")` triple resolves in registry v2 test

## Out of scope

- SDDC Manager ops (domain/cluster/host lists) — spec-ingested in #617
- CLI verbs + MCP review + recorded-fixture E2E + onboarding doc — #618

Closes #616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SDDC Manager 9.0 connector with HTTP Basic authentication support
  * Implemented target-specific credential caching
  * Added connection verification and fingerprinting capabilities

* **Documentation**
  * Added SDDC Manager connector guide covering registration, authentication, and control flow

* **Tests**
  * Added comprehensive authentication, credential handling, and connection lifecycle tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->