### PR TITLE
feat(connectors): G3.5-T5 SDDC Manager spec ingestion + core-ops curation + 9-op read-only v0.2 (#617)

### DIFF
--- a/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
@@ -26,12 +26,25 @@ because this module has already registered the hand-rolled class. Until then,
 this module is the only registration path.
 
 Operations for this connector arrive in #617 via G0.7 spec ingestion of
-the SDDC Manager VCF API against the ``endpoint_descriptor`` table. This
-Task ships only the skeleton.
+the SDDC Manager VCF API against the ``endpoint_descriptor`` table.
+The curated 9-op read-only v0.2 core ships in :mod:`.core_ops`.
 """
 
 from meho_backplane.connectors.registry import register_connector_v2
 from meho_backplane.connectors.sddc_manager.connector import SddcManagerConnector
+from meho_backplane.connectors.sddc_manager.core_ops import (
+    SDDC_CONNECTOR_ID,
+    SDDC_CORE_GROUPS,
+    SDDC_CORE_OPS,
+    SDDC_IMPL_ID,
+    SDDC_PATH_RULES,
+    SDDC_PRODUCT,
+    SDDC_VERSION,
+    SddcCoreGroup,
+    SddcCoreOp,
+    apply_sddc_core_curation,
+    classify_sddc_op,
+)
 from meho_backplane.connectors.sddc_manager.session import (
     SddcCredentialsLoader,
     SddcTargetLike,
@@ -47,9 +60,20 @@ register_connector_v2(
 )
 
 __all__ = [
+    "SDDC_CONNECTOR_ID",
+    "SDDC_CORE_GROUPS",
+    "SDDC_CORE_OPS",
+    "SDDC_IMPL_ID",
+    "SDDC_PATH_RULES",
+    "SDDC_PRODUCT",
+    "SDDC_VERSION",
+    "SddcCoreGroup",
+    "SddcCoreOp",
     "SddcCredentialsLoader",
     "SddcManagerConnector",
     "SddcTargetLike",
     "SessionCredentials",
+    "apply_sddc_core_curation",
+    "classify_sddc_op",
     "load_credentials_from_vault",
 ]

--- a/backend/src/meho_backplane/connectors/sddc_manager/core_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/core_ops.py
@@ -1,0 +1,665 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""SDDC Manager 9.0 read-only v0.2 core — curated operator-enabled subset.
+
+This module names the **9 read-only SDDC Manager operations** the G3.5
+SDDC Manager v0.2 ship enables out of the much larger VCF API corpus the
+G0.7 spec-ingestion pipeline lands under
+``connector_id="sddc-rest-9.0"``. The curation is two-layered:
+
+* :data:`SDDC_CORE_GROUPS` — the operator-reviewed ``when_to_use``
+  hint per LLM-grouping pass output group. Each entry's ``group_key``
+  is the deterministic slug the path-prefix classifier assigns to SDDC
+  Manager ops (see :func:`classify_sddc_op` below); the ``when_to_use``
+  is what the agent reads verbatim through
+  :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
+  to pick a group to search within.
+* :data:`SDDC_CORE_OPS` — the 9 ``EndpointDescriptor.op_id`` strings
+  that flip to ``is_enabled=True`` at operator-review time, paired
+  with the per-op ``llm_instructions`` blob the agent inlines into
+  the reasoning context when it sees the op in
+  :func:`~meho_backplane.operations.meta_tools.search_operations`
+  hits. Every other op under the same connector triple stays
+  ``is_enabled=False`` (the G0.7 ingestion default for
+  ``source_kind='ingested'`` rows).
+
+Per Initiative #368 and CLAUDE.md postulates 1-2, SDDC Manager is **fully
+generic-ingested**: the underlying ops are not registered in code, they
+live in the ``endpoint_descriptor`` table. This module only carries the
+**operator-review metadata** the substrate uses at the review step — the
+actual curation is applied through :func:`apply_sddc_core_curation`
+against an existing ingested connector.
+
+``SDDC_PRODUCT`` / ``SDDC_VERSION`` / ``SDDC_IMPL_ID`` note
+------------------------------------------------------------
+
+``SDDC_PRODUCT = "sddc"`` is the value
+:func:`~meho_backplane.operations._lookup.parse_connector_id` extracts
+from ``SDDC_CONNECTOR_ID = "sddc-rest-9.0"`` (``head.split("-", 1)[0]``).
+It is **not** the same as :attr:`SddcManagerConnector.product`, which is
+``"sddc-manager"`` and is used only for the v2 connector registry and the
+target-product resolver. All ``endpoint_descriptor`` and
+``operation_group`` rows for this connector triple carry
+``product="sddc"``; operators pass ``--product sddc`` when driving
+``meho connector ingest``. Review-time helpers (including
+:class:`~meho_backplane.operations.ingest.service.ReviewService`) derive
+the product via ``parse_connector_id`` so the same constant is consistent
+across the ingestion, review, and dispatch legs.
+
+The 9 ops (paths cross-checked against VCF / SDDC Manager API 9.0 at
+https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/):
+
+1. ``GET:/v1/releases/system`` — ``sddc.about`` — SDDC Manager software
+   release (version, build date, component BOM). The same surface the
+   operator reads to confirm the VCF build under management; exposing it
+   as an agent-callable op lets the agent run a sanity probe before heavier
+   inventory reads.
+2. ``GET:/v1/sddc-managers`` — ``sddc.manager.list`` — list of SDDC Manager
+   appliances (FQDN, IP, version, management domain). The primary read for
+   "which SDDC Manager appliance manages this VCF stack."
+3. ``GET:/v1/domains`` — ``sddc.domain.list`` — management + workload
+   domains under this SDDC Manager.
+4. ``GET:/v1/domains/{id}`` — ``sddc.domain.info`` — full domain detail
+   including associated vCenter(s), NSX-T cluster, clusters, and hosts.
+5. ``GET:/v1/clusters`` — ``sddc.cluster.list`` — cluster inventory across
+   all or one domain (``?domainId=`` filter).
+6. ``GET:/v1/hosts`` — ``sddc.host.list`` — ESXi host inventory across all
+   or one domain or cluster (``?domainId=`` / ``?clusterId=`` filter).
+7. ``GET:/v1/network-pools`` — ``sddc.network_pool.list`` — network pools
+   defining the IP ranges and VLANs provisioned to new hosts at commission
+   time.
+8. ``GET:/v1/bundles`` — ``sddc.bundle.list`` — LCM bundle inventory (VCF
+   update packages, async patches). Read-only; lifecycle writes stay
+   ``staged`` per Initiative #368.
+9. ``GET:/v1/tasks`` — ``sddc.workflow.list`` — in-flight and recently
+   completed VCF workflow tasks. The SDDC Manager API surface uses the term
+   ``tasks``; the issue body calls this surface ``sddc.workflow.list`` for
+   operator clarity.
+
+Path families and group_keys
+-----------------------------
+
+Every SDDC Manager REST path begins with ``/v1/``. The 9 curated ops
+span 8 distinct top-level resource families:
+``releases``, ``sddc-managers``, ``domains``, ``clusters``, ``hosts``,
+``network-pools``, ``bundles``, ``tasks``. :data:`SDDC_PATH_RULES`
+mirrors that taxonomy so an operator reviewing the connector sees the
+read-core ops fall into the expected 8 groups. The ``sddc-domains``
+group carries two ops (list + detail).
+
+Curation application
+--------------------
+
+:func:`apply_sddc_core_curation` is the operator-review-time substrate
+call that makes exactly the 9 curated ops dispatchable and leaves every
+other ingested op disabled. The substrate has no "enable only ops X, Y, Z
+under group G" verb — :meth:`ReviewService.enable_group` cascades
+``is_enabled=True`` to every child op. The helper threads this needle via
+the audit-log-driven operator-override exclusion (see
+:func:`~meho_backplane.operations.ingest._internals.operator_disabled_op_ids`),
+exactly matching the pattern :func:`apply_nsx_core_curation` in
+:mod:`meho_backplane.connectors.nsx.core_ops` established.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.operations.ingest.service import ReviewService
+
+__all__ = [
+    "SDDC_CONNECTOR_ID",
+    "SDDC_CORE_GROUPS",
+    "SDDC_CORE_OPS",
+    "SDDC_IMPL_ID",
+    "SDDC_PATH_RULES",
+    "SDDC_PRODUCT",
+    "SDDC_VERSION",
+    "SddcCoreGroup",
+    "SddcCoreOp",
+    "apply_sddc_core_curation",
+    "classify_sddc_op",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Endpoint-descriptor product key — what
+#: :func:`~meho_backplane.operations._lookup.parse_connector_id`
+#: extracts from ``"sddc-rest-9.0"`` (first hyphen-segment of
+#: impl_id ``"sddc-rest"``).
+#:
+#: Distinct from :attr:`SddcManagerConnector.product` (``"sddc-manager"``)
+#: which is the v2 registry key and resolver target. All
+#: ``endpoint_descriptor`` + ``operation_group`` rows carry
+#: ``product="sddc"``; see the module docstring for details.
+SDDC_PRODUCT: Final[str] = "sddc"
+SDDC_VERSION: Final[str] = "9.0"
+SDDC_IMPL_ID: Final[str] = "sddc-rest"
+
+#: Connector-id slug the G0.6 dispatcher's ``parse_connector_id``
+#: round-trips back to the triple above: ``"sddc-rest-9.0"``.
+SDDC_CONNECTOR_ID: Final[str] = f"{SDDC_IMPL_ID}-{SDDC_VERSION}"
+
+
+@dataclass(frozen=True, slots=True)
+class SddcCoreGroup:
+    """One curated operator-review entry for an SDDC Manager operation group.
+
+    ``group_key`` is the slug the path-prefix classifier emits (see
+    :data:`SDDC_PATH_RULES`). ``name`` is the operator-readable label
+    ``meho connector review`` renders. ``when_to_use`` is the agent-facing
+    hint :func:`list_operation_groups` returns verbatim; every entry is a
+    single complete sentence so the agent's group-selection step has
+    unambiguous guidance.
+    """
+
+    group_key: str
+    name: str
+    when_to_use: str
+
+
+@dataclass(frozen=True, slots=True)
+class SddcCoreOp:
+    """One curated operator-review entry for an SDDC Manager operation.
+
+    ``op_id`` follows the ``METHOD:path`` shape every
+    ``source_kind='ingested'`` row uses; the path matches an entry
+    in the VCF / SDDC Manager 9.0 API spec.
+
+    ``llm_instructions`` is the per-op JSON blob the meta-tools inline
+    verbatim when the op surfaces. The shape (``when_to_call`` /
+    ``output_shape`` / ``next_step``) mirrors the typed-connector convention
+    from :mod:`meho_backplane.connectors.bind9.ops_zone` and
+    :mod:`meho_backplane.connectors.nsx.core_ops` — same agent reads both
+    surfaces, so the structure stays uniform.
+    """
+
+    op_id: str
+    group_key: str
+    llm_instructions: dict[str, object]
+
+
+#: Path-prefix → group_key classifier rules for SDDC Manager.
+#:
+#: First match wins. Order: more specific prefixes first (``/v1/sddc-managers``
+#: before any hypothetical ``/v1/sddc-*`` catch-all). Every SDDC Manager
+#: path begins with ``/v1/`` so there is no manager-vs-policy split like
+#: NSX; the top-level resource name is the natural grouping key.
+SDDC_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
+    ("/v1/releases", "sddc-releases"),
+    ("/v1/sddc-managers", "sddc-managers"),
+    ("/v1/domains", "sddc-domains"),
+    ("/v1/clusters", "sddc-clusters"),
+    ("/v1/hosts", "sddc-hosts"),
+    ("/v1/network-pools", "sddc-network-pools"),
+    ("/v1/bundles", "sddc-bundles"),
+    ("/v1/tasks", "sddc-tasks"),
+)
+
+
+def classify_sddc_op(op_id: str) -> str:
+    """Return the curated ``group_key`` for an SDDC Manager op_id, or ``"none"``.
+
+    ``op_id`` is the ``METHOD:/path`` form ingested rows carry; the
+    helper strips the verb and matches the path against
+    :data:`SDDC_PATH_RULES` in order.
+
+    Returns ``"none"`` for paths outside the curated families (e.g.
+    ``/v1/vcenters``, ``/v1/nsxt-clusters``); operators reviewing
+    the ingested connector see those rows as unassigned and can either
+    tighten the rules in this module on the next release or accept them
+    as un-curated. The G0.7 canary's ``operations_unassigned < 50%`` bar
+    tolerates a long tail of un-curated paths.
+    """
+    try:
+        _, path = op_id.split(":", 1)
+    except ValueError:
+        return "none"
+    for prefix, group_key in SDDC_PATH_RULES:
+        if path.startswith(prefix):
+            return group_key
+    return "none"
+
+
+#: Operator-reviewed ``when_to_use`` hints for the 8 SDDC Manager groups
+#: the read-only v0.2 core spans. Two ops share the ``sddc-domains`` group
+#: (list + detail); every other group carries exactly one op. Every hint is
+#: one complete sentence the agent reads verbatim — vague hints poison
+#: ``search_operations`` ranking, per the ai_engineering pack.
+SDDC_CORE_GROUPS: Final[tuple[SddcCoreGroup, ...]] = (
+    SddcCoreGroup(
+        group_key="sddc-releases",
+        name="SDDC Manager (release)",
+        when_to_use=(
+            "Use this group to read the SDDC Manager's own software release — "
+            "VCF version, build date, and component BOM. The probe surface the "
+            "agent calls before any heavier inventory read or when confirming "
+            "the VCF build under management."
+        ),
+    ),
+    SddcCoreGroup(
+        group_key="sddc-managers",
+        name="SDDC Manager (appliance)",
+        when_to_use=(
+            "Use this group to list SDDC Manager appliances — their FQDN, IP "
+            "address, version, and the management domain they belong to. The "
+            "primary read for 'which SDDC Manager appliance manages this VCF "
+            "stack' questions."
+        ),
+    ),
+    SddcCoreGroup(
+        group_key="sddc-domains",
+        name="VCF Domains",
+        when_to_use=(
+            "Use this group to list or inspect VCF domains (management and "
+            "workload). The entry point for any domain-scoped cluster, host, or "
+            "network-pool query, and for mapping which vCenter or NSX-T cluster "
+            "belongs to a given domain."
+        ),
+    ),
+    SddcCoreGroup(
+        group_key="sddc-clusters",
+        name="VCF Clusters",
+        when_to_use=(
+            "Use this group to list vSphere clusters across all or one VCF "
+            "domain. The primary inventory read for 'how many clusters exist', "
+            "'what datastore type does a cluster use', or 'which hosts are in "
+            "cluster X' questions."
+        ),
+    ),
+    SddcCoreGroup(
+        group_key="sddc-hosts",
+        name="VCF Hosts",
+        when_to_use=(
+            "Use this group to enumerate ESXi hosts across all VCF domains, or "
+            "filter to a specific domain or cluster. The primary read for host "
+            "count, FQDN, ESXi version, and assignment status questions."
+        ),
+    ),
+    SddcCoreGroup(
+        group_key="sddc-network-pools",
+        name="VCF Network Pools",
+        when_to_use=(
+            "Use this group to list network pools configured in SDDC Manager. "
+            "Network pools define the IP ranges and VLANs provisioned to new "
+            "ESXi hosts during domain expansion or host commission operations."
+        ),
+    ),
+    SddcCoreGroup(
+        group_key="sddc-bundles",
+        name="VCF LCM Bundles",
+        when_to_use=(
+            "Use this group to list LCM bundles available on this SDDC Manager — "
+            "VCF update packages, component updates, and async patches. Read-only; "
+            "use when answering 'which updates are available' or 'is the VCF stack "
+            "compliant with the latest release'."
+        ),
+    ),
+    SddcCoreGroup(
+        group_key="sddc-tasks",
+        name="VCF Workflows (Tasks)",
+        when_to_use=(
+            "Use this group to list in-flight or recently completed VCF workflow "
+            "tasks. Use when answering 'what operations are running against this "
+            "VCF stack' or monitoring a domain-expand, host-commission, or "
+            "update-apply workflow."
+        ),
+    ),
+)
+
+
+def _instructions(
+    *,
+    when_to_call: str,
+    output_shape: str,
+    next_step: str,
+) -> dict[str, object]:
+    """Build the per-op ``llm_instructions`` blob with the canonical keys.
+
+    Same three-field shape :mod:`meho_backplane.connectors.nsx.core_ops` and
+    :mod:`meho_backplane.connectors.bind9.ops_zone` use so an agent crossing
+    connector boundaries sees a stable convention.
+    """
+    return {
+        "when_to_call": when_to_call,
+        "output_shape": output_shape,
+        "next_step": next_step,
+    }
+
+
+#: The 9 curated read-only SDDC Manager core ops. Each entry carries the
+#: op_id (``GET:/path`` form), the curated group assignment, and the
+#: operator-reviewed ``llm_instructions`` blob.
+#:
+#: Paths sourced against VCF / SDDC Manager API 9.0 at
+#: https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/.
+SDDC_CORE_OPS: Final[tuple[SddcCoreOp, ...]] = (
+    SddcCoreOp(
+        op_id="GET:/v1/releases/system",
+        group_key="sddc-releases",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read the SDDC Manager's own software release — VCF "
+                "version string, release date, and the component BOM listing "
+                "every bundled product's version. Useful as a pre-flight probe "
+                "before heavier inventory reads or to confirm the VCF build "
+                "under management."
+            ),
+            output_shape=(
+                "Object with version, releaseDate, description, and bom[] "
+                "(each entry carries componentType and componentVersion)."
+            ),
+            next_step=(
+                "If the release looks current, proceed to domain or cluster "
+                "reads; if behind, surface the version to the operator for an "
+                "LCM update check via sddc.bundle.list."
+            ),
+        ),
+    ),
+    SddcCoreOp(
+        op_id="GET:/v1/sddc-managers",
+        group_key="sddc-managers",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list SDDC Manager appliances — their FQDN, IP address, "
+                "version, and the management domain they belong to. The primary "
+                "read for 'which SDDC Manager manages this VCF stack' questions, "
+                "or when you need the appliance FQDN before making further "
+                "targeted calls."
+            ),
+            output_shape=(
+                "Paginated envelope with elements[] and pageMetadata; each "
+                "element carries id, fqdn, ipAddress, version, and a domain "
+                "object with id and name."
+            ),
+            next_step=(
+                "Cross-reference the management domain name against sddc.domain.list "
+                "for domain-scoped queries, or use the FQDN when targeting a "
+                "specific appliance."
+            ),
+        ),
+    ),
+    SddcCoreOp(
+        op_id="GET:/v1/domains",
+        group_key="sddc-domains",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list all VCF domains managed by this SDDC Manager — "
+                "the management domain and any workload domains. The entry point "
+                "for domain-scoped cluster, host, or network-pool queries and for "
+                "mapping which vCenter or NSX-T cluster belongs to a given domain."
+            ),
+            output_shape=(
+                "Paginated envelope with elements[] and pageMetadata; each domain "
+                "carries id, name, type (MANAGEMENT or WORKLOAD), and references "
+                "to associated vcenters and nsxtCluster."
+            ),
+            next_step=(
+                "Pick a domain id for sddc.domain.info to get the full detail "
+                "including vCenter FQDN and NSX-T cluster, or pass domainId as a "
+                "filter to sddc.cluster.list / sddc.host.list."
+            ),
+        ),
+    ),
+    SddcCoreOp(
+        op_id="GET:/v1/domains/{id}",
+        group_key="sddc-domains",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read the full detail of one VCF domain — its associated "
+                "vCenter(s), NSX-T cluster (with VIP FQDN), cluster list, and host "
+                "references. Requires a domain id from sddc.domain.list; use after "
+                "listing domains to answer 'which vCenter manages domain X' or "
+                "'what NSX-T cluster backs this workload domain'."
+            ),
+            output_shape=(
+                "Domain object with vcenters[] (id, fqdn), nsxtCluster (id, "
+                "vipFqdn), clusters[] (id, name), and ssoId/ssoName fields."
+            ),
+            next_step=(
+                "Cross-reference vcenters[].fqdn against the vSphere connector "
+                "for VM reads, or use cluster ids for targeted sddc.cluster.list "
+                "or sddc.host.list queries."
+            ),
+        ),
+    ),
+    SddcCoreOp(
+        op_id="GET:/v1/clusters",
+        group_key="sddc-clusters",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list vSphere clusters across all VCF domains, or filter "
+                "to a specific domain by passing domainId as a query parameter. "
+                "The primary inventory read for cluster count, datastore type, "
+                "and host membership questions."
+            ),
+            output_shape=(
+                "Paginated envelope with elements[] and pageMetadata; each cluster "
+                "carries id, name, primaryDatastoreType, domainId, and a hosts[] "
+                "array of host references."
+            ),
+            next_step=(
+                "Cross-reference domainId against the domain listing for "
+                "context, or use cluster ids to filter sddc.host.list to the "
+                "specific cluster's hosts."
+            ),
+        ),
+    ),
+    SddcCoreOp(
+        op_id="GET:/v1/hosts",
+        group_key="sddc-hosts",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to enumerate ESXi hosts across all VCF domains, or filter "
+                "by domainId or clusterId query parameters. The primary inventory "
+                "read for host count, FQDN, ESXi version, IP addresses, and "
+                "assignment status. Large VCF deployments may return dozens or "
+                "hundreds of hosts — use the JSONFlux handle path for big sets."
+            ),
+            output_shape=(
+                "Paginated envelope with elements[] and pageMetadata; each host "
+                "carries id, fqdn, esxiVersion, ipAddresses[], domain.id, "
+                "cluster.id, networkPool.id, and status "
+                "(ASSIGNED or UNASSIGNED_USEABLE)."
+            ),
+            next_step=(
+                "Cross-reference cluster.id against sddc.cluster.list, or use "
+                "fqdn when targeting a specific host for vSphere reads. For "
+                "hosts in UNASSIGNED_USEABLE status, surface them to the operator "
+                "as available for domain expansion."
+            ),
+        ),
+    ),
+    SddcCoreOp(
+        op_id="GET:/v1/network-pools",
+        group_key="sddc-network-pools",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list network pools configured in SDDC Manager. Network "
+                "pools define the IP ranges, VLANs, and subnets provisioned to "
+                "new ESXi hosts during domain expansion or host commission. Use "
+                "when answering 'what network pool will be used for the next "
+                "host commission' or verifying VLAN assignments."
+            ),
+            output_shape=(
+                "Paginated envelope with elements[] and pageMetadata; each pool "
+                "carries id, name, and networks[] (each network has type, vlanId, "
+                "subnet, mask, gateway, and ipPools[] with start/end ranges)."
+            ),
+            next_step=(
+                "Cross-reference a pool's id against cluster or host records when "
+                "answering 'which network pool covers this host' or confirming "
+                "pre-commission networking requirements."
+            ),
+        ),
+    ),
+    SddcCoreOp(
+        op_id="GET:/v1/bundles",
+        group_key="sddc-bundles",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list LCM bundles available on this SDDC Manager — VCF "
+                "update packages, component patches, and async updates. Read-only; "
+                "use when answering 'which updates are available', 'is the VCF "
+                "stack compliant with the latest release', or 'what version does "
+                "bundle X contain'."
+            ),
+            output_shape=(
+                "Array of bundle objects; each carries id, type "
+                "(VMWARE_SOFTWARE), version, description, sizeMB, "
+                "downloadStatus, isCumulative, isCompliant, "
+                "applicabilityStatus, and components[] (component name + "
+                "version pairs)."
+            ),
+            next_step=(
+                "Surface bundle isCompliant and applicabilityStatus to the "
+                "operator; cross-reference the VCF release version from "
+                "sddc.about to identify applicable update bundles."
+            ),
+        ),
+    ),
+    SddcCoreOp(
+        op_id="GET:/v1/tasks",
+        group_key="sddc-tasks",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list in-flight or recently completed VCF workflow tasks "
+                "(SDDC Manager calls these 'tasks'; the operator-facing name is "
+                "sddc.workflow.list). Use when answering 'what operations are "
+                "running against this VCF stack', monitoring a domain-expand or "
+                "host-commission operation, or triaging a workflow that failed. "
+                "Supports status filtering via the status query parameter "
+                "(Successful, Failed, In_Progress, Pending, Cancelled)."
+            ),
+            output_shape=(
+                "Task objects with id, name, status, type, creationTimestamp, "
+                "completionTimestamp, subtasks[] (nested task tree), and "
+                "errors[] (message + remediation hints for failed tasks)."
+            ),
+            next_step=(
+                "For a failed task, surface errors[].message and "
+                "errors[].remediationMessage to the operator. For an "
+                "in-progress task, poll via this op or wait for the status "
+                "to transition before proceeding with the next workflow step."
+            ),
+        ),
+    ),
+)
+
+
+async def apply_sddc_core_curation(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Apply the curated 9-op read core against an ingested SDDC Manager connector.
+
+    Drives the substrate so that, after this call returns, exactly
+    the 9 ops in :data:`SDDC_CORE_OPS` are dispatchable
+    (``is_enabled=True``) and every other ingested op stays
+    ``is_enabled=False``. The 8 curated groups land
+    ``review_status='enabled'`` so the agent's
+    :func:`~meho_backplane.operations.meta_tools.search_operations`
+    surfaces the core ops; non-curated groups are left untouched
+    (``review_status='staged'`` from the G0.7 ingest default).
+
+    The substrate doesn't expose "enable only ops X, Y, Z under
+    group G": :meth:`ReviewService.enable_group`'s cascade flips
+    ``is_enabled=True`` on every child op in the group. The helper
+    works around this via the audit-log-driven operator-override
+    exclusion:
+
+    1. :meth:`ReviewService.get_review_payload` loads the current
+       state of every curated group and its child ops.
+    2. For each child op in a curated group that **isn't** in the
+       :data:`SDDC_CORE_OPS` allow-list,
+       :meth:`ReviewService.edit_op` with ``is_enabled=False``
+       writes the operator-override audit row. The follow-on
+       :meth:`enable_group` cascade detects these rows and skips
+       them.
+    3. :meth:`ReviewService.edit_group` lands the operator-reviewed
+       ``name`` + ``when_to_use`` on each curated group.
+    4. :meth:`ReviewService.enable_group` flips
+       ``review_status='enabled'`` and cascades ``is_enabled=True``
+       to the curated child ops (operator-overridden non-core ops
+       are skipped).
+    5. :meth:`ReviewService.edit_op` lands the curated
+       ``llm_instructions`` blob per entry in :data:`SDDC_CORE_OPS`.
+
+    Re-running is safe but not idempotent at the audit layer.
+    :meth:`enable_group` short-circuits on groups already in
+    ``review_status='enabled'`` (no audit row), but
+    :meth:`edit_group` and :meth:`edit_op` always emit one audit
+    row per call — even when the incoming value equals the
+    persisted one.
+
+    Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
+    if no groups exist for ``sddc-rest-9.0`` under *tenant_id* (the
+    operator must run ``meho connector ingest`` against the VCF spec
+    before this helper applies).
+    """
+    payload = await review_service.get_review_payload(
+        SDDC_CONNECTOR_ID,
+        tenant_id,
+    )
+
+    core_op_ids_by_group: dict[str, set[str]] = {}
+    for op in SDDC_CORE_OPS:
+        core_op_ids_by_group.setdefault(op.group_key, set()).add(op.op_id)
+
+    for group_payload in payload.groups:
+        allow_list = core_op_ids_by_group.get(group_payload.group_key)
+        if allow_list is None:
+            continue
+        for review_op in group_payload.ops:
+            if review_op.op_id in allow_list:
+                continue
+            await review_service.edit_op(
+                SDDC_CONNECTOR_ID,
+                review_op.op_id,
+                tenant_id=tenant_id,
+                is_enabled=False,
+            )
+            _log.info(
+                "sddc_non_core_op_disabled",
+                connector_id=SDDC_CONNECTOR_ID,
+                op_id=review_op.op_id,
+                group_key=group_payload.group_key,
+            )
+
+    for group in SDDC_CORE_GROUPS:
+        await review_service.edit_group(
+            SDDC_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+            name=group.name,
+            when_to_use=group.when_to_use,
+        )
+        await review_service.enable_group(
+            SDDC_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+        )
+        _log.info(
+            "sddc_core_group_enabled",
+            connector_id=SDDC_CONNECTOR_ID,
+            group_key=group.group_key,
+        )
+
+    for op in SDDC_CORE_OPS:
+        await review_service.edit_op(
+            SDDC_CONNECTOR_ID,
+            op.op_id,
+            tenant_id=tenant_id,
+            llm_instructions=op.llm_instructions,
+        )
+        _log.info(
+            "sddc_core_op_curated",
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id=op.op_id,
+        )

--- a/backend/tests/acceptance/_sddc_canary_fixtures.py
+++ b/backend/tests/acceptance/_sddc_canary_fixtures.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared minimal-setup fixtures for the G3.5 SDDC Manager dispatch tests.
+
+Two SDDC Manager acceptance modules (dispatch smoke + JSONFlux force-handle)
+share the same plumbing: a registered
+:class:`~meho_backplane.connectors.sddc_manager.SddcManagerConnector` instance
+with a stub credentials loader (so no Vault read is required), a probed
+:class:`~meho_backplane.db.models.Target` row, the 9 curated
+:class:`~meho_backplane.db.models.EndpointDescriptor` rows from
+:data:`~meho_backplane.connectors.sddc_manager.core_ops.SDDC_CORE_OPS`, and a
+:mod:`respx`-mocked SDDC Manager REST surface answering each of the 9 curated
+read ops.
+
+SDDC Manager uses HTTP Basic auth on every request — no session establish
+or XSRF-token dance is needed. The stub credentials loader bypasses the
+Vault-backed loader; the respx router matches requests by path (Basic auth
+header is not asserted by default).
+
+Why a minimal direct-insert path (not full G0.7 canary ingest)
+==============================================================
+
+The full VCF API spec ingest needs the SDDC Manager 9.0 OpenAPI spec file
+reachable on the CI runner. Until the spec-shelf is wired to the
+meho-runners pool, the dispatch leg is exercised against a minimal
+direct-insert path that seeds the 9 curated endpoint_descriptor rows by
+hand. Same pattern :mod:`tests.acceptance._nsx_canary_fixtures` established
+for NSX (which also has no public CI simulator).
+
+``EndpointDescriptor.product`` note
+====================================
+
+Rows are inserted with ``product=SDDC_PRODUCT="sddc"`` — the value
+:func:`~meho_backplane.operations._lookup.parse_connector_id` derives from
+``"sddc-rest-9.0"`` (first hyphen-segment of impl_id). The :class:`Target`
+row uses ``product="sddc-manager"`` so the resolver finds
+:class:`SddcManagerConnector` (registered with ``product="sddc-manager"``
+in the v2 registry). These product values serve different purposes; both
+are required for end-to-end dispatch to succeed.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.connectors.sddc_manager import (
+    SDDC_CONNECTOR_ID,
+    SDDC_CORE_GROUPS,
+    SDDC_CORE_OPS,
+    SDDC_IMPL_ID,
+    SDDC_PRODUCT,
+    SDDC_VERSION,
+    SddcManagerConnector,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+
+_PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")
+
+__all__ = [
+    "SDDC_CANARY_BASE_URL",
+    "SDDC_CANARY_BUNDLES",
+    "SDDC_CANARY_DOMAINS",
+    "SDDC_CANARY_FINGERPRINT",
+    "SDDC_CANARY_HOSTS",
+    "SDDC_CANARY_OPERATOR_TENANT",
+    "SDDC_FORCE_HANDLE_LIST_OP_ID",
+    "SDDC_TARGET_NAME",
+    "IngestedSddcCanary",
+    "ingested_sddc_canary",
+    "sddc_acceptance_operator",
+]
+
+#: Tenant the SDDC Manager dispatch tests act under.
+SDDC_CANARY_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000fe")
+
+#: Stable :class:`Target.name` for the seeded SDDC Manager target.
+SDDC_TARGET_NAME: str = "sddc-acceptance"
+
+#: ``.test.invalid`` (RFC 6761 reserved) so no real network egress fires.
+SDDC_CANARY_BASE_URL: str = "https://sddc-canary.test.invalid"
+
+#: Persisted as ``Target.fingerprint`` so the resolver binds
+#: :class:`SddcManagerConnector` (``supported_version_range=">=9.0,<10.0"``).
+SDDC_CANARY_FINGERPRINT: dict[str, object] = FingerprintResult(
+    vendor="vmware",
+    product="sddc-manager",
+    version=SDDC_VERSION,
+    build=None,
+    reachable=True,
+    probed_at=datetime(2026, 5, 19, 10, 0, 0, tzinfo=UTC),
+    probe_method="GET /v1/sddc-managers",
+    extras={
+        "id": "sddc-canary-id",
+        "fqdn": "sddc-canary.test.invalid",
+        "management_domain": "MGMT",
+        "management_domain_id": "domain-mgmt",
+    },
+).model_dump(mode="json")
+
+#: The list op the JSONFlux force-handle test dispatches. Hosts is the
+#: largest list surface in a typical VCF deployment (dozens or hundreds of
+#: rows), mirroring the NSX segment-list choice.
+SDDC_FORCE_HANDLE_LIST_OP_ID: str = "GET:/v1/hosts"
+
+#: Synthetic release info.
+SDDC_CANARY_RELEASE: dict[str, object] = {
+    "version": "9.0.0.0-24000000",
+    "releaseDate": "2026-01-15",
+    "description": "VMware Cloud Foundation 9.0",
+    "bom": [
+        {"componentType": "VCENTER", "componentVersion": "8.0.3"},
+        {"componentType": "NSX", "componentVersion": "4.2.1"},
+        {"componentType": "ESXI", "componentVersion": "8.0.3"},
+    ],
+}
+
+#: Synthetic SDDC Manager appliance list.
+SDDC_CANARY_MANAGERS: dict[str, object] = {
+    "elements": [
+        {
+            "id": "sddc-canary-id",
+            "fqdn": "sddc-canary.test.invalid",
+            "ipAddress": "192.168.1.5",
+            "version": "9.0.0.0-24000000",
+            "domain": {"id": "domain-mgmt", "name": "MGMT"},
+        }
+    ],
+    "pageMetadata": {"pageNumber": 0, "pageSize": 10, "totalElements": 1, "totalPages": 1},
+}
+
+#: Synthetic domain list — one management domain + one workload domain.
+SDDC_CANARY_DOMAINS: dict[str, object] = {
+    "elements": [
+        {
+            "id": "domain-mgmt",
+            "name": "MGMT",
+            "type": "MANAGEMENT",
+            "vcenters": [{"id": "vcenter-mgmt", "fqdn": "vcenter-mgmt.test.invalid"}],
+            "nsxtCluster": {"id": "nsx-mgmt", "vipFqdn": "nsx-mgmt.test.invalid"},
+        },
+        {
+            "id": "domain-wld01",
+            "name": "WLD-01",
+            "type": "WORKLOAD",
+            "vcenters": [{"id": "vcenter-wld01", "fqdn": "vcenter-wld01.test.invalid"}],
+            "nsxtCluster": {"id": "nsx-wld01", "vipFqdn": "nsx-wld01.test.invalid"},
+        },
+    ],
+    "pageMetadata": {"pageNumber": 0, "pageSize": 10, "totalElements": 2, "totalPages": 1},
+}
+
+#: Synthetic domain detail for ``domain-mgmt``.
+SDDC_CANARY_DOMAIN_DETAIL: dict[str, object] = {
+    "id": "domain-mgmt",
+    "name": "MGMT",
+    "type": "MANAGEMENT",
+    "vcenters": [{"id": "vcenter-mgmt", "fqdn": "vcenter-mgmt.test.invalid"}],
+    "nsxtCluster": {"id": "nsx-mgmt", "vipFqdn": "nsx-mgmt.test.invalid"},
+    "clusters": [{"id": "cluster-mgmt-01", "name": "Cluster-MGMT-01"}],
+    "ssoId": "vsphere.local",
+    "ssoName": "vsphere.local",
+}
+
+#: Synthetic cluster list.
+SDDC_CANARY_CLUSTERS: dict[str, object] = {
+    "elements": [
+        {
+            "id": "cluster-mgmt-01",
+            "name": "Cluster-MGMT-01",
+            "primaryDatastoreType": "VMFS_FC",
+            "domainId": "domain-mgmt",
+            "hosts": [{"id": f"host-{i}"} for i in range(4)],
+        },
+        {
+            "id": "cluster-wld-01",
+            "name": "Cluster-WLD-01",
+            "primaryDatastoreType": "VSAN",
+            "domainId": "domain-wld01",
+            "hosts": [{"id": f"host-{i}"} for i in range(4, 8)],
+        },
+    ],
+    "pageMetadata": {"pageNumber": 0, "pageSize": 10, "totalElements": 2, "totalPages": 1},
+}
+
+#: Synthetic host list — 12 hosts so the force-handle reducer sees a
+#: populated set with a sample-row slice.
+SDDC_CANARY_HOSTS: dict[str, object] = {
+    "elements": [
+        {
+            "id": f"host-{i}",
+            "fqdn": f"esx-canary-{i:02d}.test.invalid",
+            "esxiVersion": "8.0.3",
+            "ipAddresses": [{"ipAddress": f"192.168.10.{10 + i}", "type": "MANAGEMENT"}],
+            "domain": {"id": "domain-mgmt" if i < 4 else "domain-wld01"},
+            "cluster": {"id": "cluster-mgmt-01" if i < 4 else "cluster-wld-01"},
+            "networkPool": {"id": "pool-01"},
+            "status": "ASSIGNED",
+        }
+        for i in range(12)
+    ],
+    "pageMetadata": {"pageNumber": 0, "pageSize": 20, "totalElements": 12, "totalPages": 1},
+}
+
+#: Synthetic network pool list.
+SDDC_CANARY_NETWORK_POOLS: dict[str, object] = {
+    "elements": [
+        {
+            "id": "pool-01",
+            "name": "NetworkPool-01",
+            "networks": [
+                {
+                    "type": "VSAN",
+                    "vlanId": 1011,
+                    "subnet": "192.168.20.0",
+                    "mask": "255.255.255.0",
+                    "gateway": "192.168.20.1",
+                    "ipPools": [{"start": "192.168.20.10", "end": "192.168.20.50"}],
+                }
+            ],
+        }
+    ],
+    "pageMetadata": {"pageNumber": 0, "pageSize": 10, "totalElements": 1, "totalPages": 1},
+}
+
+#: Synthetic LCM bundle list.
+SDDC_CANARY_BUNDLES: dict[str, object] = {
+    "elements": [
+        {
+            "id": "bundle-vcf-9-0-1",
+            "type": "VMWARE_SOFTWARE",
+            "version": "9.0.1.0",
+            "description": "VCF 9.0.1 cumulative update",
+            "sizeMB": 14500,
+            "downloadStatus": "SUCCESSFUL",
+            "isCumulative": True,
+            "isCompliant": False,
+            "applicabilityStatus": "APPLICABLE",
+            "components": [
+                {"componentType": "VCENTER", "componentVersion": "8.0.3.1"},
+                {"componentType": "NSX", "componentVersion": "4.2.2"},
+            ],
+        }
+    ],
+    "pageMetadata": {"pageNumber": 0, "pageSize": 10, "totalElements": 1, "totalPages": 1},
+}
+
+#: Synthetic VCF task list.
+SDDC_CANARY_TASKS: dict[str, object] = {
+    "elements": [
+        {
+            "id": "task-expand-wld01",
+            "name": "Expand Workload Domain WLD-01",
+            "status": "Successful",
+            "type": "WORKLOAD_DOMAIN_EXPAND",
+            "creationTimestamp": "2026-05-19T08:00:00.000Z",
+            "completionTimestamp": "2026-05-19T08:45:00.000Z",
+            "subtasks": [],
+            "errors": [],
+        }
+    ],
+    "pageMetadata": {"pageNumber": 0, "pageSize": 10, "totalElements": 1, "totalPages": 1},
+}
+
+
+@dataclass(frozen=True)
+class IngestedSddcCanary:
+    """Bundle returned by :func:`ingested_sddc_canary`."""
+
+    operator: Operator
+    connector_id: str
+    target_name: str
+    base_url: str
+
+
+async def _insert_sddc_descriptors() -> None:
+    """Seed the 9 curated SDDC Manager core ops + their groups as enabled rows.
+
+    One :class:`OperationGroup` per entry in :data:`SDDC_CORE_GROUPS`
+    (``review_status='enabled'``), one :class:`EndpointDescriptor` per entry
+    in :data:`SDDC_CORE_OPS` (``is_enabled=True``, ``source_kind='ingested'``,
+    ``handler_ref=None``).
+
+    Rows use ``product=SDDC_PRODUCT="sddc"`` (from
+    :func:`parse_connector_id("sddc-rest-9.0")`), not the connector class's
+    ``product="sddc-manager"``. The target row uses ``product="sddc-manager"``
+    so the resolver finds :class:`SddcManagerConnector`.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, UUID] = {}
+    async with sessionmaker() as session:
+        for group in SDDC_CORE_GROUPS:
+            group_row = OperationGroup(
+                tenant_id=None,
+                product=SDDC_PRODUCT,
+                version=SDDC_VERSION,
+                impl_id=SDDC_IMPL_ID,
+                group_key=group.group_key,
+                name=group.name,
+                when_to_use=group.when_to_use,
+                review_status="enabled",
+            )
+            session.add(group_row)
+            await session.flush()
+            group_ids[group.group_key] = group_row.id
+
+        for op in SDDC_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            descriptor = EndpointDescriptor(
+                tenant_id=None,
+                product=SDDC_PRODUCT,
+                version=SDDC_VERSION,
+                impl_id=SDDC_IMPL_ID,
+                op_id=op.op_id,
+                source_kind="ingested",
+                method=method,
+                path=path,
+                handler_ref=None,
+                group_id=group_ids[op.group_key],
+                summary=f"SDDC Manager core op {op.op_id} (curated read).",
+                description=f"SDDC Manager core op {op.op_id} (curated read).",
+                parameter_schema=_param_schema_for(path),
+                response_schema={"type": "object"},
+                llm_instructions=op.llm_instructions,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                tags=["spec:sddc-manager-9.0/api.yaml"],
+            )
+            session.add(descriptor)
+        await session.commit()
+
+
+def _param_schema_for(path: str) -> dict[str, object]:
+    """Build a minimal ``parameter_schema`` for each ``{var}`` in *path*.
+
+    Mirrors :func:`tests.acceptance._nsx_canary_fixtures._param_schema_for`.
+    Only ``GET:/v1/domains/{id}`` has a path parameter in the curated SDDC
+    Manager core; all other ops return the empty-properties schema.
+    """
+    placeholders = _PATH_VAR_RE.findall(path)
+    if not placeholders:
+        return {"type": "object", "properties": {}}
+    return {
+        "type": "object",
+        "properties": {
+            name: {"type": "string", "x-meho-param-loc": "path"} for name in placeholders
+        },
+        "required": list(placeholders),
+    }
+
+
+async def _sddc_credentials_loader(_target: object) -> dict[str, str]:
+    """Stub credentials loader — bypasses the not-yet-wired Vault read."""
+    return {"username": "sddc-canary-svc", "password": "sddc-canary-pw"}
+
+
+def _register_sddc_routes(mock: respx.MockRouter) -> None:
+    """Register the 9 SDDC Manager read-op routes on *mock*.
+
+    SDDC Manager uses HTTP Basic on every request — no session establish
+    call is needed. Each route returns a pre-seeded JSON body matching
+    the rough shape SDDC Manager returns for that path family.
+
+    The ``GET:/v1/domains/{id}`` route is registered for the specific
+    ``domain-mgmt`` id the dispatch smoke test uses as its path parameter.
+    """
+    mock.get("/v1/releases/system").respond(200, json=SDDC_CANARY_RELEASE)
+    mock.get("/v1/sddc-managers").respond(200, json=SDDC_CANARY_MANAGERS)
+    mock.get("/v1/domains").respond(200, json=SDDC_CANARY_DOMAINS)
+    # Path-templated domain detail — match the specific id the smoke test
+    # passes as the ``{id}`` parameter.
+    mock.get("/v1/domains/domain-mgmt").respond(200, json=SDDC_CANARY_DOMAIN_DETAIL)
+    mock.get("/v1/clusters").respond(200, json=SDDC_CANARY_CLUSTERS)
+    mock.get("/v1/hosts").respond(200, json=SDDC_CANARY_HOSTS)
+    mock.get("/v1/network-pools").respond(200, json=SDDC_CANARY_NETWORK_POOLS)
+    mock.get("/v1/bundles").respond(200, json=SDDC_CANARY_BUNDLES)
+    mock.get("/v1/tasks").respond(200, json=SDDC_CANARY_TASKS)
+
+
+@pytest.fixture
+def sddc_acceptance_operator() -> Operator:
+    """Frozen :class:`Operator` the SDDC Manager dispatch tests act as."""
+    return Operator(
+        sub="g35-sddc-acceptance",
+        name="G3.5-T5 SDDC Acceptance",
+        email=None,
+        raw_jwt="<sddc-acceptance-raw-jwt>",
+        tenant_id=SDDC_CANARY_OPERATOR_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+@pytest.fixture
+async def ingested_sddc_canary(
+    pg_engine: None,
+    sddc_acceptance_operator: Operator,
+) -> AsyncIterator[IngestedSddcCanary]:
+    """Yield a dispatcher-ready SDDC Manager setup over a respx-mocked appliance.
+
+    Setup mirrors :func:`tests.acceptance._nsx_canary_fixtures.ingested_nsx_canary`:
+
+    1. Insert built-in :class:`OperationGroup` + :class:`EndpointDescriptor`
+       rows for the 9 curated SDDC Manager core ops.
+    2. Seed a :class:`Target` with ``product="sddc-manager"`` and the
+       :data:`SDDC_CANARY_FINGERPRINT` so the resolver binds
+       :class:`SddcManagerConnector`.
+    3. Resolve + cache the :class:`SddcManagerConnector` instance the
+       dispatcher will use, patching only its ``_credentials_loader``.
+    4. Activate a respx router for :data:`SDDC_CANARY_BASE_URL` and
+       register the SDDC Manager REST surface.
+    """
+    await _insert_sddc_descriptors()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=SDDC_CANARY_OPERATOR_TENANT,
+            name=SDDC_TARGET_NAME,
+            aliases=[],
+            product="sddc-manager",
+            host=SDDC_CANARY_BASE_URL.removeprefix("https://"),
+            port=443,
+            fqdn=None,
+            secret_ref="kv/data/sddc-manager/sddc-canary",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=SDDC_CANARY_FINGERPRINT,
+            notes="seeded by tests.acceptance._sddc_canary_fixtures.ingested_sddc_canary",
+        )
+        session.add(target)
+        await session.commit()
+
+    registry = all_connectors_v2()
+    connector_cls = registry.get(("sddc-manager", SDDC_VERSION, "sddc-rest"))
+    if connector_cls is None:
+        import importlib
+
+        import meho_backplane.connectors.sddc_manager as _sddc_pkg
+
+        importlib.reload(_sddc_pkg)
+        registry = all_connectors_v2()
+        connector_cls = registry.get(("sddc-manager", SDDC_VERSION, "sddc-rest"))
+
+    assert connector_cls is SddcManagerConnector, (
+        f"expected SddcManagerConnector registered for "
+        f"(sddc-manager, {SDDC_VERSION}, sddc-rest); got {connector_cls!r}"
+    )
+
+    instance = get_or_create_connector_instance(connector_cls)
+    instance._credentials_loader = _sddc_credentials_loader  # type: ignore[attr-defined]
+
+    async with respx.mock(
+        base_url=SDDC_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_sddc_routes(mock)
+        try:
+            yield IngestedSddcCanary(
+                operator=sddc_acceptance_operator,
+                connector_id=SDDC_CONNECTOR_ID,
+                target_name=SDDC_TARGET_NAME,
+                base_url=SDDC_CANARY_BASE_URL,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -68,6 +68,12 @@ from tests.acceptance._nsx_canary_fixtures import (
     ingested_nsx_canary,
     nsx_acceptance_operator,
 )
+from tests.acceptance._sddc_canary_fixtures import (
+    SDDC_CANARY_OPERATOR_TENANT,
+    IngestedSddcCanary,
+    ingested_sddc_canary,
+    sddc_acceptance_operator,
+)
 from tests.acceptance._vcsim import (
     DEFAULT_VCSIM_TOPOLOGY,
     VcsimEndpoint,
@@ -87,19 +93,23 @@ __all__ = [
     "DEFAULT_VCSIM_TOPOLOGY",
     "DOCKER_AVAILABLE",
     "NSX_CANARY_OPERATOR_TENANT",
+    "SDDC_CANARY_OPERATOR_TENANT",
     "SKIP_REASON",
     "IngestedCanaryVcsim",
     "IngestedNsxCanary",
+    "IngestedSddcCanary",
     "VcsimEndpoint",
     "VcsimTopology",
     "acceptance_operator",
     "async_pg_url",
     "ingested_canary_vcsim",
     "ingested_nsx_canary",
+    "ingested_sddc_canary",
     "integration_env",
     "nsx_acceptance_operator",
     "pg_engine",
     "prewarmed_embeddings",
+    "sddc_acceptance_operator",
     "vcsim_endpoint",
 ]
 

--- a/backend/tests/acceptance/test_g35_sddc_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g35_sddc_dispatch_smoke.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.5-T5 dispatch smoke — the 9 curated SDDC Manager read ops over respx.
+
+Closes the substrate-proves-out half of the SDDC Manager v0.2 ship for
+Initiative #368: each entry in
+:data:`~meho_backplane.connectors.sddc_manager.core_ops.SDDC_CORE_OPS` is
+dispatched against a respx-mocked SDDC Manager appliance and the dispatcher
+returns a structured :class:`~meho_backplane.connectors.schemas.OperationResult`
+for every one.
+
+Why respx and not a real SDDC Manager target: SDDC Manager has no public CI
+simulator. Per Initiative #368's DoD, SDDC Manager uses the vcsim-style
+record/replay fixture pattern (a known limitation; documented in the
+Initiative DoD). The full env-gated spec-canary ingest is a follow-up to
+this Task (planned for G3.5-T6 #618); until then, the dispatch leg is
+exercised directly against the curated descriptor set the
+:data:`SDDC_CORE_OPS` constants describe.
+
+Skip conditions: no Postgres — the ``pg_engine`` fixture skips when the
+integration database isn't reachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.connectors.sddc_manager import SDDC_CORE_OPS
+from meho_backplane.operations.meta_tools import call_operation
+from tests.acceptance._sddc_canary_fixtures import IngestedSddcCanary
+
+SMOKE_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in SDDC_CORE_OPS)
+
+#: Per-op parameter map. Only ``GET:/v1/domains/{id}`` carries a path
+#: template (``{id}``) that needs substitution. The smoke passes
+#: ``id=domain-mgmt`` to hit the registered respx route.
+SMOKE_PARAMS: dict[str, dict[str, object]] = {
+    "GET:/v1/domains/{id}": {"id": "domain-mgmt"},
+}
+
+
+@pytest.mark.parametrize("op_id", SMOKE_OP_IDS, ids=lambda op: op)
+async def test_dispatch_smoke_sddc_core_op_returns_ok(
+    op_id: str,
+    ingested_sddc_canary: IngestedSddcCanary,
+) -> None:
+    """Each curated SDDC Manager core op dispatches over respx and returns ``status='ok'``.
+
+    HTTP Basic auth is computed by the connector on each request (no
+    session establish); the connector's stub credentials loader returns a
+    static pair. Asserting only ``status='ok'`` keeps the smoke focused
+    on the dispatch leg — payload shape is the JSONFlux force-handle
+    test's job.
+    """
+    params = SMOKE_PARAMS.get(op_id, {})
+    result = await call_operation(
+        ingested_sddc_canary.operator,
+        {
+            "connector_id": ingested_sddc_canary.connector_id,
+            "op_id": op_id,
+            "target": {"name": ingested_sddc_canary.target_name},
+            "params": params,
+        },
+    )
+
+    assert result["status"] == "ok", (
+        f"SDDC Manager op {op_id!r} failed against the respx-mocked appliance at "
+        f"{ingested_sddc_canary.base_url}: {result.get('error')!r}; "
+        f"full result={result!r}"
+    )

--- a/backend/tests/acceptance/test_g35_sddc_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_g35_sddc_jsonflux_force_handle.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.5-T5 JSONFlux force-mode acceptance for the SDDC Manager connector.
+
+v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
+— the production reducer never produces a :class:`ResultHandle`. This test
+mirrors :mod:`tests.acceptance.test_g35_nsx_jsonflux_force_handle` verbatim,
+swapping in SDDC Manager as the dispatched connector: it installs a test-only
+:class:`ForceHandleReducer` that wraps every payload in a synthetic handle,
+dispatches ``GET:/v1/hosts`` against the seeded SDDC Manager core, and asserts
+the :class:`~meho_backplane.connectors.schemas.OperationResult`'s ``handle``
+field carries a populated :class:`ResultHandle`.
+
+The SDDC Manager API returns paginated results under an ``elements[]`` key
+(vs NSX's ``results[]``). The :class:`ForceHandleReducer` handles both shapes
+so the dispatcher-seam test doesn't depend on a specific list-key name.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+from tests.acceptance._sddc_canary_fixtures import (
+    SDDC_CANARY_HOSTS,
+    SDDC_FORCE_HANDLE_LIST_OP_ID,
+    IngestedSddcCanary,
+)
+
+
+class ForceHandleReducer:
+    """Test-only reducer that always produces a :class:`ResultHandle`.
+
+    Recognises three pagination shapes the SDDC Manager and NSX APIs use:
+
+    * ``dict`` with ``"elements"`` key (SDDC Manager paginated envelope).
+    * ``dict`` with ``"results"`` key (NSX policy/manager API list shape).
+    * ``dict`` with ``"value"`` key (vCenter REST list shape).
+    * ``list`` → total = ``len(payload)``.
+    * Anything else → total = 1, sample = ().
+    """
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        """Always return ``(summary_dict, ResultHandle)``."""
+        del schema, context
+        if isinstance(payload, dict):
+            for key in ("elements", "results", "value"):
+                rows = payload.get(key)
+                if isinstance(rows, list):
+                    total = len(rows)
+                    sample = tuple(rows[:5]) if rows else ()
+                    break
+            else:
+                total = 1
+                sample = ()
+        elif isinstance(payload, list):
+            total = len(payload)
+            sample = tuple(payload[:5]) if payload else ()
+        else:
+            total = 1
+            sample = ()
+
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"force-mode handle ({total} rows)",
+            schema_={"type": "array", "items": {"type": "object"}},
+            total_rows=total,
+            sample_rows=sample if sample else None,
+            ttl_seconds=3600,
+        )
+        summary = {"row_count": total, "sample": list(sample)}
+        return summary, handle
+
+
+@pytest.fixture
+def force_handle_reducer() -> Any:
+    """Install :class:`ForceHandleReducer` as the dispatcher's default."""
+    set_default_reducer(ForceHandleReducer())
+    try:
+        yield
+    finally:
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+
+async def test_force_handle_reducer_populates_operation_result_handle_for_sddc(
+    force_handle_reducer: None,
+    ingested_sddc_canary: IngestedSddcCanary,
+) -> None:
+    """Dispatching the SDDC Manager host list populates ``OperationResult.handle``.
+
+    Confirms the JSONFlux dispatcher seam end-to-end for SDDC Manager:
+
+    * ``status == 'ok'`` — dispatch succeeded (HTTP Basic auth + GET
+      against ``/v1/hosts``).
+    * ``handle`` is a :class:`ResultHandle` — the reducer's return value
+      flowed through ``wrap_ok_result``.
+    * ``handle.total_rows`` matches the seeded host count from
+      :data:`SDDC_CANARY_HOSTS`.
+    * ``handle.summary_md`` is non-empty and mentions the row count.
+    * ``handle.schema_`` is a non-empty mapping.
+    * ``handle.sample_rows`` is populated — at least one row from the
+      seeded host list.
+    * ``result['row_count']`` matches the handle's total.
+    """
+    expected_rows = len(SDDC_CANARY_HOSTS["elements"])  # type: ignore[arg-type]
+
+    result_envelope = await call_operation(
+        ingested_sddc_canary.operator,
+        {
+            "connector_id": ingested_sddc_canary.connector_id,
+            "op_id": SDDC_FORCE_HANDLE_LIST_OP_ID,
+            "target": {"name": ingested_sddc_canary.target_name},
+            "params": {},
+        },
+    )
+
+    assert result_envelope["status"] == "ok", (
+        f"force-handle dispatch did not succeed: {result_envelope!r}"
+    )
+
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        f"expected OperationResult.handle to be populated by ForceHandleReducer; "
+        f"got handle=None on envelope={result_envelope!r}"
+    )
+    uuid.UUID(handle["handle_id"])
+    assert handle["total_rows"] == expected_rows, (
+        f"expected {expected_rows} hosts from the seeded SDDC_CANARY_HOSTS; "
+        f"got handle.total_rows={handle['total_rows']}"
+    )
+    assert handle["summary_md"], "handle.summary_md must be non-empty"
+    assert str(expected_rows) in handle["summary_md"], (
+        f"expected summary_md to mention the row count; got {handle['summary_md']!r}"
+    )
+    assert isinstance(handle["schema_"], dict) and handle["schema_"], (
+        f"handle.schema_ must be a non-empty mapping; got {handle['schema_']!r}"
+    )
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        f"expected ≥1 sample row from the seeded SDDC host list; got sample_rows={sample_rows!r}"
+    )
+
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == expected_rows, (
+        f"expected the reducer's summary on result; got result={payload!r}"
+    )

--- a/backend/tests/test_connectors_sddc_manager_core_ops.py
+++ b/backend/tests/test_connectors_sddc_manager_core_ops.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the SDDC Manager read-only v0.2 core-ops curation.
+
+Covers :mod:`meho_backplane.connectors.sddc_manager.core_ops`:
+
+* :func:`classify_sddc_op` — path-prefix classifier rules.
+* :func:`apply_sddc_core_curation` — the operator-review-time
+  substrate call that flips ``review_status='enabled'`` on the 8
+  curated groups, lands ``llm_instructions`` on the 9 curated ops,
+  and explicitly disables non-core ops in curated groups via the
+  audit-log-driven operator-override exclusion so the
+  :meth:`enable_group` cascade skips them. The load-bearing
+  assertion is "9 ops dispatchable, every other op in curated
+  groups stays ``is_enabled=False``".
+
+Test harness mirrors :mod:`tests.test_connectors_nsx_core_ops`:
+SQLite via the autouse ``_default_database_url`` fixture, hand-rolled
+operator + connector seeding, audit-row counting from the chassis
+``audit_log`` table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.sddc_manager import (
+    SDDC_CORE_GROUPS,
+    SDDC_CORE_OPS,
+    SDDC_IMPL_ID,
+    SDDC_PRODUCT,
+    SDDC_VERSION,
+    apply_sddc_core_curation,
+    classify_sddc_op,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import ReviewService
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env vars Operator construction reads transitively.
+
+    Mirrors :mod:`tests.test_connectors_nsx_core_ops` — the chassis
+    :func:`get_settings` is cached, so each test rotates the cache
+    before and after to keep cross-test leakage out.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+_FAKE_JWT = "header.payload.signature"
+
+_TEST_TENANT: uuid.UUID = uuid.UUID("22222222-3333-4444-5555-666666666666")
+
+
+def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
+    """Build a tenant-admin :class:`Operator` for the curation tests."""
+    return Operator(
+        sub=f"sddc-core-ops-test-{uuid.uuid4()}",
+        name="SDDC Core Ops Test",
+        email=None,
+        raw_jwt=_FAKE_JWT,
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+async def _seed_curated_groups_and_ops(
+    *,
+    tenant_id: uuid.UUID,
+    extra_ops_per_group: int = 0,
+) -> dict[str, uuid.UUID]:
+    """Seed every :data:`SDDC_CORE_GROUPS` entry + its child ops.
+
+    Inserts one :class:`OperationGroup` per curated group_key
+    (``review_status='staged'``, placeholder name + when_to_use so
+    :func:`apply_sddc_core_curation`'s ``edit_group`` step has something
+    to overwrite). For each :data:`SDDC_CORE_OPS` entry, inserts the
+    curated op (``is_enabled=False`` to match the G0.7 ingest default
+    for ``source_kind='ingested'`` rows).
+
+    When *extra_ops_per_group* > 0, also seeds *N* non-curated ops per
+    curated group with deterministic op_ids
+    (``f"GET:/canary-extra/{group_key}/{i}"``) so the test can assert
+    :func:`apply_sddc_core_curation` correctly disables them.
+
+    Returns ``{group_key: group_id}`` for follow-up assertions.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, uuid.UUID] = {}
+    async with sessionmaker() as session:
+        for group in SDDC_CORE_GROUPS:
+            group_id = uuid.uuid4()
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=tenant_id,
+                    product=SDDC_PRODUCT,
+                    version=SDDC_VERSION,
+                    impl_id=SDDC_IMPL_ID,
+                    group_key=group.group_key,
+                    name=f"PLACEHOLDER NAME for {group.group_key}",
+                    when_to_use=f"PLACEHOLDER when_to_use for {group.group_key}",
+                    review_status="staged",
+                ),
+            )
+            group_ids[group.group_key] = group_id
+
+        for op in SDDC_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=tenant_id,
+                    product=SDDC_PRODUCT,
+                    version=SDDC_VERSION,
+                    impl_id=SDDC_IMPL_ID,
+                    op_id=op.op_id,
+                    source_kind="ingested",
+                    method=method,
+                    path=path,
+                    group_id=group_ids[op.group_key],
+                    summary=f"ingested op {op.op_id}",
+                    is_enabled=False,
+                ),
+            )
+
+        if extra_ops_per_group:
+            for group in SDDC_CORE_GROUPS:
+                for i in range(extra_ops_per_group):
+                    extra_op_id = f"GET:/canary-extra/{group.group_key}/{i}"
+                    session.add(
+                        EndpointDescriptor(
+                            tenant_id=tenant_id,
+                            product=SDDC_PRODUCT,
+                            version=SDDC_VERSION,
+                            impl_id=SDDC_IMPL_ID,
+                            op_id=extra_op_id,
+                            source_kind="ingested",
+                            method="GET",
+                            path=f"/canary-extra/{group.group_key}/{i}",
+                            group_id=group_ids[group.group_key],
+                            summary=f"non-core op in {group.group_key}",
+                            is_enabled=False,
+                        ),
+                    )
+        await session.commit()
+    return group_ids
+
+
+async def _ops_state(
+    *,
+    tenant_id: uuid.UUID,
+) -> dict[str, dict[str, Any]]:
+    """Return ``{op_id: {is_enabled, llm_instructions}}`` for every SDDC Manager op."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(EndpointDescriptor).where(
+            EndpointDescriptor.tenant_id == tenant_id,
+            EndpointDescriptor.product == SDDC_PRODUCT,
+            EndpointDescriptor.version == SDDC_VERSION,
+            EndpointDescriptor.impl_id == SDDC_IMPL_ID,
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+    return {
+        row.op_id: {
+            "is_enabled": row.is_enabled,
+            "llm_instructions": row.llm_instructions,
+        }
+        for row in rows
+    }
+
+
+async def _group_statuses(*, tenant_id: uuid.UUID) -> dict[str, str]:
+    """Return ``{group_key: review_status}`` for every SDDC Manager group."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(OperationGroup).where(
+            OperationGroup.tenant_id == tenant_id,
+            OperationGroup.product == SDDC_PRODUCT,
+            OperationGroup.version == SDDC_VERSION,
+            OperationGroup.impl_id == SDDC_IMPL_ID,
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+    return {row.group_key: row.review_status for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# classify_sddc_op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,expected",
+    [
+        ("GET:/v1/releases/system", "sddc-releases"),
+        ("GET:/v1/sddc-managers", "sddc-managers"),
+        ("GET:/v1/domains", "sddc-domains"),
+        ("GET:/v1/domains/some-uuid", "sddc-domains"),
+        ("GET:/v1/clusters", "sddc-clusters"),
+        ("GET:/v1/hosts", "sddc-hosts"),
+        ("GET:/v1/network-pools", "sddc-network-pools"),
+        ("GET:/v1/bundles", "sddc-bundles"),
+        ("GET:/v1/tasks", "sddc-tasks"),
+        ("GET:/v1/vcenters", "none"),
+        ("GET:/v1/nsxt-clusters", "none"),
+        ("GET:/v2/domains", "none"),
+        ("malformed_op_id_no_colon", "none"),
+    ],
+)
+def test_classify_sddc_op_maps_paths_to_expected_group_keys(
+    op_id: str,
+    expected: str,
+) -> None:
+    """Path-prefix classifier returns the canonical ``group_key`` per path."""
+    assert classify_sddc_op(op_id) == expected
+
+
+# ---------------------------------------------------------------------------
+# apply_sddc_core_curation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_enables_groups_and_lands_llm_instructions() -> None:
+    """All 8 curated groups end ``enabled``; all 9 core ops carry the curated blob."""
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_sddc_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    statuses = await _group_statuses(tenant_id=tenant_id)
+    assert all(s == "enabled" for s in statuses.values()), statuses
+    assert set(statuses) == {g.group_key for g in SDDC_CORE_GROUPS}
+
+    state = await _ops_state(tenant_id=tenant_id)
+    for op in SDDC_CORE_OPS:
+        row = state[op.op_id]
+        assert row["is_enabled"] is True, op.op_id
+        assert row["llm_instructions"] == op.llm_instructions, op.op_id
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_keeps_non_core_ops_disabled_via_override_path() -> None:
+    """Non-core ops in curated groups stay ``is_enabled=False`` after enable_group cascade.
+
+    Seeds 2 extra non-core ops per curated group, runs the helper, and
+    asserts only the 9 curated ops flip to ``is_enabled=True`` while the
+    16 non-core ops (8 groups times 2 extras) stay ``False``.
+    """
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=2)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_sddc_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    state = await _ops_state(tenant_id=tenant_id)
+    core_op_ids = {op.op_id for op in SDDC_CORE_OPS}
+    for op_id, row in state.items():
+        if op_id in core_op_ids:
+            assert row["is_enabled"] is True, (
+                f"curated core op {op_id} should be enabled after curation"
+            )
+        else:
+            assert row["is_enabled"] is False, (
+                f"non-core op {op_id} should stay disabled after curation; "
+                f"the operator-override path was the safeguard"
+            )
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_writes_expected_audit_rows() -> None:
+    """The curation step emits the expected audit-row breakdown.
+
+    Per group: 1 ``meho.connector.edit_group`` row + at most 1
+    ``meho.connector.enable_group`` row (suppressed when already enabled).
+    Per non-core op in a curated group: 1 ``meho.connector.edit_op`` row
+    with ``is_enabled_set_to=False``. Per core op: 1
+    ``meho.connector.edit_op`` row with
+    ``fields_updated=['llm_instructions']``.
+    """
+    tenant_id = _TEST_TENANT
+    extras_per_group = 1
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=extras_per_group)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_sddc_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+
+    by_path: dict[str, list[AuditLog]] = {}
+    for row in rows:
+        by_path.setdefault(row.path, []).append(row)
+
+    group_count = len(SDDC_CORE_GROUPS)
+    op_count = len(SDDC_CORE_OPS)
+    non_core_count = group_count * extras_per_group
+
+    assert len(by_path.get("meho.connector.edit_group", [])) == group_count, (
+        f"one edit_group row per curated group; got "
+        f"{len(by_path.get('meho.connector.edit_group', []))}"
+    )
+    assert len(by_path.get("meho.connector.enable_group", [])) == group_count, (
+        f"one enable_group row per curated group; got "
+        f"{len(by_path.get('meho.connector.enable_group', []))}"
+    )
+    edit_op_rows = by_path.get("meho.connector.edit_op", [])
+    assert len(edit_op_rows) == non_core_count + op_count, (
+        f"expected {non_core_count + op_count} edit_op rows "
+        f"({non_core_count} non-core disables + {op_count} curated "
+        f"llm_instructions); got {len(edit_op_rows)}"
+    )
+    disable_rows = [r for r in edit_op_rows if r.payload.get("is_enabled_set_to") is False]
+    assert len(disable_rows) == non_core_count, (
+        f"expected {non_core_count} disable rows; got {len(disable_rows)}"
+    )
+    llm_rows = [r for r in edit_op_rows if r.payload.get("fields_updated") == ["llm_instructions"]]
+    assert len(llm_rows) == op_count, (
+        f"expected {op_count} llm_instructions rows; got {len(llm_rows)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_is_safe_to_rerun() -> None:
+    """Re-running the helper on an already-curated connector keeps state correct."""
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=1)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_sddc_core_curation(ReviewService(operator), tenant_id=tenant_id)
+    await apply_sddc_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    state = await _ops_state(tenant_id=tenant_id)
+    core_op_ids = {op.op_id for op in SDDC_CORE_OPS}
+    for op_id, row in state.items():
+        if op_id in core_op_ids:
+            assert row["is_enabled"] is True, op_id
+        else:
+            assert row["is_enabled"] is False, op_id
+    statuses = await _group_statuses(tenant_id=tenant_id)
+    assert all(s == "enabled" for s in statuses.values()), statuses

--- a/docs/codebase/connectors-sddc-manager.md
+++ b/docs/codebase/connectors-sddc-manager.md
@@ -14,6 +14,22 @@ Source: `backend/src/meho_backplane/connectors/sddc_manager/`.
 
 ## Key types
 
+- **`SddcCoreGroup`** (`core_ops.py`) — frozen dataclass carrying `group_key`,
+  `name`, and `when_to_use` for one operator-reviewed LLM-grouping output group.
+  8 entries in `SDDC_CORE_GROUPS` span the 8 SDDC Manager path families.
+- **`SddcCoreOp`** (`core_ops.py`) — frozen dataclass carrying `op_id`,
+  `group_key`, and `llm_instructions` for one curated read op. 9 entries in
+  `SDDC_CORE_OPS` (2 in the `sddc-domains` group; 1 in every other group).
+- **`SDDC_PATH_RULES`** (`core_ops.py`) — ordered tuple of `(path_prefix,
+  group_key)` pairs used by `classify_sddc_op` to assign a VCF API path to its
+  curated group. First match wins; covers the 8 top-level resource families
+  (`releases`, `sddc-managers`, `domains`, `clusters`, `hosts`, `network-pools`,
+  `bundles`, `tasks`).
+- **`SDDC_PRODUCT`** (`core_ops.py`) — `"sddc"`, the value
+  `parse_connector_id("sddc-rest-9.0")` extracts (first hyphen-segment of
+  `impl_id="sddc-rest"`). This is the `product` stored in `endpoint_descriptor`
+  and `operation_group` rows — **distinct** from `SddcManagerConnector.product`
+  (`"sddc-manager"`), which is the v2 registry key and resolver target.
 - **`SddcManagerConnector`** (`connector.py`) — `HttpConnector` subclass.
   Class attributes: `product="sddc-manager"`, `version="9.0"`,
   `impl_id="sddc-rest"`, `supported_version_range=">=9.0,<10.0"`,
@@ -126,6 +142,54 @@ client.
   shape without a network call.
 - **structlog** — a single `sddc_manager_credentials_loaded` info event per
   successful first-use credential load; no other emit points in this skeleton.
+
+## `core_ops.py` — curation module
+
+`core_ops.py` is the operator-review metadata store for the curated 9-op read
+core. It mirrors the pattern `connectors/nsx/core_ops.py` established for NSX.
+
+### `classify_sddc_op(op_id) -> str`
+
+Strips the `METHOD:` prefix and walks `SDDC_PATH_RULES` in order, returning
+the first matching `group_key` or `"none"` for uncurated paths. Used during
+operator review to assign new ingested ops to groups without manual
+classification.
+
+### `apply_sddc_core_curation(review_service, *, tenant_id)`
+
+The operator-review-time substrate call. After this call:
+
+- All 8 curated groups land `review_status='enabled'`.
+- Exactly the 9 ops in `SDDC_CORE_OPS` are `is_enabled=True`.
+- Every other op in a curated group carries an operator-override audit row
+  (`is_enabled=False`) that the `enable_group` cascade respects.
+- Each curated op carries the reviewed `llm_instructions` blob.
+
+The helper uses `ReviewService.get_review_payload` + `edit_op(is_enabled=False)`
+(for non-core ops) + `edit_group` + `enable_group` + `edit_op(llm_instructions=...)`
+in that order, exactly matching the `apply_nsx_core_curation` pattern.
+
+Re-running is safe: `enable_group` short-circuits on already-enabled groups
+(no audit row), but `edit_group` and `edit_op` always emit one audit row per
+call even on no-op values. Intended posture is a one-shot curation after ingest.
+
+### The 9 curated ops
+
+| op_id | group | cli alias |
+|---|---|---|
+| `GET:/v1/releases/system` | `sddc-releases` | `sddc.about` |
+| `GET:/v1/sddc-managers` | `sddc-managers` | `sddc.manager.list` |
+| `GET:/v1/domains` | `sddc-domains` | `sddc.domain.list` |
+| `GET:/v1/domains/{id}` | `sddc-domains` | `sddc.domain.info` |
+| `GET:/v1/clusters` | `sddc-clusters` | `sddc.cluster.list` |
+| `GET:/v1/hosts` | `sddc-hosts` | `sddc.host.list` |
+| `GET:/v1/network-pools` | `sddc-network-pools` | `sddc.network_pool.list` |
+| `GET:/v1/bundles` | `sddc-bundles` | `sddc.bundle.list` |
+| `GET:/v1/tasks` | `sddc-tasks` | `sddc.workflow.list` |
+
+Lifecycle-write ops (`workflow start`, `domain create`, `cluster expand`,
+`host commission`) remain `staged` (never enabled) per Initiative #368 v0.2
+scope.
 
 ## Known issues
 


### PR DESCRIPTION
## Summary

- Adds `connectors/sddc_manager/core_ops.py`: 8 curated groups, 9 read-only ops, `classify_sddc_op`, `apply_sddc_core_curation` — mirrors the NSX precedent exactly.
- `apply_sddc_core_curation` uses the audit-log-driven operator-override pattern: disable non-core ops first, then `enable_group` cascade skips them, so only the 9 curated ops end `is_enabled=True`.
- `SDDC_PRODUCT = "sddc"` (from `parse_connector_id("sddc-rest-9.0")`) kept distinct from `SddcManagerConnector.product = "sddc-manager"` (v2 registry key) — both values used correctly across descriptor rows and Target row.
- Acceptance fixture layer added (`_sddc_canary_fixtures.py`, registered in `tests/acceptance/conftest.py`); HTTP Basic auth means no session-establish route in respx mocks.

## Test plan

- [x] `ruff check` — clean (2 auto-fixes applied: unused import + import sort)
- [x] `ruff format --check` — clean (1 file reformatted before final check)
- [x] `mypy src/meho_backplane/connectors/sddc_manager/ --ignore-missing-imports` — 0 issues, 4 files
- [x] `pytest tests/test_connectors_sddc_manager_core_ops.py -x -q` — 17 passed
  - `test_classify_sddc_op_maps_paths_to_expected_group_keys` — 13 parametrized path/group mappings verified
  - `test_apply_curation_enables_groups_and_lands_llm_instructions` — all 8 groups `enabled`, all 9 ops carry curated blob
  - `test_apply_curation_keeps_non_core_ops_disabled_via_override_path` — 16 non-core ops stay `is_enabled=False`
  - `test_apply_curation_writes_expected_audit_rows` — correct edit_group / enable_group / edit_op breakdown
  - `test_apply_curation_is_safe_to_rerun` — idempotency verified
- [x] `pytest tests/acceptance/test_g35_sddc_dispatch_smoke.py tests/acceptance/test_g35_sddc_jsonflux_force_handle.py -x -q` — 10 passed
  - Dispatch smoke: all 9 `SDDC_CORE_OPS` op_ids return `status='ok'` over respx-mocked appliance
  - JSONFlux force-handle: `GET:/v1/hosts` with `ForceHandleReducer` populates `OperationResult.handle` with correct `total_rows=12`

## Out of scope

- CLI verbs (`sddc.about`, `sddc.domain.list`, etc.) and MCP review — G3.5-T6 #618
- Production Vault credentials loader — G0.3 #224

Closes #617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 9 curated core read operations for SDDC Manager connector v9.0, with operator-reviewed metadata and automatic enablement.

* **Tests**
  * Added comprehensive acceptance and unit tests validating SDDC Manager operations dispatch and curation behavior.

* **Documentation**
  * Added detailed documentation for SDDC Manager core operations, curation metadata, and usage patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->