### PR TITLE
fix(lint): shorten bind9 test name to clear E501 ruff failure on main

### DIFF
--- a/backend/tests/test_connectors_bind9.py
+++ b/backend/tests/test_connectors_bind9.py
@@ -263,7 +263,7 @@ def _mock_ssh_conn() -> MagicMock:
     return conn
 
 
-async def test_remote_bash_with_sudo_argv_carries_only_script_byte_count_and_streams_password_via_stdin(
+async def test_remote_bash_with_sudo_argv_holds_byte_count_streams_password_via_stdin(
     _mock_ssh_conn: MagicMock,
 ) -> None:
     """argv is boilerplate + script byte count; password is on stdin, never argv."""


### PR DESCRIPTION
Follow-up to #703 (already merged). The test function name landed at 104 chars on `tests/test_connectors_bind9.py:266` and trips ruff E501 (limit 100). CI's repo-root `uv run ruff check src/ tests/` catches it and blocks the required `Python (ruff + mypy + pytest)` gate on `main` — blocking every subsequent PR (especially urgent now that `Python (integration testcontainers)` was also promoted to a required check; main needs to be green for #698-class enforcement to actually flow).

Renames the function to 86 chars; same assertions, zero logic change. ruff + format clean; 34 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test naming for improved clarity and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->