### PR TITLE
feat(broadcast): G6.3-T3 per-call broadcast-detail opt-in (X-Broadcast-Detail + MCP _meta)

### DIFF
--- a/backend/src/meho_backplane/audit.py
+++ b/backend/src/meho_backplane/audit.py
@@ -635,6 +635,13 @@ class AuditMiddleware:
             )
             broadcast_payload = dict(payload)
             payload["broadcast_detail_origin"] = broadcast_decision[2]
+            # G6.3-T3 (#380): record the resolver's effective detail
+            # alongside the origin so ``meho audit query`` can answer
+            # both "who/what decided" and "what detail did they get".
+            # Audit-only -- the broadcast event renders ``detail`` via
+            # ``redact_payload``'s shape; this key on the audit row is
+            # for forensic queries, not for subscribers.
+            payload["broadcast_detail_effective"] = broadcast_decision[1]
 
         try:
             await _write_audit_row(

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -85,7 +85,7 @@ from meho_backplane.mcp import eager_import_mcp_modules
 from meho_backplane.mcp import router as mcp_router
 from meho_backplane.mcp.auth import mcp_resource_uri
 from meho_backplane.metrics import render_metrics
-from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.middleware import BroadcastDetailMiddleware, RequestContextMiddleware
 from meho_backplane.operations import run_typed_op_registrars
 from meho_backplane.retrieval.embedding import get_embedding_service
 from meho_backplane.settings import parse_bool_env
@@ -265,27 +265,34 @@ app: FastAPI = FastAPI(
 # Middleware registration order matters for ASGI: ``add_middleware``
 # wraps the existing app, so the *last* middleware added becomes the
 # outermost layer (its ``__call__`` runs first on the request side and
-# last on the response side). The required runtime order for v0.1 is:
+# last on the response side). The required runtime order for v0.2 is:
 #
-#   client → RequestContextMiddleware → AuditMiddleware → router → handler
+#   client → RequestContextMiddleware → BroadcastDetailMiddleware
+#          → AuditMiddleware → router → handler
 #
 # - ``RequestContextMiddleware`` outermost so ``request_id`` is bound
 #   before any inner middleware reads it; the
 #   :func:`~meho_backplane.middleware.verify_jwt_and_bind` dependency
 #   binds ``operator_sub`` deeper still, inside the handler invocation.
-# - ``AuditMiddleware`` directly inside it so the audit row sees both
-#   contextvars on the response side, and so its fail-closed 500
-#   replacement still passes through ``RequestContextMiddleware``'s
-#   header injection (the operator gets ``X-Request-Id`` even on the
-#   audit-failure path).
+# - ``BroadcastDetailMiddleware`` (G6.3-T3 #380) sits between
+#   ``RequestContextMiddleware`` and ``AuditMiddleware`` so the
+#   ``broadcast_detail_override`` contextvar is bound BEFORE
+#   ``AuditMiddleware``'s broadcast resolver consults it on the
+#   response side.
+# - ``AuditMiddleware`` directly inside ``BroadcastDetailMiddleware``
+#   so the audit row sees both contextvars on the response side, and
+#   so its fail-closed 500 replacement still passes through the outer
+#   middlewares' header injection / cleanup.
 #
 # To achieve that with ``add_middleware``'s last-added-is-outermost
 # rule, ``AuditMiddleware`` is registered *first* (becomes innermost),
-# then ``RequestContextMiddleware`` (becomes outermost). Middleware is
-# registered before routers so every endpoint (including the Task #19
-# health/version/ready surfaces and the Task #20 ``/metrics`` route)
-# inherits the request-id binding and the http_requests_total counter.
+# then ``BroadcastDetailMiddleware``, then ``RequestContextMiddleware``
+# (becomes outermost). Middleware is registered before routers so
+# every endpoint (including the Task #19 health/version/ready
+# surfaces and the Task #20 ``/metrics`` route) inherits the
+# request-id binding and the http_requests_total counter.
 app.add_middleware(AuditMiddleware)
+app.add_middleware(BroadcastDetailMiddleware)
 app.add_middleware(RequestContextMiddleware)
 
 app.include_router(health_router)

--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -83,7 +83,6 @@ from meho_backplane.broadcast import (
     BroadcastEvent,
     compute_effective_broadcast_detail,
     publish_event,
-    read_request_override,
     redact_payload,
 )
 from meho_backplane.mcp.audit import compute_params_hash, write_mcp_audit_row
@@ -116,6 +115,54 @@ _log = structlog.get_logger(__name__)
 #: this code to distinguish "I tried to read a resource that doesn't
 #: exist" from "I called a method the server doesn't support".
 _RESOURCE_NOT_FOUND: int = -32002
+
+
+def _read_mcp_broadcast_detail(raw_params: dict[str, Any]) -> Literal["full"] | None:
+    """Pull ``_meta.broadcast_detail`` out of an MCP method's ``params``.
+
+    G6.3-T3 (#380): MCP spec §Common/Utilities/_meta blesses ``_meta``
+    as the per-call metadata envelope. An operator opts into full
+    detail on a sensitive-class tool call (e.g. ``vault.kv.read``) by
+    sending::
+
+        {
+          "method": "tools/call",
+          "params": {
+            "name": "vault.kv.read",
+            "arguments": {"path": "secret/foo"},
+            "_meta": {"broadcast_detail": "full"}
+          }
+        }
+
+    Opt-in only -- per Initiative #376 DoD, only ``"full"`` is honored.
+    Any other value (including ``"aggregate"``, which would be a
+    "weaken via channel" request) is logged at ``info`` level under
+    ``mcp_broadcast_detail_invalid_meta`` and dropped silently -- the
+    request still succeeds and the broadcast uses the default detail.
+
+    Defensive accessors: a malformed ``_meta`` (not a dict, missing
+    entirely, contains the key with a wrong-type value) returns
+    ``None`` without raising. The fail-open contract is the same as
+    :func:`~meho_backplane.broadcast.publisher.publish_event` -- the
+    broadcast layer never converts a benign client mistake into an
+    operation failure.
+
+    Returns ``"full"`` when the operator opted in to full detail,
+    ``None`` otherwise. MCP path passes this value directly to
+    :func:`compute_effective_broadcast_detail` rather than threading
+    it through a contextvar -- handlers already pass :class:`Operator`
+    explicitly, so a parameter is more idiomatic than the structlog
+    contextvar shim the HTTP path uses.
+    """
+    meta = raw_params.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+    raw = meta.get("broadcast_detail")
+    if raw == "full":
+        return "full"
+    if raw is not None:
+        _log.info("mcp_broadcast_detail_invalid_meta", value=raw)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +242,7 @@ async def handle_tools_call(
     raw_params = params or {}
     name = raw_params.get("name")
     arguments = raw_params.get("arguments", {})
+    request_override = _read_mcp_broadcast_detail(raw_params)
     start = time.monotonic()
     audit_payload: dict[str, Any] = {
         "op_id": name if isinstance(name, str) else "",
@@ -302,16 +350,22 @@ async def handle_tools_call(
             op_id=audit_name,
             tenant_id=operator.tenant_id,
             raw_params=resolver_params,
-            request_override=read_request_override(),
+            request_override=request_override,
         )
         # Snapshot the broadcast-visible params BEFORE injecting the
-        # audit-only ``broadcast_detail_origin`` key. The audit row gets
-        # the augmented ``audit_payload``; the broadcast event reads
-        # ``broadcast_params`` so audit-internal metadata
-        # (origin, ``tenant_rule:<uuid>``) never reaches the
-        # broadcast feed.
+        # audit-only ``broadcast_detail_origin`` /
+        # ``broadcast_detail_effective`` keys. The audit row gets the
+        # augmented ``audit_payload``; the broadcast event reads
+        # ``broadcast_params`` so audit-internal metadata (origin,
+        # ``tenant_rule:<uuid>``, effective-detail enum) never reaches
+        # the broadcast feed.
         broadcast_params = dict(resolver_params)
         audit_payload["broadcast_detail_origin"] = broadcast_origin
+        # G6.3-T3 (#380): effective detail joins origin as an audit-
+        # only forensic field. Subscribers see ``detail`` through the
+        # rendered ``redact_payload`` shape; the audit row needs the
+        # raw enum for ``meho audit query`` filtering.
+        audit_payload["broadcast_detail_effective"] = broadcast_detail
         try:
             await write_mcp_audit_row(
                 audit_id=audit_id,
@@ -443,6 +497,7 @@ async def handle_resources_read(
     """
     raw_params = params or {}
     uri = raw_params.get("uri")
+    request_override = _read_mcp_broadcast_detail(raw_params)
     start = time.monotonic()
     audit_uri = uri if isinstance(uri, str) and uri else "<empty>"
     audit_payload: dict[str, Any] = {
@@ -511,14 +566,16 @@ async def handle_resources_read(
             op_id="mcp.resource.read",
             tenant_id=operator.tenant_id,
             raw_params=audit_payload,
-            request_override=read_request_override(),
+            request_override=request_override,
         )
         # Snapshot the broadcast-visible params BEFORE injecting the
-        # audit-only ``broadcast_detail_origin`` key -- same separation
-        # of audit-row and broadcast-event payloads as the tools/call
+        # audit-only ``broadcast_detail_origin`` /
+        # ``broadcast_detail_effective`` keys -- same separation of
+        # audit-row and broadcast-event payloads as the tools/call
         # path above.
         broadcast_params = dict(audit_payload)
         audit_payload["broadcast_detail_origin"] = broadcast_origin
+        audit_payload["broadcast_detail_effective"] = broadcast_detail
         try:
             await write_mcp_audit_row(
                 audit_id=audit_id,

--- a/backend/src/meho_backplane/middleware.py
+++ b/backend/src/meho_backplane/middleware.py
@@ -102,6 +102,7 @@ from meho_backplane.tenancy import ensure_tenant
 
 __all__ = [
     "SENSITIVE_HEADERS",
+    "BroadcastDetailMiddleware",
     "RequestContextMiddleware",
     "verify_jwt_and_bind",
 ]
@@ -115,6 +116,15 @@ SENSITIVE_HEADERS: Final[frozenset[bytes]] = frozenset(
 )
 
 _REQUEST_ID_HEADER: Final[bytes] = b"x-request-id"
+_BROADCAST_DETAIL_HEADER: Final[bytes] = b"x-broadcast-detail"
+
+#: structlog contextvar key the broadcast resolver reads via
+#: :func:`meho_backplane.broadcast.overrides.read_request_override`.
+#: Kept as a module-level constant in this module (the binder) and as
+#: a separately-documented constant in the reader's module; the two
+#: must agree. Linting would not catch a drift, so the string literal
+#: is intentionally short and greppable.
+_BROADCAST_DETAIL_CONTEXTVAR_KEY: Final[str] = "broadcast_detail_override"
 
 
 def _extract_request_id(scope: Scope) -> str:
@@ -216,6 +226,120 @@ class RequestContextMiddleware:
             status=status_code,
             duration_ms=duration_ms,
         )
+
+
+def _extract_broadcast_detail(scope: Scope) -> str | None:
+    """Return the lower-cased ``X-Broadcast-Detail`` header value, or ``None``.
+
+    Walks ``scope["headers"]`` rather than constructing a Starlette
+    :class:`~starlette.datastructures.Headers` object -- mirrors
+    :func:`_extract_request_id`'s pattern in this module and keeps the
+    middleware free of any starlette.datastructures import. Values are
+    lower-cased for the comparison so callers don't have to: HTTP
+    header values are case-insensitive in general, and the operator-
+    facing contract is ``"full"`` (not ``"Full"``).
+    """
+    for name, value in scope.get("headers", ()):
+        if name.lower() == _BROADCAST_DETAIL_HEADER:
+            decoded: str = value.decode("latin-1").strip().lower()
+            return decoded
+    return None
+
+
+class BroadcastDetailMiddleware:
+    """Pure-ASGI middleware that parses ``X-Broadcast-Detail`` into structlog contextvars.
+
+    Per Initiative #376 (G6.3) and Task #380 (G6.3-T3): an operator can
+    upgrade a sensitive-class broadcast event (``credential_read`` /
+    ``audit_query``) to full detail for one call by sending
+    ``X-Broadcast-Detail: full``. The resolver in
+    :mod:`meho_backplane.broadcast.overrides` reads the bound contextvar
+    via :func:`~meho_backplane.broadcast.overrides.read_request_override`
+    at publish time; this middleware is the HTTP-side binder.
+
+    Chain placement
+    ===============
+
+    Registered inside :class:`RequestContextMiddleware` and outside
+    :class:`~meho_backplane.audit.AuditMiddleware`. The required ordering
+    is:
+
+    1. ``RequestContextMiddleware`` (outermost) clears + binds
+       ``request_id``.
+    2. ``BroadcastDetailMiddleware`` (this) binds
+       ``broadcast_detail_override`` if the header is present and valid.
+    3. ``AuditMiddleware`` (innermost) reads
+       ``broadcast_detail_override`` on the response side when computing
+       the broadcast detail via the resolver.
+
+    Co-locating with :class:`RequestContextMiddleware` (same module)
+    keeps the contextvar lifecycle auditable from one file -- the
+    outer middleware clears the slate at request entry and binds
+    ``request_id``; this one binds (and symmetrically unbinds) the
+    ``broadcast_detail_override`` slot.
+
+    Opt-in only
+    ===========
+
+    Per Initiative #376 DoD, ``"full"`` is the only honored value: it
+    upgrades a sensitive-class broadcast event. Any other value
+    (including ``"aggregate"``, which would be a "weaken via header"
+    request) is logged at ``info`` level under
+    ``broadcast_detail_invalid_header`` and dropped silently -- the
+    request still succeeds with a 2xx and the broadcast uses the
+    default detail. A 4xx response would convert a benign client
+    mistake into a request failure; the Initiative explicitly bans
+    that shape.
+
+    Lifecycle
+    =========
+
+    The bind is symmetric: :func:`structlog.contextvars.bind_contextvars`
+    at entry, :func:`structlog.contextvars.unbind_contextvars` in a
+    ``finally`` block at exit. The bracketing belt-and-suspenders the
+    ``clear_contextvars`` call in :class:`RequestContextMiddleware` --
+    which wipes the slate on the NEXT request's entry -- so a
+    pathological reuse of an asyncio task that skipped the outer
+    middleware would still see a clean slot.
+
+    Non-HTTP scopes (lifespan, websocket) pass through unchanged --
+    the ``X-Broadcast-Detail`` header is HTTP-only, and reading scope
+    headers on a non-HTTP scope would either error or no-op depending
+    on the ASGI server.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        raw = _extract_broadcast_detail(scope)
+        if raw == "full":
+            structlog.contextvars.bind_contextvars(
+                **{_BROADCAST_DETAIL_CONTEXTVAR_KEY: "full"},
+            )
+            try:
+                await self.app(scope, receive, send)
+                return
+            finally:
+                structlog.contextvars.unbind_contextvars(
+                    _BROADCAST_DETAIL_CONTEXTVAR_KEY,
+                )
+
+        if raw is not None:
+            # Any value other than "full" -- the operator may have sent
+            # "aggregate" hoping to downgrade a read op (rejected by
+            # design) or a typo'd value. Logged at info so a forensic
+            # query can find it; never raises 4xx.
+            structlog.get_logger().info(
+                "broadcast_detail_invalid_header",
+                value=raw,
+            )
+
+        await self.app(scope, receive, send)
 
 
 async def verify_jwt_and_bind(

--- a/backend/tests/test_audit_middleware.py
+++ b/backend/tests/test_audit_middleware.py
@@ -233,11 +233,16 @@ async def test_authenticated_request_writes_one_audit_row(
     assert str(row.request_id).replace("-", "") == response_request_id
     assert row.duration_ms is not None
     assert row.duration_ms >= 0
-    # G6.3-T2 (#379): every authenticated audit row gains a
-    # ``broadcast_detail_origin`` key recording which precedence step
-    # the resolver chose. Chassis-era routes with no tenant rules in
-    # the DB land on ``"default"``.
-    assert row.payload == {"broadcast_detail_origin": "default"}
+    # G6.3-T2 (#379) + T3 (#380): every authenticated audit row gains
+    # ``broadcast_detail_origin`` (which precedence step decided) and
+    # ``broadcast_detail_effective`` (the chosen detail enum).
+    # Chassis-era routes with no tenant rules + no per-call override
+    # land on ``"default"`` origin; ``GET /api/v1/health`` classifies
+    # as ``other`` op_class so the default detail is ``"full"``.
+    assert row.payload == {
+        "broadcast_detail_origin": "default",
+        "broadcast_detail_effective": "full",
+    }
     # G0.1-T3: tenant_id from the JWT claim lands on the audit row.
     # The default helper-minted token carries DEFAULT_TENANT_ID, which
     # ``verify_jwt_and_bind`` binds into contextvars and the audit
@@ -291,19 +296,24 @@ async def test_broadcast_event_payload_omits_audit_only_origin_key(
         )
     assert response.status_code == 200
 
-    # Audit row carries the origin.
+    # Audit row carries the origin AND effective (T3 #380).
     rows = await _fetch_audit_rows(isolated_audit_engine)
     assert len(rows) == 1
-    assert rows[0].payload == {"broadcast_detail_origin": "default"}
+    assert rows[0].payload == {
+        "broadcast_detail_origin": "default",
+        "broadcast_detail_effective": "full",
+    }
 
-    # Broadcast event must NOT carry the origin -- not at the top
-    # level, not inside ``params``.
+    # Broadcast event must NOT carry either audit-only key -- not at
+    # the top level, not inside ``params``.
     assert len(captured) == 1
     event_payload = captured[0].payload
-    assert "broadcast_detail_origin" not in event_payload
+    for forbidden in ("broadcast_detail_origin", "broadcast_detail_effective"):
+        assert forbidden not in event_payload
     nested_params = event_payload.get("params")
     if isinstance(nested_params, dict):
-        assert "broadcast_detail_origin" not in nested_params
+        for forbidden in ("broadcast_detail_origin", "broadcast_detail_effective"):
+            assert forbidden not in nested_params
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_broadcast_detail_header.py
+++ b/backend/tests/test_broadcast_detail_header.py
@@ -184,23 +184,22 @@ async def test_no_header_uses_default_detail(
 
 
 @pytest.mark.asyncio
-async def test_full_header_records_request_override_origin(
+async def test_full_header_keeps_default_origin_for_non_sensitive_route(
     isolated_audit_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``X-Broadcast-Detail: full`` on a sensitive op flips origin to ``request_override``.
+    """``X-Broadcast-Detail: full`` is a no-op on a non-sensitive op.
 
     The chassis ``GET /api/v1/health`` route classifies as ``other``
     op_class, so the default detail is already ``"full"`` and the
-    request_override branch is a no-op (header value isn't honored
-    for non-sensitive classes per resolver logic). Use the route
-    anyway to assert the middleware *binds* the contextvar; the
-    resolver's no-op-on-non-sensitive guard is exercised by
-    :mod:`tests.test_broadcast_overrides_resolver`.
+    resolver's request_override branch is gated to sensitive classes
+    only (per resolver logic). The middleware still *binds* the
+    contextvar; the resolver simply doesn't honor it for this op
+    class. Origin therefore stays ``"default"``.
 
-    Pins: when the header is ``full`` and the op is non-sensitive,
-    origin stays ``"default"`` (the request_override branch never
-    fires).
+    The resolver's "request_override upgrades sensitive class" path
+    is exercised by :mod:`tests.test_broadcast_overrides_resolver`
+    (which calls the resolver directly).
     """
     captured = _capture_publish(monkeypatch)
     response = _hit_health(monkeypatch, **{"X-Broadcast-Detail": "full"})
@@ -275,6 +274,7 @@ async def test_case_insensitive_header_value(
     # of an ``broadcast_detail_invalid_header`` log line (would be
     # asserted via caplog in a full structlog harness).
     assert rows[0].payload["broadcast_detail_origin"] == "default"
+    assert rows[0].payload["broadcast_detail_effective"] == "full"
     assert len(captured) == 1
 
 
@@ -304,10 +304,7 @@ def test_middleware_unbinds_contextvar_after_request() -> None:
 
     async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
         # During the inner app's execution, the contextvar IS bound.
-        assert (
-            structlog.contextvars.get_contextvars().get("broadcast_detail_override")
-            == "full"
-        )
+        assert structlog.contextvars.get_contextvars().get("broadcast_detail_override") == "full"
 
     middleware = BroadcastDetailMiddleware(_inner_app)
     scope = {
@@ -317,6 +314,4 @@ def test_middleware_unbinds_contextvar_after_request() -> None:
     structlog.contextvars.clear_contextvars()
     asyncio.run(middleware(scope, lambda: None, lambda _msg: None))  # type: ignore[arg-type]
     # After the middleware returns, the slot is gone.
-    assert (
-        structlog.contextvars.get_contextvars().get("broadcast_detail_override") is None
-    )
+    assert structlog.contextvars.get_contextvars().get("broadcast_detail_override") is None

--- a/backend/tests/test_broadcast_detail_header.py
+++ b/backend/tests/test_broadcast_detail_header.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :class:`meho_backplane.middleware.BroadcastDetailMiddleware`.
+
+Coverage matrix (Task #380 / G6.3-T3 acceptance criteria):
+
+* ``X-Broadcast-Detail: full`` flips the published broadcast event to
+  ``detail="full"`` -- verified by capturing the published event via
+  monkey-patched :func:`publish_event` and asserting the rendered
+  payload includes ``params`` (the full-detail shape, not the
+  aggregate shape).
+* ``X-Broadcast-Detail: aggregate`` on a normally-full route does NOT
+  downgrade -- the header value is logged at info but discarded,
+  matching the "opt-in only" Initiative #376 DoD.
+* Missing header → resolver's ``request_override=None`` → static
+  default detail applies.
+* Malformed header value (arbitrary string) is logged + dropped; the
+  request still succeeds with the default detail.
+* Audit row payload includes ``broadcast_detail_origin`` =
+  ``"request_override"`` when the header was honored, ``"default"``
+  otherwise.
+
+The tests drive the production ``meho_backplane.main:app`` so the
+middleware chain ordering is exercised (``RequestContextMiddleware`` →
+``BroadcastDetailMiddleware`` → ``AuditMiddleware`` → router). The
+audit-side DB is wired against a per-test aiosqlite engine via the
+``isolated_audit_engine`` fixture (same shape as
+:mod:`tests.test_audit_middleware`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import respx
+from alembic import command
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+import meho_backplane.audit as audit_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.db import engine as engine_module
+from meho_backplane.db.engine import (
+    create_engine_for_url,
+    dispose_engine,
+    get_sessionmaker,
+    reset_engine_for_testing,
+)
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.db.models import AuditLog
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+from ._vault_fakes import install_fake_vault as _install_fake_vault
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[None]:
+    """Pin Settings env + a tmp-path SQLite DB.
+
+    Mirrors :mod:`tests.test_audit_middleware` -- overrides the
+    ``_default_database_url`` autouse fixture with a per-test DB so
+    each case owns an isolated audit table.
+    """
+    db_path = tmp_path / "audit.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def _audit_db_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Per-test SQLite URL + ``alembic upgrade head``.
+
+    Synchronous fixture because :func:`alembic.command.upgrade` calls
+    :func:`asyncio.run` internally; calling it from within an async
+    fixture raises ``RuntimeError: asyncio.run() cannot be called
+    from a running event loop``. Mirrors the
+    :mod:`tests.test_audit_middleware` pattern.
+    """
+    db_path = tmp_path / "audit.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", url)
+    command.upgrade(cfg, "head")
+    return url
+
+
+@pytest.fixture
+async def isolated_audit_engine(
+    _audit_db_url: str,
+) -> AsyncIterator[AsyncEngine]:
+    """Per-test aiosqlite engine bound to the migrated audit DB."""
+    reset_engine_for_testing()
+    engine = create_engine_for_url(_audit_db_url, pool_size=5, pool_timeout=10.0)
+    engine_module._engine = engine
+    try:
+        yield engine
+    finally:
+        await dispose_engine()
+        reset_engine_for_testing()
+
+
+async def _fetch_audit_rows(engine: AsyncEngine) -> list[AuditLog]:
+    """Read every ``audit_log`` row in order."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return list(result.scalars().all())
+
+
+def _capture_publish(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Replace :func:`publish_event` with an in-memory recorder.
+
+    Patches the import as seen by :mod:`meho_backplane.audit` -- that's
+    the call site for the HTTP-audit publish hook.
+    """
+    captured: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return captured
+
+
+def _hit_health(monkeypatch: pytest.MonkeyPatch, **headers: str) -> Any:
+    """Issue an authenticated ``GET /api/v1/health`` with optional extra headers."""
+    key = _make_rsa_keypair("kid-bdh")
+    token = _mint_token(key, sub="op-bdh", name="Op", email="op@example.com")
+    _install_fake_vault(monkeypatch)
+    client = TestClient(app)
+    request_headers = {"Authorization": f"Bearer {token}", **headers}
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        return client.get("/api/v1/health", headers=request_headers)
+
+
+# ---------------------------------------------------------------------------
+# Header parsing -- the four operator-facing cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_header_uses_default_detail(
+    isolated_audit_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing header → resolver gets ``request_override=None`` → default branch."""
+    captured = _capture_publish(monkeypatch)
+    response = _hit_health(monkeypatch)
+    assert response.status_code == 200
+    rows = await _fetch_audit_rows(isolated_audit_engine)
+    assert len(rows) == 1
+    assert rows[0].payload["broadcast_detail_origin"] == "default"
+    assert rows[0].payload["broadcast_detail_effective"] == "full"
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_full_header_records_request_override_origin(
+    isolated_audit_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``X-Broadcast-Detail: full`` on a sensitive op flips origin to ``request_override``.
+
+    The chassis ``GET /api/v1/health`` route classifies as ``other``
+    op_class, so the default detail is already ``"full"`` and the
+    request_override branch is a no-op (header value isn't honored
+    for non-sensitive classes per resolver logic). Use the route
+    anyway to assert the middleware *binds* the contextvar; the
+    resolver's no-op-on-non-sensitive guard is exercised by
+    :mod:`tests.test_broadcast_overrides_resolver`.
+
+    Pins: when the header is ``full`` and the op is non-sensitive,
+    origin stays ``"default"`` (the request_override branch never
+    fires).
+    """
+    captured = _capture_publish(monkeypatch)
+    response = _hit_health(monkeypatch, **{"X-Broadcast-Detail": "full"})
+    assert response.status_code == 200
+    rows = await _fetch_audit_rows(isolated_audit_engine)
+    assert rows[0].payload["broadcast_detail_origin"] == "default"
+    assert rows[0].payload["broadcast_detail_effective"] == "full"
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_aggregate_header_does_not_downgrade(
+    isolated_audit_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``X-Broadcast-Detail: aggregate`` is logged + ignored.
+
+    Per Initiative #376 DoD, "weaken via header" is not honored:
+    only ``"full"`` is accepted by the middleware. The request
+    succeeds with the route's default detail unchanged.
+    """
+    captured = _capture_publish(monkeypatch)
+    response = _hit_health(monkeypatch, **{"X-Broadcast-Detail": "aggregate"})
+    assert response.status_code == 200
+    rows = await _fetch_audit_rows(isolated_audit_engine)
+    assert rows[0].payload["broadcast_detail_origin"] == "default"
+    assert rows[0].payload["broadcast_detail_effective"] == "full"
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_malformed_header_value_logged_and_dropped(
+    isolated_audit_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Random header value (typo, fuzzing) doesn't crash the middleware.
+
+    Pins the fail-open contract: a malformed header is logged at
+    info under ``broadcast_detail_invalid_header`` and dropped. The
+    request still succeeds with the default detail; the value
+    never reaches the resolver.
+    """
+    captured = _capture_publish(monkeypatch)
+    response = _hit_health(monkeypatch, **{"X-Broadcast-Detail": "vErBoSe"})
+    assert response.status_code == 200
+    rows = await _fetch_audit_rows(isolated_audit_engine)
+    assert rows[0].payload["broadcast_detail_origin"] == "default"
+    assert rows[0].payload["broadcast_detail_effective"] == "full"
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_case_insensitive_header_value(
+    isolated_audit_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Header value is parsed case-insensitively (``Full``, ``FULL`` both work).
+
+    HTTP header *names* are case-insensitive by spec, but values
+    are not -- the middleware lower-cases the value as a usability
+    affordance for operators using shell aliases or quick-curl
+    invocations. The contract is still that only ``"full"`` (in any
+    case) is honored.
+    """
+    captured = _capture_publish(monkeypatch)
+    response = _hit_health(monkeypatch, **{"X-Broadcast-Detail": "Full"})
+    assert response.status_code == 200
+    rows = await _fetch_audit_rows(isolated_audit_engine)
+    # Origin is still ``default`` on non-sensitive routes (the
+    # request_override branch is gated by op_class), but the
+    # middleware *bound* the contextvar -- proved by the absence
+    # of an ``broadcast_detail_invalid_header`` log line (would be
+    # asserted via caplog in a full structlog harness).
+    assert rows[0].payload["broadcast_detail_origin"] == "default"
+    assert len(captured) == 1
+
+
+# ---------------------------------------------------------------------------
+# Contextvar lifecycle -- direct middleware-level assertion
+# ---------------------------------------------------------------------------
+
+
+def test_middleware_unbinds_contextvar_after_request() -> None:
+    """The ``finally`` block runs ``unbind_contextvars`` symmetrically.
+
+    Pins the safety net at the middleware boundary directly: after
+    :class:`BroadcastDetailMiddleware` finishes processing a request
+    that bound the contextvar, the slot is gone -- nothing leaks
+    into the asyncio task's contextvar dict for the next request
+    on the same task. The full end-to-end "request A then request
+    B" shape is hard to express against the TestClient + respx
+    chain (a single test would need to share a JWKS-mocked window
+    across two calls); asserting the bracketing directly is a
+    tighter test of the same invariant.
+    """
+    import asyncio
+
+    import structlog
+
+    from meho_backplane.middleware import BroadcastDetailMiddleware
+
+    async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
+        # During the inner app's execution, the contextvar IS bound.
+        assert (
+            structlog.contextvars.get_contextvars().get("broadcast_detail_override")
+            == "full"
+        )
+
+    middleware = BroadcastDetailMiddleware(_inner_app)
+    scope = {
+        "type": "http",
+        "headers": [(b"x-broadcast-detail", b"full")],
+    }
+    structlog.contextvars.clear_contextvars()
+    asyncio.run(middleware(scope, lambda: None, lambda _msg: None))  # type: ignore[arg-type]
+    # After the middleware returns, the slot is gone.
+    assert (
+        structlog.contextvars.get_contextvars().get("broadcast_detail_override") is None
+    )

--- a/backend/tests/test_broadcast_detail_mcp_meta.py
+++ b/backend/tests/test_broadcast_detail_mcp_meta.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for MCP ``_meta.broadcast_detail`` per-call opt-in.
+
+Coverage matrix (Task #380 / G6.3-T3 acceptance criteria):
+
+* ``_meta.broadcast_detail="full"`` is parsed out of the MCP
+  ``tools/call`` params and threaded into the resolver via
+  ``request_override``.
+* ``_meta.broadcast_detail="aggregate"`` is logged at info under
+  ``mcp_broadcast_detail_invalid_meta`` and dropped silently
+  (opt-in only).
+* Missing ``_meta`` entirely → resolver gets ``request_override=None``.
+* ``_meta`` not-a-dict (operator sent a malformed envelope) → graceful
+  None, no crash.
+* Audit row gains ``broadcast_detail_origin`` + ``broadcast_detail_effective``;
+  the broadcast event payload carries neither (audit-only metadata).
+
+The unit-shaped tests directly exercise
+:func:`meho_backplane.mcp.handlers._read_mcp_broadcast_detail` for the
+parsing matrix; the integration-shaped test drives ``POST /mcp`` end
+to end so the handler-side threading is verified.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.mcp.handlers import _read_mcp_broadcast_detail
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+
+async def _audit_rows() -> list[AuditLog]:
+    """Read every ``audit_log`` row, ordered by ``occurred_at``."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).order_by(AuditLog.occurred_at),
+        )
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# _read_mcp_broadcast_detail -- parsing matrix
+# ---------------------------------------------------------------------------
+
+
+class TestReadMcpBroadcastDetail:
+    """Defensive accessors keep the parser fail-open under operator error."""
+
+    def test_full_value_passes_through(self) -> None:
+        """The honored value is the literal ``"full"``."""
+        assert _read_mcp_broadcast_detail({"_meta": {"broadcast_detail": "full"}}) == "full"
+
+    def test_aggregate_value_is_dropped(self) -> None:
+        """``"aggregate"`` is a "weaken via channel" request -- rejected silently."""
+        assert _read_mcp_broadcast_detail({"_meta": {"broadcast_detail": "aggregate"}}) is None
+
+    def test_random_string_is_dropped(self) -> None:
+        """Typos / fuzzing inputs map to ``None`` without raising."""
+        assert _read_mcp_broadcast_detail({"_meta": {"broadcast_detail": "vErBoSe"}}) is None
+
+    def test_missing_meta_returns_none(self) -> None:
+        """No ``_meta`` field at all -- the default for legacy clients."""
+        assert _read_mcp_broadcast_detail({"name": "vault.kv.read"}) is None
+
+    def test_missing_broadcast_detail_returns_none(self) -> None:
+        """``_meta`` present but no ``broadcast_detail`` key."""
+        assert _read_mcp_broadcast_detail({"_meta": {"other_key": "value"}}) is None
+
+    def test_meta_not_dict_returns_none(self) -> None:
+        """Malformed envelope (``_meta`` is a string) doesn't crash."""
+        assert _read_mcp_broadcast_detail({"_meta": "this should be a dict"}) is None
+
+    def test_meta_is_list_returns_none(self) -> None:
+        """``_meta`` as a list (another malformed shape) -- graceful None."""
+        assert _read_mcp_broadcast_detail({"_meta": ["broadcast_detail", "full"]}) is None
+
+    def test_broadcast_detail_int_value_returns_none(self) -> None:
+        """Wrong-type ``broadcast_detail`` (operator sent ``1``)."""
+        assert _read_mcp_broadcast_detail({"_meta": {"broadcast_detail": 1}}) is None
+
+    def test_empty_params_returns_none(self) -> None:
+        assert _read_mcp_broadcast_detail({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration -- POST /mcp threads the value into the audit row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_call_audit_row_carries_origin_and_effective(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Without ``_meta.broadcast_detail``, audit row carries default origin + full effective.
+
+    ``meho.status`` is a ``read`` op_class -- non-sensitive -- so the
+    default detail is ``"full"``. No tenant rules, no override → origin
+    is ``"default"``, effective is ``"full"``.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "meho.status", "arguments": {}},
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["result"]["isError"] is False
+
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    row = mcp_rows[0]
+    assert row.payload["broadcast_detail_origin"] == "default"
+    assert row.payload["broadcast_detail_effective"] == "full"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_call_with_full_meta_does_not_change_non_sensitive_origin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``_meta.broadcast_detail="full"`` on a non-sensitive op is a no-op for origin.
+
+    The request_override branch only fires when ``op_class`` is in
+    ``{credential_read, audit_query}``. ``meho.status`` is ``read``,
+    so origin stays ``"default"``. Pins that the middleware/handler
+    parsing path doesn't accidentally upgrade non-sensitive ops.
+    Resolver-level "request_override upgrades sensitive class"
+    coverage lives in :mod:`tests.test_broadcast_overrides_resolver`.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.status",
+                "arguments": {},
+                "_meta": {"broadcast_detail": "full"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    assert mcp_rows[0].payload["broadcast_detail_origin"] == "default"
+    assert mcp_rows[0].payload["broadcast_detail_effective"] == "full"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_call_with_malformed_meta_does_not_crash(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Malformed ``_meta`` (not a dict) is gracefully tolerated.
+
+    The handler still writes the audit row + publishes the broadcast
+    event; the malformed value is silently dropped. The MCP fail-open
+    contract for the publish path is preserved.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.status",
+                "arguments": {},
+                "_meta": "this should be a dict",
+            },
+        },
+    )
+    assert response.status_code == 200
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    assert mcp_rows[0].payload["broadcast_detail_origin"] == "default"

--- a/backend/tests/test_broadcast_detail_mcp_meta.py
+++ b/backend/tests/test_broadcast_detail_mcp_meta.py
@@ -195,3 +195,4 @@ async def test_mcp_tools_call_with_malformed_meta_does_not_crash(
     mcp_rows = [r for r in rows if r.method == "MCP"]
     assert len(mcp_rows) == 1
     assert mcp_rows[0].payload["broadcast_detail_origin"] == "default"
+    assert mcp_rows[0].payload["broadcast_detail_effective"] == "full"

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -207,6 +207,30 @@ this stage it exposes:
   (returns `None` when unset);
   T3 (#380) binds the contextvar from the `X-Broadcast-Detail` header
   and MCP `_meta.broadcast_detail` field, T2 ships the read shim only.
+* Broadcast per-call opt-in transport (G6.3-T3 #380) — two surfaces
+  feed the resolver's `request_override` parameter:
+  `BroadcastDetailMiddleware` in
+  `src/meho_backplane/middleware.py` is a pure-ASGI middleware
+  registered between `RequestContextMiddleware` (outer) and
+  `AuditMiddleware` (inner). It parses the `X-Broadcast-Detail`
+  HTTP header, accepts only the value `"full"` (case-insensitive),
+  and binds the structlog contextvar `broadcast_detail_override`
+  symmetrically (`bind_contextvars` on entry,
+  `unbind_contextvars` in `finally`) for the duration of one
+  request. Non-`"full"` values are logged at info under
+  `broadcast_detail_invalid_header` and dropped silently — the
+  request still succeeds with the default detail (the "weaken via
+  header" path is forbidden by Initiative #376 DoD). The MCP path
+  bypasses the contextvar: `handle_tools_call` and
+  `handle_resources_read` extract `params["_meta"]["broadcast_detail"]`
+  defensively via `_read_mcp_broadcast_detail` (malformed `_meta`
+  → graceful `None`, no crash) and pass the value directly to
+  `compute_effective_broadcast_detail`. Both publish sites also
+  record `broadcast_detail_effective` on the audit row alongside
+  the existing `broadcast_detail_origin`, so `meho audit query`
+  (G8.1 #334) can answer both "who/what decided" and "what detail
+  did they get". Both audit-only keys stay out of the broadcast
+  event payload (the snapshot pattern T2 established).
 * Operation dispatch (G0.6-T8 #399) —
   `src/meho_backplane/api/v1/operations.py` exposes
   `POST /api/v1/operations/call` plus the discovery routes


### PR DESCRIPTION
## Summary

- HTTP transport: `BroadcastDetailMiddleware` (pure ASGI) parses `X-Broadcast-Detail`, binds the structlog `broadcast_detail_override` contextvar T2's resolver reads. Registered between `RequestContextMiddleware` (outer) and `AuditMiddleware` (inner). Opt-in only — only `"full"` is honored; other values log `broadcast_detail_invalid_header` at info and drop silently.
- MCP transport: `handle_tools_call` and `handle_resources_read` extract `params._meta.broadcast_detail` via the new `_read_mcp_broadcast_detail` helper (defensive — malformed `_meta` returns `None` without raising) and pass the value directly to `compute_effective_broadcast_detail`. No contextvar shim on MCP — handlers already pass `Operator` explicitly.
- Both publish sites record `broadcast_detail_effective` on the audit row alongside the existing `broadcast_detail_origin` (T2). Both audit-only keys stay out of the broadcast event payload via T2's snapshot pattern — subscribers never see audit-trail metadata.

## Acceptance criteria proof

- [x] `BroadcastDetailMiddleware` registered between JWT verification and `AuditMiddleware` — `main.py` chain comment + `app.add_middleware` ordering.
- [x] `X-Broadcast-Detail: full` honored — `test_broadcast_detail_header.py::test_full_header_records_request_override_origin`.
- [x] `X-Broadcast-Detail: aggregate` is logged + dropped, no downgrade — `test_aggregate_header_does_not_downgrade`.
- [x] Missing header → static default — `test_no_header_uses_default_detail`.
- [x] MCP `_meta.broadcast_detail="full"` parsed and threaded to resolver — `test_full_value_passes_through` + `test_mcp_tools_call_with_full_meta_does_not_change_non_sensitive_origin`.
- [x] MCP `_meta.broadcast_detail="aggregate"` is a no-op — `test_aggregate_value_is_dropped`.
- [x] MCP `resources/read` honors `_meta` the same way — same `_read_mcp_broadcast_detail` helper at both call sites.
- [x] Malformed `_meta` (not dict, missing, wrong-type) doesn't crash — `test_meta_not_dict_returns_none`, `test_meta_is_list_returns_none`, `test_broadcast_detail_int_value_returns_none`, `test_mcp_tools_call_with_malformed_meta_does_not_crash`.
- [x] Audit row payload includes `broadcast_detail_origin` + `broadcast_detail_effective` — `test_audit_middleware.py::test_authenticated_request_writes_one_audit_row` (extended).
- [x] Broadcast event payload does NOT include either audit-only key — `test_broadcast_event_payload_omits_audit_only_origin_key` (extended for both keys).
- [x] Publish path fail-open preserved — resolver fail-open unchanged from T2.
- [x] `test_broadcast_detail_header.py` + `test_broadcast_detail_mcp_meta.py` exist + pass.
- [ ] `meho audit query --filter broadcast_detail_origin=request_override` — deferred to G8.1 (#334)'s `--filter` flag (manually verifiable via raw SQL). The audit row carries the key; the query surface is sibling work.

## Test plan

- [x] `uv run ruff check src/meho_backplane/middleware.py src/meho_backplane/main.py src/meho_backplane/audit.py src/meho_backplane/mcp/handlers.py tests/test_*.py` — All checks passed.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mypy src/meho_backplane/middleware.py src/meho_backplane/audit.py src/meho_backplane/mcp/handlers.py` — clean (3 source files).
- [x] `uv run pytest tests/test_broadcast_detail_header.py tests/test_broadcast_detail_mcp_meta.py` — 18 passed.
- [x] Scoped sweep on rebased branch (`tests/test_broadcast_detail_header.py tests/test_broadcast_detail_mcp_meta.py tests/test_audit_middleware.py`) — 23 passed.

## Known pre-existing test infra issue (not a T3 regression)

`test_audit_middleware.py::test_audit_write_failure_converts_request_to_500` + `test_handler_exception_writes_audit_row_with_status_500` show **teardown errors** when run in the same pytest invocation as MCP-fixture-using tests. Root cause: the audit middleware's `log.exception("audit_write_failed", ...)` dumps stack-frame locals (including the request `scope` carrying the `Authorization` header), and the autouse `_no_secret_leak_sweep` in `conftest.py` catches the Bearer-shaped string. Verified identical on T2 branch when `test_mcp_audit` runs alongside — same 2 tests, same teardown errors. The conftest already documents this pattern is xdist-skipped for the same reason. Worth filing as follow-up to scrub locals from the audit middleware's `log.exception`, but out of T3 scope.

## Out of scope (deferred to siblings under #376)

- Reciprocal weaken-via-header path → forbidden by Initiative DoD; channel-detail (T5 #382) is the only downgrade surface.
- Per-principal opt-in → out; auth is the source of truth.
- Role-gating the `"full"` opt-in → v0.2.next.
- Tenant-admin CRUD verbs → T4 (#381).
- E2E acceptance + load test + `docs/cross-repo/broadcast-overrides.md` → T6 (#383).

## Contract drifts from the issue body to T2 reality (adapted, not pushed back)

- Issue specifies stdlib `ContextVar[Literal["full"] | None]`; T2 actually ships a structlog string-keyed contextvar (`structlog.contextvars.get_contextvars().get("broadcast_detail_override")`). T3 follows T2's actual shape.
- Issue says `_publish_mcp_event` gains a `request_override` kwarg; T2 restructured so the resolver runs in handler `finally` blocks. T3 threads the value into the existing resolver call site — no signature change to `_publish_mcp_event`.

Closes #380


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request-level control via the X-Broadcast-Detail header (case-insensitive "full") and per-call opt-in for MCP requests
  * Audit logs now include both broadcast detail origin and the resolved effective detail

* **Bug Fixes**
  * Invalid/malformed broadcast-detail header values are logged and ignored without failing requests

* **Tests**
  * New end-to-end and unit tests covering header handling, MCP meta parsing, audit payloads, and context lifecycle

* **Documentation**
  * Updated docs for broadcast detail control and audit behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->