### PR TITLE
fix(dispatch): MRO-aware is_unbound_method + fail-loud unbound handler (#697)

### DIFF
--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -224,9 +224,21 @@ async def dispatch_typed(
     """
     sig = inspect.signature(handler)
     param_names = list(sig.parameters.keys())
-    # Drop ``self`` if present (unbound-method shape that wasn't rebound).
+    # A handler still carrying ``self`` here is an unbound connector
+    # method the dispatcher failed to bind to an instance (resolver
+    # miss / instance-cache miss). The previous code silently dropped
+    # ``self`` and then called ``handler(target=, params=)`` anyway —
+    # which always TypeErrors and was masked upstream as the misleading
+    # ``handler_unreachable`` (#697, the green-but-hollow class). Fail
+    # loud and accurately instead of mis-calling.
     if param_names and param_names[0] == "self":
-        param_names = param_names[1:]
+        raise RuntimeError(
+            f"typed handler {getattr(handler, '__qualname__', handler)!r} reached "
+            f"dispatch still unbound (first parameter 'self'): the dispatcher could "
+            f"not bind it to a connector instance. This is a connector-resolution / "
+            f"instance-cache fault, not a missing handler — do not mask it as "
+            f"handler_unreachable."
+        )
     if "operator" in param_names:
         return await handler(operator=operator, target=target, params=params)
     return await handler(target=target, params=params)

--- a/backend/src/meho_backplane/operations/_handler_resolve.py
+++ b/backend/src/meho_backplane/operations/_handler_resolve.py
@@ -26,6 +26,7 @@ Two related concerns the dispatcher needs but that don't belong in
 from __future__ import annotations
 
 import importlib
+import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -138,17 +139,39 @@ def get_or_create_connector_instance(cls: type[Connector]) -> Connector:
 
 
 def is_unbound_method(handler: Any, connector_cls: type[Connector]) -> bool:
-    """True when *handler* is an unbound function defined on *connector_cls*.
+    """True when *handler* is an unbound function defined anywhere on *connector_cls*'s MRO.
 
     :func:`import_handler` walks the dotted path with :func:`getattr`,
     which returns the **unbound** function for class-attribute lookups
     in Python 3 (no descriptor binding without an instance). The
-    dispatcher needs to bind to the connector instance the resolver
-    chose so bound-method handlers register against the right
-    transport. Heuristic: the handler's ``__qualname__`` starts with
-    ``ConnectorCls.``; that pattern is what
-    :func:`~meho_backplane.operations.typed_register.derive_handler_ref`
-    serialises for bound-method registrations.
+    dispatcher rebinds these against the connector instance the resolver
+    chose so bound-method handlers hit the right transport.
+
+    Identity-based, not a string heuristic. The previous implementation
+    tested ``handler.__qualname__.startswith(f"{connector_cls.__name__}.")``,
+    which silently returned ``False`` — leaving the handler **unbound** and
+    surfacing a misleading ``handler_unreachable`` (#697) — in two real
+    cases:
+
+    * The resolved connector instance is a **subclass** of the class that
+      defines the handler. E.g. the bind9 E2E harness seeds a
+      ``_SeededBind9Connector`` instance under the ``Bind9Connector``
+      registry key (the documented test pattern):
+      ``"Bind9Connector.about"`` does not start with
+      ``"_SeededBind9Connector."``.
+    * The handler is defined on a base / mixin, so ``__qualname__``
+      carries the base's name rather than the concrete connector's.
+
+    Walking ``connector_cls.__mro__`` and matching the exact function
+    object stored in a class ``__dict__`` is subclass- and mixin-correct.
+    Already-bound methods (``inspect.ismethod``) are not unbound — return
+    ``False`` so they are not double-bound. Module-level function handlers
+    are not in any connector's MRO, so they correctly return ``False`` and
+    are dispatched as ``handler(operator, target, params)`` unchanged.
     """
-    qualname = getattr(handler, "__qualname__", "")
-    return qualname.startswith(f"{connector_cls.__name__}.")
+    if inspect.ismethod(handler):
+        return False
+    name = getattr(handler, "__name__", None)
+    if name is None:
+        return False
+    return any(klass.__dict__.get(name) is handler for klass in connector_cls.__mro__)

--- a/backend/tests/test_operations_handler_resolve.py
+++ b/backend/tests/test_operations_handler_resolve.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Regression tests for #697 — connector-bound handler binding.
+
+Two defects closed:
+
+* :func:`is_unbound_method` used a ``__qualname__.startswith`` string
+  heuristic that returned ``False`` when the resolved connector instance
+  was a **subclass** of the class defining the handler (the bind9 E2E
+  harness seeds ``_SeededBind9Connector`` under the ``Bind9Connector``
+  registry key). The handler was then invoked **unbound**, surfacing as
+  a misleading ``handler_unreachable``.
+
+* :func:`dispatch_typed` silently dropped a leading ``self`` and called
+  the handler anyway (guaranteed ``TypeError``, masked upstream as
+  ``handler_unreachable``). It now fails loud and accurately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.connectors.bind9.connector import Bind9Connector
+from meho_backplane.operations._branches import dispatch_typed
+from meho_backplane.operations._handler_resolve import import_handler, is_unbound_method
+
+
+class _SeededBind9Connector(Bind9Connector):
+    """Mirrors the bind9 E2E harness Phase-6 subclass-seed pattern."""
+
+
+def _module_level_handler(operator: object, target: object, params: dict) -> None:
+    """A non-connector module-level handler (must NOT be treated as unbound)."""
+
+
+class TestIsUnboundMethodMroAware:
+    def test_handler_on_exact_class(self) -> None:
+        handler = import_handler("meho_backplane.connectors.bind9.connector.Bind9Connector.about")
+        assert is_unbound_method(handler, Bind9Connector) is True
+
+    def test_handler_on_base_resolved_via_subclass_instance(self) -> None:
+        # The #697 case: instance is a subclass; handler is defined on the
+        # base. The old startswith heuristic returned False here.
+        handler = import_handler("meho_backplane.connectors.bind9.connector.Bind9Connector.about")
+        assert is_unbound_method(handler, _SeededBind9Connector) is True
+
+    def test_module_level_handler_is_not_unbound(self) -> None:
+        assert is_unbound_method(_module_level_handler, Bind9Connector) is False
+
+    def test_already_bound_method_is_not_unbound(self) -> None:
+        bound = _SeededBind9Connector().about  # bound method
+        assert is_unbound_method(bound, _SeededBind9Connector) is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_typed_fails_loud_on_unbound_self_handler() -> None:
+    """An unbound connector method reaching dispatch_typed must raise a clear
+    error — never a silent mis-call masked as handler_unreachable."""
+
+    async def about(self, target, params):
+        return {"ok": True}
+
+    with pytest.raises(RuntimeError, match=r"still unbound \(first parameter 'self'\)"):
+        await dispatch_typed(
+            handler=about,
+            operator=object(),
+            target=object(),
+            params={},
+        )


### PR DESCRIPTION
Closes the v0.3 ship-blocker triaged in **#697** (under reopened **#367**).

## Root cause
`tests/integration/test_g3_4_bind9_e2e.py::test_call_operation_about_dispatches_through_meta_tool` failed on `origin/main` with `handler_unreachable: ...Bind9Connector.about` — a **misleading symptom**, not a handler-resolution failure (`import_handler` resolves it fine; the signature is identical to the working k8s connector).

`is_unbound_method` used `handler.__qualname__.startswith(f"{connector_cls.__name__}.")`. The bind9 E2E harness seeds a **subclass** `_SeededBind9Connector` instance under the `Bind9Connector` registry key (its documented Phase-6 pattern), so the check evaluated `"Bind9Connector.about".startswith("_SeededBind9Connector.")` → **False** → handler never rebound → `dispatch_typed` called the unbound method without `self` → `TypeError` → masked upstream as `handler_unreachable`. Same failure for any handler defined on a base/mixin class.

Deterministically confirmed: `is_unbound_method(import_handler(".../Bind9Connector.about"), _SeededBind9Connector)` → `False` (bug) vs `Bind9Connector` → `True`.

## Fixes
1. **`is_unbound_method` → identity-based, MRO-aware.** True iff the handler is the exact function object in some class `__dict__` along `connector_cls.__mro__`. Subclass- and mixin-correct; already-bound methods + module-level handlers still return `False` (behaviour preserved — 128 existing dispatcher/connector tests pass).
2. **`dispatch_typed` fails loud.** It no longer silently drops a leading `self` and mis-calls; an unbound connector method reaching dispatch now raises a precise `RuntimeError` (resolver/instance-cache fault) instead of the masked `handler_unreachable`. Kills this green-but-hollow class.
3. **Regression test** `tests/test_operations_handler_resolve.py` — the exact #697 subclass-seed scenario + the fail-loud guard.

## Verification
- New regression test: 5 passed.
- `test_operations_dispatcher` + `test_connectors_k8s_dispatcher_shim` + `test_connectors_bind9*`: 128 passed (no regression).
- ruff + ruff format + mypy clean on touched files.
- The integration lane (`test_g3_4_bind9_e2e.py`, needs the bind9 SSH testcontainer) runs in CI — this PR makes its binding path correct.

## Scope / follow-on
The registration-time *resolvable-handler* guard from the #697 acceptance criteria (a connector cannot register a non-dispatchable op and close green) is a deliberately separate, larger change — tracked on #697; **#698** (make the integration lane a required merge gate) is the structural backstop so this can't ship hollow again.

3rd of the 3 red v0.3 lanes (with #695 Go, #696 unit-conftest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handler binding detection to identify unbound methods and fail fast with explicit error messages, replacing silent failures with clear diagnostics for connector configuration issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->