### PR TITLE
feat(migrate): G5.3-T4 interactive huh picker + --dry-run/--non-interactive (#611)

### DIFF
--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -366,6 +366,23 @@ async def handle_tools_call(
         # rendered ``redact_payload`` shape; the audit row needs the
         # raw enum for ``meho audit query`` filtering.
         audit_payload["broadcast_detail_effective"] = broadcast_detail
+        # #704 strip-and-merge, applied to MCP path. Per-tool handlers
+        # bind ``audit_*`` contextvars (e.g. ``audit_override_op`` from
+        # G6.3-T5's broadcast-overrides verbs); the chassis HTTP route
+        # path merges them via :func:`audit._resolve_audit_payload` and
+        # the typed-op dispatcher path via
+        # :func:`operations._audit._build_audit_payload`. MCP was the
+        # third audit-write path missing the merge — the test
+        # ``test_set_via_mcp_writes_audit_row_with_override_diff``
+        # expects ``override_op``/``override_id``/``override_pattern``/
+        # ``override_detail`` to land on the row's payload.
+        _audit_prefix = "audit_"
+        for _k, _v in structlog.contextvars.get_contextvars().items():
+            if not _k.startswith(_audit_prefix) or _v is None:
+                continue
+            _stripped = _k[len(_audit_prefix) :]
+            if _stripped:
+                audit_payload.setdefault(_stripped, _v)
         try:
             await write_mcp_audit_row(
                 audit_id=audit_id,

--- a/cli/internal/cmd/migrate/memory.go
+++ b/cli/internal/cmd/migrate/memory.go
@@ -5,10 +5,12 @@ package migrate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/migrate"
@@ -90,7 +92,7 @@ func newMemoryCmdWithSubmit(submitFn SubmitFn) *cobra.Command {
 				plans, refused := nonInteractivePlans(files, opts)
 				if len(refused) > 0 {
 					for _, f := range refused {
-						fmt.Fprintf(os.Stderr,
+						fmt.Fprintf(cmd.ErrOrStderr(),
 							"meho migrate memory: skipping %s (type %q requires interactive review)\n",
 							f.Path, f.Type,
 						)
@@ -99,21 +101,27 @@ func newMemoryCmdWithSubmit(submitFn SubmitFn) *cobra.Command {
 				if err := submitFn(plans); err != nil {
 					return err
 				}
-				if markMigrated {
-					_ = migrate.TouchMarker(dir) // non-fatal in T4 stub
-				}
 				if len(refused) > 0 {
 					return fmt.Errorf("meho migrate memory: %d entries require interactive review", len(refused))
+				}
+				if markMigrated {
+					_ = migrate.TouchMarker(dir) // non-fatal in T4 stub
 				}
 				return nil
 			}
 
 			// ── Interactive path ──────────────────────────────────────
 			form, plans := migrate.BuildForm(files, opts)
-			accessible := os.Getenv("MEHO_ACCESSIBLE") != ""
+			accessible := os.Getenv("MEHO_ACCESSIBLE") == "1"
 			form = form.WithAccessible(accessible)
 
 			if err := form.Run(); err != nil {
+				// Operator aborted (Ctrl+C / Esc, or said "No" on the
+				// batch-confirm then aborted) — surface as clean exit.
+				if errors.Is(err, huh.ErrUserAborted) {
+					fmt.Fprintf(cmd.OutOrStdout(), "Migration cancelled.\n")
+					return nil
+				}
 				return fmt.Errorf("picker: %w", err)
 			}
 

--- a/cli/internal/cmd/migrate/memory.go
+++ b/cli/internal/cmd/migrate/memory.go
@@ -4,76 +4,230 @@
 package migrate
 
 import (
-	"errors"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
 
+	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/migrate"
 )
 
-// newMemoryCmd returns the `meho migrate memory` subcommand. The cobra
-// surface is fully wired — all flags registered, short/long help text
-// describing the future interactive migration flow. The RunE stub returns
-// a "not yet implemented" error so the skeleton compiles and is discoverable
-// via `meho migrate memory --help` without accidentally running a partial
-// flow.
-//
-// Flow logic (local memory file scanner, interactive huh form picker, dry-run
-// preview, backplane submit, mark-migrated) lands in G5.3-T2–T5 (#609–#612).
+// SubmitFn is the seam T5 replaces with the real backplane POST.
+// T4 wires a no-op stub so the command tree compiles and the dry-run
+// path works end-to-end without a network call.
+type SubmitFn func(plans []migrate.SubmitPlan) error
+
+// dryRunEnvelope is the machine-readable shape emitted by --dry-run
+// (one JSON object per line). Matches the T5 POST body exactly.
+type dryRunEnvelope struct {
+	Scope    string         `json:"scope"`
+	Slug     string         `json:"slug"`
+	Body     string         `json:"body"`
+	Metadata map[string]any `json:"metadata"`
+	SourceID string         `json:"source_id"`
+}
+
+// SourceIDPrefix is the number of hex chars taken from the SHA-256 body
+// hash to build a source_id. Shared constant between T4 dry-run output
+// and T5 POST (keeping them bit-for-bit identical ensures --dry-run
+// preview = exactly what would be sent).
+const SourceIDPrefix = 12
+
 func newMemoryCmd() *cobra.Command {
+	return newMemoryCmdWithSubmit(stubSubmitFn)
+}
+
+// newMemoryCmdWithSubmit is the testable variant: callers inject a submitFn.
+func newMemoryCmdWithSubmit(submitFn SubmitFn) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "memory",
 		Short:        "Migrate laptop-local memory entries to the backplane",
 		SilenceUsage: true,
 		Long: "Scan a local memory directory (or the default XDG location), " +
 			"present an interactive picker for entries to migrate, preview " +
-			"changes in dry-run mode, and submit selected entries to the " +
-			"backplane knowledge base. Full flow lands in G5.3-T2–T5 " +
-			"(Initiative #375).",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return errors.New("meho migrate memory: not yet implemented (G5.3-T2–T5)")
+			"changes in --dry-run mode, or run headlessly with " +
+			"--non-interactive.\n\n" +
+			"Set MEHO_ACCESSIBLE=1 for screen-reader-friendly output.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			flags := cmd.Flags()
+			source, _ := flags.GetString("source")
+			dryRun, _ := flags.GetBool("dry-run")
+			nonInteractive, _ := flags.GetBool("non-interactive")
+			includeML, _ := flags.GetBool("include-machine-local")
+			markMigrated, _ := flags.GetBool("mark-migrated")
+
+			// ── Resolve source directory ──────────────────────────────
+			dir, err := migrate.ResolveSourceDir(source)
+			if err != nil {
+				return fmt.Errorf("resolve source dir: %w", err)
+			}
+
+			// ── Scan ──────────────────────────────────────────────────
+			files, err := migrate.ScanDir(dir)
+			if err != nil {
+				return fmt.Errorf("scan %s: %w", dir, err)
+			}
+			if len(files) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "No memory files found in %s.\n", dir)
+				return nil
+			}
+
+			opts := migrate.BuildFormOpts{
+				IncludeMachineLocal: includeML,
+				// TenantConfigured / IsTenantAdmin resolved from auth in T5;
+				// T4 leaves these at their zero values (conservative defaults).
+			}
+
+			// ── --dry-run path ────────────────────────────────────────
+			if dryRun {
+				return runDryRun(cmd, files, opts)
+			}
+
+			// ── --non-interactive path ────────────────────────────────
+			if nonInteractive {
+				plans, refused := nonInteractivePlans(files, opts)
+				if len(refused) > 0 {
+					for _, f := range refused {
+						fmt.Fprintf(os.Stderr,
+							"meho migrate memory: skipping %s (type %q requires interactive review)\n",
+							f.Path, f.Type,
+						)
+					}
+				}
+				if err := submitFn(plans); err != nil {
+					return err
+				}
+				if markMigrated {
+					_ = migrate.TouchMarker(dir) // non-fatal in T4 stub
+				}
+				if len(refused) > 0 {
+					return fmt.Errorf("meho migrate memory: %d entries require interactive review", len(refused))
+				}
+				return nil
+			}
+
+			// ── Interactive path ──────────────────────────────────────
+			form, plans := migrate.BuildForm(files, opts)
+			accessible := os.Getenv("MEHO_ACCESSIBLE") != ""
+			form = form.WithAccessible(accessible)
+
+			if err := form.Run(); err != nil {
+				return fmt.Errorf("picker: %w", err)
+			}
+
+			migrate.FinalizeSkip(plans)
+
+			toSubmit := filterMigrate(plans)
+			if len(toSubmit) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "No entries selected for migration.\n")
+				return nil
+			}
+
+			if err := submitFn(toSubmit); err != nil {
+				return err
+			}
+			if markMigrated {
+				_ = migrate.TouchMarker(dir)
+			}
+			return nil
 		},
 	}
 
-	// --source: local memory directory to scan. Empty default defers to
-	// the XDG-aware resolver added in T2 (#609).
-	cmd.Flags().String(
-		"source",
-		"",
-		"path to the local memory directory to scan (default: XDG-resolved in T2)",
-	)
-
-	// --dry-run: preview which entries would be migrated without sending
-	// anything to the backplane.
-	cmd.Flags().Bool(
-		"dry-run",
-		false,
-		"preview entries that would be migrated without submitting",
-	)
-
-	// --non-interactive: skip the huh picker and migrate all discovered
-	// entries that pass the filter criteria.
-	cmd.Flags().Bool(
-		"non-interactive",
-		false,
-		"skip the interactive picker and migrate all discovered entries",
-	)
-
-	// --include-machine-local: include entries tagged as machine-local
-	// (hostname-scoped) which are excluded by default because they rarely
-	// transfer meaningfully across machines.
-	cmd.Flags().Bool(
-		"include-machine-local",
-		false,
-		"include machine-local (hostname-scoped) entries in the migration set",
-	)
-
-	// --mark-migrated: after successful submission, write a sentinel
-	// marker in the source directory so a re-run skips already-migrated
-	// entries.
-	cmd.Flags().Bool(
-		"mark-migrated",
-		false,
-		"write a migration-complete marker after successful submission",
-	)
+	cmd.Flags().String("source", "", "path to the local memory directory to scan (default: XDG-resolved)")
+	cmd.Flags().Bool("dry-run", false, "preview entries that would be migrated without submitting")
+	cmd.Flags().Bool("non-interactive", false, "skip the interactive picker; migrates only user/feedback entries")
+	cmd.Flags().Bool("include-machine-local", false, "include machine-local entries (default: skip them)")
+	cmd.Flags().Bool("mark-migrated", false, "touch the migration-complete marker after successful submission")
 
 	return cmd
 }
+
+// runDryRun prints one JSON envelope per migrate-selected file (default
+// plan, no form) and makes no network call.
+func runDryRun(cmd *cobra.Command, files []migrate.MemoryFile, opts migrate.BuildFormOpts) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetEscapeHTML(false)
+	for _, f := range files {
+		plan := migrate.DefaultPlan(f, opts)
+		if plan.Skip {
+			continue
+		}
+		env := dryRunEnvelope{
+			Scope:    plan.Scope,
+			Slug:     plan.Slug,
+			Body:     plan.Body,
+			Metadata: map[string]any{"tags": []string{}},
+			SourceID: sourceID(plan),
+		}
+		if err := enc.Encode(env); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// nonInteractivePlans returns plans for user/feedback files (at their
+// suggested scope) and the refused list (project/reference).
+// Machine-local files are always skipped in non-interactive mode,
+// regardless of IncludeMachineLocal (spec requirement: operator must
+// review machine-local content interactively).
+func nonInteractivePlans(files []migrate.MemoryFile, opts migrate.BuildFormOpts) (plans []migrate.SubmitPlan, refused []migrate.MemoryFile) {
+	safeOpts := opts
+	safeOpts.IncludeMachineLocal = false
+	for _, f := range files {
+		plan := migrate.DefaultPlan(f, safeOpts)
+		if plan.Skip {
+			continue
+		}
+		switch f.Type {
+		case "user", "feedback":
+			plans = append(plans, plan)
+		default:
+			refused = append(refused, f)
+		}
+	}
+	return plans, refused
+}
+
+// filterMigrate returns only the non-skip plans.
+func filterMigrate(plans []migrate.SubmitPlan) []migrate.SubmitPlan {
+	var out []migrate.SubmitPlan
+	for _, p := range plans {
+		if !p.Skip {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// sourceID builds the stable source_id string from a plan's BodySHA256.
+// Uses the first SourceIDPrefix hex chars of the SHA-256 hash.
+func sourceID(plan migrate.SubmitPlan) string {
+	prefix := plan.File.BodySHA256
+	if len(prefix) > SourceIDPrefix {
+		prefix = prefix[:SourceIDPrefix]
+	}
+	return "laptop-migration/" + prefix
+}
+
+// stubSubmitFn is the T4 no-op seam. T5 replaces it with the real
+// backplane POST implementation.
+func stubSubmitFn(plans []migrate.SubmitPlan) error {
+	_ = time.Now() // suppress unused import if huh brings in time
+	if len(plans) == 0 {
+		return nil
+	}
+	scopes := make([]string, 0, len(plans))
+	for _, p := range plans {
+		scopes = append(scopes, fmt.Sprintf("%s (%s)", p.Slug, p.Scope))
+	}
+	return fmt.Errorf("meho migrate memory: submit not yet implemented (T5); would send: %s",
+		strings.Join(scopes, ", "))
+}
+
+// withHuhForm is used in tests to replace the form runner.
+var withHuhForm = func(form *huh.Form) error { return form.Run() }

--- a/cli/internal/cmd/migrate/memory.go
+++ b/cli/internal/cmd/migrate/memory.go
@@ -8,9 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
-	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/migrate"
@@ -156,11 +154,15 @@ func runDryRun(cmd *cobra.Command, files []migrate.MemoryFile, opts migrate.Buil
 		if plan.Skip {
 			continue
 		}
+		md := plan.File.Metadata
+		if md == nil {
+			md = map[string]any{}
+		}
 		env := dryRunEnvelope{
 			Scope:    plan.Scope,
 			Slug:     plan.Slug,
 			Body:     plan.Body,
-			Metadata: map[string]any{"tags": []string{}},
+			Metadata: md,
 			SourceID: sourceID(plan),
 		}
 		if err := enc.Encode(env); err != nil {
@@ -217,7 +219,6 @@ func sourceID(plan migrate.SubmitPlan) string {
 // stubSubmitFn is the T4 no-op seam. T5 replaces it with the real
 // backplane POST implementation.
 func stubSubmitFn(plans []migrate.SubmitPlan) error {
-	_ = time.Now() // suppress unused import if huh brings in time
 	if len(plans) == 0 {
 		return nil
 	}
@@ -228,6 +229,3 @@ func stubSubmitFn(plans []migrate.SubmitPlan) error {
 	return fmt.Errorf("meho migrate memory: submit not yet implemented (T5); would send: %s",
 		strings.Join(scopes, ", "))
 }
-
-// withHuhForm is used in tests to replace the form runner.
-var withHuhForm = func(form *huh.Form) error { return form.Run() }

--- a/cli/internal/cmd/migrate/memory_test.go
+++ b/cli/internal/cmd/migrate/memory_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/migrate"
+)
+
+// writeFixture creates a memory-file fixture under dir.
+func writeFixture(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+// runMemory executes the memory command with args and a captured
+// stdout, returning (stdout, stderr, error).
+func runMemory(t *testing.T, args []string, submitFn SubmitFn) (string, string, error) {
+	t.Helper()
+	cmd := newMemoryCmdWithSubmit(submitFn)
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// ── --dry-run ─────────────────────────────────────────────────────────────────
+
+const userFixture = `---
+name: daily-routine
+description: my daily workflow
+type: user
+---
+I start my day by checking email.
+`
+
+const feedbackFixture = `---
+name: code-style
+description: coding preferences
+type: feedback
+---
+Prefer explicit error handling.
+`
+
+const projectFixture = `---
+name: project-notes
+description: team context
+type: project
+---
+Team uses a shared kanban board.
+`
+
+func TestDryRun_EmitsJSONEnvelopes(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "user.md", userFixture)
+	writeFixture(t, dir, "feedback.md", feedbackFixture)
+
+	called := false
+	submitFn := func(_ []migrate.SubmitPlan) error { called = true; return nil }
+
+	stdout, _, err := runMemory(t, []string{"--source", dir, "--dry-run"}, submitFn)
+	if err != nil {
+		t.Fatalf("dry-run failed: %v", err)
+	}
+	if called {
+		t.Error("--dry-run must not call submitFn")
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 JSON lines, got %d: %q", len(lines), stdout)
+	}
+	for _, line := range lines {
+		var env map[string]any
+		if err := json.Unmarshal([]byte(line), &env); err != nil {
+			t.Errorf("line is not valid JSON: %q — %v", line, err)
+		}
+		for _, field := range []string{"scope", "slug", "body", "metadata", "source_id"} {
+			if _, ok := env[field]; !ok {
+				t.Errorf("dry-run envelope missing field %q", field)
+			}
+		}
+		sid, _ := env["source_id"].(string)
+		if !strings.HasPrefix(sid, "laptop-migration/") {
+			t.Errorf("source_id = %q; want prefix laptop-migration/", sid)
+		}
+		// prefix length check: 17 ("laptop-migration/") + SourceIDPrefix hex chars
+		wantLen := 17 + SourceIDPrefix
+		if len(sid) != wantLen {
+			t.Errorf("source_id len = %d; want %d", len(sid), wantLen)
+		}
+	}
+}
+
+func TestDryRun_MachineLocalFilesSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "user.md", userFixture)
+	writeFixture(t, dir, "local.md", "---\nname: local\ndescription: d\ntype: user\n---\n/Users/bob/mypath\n")
+
+	stdout, _, err := runMemory(t, []string{"--source", dir, "--dry-run"}, func(_ []migrate.SubmitPlan) error { return nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	// only user.md emits an envelope (local.md is skipped)
+	if len(lines) != 1 {
+		t.Errorf("expected 1 envelope (machine-local skipped), got %d: %q", len(lines), stdout)
+	}
+}
+
+func TestDryRun_IncludeMachineLocalFlag(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "local.md", "---\nname: local\ndescription: d\ntype: user\n---\n/Users/bob/mypath\n")
+
+	stdout, _, err := runMemory(t, []string{"--source", dir, "--dry-run", "--include-machine-local"},
+		func(_ []migrate.SubmitPlan) error { return nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 envelope with --include-machine-local, got %d", len(lines))
+	}
+}
+
+// ── --non-interactive ─────────────────────────────────────────────────────────
+
+func TestNonInteractive_UserFeedbackMigrated(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "user.md", userFixture)
+	writeFixture(t, dir, "feedback.md", feedbackFixture)
+
+	var submitted []migrate.SubmitPlan
+	submitFn := func(plans []migrate.SubmitPlan) error {
+		submitted = append(submitted, plans...)
+		return nil
+	}
+
+	_, _, err := runMemory(t, []string{"--source", dir, "--non-interactive"}, submitFn)
+	if err != nil {
+		t.Fatalf("non-interactive failed: %v", err)
+	}
+	if len(submitted) != 2 {
+		t.Errorf("expected 2 submitted plans, got %d", len(submitted))
+	}
+}
+
+func TestNonInteractive_ProjectRefused(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "project.md", projectFixture)
+
+	var submitted []migrate.SubmitPlan
+	submitFn := func(plans []migrate.SubmitPlan) error {
+		submitted = append(submitted, plans...)
+		return nil
+	}
+
+	_, stderr, err := runMemory(t, []string{"--source", dir, "--non-interactive"}, submitFn)
+	if err == nil {
+		t.Error("expected non-zero exit when project entries present")
+	}
+	if len(submitted) != 0 {
+		t.Errorf("expected 0 submitted (project skipped), got %d", len(submitted))
+	}
+	if !strings.Contains(stderr, "interactive review") {
+		t.Errorf("stderr should mention interactive review, got: %q", stderr)
+	}
+}
+
+func TestNonInteractive_MachineLocalSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "user.md", userFixture)
+	// machine-local file should be skipped even with --include-machine-local
+	writeFixture(t, dir, "local.md", "---\nname: local\ndescription: d\ntype: user\n---\n/Users/bob/path\n")
+
+	var submitted []migrate.SubmitPlan
+	submitFn := func(plans []migrate.SubmitPlan) error {
+		submitted = append(submitted, plans...)
+		return nil
+	}
+
+	_, _, _ = runMemory(t, []string{"--source", dir, "--non-interactive", "--include-machine-local"}, submitFn)
+	for _, p := range submitted {
+		if strings.Contains(p.File.Body, "/Users/bob") {
+			t.Error("machine-local file must not be submitted in --non-interactive mode")
+		}
+	}
+}
+
+// ── source_id stability ───────────────────────────────────────────────────────
+
+func TestDryRun_SourceIDStable(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "user.md", userFixture)
+
+	run := func() string {
+		out, _, err := runMemory(t, []string{"--source", dir, "--dry-run"},
+			func(_ []migrate.SubmitPlan) error { return nil })
+		if err != nil {
+			t.Fatalf("dry-run error: %v", err)
+		}
+		var env map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &env); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return env["source_id"].(string)
+	}
+
+	id1, id2 := run(), run()
+	if id1 != id2 {
+		t.Errorf("source_id is not stable: %q != %q", id1, id2)
+	}
+}
+
+// ── empty source dir ──────────────────────────────────────────────────────────
+
+func TestDryRun_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, err := runMemory(t, []string{"--source", dir, "--dry-run"},
+		func(_ []migrate.SubmitPlan) error { return nil })
+	if err != nil {
+		t.Fatalf("unexpected error on empty dir: %v", err)
+	}
+	if !strings.Contains(stdout, "No memory files") {
+		t.Errorf("expected 'No memory files' message, got: %q", stdout)
+	}
+}

--- a/cli/internal/cmd/sddc-manager/domain.go
+++ b/cli/internal/cmd/sddc-manager/domain.go
@@ -35,7 +35,7 @@ func newDomainListCmd() *cobra.Command {
 		Short: "List VCF domains (management + workload)",
 		Long: "list dispatches GET:/v1/domains against connector_id=\"sddc-rest-9.0\".\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager domain list --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager domain list --target rdc-sddc-manager",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -95,7 +95,7 @@ func newDomainInfoCmd() *cobra.Command {
 		Long: "info dispatches GET:/v1/domains/{id} against connector_id=\"sddc-rest-9.0\".\n" +
 			"Requires a domain id from `sddc-manager domain list`.\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager domain info domain-mgmt --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager domain info domain-mgmt --target rdc-sddc-manager",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -129,15 +129,15 @@ func printDomainInfo(w io.Writer, r *CallResult) {
 		return
 	}
 	var d struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-		Type string `json:"type"`
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Type     string `json:"type"`
 		VCenters []struct {
 			ID   string `json:"id"`
 			FQDN string `json:"fqdn"`
 		} `json:"vcenters"`
 		NsxtCluster *struct {
-			ID     string `json:"id"`
+			ID      string `json:"id"`
 			VipFQDN string `json:"vipFqdn"`
 		} `json:"nsxtCluster"`
 		Clusters []struct {

--- a/cli/internal/cmd/sddc-manager/network_pool.go
+++ b/cli/internal/cmd/sddc-manager/network_pool.go
@@ -34,7 +34,7 @@ func newNetworkPoolListCmd() *cobra.Command {
 		Short: "List VCF network pools (IP ranges and VLANs for host commission)",
 		Long: "list dispatches GET:/v1/network-pools against connector_id=\"sddc-rest-9.0\".\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager network-pool list --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager network-pool list --target rdc-sddc-manager",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cli/internal/migrate/marker.go
+++ b/cli/internal/migrate/marker.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+// TouchMarker writes the migration-complete marker for sourceDir.
+// The marker path is $XDG_CONFIG_HOME/meho/migrated-from/<sanitized-dir>.
+// Full implementation lives in T5 (#612); this stub satisfies the T4
+// compile dependency and returns nil (no-op).
+func TouchMarker(_ string) error { return nil }
+
+// MarkerExists reports whether the migration marker for sourceDir is
+// present. Full implementation in T5; stub always returns false.
+func MarkerExists(_ string) (bool, error) { return false, nil }

--- a/cli/internal/migrate/picker.go
+++ b/cli/internal/migrate/picker.go
@@ -272,16 +272,6 @@ func buildScopeOptions(opts BuildFormOpts) []huh.Option[string] {
 	return options
 }
 
-func countMigrate(plans []SubmitPlan) int {
-	n := 0
-	for _, p := range plans {
-		if !p.Skip {
-			n++
-		}
-	}
-	return n
-}
-
 func countMigrateFromPlans(plans []SubmitPlan) int {
 	n := 0
 	for _, p := range plans {

--- a/cli/internal/migrate/picker.go
+++ b/cli/internal/migrate/picker.go
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"charm.land/huh/v2"
+)
+
+// Action tokens for the per-file action select field.
+const (
+	// ActionMigrateSuggested uses the scope SuggestScope returned.
+	ActionMigrateSuggested = "migrate:suggested"
+	// ActionMigrateDifferent shows the scope picker group.
+	ActionMigrateDifferent = "migrate:different"
+	// ActionMigrateEdit shows the body-edit group before submit.
+	ActionMigrateEdit = "migrate:edit"
+	// ActionSkipManual keeps the file laptop-local by operator choice.
+	ActionSkipManual = "skip:manual"
+	// ActionSkipMachineLocal keeps a machine-local flagged file local.
+	ActionSkipMachineLocal = "skip:machine-local"
+)
+
+// SubmitPlan is one entry in the operator's migration decision. T5
+// consumes a []SubmitPlan from the interactive, --dry-run, or
+// --non-interactive paths.
+type SubmitPlan struct {
+	// File is the source MemoryFile.
+	File MemoryFile
+	// Scope is the chosen scope token (one of the Scope* constants).
+	Scope string
+	// Slug is the entry identifier validated against ^[a-z0-9][a-z0-9-]*$.
+	Slug string
+	// Body is the body text to POST (may differ from File.Body if the
+	// operator edited it via the body-edit group).
+	Body string
+	// Skip is true when the operator chose to keep the file laptop-local.
+	Skip bool
+	// Action records the raw action selection so callers can distinguish
+	// between the different migrate/skip variants. Set by BuildForm; also
+	// set to ActionMigrateSuggested by DefaultPlan for non-interactive
+	// and --dry-run paths.
+	Action string
+}
+
+// BuildFormOpts controls scope availability and picker defaults.
+type BuildFormOpts struct {
+	// IsTenantAdmin allows the tenant and target scope options. When false
+	// those options are omitted from the scope picker (the server would
+	// reject them with 403 anyway, but hiding them prevents confusion).
+	IsTenantAdmin bool
+	// TenantConfigured is true when the operator's meho config has a
+	// default tenant slug. Used by SuggestScope for the project type.
+	TenantConfigured bool
+	// TargetConfigured is true when the operator's config has a default
+	// target. Used to enable the user×target scope option.
+	TargetConfigured bool
+	// IncludeMachineLocal overrides the default-to-skip behaviour for
+	// files flagged by DetectMachineLocal or MachineLocalOptOut. The
+	// machine-local badge is still shown; only the default action flips.
+	IncludeMachineLocal bool
+}
+
+// BuildForm creates an interactive huh form over files. The returned
+// plans slice is populated as the operator advances through the form —
+// callers must not read plans until form.Run() returns nil.
+//
+// After form.Run(), call FinalizeSkip(plans) to propagate each plan's
+// Action field into its Skip bool.
+//
+// The form is designed to be run interactively (terminal); for
+// --dry-run and --non-interactive paths use DefaultPlan / NonInteractivePlans.
+func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan) {
+	plans := make([]SubmitPlan, len(files))
+	// One action string per file — kept outside SubmitPlan so we can
+	// take its address for the Select binding without the struct escaping
+	// to heap unintentionally.
+	actions := make([]string, len(files))
+
+	var groups []*huh.Group
+
+	for i, f := range files {
+		fi := i
+		ff := f
+		ml := DetectMachineLocal(ff.Body, nil)
+		isMachineLocal := ml.Flagged || ff.MachineLocalOptOut
+
+		// Initialise the plan defaults.
+		plans[fi] = SubmitPlan{
+			File:   ff,
+			Scope:  SuggestScope(ff, opts.TenantConfigured),
+			Slug:   slugFromPath(ff.Path),
+			Body:   ff.Body,
+			Action: defaultAction(isMachineLocal, opts.IncludeMachineLocal),
+		}
+		actions[fi] = plans[fi].Action
+
+		// ── Group 1: note header + action select ──────────────────────
+		noteDesc := buildNoteDescription(ff, isMachineLocal)
+		mainGroup := huh.NewGroup(
+			huh.NewNote().
+				Title(filepath.Base(ff.Path)).
+				Description(noteDesc),
+			huh.NewSelect[string]().
+				Title("Action").
+				Options(buildActionOptions(plans[fi].Scope, isMachineLocal)...).
+				Value(&actions[fi]),
+		)
+		groups = append(groups, mainGroup)
+
+		// ── Group 2: scope picker (hidden unless "migrate:different") ──
+		scopeGroup := huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Scope").
+				OptionsFunc(func() []huh.Option[string] {
+					return buildScopeOptions(opts)
+				}, nil).
+				Value(&plans[fi].Scope),
+		).WithHideFunc(func() bool {
+			return actions[fi] != ActionMigrateDifferent
+		})
+		groups = append(groups, scopeGroup)
+
+		// ── Group 3: slug input (hidden when skipping) ─────────────────
+		slugGroup := huh.NewGroup(
+			huh.NewInput().
+				Title("Slug").
+				Description("Identifier stored in the backplane (^[a-z0-9][a-z0-9-]*$)").
+				Value(&plans[fi].Slug).
+				Validate(validateSlug),
+		).WithHideFunc(func() bool {
+			return strings.HasPrefix(actions[fi], "skip:")
+		})
+		groups = append(groups, slugGroup)
+
+		// ── Group 4: body edit (hidden unless "migrate:edit") ──────────
+		editGroup := huh.NewGroup(
+			huh.NewText().
+				Title("Edit body before migrating").
+				Description("Strip machine-local snippets before sending.").
+				Value(&plans[fi].Body),
+		).WithHideFunc(func() bool {
+			return actions[fi] != ActionMigrateEdit
+		})
+		groups = append(groups, editGroup)
+	}
+
+	// ── Final confirm group ────────────────────────────────────────────
+	migrateCount := countMigrate(plans)
+	var confirmed bool
+	confirmGroup := huh.NewGroup(
+		huh.NewConfirm().
+			TitleFunc(func() string {
+				mc := countMigrateFromActions(actions)
+				sc := len(actions) - mc
+				return fmt.Sprintf("Migrate %d entries (%d skipped). Proceed?", mc, sc)
+			}, &actions).
+			Value(&confirmed),
+	)
+	_ = migrateCount // used via TitleFunc closure
+	groups = append(groups, confirmGroup)
+
+	return huh.NewForm(groups...), plans
+}
+
+// FinalizeSkip propagates each plan's Action field into its Skip bool.
+// Call after form.Run() returns nil.
+func FinalizeSkip(plans []SubmitPlan) {
+	for i := range plans {
+		plans[i].Skip = strings.HasPrefix(plans[i].Action, "skip:")
+		if plans[i].Action == ActionMigrateSuggested {
+			// Re-derive suggested scope in case opts changed after form
+			// construction; for well-formed calls this is a no-op.
+			// (plans[i].Scope was already set to SuggestScope at build time.)
+		}
+	}
+}
+
+// DefaultPlan returns the default SubmitPlan for a file without running
+// the interactive form. Used by --dry-run (all files) and
+// --non-interactive (user/feedback files only).
+func DefaultPlan(f MemoryFile, opts BuildFormOpts) SubmitPlan {
+	ml := DetectMachineLocal(f.Body, nil)
+	isMachineLocal := ml.Flagged || f.MachineLocalOptOut
+	action := defaultAction(isMachineLocal, opts.IncludeMachineLocal)
+	return SubmitPlan{
+		File:   f,
+		Scope:  SuggestScope(f, opts.TenantConfigured),
+		Slug:   slugFromPath(f.Path),
+		Body:   f.Body,
+		Skip:   strings.HasPrefix(action, "skip:"),
+		Action: action,
+	}
+}
+
+// slugFromPath derives a default slug from the file's base name:
+//   - strip the .md extension
+//   - lowercase
+//   - replace any run of characters not in [a-z0-9] with a single "-"
+//   - trim leading/trailing "-"
+//   - if the result is empty or starts with a digit, prepend "entry-"
+func slugFromPath(path string) string {
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	base = strings.ToLower(base)
+	re := regexp.MustCompile(`[^a-z0-9]+`)
+	slug := strings.Trim(re.ReplaceAllString(base, "-"), "-")
+	if slug == "" || (slug[0] >= '0' && slug[0] <= '9') {
+		slug = "entry-" + slug
+	}
+	return slug
+}
+
+var slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// validateSlug rejects slugs that don't match ^[a-z0-9][a-z0-9-]*$.
+func validateSlug(s string) error {
+	if !slugRe.MatchString(s) {
+		return fmt.Errorf("slug must match ^[a-z0-9][a-z0-9-]*$ (got %q)", s)
+	}
+	return nil
+}
+
+// defaultAction returns the initial action for a file.
+func defaultAction(isMachineLocal, includeML bool) string {
+	if isMachineLocal && !includeML {
+		return ActionSkipMachineLocal
+	}
+	return ActionMigrateSuggested
+}
+
+// buildNoteDescription returns the header description for a file.
+// Body is truncated to 200 chars with newlines stripped.
+func buildNoteDescription(f MemoryFile, isMachineLocal bool) string {
+	body := strings.ReplaceAll(f.Body, "\n", " ")
+	const maxLen = 200
+	if len(body) > maxLen {
+		body = body[:maxLen] + "…"
+	}
+	badge := ""
+	if isMachineLocal {
+		badge = " [machine-local]"
+	}
+	if f.ParseWarning != "" {
+		return fmt.Sprintf("⚠ %s%s\n%s", f.ParseWarning, badge, body)
+	}
+	return fmt.Sprintf("%s%s", body, badge)
+}
+
+// buildActionOptions returns the action select options for one file.
+func buildActionOptions(suggestedScope string, isMachineLocal bool) []huh.Option[string] {
+	migrateLabel := fmt.Sprintf("Migrate to %s", suggestedScope)
+	opts := []huh.Option[string]{
+		huh.NewOption(migrateLabel, ActionMigrateSuggested),
+		huh.NewOption("Migrate to a different scope…", ActionMigrateDifferent),
+		huh.NewOption("Migrate (edit body first)", ActionMigrateEdit),
+		huh.NewOption("Skip (keep laptop-local)", ActionSkipManual),
+	}
+	if isMachineLocal {
+		opts = append(opts, huh.NewOption("Skip — machine-local", ActionSkipMachineLocal))
+	}
+	return opts
+}
+
+// buildScopeOptions returns the scope select options filtered by role.
+func buildScopeOptions(opts BuildFormOpts) []huh.Option[string] {
+	options := []huh.Option[string]{
+		huh.NewOption("user", ScopeUser),
+	}
+	if opts.TenantConfigured {
+		options = append(options, huh.NewOption("user×tenant", ScopeUserTenant))
+	}
+	if opts.TargetConfigured {
+		options = append(options, huh.NewOption("user×target", ScopeUserTarget))
+	}
+	if opts.IsTenantAdmin {
+		options = append(options, huh.NewOption("tenant", ScopeTenant))
+		options = append(options, huh.NewOption("target", ScopeTarget))
+	}
+	return options
+}
+
+func countMigrate(plans []SubmitPlan) int {
+	n := 0
+	for _, p := range plans {
+		if !p.Skip {
+			n++
+		}
+	}
+	return n
+}
+
+func countMigrateFromActions(actions []string) int {
+	n := 0
+	for _, a := range actions {
+		if !strings.HasPrefix(a, "skip:") {
+			n++
+		}
+	}
+	return n
+}

--- a/cli/internal/migrate/picker.go
+++ b/cli/internal/migrate/picker.go
@@ -4,6 +4,7 @@
 package migrate
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -146,14 +147,23 @@ func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan)
 	}
 
 	// ── Final confirm group ────────────────────────────────────────────
-	var confirmed bool
+	// Validate enforces operator consent: a non-nil error stalls form
+	// submission (huh v2.0.3 gates nextGroupMsg on group.Errors()), so
+	// "No" cannot accidentally submit. The operator's exit paths are
+	// toggle-to-Yes or abort (Ctrl+C, which surfaces as huh.ErrUserAborted
+	// from form.Run() — the caller treats it as a clean cancellation).
 	confirmGroup := huh.NewGroup(
 		huh.NewConfirm().
 			TitleFunc(func() string {
 				mc := countMigrateFromPlans(plans)
 				return fmt.Sprintf("Migrate %d entries (%d skipped). Proceed?", mc, len(plans)-mc)
 			}, nil).
-			Value(&confirmed),
+			Validate(func(b bool) error {
+				if !b {
+					return errors.New("migration cancelled — toggle to Yes or press Ctrl+C to abort")
+				}
+				return nil
+			}),
 	)
 	groups = append(groups, confirmGroup)
 

--- a/cli/internal/migrate/picker.go
+++ b/cli/internal/migrate/picker.go
@@ -77,10 +77,6 @@ type BuildFormOpts struct {
 // --dry-run and --non-interactive paths use DefaultPlan / NonInteractivePlans.
 func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan) {
 	plans := make([]SubmitPlan, len(files))
-	// One action string per file — kept outside SubmitPlan so we can
-	// take its address for the Select binding without the struct escaping
-	// to heap unintentionally.
-	actions := make([]string, len(files))
 
 	var groups []*huh.Group
 
@@ -98,7 +94,6 @@ func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan)
 			Body:   ff.Body,
 			Action: defaultAction(isMachineLocal, opts.IncludeMachineLocal),
 		}
-		actions[fi] = plans[fi].Action
 
 		// ── Group 1: note header + action select ──────────────────────
 		noteDesc := buildNoteDescription(ff, isMachineLocal)
@@ -109,7 +104,7 @@ func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan)
 			huh.NewSelect[string]().
 				Title("Action").
 				Options(buildActionOptions(plans[fi].Scope, isMachineLocal)...).
-				Value(&actions[fi]),
+				Value(&plans[fi].Action),
 		)
 		groups = append(groups, mainGroup)
 
@@ -122,7 +117,7 @@ func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan)
 				}, nil).
 				Value(&plans[fi].Scope),
 		).WithHideFunc(func() bool {
-			return actions[fi] != ActionMigrateDifferent
+			return plans[fi].Action != ActionMigrateDifferent
 		})
 		groups = append(groups, scopeGroup)
 
@@ -134,7 +129,7 @@ func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan)
 				Value(&plans[fi].Slug).
 				Validate(validateSlug),
 		).WithHideFunc(func() bool {
-			return strings.HasPrefix(actions[fi], "skip:")
+			return strings.HasPrefix(plans[fi].Action, "skip:")
 		})
 		groups = append(groups, slugGroup)
 
@@ -145,24 +140,21 @@ func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan)
 				Description("Strip machine-local snippets before sending.").
 				Value(&plans[fi].Body),
 		).WithHideFunc(func() bool {
-			return actions[fi] != ActionMigrateEdit
+			return plans[fi].Action != ActionMigrateEdit
 		})
 		groups = append(groups, editGroup)
 	}
 
 	// ── Final confirm group ────────────────────────────────────────────
-	migrateCount := countMigrate(plans)
 	var confirmed bool
 	confirmGroup := huh.NewGroup(
 		huh.NewConfirm().
 			TitleFunc(func() string {
-				mc := countMigrateFromActions(actions)
-				sc := len(actions) - mc
-				return fmt.Sprintf("Migrate %d entries (%d skipped). Proceed?", mc, sc)
-			}, &actions).
+				mc := countMigrateFromPlans(plans)
+				return fmt.Sprintf("Migrate %d entries (%d skipped). Proceed?", mc, len(plans)-mc)
+			}, nil).
 			Value(&confirmed),
 	)
-	_ = migrateCount // used via TitleFunc closure
 	groups = append(groups, confirmGroup)
 
 	return huh.NewForm(groups...), plans
@@ -173,11 +165,6 @@ func BuildForm(files []MemoryFile, opts BuildFormOpts) (*huh.Form, []SubmitPlan)
 func FinalizeSkip(plans []SubmitPlan) {
 	for i := range plans {
 		plans[i].Skip = strings.HasPrefix(plans[i].Action, "skip:")
-		if plans[i].Action == ActionMigrateSuggested {
-			// Re-derive suggested scope in case opts changed after form
-			// construction; for well-formed calls this is a no-op.
-			// (plans[i].Scope was already set to SuggestScope at build time.)
-		}
 	}
 }
 
@@ -295,10 +282,10 @@ func countMigrate(plans []SubmitPlan) int {
 	return n
 }
 
-func countMigrateFromActions(actions []string) int {
+func countMigrateFromPlans(plans []SubmitPlan) int {
 	n := 0
-	for _, a := range actions {
-		if !strings.HasPrefix(a, "skip:") {
+	for _, p := range plans {
+		if !strings.HasPrefix(p.Action, "skip:") {
 			n++
 		}
 	}

--- a/cli/internal/migrate/picker_test.go
+++ b/cli/internal/migrate/picker_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+import (
+	"testing"
+)
+
+// ── slugFromPath ─────────────────────────────────────────────────────────────
+
+func TestSlugFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/home/x/memory/daily-routine.md", "daily-routine"},
+		{"/home/x/memory/Daily Routine.md", "daily-routine"},
+		{"/home/x/memory/my_project.md", "my-project"},
+		{"/home/x/memory/123-numbers.md", "entry-123-numbers"},
+		{"/home/x/memory/foo.md", "foo"},
+		{"/home/x/memory/FOO BAR.md", "foo-bar"},
+	}
+	for _, tc := range cases {
+		got := slugFromPath(tc.path)
+		if got != tc.want {
+			t.Errorf("slugFromPath(%q) = %q; want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// ── validateSlug ─────────────────────────────────────────────────────────────
+
+func TestValidateSlug(t *testing.T) {
+	accept := []string{"daily-routine", "a", "foo123", "abc-def-ghi"}
+	for _, s := range accept {
+		if err := validateSlug(s); err != nil {
+			t.Errorf("validateSlug(%q) unexpected error: %v", s, err)
+		}
+	}
+	// "1start" is valid per spec regex ^[a-z0-9][a-z0-9-]*$ (digit is allowed first char)
+	reject := []string{"Daily Routine", "-x", "x_y", ""}
+	for _, s := range reject {
+		if err := validateSlug(s); err == nil {
+			t.Errorf("validateSlug(%q) expected error, got nil", s)
+		}
+	}
+}
+
+// ── BuildForm structure ───────────────────────────────────────────────────────
+
+func TestBuildForm_GroupCount(t *testing.T) {
+	files := []MemoryFile{
+		{Path: "/mem/a.md", Type: "user", Body: "hello"},
+		{Path: "/mem/b.md", Type: "feedback", Body: "world"},
+	}
+	form, plans := BuildForm(files, BuildFormOpts{})
+	if form == nil {
+		t.Fatal("BuildForm returned nil form")
+	}
+	// 4 groups per file + 1 confirm group
+	want := len(files)*4 + 1
+	got := len(plans) // plans length equals len(files)
+	if got != len(files) {
+		t.Errorf("plans length = %d; want %d", got, len(files))
+	}
+	_ = want // form.Groups() is not exported; we verify via plans length
+}
+
+func TestBuildForm_DefaultActions(t *testing.T) {
+	files := []MemoryFile{
+		{Path: "/m/user.md", Type: "user", Body: "hello"},
+		// machine-local flagged file → default skip
+		{Path: "/m/local.md", Type: "user", Body: "/Users/bob/code is here"},
+	}
+	_, plans := BuildForm(files, BuildFormOpts{})
+	if plans[0].Action != ActionMigrateSuggested {
+		t.Errorf("plans[0].Action = %q; want %q", plans[0].Action, ActionMigrateSuggested)
+	}
+	if plans[1].Action != ActionSkipMachineLocal {
+		t.Errorf("plans[1].Action = %q; want %q", plans[1].Action, ActionSkipMachineLocal)
+	}
+}
+
+func TestBuildForm_IncludeMachineLocalFlipsDefault(t *testing.T) {
+	files := []MemoryFile{
+		{Path: "/m/local.md", Type: "user", Body: "/Users/bob/code"},
+	}
+	_, plans := BuildForm(files, BuildFormOpts{IncludeMachineLocal: true})
+	if plans[0].Action != ActionMigrateSuggested {
+		t.Errorf("with IncludeMachineLocal=true, action = %q; want %q",
+			plans[0].Action, ActionMigrateSuggested)
+	}
+}
+
+// ── Role-filtered scope options ───────────────────────────────────────────────
+
+func TestBuildScopeOptions_NoTenantAdmin(t *testing.T) {
+	opts := buildScopeOptions(BuildFormOpts{IsTenantAdmin: false, TenantConfigured: true, TargetConfigured: true})
+	for _, o := range opts {
+		if o.Value == ScopeTenant || o.Value == ScopeTarget {
+			t.Errorf("scope option %q present without tenant_admin", o.Value)
+		}
+	}
+}
+
+func TestBuildScopeOptions_TenantAdmin(t *testing.T) {
+	opts := buildScopeOptions(BuildFormOpts{IsTenantAdmin: true, TenantConfigured: true, TargetConfigured: true})
+	has := func(scope string) bool {
+		for _, o := range opts {
+			if o.Value == scope {
+				return true
+			}
+		}
+		return false
+	}
+	for _, scope := range []string{ScopeUser, ScopeUserTenant, ScopeUserTarget, ScopeTenant, ScopeTarget} {
+		if !has(scope) {
+			t.Errorf("scope %q missing when IsTenantAdmin=true", scope)
+		}
+	}
+}
+
+// ── FinalizeSkip ─────────────────────────────────────────────────────────────
+
+func TestFinalizeSkip(t *testing.T) {
+	plans := []SubmitPlan{
+		{Action: ActionMigrateSuggested},
+		{Action: ActionSkipManual},
+		{Action: ActionSkipMachineLocal},
+		{Action: ActionMigrateEdit},
+	}
+	FinalizeSkip(plans)
+	if plans[0].Skip {
+		t.Error("migrate:suggested should not be Skip")
+	}
+	if !plans[1].Skip {
+		t.Error("skip:manual should be Skip")
+	}
+	if !plans[2].Skip {
+		t.Error("skip:machine-local should be Skip")
+	}
+	if plans[3].Skip {
+		t.Error("migrate:edit should not be Skip")
+	}
+}
+
+// ── DefaultPlan ──────────────────────────────────────────────────────────────
+
+func TestDefaultPlan_UserType(t *testing.T) {
+	f := MemoryFile{Path: "/m/user.md", Type: "user", Body: "notes", BodySHA256: "abcdef012345"}
+	plan := DefaultPlan(f, BuildFormOpts{})
+	if plan.Scope != ScopeUser {
+		t.Errorf("scope = %q; want %q", plan.Scope, ScopeUser)
+	}
+	if plan.Skip {
+		t.Error("user file should not be skipped by default")
+	}
+	if plan.Slug != "user" {
+		t.Errorf("slug = %q; want %q", plan.Slug, "user")
+	}
+}
+
+func TestDefaultPlan_MachineLocalOptOut(t *testing.T) {
+	f := MemoryFile{
+		Path:               "/m/ml.md",
+		Type:               "user",
+		Body:               "text",
+		MachineLocalOptOut: true,
+	}
+	plan := DefaultPlan(f, BuildFormOpts{IncludeMachineLocal: false})
+	if !plan.Skip {
+		t.Error("MachineLocalOptOut file should be skipped when IncludeMachineLocal=false")
+	}
+}

--- a/cli/internal/migrate/picker_test.go
+++ b/cli/internal/migrate/picker_test.go
@@ -4,6 +4,7 @@
 package migrate
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -58,13 +59,28 @@ func TestBuildForm_GroupCount(t *testing.T) {
 	if form == nil {
 		t.Fatal("BuildForm returned nil form")
 	}
-	// 4 groups per file + 1 confirm group
-	want := len(files)*4 + 1
-	got := len(plans) // plans length equals len(files)
-	if got != len(files) {
-		t.Errorf("plans length = %d; want %d", got, len(files))
+	if len(plans) != len(files) {
+		t.Errorf("plans length = %d; want %d", len(plans), len(files))
 	}
-	_ = want // form.Groups() is not exported; we verify via plans length
+	// Structural: default action is migrate:suggested, so scope and edit
+	// groups should be hidden, slug group should be visible.
+	for i := range plans {
+		if plans[i].Action != ActionMigrateSuggested {
+			t.Errorf("plans[%d].Action = %q; want %q", i, plans[i].Action, ActionMigrateSuggested)
+		}
+		// scope group hidden unless migrate:different
+		if plans[i].Action == ActionMigrateDifferent {
+			t.Errorf("plans[%d]: unexpected ActionMigrateDifferent at default", i)
+		}
+		// slug group visible (not skip:*)
+		if strings.HasPrefix(plans[i].Action, "skip:") {
+			t.Errorf("plans[%d]: slug group should be visible for Action=%q", i, plans[i].Action)
+		}
+		// edit group hidden unless migrate:edit
+		if plans[i].Action == ActionMigrateEdit {
+			t.Errorf("plans[%d]: unexpected ActionMigrateEdit at default", i)
+		}
+	}
 }
 
 func TestBuildForm_DefaultActions(t *testing.T) {

--- a/cli/internal/migrate/scan.go
+++ b/cli/internal/migrate/scan.go
@@ -193,16 +193,22 @@ func splitFrontmatter(raw []byte) (fm []byte, body []byte, ok bool, warning stri
 	const delim = "---\n"
 	const delimEnd = "---"
 
-	if !bytes.HasPrefix(raw, []byte(delim)) {
-		// Also accept bare "---" at start of file (no trailing newline
-		// edge case seen on some editors).
-		if !bytes.HasPrefix(raw, []byte(delimEnd)) {
-			return nil, nil, false, "no frontmatter delimiter found"
+	var stripLen int
+	if bytes.HasPrefix(raw, []byte(delim)) {
+		stripLen = len(delim)
+	} else if bytes.HasPrefix(raw, []byte(delimEnd)) {
+		// Bare "---" at start of file (no trailing newline — edge case).
+		// A 3-byte input that is exactly "---" has no closing delimiter.
+		stripLen = len(delimEnd)
+		if len(raw) <= stripLen {
+			return nil, nil, false, "no closing '---'"
 		}
+	} else {
+		return nil, nil, false, "no frontmatter delimiter found"
 	}
 
-	// Strip the opening "---\n".
-	rest := raw[len(delim):]
+	// Strip the opening delimiter.
+	rest := raw[stripLen:]
 
 	// Find the closing "---" on its own line.
 	closeIdx := bytes.Index(rest, []byte("\n---\n"))

--- a/cli/internal/migrate/scan.go
+++ b/cli/internal/migrate/scan.go
@@ -254,17 +254,20 @@ func hasMachineLocalComment(s string) bool {
 			return false
 		}
 		start += idx
-		end := strings.Index(s[start:], close)
-		if end == -1 {
+		// Search for close strictly after the open delimiter so that a
+		// degenerate comment like <!--> or <!--->, whose --> shares
+		// characters with the opening <!--, cannot produce a negative
+		// inner slice range and panic.
+		innerStart := start + len(open)
+		rel := strings.Index(s[innerStart:], close)
+		if rel == -1 {
 			return false
 		}
-		end += start + len(close)
-
-		inner := s[start+len(open) : end-len(close)]
-		if strings.TrimSpace(inner) == tag {
+		innerEnd := innerStart + rel
+		if strings.TrimSpace(s[innerStart:innerEnd]) == tag {
 			return true
 		}
-		idx = end
+		idx = innerEnd + len(close)
 	}
 }
 

--- a/cli/internal/migrate/scan.go
+++ b/cli/internal/migrate/scan.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MemoryFile holds the parsed representation of a single Claude Code
+// memory entry (a *.md file in the laptop-local memory directory).
+// Fields are exported so callers (T4 picker, T5 submit client) can
+// access them directly.
+type MemoryFile struct {
+	// Path is the absolute path to the source file.
+	Path string
+
+	// Name is the `name:` frontmatter field, or empty when
+	// FrontmatterOK is false.
+	Name string
+
+	// Description is the `description:` frontmatter field.
+	Description string
+
+	// Type is the `type:` frontmatter field (e.g. "user", "project",
+	// "reference", "feedback"). Empty when FrontmatterOK is false.
+	Type string
+
+	// Metadata holds the raw `metadata:` frontmatter value as a
+	// passthrough map; callers that need it unmarshal from this map.
+	Metadata map[string]any
+
+	// Body is the post-frontmatter content. When FrontmatterOK is
+	// false, Body holds the entire file content.
+	Body string
+
+	// BodySHA256 is the lowercase hex SHA-256 of the Body bytes. Used
+	// by T5 as the idempotency source_id; stable across calls and
+	// changes whenever Body changes.
+	BodySHA256 string
+
+	// FrontmatterOK is true iff the file began with a well-formed
+	// YAML frontmatter block delimited by `---` lines. A file with no
+	// frontmatter or malformed YAML sets this to false without causing
+	// an error return.
+	FrontmatterOK bool
+
+	// ParseWarning carries a human-readable description of the
+	// parsing problem when FrontmatterOK is false. Empty when
+	// FrontmatterOK is true.
+	ParseWarning string
+
+	// MachineLocalOptOut is true iff the Body contains the literal
+	// HTML comment `<!-- meho:machine-local -->` (case-sensitive;
+	// whitespace-tolerant inside the delimiters). Operators place this
+	// marker to explicitly exclude a file from cross-machine migration.
+	MachineLocalOptOut bool
+}
+
+// ResolveSourceDir resolves the memory directory to scan.
+//
+// Resolution order (first non-empty wins):
+//  1. override — returned verbatim when non-empty.
+//  2. $CLAUDE_PROJECT_DIR/memory/ — when that env var is set.
+//  3. <os.UserHomeDir()>/.claude/projects/<sanitized-abs-cwd>/memory/
+//
+// The sanitized-abs-cwd transform replaces every '/' in the absolute
+// working directory with '-', so the leading '/' becomes a leading '-'
+// (e.g. "/Users/x/repos/meho" → "-Users-x-repos-meho"). The leading
+// separator is retained. This mirrors the layout Claude Code uses when
+// writing project-scoped memory files under $HOME/.claude/projects/.
+func ResolveSourceDir(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+
+	if projectDir := os.Getenv("CLAUDE_PROJECT_DIR"); projectDir != "" {
+		return filepath.Join(projectDir, "memory"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve cwd: %w", err)
+	}
+
+	sanitized := strings.ReplaceAll(cwd, "/", "-")
+	return filepath.Join(home, ".claude", "projects", sanitized, "memory"), nil
+}
+
+// ScanDir walks dir for *.md files (non-recursive; the memory directory
+// is flat) and returns a MemoryFile for each. A file with no or malformed
+// frontmatter is not an error: its MemoryFile has FrontmatterOK=false,
+// Body set to the entire file content, and ParseWarning describing the
+// issue.
+//
+// Returns an error only when dir is unreadable.
+func ScanDir(dir string) ([]MemoryFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("scan dir %q: %w", dir, err)
+	}
+
+	var files []MemoryFile
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %q: %w", path, err)
+		}
+
+		mf := parseMemoryFile(path, raw)
+		files = append(files, mf)
+	}
+	return files, nil
+}
+
+// parseMemoryFile parses raw file content into a MemoryFile. It is
+// exported only to the test file via the package boundary; callers
+// outside the package use ScanDir.
+func parseMemoryFile(path string, raw []byte) MemoryFile {
+	mf := MemoryFile{Path: path}
+
+	fm, body, ok, warn := splitFrontmatter(raw)
+	if !ok {
+		mf.FrontmatterOK = false
+		mf.ParseWarning = warn
+		mf.Body = string(raw)
+		mf.BodySHA256 = sha256Hex(raw)
+		mf.MachineLocalOptOut = hasMachineLocalComment(string(raw))
+		return mf
+	}
+
+	var header struct {
+		Name        string         `yaml:"name"`
+		Description string         `yaml:"description"`
+		Type        string         `yaml:"type"`
+		Metadata    map[string]any `yaml:"metadata"`
+	}
+
+	if err := yaml.Unmarshal(fm, &header); err != nil {
+		mf.FrontmatterOK = false
+		mf.ParseWarning = fmt.Sprintf("frontmatter YAML parse error: %v", err)
+		mf.Body = string(raw)
+		mf.BodySHA256 = sha256Hex(raw)
+		mf.MachineLocalOptOut = hasMachineLocalComment(string(raw))
+		return mf
+	}
+
+	mf.FrontmatterOK = true
+	mf.Name = header.Name
+	mf.Description = header.Description
+	mf.Type = header.Type
+	mf.Metadata = header.Metadata
+	mf.Body = string(body)
+	mf.BodySHA256 = sha256Hex(body)
+	mf.MachineLocalOptOut = hasMachineLocalComment(string(body))
+	return mf
+}
+
+// splitFrontmatter splits raw file bytes into (frontmatter, body, ok,
+// warning). A file without a leading `---\n` returns ok=false and the
+// caller treats the whole file as body. An unterminated frontmatter
+// block (opening `---` without a closing `---`) also returns ok=false.
+//
+// The frontmatter bytes contain only the YAML between the delimiters
+// (delimiters excluded). The body bytes begin on the line after the
+// closing `---`.
+func splitFrontmatter(raw []byte) (fm []byte, body []byte, ok bool, warning string) {
+	// Normalise CRLF → LF so the delimiter check works on Windows-
+	// edited files.
+	raw = bytes.ReplaceAll(raw, []byte("\r\n"), []byte("\n"))
+
+	const delim = "---\n"
+	const delimEnd = "---"
+
+	if !bytes.HasPrefix(raw, []byte(delim)) {
+		// Also accept bare "---" at start of file (no trailing newline
+		// edge case seen on some editors).
+		if !bytes.HasPrefix(raw, []byte(delimEnd)) {
+			return nil, nil, false, "no frontmatter delimiter found"
+		}
+	}
+
+	// Strip the opening "---\n".
+	rest := raw[len(delim):]
+
+	// Find the closing "---" on its own line.
+	closeIdx := bytes.Index(rest, []byte("\n---\n"))
+	if closeIdx == -1 {
+		// Try closing at EOF: "...\n---" (no trailing newline).
+		if bytes.HasSuffix(rest, []byte("\n---")) {
+			closeIdx = len(rest) - len("\n---")
+			fm = rest[:closeIdx]
+			// body is empty after a "---" at EOF.
+			return fm, []byte{}, true, ""
+		}
+		return nil, nil, false, "frontmatter opening '---' has no closing '---'"
+	}
+
+	fm = rest[:closeIdx]
+	// body starts after "\n---\n" (skip the 5-byte sequence).
+	bodyStart := closeIdx + len("\n---\n")
+	if bodyStart > len(rest) {
+		bodyStart = len(rest)
+	}
+	body = rest[bodyStart:]
+	return fm, body, true, ""
+}
+
+// hasMachineLocalComment reports whether s contains the exact HTML
+// comment <!-- meho:machine-local --> allowing arbitrary whitespace
+// between the tokens (case-sensitive tag name).
+//
+// Valid forms:
+//
+//	<!-- meho:machine-local -->
+//	<!--meho:machine-local-->
+//	<!--  meho:machine-local  -->
+func hasMachineLocalComment(s string) bool {
+	const open = "<!--"
+	const tag = "meho:machine-local"
+	const close = "-->"
+
+	idx := 0
+	for {
+		start := strings.Index(s[idx:], open)
+		if start == -1 {
+			return false
+		}
+		start += idx
+		end := strings.Index(s[start:], close)
+		if end == -1 {
+			return false
+		}
+		end += start + len(close)
+
+		inner := s[start+len(open) : end-len(close)]
+		if strings.TrimSpace(inner) == tag {
+			return true
+		}
+		idx = end
+	}
+}
+
+// sha256Hex returns the lowercase hex-encoded SHA-256 digest of b.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/cli/internal/migrate/scan.go
+++ b/cli/internal/migrate/scan.go
@@ -245,7 +245,7 @@ func splitFrontmatter(raw []byte) (fm []byte, body []byte, ok bool, warning stri
 func hasMachineLocalComment(s string) bool {
 	const open = "<!--"
 	const tag = "meho:machine-local"
-	const close = "-->"
+	const closeDelim = "-->"
 
 	idx := 0
 	for {
@@ -254,12 +254,12 @@ func hasMachineLocalComment(s string) bool {
 			return false
 		}
 		start += idx
-		// Search for close strictly after the open delimiter so that a
+		// Search for closeDelim strictly after the open delimiter so that a
 		// degenerate comment like <!--> or <!--->, whose --> shares
 		// characters with the opening <!--, cannot produce a negative
 		// inner slice range and panic.
 		innerStart := start + len(open)
-		rel := strings.Index(s[innerStart:], close)
+		rel := strings.Index(s[innerStart:], closeDelim)
 		if rel == -1 {
 			return false
 		}
@@ -267,7 +267,7 @@ func hasMachineLocalComment(s string) bool {
 		if strings.TrimSpace(s[innerStart:innerEnd]) == tag {
 			return true
 		}
-		idx = innerEnd + len(close)
+		idx = innerEnd + len(closeDelim)
 	}
 }
 

--- a/cli/internal/migrate/scan_test.go
+++ b/cli/internal/migrate/scan_test.go
@@ -4,7 +4,6 @@
 package migrate
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -239,12 +238,12 @@ func TestHasMachineLocalComment_DegenerateComments(t *testing.T) {
 		input string
 		want  bool
 	}{
-		{"bare <!-->"                  , "<!-->"                        , false},
-		{"bare <!--->"                 , "<!--->"                       , false},
-		{"inline x <!---> y"          , "x <!---> y"                   , false},
-		{"empty proper comment <!---->", "<!---->"                      , false},
-		{"valid opt-out"              , "<!-- meho:machine-local -->"   , true},
-		{"valid with extra whitespace", "<!--  meho:machine-local  -->" , true},
+		{"bare <!-->", "<!-->", false},
+		{"bare <!--->", "<!--->", false},
+		{"inline x <!---> y", "x <!---> y", false},
+		{"empty proper comment <!---->", "<!---->", false},
+		{"valid opt-out", "<!-- meho:machine-local -->", true},
+		{"valid with extra whitespace", "<!--  meho:machine-local  -->", true},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -287,7 +286,7 @@ func TestBodySHA256_IsHex(t *testing.T) {
 	content := "---\ntype: user\n---\nbody\n"
 	mf := parseMemoryFile("/tmp/a.md", []byte(content))
 	for _, c := range mf.BodySHA256 {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("BodySHA256 is not lowercase hex: %q", mf.BodySHA256)
 			return
 		}
@@ -417,7 +416,7 @@ func TestResolveSourceDir_LeadingDashRetained(t *testing.T) {
 	if sanitized[0] != '-' {
 		t.Errorf("leading '/' must become leading '-'; got %q", sanitized)
 	}
-	want := fmt.Sprintf("-a-b-c")
+	want := "-a-b-c"
 	if sanitized != want {
 		t.Errorf("sanitized: got %q want %q", sanitized, want)
 	}

--- a/cli/internal/migrate/scan_test.go
+++ b/cli/internal/migrate/scan_test.go
@@ -225,6 +225,39 @@ func TestParseMemoryFile(t *testing.T) {
 }
 
 // --------------------------------------------------------------------
+// hasMachineLocalComment degenerate-comment regression tests
+// --------------------------------------------------------------------
+
+// TestHasMachineLocalComment_DegenerateComments guards against the
+// slice-bounds panic that arises when --> shares characters with the
+// opening <!-- (e.g. <!-->  or <!-->). The fix anchors the close
+// search to start strictly after the four-byte <!-- so the inner
+// range [innerStart:innerEnd] can never be negative.
+func TestHasMachineLocalComment_DegenerateComments(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"bare <!-->"                  , "<!-->"                        , false},
+		{"bare <!--->"                 , "<!--->"                       , false},
+		{"inline x <!---> y"          , "x <!---> y"                   , false},
+		{"empty proper comment <!---->", "<!---->"                      , false},
+		{"valid opt-out"              , "<!-- meho:machine-local -->"   , true},
+		{"valid with extra whitespace", "<!--  meho:machine-local  -->" , true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasMachineLocalComment(tc.input)
+			if got != tc.want {
+				t.Errorf("hasMachineLocalComment(%q) = %v; want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------
 // BodySHA256 stability tests
 // --------------------------------------------------------------------
 

--- a/cli/internal/migrate/scan_test.go
+++ b/cli/internal/migrate/scan_test.go
@@ -89,6 +89,15 @@ func TestSplitFrontmatter_EmptyBody(t *testing.T) {
 	}
 }
 
+func TestSplitFrontmatter_BareDelimiterNoPanic(t *testing.T) {
+	// A bare "---" (3 bytes, no newline, no closing delimiter) must not
+	// panic and must return ok=false. Regression for the stripLen bug.
+	_, _, ok, _ := splitFrontmatter([]byte("---"))
+	if ok {
+		t.Fatal("expected ok=false for bare 3-byte '---' input")
+	}
+}
+
 // --------------------------------------------------------------------
 // parseMemoryFile table-driven tests
 // --------------------------------------------------------------------

--- a/cli/internal/migrate/scan_test.go
+++ b/cli/internal/migrate/scan_test.go
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --------------------------------------------------------------------
+// helpers
+// --------------------------------------------------------------------
+
+// writeFile creates a file in dir with the given content.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeFile %q: %v", path, err)
+	}
+	return path
+}
+
+// --------------------------------------------------------------------
+// splitFrontmatter unit tests
+// --------------------------------------------------------------------
+
+func TestSplitFrontmatter_WellFormed(t *testing.T) {
+	input := "---\nname: foo\ntype: user\n---\nbody text\n"
+	fm, body, ok, warn := splitFrontmatter([]byte(input))
+	if !ok {
+		t.Fatalf("expected ok=true, warning=%q", warn)
+	}
+	if want := "name: foo\ntype: user"; string(fm) != want {
+		t.Errorf("fm: got %q want %q", fm, want)
+	}
+	if want := "body text\n"; string(body) != want {
+		t.Errorf("body: got %q want %q", body, want)
+	}
+}
+
+func TestSplitFrontmatter_NoDelimiter(t *testing.T) {
+	input := "just body text\n"
+	_, _, ok, warn := splitFrontmatter([]byte(input))
+	if ok {
+		t.Fatal("expected ok=false for file without delimiter")
+	}
+	if warn == "" {
+		t.Error("expected a warning message")
+	}
+}
+
+func TestSplitFrontmatter_Unterminated(t *testing.T) {
+	input := "---\nname: foo\ntype: user\n"
+	_, _, ok, warn := splitFrontmatter([]byte(input))
+	if ok {
+		t.Fatal("expected ok=false for unterminated frontmatter")
+	}
+	if !strings.Contains(warn, "closing") {
+		t.Errorf("expected warning to mention closing delimiter; got %q", warn)
+	}
+}
+
+func TestSplitFrontmatter_BadIndentation(t *testing.T) {
+	// Malformed YAML but valid delimiter structure; splitFrontmatter
+	// should still return ok=true — YAML parse happens later.
+	input := "---\n\tbad: indentation\n---\nbody\n"
+	fm, _, ok, _ := splitFrontmatter([]byte(input))
+	if !ok {
+		t.Fatal("expected ok=true from splitFrontmatter for valid delimiters")
+	}
+	if !strings.Contains(string(fm), "bad: indentation") {
+		t.Errorf("expected fm to contain the raw content; got %q", fm)
+	}
+}
+
+func TestSplitFrontmatter_EmptyBody(t *testing.T) {
+	input := "---\nname: x\n---\n"
+	_, body, ok, _ := splitFrontmatter([]byte(input))
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if len(body) != 0 {
+		t.Errorf("expected empty body; got %q", body)
+	}
+}
+
+// --------------------------------------------------------------------
+// parseMemoryFile table-driven tests
+// --------------------------------------------------------------------
+
+type parseFMCase struct {
+	name          string
+	content       string
+	wantFMOK      bool
+	wantType      string
+	wantName      string
+	wantWarning   bool
+	wantBodyPart  string
+	wantMachLocal bool
+}
+
+var parseFMCases = []parseFMCase{
+	{
+		name:         "well-formed user type",
+		content:      "---\nname: My Rule\ndescription: always do X\ntype: user\n---\nbody text\n",
+		wantFMOK:     true,
+		wantType:     "user",
+		wantName:     "My Rule",
+		wantBodyPart: "body text",
+	},
+	{
+		name:         "well-formed project type",
+		content:      "---\nname: Project Rule\ntype: project\n---\nproject body\n",
+		wantFMOK:     true,
+		wantType:     "project",
+		wantName:     "Project Rule",
+		wantBodyPart: "project body",
+	},
+	{
+		name:         "well-formed reference type",
+		content:      "---\nname: Ref\ntype: reference\n---\nref body\n",
+		wantFMOK:     true,
+		wantType:     "reference",
+		wantName:     "Ref",
+		wantBodyPart: "ref body",
+	},
+	{
+		name:     "well-formed feedback type",
+		content:  "---\ntype: feedback\nname: Feedback\n---\nfb\n",
+		wantFMOK: true,
+		wantType: "feedback",
+	},
+	{
+		name:        "missing frontmatter",
+		content:     "just plain markdown\nno frontmatter\n",
+		wantFMOK:    false,
+		wantWarning: true,
+		// Body is the entire file when no frontmatter.
+		wantBodyPart: "just plain markdown",
+	},
+	{
+		name:        "malformed YAML bad indentation",
+		content:     "---\n\tbad indentation:\n---\nbody after bad yaml\n",
+		wantFMOK:    false,
+		wantWarning: true,
+	},
+	{
+		name:        "unterminated frontmatter",
+		content:     "---\nname: x\ntype: user\n",
+		wantFMOK:    false,
+		wantWarning: true,
+		// whole file is body
+		wantBodyPart: "name: x",
+	},
+	{
+		name:          "machine-local comment in body",
+		content:       "---\nname: local\ntype: user\n---\n<!-- meho:machine-local -->\nsome text\n",
+		wantFMOK:      true,
+		wantMachLocal: true,
+	},
+	{
+		name:          "machine-local comment absent",
+		content:       "---\nname: normal\ntype: user\n---\nnormal body\n",
+		wantFMOK:      true,
+		wantMachLocal: false,
+	},
+	{
+		name:          "machine-local comment with extra whitespace",
+		content:       "---\ntype: user\n---\n<!--  meho:machine-local  -->\n",
+		wantFMOK:      true,
+		wantMachLocal: true,
+	},
+	{
+		name:          "machine-local comment missing when opt-out absent",
+		content:       "---\ntype: user\n---\n<!-- not-the-tag -->\n",
+		wantFMOK:      true,
+		wantMachLocal: false,
+	},
+}
+
+func TestParseMemoryFile(t *testing.T) {
+	for _, tc := range parseFMCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			mf := parseMemoryFile("/tmp/test.md", []byte(tc.content))
+
+			if mf.FrontmatterOK != tc.wantFMOK {
+				t.Errorf("FrontmatterOK: got %v want %v (warning=%q)",
+					mf.FrontmatterOK, tc.wantFMOK, mf.ParseWarning)
+			}
+			if tc.wantType != "" && mf.Type != tc.wantType {
+				t.Errorf("Type: got %q want %q", mf.Type, tc.wantType)
+			}
+			if tc.wantName != "" && mf.Name != tc.wantName {
+				t.Errorf("Name: got %q want %q", mf.Name, tc.wantName)
+			}
+			if tc.wantWarning && mf.ParseWarning == "" {
+				t.Error("expected ParseWarning to be set")
+			}
+			if !tc.wantWarning && mf.ParseWarning != "" {
+				t.Errorf("unexpected ParseWarning: %q", mf.ParseWarning)
+			}
+			if tc.wantBodyPart != "" && !strings.Contains(mf.Body, tc.wantBodyPart) {
+				t.Errorf("Body: expected to contain %q; got %q", tc.wantBodyPart, mf.Body)
+			}
+			if mf.MachineLocalOptOut != tc.wantMachLocal {
+				t.Errorf("MachineLocalOptOut: got %v want %v", mf.MachineLocalOptOut, tc.wantMachLocal)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------
+// BodySHA256 stability tests
+// --------------------------------------------------------------------
+
+func TestBodySHA256_StableAcrossCalls(t *testing.T) {
+	content := "---\ntype: user\n---\nstable body content\n"
+	a := parseMemoryFile("/tmp/a.md", []byte(content))
+	b := parseMemoryFile("/tmp/a.md", []byte(content))
+	if a.BodySHA256 != b.BodySHA256 {
+		t.Errorf("BodySHA256 not stable: %q vs %q", a.BodySHA256, b.BodySHA256)
+	}
+	if a.BodySHA256 == "" {
+		t.Error("BodySHA256 must not be empty")
+	}
+}
+
+func TestBodySHA256_ChangesWhenBodyChanges(t *testing.T) {
+	c1 := "---\ntype: user\n---\nbody v1\n"
+	c2 := "---\ntype: user\n---\nbody v2\n"
+	mf1 := parseMemoryFile("/tmp/a.md", []byte(c1))
+	mf2 := parseMemoryFile("/tmp/a.md", []byte(c2))
+	if mf1.BodySHA256 == mf2.BodySHA256 {
+		t.Error("BodySHA256 must differ when body content changes")
+	}
+}
+
+func TestBodySHA256_IsHex(t *testing.T) {
+	content := "---\ntype: user\n---\nbody\n"
+	mf := parseMemoryFile("/tmp/a.md", []byte(content))
+	for _, c := range mf.BodySHA256 {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("BodySHA256 is not lowercase hex: %q", mf.BodySHA256)
+			return
+		}
+	}
+	if len(mf.BodySHA256) != 64 {
+		t.Errorf("BodySHA256 expected 64 chars (SHA-256 hex); got %d: %q",
+			len(mf.BodySHA256), mf.BodySHA256)
+	}
+}
+
+// --------------------------------------------------------------------
+// ScanDir tests
+// --------------------------------------------------------------------
+
+func TestScanDir_ReturnsOnlyMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.md", "---\ntype: user\n---\nbody a\n")
+	writeFile(t, dir, "b.txt", "ignored")
+	writeFile(t, dir, "c.md", "---\ntype: project\n---\nbody c\n")
+
+	files, err := ScanDir(dir)
+	if err != nil {
+		t.Fatalf("ScanDir: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files; got %d", len(files))
+	}
+}
+
+func TestScanDir_NonExistentDir(t *testing.T) {
+	_, err := ScanDir(filepath.Join(t.TempDir(), "no-such-dir"))
+	if err == nil {
+		t.Error("expected error for non-existent dir")
+	}
+}
+
+func TestScanDir_NonRecursive(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "top.md", "---\ntype: user\n---\ntop\n")
+	writeFile(t, subdir, "nested.md", "---\ntype: user\n---\nnested\n")
+
+	files, err := ScanDir(dir)
+	if err != nil {
+		t.Fatalf("ScanDir: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 file (non-recursive); got %d", len(files))
+	}
+	if !strings.HasSuffix(files[0].Path, "top.md") {
+		t.Errorf("expected top.md; got %q", files[0].Path)
+	}
+}
+
+// --------------------------------------------------------------------
+// ResolveSourceDir tests
+// --------------------------------------------------------------------
+
+func TestResolveSourceDir_Explicit(t *testing.T) {
+	got, err := ResolveSourceDir("/explicit/path")
+	if err != nil {
+		t.Fatalf("ResolveSourceDir: %v", err)
+	}
+	if got != "/explicit/path" {
+		t.Errorf("expected /explicit/path; got %q", got)
+	}
+}
+
+func TestResolveSourceDir_CLAUDE_PROJECT_DIR(t *testing.T) {
+	t.Setenv("CLAUDE_PROJECT_DIR", "/some/project")
+	got, err := ResolveSourceDir("")
+	if err != nil {
+		t.Fatalf("ResolveSourceDir: %v", err)
+	}
+	want := "/some/project/memory"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestResolveSourceDir_HomeDir_LeadingDash(t *testing.T) {
+	// Unset CLAUDE_PROJECT_DIR so the home-dir fallback runs.
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+
+	// Override HOME to a known temp dir so the test is hermetic.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// The current working directory is whatever the test runner sets.
+	// We pin a known abs path by overriding $HOME and constructing the
+	// expected sanitized form from the real cwd.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+
+	got, err := ResolveSourceDir("")
+	if err != nil {
+		t.Fatalf("ResolveSourceDir: %v", err)
+	}
+
+	sanitized := strings.ReplaceAll(cwd, "/", "-")
+	want := filepath.Join(home, ".claude", "projects", sanitized, "memory")
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestResolveSourceDir_LeadingDashRetained(t *testing.T) {
+	// Pins the exact transform documented in the function's doc comment:
+	// /a/b/c → <home>/.claude/projects/-a-b-c/memory
+	//
+	// This test exercises the transform by constructing the expected
+	// result from a known absolute path "/a/b/c".
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// We can't change os.Getwd(), so we verify the transform function
+	// itself rather than round-tripping through ResolveSourceDir with
+	// a controlled cwd.
+	path := "/a/b/c"
+	sanitized := strings.ReplaceAll(path, "/", "-")
+	if sanitized[0] != '-' {
+		t.Errorf("leading '/' must become leading '-'; got %q", sanitized)
+	}
+	want := fmt.Sprintf("-a-b-c")
+	if sanitized != want {
+		t.Errorf("sanitized: got %q want %q", sanitized, want)
+	}
+
+	// And verify the full path template.
+	full := filepath.Join(home, ".claude", "projects", sanitized, "memory")
+	wantFull := filepath.Join(home, ".claude", "projects", "-a-b-c", "memory")
+	if full != wantFull {
+		t.Errorf("full path: got %q want %q", full, wantFull)
+	}
+}

--- a/cli/internal/migrate/suggest.go
+++ b/cli/internal/migrate/suggest.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+// Canonical scope tokens shared by the T4 picker and T5 submission.
+// Define them here so there is one source of truth and callers can
+// compare with == rather than with magic strings.
+const (
+	// ScopeUser is the safest default — entry visible only to the
+	// authenticated user across all tenants they belong to.
+	ScopeUser = "user"
+
+	// ScopeUserTenant scopes the entry to the user within a specific
+	// tenant. Suggested for `type: project` when a tenant backplane is
+	// configured.
+	ScopeUserTenant = "user×tenant"
+
+	// ScopeUserTarget scopes the entry to the user within a specific
+	// target system.
+	ScopeUserTarget = "user×target"
+
+	// ScopeTenant scopes the entry to the entire tenant (all users).
+	ScopeTenant = "tenant"
+
+	// ScopeTarget scopes the entry to a specific target system
+	// (all users in the tenant).
+	ScopeTarget = "target"
+)
+
+// SuggestScope returns the recommended canonical scope token for m
+// based on its frontmatter type and whether a tenant backplane is
+// configured.
+//
+// Mapping table (deterministic; no AI inference — see Initiative #375
+// and ai_engineering_best_practices §Architecture-&-boundaries):
+//
+//   - type "user" or "feedback" → ScopeUser
+//   - type "project"            → ScopeUserTenant if tenantConfigured, else ScopeUser
+//   - type "reference"          → ScopeUser
+//   - any other / empty type    → ScopeUser (safest default; T4 surfaces as overridable)
+//
+// The returned value is always one of the exported Scope* constants.
+func SuggestScope(m MemoryFile, tenantConfigured bool) string {
+	switch m.Type {
+	case "user", "feedback":
+		return ScopeUser
+	case "project":
+		if tenantConfigured {
+			return ScopeUserTenant
+		}
+		return ScopeUser
+	case "reference":
+		return ScopeUser
+	default:
+		return ScopeUser
+	}
+}

--- a/cli/internal/migrate/suggest_test.go
+++ b/cli/internal/migrate/suggest_test.go
@@ -53,7 +53,7 @@ func TestSuggestScope(t *testing.T) {
 }
 
 // TestScopeConstantsAreDistinct guards against accidental equal values.
-func TestScopeCostantsAreDistinct(t *testing.T) {
+func TestScopeConstantsAreDistinct(t *testing.T) {
 	all := []string{ScopeUser, ScopeUserTenant, ScopeUserTarget, ScopeTenant, ScopeTarget}
 	seen := map[string]bool{}
 	for _, s := range all {

--- a/cli/internal/migrate/suggest_test.go
+++ b/cli/internal/migrate/suggest_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package migrate
+
+import (
+	"testing"
+)
+
+// TestSuggestScope exercises the full mapping table including the
+// tenantConfigured branch for type "project" and the unknown-type
+// fallback.
+func TestSuggestScope(t *testing.T) {
+	cases := []struct {
+		name             string
+		memType          string
+		tenantConfigured bool
+		want             string
+	}{
+		// type: user → ScopeUser regardless of tenant.
+		{name: "user no tenant", memType: "user", tenantConfigured: false, want: ScopeUser},
+		{name: "user with tenant", memType: "user", tenantConfigured: true, want: ScopeUser},
+
+		// type: feedback → ScopeUser.
+		{name: "feedback no tenant", memType: "feedback", tenantConfigured: false, want: ScopeUser},
+		{name: "feedback with tenant", memType: "feedback", tenantConfigured: true, want: ScopeUser},
+
+		// type: project → ScopeUserTenant when tenant configured, ScopeUser otherwise.
+		{name: "project no tenant", memType: "project", tenantConfigured: false, want: ScopeUser},
+		{name: "project with tenant", memType: "project", tenantConfigured: true, want: ScopeUserTenant},
+
+		// type: reference → ScopeUser.
+		{name: "reference no tenant", memType: "reference", tenantConfigured: false, want: ScopeUser},
+		{name: "reference with tenant", memType: "reference", tenantConfigured: true, want: ScopeUser},
+
+		// unknown type → ScopeUser (safe default).
+		{name: "unknown empty", memType: "", tenantConfigured: false, want: ScopeUser},
+		{name: "unknown string", memType: "something-else", tenantConfigured: false, want: ScopeUser},
+		{name: "unknown with tenant", memType: "custom", tenantConfigured: true, want: ScopeUser},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			mf := MemoryFile{Type: tc.memType}
+			got := SuggestScope(mf, tc.tenantConfigured)
+			if got != tc.want {
+				t.Errorf("SuggestScope(type=%q, tenant=%v): got %q want %q",
+					tc.memType, tc.tenantConfigured, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScopeConstantsAreDistinct guards against accidental equal values.
+func TestScopeCostantsAreDistinct(t *testing.T) {
+	all := []string{ScopeUser, ScopeUserTenant, ScopeUserTarget, ScopeTenant, ScopeTarget}
+	seen := map[string]bool{}
+	for _, s := range all {
+		if seen[s] {
+			t.Errorf("duplicate scope constant value: %q", s)
+		}
+		seen[s] = true
+	}
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -162,7 +162,7 @@ cli/
     │   │   └── retire_checklist_test.go # surface-bucket + table-render + marshal tests.
     │   ├── migrate/           # G5.3 #608–#611 — `meho migrate …` laptop-local migration verb tree (Initiative #375).
     │   │   ├── migrate.go        # NewRootCmd + _ import charm.land/huh/v2.
-    │   │   ├── memory.go         # `meho migrate memory` RunE — interactive picker / --dry-run / --non-interactive; submitFn seam for T5 (#611).
+    │   │   ├── memory.go         # `meho migrate memory` RunE — interactive picker / --dry-run / --non-interactive; submitFn seam for T5 (#612).
     │   │   └── memory_test.go    # --dry-run envelope + source_id, --non-interactive filter, machine-local skip, empty-dir guard.
     │   ├── vmware/            # G3.1-T7 #511 — `meho vmware …` alias verb tree (connector_id="vmware-rest-9.0" pre-baked).
     │   ├── vault/             # G3.3-T6 #550 — `meho vault …` alias verb tree (connector_id="vault-1.x" pre-baked).

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -54,13 +54,14 @@ names.
   `user-tenant` / `user-target` / `tenant` / `target`. The two
   target-scoped values require `--target NAME`; the CLI rejects a
   missing `--target` client-side before the round-trip.
-- `meho migrate ...` (G5.3-T1 #608) — laptop-local memory migration
-  surface. T1 ships the `migrate` parent + `memory` subcommand skeleton
-  (flags wired, RunE stub). Flow logic (scanner, huh interactive picker,
-  dry-run preview, backplane submit, mark-migrated) lands in T2–T5 of
-  Initiative #375 (#609–#612). The `charm.land/huh/v2` interactive-form
-  library (MIT) is declared as a direct dependency in T1 and used by
-  T2–T5 for the interactive migration UX.
+- `meho migrate ...` (G5.3 #608–#611) — laptop-local memory migration
+  surface. T1 (#608) ships the `migrate` parent + `memory` subcommand
+  skeleton. T2 (#609) adds the frontmatter scanner + scope-suggestion
+  table. T3 (#610) adds the machine-local detector. T4 (#611) wires the
+  interactive `huh` picker, `--dry-run` (JSON envelopes), and
+  `--non-interactive` (user/feedback only) paths. Submission (POST
+  `/api/v1/memory`), post-login nudge, and marker file land in T5
+  (#612). Depends on `charm.land/huh/v2` (MIT).
 
 ## Module layout
 
@@ -159,9 +160,10 @@ cli/
     │   │   ├── usage_test.go           # query-param + wire-shape + 403/400 routing tests.
     │   │   ├── retire_checklist.go     # `meho retrieval retire-checklist` (POST /api/v1/retrieve/retire-checklist) — G4.3-T6 #445.
     │   │   └── retire_checklist_test.go # surface-bucket + table-render + marshal tests.
-    │   ├── migrate/           # G5.3-T1 #608 — `meho migrate …` laptop-local migration verb tree (Initiative #375).
-    │   │   ├── migrate.go        # NewRootCmd + _ import charm.land/huh/v2 (declares dep; used by T2–T5).
-    │   │   └── memory.go         # `meho migrate memory` skeleton — 5 flags wired, RunE stub.
+    │   ├── migrate/           # G5.3 #608–#611 — `meho migrate …` laptop-local migration verb tree (Initiative #375).
+    │   │   ├── migrate.go        # NewRootCmd + _ import charm.land/huh/v2.
+    │   │   ├── memory.go         # `meho migrate memory` RunE — interactive picker / --dry-run / --non-interactive; submitFn seam for T5 (#611).
+    │   │   └── memory_test.go    # --dry-run envelope + source_id, --non-interactive filter, machine-local skip, empty-dir guard.
     │   ├── vmware/            # G3.1-T7 #511 — `meho vmware …` alias verb tree (connector_id="vmware-rest-9.0" pre-baked).
     │   ├── vault/             # G3.3-T6 #550 — `meho vault …` alias verb tree (connector_id="vault-1.x" pre-baked).
     │   └── topology/          # G9.1-T6 #454 + G9.2-T6 #599 — `meho topology refresh/dependents/dependencies/path/annotate/unannotate/list-edges` over the T5 REST surface (#453, #597).
@@ -173,9 +175,12 @@ cli/
     │       ├── auth.go           # `meho vault auth userpass/approle list+read` (vault.auth.* ops, #547).
     │       └── vault_test.go     # helpers + verb-tree wiring + flag→params wire-shape + e2e mocked-backplane tests.
     ├── migrate/               # G5.3 — pure-logic helpers for the memory migration flow (Initiative #375).
-    │   ├── doc.go                # package doc; flow helpers land in T2–T5 (#609–#612).
+    │   ├── doc.go                # package doc.
     │   ├── machinelocal.go       # DetectMachineLocal — heuristic detector for laptop-local content (#610).
     │   ├── machinelocal_test.go  # table-driven per-Category tests + truncation + seam coverage (#610).
+    │   ├── marker.go             # TouchMarker / MarkerExists — migration-complete marker file (T5 stub in T4, #611; full impl #612).
+    │   ├── picker.go             # G5.3-T4 #611 — BuildForm (huh), SubmitPlan, FinalizeSkip, DefaultPlan, slugFromPath, scope/action option builders.
+    │   ├── picker_test.go        # slug, validateSlug, BuildForm structure, role-filtered scope options, FinalizeSkip, DefaultPlan.
     │   ├── scan.go               # G5.3-T2 #609 — ResolveSourceDir + ScanDir + MemoryFile (frontmatter parser + BodySHA256 + MachineLocalOptOut).
     │   ├── scan_test.go          # table-driven: well-formed/missing/malformed frontmatter, machine-local comment, BodySHA256 stability, ScanDir, ResolveSourceDir.
     │   ├── suggest.go            # G5.3-T2 #609 — SuggestScope table + exported Scope* constants.

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -172,10 +172,14 @@ cli/
     │       ├── sys.go            # `meho vault sys health|seal-status|mounts-list|auth-list` (vault.sys.* ops, #546).
     │       ├── auth.go           # `meho vault auth userpass/approle list+read` (vault.auth.* ops, #547).
     │       └── vault_test.go     # helpers + verb-tree wiring + flag→params wire-shape + e2e mocked-backplane tests.
-    ├── migrate/               # G5.3 Initiative #375 — pure-logic helpers for the memory migration flow.
-    │   ├── doc.go                # package declaration + overview comment.
+    ├── migrate/               # G5.3 — pure-logic helpers for the memory migration flow (Initiative #375).
+    │   ├── doc.go                # package doc; flow helpers land in T2–T5 (#609–#612).
     │   ├── machinelocal.go       # DetectMachineLocal — heuristic detector for laptop-local content (#610).
-    │   └── machinelocal_test.go  # table-driven per-Category tests + truncation + seam coverage (#610).
+    │   ├── machinelocal_test.go  # table-driven per-Category tests + truncation + seam coverage (#610).
+    │   ├── scan.go               # G5.3-T2 #609 — ResolveSourceDir + ScanDir + MemoryFile (frontmatter parser + BodySHA256 + MachineLocalOptOut).
+    │   ├── scan_test.go          # table-driven: well-formed/missing/malformed frontmatter, machine-local comment, BodySHA256 stability, ScanDir, ResolveSourceDir.
+    │   ├── suggest.go            # G5.3-T2 #609 — SuggestScope table + exported Scope* constants.
+    │   └── suggest_test.go       # full mapping table including tenantConfigured branch and unknown-type fallback.
     ├── discovery/
     │   ├── discovery.go       # /api/v1/commands manifest fetch + cobra graft.
     │   └── discovery_test.go  # 200/404/transport/decode + collision tests.


### PR DESCRIPTION
Closes #611
Closes #609

Depends-on: #608, #610

> **Note on #609 provenance.** PR #645 (T2) was merged to `feat/608-…` rather than `main`, so T2's code (`scan.go` / `suggest.go` / `scan_test.go` / `suggest_test.go`) only reached `main` via this PR's diff. Adding `Closes #609` here so issue auto-close fires on merge; the unusual provenance is recorded in this note.

## What this does

Wires `meho migrate memory`'s `RunE` stub with the full G5.3-T4 picker flow:

**Interactive path** (default): builds a `huh.NewForm` over the `ScanDir` output. Per-file group structure:
- `huh.NewNote` header (filename + first 200 chars of body + machine-local badge)
- `huh.NewSelect[string]` action: Migrate to `<suggested-scope>` / Migrate to a different scope… / Migrate (edit body first) / Skip (keep laptop-local) / Skip — machine-local
- Hidden `huh.NewGroup` scope picker (via `WithHideFunc`) with role-aware options: `user`/`user×tenant`/`user×target` always present; `tenant`/`target` only when `IsTenantAdmin=true`
- `huh.NewInput` slug (validates `^[a-z0-9][a-z0-9-]*$`)
- Hidden `huh.NewGroup` body-edit text, revealed for the "edit" action variant
- Final `huh.NewConfirm`

`MEHO_ACCESSIBLE=1` activates `form.WithAccessible(true)`.

**`--dry-run`**: prints one JSON envelope per migrate-selected file (default plan, no form, no network). `source_id = "laptop-migration/<12 hex chars of SHA-256 body>"` — same constant used by T5 POST for idempotency.

**`--non-interactive`**: migrates only `type:user` and `type:feedback`; prints stderr refusal + exits non-zero for `project`/`reference`; always skips machine-local regardless of `--include-machine-local`.

**`submitFn` seam**: `newMemoryCmdWithSubmit(fn)` lets T5 inject the real backplane POST without touching `RunE`.

## New files
- `cli/internal/migrate/picker.go` — `BuildForm`, `SubmitPlan`, `FinalizeSkip`, `DefaultPlan`, `slugFromPath`, scope/action option builders
- `cli/internal/migrate/picker_test.go` — slug, validate, BuildForm structure, role-filtered scopes, FinalizeSkip, DefaultPlan
- `cli/internal/migrate/marker.go` — `TouchMarker`/`MarkerExists` stubs (full impl T5)
- `cli/internal/cmd/migrate/memory_test.go` — dry-run envelope + source_id, non-interactive filter, machine-local skip, empty-dir guard

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/migrate/... ./internal/cmd/migrate/...` — all pass
- [ ] CI green (depends on T1/T2/T3 merging; branch based on T3 branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory migration CLI: preview JSON (--dry-run) with stable source IDs, non-interactive submission, and interactive form-based selection; optional include-machine-local flag and migration-complete marker touch.
* **Bug Fixes / Behavior**
  * Machine-local entries are skipped by default; parsing is tolerant of malformed frontmatter with warnings.
* **Tests**
  * Extensive unit/integration tests for scanning, parsing, ID stability, picker logic, and CLI modes.
* **Documentation**
  * CLI docs updated to cover migration flows, dry-run output, and interactive picker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
