### PR TITLE
fix(test): drop `sudo -S` from bind9 e2e restore — stdin buffer was corrupting tar

### DIFF
--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -424,17 +424,30 @@ async def _restore_etc_bind(host: str, port: int, creds: _ContainerCreds, snapsh
         # explicit (rm -rf /etc/bind/*) so any files added by the
         # test that the snapshot didn't carry are removed before the
         # restore lays down the original tree.
+        #
+        # **Do not use ``sudo -S``** here. ``-S`` reads the password
+        # line from stdin via buffered stdio, which consumes not only
+        # the leading newline but also adjacent buffered bytes from the
+        # same read — silently corrupting the tar archive that follows.
+        # With the testcontainer's ``NOPASSWD: ALL`` sudoers line, sudo
+        # doesn't need stdin at all; the clean shape is to drop ``-S``
+        # and pipe the archive to bash's stdin unaltered. The prior
+        # ``-S -p ''`` + leading ``\n`` shape silently broke restore:
+        # ``rm -rf /etc/bind/*`` ran, ``tar -xf -`` exited 2 on the
+        # corrupted input, and ``/etc/bind/`` was left empty between
+        # tests — making every test after the first one (the only one
+        # that ran against the fresh container) fail with
+        # ``open: /etc/bind/named.conf: file not found`` against
+        # ``named-checkconf -p``. The first test in the file passed;
+        # every subsequent zone.list / zone.read / config.show / etc.
+        # was hollow.
         process = await conn.create_process(
-            "sudo -S -p '' bash -c 'rm -rf /etc/bind/* && tar -C / -xf -'",
+            "sudo bash -c 'rm -rf /etc/bind/* && tar -C / -xf -'",
             stdin=asyncssh.PIPE,
             stdout=asyncssh.PIPE,
             stderr=asyncssh.PIPE,
             encoding=None,
         )
-        # The sudoers line is NOPASSWD, but sudo -S still consumes
-        # a leading newline as the "password" before reading the
-        # archive bytes off stdin.
-        process.stdin.write(b"\n")
         process.stdin.write(snapshot)
         process.stdin.write_eof()
         await process.wait()


### PR DESCRIPTION
## Root cause (decisively reproduced locally)

The bind9 integration suite's per-test \`_restore_etc_bind\` was silently corrupting \`/etc/bind/\` between tests. Local repro proved it directly: \`sudo -S\` reads the password line via buffered stdio, consuming the leading \`\\n\` **and** adjacent bytes of the tar archive that follows — \`tar -xf -\` exits 2 on the truncated input, but only **after** \`rm -rf /etc/bind/*\` already wiped the directory. So every test after the first one sees an empty \`/etc/bind/\` and \`named-checkconf -p\` returns \`open: /etc/bind/named.conf: file not found\`.

Found while triaging #697's CI cascade: full-file order → test 1 (\`about\`, doesn't read \`/etc/bind/\`) passes; tests 2+ (zone.list, etc.) fail because /etc/bind/ was destroyed by test 1's teardown.

## Fix
Drop \`-S\` and the \`\\n\` write. The testcontainer's \`NOPASSWD: ALL\` sudoers line means sudo doesn't need stdin; piping the snapshot bytes directly to \`bash\`'s stdin (and thence to \`tar -xf -\`) is correct.

## Verified locally
\`\`\`
before:  3 passed + 1 failed  (maxfail=1 stopped at zone.list)
after:  12 passed + 6 failed  (6 remaining are write-op tests; likely a
                              sibling sudo-stdin pattern in
                              _remote_bash_with_sudo — tracked under #367)
\`\`\`
ruff + format clean.

#367 op-by-op stabilisation: #699 fixed dispatch (\`about\`); this fixes restore (zone.list + 10 others); write ops are the next layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced DNS server restore testing to fix stdin corruption during tar archive extraction. Modified the restore command to directly pipe archives without intermediate processing, preventing data corruption during extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->