### PR TITLE
fix(test): autouse chassis env in acceptance conftest — unblock required unit lane

### DIFF
--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -48,12 +48,14 @@ from collections.abc import AsyncIterator, Iterator
 import pytest
 from sqlalchemy import text
 
+from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.db import engine as engine_module
 from meho_backplane.db.engine import (
     create_engine_for_url,
     dispose_engine,
     reset_engine_for_testing,
 )
+from meho_backplane.settings import get_settings
 from tests.acceptance._canary_fixtures import (
     CANARY_CONNECTOR_ID,
     CANARY_OPERATOR_TENANT,
@@ -81,6 +83,7 @@ from tests.acceptance._vcsim import (
     resolve_vcsim_endpoint,
 )
 from tests.integration.conftest import (
+    _CHASSIS_ENV,
     DOCKER_AVAILABLE,
     SKIP_REASON,
     async_pg_url,
@@ -138,6 +141,42 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     "targets",
     "tenant",
 )
+
+
+@pytest.fixture(autouse=True)
+def _acceptance_default_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    """Pin chassis env vars Settings() requires, for every acceptance test.
+
+    The autouse ``_integration_default_env`` fixture that does this for
+    the integration suite lives in :mod:`tests.integration.conftest`,
+    so pytest scopes it to ``tests/integration/`` only — it does **not**
+    apply to ``tests/acceptance/``. Acceptance tests that load
+    :class:`Settings` without depending on a fixture that transitively
+    pins the env (e.g. ``test_g81_audit_query_acceptance`` via
+    ``pg_engine`` → ``integration_env``, which only overrides
+    ``DATABASE_URL``) therefore die with
+    ``KeyError: 'KEYCLOAK_ISSUER_URL'`` at ``settings.py``'s eager
+    ``os.environ["..."]`` access.
+
+    Reuses :data:`tests.integration.conftest._CHASSIS_ENV` verbatim so
+    the two suites cannot drift. Mirrors the autouse-for-invariants
+    discipline of ``_integration_default_env`` (#679) and the unit-level
+    ``_default_database_url`` fixture; brackets the yield with
+    ``get_settings.cache_clear()`` / ``clear_jwks_cache()`` so neither
+    cache bleeds between tests.
+    """
+    for key, value in _CHASSIS_ENV.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+    yield
+
+    get_settings.cache_clear()
+    clear_jwks_cache()
 
 
 @pytest.fixture


### PR DESCRIPTION
`Python (ruff + mypy + pytest)` (a **required** merge gate) is red on `origin/main` @ 4d17b46:

```
FAILED tests/acceptance/test_g81_audit_query_acceptance.py::test_scenario_1_tenant_a_query_never_returns_tenant_b_rows
  - KeyError: 'KEYCLOAK_ISSUER_URL'
===== 1 failed, 1804 passed, 29 skipped (maxfail=1) =====
```

## Root cause
The autouse `_integration_default_env` fixture that pins chassis env vars lives in `tests/integration/conftest.py` → pytest scopes autouse fixtures to their conftest's directory, so it **never applied to `tests/acceptance/`**. `acceptance/conftest.py` re-exports `integration_env`/`async_pg_url` but not the autouse env fixture; `integration_env` only overrides `DATABASE_URL`. So `test_g81` (→ `pg_engine` → `integration_env`) loads `Settings` with no `KEYCLOAK_ISSUER_URL` and KeyErrors.

## Fix
Adds an autouse `_acceptance_default_env` to `tests/acceptance/conftest.py`, **reusing `tests.integration.conftest._CHASSIS_ENV` verbatim** (no drift), with `get_settings.cache_clear()` / `clear_jwks_cache()` bracketing. Directly mirrors the merged #679 pattern (`fix(test): G3.2 autouse chassis env-vars in integration conftest`). ruff/format clean; target test now collects.

⚠️ The unit lane runs `--maxfail=1`, so this clears the **first** (known) failure; a green CI re-run is required to confirm nothing else is hidden behind it.

2 of 3 red lanes in the v0.3 ship-readiness sweep (with #695 for Go). The 3rd — `Python (integration testcontainers)` — is a **real bind9 dispatch defect**, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced acceptance test suite isolation by automatically configuring environment defaults and clearing caches between test runs, improving test reliability and preventing cross-test cache interference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->