### PR TITLE
fix(topology): key node-reconcile on tenant-wide natural key (#673)

### DIFF
--- a/backend/src/meho_backplane/topology/refresh.py
+++ b/backend/src/meho_backplane/topology/refresh.py
@@ -45,7 +45,7 @@ from typing import Any
 
 import structlog
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select
+from sqlalchemy import false, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator
@@ -99,7 +99,18 @@ class RefreshResult(BaseModel):
 
 
 def _node_key(kind: str, name: str) -> tuple[str, str]:
-    """Natural key for a node within a ``(tenant_id, target scope)``."""
+    """Natural key for a node within a tenant.
+
+    ``graph_node`` is unique on ``(tenant_id, kind, name)`` — the
+    ``graph_node_tenant_kind_name_idx`` index is **target-independent**.
+    A node can therefore already exist in the tenant under a different
+    ``target_id`` (discovered by another target) or under
+    ``target_id IS NULL`` (a manually-annotated node — see
+    :func:`meho_backplane.topology.resolvers.resolve_node`). The
+    reconcile must key its upsert decision on this tenant-wide grain,
+    not on the per-target scope, or a node the snapshot re-asserts
+    collides with the existing row on the unique index.
+    """
     return (kind, name)
 
 
@@ -189,6 +200,54 @@ def _merge_edge_properties(
     return merged
 
 
+async def _load_reconcile_candidate_nodes(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    target_id: uuid.UUID,
+    nodes: tuple[NodeHint, ...],
+) -> list[GraphNode]:
+    """Load every node a node-reconcile pass might touch, by natural key.
+
+    ``graph_node`` is unique on ``(tenant_id, kind, name)``
+    (target-independent), so the upsert decision must consider rows
+    under *any* ``target_id`` — a node discovered by this target may
+    already exist because another target discovered it, or because an
+    operator annotated it (``target_id IS NULL``). The query unions two
+    row sets within the tenant:
+
+    * rows whose ``(kind, name)`` is in the current snapshot — the
+      upsert candidates (the set the old ``target_id``-only filter
+      missed, which is the #673 collision: a re-INSERT of a row that
+      already exists under a different / NULL ``target_id`` blew the
+      unique index mid-reconcile under autoflush);
+    * rows already owned by *this* target — needed for the soft-delete
+      pass, which must stay scoped to this target so a refresh never
+      soft-deletes another target's node or a manual annotation.
+    """
+    discovered_pairs = {(n.kind, n.name) for n in nodes}
+    snapshot_predicate = (
+        tuple_(GraphNode.kind, GraphNode.name).in_(sorted(discovered_pairs))
+        if discovered_pairs
+        else false()
+    )
+    return list(
+        (
+            await session.execute(
+                select(GraphNode).where(
+                    GraphNode.tenant_id == tenant_id,
+                    or_(
+                        snapshot_predicate,
+                        GraphNode.target_id == target_id,
+                    ),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
 async def _reconcile_nodes(
     session: AsyncSession,
     *,
@@ -210,23 +269,15 @@ async def _reconcile_nodes(
       (inserted or kept). The edge pass resolves *discovered* edge
       endpoints through this map; an edge pointing at a node the
       current discovery dropped is itself dropped (soft-deleted).
-    * ``all_key_to_id`` — every node in the ``(tenant, target)`` scope,
-      including ones soft-deleted this refresh or on a prior one. The
-      edge pass needs this to map an *existing* edge's ``from/to`` node
-      ids back to keys so it can decide whether that edge is still
-      discovered (and to soft-delete it when it is not).
+    * ``all_key_to_id`` — every loaded node (see
+      :func:`_load_reconcile_candidate_nodes`), including ones
+      soft-deleted this refresh or on a prior one. The edge pass needs
+      this to map an *existing* edge's ``from/to`` node ids back to keys
+      so it can decide whether that edge is still discovered (and to
+      soft-delete it when it is not).
     """
-    existing_rows = (
-        (
-            await session.execute(
-                select(GraphNode).where(
-                    GraphNode.tenant_id == tenant_id,
-                    GraphNode.target_id == target_id,
-                )
-            )
-        )
-        .scalars()
-        .all()
+    existing_rows = await _load_reconcile_candidate_nodes(
+        session, tenant_id=tenant_id, target_id=target_id, nodes=nodes
     )
     existing_by_key = {_node_key(r.kind, r.name): r for r in existing_rows}
 
@@ -261,15 +312,30 @@ async def _reconcile_nodes(
             all_key_to_id[key] = new_id
             added += 1
             continue
-        # Present in both — refresh last_seen, and properties when changed.
-        if row.last_seen is None or _properties_differ(row.properties, hint.properties):
+        # Present in both — refresh last_seen, and properties when
+        # changed. Also adopt the row onto this target: a node first
+        # seen as a manual annotation (``target_id IS NULL``) or
+        # discovered by another target is now observed by *this*
+        # target's probe, so this target owns its lifecycle (and its
+        # future soft-delete) going forward.
+        if (
+            row.last_seen is None
+            or row.target_id != target_id
+            or _properties_differ(row.properties, hint.properties)
+        ):
             updated += 1
         row.properties = dict(hint.properties)
+        row.target_id = target_id
         row.last_seen = now
         live_key_to_id[key] = row.id
 
     for key, row in existing_by_key.items():
         if key in discovered_by_key:
+            continue
+        if row.target_id != target_id:
+            # Owned by another target (or a manual annotation): not in
+            # this target's snapshot is expected, not a removal. The
+            # owning target's own refresh decides its fate.
             continue
         if row.last_seen is None:
             # Already soft-deleted on a prior refresh; not a fresh removal.

--- a/backend/tests/test_topology_refresh.py
+++ b/backend/tests/test_topology_refresh.py
@@ -466,3 +466,135 @@ async def test_refresh_is_tenant_scoped() -> None:
     assert len(a_nodes) == 3
     assert b_nodes == []
     assert all(n.tenant_id == tenant_a for n in a_nodes)
+
+
+# ---------------------------------------------------------------------------
+# Cross-target / manual-annotation collision (#673 regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_adopts_pre_existing_target_null_node_without_collision() -> None:
+    """A snapshot node that already exists under ``target_id IS NULL``.
+
+    ``graph_node`` is unique on ``(tenant_id, kind, name)`` — the index
+    is target-independent. A node first created as a manual annotation
+    (``target_id IS NULL``, the documented :func:`resolve_node` shape)
+    or by another target can be re-asserted by *this* target's probe.
+    The pre-#673 reconcile scoped its existing-node lookup by
+    ``target_id`` only, missed the row, issued a second INSERT for the
+    same ``(tenant, kind, name)`` and blew the unique index mid-reconcile
+    (``UniqueViolationError`` surfaced via query-invoked autoflush in
+    ``_reconcile_edges``). The fix keys the upsert on the tenant-wide
+    natural key: the existing row is **adopted** (``last_seen`` bumped,
+    ``target_id`` claimed) instead of duplicated.
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    op = _operator(tenant_id)
+
+    # Pre-seed ``vm-a`` as a manual annotation: same (tenant, kind, name)
+    # the snapshot below re-asserts, but unowned by any target.
+    sessionmaker = get_sessionmaker()
+    annotated_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphNode(
+                id=annotated_id,
+                tenant_id=tenant_id,
+                kind="vm",
+                name="vm-a",
+                target_id=None,
+                properties={},
+                discovered_by="curated",
+                first_seen=datetime.now(UTC),
+                last_seen=None,
+            )
+        )
+        await session.commit()
+
+    _FakeConnector.hints = _hints_3n2e()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        result = await refresh_target_topology(target, op)
+
+    # vm-a is adopted (updated, not added); vm-b + ds-1 are genuinely new.
+    assert result.added_nodes == 2
+    assert result.updated_nodes == 1
+    assert result.removed_nodes == 0
+    assert result.added_edges == 2
+
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(GraphNode).where(GraphNode.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+    by_name = {n.name: n for n in rows}
+    # Exactly three rows — no duplicate vm-a.
+    assert sorted(by_name) == ["ds-1", "vm-a", "vm-b"]
+    # The annotated row was adopted in place: same id, now owned by the
+    # discovering target, last_seen stamped, probe properties applied.
+    vm_a = by_name["vm-a"]
+    assert vm_a.id == annotated_id
+    assert vm_a.target_id == target.id
+    assert vm_a.last_seen is not None
+    assert vm_a.properties == {"power": "on"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_soft_delete_other_targets_nodes() -> None:
+    """The soft-delete pass stays scoped to the refreshing target.
+
+    Two targets in the same tenant. Target A discovers ``vm-a``; a later
+    refresh of target B (whose snapshot does not contain ``vm-a``) must
+    not soft-delete A's row — the widened upsert lookup must not widen
+    the removal pass.
+    """
+    _register_fake()
+    tenant_id, target_a = await _seed_tenant_and_target("tenant-x")
+    op = _operator(tenant_id)
+
+    # Second target in the same tenant.
+    sessionmaker = get_sessionmaker()
+    target_b = Target(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        name="vcenter-b",
+        aliases=[],
+        product="faketopo",
+        host="vc-b.example.test",
+    )
+    async with sessionmaker() as session:
+        session.add(target_b)
+        await session.commit()
+        await session.refresh(target_b)
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        # Target A discovers the 3n/2e snapshot.
+        _FakeConnector.hints = _hints_3n2e()
+        await refresh_target_topology(target_a, op)
+        # Target B discovers a disjoint single node.
+        _FakeConnector.hints = TopologyHints(
+            discovered_at=datetime.now(UTC),
+            nodes=(NodeHint(kind="vm", name="vm-z"),),
+            edges=(),
+        )
+        result_b = await refresh_target_topology(target_b, op)
+
+    # B added its own node and removed nothing — A's nodes are off-limits.
+    assert result_b.added_nodes == 1
+    assert result_b.removed_nodes == 0
+
+    async with sessionmaker() as session:
+        a_vm_a = (
+            await session.execute(
+                select(GraphNode).where(
+                    GraphNode.tenant_id == tenant_id,
+                    GraphNode.kind == "vm",
+                    GraphNode.name == "vm-a",
+                )
+            )
+        ).scalar_one()
+    assert a_vm_a.target_id == target_a.id
+    assert a_vm_a.last_seen is not None, "target B's refresh must not soft-delete target A's node"

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -187,15 +187,36 @@ separately via `resolve_node`.
    snapshot (nodes + edges, each with `properties`).
 3. Open one transactional session (`sessionmaker() ... session.begin()`).
 4. `_reconcile_nodes` — diff the snapshot nodes against existing
-   `graph_node` rows for `(tenant_id, target_id)`:
-   - INSERT nodes in the snapshot but not the DB.
-   - For nodes in both: refresh `last_seen`, and `properties` when they
-     changed (a no-change refresh only touches `last_seen`, so the
-     `unchanged` path reports zero `updated`).
-   - Soft-delete (set `last_seen = NULL`) nodes in the DB but absent
-     from the snapshot. A node already soft-deleted is not re-counted.
+   `graph_node` rows. The upsert decision is keyed on the **tenant-wide
+   natural key** `(tenant_id, kind, name)` — the same grain as the
+   `graph_node_tenant_kind_name_idx` unique index, which is
+   target-independent. The existing-node lookup therefore unions, within
+   the tenant, every row whose `(kind, name)` is in the snapshot **or**
+   whose `target_id` is the refreshing target's id:
+   - INSERT nodes in the snapshot with no existing `(tenant, kind, name)`
+     row.
+   - For a node already present under *any* `target_id` (another
+     target's discovery, or a manual annotation with `target_id IS
+     NULL`): refresh `last_seen`, apply the probe `properties`, and
+     **adopt** the row onto the refreshing target (`target_id` claimed)
+     so this target owns its lifecycle going forward. A no-change
+     refresh of an already-owned node only touches `last_seen`, so the
+     `unchanged` path reports zero `updated`.
+   - Soft-delete (set `last_seen = NULL`) only nodes **owned by the
+     refreshing target** (`target_id == target_id`) that are absent
+     from the snapshot. Rows owned by another target — or a manual
+     annotation — are never soft-deleted by a refresh that does not own
+     them. A node already soft-deleted is not re-counted.
    Returns two key→id maps: `live` (snapshot-present nodes only) and
-   `all` (every node in the target scope, including soft-deleted).
+   `all` (every loaded node, including soft-deleted ones owned by this
+   target).
+
+   Keying the lookup on `(tenant_id, target_id)` only was a defect
+   (#673): a snapshot node that already existed under a different /
+   `NULL` `target_id` was missed, re-INSERTed, and collided with the
+   unique index mid-reconcile (the violation surfaced as an
+   `IntegrityError` via query-invoked autoflush inside
+   `_reconcile_edges`).
 5. `_reconcile_edges` — same diff for edges, keyed by
    `(from_kind, from_name, to_kind, to_name, kind)`. Existing edges are
    loaded by `from_node_id` over the **`all`** node-id set so an edge


### PR DESCRIPTION
## Summary

- Fixes the deterministically-failing integration test
  `test_topology_annotate.py::test_conflict_same_kind_marks_auto_superseded_and_survives_refresh`
  by fixing a real defect in the topology refresh node-reconcile path.
- **Root cause: candidate (2) — a real defect, not (1) xdist contention.**
  Evidence: the CI integration lane runs `uv run pytest -x tests/integration/`
  with **no `-n auto`** (ci.yml line 337, explicitly `# Deliberately NOT
  parallelized`), and the failure reproduces in a single-test, no-xdist
  run. The asyncpg error is precise: `Key (tenant_id, kind, name)=(…, vm,
  vm-A) already exists` on `graph_node_tenant_kind_name_idx`, raised via
  query-invoked autoflush inside `_reconcile_edges`'s SELECT.
- `_reconcile_nodes` scoped its existing-node lookup by
  `(tenant_id, target_id)`, but `graph_node` is unique on
  `(tenant_id, kind, name)` — the index is target-independent. A node
  already present under a different `target_id` or under
  `target_id IS NULL` (a manually-annotated node — a documented
  `resolve_node` scenario) was missed and re-INSERTed, colliding with the
  unique index mid-reconcile. The fix keys the upsert on the true
  uniqueness grain and adopts the pre-existing row instead of duplicating
  it; the soft-delete pass stays scoped to the refreshing target.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/topology/refresh.py` — clean
- [x] `code-quality.py --diff` — 0 blockers (extracted
      `_load_reconcile_candidate_nodes` to keep `_reconcile_nodes` under
      the 100-line limit; remaining warnings are pre-existing PLR0913 /
      file-size legacy debt, not introduced here)
- [x] `pytest tests/test_topology_refresh.py` — 10 passed (8 original +
      2 new regression tests: cross-target / `target_id IS NULL`
      adoption, and target-scoped soft-delete boundary)
- [x] **AC2** `uv run pytest …::test_conflict_same_kind_marks_auto_superseded_and_survives_refresh -n auto -q`
      run **5× consecutively** against a real Postgres testcontainer —
      `1 passed` every run (deterministic):

  ```
  RUN 1: 1 passed, 13 warnings in 4.96s
  RUN 2: 1 passed, 13 warnings in 4.86s
  RUN 3: 1 passed, 13 warnings in 4.83s
  RUN 4: 1 passed, 13 warnings in 4.47s
  RUN 5: 1 passed, 13 warnings in 4.70s
  ```
- [x] 123 passed across the broader topology unit surface
      (`test_topology_refresh` / `test_topology_scheduler` /
      `test_topology_annotate` / `test_api_v1_topology` /
      `test_connectors_topology`) — no regression
- [x] **AC4** no assertion weakened, no `xfail`/`skip` added; the
      production fix is covered by the existing integration assertion
      plus the two new unit tests
- [x] **AC5** N/A — root cause is (2), so the production fix in
      `backend/src/` is expected and correct (criterion 5 only applies
      to a test-only fix)

## Out of scope

- **Pre-existing, unrelated failure (filed/trackable separately, not
  fixed here):**
  `test_topology_annotate.py::test_conflict_incompatible_kinds_persists_both_rows_with_bidirectional_markers`
  fails identically on pristine `origin/main` with a **different** root
  cause — `ck_graph_node_kind` *check*-constraint violation (its fixture
  seeds `kind="service"` / `kind="database"` nodes not in the allowed
  `_GRAPH_NODE_KINDS` enum). Distinct test, distinct constraint, never
  calls refresh, not caused by this change. The issue scopes this Task to
  `test_conflict_same_kind_marks_auto_superseded_and_survives_refresh`
  only and explicitly forbids whole-suite remediation.
- Pre-existing PLR0913 / file-size code-quality warnings on `refresh.py`
  (not introduced here).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #673


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed topology refresh failures caused by node unique key collisions when nodes already existed under different target assignments or without explicit target assignment.

* **Tests**
  * Added integration tests validating node adoption across different target contexts and ensuring isolated soft-delete behavior between targets.

* **Documentation**
  * Updated refresh logic documentation to clarify tenant-wide node key scoping and uniqueness constraint handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->