### PR TITLE
feat(memory): G5.1-T4 meho remember/recall/forget/list top-level CLI verbs (#424)

### DIFF
--- a/cli/internal/cmd/memory/forget.go
+++ b/cli/internal/cmd/memory/forget.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package memory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewForgetCmd returns the top-level `meho forget` command (issue
+// #424).
+//
+// CLI shape:
+//
+//	meho forget <scope>/<slug> [--target NAME] [--confirm] [--json] [--backplane <url>]
+//
+// Role: any authenticated operator. The service-layer
+// MemoryRbacResolver further restricts `tenant` forgets to
+// `tenant_admin`; that surfaces as 403 insufficient_role.
+//
+// Default behaviour prompts for a y/N confirmation on stdin;
+// `--confirm` skips the prompt for scripted use. Delete is
+// **idempotent** at the backend: a forget against an absent slug
+// returns 204 (not 404), matching the route's info-leak avoidance.
+// The CLI mentions idempotency in the success line so operators
+// rerunning the command after a previous successful run don't
+// mistake the no-op for an error.
+//
+// Exit codes:
+//   - 0   delete succeeded (204) or operator declined the prompt
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response
+//   - 5   insufficient_role (e.g. operator forgetting `tenant` scope)
+func NewForgetCmd() *cobra.Command {
+	var (
+		confirm           bool
+		targetFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "forget <scope>/<slug>",
+		Short: "Delete one memory by natural key (DELETE /api/v1/memory)",
+		Long: "forget calls DELETE /api/v1/memory/{scope}/{slug}. " +
+			"Idempotent server-side: a forget against an absent slug " +
+			"returns 204 (the conflation prevents enumerating other " +
+			"tenants via status-code differential).\n\n" +
+			"Without --confirm, the verb prompts on stdin for a y/N " +
+			"confirmation; --confirm skips the prompt for scripted use " +
+			"(CI pipelines, etc.). Declining the prompt exits 0 " +
+			"without calling the backend.\n\n" +
+			"--target NAME is required when --scope=target or " +
+			"user-target. The check fires client-side so a forgotten " +
+			"flag surfaces without a round-trip.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runForget(cmd, forgetOptions{
+				ScopeSlugArg:      args[0],
+				TargetArg:         targetFlag,
+				Confirm:           confirm,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&confirm, "confirm", false,
+		"skip the stdin confirmation prompt")
+	cmd.Flags().StringVar(&targetFlag, "target", "",
+		"target name (required when --scope=target or user-target)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit a machine-readable success envelope instead of the human line")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by `meho login`)")
+	return cmd
+}
+
+type forgetOptions struct {
+	ScopeSlugArg      string
+	TargetArg         string
+	Confirm           bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// forgetResult is the structure printed in --json mode. Kept small
+// (scope + slug + status) so operators piping into jq get a stable
+// envelope regardless of whether the row existed server-side (the
+// substrate doesn't surface that distinction back to the CLI).
+type forgetResult struct {
+	Scope  string `json:"scope"`
+	Slug   string `json:"slug"`
+	Status string `json:"status"`
+}
+
+func runForget(cmd *cobra.Command, opts forgetOptions) error {
+	scope, slug, err := parseScopeSlugArg(opts.ScopeSlugArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	if err := requireTargetForScope(scope, opts.TargetArg); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	// Confirm BEFORE resolving the backplane so that an operator who
+	// declines (or hits ^D / EOF on a piped /dev/null) exits 0
+	// regardless of whether `meho login` has been run. Resolving
+	// first would surface auth_expired on a no-config workstation
+	// even when the operator was about to type `n` — the prompt
+	// would never appear, and the "ask before doing destructive
+	// things" promise would be violated. Same shape `meho kb
+	// delete` adopted.
+	if !opts.Confirm {
+		prompt := fmt.Sprintf(
+			"Forget memory %s/%s — idempotent (no-op if already absent). Continue?",
+			scope, slug,
+		)
+		// Route the prompt to stderr in --json mode so the JSON
+		// envelope on stdout stays parseable for `jq` consumers; the
+		// human-facing mode keeps the prompt on stdout for the
+		// familiar interactive shape.
+		promptW := cmd.OutOrStdout()
+		if opts.JSONOut {
+			promptW = cmd.ErrOrStderr()
+		}
+		if !confirmPrompt(cmd, promptW, prompt) {
+			result := forgetResult{
+				Scope:  string(scope),
+				Slug:   slug,
+				Status: "declined",
+			}
+			if opts.JSONOut {
+				return output.PrintJSON(cmd.OutOrStdout(), result)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"declined: memory %s/%s not deleted\n", scope, slug)
+			return nil
+		}
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			classifyBackplaneError(err), opts.JSONOut)
+	}
+	if err := callForget(cmd.Context(), backplaneURL, scope, slug, opts.TargetArg); err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	result := forgetResult{
+		Scope:  string(scope),
+		Slug:   slug,
+		Status: "deleted",
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"forgot memory %s/%s (idempotent: no-op if already absent)\n", scope, slug)
+	return nil
+}
+
+func callForget(
+	ctx context.Context,
+	backplaneURL string,
+	scope Scope,
+	slug, targetName string,
+) error {
+	// doAuthedRequest returns (nil, nil) on a 204; the forget route
+	// emits an empty 204 body whether or not the row existed
+	// server-side. We discard the (nil) response — the success
+	// signal is the absence of an error.
+	_, err := doAuthedRequest(
+		ctx, backplaneURL, "DELETE", buildRecallPath(scope, slug, targetName), nil,
+	)
+	return err
+}

--- a/cli/internal/cmd/memory/list.go
+++ b/cli/internal/cmd/memory/list.go
@@ -116,10 +116,19 @@ type listOptions struct {
 
 func runList(cmd *cobra.Command, opts listOptions) error {
 	if opts.ScopeArg != "" {
-		if _, err := parseScope(opts.ScopeArg); err != nil {
+		scope, err := parseScope(opts.ScopeArg)
+		if err != nil {
 			return output.RenderError(cmd.ErrOrStderr(),
 				output.Unexpected(err.Error()), opts.JSONOut)
 		}
+		// Write the trimmed Scope value back so buildListPath
+		// forwards the normalised form. Without this, a padded
+		// input like `--scope " user "` passes the preflight (the
+		// validScopes lookup trims) and then 422s on the backend
+		// when the raw query string reaches FastAPI's enum check.
+		// Mirrors the recall.go:191-203 pattern where parseScope's
+		// return value is propagated through kindFilter.
+		opts.ScopeArg = string(scope)
 	}
 	// Mirror the kb list helper's bound check: server clamps with
 	// Query(ge=1, le=500). Surface the constraint string locally so

--- a/cli/internal/cmd/memory/list.go
+++ b/cli/internal/cmd/memory/list.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewListCmd returns the top-level `meho list` command (issue
+// #424).
+//
+// CLI shape:
+//
+//	meho list [--scope SCOPE] [--tag T] [--slug-pattern P]
+//	          [--include-expired] [--limit N] [--json] [--backplane <url>]
+//
+// Calls GET /api/v1/memory and renders the visible memories as a
+// text table sorted by (scope, slug). Tenant-scoped server-side
+// via the JWT — no surface accepts a tenant id.
+//
+// The verb is named `list` (no namespace) per the consumer-needs.md
+// §G5 ergonomic shape and the explicit issue #424 contract
+// (`meho list --scope user`). The collision-note escape valve
+// (namespace under `memory` if cobra refuses to register the
+// top-level name) does not fire — cobra has no built-in `list` verb.
+//
+// Role: any authenticated operator including `read_only` (the
+// substrate explicitly allows read_only to read tenant/target
+// memories; user-scoped rows still filter by user_sub at the
+// service layer).
+//
+// Exit codes:
+//   - 0   list returned cleanly (including zero rows)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 422 invalid_scope / limit_out_of_range)
+//   - 5   insufficient_role
+func NewListCmd() *cobra.Command {
+	var (
+		scopeFlag         string
+		tagFlag           string
+		slugPatternFlag   string
+		includeExpired    bool
+		limitFlag         int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List memories visible to the operator (GET /api/v1/memory)",
+		Long: "list calls GET /api/v1/memory and renders the memories " +
+			"visible to the operator in their tenant. Tenant-scoping " +
+			"is enforced server-side via the JWT; user-scoped rows " +
+			"further filter to the operator that wrote them.\n\n" +
+			"--scope narrows by one of user|user-tenant|user-target|" +
+			"tenant|target (omitted: every scope visible to the " +
+			"operator is shown). --tag narrows to memories carrying " +
+			"the supplied tag in metadata. --slug-pattern narrows via " +
+			"a substring match on the slug. --include-expired surfaces " +
+			"memories past their expires_at (omitted: expired entries " +
+			"are filtered out per the G5.1 read-side contract; G5.2 " +
+			"ships the daily cleanup task that physically removes " +
+			"them). --limit caps the page size (1..500, server default " +
+			"100).",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runList(cmd, listOptions{
+				ScopeArg:          scopeFlag,
+				TagArg:            tagFlag,
+				SlugPatternArg:    slugPatternFlag,
+				IncludeExpired:    includeExpired,
+				LimitArg:          limitFlag,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&scopeFlag, "scope", "",
+		"filter by memory scope: user|user-tenant|user-target|tenant|target")
+	cmd.Flags().StringVar(&tagFlag, "tag", "",
+		"filter by tag (memories whose metadata.tags contains this string)")
+	cmd.Flags().StringVar(&slugPatternFlag, "slug-pattern", "",
+		"filter by substring match on slug (forwarded to MemoryService.list_memories)")
+	cmd.Flags().BoolVar(&includeExpired, "include-expired", false,
+		"include memories past their expires_at (omitted: expired entries filtered out)")
+	cmd.Flags().IntVar(&limitFlag, "limit", 0,
+		"max memories per page (1..500, server default 100 when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw ListResponse JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by `meho login`)")
+	return cmd
+}
+
+type listOptions struct {
+	ScopeArg          string
+	TagArg            string
+	SlugPatternArg    string
+	IncludeExpired    bool
+	LimitArg          int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runList(cmd *cobra.Command, opts listOptions) error {
+	if opts.ScopeArg != "" {
+		if _, err := parseScope(opts.ScopeArg); err != nil {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(err.Error()), opts.JSONOut)
+		}
+	}
+	// Mirror the kb list helper's bound check: server clamps with
+	// Query(ge=1, le=500). Surface the constraint string locally so
+	// operators see the bound without a 422 round-trip.
+	if opts.LimitArg < 0 || opts.LimitArg > 500 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--limit must be between 1 and 500; got %d", opts.LimitArg)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			classifyBackplaneError(err), opts.JSONOut)
+	}
+	resp, err := getList(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	}
+	printListTable(cmd.OutOrStdout(), resp)
+	return nil
+}
+
+// buildListPath assembles the GET /api/v1/memory query string from
+// the per-call options. Exposed for unit tests so the URL
+// construction stays unit-checkable without standing up an
+// httptest.Server.
+func buildListPath(opts listOptions) string {
+	q := url.Values{}
+	if opts.ScopeArg != "" {
+		q.Set("scope", opts.ScopeArg)
+	}
+	if opts.SlugPatternArg != "" {
+		q.Set("slug_pattern", opts.SlugPatternArg)
+	}
+	if opts.TagArg != "" {
+		q.Set("tag", opts.TagArg)
+	}
+	if opts.IncludeExpired {
+		q.Set("include_expired", "true")
+	}
+	if opts.LimitArg > 0 {
+		q.Set("limit", strconv.Itoa(opts.LimitArg))
+	}
+	path := "/api/v1/memory"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path
+}
+
+func getList(ctx context.Context, backplaneURL string, opts listOptions) (*ListResponse, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out ListResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode list response: %w", err)
+	}
+	return &out, nil
+}
+
+// printListTable renders the list as a compact, scannable table.
+// Columns: SCOPE, SLUG, EXPIRES, BODY (preview). The full ISO-8601
+// expires_at is kept verbatim because operators correlating with
+// audit-log rows want the precise cutoff; "(none)" is rendered for
+// the absent case. Body is truncated to 60 chars so a default
+// terminal width doesn't wrap.
+func printListTable(w io.Writer, r *ListResponse) {
+	if r == nil || len(r.Entries) == 0 {
+		fmt.Fprintln(w, "no memories visible in this tenant")
+		return
+	}
+	fmt.Fprintf(w, "%-14s %-32s %-32s %s\n",
+		"SCOPE", "SLUG", "EXPIRES", "BODY")
+	for _, e := range r.Entries {
+		fmt.Fprintf(w, "%-14s %-32s %-32s %s\n",
+			truncate(string(e.Scope), 14),
+			truncate(e.Slug, 32),
+			truncate(pluralisePtr(e.ExpiresAt), 32),
+			truncate(snippetOf(e.Body), 60),
+		)
+	}
+}

--- a/cli/internal/cmd/memory/memory.go
+++ b/cli/internal/cmd/memory/memory.go
@@ -1,0 +1,769 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package memory hosts the top-level cobra commands `meho remember`,
+// `meho recall`, `meho forget`, and `meho list` for G5.1-T4 (#424) of
+// Initiative #332. The four verbs wrap the four REST routes shipped
+// by G5.1-T2 (#422) plus the G0.4-T5 `/api/v1/retrieve` route for the
+// `meho recall --query` retrieval form:
+//
+//   - `meho remember "body" [--scope SCOPE] [--slug SLUG]
+//     [--target NAME] [--tag T] [--ttl 7d] [--json]` —
+//     POST /api/v1/memory. Default scope `user-tenant`. Body can be
+//     piped on stdin when the positional arg is `-`.
+//   - `meho recall <scope>/<slug> [--target NAME] [--json]` —
+//     GET /api/v1/memory/{scope}/{slug}.
+//   - `meho recall --query "search terms" [--scope SCOPE] [--limit N]
+//     [--json]` — POST /api/v1/retrieve with source="memory".
+//   - `meho forget <scope>/<slug> [--target NAME] [--confirm]
+//     [--json]` — DELETE /api/v1/memory/{scope}/{slug}.
+//   - `meho list [--scope SCOPE] [--tag T] [--include-expired]
+//     [--slug-pattern P] [--limit N] [--json]` —
+//     GET /api/v1/memory.
+//
+// The verbs are registered as **top-level** cobra commands per the
+// consumer-needs.md §G5 ergonomic shape (the consumer-facing CLI
+// spec calls out `meho remember` and `meho recall`, not
+// `meho memory remember`). The acceptance criterion in #424 names
+// `meho list --scope user` verbatim; `meho memory list` would
+// violate the contract.
+//
+// The implementation deliberately follows the in-package HTTP helper
+// pattern the sibling verb trees use (one resolveBackplane /
+// doAuthedRequest / renderRequestError trio per package) rather
+// than a shared cli/internal/api_client package. The reason is the
+// import-cycle one: each verb tree is registered onto the root
+// command, so a shared helper imported from cmd/* and from any
+// per-tree package would close the cycle. Duplicating the helpers
+// (a handful of small, stable functions) is the convention every
+// sibling package follows — see cli/internal/cmd/kb/kb.go's identical
+// docstring for the matching justification.
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// Scope is the wire-level identifier matching the backend's
+// MemoryScope StrEnum (`backend/src/meho_backplane/memory/schemas.py`
+// L87-107). Five values; one per consumer-needs.md §G5 row. The
+// string values are the same identifier the route path segment,
+// `--scope` flag value, and the audit/broadcast contextvar carry.
+//
+// Hand-typed rather than aliased to a generated client type so the
+// memory package stays decoupled from oapi-codegen churn — same
+// stance every sibling package (kb, audit, targets, ...) takes for
+// its mirrored enums.
+type Scope string
+
+const (
+	// ScopeUser is the per-operator-across-tenants scope — a memory
+	// only the writing operator can read, across every tenant they
+	// belong to.
+	ScopeUser Scope = "user"
+	// ScopeUserTenant is the operator-within-one-tenant scope — the
+	// default for `meho remember` because consumer-needs.md §G5 L137
+	// identifies it as the most common case.
+	ScopeUserTenant Scope = "user-tenant"
+	// ScopeUserTarget is the operator-against-one-target scope —
+	// requires `--target`.
+	ScopeUserTarget Scope = "user-target"
+	// ScopeTenant is the tenant-wide scope — write requires
+	// `tenant_admin`; the substrate's RBAC matrix surfaces this as
+	// 403 from the service.
+	ScopeTenant Scope = "tenant"
+	// ScopeTarget is the per-target-shared scope — every operator
+	// touching one infrastructure target sees the same memory.
+	// Requires `--target`.
+	ScopeTarget Scope = "target"
+)
+
+// validScopes is the set the parseScope helper uses to reject typos
+// client-side rather than relying on a 422 round-trip. Membership
+// (not lookup) matters; the helper returns a Scope value verbatim
+// when the input matches.
+var validScopes = map[string]Scope{
+	"user":        ScopeUser,
+	"user-tenant": ScopeUserTenant,
+	"user-target": ScopeUserTarget,
+	"tenant":      ScopeTenant,
+	"target":      ScopeTarget,
+}
+
+// targetScoped names the scope values where `--target` is required
+// at the CLI layer (mirrors the backend's TARGET_SCOPED frozenset in
+// `backend/src/meho_backplane/memory/schemas.py` L113). Failing fast
+// client-side beats a 422 round-trip and makes the error message
+// say what the operator needs to fix rather than relaying a server
+// message that mentions backend-internal field names.
+var targetScoped = map[Scope]bool{
+	ScopeUserTarget: true,
+	ScopeTarget:     true,
+}
+
+// Entry mirrors the backend `MemoryEntry` pydantic model
+// (`backend/src/meho_backplane/memory/schemas.py` L152-177). One
+// row as returned by GET /api/v1/memory/{scope}/{slug} and
+// POST /api/v1/memory.
+type Entry struct {
+	ID         string         `json:"id"`
+	TenantID   string         `json:"tenant_id"`
+	Scope      Scope          `json:"scope"`
+	Slug       string         `json:"slug"`
+	Body       string         `json:"body"`
+	Metadata   map[string]any `json:"metadata"`
+	ExpiresAt  *string        `json:"expires_at"`
+	UserSub    *string        `json:"user_sub"`
+	TargetName *string        `json:"target_name"`
+	CreatedAt  string         `json:"created_at"`
+	UpdatedAt  string         `json:"updated_at"`
+}
+
+// ListResponse mirrors the backend `MemoryListResponse` envelope.
+// Wrapped in `{"entries": [...]}` for forward-compat with future
+// cursor / paging fields — same shape kb / connectors_ingest adopt.
+type ListResponse struct {
+	Entries []Entry `json:"entries"`
+}
+
+// RetrievalHit mirrors the backend `RetrievalHit` pydantic model
+// (`backend/src/meho_backplane/retrieval/retriever.py`). Returned by
+// POST /api/v1/retrieve. `BM25Score`, `CosineScore`, `BM25Rank`, and
+// `CosineRank` are pointer-typed because the backend emits `null`
+// for documents that did not appear in that signal's top-K
+// candidate list.
+type RetrievalHit struct {
+	DocumentID  string         `json:"document_id"`
+	TenantID    string         `json:"tenant_id"`
+	Source      string         `json:"source"`
+	SourceID    string         `json:"source_id"`
+	Kind        string         `json:"kind"`
+	Body        string         `json:"body"`
+	DocMetadata map[string]any `json:"doc_metadata"`
+	FusedScore  float64        `json:"fused_score"`
+	BM25Score   *float64       `json:"bm25_score"`
+	CosineScore *float64       `json:"cosine_score"`
+	BM25Rank    *int           `json:"bm25_rank"`
+	CosineRank  *int           `json:"cosine_rank"`
+}
+
+// RetrieveResponse mirrors the backend `RetrieveResponse` envelope.
+type RetrieveResponse struct {
+	Hits            []RetrievalHit `json:"hits"`
+	QueryDurationMS float64        `json:"query_duration_ms"`
+}
+
+// rememberRequest mirrors the backend `RememberBody` pydantic model
+// (`backend/src/meho_backplane/api/v1/memory.py` L174-211). Fields
+// without JSON `omitempty` are mandatory at the wire level.
+type rememberRequest struct {
+	Scope      Scope          `json:"scope"`
+	Body       string         `json:"body"`
+	Slug       string         `json:"slug,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	ExpiresAt  string         `json:"expires_at,omitempty"`
+	TargetName string         `json:"target_name,omitempty"`
+}
+
+// retrieveRequest mirrors the backend `RetrieveRequest` pydantic
+// model (`backend/src/meho_backplane/api/v1/retrieve.py` L102-120).
+// `meho recall --query` pins `source="memory"` so the substrate
+// only ranks memory-scoped rows.
+type retrieveRequest struct {
+	Query  string `json:"query"`
+	Source string `json:"source,omitempty"`
+	Kind   string `json:"kind,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" (→ auth_expired exit
+// code 2 — fix is `meho login`) from URL-parse failures (→
+// unexpected exit code 4 — fix is correcting argv). Same shape as
+// the audit / kb / targets / connector siblings; duplicated here
+// because importing those packages would create cycles via
+// cmd/root.go (this package is registered onto the root the same
+// way they are).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// errMissingAccessToken is the sentinel doAuthedRequest returns
+// when the stored token row exists but its access_token field is
+// empty. Routed to auth_expired (exit 2) with a `meho login` hint
+// rather than the generic transport-error path. Mirrors the kb
+// sibling's fix that landed in PR #500 review iteration 1.
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+// responseBodyCap is the hard upper bound on a backplane response
+// body the CLI is willing to read. Memory list pages cap at 500
+// rows server-side; an average memory body is small (consumer-needs
+// describes them as "useful behavioral preferences" not multi-KB
+// blobs), so 1 MiB is comfortable headroom. The +1 byte read in
+// doAuthedRequest distinguishes "fits in the cap" from "truncated
+// at the cap" so a silently-truncated JSON payload never reaches
+// the decoder.
+const responseBodyCap int64 = 1 << 20
+
+// loadBodyStdinCap bounds the `-` (stdin) read on `meho remember`
+// so an adversarial / malformed pipe can't pin the verb in
+// unbounded io.ReadAll. 1 MiB matches the response cap; memory
+// bodies are expected to be hand-written notes, not megabyte
+// blobs.
+const loadBodyStdinCap int64 = 1 << 20
+
+// resolveBackplane mirrors the kb / audit / targets sibling helper.
+// Returns the backplane URL from the --backplane override or the
+// `meho login` config; wraps auth.ErrConfigNotFound so an absent
+// config maps to auth_expired (exit 2), not unexpected (exit 4).
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical contract to the kb /
+// audit / targets siblings.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes and parses the URL to fail
+// fast on garbage input. Mirrors the sibling-package helpers.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// httpError carries a non-2xx response so per-verb runners can
+// render the right category. Same shape as the kb sibling.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// renderRequestError translates an error from one of the per-verb
+// request helpers into the right output.StructuredError category.
+// Same classification ladder as kb / audit / targets, with the
+// memory-route-specific 4xx handling lifted into renderHTTPError.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if errors.Is(err, errMissingAccessToken) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderHTTPError classifies a non-2xx response into the right
+// StructuredError category.
+//
+// Memory-route-specific notes:
+//
+//   - 403 — write to a scope the operator's tenant role can't reach.
+//     The backend's detail string is `permission_denied: <reason>`;
+//     surface verbatim so the operator sees the matrix mismatch
+//     directly.
+//   - 404 — read / delete against a missing slug. The memory recall
+//     route deliberately collapses "missing" and "no access" into
+//     404 to avoid leaking tenant boundaries via status-code
+//     differential. Surface the detail (`memory_not_found`) verbatim.
+//   - 422 — pydantic validation (invalid slug shape, missing required
+//     body field, target_name missing for target-scoped writes).
+//     Surface the validation envelope so the operator sees the
+//     field that failed.
+//   - 401 — backplane rejected the stored token after a refresh
+//     attempt; auth_expired with a `meho login` hint.
+//   - Pure transport errors fall through to unreachable.
+func renderHTTPError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	he *httpError,
+	jsonOut bool,
+) error {
+	switch he.StatusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusNotFound:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusUnprocessableEntity:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
+			jsonOut,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape.
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error
+// body when it's a plain string. Falls back to the raw body when the
+// JSON shape doesn't match. Same shape as the kb sibling.
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection and one-shot 401-refresh-retry. Returns the
+// response body bytes (already drained) on 2xx, or an *httpError on
+// non-2xx, or an error categorised by api.IsTokenNotFound /
+// api.IsNoRefreshToken / generic transport.
+//
+// Mirrors cli/internal/cmd/kb/kb.go::doAuthedRequest and its
+// targets / operation / audit / connector siblings.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errMissingAccessToken
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	// Read with a 1-MiB cap and the +1 byte truncation-detection
+	// trick — same shape as the kb sibling. A response that fills
+	// the cap is treated as oversized rather than fed to the JSON
+	// decoder where it would surface as "unexpected end of JSON
+	// input" without naming the real cause.
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if int64(len(raw)) > responseBodyCap {
+		return nil, fmt.Errorf(
+			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
+			responseBodyCap,
+		)
+	}
+	// DELETE /api/v1/memory/{scope}/{slug} returns 204 with no body
+	// whether or not the row existed (idempotent contract — same
+	// shape kb adopted; the conflation prevents tenant-probe by
+	// status-code differential).
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// sendRequest is the bottom of the stack: build the http.Request,
+// stamp bearer + content headers, fire it. Mirrors the kb sibling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// pathEscape escapes a single path segment for use inside a backend
+// URL. Mirrors the kb sibling.
+func pathEscape(segment string) string {
+	return url.PathEscape(segment)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Rune-aware so multi-byte UTF-8 survives the
+// cut. Mirrors the sibling-package helper.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// parseScope normalises a --scope flag value to a typed Scope or
+// returns a descriptive error. Defaults are applied by the caller
+// (Cobra's StringVar default), not here — this helper exists to
+// reject typos client-side rather than relying on a 422 round-trip
+// (which would carry a backend-internal error string mentioning
+// pydantic types).
+func parseScope(raw string) (Scope, error) {
+	v, ok := validScopes[strings.TrimSpace(raw)]
+	if !ok {
+		return "", fmt.Errorf(
+			"invalid --scope %q (allowed: user, user-tenant, user-target, tenant, target)",
+			raw,
+		)
+	}
+	return v, nil
+}
+
+// parseScopeSlugArg parses the `<scope>/<slug>` positional argument
+// shared by `meho recall` and `meho forget`. The split keeps the
+// scope and slug typed; an arg without `/` or with an empty side
+// returns a clear error rather than a confusing 404 from the
+// backend.
+//
+// We deliberately split on the FIRST `/` (strings.Cut) so a slug
+// containing dots, hyphens, or underscores survives — the substrate's
+// SLUG_PATTERN admits `[A-Za-z0-9_.-]+`, so a slug like
+// `k8s.rollout-note` is legal and we must not mangle it. The
+// substrate rejects slashes inside a slug, so any second `/` in the
+// input is a syntax error the operator should fix.
+func parseScopeSlugArg(arg string) (Scope, string, error) {
+	trimmed := strings.TrimSpace(arg)
+	if trimmed == "" {
+		return "", "", errors.New("expected <scope>/<slug>; got empty argument")
+	}
+	scopePart, slugPart, ok := strings.Cut(trimmed, "/")
+	if !ok {
+		return "", "", fmt.Errorf(
+			"expected <scope>/<slug>; got %q (missing '/' separator)", arg,
+		)
+	}
+	scopePart = strings.TrimSpace(scopePart)
+	slugPart = strings.TrimSpace(slugPart)
+	if scopePart == "" || slugPart == "" {
+		return "", "", fmt.Errorf(
+			"expected <scope>/<slug>; got %q (empty scope or slug)", arg,
+		)
+	}
+	if strings.Contains(slugPart, "/") {
+		return "", "", fmt.Errorf(
+			"slug %q contains '/' which is not allowed", slugPart,
+		)
+	}
+	scope, err := parseScope(scopePart)
+	if err != nil {
+		return "", "", err
+	}
+	return scope, slugPart, nil
+}
+
+// parseTagsFlag parses the `--tag T` flag value(s) into a slice for
+// inclusion under `metadata.tags`. Cobra's StringSliceVar already
+// supports `--tag a --tag b`; the helper trims whitespace and drops
+// empty strings so a bare `--tag ""` is ignored rather than
+// silently smuggled into the JSON payload. Returns nil for an empty
+// input slice so the caller can omit the field.
+func parseTagsFlag(tags []string) []string {
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		out = append(out, t)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseTTLFlag parses the `--ttl 7d` flag value into an ISO-8601
+// timestamp suitable for the wire-level `expires_at` field. The
+// helper accepts shorthand units (`s`/`m`/`h`/`d`) plus the
+// `time.ParseDuration` set (`s`/`m`/`h`); pure-Go ParseDuration
+// doesn't accept `d`, so the day suffix is handled explicitly.
+// Returns the ISO-8601 expires_at as `time.Now().UTC()` plus the
+// parsed duration so the backend sees a clock-aligned cutoff.
+//
+// Empty input returns ("", nil) so the caller can omit the field
+// and let the substrate apply its own default (no automatic TTL in
+// G5.1; G5.2 #374 ships the default-7-day injection on
+// `memory-user` writes).
+//
+// The `now` parameter is injectable so tests can pin the reference
+// time. Production callers pass `time.Now`.
+func parseTTLFlag(raw string, now func() time.Time) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	d, err := parseDurationShorthand(raw)
+	if err != nil {
+		return "", err
+	}
+	if d <= 0 {
+		return "", fmt.Errorf("--ttl %q must be positive", raw)
+	}
+	expires := now().UTC().Add(d)
+	return expires.Format(time.RFC3339), nil
+}
+
+// parseDurationShorthand extends time.ParseDuration with a `d`
+// (days) suffix. The shape `7d` is the canonical TTL UX from the
+// issue body's `--ttl 7d` example; ParseDuration only accepts
+// h/m/s/ms/us/ns so days must be handled here.
+//
+// Accepts the same h/m/s units ParseDuration handles, so an
+// operator who wants `--ttl 36h` doesn't need to think about
+// whether the CLI rolled its own parser.
+func parseDurationShorthand(raw string) (time.Duration, error) {
+	if strings.HasSuffix(raw, "d") {
+		var days int
+		if _, err := fmt.Sscanf(raw, "%dd", &days); err != nil {
+			return 0, fmt.Errorf("--ttl %q: %w", raw, err)
+		}
+		if days <= 0 {
+			return 0, fmt.Errorf("--ttl %q: days must be positive", raw)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("--ttl %q: %w (expected e.g. 30m, 24h, 7d)", raw, err)
+	}
+	return d, nil
+}
+
+// requireTargetForScope enforces the AC "scope=target/user-target
+// requires --target" client-side. Returning a CLI error before the
+// HTTP round-trip makes the operator's fix obvious — the alternative
+// (a 422 from the backend with a pydantic-shaped error) leaks
+// implementation details and reads as a server fault.
+func requireTargetForScope(scope Scope, target string) error {
+	if !targetScoped[scope] {
+		return nil
+	}
+	if strings.TrimSpace(target) == "" {
+		return fmt.Errorf("--target is required when --scope=%s", scope)
+	}
+	return nil
+}
+
+// loadBody resolves the positional body argument for `meho
+// remember`. The shape mirrors `meho kb add --body`: inline text by
+// default; `-` (the bare hyphen) reads from cmd.InOrStdin() so the
+// issue's `echo "body" | meho remember` UX works. The substrate's
+// `min_length=1` constraint surfaces as a client-side error rather
+// than a 422 round-trip.
+//
+// `meho remember` differs from `meho kb add` in two ways:
+//
+//   - The body is the positional argument (not a --body flag).
+//   - The stdin sentinel is `-` (bare hyphen), matching the UNIX
+//     convention many CLIs use. kb's `--body @-` shape is flag-
+//     prefixed because `meho kb add <slug> --body @-` carries the
+//     slug as the positional; `meho remember` flips that — the
+//     body is the positional, slug is `--slug`.
+//
+// Trailing newlines from stdin reads are stripped so a piped
+// `echo "body"` doesn't carry the gratuitous `\n` echo appends.
+// Embedded newlines inside the body are preserved.
+func loadBody(cmd *cobra.Command, raw string) (string, error) {
+	if raw == "-" {
+		blob, err := io.ReadAll(io.LimitReader(cmd.InOrStdin(), loadBodyStdinCap+1))
+		if err != nil {
+			return "", fmt.Errorf("read body from stdin: %w", err)
+		}
+		if int64(len(blob)) > loadBodyStdinCap {
+			return "", fmt.Errorf(
+				"body from stdin exceeds %d-byte cap", loadBodyStdinCap,
+			)
+		}
+		out := strings.TrimRight(string(blob), "\r\n")
+		if out == "" {
+			return "", errors.New("body from stdin is empty; cannot create memory with empty body")
+		}
+		return out, nil
+	}
+	if strings.TrimSpace(raw) == "" {
+		return "", errors.New(
+			"body is required (inline text or '-' to read from stdin)",
+		)
+	}
+	return raw, nil
+}
+
+// confirmPrompt prompts the operator and returns true only when the
+// answer is y/yes (case-insensitive). EOF (closed stdin) reads as no
+// — scripted use must pass --confirm.
+//
+// The prompt text is written to `promptW`; callers pass stderr when
+// `--json` is set so the JSON envelope on stdout stays parseable
+// (`jq` consumers shouldn't have to skip past the prompt). Callers
+// passing stdout for a human-facing prompt match the kb sibling's
+// shape.
+//
+// Honours cmd.InOrStdin() so tests can wire a bytes.Buffer.
+func confirmPrompt(cmd *cobra.Command, promptW io.Writer, prompt string) bool {
+	fmt.Fprintf(promptW, "%s [y/N]: ", prompt)
+	var answer string
+	if _, err := fmt.Fscanln(cmd.InOrStdin(), &answer); err != nil {
+		// Most common error: io.EOF from a piped empty stdin. Treat
+		// as "no" so scripts that pipe /dev/null don't accidentally
+		// delete a memory.
+		return false
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
+}
+
+// pluralisePtr renders a *string as the underlying value when set or
+// the literal "(none)" when nil. Pulled into a helper because every
+// summary printer in this package renders the same three optional
+// fields (expires_at / user_sub / target_name) the same way; a
+// shared helper keeps the table-render lines identical across
+// remember / recall / list.
+func pluralisePtr(p *string) string {
+	if p == nil || *p == "" {
+		return "(none)"
+	}
+	return *p
+}
+
+// writeBodyToStdout writes the entry body verbatim plus exactly one
+// trailing newline. Same single-trailing-newline contract `meho kb
+// show` uses — the substrate stores the body unmodified, so a
+// hand-written memory that already ends in `\n` would otherwise
+// produce two newlines when Fprintln adds its own.
+func writeBodyToStdout(w io.Writer, body string) {
+	fmt.Fprintln(w, strings.TrimRight(body, "\r\n"))
+}

--- a/cli/internal/cmd/memory/memory_test.go
+++ b/cli/internal/cmd/memory/memory_test.go
@@ -1207,6 +1207,42 @@ func TestRunListForwardsFilters(t *testing.T) {
 	}
 }
 
+func TestRunListNormalisesScopeWhitespace(t *testing.T) {
+	// Whitespace-padded --scope must reach the backend trimmed.
+	// Without normalisation runList passed parseScope's preflight
+	// (validScopes lookup trims internally) and then forwarded the
+	// raw " user " back into the query string, producing a 422 on
+	// the FastAPI enum check. Mirrors the recall.go fix shape that
+	// already propagates parseScope's typed return value.
+	var capturedQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(ListResponse{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runList(cmd, listOptions{
+		ScopeArg:          " user ",
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+	if !strings.Contains(capturedQuery, "scope=user") {
+		t.Errorf("expected trimmed scope in query; got %q", capturedQuery)
+	}
+	// Defensive: no URL-encoded space should leak through.
+	for _, bad := range []string{"scope=%20user", "scope=user%20", "scope=+user", "scope=user+"} {
+		if strings.Contains(capturedQuery, bad) {
+			t.Errorf("query string %q still carries un-trimmed scope (%q)", capturedQuery, bad)
+		}
+	}
+}
+
 func TestRunListRejectsBadLimit(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	cmd.SetIn(bytes.NewBufferString(""))

--- a/cli/internal/cmd/memory/memory_test.go
+++ b/cli/internal/cmd/memory/memory_test.go
@@ -1,0 +1,1293 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// seedXDGAndToken seeds a per-test config dir + token store the way
+// the sibling test files do. Mirrors the helper in
+// cli/internal/cmd/kb/kb_test.go.
+func seedXDGAndToken(t *testing.T, backplaneURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  "eyJ.test.token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return dir
+}
+
+// newRunCmd builds a fresh cobra.Command with stdout/stderr buffers.
+// The runXxx helpers consume cmd.OutOrStdout / cmd.ErrOrStderr;
+// tests inspect the buffers afterwards.
+func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	return cmd, &stdout, &stderr
+}
+
+// fixedNow returns a deterministic clock for parseTTLFlag tests.
+func fixedNow() time.Time {
+	return time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+}
+
+// ---------------------------------------------------------------
+// Helpers — pure functions exercised first because the verbs build
+// on them.
+// ---------------------------------------------------------------
+
+func TestParseScopeAcceptsAllFive(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Scope
+	}{
+		{"user", ScopeUser},
+		{"user-tenant", ScopeUserTenant},
+		{"user-target", ScopeUserTarget},
+		{"tenant", ScopeTenant},
+		{"target", ScopeTarget},
+	}
+	for _, c := range cases {
+		got, err := parseScope(c.in)
+		if err != nil {
+			t.Errorf("parseScope(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseScope(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseScopeRejectsTypo(t *testing.T) {
+	if _, err := parseScope("Tenant"); err == nil {
+		t.Errorf("expected error for case-mismatched scope")
+	}
+	if _, err := parseScope("user_tenant"); err == nil {
+		t.Errorf("expected error for underscore-separator scope")
+	}
+	if _, err := parseScope(""); err == nil {
+		t.Errorf("expected error for empty scope")
+	}
+}
+
+func TestParseScopeSlugArgHappyPath(t *testing.T) {
+	scope, slug, err := parseScopeSlugArg("user-tenant/wine-preference")
+	if err != nil {
+		t.Fatalf("parseScopeSlugArg: %v", err)
+	}
+	if scope != ScopeUserTenant {
+		t.Errorf("expected user-tenant; got %q", scope)
+	}
+	if slug != "wine-preference" {
+		t.Errorf("expected slug; got %q", slug)
+	}
+}
+
+func TestParseScopeSlugArgRejectsNoSeparator(t *testing.T) {
+	if _, _, err := parseScopeSlugArg("user-tenant-wine-preference"); err == nil {
+		t.Errorf("expected error when '/' separator absent")
+	}
+}
+
+func TestParseScopeSlugArgRejectsEmpty(t *testing.T) {
+	if _, _, err := parseScopeSlugArg(""); err == nil {
+		t.Errorf("expected error for empty arg")
+	}
+	if _, _, err := parseScopeSlugArg("   "); err == nil {
+		t.Errorf("expected error for whitespace-only arg")
+	}
+}
+
+func TestParseScopeSlugArgRejectsEmptySide(t *testing.T) {
+	if _, _, err := parseScopeSlugArg("/wine-preference"); err == nil {
+		t.Errorf("expected error for empty scope")
+	}
+	if _, _, err := parseScopeSlugArg("user/"); err == nil {
+		t.Errorf("expected error for empty slug")
+	}
+}
+
+func TestParseScopeSlugArgRejectsExtraSlash(t *testing.T) {
+	// A slug like `foo/bar` would violate the substrate's
+	// SLUG_PATTERN; reject before the round-trip so the operator
+	// fix is obvious.
+	if _, _, err := parseScopeSlugArg("user/foo/bar"); err == nil {
+		t.Errorf("expected error for second '/' inside slug")
+	}
+}
+
+func TestParseTTLEmptyReturnsEmpty(t *testing.T) {
+	got, err := parseTTLFlag("", fixedNow)
+	if err != nil {
+		t.Fatalf("parseTTL empty: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for empty input; got %q", got)
+	}
+}
+
+func TestParseTTLDayShorthand(t *testing.T) {
+	got, err := parseTTLFlag("7d", fixedNow)
+	if err != nil {
+		t.Fatalf("parseTTL 7d: %v", err)
+	}
+	// 2026-05-19T12:00:00Z + 7 * 24h = 2026-05-26T12:00:00Z.
+	want := "2026-05-26T12:00:00Z"
+	if got != want {
+		t.Errorf("parseTTL 7d: got %q; want %q", got, want)
+	}
+}
+
+func TestParseTTLHourShorthand(t *testing.T) {
+	got, err := parseTTLFlag("36h", fixedNow)
+	if err != nil {
+		t.Fatalf("parseTTL 36h: %v", err)
+	}
+	want := "2026-05-21T00:00:00Z"
+	if got != want {
+		t.Errorf("parseTTL 36h: got %q; want %q", got, want)
+	}
+}
+
+func TestParseTTLMinuteShorthand(t *testing.T) {
+	got, err := parseTTLFlag("30m", fixedNow)
+	if err != nil {
+		t.Fatalf("parseTTL 30m: %v", err)
+	}
+	want := "2026-05-19T12:30:00Z"
+	if got != want {
+		t.Errorf("parseTTL 30m: got %q; want %q", got, want)
+	}
+}
+
+func TestParseTTLRejectsNegative(t *testing.T) {
+	if _, err := parseTTLFlag("-1d", fixedNow); err == nil {
+		t.Errorf("expected error for negative TTL")
+	}
+	// Bare `0` has no unit; ParseDuration would reject; either way an
+	// error is fine.
+	if _, err := parseTTLFlag("0d", fixedNow); err == nil {
+		t.Errorf("expected error for zero-day TTL")
+	}
+}
+
+func TestParseTTLRejectsGarbage(t *testing.T) {
+	if _, err := parseTTLFlag("seven days", fixedNow); err == nil {
+		t.Errorf("expected error for prose duration")
+	}
+}
+
+func TestParseTagsFlagDropsEmpty(t *testing.T) {
+	got := parseTagsFlag([]string{"keep", "", "  ", "also-keep"})
+	if len(got) != 2 || got[0] != "keep" || got[1] != "also-keep" {
+		t.Errorf("expected [keep also-keep]; got %+v", got)
+	}
+}
+
+func TestParseTagsFlagNilForEmpty(t *testing.T) {
+	if got := parseTagsFlag([]string{"", "  "}); got != nil {
+		t.Errorf("expected nil for all-empty tags; got %+v", got)
+	}
+	if got := parseTagsFlag(nil); got != nil {
+		t.Errorf("expected nil for nil input; got %+v", got)
+	}
+}
+
+func TestRequireTargetForScopePasses(t *testing.T) {
+	// Non-target scopes never need --target.
+	for _, s := range []Scope{ScopeUser, ScopeUserTenant, ScopeTenant} {
+		if err := requireTargetForScope(s, ""); err != nil {
+			t.Errorf("scope=%s should not require target; got %v", s, err)
+		}
+	}
+}
+
+func TestRequireTargetForScopeBlocks(t *testing.T) {
+	for _, s := range []Scope{ScopeUserTarget, ScopeTarget} {
+		if err := requireTargetForScope(s, ""); err == nil {
+			t.Errorf("scope=%s should require --target", s)
+		}
+		if err := requireTargetForScope(s, "rdc-vault"); err != nil {
+			t.Errorf("scope=%s with target should pass; got %v", s, err)
+		}
+	}
+}
+
+func TestNormaliseURLHappy(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Errorf("trailing slash not stripped: %q", got)
+	}
+}
+
+func TestNormaliseURLRejectsHostless(t *testing.T) {
+	if _, err := normaliseURL("/just/a/path"); err == nil {
+		t.Errorf("expected error for hostless URL")
+	}
+}
+
+func TestNormaliseURLRejectsEmpty(t *testing.T) {
+	if _, err := normaliseURL("   "); err == nil {
+		t.Errorf("expected error for empty URL")
+	}
+}
+
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	other := errors.New("invalid URL")
+	se = classifyBackplaneError(other)
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("other errors should classify as unexpected; got %+v", se)
+	}
+}
+
+func TestDecodeDetailStringFromFastAPI(t *testing.T) {
+	body := `{"detail": "memory_not_found"}`
+	if got := decodeDetailString(body); got != "memory_not_found" {
+		t.Errorf("decodeDetailString: got %q", got)
+	}
+}
+
+func TestDecodeDetailStringFallback(t *testing.T) {
+	if got := decodeDetailString("  plain text\n"); got != "plain text" {
+		t.Errorf("decodeDetailString fallback: got %q", got)
+	}
+}
+
+func TestTruncateRuneAware(t *testing.T) {
+	if got := truncate("café", 3); got != "ca…" {
+		t.Errorf("truncate multi-byte: got %q", got)
+	}
+	if got := truncate("short", 10); got != "short" {
+		t.Errorf("truncate within budget: got %q", got)
+	}
+}
+
+func TestPathEscapePreservesSlugChars(t *testing.T) {
+	if got := pathEscape("k8s.rollout-note"); got != "k8s.rollout-note" {
+		t.Errorf("PathEscape stripped legal slug chars; got %q", got)
+	}
+}
+
+func TestLoadBodyInline(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	got, err := loadBody(cmd, "inline content")
+	if err != nil {
+		t.Fatalf("loadBody inline: %v", err)
+	}
+	if got != "inline content" {
+		t.Errorf("expected verbatim inline; got %q", got)
+	}
+}
+
+func TestLoadBodyStdin(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString("piped body\n"))
+	got, err := loadBody(cmd, "-")
+	if err != nil {
+		t.Fatalf("loadBody stdin: %v", err)
+	}
+	if got != "piped body" {
+		t.Errorf("expected stripped trailing newline; got %q", got)
+	}
+}
+
+func TestLoadBodyRejectsEmptyStdin(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	if _, err := loadBody(cmd, "-"); err == nil {
+		t.Errorf("expected error for empty stdin")
+	}
+}
+
+func TestLoadBodyRejectsEmptyInline(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(bytes.NewBufferString(""))
+	if _, err := loadBody(cmd, ""); err == nil {
+		t.Errorf("expected error for empty inline body")
+	}
+	if _, err := loadBody(cmd, "   "); err == nil {
+		t.Errorf("expected error for whitespace-only body")
+	}
+}
+
+func TestConfirmPromptYesNo(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"yes\n", true},
+		{"Y\n", true},
+		{"YES\n", true},
+		{"n\n", false},
+		{"no\n", false},
+		{"\n", false},
+		{"", false}, // EOF on closed stdin
+		{"sure\n", false},
+	}
+	for _, c := range cases {
+		cmd := &cobra.Command{}
+		var stdout bytes.Buffer
+		cmd.SetIn(bytes.NewBufferString(c.input))
+		cmd.SetOut(&stdout)
+		if got := confirmPrompt(cmd, &stdout, "test"); got != c.want {
+			t.Errorf("confirmPrompt(%q): got %v; want %v", c.input, got, c.want)
+		}
+		if !strings.Contains(stdout.String(), "test") {
+			t.Errorf("prompt text not echoed: %q", stdout.String())
+		}
+	}
+}
+
+func TestBuildRecallPathBasic(t *testing.T) {
+	got := buildRecallPath(ScopeUserTenant, "wine-preference", "")
+	want := "/api/v1/memory/user-tenant/wine-preference"
+	if got != want {
+		t.Errorf("buildRecallPath: got %q; want %q", got, want)
+	}
+}
+
+func TestBuildRecallPathWithTarget(t *testing.T) {
+	got := buildRecallPath(ScopeTarget, "rollout", "rke2-meho")
+	want := "/api/v1/memory/target/rollout?target_name=rke2-meho"
+	if got != want {
+		t.Errorf("buildRecallPath with target: got %q; want %q", got, want)
+	}
+}
+
+func TestBuildRecallPathEscapesSlug(t *testing.T) {
+	// SLUG_PATTERN admits letters/digits/hyphen/underscore/dot, all
+	// of which url.PathEscape passes through. A space (which would
+	// fail server-side validation but should still escape cleanly)
+	// proves the encoding seam.
+	got := buildRecallPath(ScopeUser, "weird slug", "")
+	if !strings.Contains(got, "weird%20slug") {
+		t.Errorf("expected escaped slug; got %q", got)
+	}
+}
+
+func TestBuildListPathOmitsEmptyFilters(t *testing.T) {
+	got := buildListPath(listOptions{})
+	if got != "/api/v1/memory" {
+		t.Errorf("expected bare path; got %q", got)
+	}
+}
+
+func TestBuildListPathIncludesProvidedFilters(t *testing.T) {
+	got := buildListPath(listOptions{
+		ScopeArg:       "user-tenant",
+		TagArg:         "rollout",
+		SlugPatternArg: "wine",
+		IncludeExpired: true,
+		LimitArg:       50,
+	})
+	for _, want := range []string{
+		"scope=user-tenant",
+		"tag=rollout",
+		"slug_pattern=wine",
+		"include_expired=true",
+		"limit=50",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildListPath missing %q; got %q", want, got)
+		}
+	}
+}
+
+func TestScopeFromKindStripsPrefix(t *testing.T) {
+	if got := scopeFromKind("memory-user-tenant"); got != "user-tenant" {
+		t.Errorf("scopeFromKind: got %q", got)
+	}
+	if got := scopeFromKind("kb-entry"); got != "kb-entry" {
+		t.Errorf("non-memory kind should round-trip; got %q", got)
+	}
+}
+
+func TestSlugFromSourceIDStripsSegments(t *testing.T) {
+	// The source_id encoding the backend uses for memory rows is
+	// `<scope>:<user_sub or target>:<slug>` for user/target-scoped
+	// and `<scope>:<slug>` for tenant-scoped. The CLI's renderer
+	// only needs the slug (the last segment).
+	if got := slugFromSourceID("user-tenant:abc-def-123:wine-preference"); got != "wine-preference" {
+		t.Errorf("slugFromSourceID 3-segment: got %q", got)
+	}
+	if got := slugFromSourceID("tenant:team-runbook"); got != "team-runbook" {
+		t.Errorf("slugFromSourceID 2-segment: got %q", got)
+	}
+	if got := slugFromSourceID("plain"); got != "plain" {
+		t.Errorf("slugFromSourceID no-segment: got %q", got)
+	}
+}
+
+func TestPluralisePtrRendersNone(t *testing.T) {
+	if got := pluralisePtr(nil); got != "(none)" {
+		t.Errorf("nil pointer should render '(none)'; got %q", got)
+	}
+	empty := ""
+	if got := pluralisePtr(&empty); got != "(none)" {
+		t.Errorf("empty string should render '(none)'; got %q", got)
+	}
+	val := "set"
+	if got := pluralisePtr(&val); got != "set" {
+		t.Errorf("set value should render verbatim; got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------
+// remember
+// ---------------------------------------------------------------
+
+func TestRunRememberHappyPath(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &bodyJSON); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		expiresStr := "2026-05-26T12:00:00Z"
+		_ = json.NewEncoder(w).Encode(Entry{
+			ID:        "00000000-0000-0000-0000-000000000001",
+			TenantID:  "00000000-0000-0000-0000-000000000002",
+			Scope:     ScopeUserTenant,
+			Slug:      "wine-preference",
+			Body:      "I prefer dry red wines.",
+			Metadata:  map[string]any{"tags": []string{"food", "pref"}},
+			ExpiresAt: &expiresStr,
+			CreatedAt: "2026-05-19T12:00:00Z",
+			UpdatedAt: "2026-05-19T12:00:00Z",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRemember(cmd, rememberOptions{
+		BodyArg:           "I prefer dry red wines.",
+		ScopeArg:          "user-tenant",
+		SlugArg:           "wine-preference",
+		TagsArg:           []string{"food", "pref"},
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runRemember: %v; stderr=%s", err, stderr.String())
+	}
+	if got := bodyJSON["scope"]; got != "user-tenant" {
+		t.Errorf("expected scope in body; got %+v", bodyJSON)
+	}
+	if got := bodyJSON["body"]; got != "I prefer dry red wines." {
+		t.Errorf("expected body in request; got %+v", bodyJSON)
+	}
+	if got := bodyJSON["slug"]; got != "wine-preference" {
+		t.Errorf("expected slug in body; got %+v", bodyJSON)
+	}
+	md, ok := bodyJSON["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected metadata map; got %T", bodyJSON["metadata"])
+	}
+	tags, ok := md["tags"].([]any)
+	if !ok || len(tags) != 2 {
+		t.Errorf("expected tags slice; got %+v", md)
+	}
+	if !strings.Contains(stdout.String(), "remembered user-tenant/wine-preference") {
+		t.Errorf("expected success line; got %q", stdout.String())
+	}
+}
+
+func TestRunRememberOmitsSlugWhenAbsent(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &bodyJSON); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "auto-gen"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runRemember(cmd, rememberOptions{
+		BodyArg: "body", ScopeArg: "user", BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runRemember: %v", err)
+	}
+	if _, ok := bodyJSON["slug"]; ok {
+		t.Errorf("expected slug absent when not provided; got %+v", bodyJSON)
+	}
+	if _, ok := bodyJSON["metadata"]; ok {
+		t.Errorf("expected metadata absent when no tags; got %+v", bodyJSON)
+	}
+}
+
+func TestRunRememberJSONOutEmitsEntry(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Entry{
+			Scope: ScopeUserTenant, Slug: "x", Body: "y",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "user-tenant", JSONOut: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runRemember --json: %v", err)
+	}
+	var decoded Entry
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.Slug != "x" || decoded.Body != "y" {
+		t.Errorf("decoded: %+v", decoded)
+	}
+}
+
+func TestRunRememberSendsExpiresAtFromTTL(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &bodyJSON); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "x"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "user", TTLArg: "1d", BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runRemember: %v", err)
+	}
+	got, ok := bodyJSON["expires_at"].(string)
+	if !ok || got == "" {
+		t.Fatalf("expected expires_at in body; got %+v", bodyJSON)
+	}
+	// Sanity: parses as RFC3339 and is in the future.
+	parsed, err := time.Parse(time.RFC3339, got)
+	if err != nil {
+		t.Fatalf("expires_at %q not RFC3339: %v", got, err)
+	}
+	if !parsed.After(time.Now()) {
+		t.Errorf("expires_at %v should be in the future", parsed)
+	}
+}
+
+func TestRunRememberTargetScopeRequiresTargetFlag(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "target", BackplaneOverride: "https://meho.test",
+	})
+	if err == nil {
+		t.Fatalf("expected error when --scope=target without --target")
+	}
+	if !strings.Contains(stderr.String(), "--target is required") {
+		t.Errorf("expected target-required message; got %q", stderr.String())
+	}
+}
+
+func TestRunRememberInvalidScopeFailsFast(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "bogus", BackplaneOverride: "https://meho.test",
+	})
+	if err == nil {
+		t.Fatalf("expected error for invalid scope")
+	}
+	if !strings.Contains(stderr.String(), "invalid --scope") {
+		t.Errorf("expected invalid-scope message; got %q", stderr.String())
+	}
+}
+
+func TestRunRemember403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"permission_denied: role=operator cannot write scope=tenant"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "tenant", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error from 403")
+	}
+	if !strings.Contains(stderr.String(), "insufficient_role") {
+		t.Errorf("expected insufficient_role; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "permission_denied") {
+		t.Errorf("expected detail to round-trip; got %q", stderr.String())
+	}
+	var ec interface{ ExitCode() int }
+	if !errors.As(err, &ec) || ec.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+func TestRunRemember422SurfacesValidationDetail(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"detail":[{"loc":["body","slug"],"msg":"string does not match pattern"}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "user", SlugArg: "BAD!",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 422")
+	}
+	if !strings.Contains(stderr.String(), "invalid request") {
+		t.Errorf("expected invalid-request prefix; got %q", stderr.String())
+	}
+}
+
+func TestRunRememberReadsBodyFromStdin(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &bodyJSON); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "x", Body: "piped"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString("piped body\n"))
+	if err := runRemember(cmd, rememberOptions{
+		BodyArg: "-", ScopeArg: "user", BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runRemember stdin: %v", err)
+	}
+	if got := bodyJSON["body"]; got != "piped body" {
+		t.Errorf("expected piped body; got %+v", bodyJSON)
+	}
+}
+
+// ---------------------------------------------------------------
+// recall
+// ---------------------------------------------------------------
+
+func TestRunRecallByKeyPrintsBody(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user-tenant/wine-preference",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET; got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(Entry{
+				Scope: ScopeUserTenant,
+				Slug:  "wine-preference",
+				Body:  "Prefers dry red.",
+			})
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRecall(cmd, recallOptions{
+		ScopeSlugArg: "user-tenant/wine-preference", BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runRecall: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Prefers dry red.") {
+		t.Errorf("expected body on stdout; got %q", stdout.String())
+	}
+}
+
+func TestRunRecallByKey404SurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/no-such",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"detail":"memory_not_found"}`)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRecall(cmd, recallOptions{
+		ScopeSlugArg: "user/no-such", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error from 404")
+	}
+	if !strings.Contains(stderr.String(), "memory_not_found") {
+		t.Errorf("expected memory_not_found in stderr; got %q", stderr.String())
+	}
+}
+
+func TestRunRecallByKeyJSONOutEmitsEntry(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/wine",
+		func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "wine", Body: "y"})
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runRecall(cmd, recallOptions{
+		ScopeSlugArg: "user/wine", JSONOut: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runRecall --json: %v", err)
+	}
+	var got Entry
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if got.Slug != "wine" {
+		t.Errorf("decoded: %+v", got)
+	}
+}
+
+func TestRunRecallTargetScopeRequiresTargetFlag(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRecall(cmd, recallOptions{
+		ScopeSlugArg: "target/rollout", BackplaneOverride: "https://meho.test",
+	})
+	if err == nil {
+		t.Fatalf("expected error when --scope=target without --target")
+	}
+	if !strings.Contains(stderr.String(), "--target is required") {
+		t.Errorf("expected target-required message; got %q", stderr.String())
+	}
+}
+
+func TestRunRecallRequiresExactlyOneMode(t *testing.T) {
+	// Neither positional nor --query: error.
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runRecall(cmd, recallOptions{BackplaneOverride: "https://meho.test"}); err == nil {
+		t.Fatalf("expected error with neither arg nor --query")
+	}
+	if !strings.Contains(stderr.String(), "exactly one") {
+		t.Errorf("expected exactly-one message; got %q", stderr.String())
+	}
+
+	// Both positional and --query: error.
+	cmd2, _, stderr2 := newRunCmd(t)
+	cmd2.SetIn(bytes.NewBufferString(""))
+	if err := runRecall(cmd2, recallOptions{
+		ScopeSlugArg: "user/x", QueryArg: "wine",
+		BackplaneOverride: "https://meho.test",
+	}); err == nil {
+		t.Fatalf("expected error with both arg and --query")
+	}
+	if !strings.Contains(stderr2.String(), "exactly one") {
+		t.Errorf("expected exactly-one message; got %q", stderr2.String())
+	}
+}
+
+func TestRunRecallByQueryHappyPath(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/retrieve", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &bodyJSON); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(RetrieveResponse{
+			Hits: []RetrievalHit{
+				{
+					DocumentID: "1",
+					Source:     "memory",
+					SourceID:   "user-tenant:abc:wine",
+					Kind:       "memory-user-tenant",
+					Body:       "I prefer dry red wines.",
+					FusedScore: 0.9,
+				},
+			},
+			QueryDurationMS: 12.5,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRecall(cmd, recallOptions{
+		QueryArg:          "wine",
+		ScopeFilterArg:    "user-tenant",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runRecall --query: %v; stderr=%s", err, stderr.String())
+	}
+	if got := bodyJSON["source"]; got != "memory" {
+		t.Errorf("expected source=memory; got %+v", bodyJSON)
+	}
+	if got := bodyJSON["kind"]; got != "memory-user-tenant" {
+		t.Errorf("expected kind=memory-user-tenant; got %+v", bodyJSON)
+	}
+	if got := bodyJSON["query"]; got != "wine" {
+		t.Errorf("expected query forwarded; got %+v", bodyJSON)
+	}
+	if !strings.Contains(stdout.String(), "wine") {
+		t.Errorf("expected slug 'wine' in rendered table; got %q", stdout.String())
+	}
+}
+
+func TestRunRecallQueryRejectsBadLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRecall(cmd, recallOptions{
+		QueryArg: "x", LimitArg: 51, BackplaneOverride: "https://meho.test",
+	})
+	if err == nil {
+		t.Fatalf("expected error for --limit=51")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 50") {
+		t.Errorf("expected limit-range message; got %q", stderr.String())
+	}
+}
+
+// ---------------------------------------------------------------
+// forget
+// ---------------------------------------------------------------
+
+func TestRunForgetHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user-tenant/wine-preference",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				t.Errorf("expected DELETE; got %s", r.Method)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runForget(cmd, forgetOptions{
+		ScopeSlugArg:      "user-tenant/wine-preference",
+		Confirm:           true,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runForget: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "forgot memory user-tenant/wine-preference") {
+		t.Errorf("expected success line; got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "idempotent") {
+		t.Errorf("expected idempotent hint; got %q", stdout.String())
+	}
+}
+
+func TestRunForgetIdempotentOnMissing(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/gone",
+		func(w http.ResponseWriter, _ *http.Request) {
+			// Backend returns 204 whether or not the row existed.
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runForget(cmd, forgetOptions{
+		ScopeSlugArg: "user/gone", Confirm: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runForget idempotent: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "forgot") {
+		t.Errorf("expected success line; got %q", stdout.String())
+	}
+}
+
+func TestRunForgetDeclinedExits0WithoutBackend(t *testing.T) {
+	called := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/wine",
+		func(w http.ResponseWriter, _ *http.Request) {
+			called++
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString("n\n")) // decline
+	if err := runForget(cmd, forgetOptions{
+		ScopeSlugArg: "user/wine", BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runForget declined: %v", err)
+	}
+	if called != 0 {
+		t.Errorf("backend should not be called on decline; calls=%d", called)
+	}
+	if !strings.Contains(stdout.String(), "declined") {
+		t.Errorf("expected declined hint; got %q", stdout.String())
+	}
+}
+
+func TestRunForgetJSONOnDecline(t *testing.T) {
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString("\n")) // decline (default)
+	if err := runForget(cmd, forgetOptions{
+		ScopeSlugArg: "user/wine", JSONOut: true,
+		BackplaneOverride: "https://meho.test",
+	}); err != nil {
+		t.Fatalf("runForget declined --json: %v", err)
+	}
+	// In --json mode the prompt is routed to stderr so the JSON
+	// envelope on stdout stays parseable for `jq` consumers.
+	var got forgetResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not JSON: %v; stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if got.Status != "declined" {
+		t.Errorf("expected declined; got %+v", got)
+	}
+	if !strings.Contains(stderr.String(), "Forget memory") {
+		t.Errorf("expected prompt on stderr in --json mode; got %q", stderr.String())
+	}
+}
+
+func TestRunForgetRejectsTargetScopeWithoutTarget(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runForget(cmd, forgetOptions{
+		ScopeSlugArg: "target/rollout", Confirm: true,
+		BackplaneOverride: "https://meho.test",
+	})
+	if err == nil {
+		t.Fatalf("expected error for target scope without --target")
+	}
+	if !strings.Contains(stderr.String(), "--target is required") {
+		t.Errorf("expected target-required message; got %q", stderr.String())
+	}
+}
+
+func TestRunForget403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/tenant/team-note",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"detail":"permission_denied: role=operator"}`)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runForget(cmd, forgetOptions{
+		ScopeSlugArg: "tenant/team-note", Confirm: true, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error from 403")
+	}
+	if !strings.Contains(stderr.String(), "insufficient_role") {
+		t.Errorf("expected insufficient_role; got %q", stderr.String())
+	}
+}
+
+// ---------------------------------------------------------------
+// list
+// ---------------------------------------------------------------
+
+func TestRunListHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET; got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ListResponse{
+			Entries: []Entry{
+				{Scope: ScopeUser, Slug: "wine", Body: "dry red"},
+				{Scope: ScopeUserTenant, Slug: "k8s.note", Body: "rollout"},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runList: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"user", "wine", "user-tenant", "k8s.note"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in rendered table; got %q", want, out)
+		}
+	}
+}
+
+func TestRunListJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListResponse{
+			Entries: []Entry{{Scope: ScopeUser, Slug: "x", Body: "y"}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runList(cmd, listOptions{
+		JSONOut: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runList --json: %v", err)
+	}
+	var resp ListResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if len(resp.Entries) != 1 || resp.Entries[0].Slug != "x" {
+		t.Errorf("decoded: %+v", resp)
+	}
+}
+
+func TestRunListEmptyResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListResponse{Entries: nil})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runList empty: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no memories") {
+		t.Errorf("expected empty hint; got %q", stdout.String())
+	}
+}
+
+func TestRunListForwardsFilters(t *testing.T) {
+	var capturedQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(ListResponse{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runList(cmd, listOptions{
+		ScopeArg: "user-tenant", TagArg: "rollout",
+		IncludeExpired:    true,
+		LimitArg:          50,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runList filters: %v", err)
+	}
+	for _, want := range []string{
+		"scope=user-tenant", "tag=rollout", "include_expired=true", "limit=50",
+	} {
+		if !strings.Contains(capturedQuery, want) {
+			t.Errorf("expected %q in query; got %q", want, capturedQuery)
+		}
+	}
+}
+
+func TestRunListRejectsBadLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runList(cmd, listOptions{
+		LimitArg: 501, BackplaneOverride: "https://meho.test",
+	}); err == nil {
+		t.Fatalf("expected error for --limit=501")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 500") {
+		t.Errorf("expected limit message; got %q", stderr.String())
+	}
+}
+
+func TestRunListInvalidScopeFailsFast(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runList(cmd, listOptions{
+		ScopeArg: "bogus", BackplaneOverride: "https://meho.test",
+	}); err == nil {
+		t.Fatalf("expected error for invalid scope")
+	}
+	if !strings.Contains(stderr.String(), "invalid --scope") {
+		t.Errorf("expected invalid-scope message; got %q", stderr.String())
+	}
+}
+
+// ---------------------------------------------------------------
+// Cobra registration — every advertised verb must register.
+// ---------------------------------------------------------------
+
+func TestNewRememberCmdRegistersFlags(t *testing.T) {
+	c := NewRememberCmd()
+	for _, want := range []string{"scope", "slug", "target", "tag", "ttl", "json", "backplane"} {
+		if c.Flags().Lookup(want) == nil {
+			t.Errorf("remember missing flag --%s", want)
+		}
+	}
+}
+
+func TestNewRecallCmdRegistersFlags(t *testing.T) {
+	c := NewRecallCmd()
+	for _, want := range []string{"query", "scope", "limit", "target", "json", "backplane"} {
+		if c.Flags().Lookup(want) == nil {
+			t.Errorf("recall missing flag --%s", want)
+		}
+	}
+}
+
+func TestNewForgetCmdRegistersFlags(t *testing.T) {
+	c := NewForgetCmd()
+	for _, want := range []string{"confirm", "target", "json", "backplane"} {
+		if c.Flags().Lookup(want) == nil {
+			t.Errorf("forget missing flag --%s", want)
+		}
+	}
+}
+
+func TestNewListCmdRegistersFlags(t *testing.T) {
+	c := NewListCmd()
+	for _, want := range []string{
+		"scope", "tag", "slug-pattern", "include-expired", "limit", "json", "backplane",
+	} {
+		if c.Flags().Lookup(want) == nil {
+			t.Errorf("list missing flag --%s", want)
+		}
+	}
+}
+
+func TestNewRememberCmdHelpMentionsKeyFlags(t *testing.T) {
+	c := NewRememberCmd()
+	var buf bytes.Buffer
+	c.SetOut(&buf)
+	c.SetErr(&buf)
+	c.SetArgs([]string{"--help"})
+	if err := c.Execute(); err != nil {
+		t.Fatalf("`meho remember --help`: %v", err)
+	}
+	help := buf.String()
+	for _, want := range []string{"scope", "ttl", "tag", "target", "json"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("expected help to mention %q; got:\n%s", want, help)
+		}
+	}
+}

--- a/cli/internal/cmd/memory/recall.go
+++ b/cli/internal/cmd/memory/recall.go
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRecallCmd returns the top-level `meho recall` command. Two
+// modes (issue #424):
+//
+//   - `meho recall <scope>/<slug> [--target NAME]` — exact-key
+//     fetch via GET /api/v1/memory/{scope}/{slug}. The route
+//     deliberately conflates "missing" and "no access" into 404 to
+//     avoid leaking tenant boundaries via status-code differential;
+//     the CLI surfaces the detail string (`memory_not_found`) verbatim.
+//   - `meho recall --query "search terms" [--scope SCOPE] [--limit N]`
+//     — hybrid retrieval via POST /api/v1/retrieve with
+//     source="memory" and optional kind=memory-<scope>. The substrate
+//     post-filters user-scoped hits against operator.sub so a search
+//     never surfaces another operator's user-scoped row.
+//
+// The two modes are mutually exclusive — supplying both a positional
+// arg and `--query` fails fast client-side. Supplying neither also
+// fails fast.
+//
+// Role: any authenticated operator including `read_only` (the
+// substrate explicitly allows read_only to read tenant/target
+// memories per consumer-needs.md §G5 L131's "team becomes the unit
+// of memory" property; user-scoped rows still filter by user_sub at
+// the service layer).
+//
+// Exit codes:
+//   - 0   entry rendered cleanly (positional mode) or hits returned
+//     (query mode, including the zero-hit case)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 404 memory_not_found,
+//     422 invalid_scope)
+//   - 5   insufficient_role
+func NewRecallCmd() *cobra.Command {
+	var (
+		queryFlag         string
+		scopeFlag         string
+		limitFlag         int
+		targetFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "recall <scope>/<slug>",
+		Short: "Fetch a memory by natural key or via retrieval (GET /api/v1/memory or /api/v1/retrieve)",
+		Long: "recall has two modes. The positional form fetches one " +
+			"memory by its <scope>/<slug> natural key via " +
+			"GET /api/v1/memory/{scope}/{slug}; the body is written to " +
+			"stdout (memory bodies are stored verbatim, so pipe through " +
+			"`glow` or `bat -l md` if you want them rendered). The " +
+			"query form (--query \"search terms\") runs hybrid " +
+			"BM25 + cosine retrieval over the operator's visible " +
+			"memories via POST /api/v1/retrieve, pinning " +
+			"source=\"memory\" so only memory rows are ranked.\n\n" +
+			"--scope narrows the query-mode search to one scope " +
+			"(translated to kind=memory-<scope> server-side); without " +
+			"it, every scope visible to the operator is considered. " +
+			"--limit caps the result count (1..50, server default 10 " +
+			"when omitted). --target is only consulted in positional " +
+			"mode for user-target / target scopes; without it, those " +
+			"scopes surface as 404 by the route's info-leak avoidance " +
+			"(the substrate can't tell which target the operator meant).\n\n" +
+			"A 404 in positional mode means the slug doesn't exist in " +
+			"your tenant (the route deliberately conflates cross-tenant " +
+			"probes with genuine absence so existence is never leaked " +
+			"across tenant boundaries).",
+		// MaximumNArgs(1) — positional arg is optional when --query
+		// is set; the runner enforces "exactly one of (positional,
+		// --query)" with a clearer message than cobra's default.
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			arg := ""
+			if len(args) == 1 {
+				arg = args[0]
+			}
+			return runRecall(cmd, recallOptions{
+				ScopeSlugArg:      arg,
+				QueryArg:          queryFlag,
+				ScopeFilterArg:    scopeFlag,
+				LimitArg:          limitFlag,
+				TargetArg:         targetFlag,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&queryFlag, "query", "",
+		"run hybrid retrieval against memories with this query; "+
+			"mutually exclusive with the <scope>/<slug> positional")
+	cmd.Flags().StringVar(&scopeFlag, "scope", "",
+		"narrow --query mode to one scope: user|user-tenant|user-target|tenant|target")
+	cmd.Flags().IntVar(&limitFlag, "limit", 0,
+		"max hits to return in --query mode (1..50, server default 10 when omitted)")
+	cmd.Flags().StringVar(&targetFlag, "target", "",
+		"target name for user-target / target scopes (positional mode only)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw Entry / RetrieveResponse JSON instead of human output")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by `meho login`)")
+	return cmd
+}
+
+type recallOptions struct {
+	ScopeSlugArg      string
+	QueryArg          string
+	ScopeFilterArg    string
+	LimitArg          int
+	TargetArg         string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runRecall(cmd *cobra.Command, opts recallOptions) error {
+	hasArg := opts.ScopeSlugArg != ""
+	hasQuery := opts.QueryArg != ""
+	if hasArg == hasQuery {
+		// True == True (both supplied) or False == False (neither).
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(
+				"recall requires exactly one of <scope>/<slug> or --query \"...\""),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			classifyBackplaneError(err), opts.JSONOut)
+	}
+	if hasArg {
+		return runRecallByKey(cmd, backplaneURL, opts)
+	}
+	return runRecallByQuery(cmd, backplaneURL, opts)
+}
+
+func runRecallByKey(cmd *cobra.Command, backplaneURL string, opts recallOptions) error {
+	scope, slug, err := parseScopeSlugArg(opts.ScopeSlugArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	// requireTargetForScope mirrors the AC "scope=target requires
+	// --target". The backend would respond 404 (info-leak avoidance)
+	// rather than 422; the CLI's pre-flight error is more actionable.
+	if err := requireTargetForScope(scope, opts.TargetArg); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	entry, err := getRecall(cmd.Context(), backplaneURL, scope, slug, opts.TargetArg)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), entry)
+	}
+	writeBodyToStdout(cmd.OutOrStdout(), entry.Body)
+	return nil
+}
+
+func runRecallByQuery(cmd *cobra.Command, backplaneURL string, opts recallOptions) error {
+	// Mirror the --limit clamp from `meho kb search`: backend
+	// rejects with 422 outside 1..50; surface the constraint string
+	// locally so operators see the bound without a round-trip.
+	limitProvided := cmd.Flags().Changed("limit")
+	if opts.LimitArg < 0 || opts.LimitArg > 50 || (limitProvided && opts.LimitArg == 0) {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--limit must be between 1 and 50 when provided; got %d", opts.LimitArg)),
+			opts.JSONOut,
+		)
+	}
+	var kindFilter string
+	if opts.ScopeFilterArg != "" {
+		scope, err := parseScope(opts.ScopeFilterArg)
+		if err != nil {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(err.Error()), opts.JSONOut)
+		}
+		// kind_for_scope translation matches
+		// `backend/src/meho_backplane/memory/schemas.py::kind_for_scope`:
+		// `f"memory-{scope.value}"`. Inlined here (no shared package)
+		// because the CLI is a thin caller and a function would be
+		// noise.
+		kindFilter = "memory-" + string(scope)
+	}
+	resp, err := postRecallQuery(cmd.Context(), backplaneURL, opts, kindFilter)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	}
+	printRecallTable(cmd.OutOrStdout(), resp)
+	return nil
+}
+
+// buildRecallPath assembles the GET path. Exposed for unit tests so
+// URL encoding of slugs (which admit hyphen / underscore / dot per
+// SLUG_PATTERN) stays covered. The optional `target_name` query
+// param is appended only when set — `user` / `user-tenant` /
+// `tenant` recalls have no target_name semantics.
+func buildRecallPath(scope Scope, slug, targetName string) string {
+	path := fmt.Sprintf("/api/v1/memory/%s/%s",
+		pathEscape(string(scope)), pathEscape(slug))
+	if targetName != "" {
+		q := url.Values{}
+		q.Set("target_name", targetName)
+		path = path + "?" + q.Encode()
+	}
+	return path
+}
+
+func getRecall(
+	ctx context.Context,
+	backplaneURL string,
+	scope Scope,
+	slug, targetName string,
+) (*Entry, error) {
+	raw, err := doAuthedRequest(
+		ctx, backplaneURL, "GET", buildRecallPath(scope, slug, targetName), nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var out Entry
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode recall response: %w", err)
+	}
+	return &out, nil
+}
+
+func postRecallQuery(
+	ctx context.Context,
+	backplaneURL string,
+	opts recallOptions,
+	kindFilter string,
+) (*RetrieveResponse, error) {
+	req := retrieveRequest{
+		Query:  opts.QueryArg,
+		Source: "memory",
+		Kind:   kindFilter,
+	}
+	if opts.LimitArg > 0 {
+		req.Limit = opts.LimitArg
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal recall query: %w", err)
+	}
+	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/retrieve", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out RetrieveResponse
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, fmt.Errorf("decode recall query response: %w", err)
+	}
+	return &out, nil
+}
+
+// printRecallTable renders the ranked hits from --query mode as a
+// compact table. Columns: RANK (1-based), SCORE (fused), SCOPE
+// (lifted from the hit's `kind` by stripping the `memory-` prefix),
+// SLUG (the substrate's `source_id`), SNIPPET (200-char excerpt).
+// The fused / per-signal scores are visible in --json output for
+// retrieval-tuning sessions.
+func printRecallTable(w io.Writer, r *RetrieveResponse) {
+	if r == nil || len(r.Hits) == 0 {
+		fmt.Fprintln(w, "no memory hits for this query")
+		return
+	}
+	fmt.Fprintf(w, "%-5s %-8s %-14s %-40s %s\n",
+		"RANK", "SCORE", "SCOPE", "SLUG", "SNIPPET")
+	for i, hit := range r.Hits {
+		fmt.Fprintf(w, "%-5d %-8.4f %-14s %-40s %s\n",
+			i+1,
+			hit.FusedScore,
+			scopeFromKind(hit.Kind),
+			truncate(slugFromSourceID(hit.SourceID), 40),
+			truncate(snippetOf(hit.Body), 80),
+		)
+	}
+	if r.QueryDurationMS > 0 {
+		fmt.Fprintf(w, "queried in %.2f ms\n", r.QueryDurationMS)
+	}
+}
+
+// scopeFromKind reverses the `memory-<scope>` prefix the backend
+// stores. Mirrors
+// `backend/src/meho_backplane/memory/schemas.py::scope_for_kind` —
+// inlined for the table renderer because the CLI doesn't need a
+// typed Scope here (it's only printed). Returns the raw `kind` on
+// shapes that don't match so an unexpected backend value doesn't
+// crash the renderer.
+func scopeFromKind(kind string) string {
+	const prefix = "memory-"
+	if len(kind) > len(prefix) && kind[:len(prefix)] == prefix {
+		return kind[len(prefix):]
+	}
+	return kind
+}
+
+// slugFromSourceID extracts the human-friendly slug from the
+// substrate's source_id encoding. The backend's
+// `meho_backplane/memory/_internal.py::encode_source_id` joins
+// natural-key segments with `:`; the slug is always the LAST
+// segment. The CLI doesn't need to decode the user_sub / target_name
+// segments — those are visible separately in --json output.
+func slugFromSourceID(sourceID string) string {
+	// rsplit(':', 1) — same shape the backend's slug_from_source_id
+	// helper uses. Without the `:` delimiter the source_id IS the
+	// slug.
+	for i := len(sourceID) - 1; i >= 0; i-- {
+		if sourceID[i] == ':' {
+			return sourceID[i+1:]
+		}
+	}
+	return sourceID
+}
+
+// snippetOf returns the first ~200 chars of body so the table render
+// fits a default terminal width. Same shape as `meho kb search`'s
+// helper of the same name; kept inline here to avoid a cross-package
+// import that would close a cycle through cmd/root.go.
+func snippetOf(body string) string {
+	const snippetChars = 200
+	runes := []rune(body)
+	if len(runes) <= snippetChars {
+		return body
+	}
+	return string(runes[:snippetChars]) + "…"
+}

--- a/cli/internal/cmd/memory/remember.go
+++ b/cli/internal/cmd/memory/remember.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRememberCmd returns the top-level `meho remember` command.
+//
+// CLI shape (per issue #424):
+//
+//	meho remember "body text" \
+//	  [--scope user|user-tenant|user-target|tenant|target] \
+//	  [--slug SLUG] \
+//	  [--target TARGET_NAME] \
+//	  [--tag T] \
+//	  [--ttl 7d] \
+//	  [--json] \
+//	  [--backplane <url>]
+//
+// Default scope: `user-tenant` (consumer-needs.md §G5 — most common
+// case: the operator's notes scoped to one tenant).
+//
+// Body can be piped: `echo "body" | meho remember -`. The bare `-`
+// is the explicit stdin sentinel; an inline string is the
+// alternative. (Compare `meho kb add --body @-`; the body lives on
+// a flag there because the slug is the positional. Here the body is
+// the positional and `--slug` is a flag, so we use `-` as the
+// in-band stdin marker.)
+//
+// Role: any authenticated operator (`read_only` excluded at the
+// FastAPI gate). The service-layer MemoryRbacResolver further
+// restricts `tenant` writes to `tenant_admin`; that surfaces as
+// 403 insufficient_role.
+//
+// Exit codes:
+//   - 0   created (201)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 422 invalid_slug / missing body)
+//   - 5   insufficient_role (e.g. operator writing `tenant` scope)
+func NewRememberCmd() *cobra.Command {
+	var (
+		scopeFlag         string
+		slugFlag          string
+		targetFlag        string
+		tagsFlag          []string
+		ttlFlag           string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "remember <body>",
+		Short: "Persist one memory in the backplane (POST /api/v1/memory)",
+		Long: "remember calls POST /api/v1/memory to persist one memory " +
+			"under the operator's tenant. Default --scope is " +
+			"`user-tenant` (the operator's notes scoped to one tenant — " +
+			"consumer-needs.md §G5's most-common case).\n\n" +
+			"The positional <body> argument carries the memory's text. " +
+			"Pass `-` to read the body from stdin (`echo \"note\" | meho " +
+			"remember -`); the trailing newline is stripped so a piped " +
+			"`echo` doesn't smuggle a gratuitous `\\n` into the stored " +
+			"body.\n\n" +
+			"--scope=target / user-target requires --target NAME; the " +
+			"check fires client-side so a forgotten flag surfaces " +
+			"without a round-trip.\n\n" +
+			"--ttl accepts shorthand durations like `7d`, `36h`, `30m`. " +
+			"The CLI translates this into an absolute `expires_at` " +
+			"timestamp before sending; the backend only ever sees a " +
+			"clock-aligned cutoff. Memory rows past their expires_at " +
+			"are filtered out of list / recall reads (G5.2 #374 ships " +
+			"the daily cleanup task that physically removes them).\n\n" +
+			"--tag may be repeated; tags land under `metadata.tags` as " +
+			"a JSON list, mirroring the shape consumer-needs.md §G5 " +
+			"describes. --slug overrides the auto-generated identifier " +
+			"with an operator-supplied one (legal characters: letters, " +
+			"digits, hyphen, underscore, dot).",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRemember(cmd, rememberOptions{
+				BodyArg:           args[0],
+				ScopeArg:          scopeFlag,
+				SlugArg:           slugFlag,
+				TargetArg:         targetFlag,
+				TagsArg:           tagsFlag,
+				TTLArg:            ttlFlag,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&scopeFlag, "scope", string(ScopeUserTenant),
+		"memory scope: user|user-tenant|user-target|tenant|target")
+	cmd.Flags().StringVar(&slugFlag, "slug", "",
+		"override the auto-generated slug with an operator-supplied identifier")
+	cmd.Flags().StringVar(&targetFlag, "target", "",
+		"target name (required when --scope=target or user-target)")
+	cmd.Flags().StringSliceVar(&tagsFlag, "tag", nil,
+		"tag to attach to the memory; repeat for multiple tags")
+	cmd.Flags().StringVar(&ttlFlag, "ttl", "",
+		"time-to-live shorthand (e.g. `7d`, `36h`, `30m`) — set expires_at")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw Entry JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by `meho login`)")
+	return cmd
+}
+
+type rememberOptions struct {
+	BodyArg           string
+	ScopeArg          string
+	SlugArg           string
+	TargetArg         string
+	TagsArg           []string
+	TTLArg            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runRemember(cmd *cobra.Command, opts rememberOptions) error {
+	scope, err := parseScope(opts.ScopeArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	if err := requireTargetForScope(scope, opts.TargetArg); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	body, err := loadBody(cmd, opts.BodyArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	expiresAt, err := parseTTLFlag(opts.TTLArg, time.Now)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			classifyBackplaneError(err), opts.JSONOut)
+	}
+	req := rememberRequest{
+		Scope:      scope,
+		Body:       body,
+		Slug:       opts.SlugArg,
+		ExpiresAt:  expiresAt,
+		TargetName: opts.TargetArg,
+	}
+	if tags := parseTagsFlag(opts.TagsArg); tags != nil {
+		// `tags` lands under `metadata.tags` per consumer-needs.md
+		// §G5's description of memory tagging. The backend treats
+		// `metadata` as an opaque JSONB blob — no schema constraint
+		// on the `tags` key — so the CLI is the contract owner for
+		// the convention.
+		req.Metadata = map[string]any{"tags": tags}
+	}
+	entry, err := postRemember(cmd.Context(), backplaneURL, req)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), entry)
+	}
+	printRememberSummary(cmd.OutOrStdout(), entry)
+	return nil
+}
+
+func postRemember(ctx context.Context, backplaneURL string, req rememberRequest) (*Entry, error) {
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal remember request: %w", err)
+	}
+	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/memory", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out Entry
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, fmt.Errorf("decode remember response: %w", err)
+	}
+	return &out, nil
+}
+
+// printRememberSummary renders the created entry as a compact
+// confirmation line plus the natural-key coordinates the operator
+// will use for a subsequent `meho recall` / `meho forget`. Body is
+// not echoed back — the operator just typed it.
+func printRememberSummary(w io.Writer, e *Entry) {
+	if e == nil {
+		return
+	}
+	fmt.Fprintf(w, "remembered %s/%s\n", e.Scope, e.Slug)
+	fmt.Fprintf(w, "%-14s %s\n", "id:", e.ID)
+	fmt.Fprintf(w, "%-14s %s\n", "scope:", e.Scope)
+	fmt.Fprintf(w, "%-14s %s\n", "slug:", e.Slug)
+	fmt.Fprintf(w, "%-14s %s\n", "expires_at:", pluralisePtr(e.ExpiresAt))
+	fmt.Fprintf(w, "%-14s %s\n", "user_sub:", pluralisePtr(e.UserSub))
+	fmt.Fprintf(w, "%-14s %s\n", "target_name:", pluralisePtr(e.TargetName))
+	fmt.Fprintf(w, "%-14s %s\n", "created_at:", e.CreatedAt)
+	fmt.Fprintf(w, "%-14s %d bytes\n", "body:", len(e.Body))
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/connector"
 	"github.com/evoila/meho/cli/internal/cmd/k8s"
 	"github.com/evoila/meho/cli/internal/cmd/kb"
+	"github.com/evoila/meho/cli/internal/cmd/memory"
 	"github.com/evoila/meho/cli/internal/cmd/nsx"
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
@@ -129,6 +130,20 @@ func newRootCmd() *cobra.Command {
 	// registerDynamicSubcommands so the backplane manifest cannot
 	// shadow the built-in `kb` parent.
 	root.AddCommand(kb.NewRootCmd())
+
+	// G5.1-T4 (#424) -- top-level memory verbs (remember / recall /
+	// forget / list) for Initiative #332. Each verb is registered
+	// onto the root directly (not under a `memory` parent) per the
+	// consumer-needs.md §G5 ergonomic shape (`meho remember "..."`
+	// rather than `meho memory remember "..."`). Wraps the four
+	// /api/v1/memory* routes shipped by G5.1-T2 (#422) plus the
+	// /api/v1/retrieve route for the `recall --query` retrieval form.
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in verbs.
+	root.AddCommand(memory.NewRememberCmd())
+	root.AddCommand(memory.NewRecallCmd())
+	root.AddCommand(memory.NewForgetCmd())
+	root.AddCommand(memory.NewListCmd())
 
 	// G3.1-T7 (#511) -- vmware-rest-9.0 operator alias verbs for
 	// Initiative #227. The verb tree pre-bakes connector_id=

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -44,6 +44,16 @@ names.
   the five `/api/v1/kb*` routes shipped by G4.1-T2 (#416) plus the
   `/api/v1/retrieve` route (G0.4-T5 #262, `source="kb"` scoped)
   for the search verb.
+- `meho remember / recall / forget / list` (G5.1-T4 #424) — memory
+  operator surface, registered as **top-level** verbs (no `memory`
+  parent — per consumer-needs.md §G5's ergonomic shape:
+  `meho remember "note"` rather than `meho memory remember "note"`).
+  Wraps the four `/api/v1/memory*` routes shipped by G5.1-T2 (#422)
+  plus the `/api/v1/retrieve` route (G0.4-T5 #262, `source="memory"`
+  scoped) for `meho recall --query`. Five scopes: `user` /
+  `user-tenant` / `user-target` / `tenant` / `target`. The two
+  target-scoped values require `--target NAME`; the CLI rejects a
+  missing `--target` client-side before the round-trip.
 
 ## Module layout
 
@@ -111,6 +121,13 @@ cli/
     │   │   ├── show_test.go      # path-escape + Markdown body to stdout + 404 slug_not_found tests.
     │   │   ├── add_test.go       # body-from-file / @- / inline + metadata parse + 422 surface tests.
     │   │   └── delete_test.go    # confirm-prompt + idempotent-204 + --json envelope tests.
+    │   ├── memory/           # G5.1-T4 #424 — top-level `meho remember/recall/forget/list` (no parent).
+    │   │   ├── memory.go         # Scope enum + Entry/ListResponse/RetrievalHit + shared HTTP/auth helpers + parseScope/parseTTL/parseTags/parseScopeSlugArg/loadBody/confirmPrompt.
+    │   │   ├── remember.go       # `meho remember <body> [--scope --slug --target --tag --ttl --json]` (POST /api/v1/memory).
+    │   │   ├── recall.go         # `meho recall <scope>/<slug>` or `meho recall --query` (GET /api/v1/memory/{scope}/{slug} or POST /api/v1/retrieve, source="memory").
+    │   │   ├── forget.go         # `meho forget <scope>/<slug> [--confirm --target --json]` (DELETE /api/v1/memory/{scope}/{slug}).
+    │   │   ├── list.go           # `meho list [--scope --tag --slug-pattern --include-expired --limit --json]` (GET /api/v1/memory).
+    │   │   └── memory_test.go    # parseScope/parseTTL/parseScopeSlugArg + verb-happy-path + 403/404/422 + decline + JSON envelope tests.
     │   ├── connector/         # G0.7-T5 #405 — `meho connector …` verb tree.
     │   │   ├── connector.go      # NewRootCmd + shared HTTP/auth helpers.
     │   │   ├── ingest.go         # `meho connector ingest` (POST /api/v1/connectors/ingest).


### PR DESCRIPTION
## Summary
- Top-level cobra verbs `meho remember / recall / forget / list` per
  consumer-needs.md §G5's ergonomic shape (no `memory` parent —
  acceptance criteria in #424 name `meho list --scope user` verbatim).
- Wraps the four `/api/v1/memory*` routes from T2 (#422) plus
  `/api/v1/retrieve` (`source="memory"`, optional
  `kind=memory-<scope>`) for `meho recall --query`.
- Mirrors the kb sibling's in-package HTTP/auth helper convention
  (resolveBackplane / doAuthedRequest / renderRequestError) — a
  shared `cli/internal/api_client` package would close an import
  cycle through `cmd/root.go`.
- `--scope=target` and `--scope=user-target` require `--target NAME`;
  enforced client-side so the operator fix is actionable, not a 422
  with a pydantic-shaped string.
- `--ttl 7d` shorthand parser (h/m/s from `time.ParseDuration` plus
  explicit `d`); translates to an absolute RFC3339 `expires_at`
  before the request goes out so the backend only sees a
  clock-aligned cutoff.
- `meho forget`'s confirmation prompt routes to stderr in `--json`
  mode so the envelope on stdout stays parseable for `jq` consumers.

## Test plan
- [x] `gofmt -l cli/internal/cmd/memory` — clean
- [x] `go vet ./...` — clean
- [x] `revive` over the new package — clean
- [x] `staticcheck ./internal/cmd/memory/...` — clean
- [x] `go test -count=1 ./internal/cmd/memory/...` — 45 tests passing
- [x] Full `go test -count=1 ./...` across the CLI module — every
  sibling package green (kb / audit / connector / k8s / operation /
  retrieval / targets / topology / vault / vmware / nsx / bind9)
- [x] AC: `meho remember "test memory" --scope user-tenant` shape
  proven by `TestRunRememberHappyPath` (server sees
  `scope=user-tenant`, body round-trips to the response envelope)
- [x] AC: `meho remember --slug my-pref "body"` proven by
  `TestRunRememberHappyPath` (custom slug forwarded verbatim in
  request body)
- [x] AC: `meho recall --query "search terms"` proven by
  `TestRunRecallByQueryHappyPath` (POST /api/v1/retrieve with
  `source=memory`, `kind=memory-user-tenant`)
- [x] AC: `meho forget user-tenant/my-pref --confirm` proven by
  `TestRunForgetHappyPath` (DELETE issued; idempotent line printed)
- [x] AC: `meho list --scope user` proven by
  `TestRunListForwardsFilters` (scope=user-tenant + tag + include_expired
  + limit forwarded to query string)
- [x] AC: tenant-admin enforced on TENANT writes — operator gets 403
  surfaces as `insufficient_role` exit 5 (`TestRunRemember403SurfacesInsufficientRole`,
  `TestRunForget403SurfacesInsufficientRole`)
- [x] AC: scope=target requires `--target` — client-side error,
  no round-trip (`TestRunRememberTargetScopeRequiresTargetFlag`,
  `TestRunRecallTargetScopeRequiresTargetFlag`,
  `TestRunForgetRejectsTargetScopeWithoutTarget`)
- [x] AC: `--ttl 7d` parses + sets `expires_at` correctly
  (`TestParseTTLDayShorthand` pins the RFC3339 output;
  `TestRunRememberSendsExpiresAtFromTTL` proves wire shape)
- [x] AC: `--json` flag on every verb — covered by
  `TestRunRememberJSONOutEmitsEntry`, `TestRunRecallByKeyJSONOutEmitsEntry`,
  `TestRunForgetJSONOnDecline`, `TestRunListJSONHappyPath`
- [x] AC: confirmation prompt fires for `forget` by default; `--confirm`
  skips (`TestRunForgetDeclinedExits0WithoutBackend`,
  `TestRunForgetHappyPath` with `Confirm: true`)
- [x] Integration test (CLI E2E vs test backend) deferred to the
  G5.1-T5 canary acceptance task (#426) per the Initiative's wave
  structure; unit tests here cover the same surface against
  `httptest.Server` mocks of the route contracts T2 (#422) shipped.

## Out of scope
- The MCP meta-tools — landed in sibling T3 (#423, PR #646).
- The REST routes — landed in sibling T2 (#422, PR #643).
- The MemoryService class — landed in sibling T1 (#421).
- `meho promote` (scope-promotion verb) — G5.2 #374.
- `meho migrate memory` (laptop-local migration) — G5.3 #375.
- The integration canary across all 5 scopes — G5.1-T5 #426.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #424



---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-19)

Addressed review findings from `.claude/auto/review-results/pr-677-iter-1.json`:

- **B1** `3b1a03a` — rebased `feat/424-memory-cli-verbs` onto `main` with `git rebase --signoff` so every commit on the branch carries a `Signed-off-by: Ilhan Karic <ikaric@evoila.com>` trailer; DCO probot flips to SUCCESS. Original commit `d93daae` rewritten to `3b1a03a`; push used `--force-with-lease=feat/424-memory-cli-verbs:d93daae...` against the published SHA (no `--force`, no `--amend` after publish — this is the only path the DCO probot offers for an unsigned published commit).
- **M1** `bb7a140` — captured `parseScope`'s typed `Scope` return in `runList` and wrote it back to `opts.ScopeArg` before `buildListPath` reads it; mirrors the `recall.go:191-203` pattern. Added `TestRunListNormalisesScopeWhitespace` that drives `--scope " user "` through `runList` end-to-end via `httptest` and asserts the outgoing query string contains `scope=user` (no URL-encoded space, no `+`).

Local gates (cli/ tree, Go 1.22): `gofmt -l ./internal/cmd/memory/` clean, `go vet ./...` clean, `go build ./...` clean, `go test ./... -count=1` PASS (memory pkg: 72 PASS results, +1 over the pre-fix 71), `staticcheck ./internal/cmd/memory/...` clean, `revive ./internal/cmd/memory/...` clean.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `meho remember`, `meho recall`, `meho forget`, and `meho list` commands for storing, retrieving, deleting, and listing memories with tags, TTL, scope, and target options.
  * All memory commands support a JSON output mode.

* **Behavior / UX**
  * Interactive confirmation for deletes; declines return a clear declined result (JSON or human).

* **Documentation**
  * CLI docs updated with memory command usage and scopes.

* **Tests**
  * Comprehensive unit and HTTP-backed tests for memory commands and validations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
