### PR TITLE
fix(cli): gofmt broadcast.go + overrides_set_test.go — unblock required Go CI lane

### DIFF
--- a/cli/internal/cmd/broadcast/broadcast.go
+++ b/cli/internal/cmd/broadcast/broadcast.go
@@ -88,15 +88,15 @@ func newOverridesCmd() *cobra.Command {
 // preserves the explicit-null wire shape (an op-wide rule has both
 // fields null).
 type Entry struct {
-	ID            string  `json:"id"`
-	TenantID      string  `json:"tenant_id"`
-	OpIDPattern   string  `json:"op_id_pattern"`
-	ScopeField    *string `json:"scope_field"`
-	ScopeValue    *string `json:"scope_value"`
-	Detail        string  `json:"detail"`
-	CreatedBySub  string  `json:"created_by_sub"`
-	CreatedAt     string  `json:"created_at"`
-	UpdatedAt     string  `json:"updated_at"`
+	ID           string  `json:"id"`
+	TenantID     string  `json:"tenant_id"`
+	OpIDPattern  string  `json:"op_id_pattern"`
+	ScopeField   *string `json:"scope_field"`
+	ScopeValue   *string `json:"scope_value"`
+	Detail       string  `json:"detail"`
+	CreatedBySub string  `json:"created_by_sub"`
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
 }
 
 // CreateRequest mirrors the backend `BroadcastOverrideCreate` Pydantic

--- a/cli/internal/cmd/broadcast/overrides_set_test.go
+++ b/cli/internal/cmd/broadcast/overrides_set_test.go
@@ -126,8 +126,8 @@ func TestRunOverridesSetInvalidDetailRejectedClientSide(t *testing.T) {
 func TestRunOverridesSetHalfSetScopeRejectedClientSide(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	err := runOverridesSet(cmd, overridesSetOptions{
-		OpIDPattern:       "vault.kv.*",
-		ScopeField:        "namespace",
+		OpIDPattern: "vault.kv.*",
+		ScopeField:  "namespace",
 		// ScopeValue intentionally empty
 		Detail:            "aggregate",
 		BackplaneOverride: "http://unreached.test",


### PR DESCRIPTION
`golangci-lint` (a **required** merge gate) is red on `origin/main` @ 4d17b46 — gofmt alignment violations in:
- `cli/internal/cmd/broadcast/broadcast.go:91`
- `cli/internal/cmd/broadcast/overrides_set_test.go:129`

`gofmt -w` only — struct-tag and struct-literal key alignment. **Zero logic change** (`go build ./...` + `go vet` clean). Restores the Go required lane to green; part of the v0.3 ship-readiness sweep (1 of the 3 red lanes on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated JSON tag alignment and code formatting across internal modules to improve overall consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->