### PR TITLE
feat(memory): G5.2-T1 MemoryExpirySweeper + INTERNAL audit writer + MEMORY_* settings + Helm

### DIFF
--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -38,6 +38,7 @@ v0.2 adds:
   ~1-2 s ONNX model load cost.
 """
 
+import asyncio
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -87,11 +88,15 @@ from meho_backplane.logging import configure_logging
 from meho_backplane.mcp import eager_import_mcp_modules
 from meho_backplane.mcp import router as mcp_router
 from meho_backplane.mcp.auth import mcp_resource_uri
+from meho_backplane.memory import (
+    start_memory_expiry_sweeper,
+    stop_memory_expiry_sweeper,
+)
 from meho_backplane.metrics import render_metrics
 from meho_backplane.middleware import BroadcastDetailMiddleware, RequestContextMiddleware
 from meho_backplane.operations import run_typed_op_registrars
 from meho_backplane.retrieval.embedding import get_embedding_service
-from meho_backplane.settings import parse_bool_env
+from meho_backplane.settings import get_settings, parse_bool_env
 from meho_backplane.topology import (
     start_topology_refresh_scheduler,
     stop_topology_refresh_scheduler,
@@ -208,6 +213,14 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     and the lifespan crashes so the operator sees CrashLoopBackOff
     instead of a quietly-broken dispatch.
 
+    The G5.2-T1 memory-expiry sweeper (#623) starts last among
+    background tasks and stops first on shutdown so its session-borrow
+    can never outlive the engine pool teardown. The sweeper is
+    enabled by ``MEMORY_EXPIRY_ENABLED`` (default ``True``); operators
+    using an external cleanup mechanism (k8s CronJob, etc.) flip the
+    env var off and the task handle stays ``None``, which the
+    ``finally`` branch tolerates.
+
     On shutdown :func:`_run_lifespan_shutdown` releases the
     SQLAlchemy + Valkey pools with per-disposer try/except so a
     single failure can't leak a sibling pool.
@@ -251,9 +264,20 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     # so shutdown can cancel + await its unwind before the DB/redis
     # pools are disposed (a sweep mid-flight must not race pool teardown).
     topology_scheduler_task = start_topology_refresh_scheduler()
+    # Scheduled memory-expiry sweeper (G5.2-T1 #623). Gated on
+    # ``MEMORY_EXPIRY_ENABLED`` so operators relying on an external
+    # cleanup mechanism (k8s CronJob, etc.) can disable the in-process
+    # loop without forking the chassis. ``None`` when disabled; the
+    # finally branch tolerates that shape so disable-and-shutdown does
+    # not raise.
+    memory_expiry_task: asyncio.Task[None] | None = None
+    if get_settings().memory_expiry_enabled:
+        memory_expiry_task = start_memory_expiry_sweeper()
     try:
         yield
     finally:
+        if memory_expiry_task is not None:
+            await stop_memory_expiry_sweeper(memory_expiry_task)
         await stop_topology_refresh_scheduler(topology_scheduler_task)
         await _run_lifespan_shutdown()
 

--- a/backend/src/meho_backplane/memory/__init__.py
+++ b/backend/src/meho_backplane/memory/__init__.py
@@ -23,6 +23,11 @@ build on top of :class:`MemoryService`; the auto-expiry executor
 metadata field this module honours on read.
 """
 
+from meho_backplane.memory.audit import write_internal_audit_row
+from meho_backplane.memory.expiry import (
+    start_memory_expiry_sweeper,
+    stop_memory_expiry_sweeper,
+)
 from meho_backplane.memory.rbac import MemoryRbacResolver, PermissionDeniedError
 from meho_backplane.memory.schemas import (
     MemoryEntry,
@@ -40,4 +45,7 @@ __all__ = [
     "MemoryScope",
     "MemoryService",
     "PermissionDeniedError",
+    "start_memory_expiry_sweeper",
+    "stop_memory_expiry_sweeper",
+    "write_internal_audit_row",
 ]

--- a/backend/src/meho_backplane/memory/audit.py
+++ b/backend/src/meho_backplane/memory/audit.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Internal audit-row writer for system-driven memory operations (G5.2-T1).
+
+The chassis :class:`~meho_backplane.audit.AuditMiddleware` writes one
+row per authenticated HTTP request; the MCP path's
+:func:`~meho_backplane.mcp.audit.write_mcp_audit_row` writes one row
+per JSON-RPC tool dispatch. Both pull the operator identity out of a
+validated :class:`~meho_backplane.auth.operator.Operator` because both
+surfaces have an authenticated caller.
+
+The G5.2 memory-expiry sweeper has no caller: it is the background
+``asyncio`` task the FastAPI lifespan owns, running off a fixed cadence
+to delete ``source="memory"`` rows whose ``metadata.expires_at`` has
+passed. It still needs to write an ``audit_log`` row per affected
+tenant so G8's forensic queries can answer "what did the system clean
+up overnight?" -- but the row's ``operator_sub`` is the synthetic
+``"system"`` identity, not a JWT-derived ``sub``, and there is no
+:class:`Operator` to pass in.
+
+:func:`write_internal_audit_row` mirrors the
+:func:`~meho_backplane.mcp.audit.write_mcp_audit_row` shape verbatim
+except for taking ``operator_sub`` + ``tenant_id`` as explicit keyword
+arguments. Field semantics:
+
+* ``operator_sub`` -- typically the literal ``"system"`` for sweeper
+  rows; callers writing their own internal operations name themselves
+  (e.g. a future ``system:retention-sweeper``) so audit filters can
+  partition by which background job ran.
+* ``method`` -- the literal ``"INTERNAL"`` for memory-expiry sweeper
+  rows. Distinguishes background-process rows from the chassis HTTP
+  rows (``GET`` / ``POST`` / ...) and MCP rows (``"MCP"``) at audit-
+  query time without joining on ``path`` -- the same axis the chassis
+  + MCP writers already partition on.
+* ``path`` -- the op identifier *within* the INTERNAL channel, e.g.
+  ``"memory.expire"`` for the sweeper. The ``method``-is-channel,
+  ``path``-is-op-id convention is documented in
+  ``docs/architecture/audit.md`` so G8.2 (#219) audit-query consumers
+  pick these rows up by path when ``meho audit query --op
+  memory.expire`` ships.
+* ``status_code`` -- HTTP-style projection of the operation's outcome
+  (``200`` on success, ``500`` on a per-tick failure). Mirrors the
+  MCP writer's HTTP-style mapping so dashboards that group by
+  ``status_code`` see HTTP + MCP + INTERNAL traffic on the same axis.
+* ``payload`` -- the operation-specific structured payload. For the
+  memory sweeper: ``{"expired_count": N, "scopes": ["memory-user",
+  ...]}`` so audit replays can reconstruct what was reaped per tick
+  without keeping the deleted document bodies.
+
+Fail-closed contract: the helper raises on commit failure. The
+caller's per-tick ``try`` / ``except`` block (see
+:func:`meho_backplane.memory.expiry._run_one_tick`) logs and continues
+to the next cadence -- one bad audit-write must not kill the sweeper
+loop. This is the opposite of the chassis HTTP path (which fail-closes
+the *request*); for an internal background task, the loop-survival
+contract dominates: a single failed audit row is preferable to the
+loop dying and never cleaning up expired memories again.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import structlog
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+
+__all__ = ["write_internal_audit_row"]
+
+#: Synthetic ``operator_sub`` value for sweeper-written rows. Centralised
+#: so audit-query filters and downstream G8 dashboards can pin to one
+#: stable literal rather than rediscovering it per call site.
+SYSTEM_OPERATOR_SUB: str = "system"
+
+#: ``method`` value for every INTERNAL-channel row. Carried here so the
+#: caller never spells the literal at the call site and the channel-vs-
+#: op-id convention stays auditable from one symbol.
+INTERNAL_METHOD: str = "INTERNAL"
+
+#: Canonical ``path`` value for the memory-expiry sweeper. Defined here
+#: (rather than in :mod:`expiry`) so the audit-doc, the sweeper, and any
+#: future audit-query consumer share one symbol.
+MEMORY_EXPIRE_PATH: str = "memory.expire"
+
+
+async def write_internal_audit_row(
+    *,
+    operator_sub: str,
+    tenant_id: uuid.UUID,
+    method: str,
+    path: str,
+    status_code: int,
+    duration_ms: float,
+    payload: dict[str, Any],
+    request_id: uuid.UUID | None = None,
+    audit_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Commit one ``AuditLog`` row for a system-driven internal operation.
+
+    Mirrors :func:`~meho_backplane.mcp.audit.write_mcp_audit_row`'s shape
+    exactly (same DB columns, same ``Decimal(str(...))`` round-trip for
+    ``duration_ms`` to avoid float-binary artefacts) but takes
+    ``operator_sub`` + ``tenant_id`` as explicit keyword arguments rather
+    than deriving them from an :class:`Operator`: the memory-expiry
+    sweeper that calls this helper runs without a JWT, so there is no
+    validated operator to thread through.
+
+    Parameters
+    ----------
+    operator_sub:
+        Synthetic identity for the background job. Use
+        :data:`SYSTEM_OPERATOR_SUB` (``"system"``) for the memory
+        sweeper; future internal writers should pick a stable name
+        (``"system:retention-sweeper"`` etc.) so audit filters can
+        partition by background-job source.
+    tenant_id:
+        Which tenant this operation touched. The sweeper writes one row
+        per affected tenant so cross-tenant audit replays do not need
+        to fan out into joins on a ``payload.tenant_ids`` array.
+    method:
+        Channel literal -- :data:`INTERNAL_METHOD` for sweeper rows.
+        Distinguishes background-process rows from HTTP / MCP rows in
+        audit queries.
+    path:
+        Operation identifier within the channel -- e.g.
+        :data:`MEMORY_EXPIRE_PATH` (``"memory.expire"``). Documented in
+        ``docs/architecture/audit.md`` as the forward reference for
+        G8.2 (#219) audit-query consumers.
+    status_code:
+        HTTP-style projection of the operation outcome (200 on success,
+        500 on per-tick failure). Mirrors the MCP writer's HTTP-style
+        mapping.
+    duration_ms:
+        Wall-clock duration of the operation. Round-tripped through
+        ``Decimal(str(...))`` for shape consistency with the chassis +
+        MCP writers; the substrate column is :class:`Numeric` so float
+        binary artefacts would otherwise leak into stored values.
+    payload:
+        Operation-specific structured payload. For the memory sweeper:
+        ``{"expired_count": N, "scopes": ["memory-user", ...]}``.
+    request_id:
+        Optional request-id for back-correlation. Background-job rows
+        typically have no request id; the column is nullable so passing
+        ``None`` is the supported shape.
+    audit_id:
+        Optional pre-generated id. The G6.1-T3 publish-on-write hook
+        pre-generates the id at the dispatch call site so the broadcast
+        event can reference the same id post-commit. Sweeper callers
+        that don't broadcast leave this ``None`` and a fresh ``uuid4``
+        is generated.
+
+    Returns
+    -------
+    uuid.UUID
+        The audit-row id used for the row.
+
+    Raises
+    ------
+    Exception
+        Any DB-side exception propagates verbatim. The caller's per-tick
+        ``try`` / ``except`` block decides whether to swallow it (the
+        sweeper does so loud-but-non-fatal) or surface it.
+    """
+    log = structlog.get_logger(__name__)
+    if audit_id is None:
+        audit_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = AuditLog(
+            id=audit_id,
+            occurred_at=datetime.now(UTC),
+            operator_sub=operator_sub,
+            tenant_id=tenant_id,
+            method=method,
+            path=path,
+            status_code=status_code,
+            request_id=request_id,
+            # Convert ``duration_ms`` via ``Decimal(str(...))`` for shape
+            # consistency with the chassis + MCP writers. SQLAlchemy's
+            # ``Numeric`` type accepts both ``float`` and ``Decimal``, but
+            # the ``Decimal(str(value))`` path round-trips through the
+            # JSON string representation and avoids the float->Decimal
+            # binary conversion artefacts ``Decimal(float)`` would
+            # introduce.
+            duration_ms=Decimal(str(duration_ms)),
+            payload=payload,
+        )
+        session.add(row)
+        await session.commit()
+    log.info(
+        "internal_audit_row_written",
+        operator_sub=operator_sub,
+        method=method,
+        path=path,
+        status_code=status_code,
+        duration_ms=duration_ms,
+    )
+    return audit_id

--- a/backend/src/meho_backplane/memory/expiry.py
+++ b/backend/src/meho_backplane/memory/expiry.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Scheduled background memory-expiry sweeper (G5.2-T1, #623).
+
+Consumer-needs.md §G5 specifies that session-scoped memory entries
+expire by default ("session-scoped hints expire after 7 days unless
+re-pinned"). G5.1 (#332) stores the per-row ``expires_at`` in
+``doc_metadata`` and filters expired rows out of *read* paths
+(:meth:`~meho_backplane.memory.service.MemoryService.recall` /
+:meth:`~meho_backplane.memory.service.MemoryService.list_memories` /
+:meth:`~meho_backplane.memory.service.MemoryService.search_memories`).
+This module ships the corresponding *physical* cleanup: an
+``asyncio`` task the FastAPI lifespan owns that ticks on a fixed
+cadence (default 24 h) and removes the expired rows so the
+``documents`` table does not accumulate undeleted soft-hidden memory.
+
+Why ``asyncio.create_task`` and not APScheduler 4.x
+---------------------------------------------------
+
+Identical reasoning to the G9.1-T3 topology scheduler (#450):
+APScheduler 4.x has only shipped alphas which the maintainer documents
+as "should NOT be used in production". A stdlib ``asyncio`` loop in
+the lifespan is zero-dependency, follows the chassis's "no new
+substrate / minimal dependencies" discipline (``CLAUDE.md``), and is
+the same shape the lifespan already uses for long-lived resources.
+
+Per-pod leader election
+-----------------------
+
+Initiative #374 explicitly defers per-pod leader election to v0.2.next.
+Under N replicas the worst case is N identical ``DELETE`` statements
+in the same second targeting rows that are already gone from the
+previous winner -- idempotent and cheap. Adding advisory locks here
+would mirror the topology scheduler's pattern, but the topology
+substrate's stampede cost is real (each refresh hits a vendor API);
+expiry's stampede cost is "an extra DELETE that hits zero rows", which
+is below the noise floor of normal DB load.
+
+Failure isolation
+-----------------
+
+Each tick runs inside its own ``try`` / ``except`` so one bad tick
+(connector down, transient DB blip, malformed metadata row) never
+stalls the loop. The exception is logged with ``structlog.warning``
+under ``memory_expiry_tick_failed`` and the loop waits for the next
+cadence. This is the inverse of the chassis HTTP path (which
+fail-closes the *request*); for a background task, loop survival
+dominates: a single missed tick is recoverable on the next cadence,
+but a crashed loop silently stops cleanup until the next process
+restart.
+
+Cross-dialect ``expires_at`` extraction
+---------------------------------------
+
+The ``expires_at`` value lives in ``doc_metadata`` (JSONB on PG, JSON
+on SQLite) under the canonical ``expires_at`` key. PostgreSQL exposes
+the value via ``jsonb_extract_path_text(metadata, 'expires_at')``;
+SQLite exposes it via ``json_extract(metadata, '$.expires_at')``.
+:func:`_run_one_tick` picks the dialect-appropriate expression at the
+session boundary so the same handler runs on both PG (production) and
+SQLite (the test path). Values are stored as ISO 8601 strings with a
+``+00:00`` / ``Z`` offset (see
+:func:`~meho_backplane.memory._internal.build_metadata`), so the
+comparison is a stable lexicographic ``<`` against ``now(UTC)`` in the
+same format -- ISO 8601 strings sort identically to their datetime
+values when the offset is normalised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+import structlog
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Document
+from meho_backplane.memory._internal import MEMORY_SOURCE
+from meho_backplane.memory.audit import (
+    INTERNAL_METHOD,
+    MEMORY_EXPIRE_PATH,
+    SYSTEM_OPERATOR_SUB,
+    write_internal_audit_row,
+)
+from meho_backplane.settings import get_settings
+
+if TYPE_CHECKING:
+    import uuid
+
+__all__ = [
+    "start_memory_expiry_sweeper",
+    "stop_memory_expiry_sweeper",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+def _expires_at_expression(session: AsyncSession) -> sa.ColumnElement[str | None]:
+    """Build a dialect-appropriate SQL expression for ``metadata.expires_at``.
+
+    PostgreSQL: ``jsonb_extract_path_text(metadata, 'expires_at')``
+    returns ``NULL`` for absent keys and the text value for present
+    ones -- matching SQLite's ``json_extract`` shape closely enough
+    that the same ``< now_iso`` predicate works on both dialects
+    without a per-row branch.
+
+    SQLite (test path): ``json_extract(metadata, '$.expires_at')``
+    follows the JSON path grammar; the leading ``$`` and the key are
+    quoted because the column is :class:`JSON`, not native ``JSONB``.
+
+    Returning a typed :class:`sa.ColumnElement` keeps mypy happy at the
+    call site -- the expression is used in a ``where`` predicate
+    comparing the extracted string to a Python string, which the type
+    checker can resolve.
+    """
+    bind = session.bind
+    # ``bind`` is ``None`` only when the session is constructed without
+    # an engine bound, which never happens for sessions built by
+    # ``get_sessionmaker()``. Defensive cast for mypy + clarity.
+    if bind is None or bind.dialect.name != "postgresql":
+        return sa.func.json_extract(Document.doc_metadata, "$.expires_at")
+    return sa.func.jsonb_extract_path_text(Document.doc_metadata, "expires_at")
+
+
+async def _run_one_tick() -> None:
+    """One sweep: find expired ``source='memory'`` rows, delete, audit.
+
+    Two-step query (SELECT then DELETE) instead of ``DELETE ...
+    RETURNING`` for portability: SQLite under the version shipped with
+    the CI Python image lacks ``RETURNING`` support, and the cost of
+    the extra round-trip is invisible at sweeper rates (one tick every
+    24 hours in production). The select pulls the ``(tenant_id, kind,
+    id)`` tuples; the delete reaps the rows by primary key in one
+    statement; per-tenant aggregation then drives one audit row per
+    affected tenant.
+
+    The ``now_iso`` comparison uses the canonical ISO 8601 format with
+    a ``+00:00`` offset to match the storage format
+    :func:`~meho_backplane.memory._internal.build_metadata` writes. The
+    string ordering is identical to the underlying datetime ordering
+    under a fixed UTC offset, which is what every memory row carries
+    (the build_metadata path normalises to UTC before serialising).
+    """
+    tick_started = time.perf_counter()
+    now_iso = datetime.now(UTC).isoformat()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        expires_expr = _expires_at_expression(session)
+        # NULL-safe filter: rows with no ``expires_at`` key (persistent
+        # memories the operator opted out of TTL on) are skipped via
+        # ``expires_expr IS NOT NULL`` -- ``NULL < anything`` is NULL
+        # under SQL, but being explicit makes the intent visible at the
+        # query layer rather than relying on three-valued logic.
+        candidate_query = select(
+            Document.id,
+            Document.tenant_id,
+            Document.kind,
+        ).where(
+            Document.source == MEMORY_SOURCE,
+            expires_expr.is_not(None),
+            expires_expr < now_iso,
+        )
+        result = await session.execute(candidate_query)
+        candidates = list(result.all())
+        if not candidates:
+            _log.debug("memory_expiry_tick_clean")
+            return
+
+        per_tenant: dict[uuid.UUID, list[str]] = defaultdict(list)
+        ids_to_delete: list[uuid.UUID] = []
+        for doc_id, tenant_id, kind in candidates:
+            ids_to_delete.append(doc_id)
+            per_tenant[tenant_id].append(kind)
+
+        await session.execute(delete(Document).where(Document.id.in_(ids_to_delete)))
+        await session.commit()
+
+    duration_ms = (time.perf_counter() - tick_started) * 1000.0
+    for tenant_id, kinds in per_tenant.items():
+        # Deduplicated, sorted scope list so the audit payload is stable
+        # under reordering of the candidate query. Operators querying
+        # the payload by scope can rely on a canonical shape.
+        unique_scopes = sorted(set(kinds))
+        try:
+            await write_internal_audit_row(
+                operator_sub=SYSTEM_OPERATOR_SUB,
+                tenant_id=tenant_id,
+                method=INTERNAL_METHOD,
+                path=MEMORY_EXPIRE_PATH,
+                status_code=200,
+                duration_ms=duration_ms,
+                payload={
+                    "expired_count": len(kinds),
+                    "scopes": unique_scopes,
+                },
+            )
+        except Exception:
+            # An audit-write failure must not stall the tick (the rows
+            # are already deleted; we cannot roll that back from here).
+            # Surface the failure loud so operators see it in logs.
+            _log.exception(
+                "memory_expiry_audit_write_failed",
+                tenant_id=str(tenant_id),
+                expired_count=len(kinds),
+            )
+    _log.info(
+        "memory_expiry_tick_done",
+        affected_tenants=len(per_tenant),
+        expired_total=sum(len(k) for k in per_tenant.values()),
+        duration_ms=duration_ms,
+    )
+
+
+async def _sweeper_loop() -> None:
+    """The forever loop: sleep one cadence, sweep, repeat.
+
+    Order is sleep-then-sweep (rather than sweep-then-sleep) so the
+    very first tick after process start does not race the rest of the
+    startup work (eager engine init, embedding preload, typed-op
+    registration). A ``MEMORY_EXPIRY_TICK_INTERVAL_SECONDS`` delay
+    after startup is the cleanest signal that all eager init has
+    completed.
+
+    Per-tick ``try`` / ``except`` guards mean a transient DB blip is
+    logged and the loop continues to the next cadence. ``CancelledError``
+    propagates so lifespan shutdown can stop the task cleanly.
+    """
+    interval = get_settings().memory_expiry_tick_interval_seconds
+    _log.info(
+        "memory_expiry_sweeper_started",
+        interval_seconds=interval,
+    )
+    while True:
+        # Sleep first so the first tick is delayed by one cadence; the
+        # ``CancelledError` here is propagated up to ``stop_*`` cleanly.
+        await asyncio.sleep(get_settings().memory_expiry_tick_interval_seconds)
+        try:
+            await _run_one_tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning(
+                "memory_expiry_tick_failed",
+                exc_info=True,
+            )
+
+
+def start_memory_expiry_sweeper() -> asyncio.Task[None]:
+    """Start the background sweeper loop and return its task handle.
+
+    Registered in :func:`meho_backplane.main.lifespan` behind the
+    ``MEMORY_EXPIRY_ENABLED`` setting. The returned task is cancelled
+    on lifespan shutdown; the caller awaits the cancellation so the
+    loop unwinds cleanly. Returning the task (rather than fire-and-
+    forgetting) keeps a strong reference alive -- an un-referenced
+    ``asyncio.Task`` can be garbage-collected mid-flight, producing
+    the "Task was destroyed but it is pending!" warnings the AC
+    explicitly bars under pytest-asyncio shutdown.
+    """
+    return asyncio.create_task(_sweeper_loop(), name="memory-expiry-sweeper")
+
+
+async def stop_memory_expiry_sweeper(task: asyncio.Task[None]) -> None:
+    """Cancel the sweeper task and await its unwind.
+
+    Swallows the expected :class:`asyncio.CancelledError`; any other
+    exception surfaced during unwind propagates so a broken shutdown
+    is visible rather than silently swallowed. The shape mirrors
+    :func:`~meho_backplane.topology.scheduler.stop_topology_refresh_scheduler`
+    verbatim so future contributors find one disposal pattern across
+    the lifespan-owned tasks.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -292,6 +292,43 @@ class Settings(BaseModel):
         backoff is derived from this value (2x, capped at 4 h) inside
         the scheduler, not a separate knob. Read once per loop
         iteration through :func:`get_settings`'s cache.
+    memory_user_default_ttl_days:
+        Default time-to-live for user-scoped (``kind="memory-user"``)
+        memory entries, in days. G5.2-T2 (#624) consumes this on the
+        ``POST /api/v1/memory`` handler to inject
+        ``expires_at = now() + memory_user_default_ttl_days`` when the
+        caller does not supply an explicit value. Range ``[1, 365]``:
+        below one day defeats the auto-expiry contract; above one year
+        is functionally "permanent" and operators wanting that should
+        pass ``expires_at=null`` explicitly. Default 7 matches
+        consumer-needs.md §G5 ("session-scoped hints expire after 7
+        days unless re-pinned"). Carried here by G5.2-T1 so the
+        chassis owns one settings shape; the write path follows in T2.
+    memory_expiry_tick_interval_seconds:
+        Cadence of the G5.2-T1 memory-expiry sweeper background loop,
+        in seconds. The sweeper (registered in the FastAPI lifespan)
+        sleeps this long between scans of the ``documents`` table for
+        expired ``source="memory"`` rows. Default 86400 (24 h)
+        matches Initiative #374's stated cadence; tests override to
+        sub-second values via env-var monkeypatch + :func:`get_settings`
+        cache-clear. Range ``[60, 86400]``: below one minute makes the
+        sweeper compete with normal request load on a tight loop;
+        above 24 hours is the operator-facing maximum (longer than one
+        day risks accumulating soft-hidden rows that pollute
+        :meth:`~meho_backplane.memory.service.MemoryService.search_memories`'s
+        candidate pool). Read once per loop iteration through
+        :func:`get_settings`'s cache.
+    memory_expiry_enabled:
+        Whether to start the G5.2-T1 memory-expiry sweeper background
+        task in the FastAPI lifespan. Default ``True``: the in-process
+        ``asyncio`` loop is the shipped cleanup mechanism. Operators
+        running a different cleanup mechanism (k8s CronJob, etc.)
+        flip ``MEMORY_EXPIRY_ENABLED=false`` so the chassis does not
+        race the external job; expired rows still surface as soft-
+        hidden through the read-side filter
+        :func:`~meho_backplane.memory._internal.is_expired` until the
+        external job reaps them. Read once at lifespan startup; toggling
+        post-start requires a pod restart to take effect.
     """
 
     keycloak_issuer_url: HttpUrl
@@ -326,6 +363,9 @@ class Settings(BaseModel):
     broadcast_retention_hours: int = Field(default=24, gt=0)
     composite_max_depth: int = Field(default=8, gt=0)
     topology_refresh_interval_seconds: int = Field(default=3600, gt=0)
+    memory_user_default_ttl_days: int = Field(default=7, ge=1, le=365)
+    memory_expiry_tick_interval_seconds: int = Field(default=86400, ge=60, le=86400)
+    memory_expiry_enabled: bool = True
 
     @field_validator("broadcast_redis_url")
     @classmethod
@@ -445,5 +485,14 @@ def get_settings() -> Settings:
         ),
         topology_refresh_interval_seconds=int(
             os.environ.get("TOPOLOGY_REFRESH_INTERVAL_SECONDS", "3600"),
+        ),
+        memory_user_default_ttl_days=int(
+            os.environ.get("MEMORY_USER_DEFAULT_TTL_DAYS", "7"),
+        ),
+        memory_expiry_tick_interval_seconds=int(
+            os.environ.get("MEMORY_EXPIRY_TICK_INTERVAL_SECONDS", "86400"),
+        ),
+        memory_expiry_enabled=parse_bool_env(
+            os.environ.get("MEMORY_EXPIRY_ENABLED", "true"),
         ),
     )

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -321,6 +321,16 @@ def test_lifespan_calls_eager_import_connectors() -> None:
             patch("meho_backplane.main.eager_import_mcp_modules"),
             patch("meho_backplane.main._assert_mcp_resource_uri_configured"),
             patch("meho_backplane.main.get_embedding_service"),
+            # G5.2-T1 (#623) added a settings read + sweeper start to the
+            # lifespan body. Patch both so this test (which patches every
+            # other heavy dep but does not pin env vars) does not regress
+            # on the env-var lookup ``get_settings`` would otherwise hit.
+            patch(
+                "meho_backplane.main.get_settings",
+                return_value=MagicMock(memory_expiry_enabled=False),
+            ),
+            patch("meho_backplane.main.start_memory_expiry_sweeper"),
+            patch("meho_backplane.main.stop_memory_expiry_sweeper", new=AsyncMock()),
         ):
             # Manually step through the lifespan async generator.
             gen = lifespan(None)  # type: ignore[arg-type]
@@ -364,6 +374,13 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
             patch("meho_backplane.main.eager_import_mcp_modules"),
             patch("meho_backplane.main._assert_mcp_resource_uri_configured"),
             patch("meho_backplane.main.get_embedding_service"),
+            # G5.2-T1 (#623) — same patches as the sibling lifespan test.
+            patch(
+                "meho_backplane.main.get_settings",
+                return_value=MagicMock(memory_expiry_enabled=False),
+            ),
+            patch("meho_backplane.main.start_memory_expiry_sweeper"),
+            patch("meho_backplane.main.stop_memory_expiry_sweeper", new=AsyncMock()),
         ):
             gen = lifespan(None)  # type: ignore[arg-type]
             await gen.__aenter__()

--- a/backend/tests/test_memory_expiry.py
+++ b/backend/tests/test_memory_expiry.py
@@ -1,0 +1,540 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G5.2-T1 memory-expiry sweeper (#623).
+
+Coverage matrix (Task #623 acceptance criteria):
+
+* **Past-expiry rows are deleted** — a ``source="memory"`` row with
+  ``metadata.expires_at`` in the past disappears after one tick, and
+  exactly one ``audit_log`` row lands with ``method="INTERNAL"``,
+  ``path="memory.expire"``, ``payload.expired_count == 1``.
+* **Future-expiry rows survive** — a ``source="memory"`` row with
+  ``expires_at`` in the future stays put.
+* **Non-memory rows ignored** — a ``source="kb"`` row with a past
+  ``expires_at`` survives (the sweeper only touches memory).
+* **Loop survives a bad tick** — a tick that raises mid-flight logs
+  ``memory_expiry_tick_failed`` (loud-but-non-fatal) and the next
+  tick still executes.
+* **Disabled sweeper is never started** — when
+  ``MEMORY_EXPIRY_ENABLED=false`` the lifespan does not create a task
+  handle (asserted by inspecting the lifespan's local state).
+* **Settings bounds** — Pydantic validators reject out-of-range
+  values for the three new ``MEMORY_*`` knobs at construction time.
+* **start/stop lifecycle** — the lifespan helpers create and cleanly
+  cancel the background task with no "Task was destroyed" /
+  "unretrieved CancelledError" warnings under pytest-asyncio.
+
+The tests run against the autouse :func:`tests.conftest._default_database_url`
+fixture's SQLite-backed engine; the expiry sweeper's PG-vs-SQLite JSON
+extraction is exercised on the SQLite path here, with the PG path
+covered by the integration suite (driven by the migration runner that
+applies migration ``0003`` against a testcontainers Postgres).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import select
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Document, Tenant
+from meho_backplane.memory import expiry
+from meho_backplane.memory.audit import (
+    INTERNAL_METHOD,
+    MEMORY_EXPIRE_PATH,
+    SYSTEM_OPERATOR_SUB,
+    write_internal_audit_row,
+)
+from meho_backplane.memory.expiry import (
+    _run_one_tick,
+    start_memory_expiry_sweeper,
+    stop_memory_expiry_sweeper,
+)
+from meho_backplane.settings import Settings, get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+#: 384-dim placeholder embedding. The sweeper never reads the column,
+#: but the schema requires NOT NULL; a fixed list keeps the seed cheap.
+_FAKE_EMBEDDING: list[float] = [0.01] * 384
+
+
+async def _seed_tenant() -> uuid.UUID:
+    """Insert one :class:`Tenant` and return its id.
+
+    Document.tenant_id carries a real FK to ``tenant.id`` (see
+    :class:`~meho_backplane.db.models.Document`), so a sweeper test
+    that seeds documents must seed the parent tenant first.
+    """
+    sessionmaker = get_sessionmaker()
+    tid = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tid, slug=f"t-{tid.hex[:8]}", name=f"Tenant {tid.hex[:6]}"))
+        await session.commit()
+    return tid
+
+
+async def _seed_document(
+    *,
+    tenant_id: uuid.UUID,
+    source: str,
+    kind: str,
+    source_id: str,
+    expires_at: datetime | None,
+) -> uuid.UUID:
+    """Insert one :class:`Document` row and return its id.
+
+    ``expires_at`` is rendered into ``doc_metadata`` as an ISO 8601
+    string with a ``+00:00`` offset (matching
+    :func:`~meho_backplane.memory._internal.build_metadata`'s
+    serialisation) when provided, or omitted entirely when ``None``
+    (the "persistent memory, no TTL" shape).
+    """
+    sessionmaker = get_sessionmaker()
+    doc_id = uuid.uuid4()
+    metadata: dict[str, Any] = {"scope": kind}
+    if expires_at is not None:
+        metadata["expires_at"] = expires_at.isoformat()
+    async with sessionmaker() as session:
+        session.add(
+            Document(
+                id=doc_id,
+                tenant_id=tenant_id,
+                source=source,
+                source_id=source_id,
+                kind=kind,
+                body=f"body {source_id}",
+                body_hash="x" * 64,
+                embedding=_FAKE_EMBEDDING,
+                doc_metadata=metadata,
+            )
+        )
+        await session.commit()
+    return doc_id
+
+
+async def _list_documents() -> list[Document]:
+    """Return every ``documents`` row (test-helper, small datasets only)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(Document))
+        return list(result.scalars().all())
+
+
+async def _list_audit_rows() -> list[AuditLog]:
+    """Return every ``audit_log`` row (test-helper, small datasets only)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog))
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Settings validators (AC: out-of-range values rejected at construction)
+# ---------------------------------------------------------------------------
+
+
+def _settings_kwargs(**overrides: Any) -> dict[str, Any]:
+    """Build a complete :class:`Settings` kwargs dict with overrides applied.
+
+    Pydantic models reject ``__init__`` calls missing required fields,
+    so the validator tests cannot just pass the field under test --
+    every required field needs a value. Centralising the boilerplate
+    here keeps the per-test assertion focused on the one field that
+    matters.
+    """
+    base: dict[str, Any] = {
+        "keycloak_issuer_url": "https://keycloak.test/realms/meho",
+        "keycloak_audience": "meho-backplane",
+        "vault_addr": "https://vault.test",
+        "database_url": "sqlite+aiosqlite:///./test.db",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_memory_user_default_ttl_days_default_is_seven() -> None:
+    """Default 7 matches consumer-needs.md §G5 ("expires after 7 days")."""
+    s = Settings(**_settings_kwargs())
+    assert s.memory_user_default_ttl_days == 7
+
+
+def test_memory_user_default_ttl_days_rejects_zero() -> None:
+    """Range floor is 1 day; zero defeats the auto-expiry contract."""
+    with pytest.raises(ValidationError):
+        Settings(**_settings_kwargs(memory_user_default_ttl_days=0))
+
+
+def test_memory_user_default_ttl_days_rejects_above_one_year() -> None:
+    """Range ceiling is 365 days; >1 year is functionally permanent."""
+    with pytest.raises(ValidationError):
+        Settings(**_settings_kwargs(memory_user_default_ttl_days=366))
+
+
+def test_memory_expiry_tick_interval_default_is_one_day() -> None:
+    """Default 86400 (24 h) matches Initiative #374's stated cadence."""
+    s = Settings(**_settings_kwargs())
+    assert s.memory_expiry_tick_interval_seconds == 86400
+
+
+def test_memory_expiry_tick_interval_rejects_below_one_minute() -> None:
+    """Range floor is 60s; below one minute competes with request load."""
+    with pytest.raises(ValidationError):
+        Settings(**_settings_kwargs(memory_expiry_tick_interval_seconds=59))
+
+
+def test_memory_expiry_tick_interval_rejects_above_one_day() -> None:
+    """Range ceiling is 86400s; above 24 h risks soft-hidden pollution."""
+    with pytest.raises(ValidationError):
+        Settings(**_settings_kwargs(memory_expiry_tick_interval_seconds=86401))
+
+
+def test_memory_expiry_enabled_default_is_true() -> None:
+    """Default True: the in-process sweeper is the shipped mechanism."""
+    s = Settings(**_settings_kwargs())
+    assert s.memory_expiry_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Sweeper tick — happy path (AC: past-expiry row deleted + audit row written)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_deletes_past_expiry_row_and_writes_audit_row() -> None:
+    tenant_id = await _seed_tenant()
+    past = datetime.now(UTC) - timedelta(days=1)
+    doc_id = await _seed_document(
+        tenant_id=tenant_id,
+        source="memory",
+        kind="memory-user",
+        source_id="user:op-1:slug-1",
+        expires_at=past,
+    )
+
+    await _run_one_tick()
+
+    docs = await _list_documents()
+    assert all(d.id != doc_id for d in docs), "expired memory row was not deleted"
+
+    audit_rows = await _list_audit_rows()
+    assert len(audit_rows) == 1
+    row = audit_rows[0]
+    assert row.method == INTERNAL_METHOD
+    assert row.path == MEMORY_EXPIRE_PATH
+    assert row.operator_sub == SYSTEM_OPERATOR_SUB
+    assert row.tenant_id == tenant_id
+    assert row.status_code == 200
+    assert row.payload["expired_count"] == 1
+    assert row.payload["scopes"] == ["memory-user"]
+
+
+# ---------------------------------------------------------------------------
+# Future-expiry survives (AC: future expires_at is not deleted)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_does_not_delete_future_expiry_row() -> None:
+    tenant_id = await _seed_tenant()
+    future = datetime.now(UTC) + timedelta(days=7)
+    doc_id = await _seed_document(
+        tenant_id=tenant_id,
+        source="memory",
+        kind="memory-user",
+        source_id="user:op-1:still-live",
+        expires_at=future,
+    )
+
+    await _run_one_tick()
+
+    docs = await _list_documents()
+    assert any(d.id == doc_id for d in docs), "future-expiry row was wrongly deleted"
+    audit_rows = await _list_audit_rows()
+    assert audit_rows == [], "no expired rows -> no audit row should land"
+
+
+@pytest.mark.asyncio
+async def test_tick_does_not_delete_persistent_memory_with_no_expiry() -> None:
+    """A memory row without an ``expires_at`` field stays put forever.
+
+    The ``expires_expr.is_not(None)`` guard in :func:`_run_one_tick` is
+    the load-bearing branch: a JSON column with no ``expires_at`` key
+    returns NULL on both ``jsonb_extract_path_text`` (PG) and
+    ``json_extract`` (SQLite), and the sweeper must treat NULL as
+    "do not delete".
+    """
+    tenant_id = await _seed_tenant()
+    doc_id = await _seed_document(
+        tenant_id=tenant_id,
+        source="memory",
+        kind="memory-tenant",
+        source_id="tenant:persistent",
+        expires_at=None,
+    )
+
+    await _run_one_tick()
+
+    docs = await _list_documents()
+    assert any(d.id == doc_id for d in docs), "persistent memory was wrongly deleted"
+
+
+# ---------------------------------------------------------------------------
+# Non-memory rows survive (AC: kb row with past expires_at is not touched)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_does_not_delete_non_memory_rows() -> None:
+    tenant_id = await _seed_tenant()
+    past = datetime.now(UTC) - timedelta(days=1)
+    kb_id = await _seed_document(
+        tenant_id=tenant_id,
+        source="kb",
+        kind="kb-entry",
+        source_id="kb:should-survive",
+        expires_at=past,
+    )
+
+    await _run_one_tick()
+
+    docs = await _list_documents()
+    assert any(d.id == kb_id for d in docs), "non-memory row was wrongly deleted"
+
+
+# ---------------------------------------------------------------------------
+# Multi-tenant grouping (AC: one audit row per affected tenant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_writes_one_audit_row_per_affected_tenant() -> None:
+    tenant_a = await _seed_tenant()
+    tenant_b = await _seed_tenant()
+    past = datetime.now(UTC) - timedelta(days=1)
+    await _seed_document(
+        tenant_id=tenant_a,
+        source="memory",
+        kind="memory-user",
+        source_id="user:a:e1",
+        expires_at=past,
+    )
+    await _seed_document(
+        tenant_id=tenant_a,
+        source="memory",
+        kind="memory-tenant",
+        source_id="tenant:a:e2",
+        expires_at=past,
+    )
+    await _seed_document(
+        tenant_id=tenant_b,
+        source="memory",
+        kind="memory-user",
+        source_id="user:b:e1",
+        expires_at=past,
+    )
+
+    await _run_one_tick()
+
+    audit_rows = await _list_audit_rows()
+    assert len(audit_rows) == 2
+    by_tenant = {row.tenant_id: row for row in audit_rows}
+    assert by_tenant[tenant_a].payload["expired_count"] == 2
+    # ``scopes`` is sorted+deduplicated by the writer.
+    assert by_tenant[tenant_a].payload["scopes"] == ["memory-tenant", "memory-user"]
+    assert by_tenant[tenant_b].payload["expired_count"] == 1
+    assert by_tenant[tenant_b].payload["scopes"] == ["memory-user"]
+
+
+# ---------------------------------------------------------------------------
+# Loop survives bad ticks (AC: monkeypatched raise -> next tick runs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_tick_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing tick logs and the loop reaches the next sleep + tick.
+
+    Mirrors the topology scheduler's ``test_loop_survives_sweep_exception``
+    pattern: the first tick raises, the second sleep is what stops the
+    loop via ``CancelledError`` -- but we assert that the second sleep
+    *was reached*, proving the loop did not die on the first tick's
+    failure.
+    """
+    monkeypatch.setenv("MEMORY_EXPIRY_TICK_INTERVAL_SECONDS", "60")
+    get_settings.cache_clear()
+
+    tick_calls = 0
+    sleep_calls = 0
+
+    async def _flaky_tick() -> None:
+        nonlocal tick_calls
+        tick_calls += 1
+        if tick_calls == 1:
+            raise RuntimeError("transient DB blip")
+
+    async def _fake_sleep(seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            # Allow one sleep + one (failed) tick + one more sleep, then
+            # stop the loop -- the second sleep is the marker that the
+            # loop survived the failed tick.
+            raise asyncio.CancelledError
+
+    with (
+        patch(
+            "meho_backplane.memory.expiry._run_one_tick",
+            new=_flaky_tick,
+        ),
+        patch("asyncio.sleep", new=_fake_sleep),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await expiry._sweeper_loop()
+
+    assert tick_calls == 1
+    assert sleep_calls == 2
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle (AC: start/stop clean, no destroyed-task warnings)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_sweeper_lifecycle() -> None:
+    """start + stop the task on a clean async loop with no destroyed-task warnings.
+
+    The patch on ``_run_one_tick`` keeps the loop body cheap; the
+    ``stop_*`` helper's ``contextlib.suppress(CancelledError)`` is
+    what prevents the "Task was destroyed but it is pending" warning
+    pytest-asyncio would otherwise raise on unawaited cancelled tasks.
+    """
+    with (
+        patch(
+            "meho_backplane.memory.expiry._run_one_tick",
+            new=AsyncMock(),
+        ),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        task = start_memory_expiry_sweeper()
+        assert not task.done()
+        await stop_memory_expiry_sweeper(task)
+        assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_loop_sleeps_configured_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sweeper loop honours ``MEMORY_EXPIRY_TICK_INTERVAL_SECONDS``."""
+    monkeypatch.setenv("MEMORY_EXPIRY_TICK_INTERVAL_SECONDS", "1234")
+    get_settings.cache_clear()
+
+    sleeps: list[float] = []
+
+    async def _fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        # Stop the loop after the first sleep.
+        raise asyncio.CancelledError
+
+    with (
+        patch(
+            "meho_backplane.memory.expiry._run_one_tick",
+            new=AsyncMock(),
+        ),
+        patch("asyncio.sleep", new=_fake_sleep),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await expiry._sweeper_loop()
+
+    assert sleeps == [1234]
+
+
+# ---------------------------------------------------------------------------
+# MEMORY_EXPIRY_ENABLED=false (AC: sweeper task is never created)
+# ---------------------------------------------------------------------------
+
+
+def test_settings_memory_expiry_enabled_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``MEMORY_EXPIRY_ENABLED=false`` resolves to ``False`` at settings layer.
+
+    The lifespan guards ``start_memory_expiry_sweeper()`` behind this
+    setting -- when False, no task handle is created. The settings-layer
+    assertion is the cheapest test for the wiring; the lifespan-shape
+    assertion (no task handle visible) is covered by the integration
+    suite via :func:`tests.test_app_starts` once the lifespan is
+    exercised end-to-end with the env var off.
+    """
+    monkeypatch.setenv("MEMORY_EXPIRY_ENABLED", "false")
+    get_settings.cache_clear()
+    s = get_settings()
+    assert s.memory_expiry_enabled is False
+
+
+def test_settings_memory_expiry_enabled_accepts_truthy_spellings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The canonical truthy spellings (1, true, yes, on) all enable the sweeper."""
+    for spelling in ("1", "true", "yes", "on", "TRUE", "Yes"):
+        monkeypatch.setenv("MEMORY_EXPIRY_ENABLED", spelling)
+        get_settings.cache_clear()
+        s = get_settings()
+        assert s.memory_expiry_enabled is True, f"spelling {spelling!r} should be truthy"
+
+
+# ---------------------------------------------------------------------------
+# write_internal_audit_row direct-call shape (AC: writer mirrors mcp/audit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_internal_audit_row_persists_expected_columns() -> None:
+    """The direct-call writer commits the exact column shape the sweeper relies on."""
+    tenant_id = await _seed_tenant()
+    audit_id = await write_internal_audit_row(
+        operator_sub=SYSTEM_OPERATOR_SUB,
+        tenant_id=tenant_id,
+        method=INTERNAL_METHOD,
+        path=MEMORY_EXPIRE_PATH,
+        status_code=200,
+        duration_ms=12.5,
+        payload={"expired_count": 3, "scopes": ["memory-user"]},
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).where(AuditLog.id == audit_id))
+        row = result.scalar_one()
+
+    assert row.operator_sub == SYSTEM_OPERATOR_SUB
+    assert row.method == INTERNAL_METHOD
+    assert row.path == MEMORY_EXPIRE_PATH
+    assert row.tenant_id == tenant_id
+    assert row.status_code == 200
+    assert row.payload == {"expired_count": 3, "scopes": ["memory-user"]}
+    # Decimal round-trip preserves the float through string conversion.
+    assert float(row.duration_ms) == 12.5

--- a/deploy/charts/meho/templates/configmap.yaml
+++ b/deploy/charts/meho/templates/configmap.yaml
@@ -77,3 +77,13 @@ data:
   {{- if $mcpResourceUri }}
   MCP_RESOURCE_URI: {{ $mcpResourceUri | quote }}
   {{- end }}
+  # G5.2-T1 (#623) — memory layer knobs. `userDefaultTtlDays` is consumed
+  # by G5.2-T2 (#624) on `POST /api/v1/memory`; `expiryTickIntervalSeconds`
+  # + `expiryEnabled` gate the in-process memory-expiry sweeper started
+  # by the FastAPI lifespan. The env-var names are the backplane's
+  # contract (`backend/src/meho_backplane/settings.py`); the chart
+  # converts the YAML values to strings via `quote` (booleans included)
+  # so the ConfigMap stays string-typed end-to-end.
+  MEMORY_USER_DEFAULT_TTL_DAYS: {{ .Values.memory.userDefaultTtlDays | quote }}
+  MEMORY_EXPIRY_TICK_INTERVAL_SECONDS: {{ .Values.memory.expiryTickIntervalSeconds | quote }}
+  MEMORY_EXPIRY_ENABLED: {{ .Values.memory.expiryEnabled | quote }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -295,6 +295,30 @@
         "postgresOnly": { "type": "boolean" }
       }
     },
+    "memory": {
+      "type": "object",
+      "description": "G5.2 memory-layer knobs. `userDefaultTtlDays` drives the default TTL injection G5.2-T2 (#624) applies on `POST /api/v1/memory`. `expiryTickIntervalSeconds` and `expiryEnabled` gate the in-process memory-expiry sweeper started by the FastAPI lifespan (G5.2-T1 #623); set `expiryEnabled: false` when an external cleanup mechanism (k8s CronJob etc.) reaps expired rows instead. The Pydantic validators in `backend/src/meho_backplane/settings.py` enforce the same bounds at app startup; the schema here surfaces them at `helm install` / `helm template` time so misconfigured values fail before the pod ever starts.",
+      "additionalProperties": false,
+      "required": ["userDefaultTtlDays", "expiryTickIntervalSeconds", "expiryEnabled"],
+      "properties": {
+        "userDefaultTtlDays": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 365,
+          "description": "Default time-to-live for user-scoped memory entries, in days. Range [1, 365]; default 7 matches consumer-needs.md §G5."
+        },
+        "expiryTickIntervalSeconds": {
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 86400,
+          "description": "Cadence of the in-process memory-expiry sweeper, in seconds. Range [60, 86400]; default 86400 (24 h) matches Initiative #374."
+        },
+        "expiryEnabled": {
+          "type": "boolean",
+          "description": "Whether to start the in-process memory-expiry sweeper. Set false when an external cleanup mechanism reaps expired rows."
+        }
+      }
+    },
     "broadcast": {
       "type": "object",
       "description": "Activity-broadcast subchart values (Valkey 9.x per ADR 0005). When `broadcast.enabled` is false the subchart resources are skipped entirely; the rest of this block may be left at defaults in that mode. When enabled, the subchart's own values.schema.json (charts/broadcast/values.yaml shape) is also enforced — this block declares the top-level surface visible to the parent chart.",

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -202,6 +202,34 @@ config:
   retrievalEmbeddingModel: "BAAI/bge-small-en-v1.5"
   retrievalModelCacheDir: "/opt/meho/model-cache"
 
+# Memory layer (G5.2 #374). The backplane ships an in-process
+# memory-expiry sweeper that runs in the FastAPI lifespan and removes
+# `source="memory"` rows whose `metadata.expires_at` has passed. The
+# defaults here track the consumer-needs.md §G5 contract (7-day TTL,
+# 24-hour sweep cadence). Disable `expiryEnabled` only when an external
+# cleanup mechanism (k8s CronJob etc.) reaps expired rows instead;
+# expired rows remain soft-hidden via the read-side filter until the
+# external job runs.
+memory:
+  # -- Default time-to-live for user-scoped memory entries, in days.
+  # G5.2-T2 (#624) consumes this on `POST /api/v1/memory` to inject
+  # `expires_at = now() + userDefaultTtlDays` when the caller omits an
+  # explicit value. Operators wanting permanent memories pass
+  # `expires_at: null` on the write or set this to a year-class value.
+  # Range [1, 365]. Default 7 matches consumer-needs.md §G5
+  # ("session-scoped hints expire after 7 days unless re-pinned").
+  userDefaultTtlDays: 7
+  # -- Cadence of the in-process memory-expiry sweeper, in seconds.
+  # Default 86400 (24h) matches Initiative #374's stated cadence.
+  # Range [60, 86400]: below one minute competes with request load;
+  # above one day risks accumulating soft-hidden rows.
+  expiryTickIntervalSeconds: 86400
+  # -- Whether to start the in-process memory-expiry sweeper. Set
+  # false when an external cleanup mechanism reaps expired rows
+  # instead; the read-side filter still hides expired rows from
+  # consumers until the external job runs.
+  expiryEnabled: true
+
 postgres:
   # -- PostgreSQL host. v0.1 expects an operator-managed PG cluster (Goal #11
   # explicitly excludes a bundled PG subchart); typically reached over the

--- a/docs/architecture/audit.md
+++ b/docs/architecture/audit.md
@@ -97,6 +97,24 @@ Both gaps are downstream of T4 and disclosed in #468's PR body (#505). T5's acce
 
 The REST surface emits `op_id="meho.audit.query"` (the canonical, bound via the `audit_op_id` contextvar override the chassis honors). The MCP surface emits `op_id="query_audit"` (the tool name verbatim, per the MCP dispatcher convention at [`mcp/handlers.py:199`](../../backend/src/meho_backplane/mcp/handlers.py)). Same logical operation; different identifiers per dispatch path. Operators forensically searching `audit_log` for "all audit-query calls regardless of surface" today need to OR both op_ids. Unifying via a `ToolDefinition.audit_op_id` override field or a tool rename is a v0.2.next surface.
 
+## Audit-row channel convention (HTTP / MCP / INTERNAL)
+
+The `audit_log.method` column is the **channel** the row was written from; `audit_log.path` is the **op identifier within that channel**. The split keeps audit-query filters partitionable by surface without joining on `path`, and stays auditable as new background-process writers land.
+
+| `method` literal | Channel | Writer | Example `path` |
+|---|---|---|---|
+| `GET` / `POST` / `PATCH` / `DELETE` / etc. | Chassis HTTP | [`audit.py::_write_audit_row`](../../backend/src/meho_backplane/audit.py) (called by `AuditMiddleware`) | The HTTP route, e.g. `/api/v1/memory/{scope}/{slug}` |
+| `MCP` | MCP JSON-RPC dispatch | [`mcp/audit.py::write_mcp_audit_row`](../../backend/src/meho_backplane/mcp/audit.py) (called by the per-op handler) | `/mcp/tools/call/{tool_name}` or `/mcp/resources/read/{uri}` |
+| `INTERNAL` | Background-process / system | [`memory/audit.py::write_internal_audit_row`](../../backend/src/meho_backplane/memory/audit.py) (called by lifespan-owned tasks) | The op identifier, e.g. `memory.expire` |
+
+`operator_sub` on every `INTERNAL` row is a stable synthetic identity (e.g. `"system"` for the G5.2-T1 memory-expiry sweeper; future writers should pick a stable name like `"system:retention-sweeper"`). Audit-query filters partition system-driven rows from operator-driven rows by `method = 'INTERNAL'` rather than by parsing `operator_sub`.
+
+### Known `INTERNAL` `path` values
+
+- `memory.expire` — the G5.2-T1 memory-expiry sweeper (#623). One row per affected tenant per sweep tick; payload is `{"expired_count": <int>, "scopes": ["memory-user", ...]}`. Forward reference for [G8.2 #219](https://github.com/evoila/meho/issues/219): `meho audit query --op memory.expire` will pick these rows up by path when the verb ships.
+
+The convention is closed-set on the *channel* axis (HTTP / MCP / INTERNAL is the trichotomy) and open-set on the *op-id* axis (every new background writer reserves a new `path` value, documented in this section before the writer lands). The G6.1 sensitivity classifier treats `method = 'INTERNAL'` rows as non-sensitive by default (a system row reaping expired memory carries no operator intent to leak); writers handling tenant-sensitive payloads should request an `op_class` override via the same contextvar mechanism the HTTP path uses.
+
 ## Sibling Initiative
 
 [G8.2 (#377)](https://github.com/evoila/meho/issues/377) — audit replay (`meho audit replay <session-id>`) — builds a recursive-CTE traversal on top of the `parent_audit_id` filter shipped in [T1 (#465)](https://github.com/evoila/meho/issues/465). G8.1 ships the filter (which raises `UnsupportedFilterError` in v0.2 because the column hasn't landed yet); G8.2 ships the schema column, the recursive traversal, and the operator-facing `replay` verb. The split keeps each Initiative shippable on its own clock.


### PR DESCRIPTION
## Summary

- G5.2-T1 (#623) ships the background-process side of the memory layer: `MemoryExpirySweeper` is an `asyncio` task the FastAPI lifespan owns that ticks on a fixed cadence (default 24 h) and deletes `source="memory"` rows whose `metadata.expires_at` has passed, plus `write_internal_audit_row()` mirroring `mcp/audit.py`'s shape with `operator_sub="system"` + `method="INTERNAL"` + `path="memory.expire"` (one row per affected tenant per tick), plus the three `MEMORY_*` settings + Helm knobs (`memory.userDefaultTtlDays`, `memory.expiryTickIntervalSeconds`, `memory.expiryEnabled`) that gate it.
- The sweeper mirrors the G9.1-T3 topology scheduler shape exactly (`asyncio.create_task` at lifespan-begin, `task.cancel()` + `await` at lifespan-end, per-tick `try`/`except` so a bad tick logs `memory_expiry_tick_failed` loud-but-non-fatal and the loop continues). `MEMORY_EXPIRY_ENABLED=false` skips starting the task entirely so operators running an external cleanup mechanism (k8s CronJob) can opt out without forking the chassis.
- The new `method="INTERNAL"` channel convention (HTTP/MCP/INTERNAL trichotomy on `audit_log.method`; the op identifier in `path`) is documented in `docs/architecture/audit.md` as the forward reference for G8.2 audit-query (#219) — `meho audit query --op memory.expire` will pick these rows up once that verb ships.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (340 files already formatted)
- [x] `mypy src/ --ignore-missing-imports` — clean (173 files)
- [x] `pytest tests/test_memory_expiry.py -x -q` — 18 passed (covers every AC checkbox: past/future/persistent rows, non-memory rows, tick exception recovery, lifecycle clean shutdown, settings bound enforcement)
- [x] `pytest tests/ -x -q --ignore=tests/integration --ignore=tests/acceptance` — **2119 passed, 8 skipped** (no regressions across the full unit suite)
- [x] `values.schema.json` validates the `memory` block defaults and rejects out-of-range values (verified out-of-band with `jsonschema.Draft202012Validator`).

### Acceptance criteria mapping (from the issue)

- `MemoryExpirySweeper` started by `lifespan` with no "Task was destroyed" warnings — `test_start_and_stop_sweeper_lifecycle` passes; `stop_*` uses `contextlib.suppress(CancelledError)`.
- Integration test (SQLite path covered here; PG covered in the integration suite via the dialect branch in `_expires_at_expression`) — `test_tick_deletes_past_expiry_row_and_writes_audit_row` proves the row disappears and exactly one audit row with `payload.expired_count == 1` lands.
- Future-expiry rows survive; non-memory rows ignored — `test_tick_does_not_delete_future_expiry_row` + `test_tick_does_not_delete_non_memory_rows`.
- One failing tick logs and the next tick runs — `test_loop_survives_tick_exception`.
- `MEMORY_EXPIRY_ENABLED=false` → no task is created — `test_settings_memory_expiry_enabled_can_be_disabled` proves the setting wiring; the lifespan reads `get_settings().memory_expiry_enabled` and only calls `start_memory_expiry_sweeper()` when truthy.
- Settings: 3 fields with Pydantic bounds; out-of-range rejected — 7 settings tests pass (defaults + each range boundary).
- Helm: `memory.userDefaultTtlDays` / `expiryTickIntervalSeconds` / `expiryEnabled` in `values.yaml` (with comments) + `values.schema.json` (with min/max) + `configmap.yaml` (mapping to env vars).
- `docs/architecture/audit.md` documents the `method="INTERNAL"` / `path="memory.expire"` convention.

## Out of scope

- The default-TTL injection on write (`MEMORY_USER_DEFAULT_TTL_DAYS` is wired into `POST /api/v1/memory`) — G5.2-T2 (#624). This PR introduces the setting and the Helm knob; T2 consumes it.
- The promote route / RBAC helper / CLI / admin meta-tool — G5.2-T3/T4/T5 (#625/#626/#627).
- Per-pod leader election under N replicas — deferred to v0.2.next per Initiative #374; the worst case (N identical DELETEs in the same second targeting already-deleted rows) is idempotent and cheap.
- An `audit query` API consuming the new `INTERNAL` rows — G8.2 (#219); this Task only writes them + documents the convention.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic memory expiration with configurable TTL (default 7 days), tick interval, and enable/disable switch
  * Background sweeper integrated into application lifecycle to remove expired memory entries and record internal audit rows
  * Public internal audit helper for system-driven audit entries

* **Documentation**
  * Expanded audit logging docs to describe internal operation channel and memory-expire path

* **Tests**
  * Comprehensive tests for expiry behavior, multi-tenant audits, lifecycle start/stop, and configuration parsing; existing lifespan tests patched to account for sweeper

* **Chores**
  * Added memory expiry configuration to Helm chart values, schema, and ConfigMap templates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->