### PR TITLE
fix(connectors): bind9 _remote_bash_with_sudo — split stdin so sudo can't swallow script (#367 step 3)

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/connector.py
+++ b/backend/src/meho_backplane/connectors/bind9/connector.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: the load-bearing safe-sudo primitive + bind9 connector
+# class are kept colocated; the file is dense (docstrings + JSON Schemas) but
+# splitting `_remote_bash_with_sudo` out would re-create the exact "sudo argv
+# leaks from a non-whitelisted module" failure shape the safety assertion in
+# tests/integration/test_g3_4_bind9_e2e.py polices. See the helper's
+# docstring for the wire-shape + leak-prevention analysis.
 
 """Bind9Connector -- typed SSH-transport connector for ISC bind9 9.x.
 
@@ -80,15 +86,25 @@ _log = structlog.get_logger(__name__)
 # in G0.3's Target model rollout. Mirrors the placeholder in the SSH adapter.
 type Target = Any
 
-# Fixed remote command for the safe-sudo helper. Built once at module
-# scope so the helper's ``conn.run`` call site has zero string
-# interpolation -- the only caller-supplied data flows through
-# ``input=`` (stdin), never through the command string. ``-S`` makes
-# sudo read the password from stdin; ``-p ''`` suppresses the prompt
-# so the password line is not echoed; ``bash -s`` reads its commands
-# from stdin (the remainder after ``sudo -S`` has consumed its single
-# password line).
-_SUDO_BASH_REMOTE_CMD: str = "sudo -S -p '' bash -s"
+
+def _build_sudo_bash_remote_cmd(script_byte_len: int) -> str:
+    """Build the remote command for :meth:`Bind9Connector._remote_bash_with_sudo`.
+
+    Returns the constant boilerplate parameterised only by
+    *script_byte_len* — an integer derived from the caller's script
+    bytes. ``script`` and ``sudo_password`` themselves are never
+    interpolated into argv. See the helper's docstring for the full
+    wire-shape + leak-prevention analysis; module-level so the unit
+    suite (which mocks ``conn.run``) can assert against the exact
+    rendered shape without duplicating it.
+    """
+    return (
+        f"set -e; umask 077; f=$(mktemp); "
+        f'trap "rm -f $f" EXIT; '
+        f'head -c {script_byte_len} > "$f"; '
+        f'sudo -S -p "" bash "$f"'
+    )
+
 
 # Regex that recovers the ``<X.Y.Z>`` version triple from a
 # ``named -v`` banner. ISC ships the banner as
@@ -187,30 +203,57 @@ class Bind9Connector(SshConnector):
     ) -> asyncssh.SSHCompletedProcess:
         """Run *script* on *target* under ``sudo`` without leaking the password.
 
-        Safe-by-construction sudo invocation. The wire shape is fixed:
+        Safe-by-construction sudo invocation. The wire shape is built
+        by :func:`_build_sudo_bash_remote_cmd`:
 
-        1. Remote command (argv): ``"sudo -S -p '' bash -s"`` -- one
-           constant string with no caller interpolation. ``sudo -S``
-           reads the password from stdin; ``-p ''`` suppresses the
-           prompt so the password line is not echoed back; ``bash -s``
-           reads its commands from stdin once sudo has consumed the
-           password line.
-        2. Stdin payload: ``"<sudo_password>\\n<script>\\n"`` -- the
-           password is the first line; sudo reads exactly that line
-           and exec's bash with the remainder still buffered on the
-           channel; bash then reads ``script`` as its script body.
+        1. Remote command (argv): ``"set -e; umask 077; f=$(mktemp);
+           trap \"rm -f $f\" EXIT; head -c <N> > \"$f\"; sudo -S -p ''
+           bash \"$f\""``. The only caller-derived interpolation is
+           ``<N>`` — the **byte count** of the UTF-8-encoded script,
+           an integer. ``script`` and ``sudo_password`` themselves are
+           not in argv.
+        2. Stdin payload: ``script_bytes + sudo_password + "\\n"`` —
+           ``head -c N`` reads exactly the script bytes off the pipe
+           into ``$f`` via unbuffered ``read(2)`` (no stdio prefetch),
+           then ``sudo -S`` reads the password from what remains on
+           stdin (EOF immediately after the password's newline, so
+           sudo's stdio buffer has nothing past the password line to
+           swallow). ``bash "$f"`` then reads the script body from
+           the temp file, not stdin.
+
+        Why the temp-file split (#697 RCA, 2026-05-20): the previous
+        shape ``"sudo -S -p '' bash -s"`` + ``<pw>\\n<script>\\n`` on
+        stdin silently broke against real sudo. ``sudo -S`` reads
+        its password line via buffered stdio (``fgetc``/``getline``),
+        which on a pipe consumes not just the ``\\n``-terminated
+        password but a chunk of adjacent buffered bytes from the
+        same kernel read. Those bytes go into sudo's FILE* and are
+        discarded when sudo execs bash — so ``bash -s`` saw EOF
+        immediately and write ops (record.add / record.remove /
+        config.apply_*) silently no-op'd (audit ``state_after ==
+        state_before``). Reproduced locally against the bind9
+        testcontainer + Debian sudo 1.9.x. Sliding the script body
+        through a temp file isolates sudo's stdio from the script
+        bytes — sudo can prefetch all it wants, there's nothing
+        beyond the password line on its stdin to lose.
 
         The caller passes *script* and *sudo_password* as separate
         arguments and **cannot** express a mis-ordered payload: the
         helper builds the stdin string itself. The password never
         appears in the remote argv (so ``ps`` / ``/proc/<pid>/cmdline``
         cannot see it), never appears in the remote shell-history file
-        (because ``bash -s`` does not record stdin-read commands), and
+        (``bash <file>`` does not record file-sourced commands), and
         is never written to the local structured-log event (the
-        helper logs ``cmd_len`` and ``exit_status`` only; *script* and
-        *sudo_password* are not bound into any log call). The shape is
-        the encoded fix for the 2026-05-04 and 2026-05-05 credential
-        leaks documented in the parent Initiative #367's WI1.
+        helper logs ``cmd_len`` and ``script_len`` only; *script* and
+        *sudo_password* are not bound into any log call). The script
+        briefly lives on the remote SSH user's tmp under ``umask
+        077`` with a ``trap rm -f`` finaliser; the script body is
+        explicitly contracted as the bind9 op (NOT credentials), so
+        the on-disk window is acceptable. The shape is the encoded
+        fix for the 2026-05-04 / 2026-05-05 credential leaks
+        documented in the parent Initiative #367's WI1, hardened
+        against the 2026-05-20 stdio-buffer-swallow regression
+        (#697).
 
         Parameters
         ----------
@@ -265,28 +308,31 @@ class Bind9Connector(SshConnector):
                 "characters would smuggle additional bash commands onto stdin"
             )
         conn = await self._connect(target, raw_jwt)
-        stdin_payload = f"{sudo_password}\n{script}\n"
-        # ``conn.run(cmd, input=...)`` is the canonical asyncssh shape
-        # for "run cmd and feed it stdin"; the password line is
-        # therefore on the remote process's stdin, not in any argv.
-        # The asyncio.wait_for wrapper matches the parent adapter's
-        # _run_command timeout contract.
+        # New wire shape (#697 fix): script bytes first, password
+        # last, EOF immediately after. ``head -c <N>`` on the remote
+        # reads exactly the script's byte count via unbuffered
+        # read(2), so sudo's buffered stdin sees only the password
+        # line and can't prefetch-and-swallow script bytes (the bug
+        # that silently no-op'd write ops in v0.3 CI).
+        script_bytes = script.encode("utf-8")
+        cmd = _build_sudo_bash_remote_cmd(len(script_bytes))
+        stdin_payload = f"{script}{sudo_password}\n"
         result = await asyncio.wait_for(
-            conn.run(_SUDO_BASH_REMOTE_CMD, input=stdin_payload, check=False),
+            conn.run(cmd, input=stdin_payload, check=False),
             timeout=timeout,
         )
-        # Structured-logging discipline: cmd_len uses the fixed
-        # remote command's length (so the value is stable across all
-        # invocations and carries no information about the script
-        # body); script_len uses ``len(script)`` so operators can
-        # correlate stdout size against a per-invocation length
-        # signal without leaking the body itself. Neither
-        # ``sudo_password`` nor ``script`` are bound into the event.
+        # Structured-logging discipline: cmd_len records the rendered
+        # remote command's length (which varies only by the digit
+        # count of len(script_bytes) — a coarser size signal than
+        # ``script_len`` already carries); ``script_len`` is the
+        # per-invocation byte length operators correlate stdout size
+        # against. Neither ``sudo_password`` nor ``script`` are bound
+        # into the event.
         _log.info(
             "ssh_sudo_command_executed",
             target=target.name,
-            cmd_len=len(_SUDO_BASH_REMOTE_CMD),
-            script_len=len(script),
+            cmd_len=len(cmd),
+            script_len=len(script_bytes),
             exit_code=result.exit_status,
         )
         return result

--- a/backend/tests/test_connectors_bind9.py
+++ b/backend/tests/test_connectors_bind9.py
@@ -11,9 +11,11 @@ Coverage matrix (per Task #587 acceptance criteria):
   registry under that triple (and does **not** dual-write to v1).
 * :meth:`Bind9Connector._remote_bash_with_sudo` is the only sudo
   shell-construction path in the connector layer; the constructed
-  remote argv is the fixed ``"sudo -S -p '' bash -s"`` string and
-  the sudo password is streamed via ``input=``, never appearing in
-  the argv, the bound log fields, or any other observable.
+  remote argv is the shape rendered by
+  :func:`_build_sudo_bash_remote_cmd` — boilerplate parameterised
+  only by the script's UTF-8 byte count (an integer) — and the sudo
+  password is streamed via ``input=``, never appearing in the argv,
+  the bound log fields, or any other observable.
 * :func:`parse_named_version` recovers the ``<X.Y.Z>`` triple from
   the ``named -v`` banner shapes ISC ships on Debian + RHEL.
 * :meth:`Bind9Connector.fingerprint` returns the canonical
@@ -44,7 +46,7 @@ import meho_backplane.connectors.bind9  # noqa: F401 -- import for registry side
 from meho_backplane.connectors import all_connectors_v2
 from meho_backplane.connectors.bind9 import BIND9_OPS, Bind9Connector
 from meho_backplane.connectors.bind9.connector import (
-    _SUDO_BASH_REMOTE_CMD,
+    _build_sudo_bash_remote_cmd,
     parse_named_version,
     parse_os_release,
 )
@@ -261,38 +263,47 @@ def _mock_ssh_conn() -> MagicMock:
     return conn
 
 
-async def test_remote_bash_with_sudo_uses_fixed_argv_and_streams_password_via_stdin(
+async def test_remote_bash_with_sudo_argv_carries_only_script_byte_count_and_streams_password_via_stdin(
     _mock_ssh_conn: MagicMock,
 ) -> None:
-    """The constructed argv is the constant string; the password is on stdin."""
+    """argv is boilerplate + script byte count; password is on stdin, never argv."""
     connector = Bind9Connector()
+    script = "echo body-of-script"
     with patch.object(connector, "_connect", AsyncMock(return_value=_mock_ssh_conn)):
         result = await connector._remote_bash_with_sudo(
             _TARGET,
-            "echo body-of-script",
+            script,
             raw_jwt="jwt",
             sudo_password="super-secret-password",  # NOSONAR
         )
     assert result.exit_status == 0
 
-    # ``conn.run`` was called with the fixed argv string -- no
-    # caller-supplied substring lives in the remote command.
+    # ``conn.run`` was called with the rendered cmd — the only caller-
+    # derived interpolation is ``len(script.encode("utf-8"))``, an
+    # integer; ``script`` and ``sudo_password`` are not interpolated.
     args, kwargs = _mock_ssh_conn.run.call_args
-    assert args[0] == _SUDO_BASH_REMOTE_CMD
-    assert args[0] == "sudo -S -p '' bash -s"
+    expected_cmd = _build_sudo_bash_remote_cmd(len(script.encode("utf-8")))
+    assert args[0] == expected_cmd
+    # Spot-check the safety-critical fragments of the rendered shape.
+    assert args[0].startswith("set -e; umask 077; f=$(mktemp); ")
+    assert f"head -c {len(script.encode('utf-8'))} > " in args[0]
+    assert args[0].endswith('sudo -S -p "" bash "$f"')
 
     # The password must not appear anywhere in the constructed argv.
     assert "super-secret-password" not in args[0]
     # The script body must not appear in the argv either.
     assert "echo body-of-script" not in args[0]
 
-    # The stdin payload streams the password as line 1 and the script
-    # as line 2. The fixed-line-position contract is what makes the
-    # caller unable to mis-order the payload.
+    # The stdin payload — script bytes first (so ``head -c N`` reads
+    # exactly the script, unbuffered), then the password line. EOF
+    # immediately after the password's newline so sudo's stdio buffer
+    # has nothing past the password line to swallow (#697 fix).
     stdin_payload = kwargs["input"]
-    lines = stdin_payload.split("\n")
-    assert lines[0] == "super-secret-password"  # password is line 1
-    assert lines[1] == "echo body-of-script"  # script body is line 2
+    assert stdin_payload == "echo body-of-scriptsuper-secret-password\n"
+    # Reassert by region: first N bytes == script, remainder == password\n.
+    n = len(script.encode("utf-8"))
+    assert stdin_payload[:n] == script
+    assert stdin_payload[n:] == "super-secret-password\n"
 
     # ``check=False`` -- the helper never raises ProcessError on
     # non-zero exit; callers decide.


### PR DESCRIPTION
## Root cause (decisively reproduced locally + at the helper)

The production safe-sudo primitive had the **same stdin-corruption bug class** as the test-fixture restore fixed in #702. Previous wire shape:

\`\`\`
cmd:   "sudo -S -p '' bash -s"
stdin: "<password>\n<script>\n"
\`\`\`

\`sudo -S\` reads its password line via buffered stdio (\`fgetc\`/\`getline\`), which on a pipe consumes not just the \`\n\`-terminated password but a chunk of adjacent buffered bytes from the same kernel \`read()\`. Those go into sudo's FILE* buffer and are discarded when sudo execs bash → \`bash -s\` sees EOF immediately → script never runs → write ops silently no-op (audit shows \`state_after == state_before\`). Reproduced locally against the bind9 testcontainer + Debian sudo 1.9.x.

## Fix — split stdin into two unambiguous regions

New shape, built per call by \`_build_sudo_bash_remote_cmd(N)\`:

\`\`\`
cmd:   set -e; umask 077; f=$(mktemp);
       trap "rm -f $f" EXIT;
       head -c <N> > "$f";
       sudo -S -p "" bash "$f"
stdin: <script_bytes><sudo_password>\n
\`\`\`

- \`head -c N\` reads exactly the script's UTF-8 byte count via **unbuffered** \`read(2)\` (no stdio prefetch) into a \`umask 077\` temp file under the SSH user.
- Sudo then reads the password from what's left on stdin — \`EOF\` is immediately after the password's newline, so sudo's stdio buffer has nothing past the password line to swallow.
- \`bash "$f"\` reads the script body from disk, not stdin.

The only caller-derived value interpolated into argv is \`N\` (an integer). \`script\` and \`sudo_password\` are still not in argv at any site — preserving the 2026-05-04/05 credential-leak invariants. The script body briefly lives on the remote SSH user's tmp (\`umask 077\` + \`trap "rm -f $f" EXIT\`) — the script is contracted as the bind9 op (not credentials), so this on-disk window is acceptable.

## Verified locally

\`\`\`
unit: 202 passed (incl. updated argv/stdin assertions)
e2e:  test_dispatch_record_add_against_bind9_writes_state_before_after
      now reaches result.status == "ok" — the script actually executes
      (was silently no-op'ing before).
\`\`\`

The remaining e2e failure on that test is **a different defect** — \`state_before\` missing from the audit row payload, in the atomic-apply audit-binding path. That's the next #367 layer.

## #367 stabilisation progress
- ✅ #699 (merged) — dispatch mechanism (\`about\`)
- ✅ #702 (open) — test-fixture restore (zone.list + 10 read ops)
- 🟢 **this PR** — production safe-sudo primitive (write ops actually run)
- ⏳ next — atomic-apply audit-binding (\`state_before\`/\`state_after\` capture)

ruff + format clean. \`# code-quality-allow\` at file top for the load-bearing primitive's colocation (splitting would re-create the "sudo argv outside the whitelist" surface the e2e safety assertion polices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced BIND9 connector's remote command execution to prevent potential script data loss from sudo stdin buffering by optimizing the order of password and script streams.

* **Tests**
  * Updated test suite to validate improved command construction and secure stdin handling without exposing sensitive credentials in command arguments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->