### PR TITLE
fix(connectors): correct misdirecting NotImplementedError stub messages (#686)

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
@@ -3,17 +3,20 @@
 
 """Kubeconfig loading for the Kubernetes connector.
 
-The skeleton lands ahead of the Target model (G0.3 / #224) and the
-operator-context Vault read path. Both surfaces are stubbed via a
-narrow :class:`KubernetesTargetLike` Protocol plus an injectable
-``kubeconfig_loader`` callable — once G0.3 lands its concrete ``Target``
-model, the structural shape here will satisfy the Protocol unchanged.
+The connector reads its target through a narrow
+:class:`KubernetesTargetLike` Protocol and resolves a kubeconfig via an
+injectable ``kubeconfig_loader`` callable. A concrete target model that
+exposes ``name``/``host``/``port``/``secret_ref`` satisfies the Protocol
+structurally with no edits here.
 
-The default loader, :func:`load_kubeconfig_from_vault`, raises
-:exc:`NotImplementedError` until G0.3 + the operator-context Vault
-connector reads land. T2+ tasks under #320 wire the live read by
-overriding the loader at connector construction time; unit and
-integration tests inject their own (mock) loader the same way.
+The default loader, :func:`load_kubeconfig_from_vault`, is a deliberate
+stub: the operator-context per-target Vault credential read is not yet
+wired for the Kubernetes connector, so it raises
+:exc:`NotImplementedError`. The supported workaround is to inject a
+custom ``kubeconfig_loader`` on ``KubernetesConnector`` at construction
+time; unit and integration tests inject their own (mock) loader the
+same way. The live read is tracked under the open
+`Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
 """
 
 from collections.abc import Awaitable, Callable
@@ -33,9 +36,9 @@ __all__ = [
 class KubernetesTargetLike(Protocol):
     """Minimum target shape :class:`KubernetesConnector` reads.
 
-    Structural Protocol — once G0.3 (#224) lands a concrete ``Target``
-    model in :mod:`meho_backplane.targets`, the model satisfies this
-    Protocol without code changes here. ``secret_ref`` is the Vault
+    Structural Protocol — any concrete ``Target`` model in
+    :mod:`meho_backplane.targets` that exposes these attributes
+    satisfies it without code changes here. ``secret_ref`` is the Vault
     path the operator-context Vault read resolves to a kubeconfig YAML
     string under the ``kubeconfig`` field (consumer's ``targets.yaml``
     convention, locked in decision #8).
@@ -83,15 +86,20 @@ def parse_kubeconfig_yaml(kubeconfig_text: str) -> dict[str, Any]:
 async def load_kubeconfig_from_vault(target: KubernetesTargetLike) -> dict[str, Any]:
     """Default kubeconfig loader — Vault read by ``target.secret_ref``.
 
-    Stub until G0.3 (#224) lands the ``Target`` model and the
-    operator-context Vault read path. T2+ tasks under #320 override
-    this loader with the live implementation. Raising
-    :exc:`NotImplementedError` here keeps the wiring shape stable: a
-    production caller without an override receives a clear error
-    rather than a silent fallback or a hallucinated kubeconfig.
+    Deliberate stub: the operator-context per-target Vault credential
+    read is not yet wired for the Kubernetes connector. Raising
+    :exc:`NotImplementedError` here keeps the wiring shape stable — a
+    production caller without an override receives a clear error rather
+    than a silent fallback or a hallucinated kubeconfig. The supported
+    workaround is to inject a custom ``kubeconfig_loader`` on
+    ``KubernetesConnector`` at construction time. The live read is
+    tracked under the open Goal #214 (Connector parity).
     """
     raise NotImplementedError(
-        "load_kubeconfig_from_vault requires G0.3 Target model + operator-context "
-        f"Vault read; target={target.name!r} secret_ref={target.secret_ref!r}. "
-        "Inject a custom kubeconfig_loader on KubernetesConnector until G0.3 lands."
+        "load_kubeconfig_from_vault is a deliberate stub: the operator-context "
+        "per-target Vault credential read is not yet wired for the Kubernetes "
+        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
+        "Workaround: inject a custom kubeconfig_loader on KubernetesConnector. "
+        "Tracked under open Goal #214 (Connector parity): "
+        "https://github.com/evoila/meho/issues/214"
     )

--- a/backend/src/meho_backplane/connectors/vmware_rest/session.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/session.py
@@ -10,26 +10,28 @@ account ``{"username": ..., "password": ...}`` dict) is split out behind a
 narrow :class:`VsphereSessionLoader` callable so:
 
 * Production deploys can override the default loader at construction time
-  once G0.3 (#224) lands the operator-context Vault read path.
+  with the operator-context Vault read path.
 * Unit tests inject their own (mock) loader that returns a pre-built dict.
 * Integration tests against vcsim pass a loader that yields the
   simulator's hard-coded ``user``/``pass`` credentials.
 
-The default loader, :func:`load_session_credentials_from_vault`, raises
-:exc:`NotImplementedError` until G0.3 (#224) merges. Mirrors the
+The default loader, :func:`load_session_credentials_from_vault`, is a
+deliberate stub: the operator-context per-target Vault credential read
+is not yet wired for the vmware-rest connector, so it raises
+:exc:`NotImplementedError`. It mirrors the
 shape :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`
-already established for :class:`KubernetesConnector` — once the Target
-model + operator-context Vault reads land, both loaders pick up the
-concrete implementation in a single follow-up commit.
+already established for :class:`KubernetesConnector`. The live read is
+tracked under the open
+`Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
 
 The :class:`VsphereTargetLike` Protocol captures the minimum target shape
 the connector reads: ``name`` (for the per-target session cache key),
 ``host``, ``port`` (forwarded to :meth:`HttpConnector._base_url`),
 ``secret_ref`` (the Vault path the loader resolves), and ``auth_model``
 (checked by :meth:`VmwareRestConnector.auth_headers` to reject
-``per_user`` / ``impersonation`` targets at the boundary). Once G0.3 ships
-its concrete ``Target`` model in :mod:`meho_backplane.targets`, the
-model satisfies this Protocol structurally — no edits here.
+``per_user`` / ``impersonation`` targets at the boundary). Any concrete
+``Target`` model in :mod:`meho_backplane.targets` that exposes these
+attributes satisfies this Protocol structurally — no edits here.
 """
 
 from __future__ import annotations
@@ -62,9 +64,9 @@ class SessionCredentials(Protocol):
 class VsphereTargetLike(Protocol):
     """Minimum target shape :class:`VmwareRestConnector` reads.
 
-    Structural Protocol — once G0.3 (#224) lands the concrete ``Target``
-    model in :mod:`meho_backplane.targets`, that model satisfies this
-    Protocol unchanged. ``auth_model`` is checked at the boundary so a
+    Structural Protocol — any concrete ``Target`` model in
+    :mod:`meho_backplane.targets` that exposes these attributes
+    satisfies it unchanged. ``auth_model`` is checked at the boundary so a
     target tagged ``per_user`` or ``impersonation`` raises a clear error
     rather than silently authenticating as the shared service account.
 
@@ -99,22 +101,26 @@ async def load_session_credentials_from_vault(
 ) -> dict[str, str]:
     """Default credential loader — Vault read by ``target.secret_ref``.
 
-    Stubbed until G0.3 (#224) lands the ``Target`` model and the
-    operator-context Vault read path. Mirrors
+    Deliberate stub: the operator-context per-target Vault credential
+    read is not yet wired for the vmware-rest connector. Mirrors
     :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`'s
     NotImplementedError stub so the wiring shape is stable: a production
     caller without an explicit loader override receives a clear error
     rather than a silent fallback or a hallucinated credential pair.
 
-    Once G0.3 lands, this function becomes the live implementation that
-    reads the ``vsphere/<target.name>`` Vault path and returns the
-    parsed ``{"username": ..., "password": ...}`` dict. Until then,
-    tests and any acceptance harness inject a custom
-    :class:`VsphereSessionLoader` on connector construction.
+    The supported workaround is to inject a custom
+    :class:`VsphereSessionLoader` (``session_loader``) on
+    ``VmwareRestConnector`` at construction time; tests and acceptance
+    harnesses do exactly that. The live read — which will read the
+    ``vsphere/<target.name>`` Vault path and return the parsed
+    ``{"username": ..., "password": ...}`` dict — is tracked under the
+    open Goal #214 (Connector parity).
     """
     raise NotImplementedError(
-        "load_session_credentials_from_vault requires G0.3 Target model + "
-        f"operator-context Vault read; target={target.name!r} "
-        f"secret_ref={target.secret_ref!r}. Inject a custom session_loader "
-        "on VmwareRestConnector until G0.3 lands."
+        "load_session_credentials_from_vault is a deliberate stub: the "
+        "operator-context per-target Vault credential read is not yet wired "
+        f"for the vmware-rest connector; target={target.name!r} "
+        f"secret_ref={target.secret_ref!r}. Workaround: inject a custom "
+        "session_loader on VmwareRestConnector. Tracked under open "
+        "Goal #214 (Connector parity): https://github.com/evoila/meho/issues/214"
     )

--- a/backend/tests/test_connectors_k8s_auth.py
+++ b/backend/tests/test_connectors_k8s_auth.py
@@ -157,11 +157,11 @@ def test_kubernetes_connector_subclasses_connector_abc() -> None:
     assert KubernetesConnector.impl_id == "k8s"
 
 
-def test_default_loader_raises_until_g03_lands() -> None:
-    """The default Vault-shaped loader stays unimplemented until G0.3."""
+def test_default_loader_raises_deliberate_stub() -> None:
+    """The default Vault-shaped loader is a deliberate, clearly-labelled stub."""
 
     async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"G0\.3"):
+        with pytest.raises(NotImplementedError, match=r"deliberate stub.*#214"):
             await load_kubeconfig_from_vault(_TARGET_A)
 
     asyncio.run(_check())

--- a/backend/tests/test_connectors_vmware_rest_auth.py
+++ b/backend/tests/test_connectors_vmware_rest_auth.py
@@ -140,8 +140,8 @@ def test_importing_package_registers_against_v2_registry() -> None:
     assert registry[key] is VmwareRestConnector
 
 
-def test_default_session_loader_raises_until_g03_lands() -> None:
-    """The default Vault loader stays unimplemented until G0.3."""
+def test_default_session_loader_raises_deliberate_stub() -> None:
+    """The default Vault loader is a deliberate, clearly-labelled stub."""
     import asyncio
 
     from meho_backplane.connectors.vmware_rest.session import (
@@ -149,7 +149,7 @@ def test_default_session_loader_raises_until_g03_lands() -> None:
     )
 
     async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"G0\.3"):
+        with pytest.raises(NotImplementedError, match=r"deliberate stub.*#214"):
             await load_session_credentials_from_vault(_TARGET_A)
 
     asyncio.run(_check())


### PR DESCRIPTION
## Summary

- Two operator-facing credential-loader stubs (`kubernetes/kubeconfig.py` `load_kubeconfig_from_vault`, `vmware_rest/session.py` `load_session_credentials_from_vault`) raised `NotImplementedError` whose text pointed operators at the **closed/shipped** G0.3 Initiative (#224). An operator hitting either stub would read a completed Initiative and wrongly conclude they mis-deployed or were blocked on already-merged work — the same "don't send the operator chasing a phantom" defect class as #630/#684.
- Both `NotImplementedError` messages and the misleading docstring lines now state the accurate situation: deliberate stub, operator-context per-target Vault credential read not yet wired for this connector, supported workaround = inject a custom `kubeconfig_loader` / `session_loader`.
- Both now cite the **open Goal #214 (Connector parity)** — the genuine live umbrella — instead of any closed issue (#224/#227/#320), so the messages cannot recreate the phantom-pointer defect by swapping one closed issue for another.
- Behavior unchanged: both stubs still `raise NotImplementedError`. Text only.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — Success: no issues found in 185 source files
- [x] `uv run pytest tests/test_connectors_k8s_auth.py tests/test_connectors_vmware_rest_auth.py` — 54 passed (both updated stub-message tests included)
- [x] Full unit sweep — 1825 passed; the single failure (`test_g81_audit_query_acceptance.py`) is a pre-existing sandbox-only failure (`KeyError: 'KEYCLOAK_ISSUER_URL'` + Redis testcontainer), reproduced identically on clean `origin/main` — unrelated to this string-only change; runs green in CI where the env is provisioned
- [x] AC1: `grep "until G0.3 lands\|requires G0.3"` over the two src files → zero matches
- [x] AC2: messages name precondition + inject-loader workaround + cite OPEN Goal #214; `grep -nE "#224|#227|#320|G0\.3"` over the two src files → zero matches
- [x] AC3: both in-scope test files' `pytest.raises` match patterns + docstrings updated to the new wording
- [x] AC4: ruff/format/mypy clean; stubs still `raise NotImplementedError`
- [x] AC5: `git diff` touches exactly the 2 src files + 2 test files

## Out of scope

- Implementing the loaders / per-target Vault credential read — deliberate stubs tracked under the OPEN Goal #214.
- Non-operator-facing stale "until G0.3 lands" comments in `connectors/base.py`, `adapters/http.py`, `adapters/ssh.py`, `vault/connector.py`; nsx/sddc connectors; `docs/codebase/*.md` (AC5 fences the diff). Recorded as adjacent findings only.

### Adjacent findings (recorded, not edited)

- `connectors/base.py`, `adapters/http.py`, `adapters/ssh.py`, `vault/connector.py` still carry non-operator-facing "until G0.3 lands" comments.
- `docs/codebase/connectors-kubernetes.md` and `connectors-vmware-rest.md` still narrate "until G0.3 lands" (AC5 fences the diff to message/docstring strings + the two test files).
- `tests/test_connectors_k8s_auth.py:77` / `test_connectors_vmware_rest_auth.py:79` retain `G0.3 (#224)` in non-asserting fixture comments; AC3 targets only the assertion + its docstring.
- `tests/acceptance/test_g81_audit_query_acceptance.py` fails in any local sandbox without `KEYCLOAK_ISSUER_URL` + a Redis testcontainer (pre-existing, reproduced on clean main).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #686


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to override default credential loaders for Kubernetes and VMware connectors by injecting custom loaders at construction time.
  * Updated guidance and error messaging to better explain the stub behavior of default loaders and workarounds for production deployments.

* **Tests**
  * Updated test assertions to verify corrected error messaging for credential loader stubs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->