### PR TITLE
fix(cli): attach package comment in machinelocal.go — unblock required Go lane

### DIFF
--- a/cli/internal/migrate/machinelocal.go
+++ b/cli/internal/migrate/machinelocal.go
@@ -2,7 +2,6 @@
 // Copyright (c) 2026 evoila Group
 
 // Package migrate — see doc.go for the package overview.
-
 package migrate
 
 import (


### PR DESCRIPTION
Second Go-lane defect surfaced by the v0.3 ship-readiness sweep (behind the #695 gofmt fix). `cli/internal/migrate/machinelocal.go:5` — revive `package-comments` (detached package comment). One blank line removed; zero logic change; `go build` clean. G5.3 code (#644/#610) that merged onto an already-red Go required lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code formatting adjustment with no functional impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->