### PR TITLE
fix(audit): merge audit_* contextvars into dispatcher payload + bind9 write-op state (#367 step 4)

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/ops_config.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_config.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: per-op modules colocate handler + parameter_schema +
+# LLM_INSTRUCTIONS + Bind9Op metadata for all of `bind9.config.*`'s
+# operator/agent surface; splitting would scatter the load-bearing
+# atomic-apply + audit-payload bindings across multiple translation
+# units. Function-size warnings on the config-write handlers accepted:
+# each is the linear "resolve path → atomic_apply → bind audit
+# contextvars → return" sequence the docstrings spell out.
 
 """bind9 config-read + config-write op group.
 
@@ -99,6 +106,8 @@ import shlex
 import tarfile
 import time
 from typing import TYPE_CHECKING, Any
+
+import structlog.contextvars
 
 from meho_backplane.connectors.bind9._atomic import atomic_apply
 from meho_backplane.connectors.bind9.ops import Bind9Op
@@ -517,6 +526,15 @@ async def bind9_config_apply_file(
         bind_root=bind_root,
     )
 
+    # Chassis audit enrichment — bind ``audit_state_before`` /
+    # ``audit_state_after`` so the dispatcher's audit-row payload
+    # carries the config-slice snapshots (mirrors the FastAPI
+    # middleware's ``audit_*`` contextvar pattern; the merger lives
+    # in operations/_audit.py:_resolve_audit_extras_from_contextvars).
+    structlog.contextvars.bind_contextvars(
+        audit_state_before=apply_result.state_before,
+        audit_state_after=apply_result.state_after,
+    )
     return {
         "file": resolved_path,
         "op_class": "write",
@@ -717,6 +735,11 @@ async def bind9_config_apply_views(
         bind_root=bind_root,
     )
 
+    # Chassis audit enrichment — see bind9_config_apply_file for rationale.
+    structlog.contextvars.bind_contextvars(
+        audit_state_before=apply_result.state_before,
+        audit_state_after=apply_result.state_after,
+    )
     return {
         "primary_path": primary_path,
         "files": resolved_paths,
@@ -995,15 +1018,19 @@ async def bind9_config_backup(
         else:
             break
 
+    # Chassis audit enrichment — only ``state_after`` (no
+    # state_before: nothing in /etc/bind/ mutated). The backup_id is
+    # the audit row's view of "the artifact this write produced",
+    # which the G8.2 audit-replay consumer cross-references with the
+    # archive store. See bind9_config_apply_file for the binding
+    # rationale.
+    structlog.contextvars.bind_contextvars(audit_state_after=backup_id)
     return {
         "backup_id": backup_id,
         "path": backup_path,
         "rows": rows,
         "total": len(rows),
         "op_class": "write",
-        # No state_before: nothing in /etc/bind/ mutated. state_after
-        # is the backup ID -- the audit row's view of "the artifact
-        # this write produced".
         "state_after": backup_id,
     }
 
@@ -1172,6 +1199,13 @@ async def bind9_config_reload(
 
     sections = _parse_reload_output(stdout_text)
     reload_rc = int(sections.get("RELOAD_RC", "1"))
+    # Chassis audit enrichment — rndc-status snapshots before and
+    # after the reload land on the audit row's payload. See
+    # bind9_config_apply_file for the binding rationale.
+    structlog.contextvars.bind_contextvars(
+        audit_state_before=sections.get("STATE_BEFORE", ""),
+        audit_state_after=sections.get("STATE_AFTER", ""),
+    )
     return {
         "ok": reload_rc == 0,
         "rndc_reload_exit": reload_rc,

--- a/backend/src/meho_backplane/connectors/bind9/ops_record.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_record.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: per-op modules colocate handler + parameter_schema +
+# LLM_INSTRUCTIONS + Bind9Op metadata so all of `bind9.record.*`'s
+# operator/agent surface is grep-able in one file; splitting would
+# scatter the load-bearing G3.4-T3 atomic-apply audit-payload binding
+# across multiple translation units. Function-size warnings on
+# bind9_record_add / bind9_record_remove accepted: each is a linear
+# "resolve zone → read zonefile → transform → atomic_apply" sequence
+# whose readability would degrade if split for cosmetics.
 
 """bind9 record ops -- read (``record.get``) + writes (``record.add`` / ``record.remove``).
 
@@ -63,6 +71,7 @@ import dns.rdata
 import dns.rdataclass
 import dns.rdatatype
 import dns.zone
+import structlog.contextvars
 
 from meho_backplane.connectors.bind9._atomic import atomic_apply
 from meho_backplane.connectors.bind9.ops import Bind9Op
@@ -782,6 +791,16 @@ async def bind9_record_add(
         verify_command=verify_cmd,
     )
 
+    # Chassis-shape audit enrichment: bind ``audit_state_before`` /
+    # ``audit_state_after`` so the dispatcher's audit-row payload
+    # carries the zonefile-slice snapshots the G8.2 audit-replay
+    # consumer reads. Mirrors the FastAPI middleware's ``audit_*``
+    # contextvar pattern (see _resolve_audit_extras_from_contextvars
+    # in operations/_audit.py).
+    structlog.contextvars.bind_contextvars(
+        audit_state_before=apply_result.state_before,
+        audit_state_after=apply_result.state_after,
+    )
     return {
         "fqdn": fqdn,
         "ip": ip,
@@ -848,6 +867,11 @@ async def bind9_record_remove(
         verify_command=verify_cmd,
     )
 
+    # Chassis audit enrichment — see bind9_record_add for rationale.
+    structlog.contextvars.bind_contextvars(
+        audit_state_before=apply_result.state_before,
+        audit_state_after=apply_result.state_after,
+    )
     return {
         "fqdn": fqdn,
         "zone": zone_name,

--- a/backend/src/meho_backplane/operations/_audit.py
+++ b/backend/src/meho_backplane/operations/_audit.py
@@ -67,6 +67,46 @@ parent_audit_id_var: ContextVar[uuid.UUID | None] = ContextVar(
 )
 
 
+#: Prefix matching the FastAPI audit middleware's ``audit_*`` contextvar
+#: convention (:data:`meho_backplane.audit._AUDIT_PAYLOAD_PREFIX`).
+#: Connector handlers that need to enrich the dispatcher's audit row
+#: bind e.g. ``structlog.contextvars.bind_contextvars(
+#: audit_state_before=..., audit_state_after=...)`` before returning;
+#: :func:`_build_audit_payload` strips the prefix and merges the
+#: result into the payload, mirroring the chassis HTTP behaviour so
+#: the typed-op dispatch path and the FastAPI route path produce the
+#: same shape of audit row.
+_AUDIT_PAYLOAD_PREFIX: str = "audit_"
+
+
+def _resolve_audit_extras_from_contextvars() -> dict[str, Any]:
+    """Build the ``audit_*``-contextvar extras dict for the audit payload.
+
+    Reads every key in the current structlog contextvar context whose
+    name starts with :data:`_AUDIT_PAYLOAD_PREFIX`, strips the prefix,
+    and returns the result as a fresh dict. ``None`` values are
+    dropped so a handler can ``bind_contextvars(audit_kind=None)`` to
+    intentionally omit a key without writing ``"kind": null``.
+
+    Mirrors :func:`meho_backplane.audit._resolve_audit_payload` (the
+    FastAPI middleware's collector). Duplicated rather than imported
+    because the dispatcher path and the chassis HTTP middleware path
+    must remain decoupled in their imports — but the on-the-wire
+    payload shape stays identical so audit consumers (G8.1 audit
+    query, G8.2 audit replay) can treat both the same.
+    """
+    out: dict[str, Any] = {}
+    for key, value in structlog.contextvars.get_contextvars().items():
+        if not key.startswith(_AUDIT_PAYLOAD_PREFIX):
+            continue
+        if value is None:
+            continue
+        stripped = key[len(_AUDIT_PAYLOAD_PREFIX) :]
+        if stripped:
+            out[stripped] = value
+    return out
+
+
 def _build_audit_payload(
     descriptor: EndpointDescriptor,
     params_hash: str,
@@ -74,12 +114,16 @@ def _build_audit_payload(
 ) -> dict[str, Any]:
     """Compose the ``audit_log.payload`` dict for the dispatcher row.
 
-    Includes a *mirror* of the ``parent_audit_id`` contextvar value
-    in the payload for the v0.2 broadcast-event surface (the
-    broadcast schema is JSON-shaped and consumers parse the payload,
-    not the audit row); the canonical linkage now lives in the real
-    ``audit_log.parent_audit_id`` column added by migration ``0006``
-    and written by :func:`write_audit_row`.
+    Default fields (descriptor, params_hash, result_status,
+    parent_audit_id-mirror) are merged with any ``audit_*``
+    contextvars bound by the connector handler — see
+    :func:`_resolve_audit_extras_from_contextvars`. The
+    parent_audit_id mirror in the payload remains for the v0.2
+    broadcast-event surface (the broadcast schema is JSON-shaped and
+    consumers parse the payload, not the audit row); the canonical
+    linkage lives in the real ``audit_log.parent_audit_id`` column
+    added by migration ``0006`` and written by
+    :func:`write_audit_row`.
     """
     payload: dict[str, Any] = {
         "op_id": descriptor.op_id,
@@ -93,6 +137,11 @@ def _build_audit_payload(
     parent_audit_id = parent_audit_id_var.get()
     if parent_audit_id is not None:
         payload["parent_audit_id"] = str(parent_audit_id)
+    # Handler-bound extras last so a handler can intentionally override
+    # a default (e.g. a future per-op result_status override); the
+    # default keys are documented + load-bearing for audit consumers,
+    # so this layering is the explicit knob, not an accidental coupling.
+    payload.update(_resolve_audit_extras_from_contextvars())
     return payload
 
 


### PR DESCRIPTION
## What

Closes the last bind9 hollow layer in #367. The 6 write-op e2e tests reached \`result.status == "ok"\` after #703 (write ops actually execute now) but failed on the audit-row payload missing \`state_before\` / \`state_after\`.

## Two-part fix

### 1. Chassis parity — \`_build_audit_payload\` merges \`audit_*\` contextvars

\`operations/_audit.py\` now mirrors the FastAPI middleware's \`audit_*\` contextvar collector (\`audit.py:_AUDIT_PAYLOAD_PREFIX\` / \`_resolve_audit_payload\`). Handler binds e.g. \`structlog.contextvars.bind_contextvars(audit_state_before=...)\`; dispatcher strips the prefix and merges into payload. The typed-op dispatch path and the chassis HTTP route path now produce identically-shaped audit rows — same prefix discipline, same None-drop semantics. Decoupled at import (no circular dep between \`operations/\` and \`audit.py\`); the wire shape is the contract.

### 2. bind9 write-op handlers bind the right state

- **record.add / record.remove / config.apply_file / config.apply_views** → both fields from \`apply_result.state_before\` / \`.state_after\`.
- **config.reload** → both fields from the rndc-status snapshots (\`sections.STATE_BEFORE\` / \`.STATE_AFTER\`).
- **config.backup** → only \`audit_state_after=backup_id\` (no state_before — nothing in \`/etc/bind/\` mutated; matches the test's \`expect_state_after\`-only assertion).

## Verified locally — full bind9 e2e file

\`\`\`
before:  12 passed + 6 failed
after:  18 passed + 0 failed
\`\`\`
223 unit tests pass; ruff + format clean.

## #367 stabilisation — complete
| Step | Layer | State |
|---|---|---|
| #699 (merged) | dispatch mechanism (\`is_unbound_method\` MRO) | ✅ |
| #702 (merged) | e2e fixture restore (\`sudo -S\` + tar) | ✅ |
| #703 (merged) | production safe-sudo (\`sudo -S\` + stdin) | ✅ |
| **this PR** | **chassis audit + handler bindings** | ✅ **all 18 e2e tests pass** |

The bind9 connector is now genuinely E2E-verified — every one of the 11 ops dispatches through the agent meta-tool path AND write ops capture \`state_before\` / \`state_after\` on the audit row. #367 closes when this lands and CI confirms green on \`main\`.

\`code-quality-allow\` added to \`ops_record.py\` and \`ops_config.py\` (same defensible pattern as connector.py — splitting would scatter the handler/schema/LLM_INSTRUCTIONS/audit-binding quad across modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Audit logging system enhanced to capture detailed state snapshots for DNS configuration and record operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->