### PR TITLE
docs(ci): integration testcontainers is now a required merge gate (#698)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,10 +278,15 @@ jobs:
     # testcontainers) that made the combined serial sweep blow every
     # timeout cap (see python-lint-test comment). Separated so the
     # required lint+mypy+unit gate stays fast and deterministic while
-    # integration still runs on every PR. This job is NOT yet in the
-    # branch-protection required-check set — promoting it requires a
-    # repo-admin settings change (documented in the PR). Until then it
-    # is a visible, fail-loud signal but not merge-blocking.
+    # integration runs on every PR.
+    # **Required merge gate as of 2026-05-20 (#698).** This job's
+    # context ("Python (integration testcontainers)") is in
+    # ``branches/main/protection.required_status_checks.contexts``;
+    # promoting it was the structural corrective to the v0.2 / G3.4
+    # green-but-hollow incidents (#634 / #697) — the lane that
+    # exercises real connector dispatch, k3d / bind9-container /
+    # vcsim / federated-write acceptance, must be merge-blocking so
+    # red integration cannot ship to ``main`` again.
     # 60-min cap: container pulls + DinD spin-up + the serial
     # integration sweep. pytest-xdist loadgroup parallelization to
     # bring this well under cap is tracked in #564.

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -589,22 +589,32 @@ into `GITHUB_STEP_SUMMARY` on every successful publish.
 ## PR-level CI (`.github/workflows/ci.yml`)
 
 `ci.yml` is the central per-PR test harness. Every PR targeting `main`
-runs three jobs in parallel, one per in-tree toolchain, and every push
-to `main` re-runs the same matrix as a regression catch. Branch
-protection consumes the workflow's overall status as a required check.
+runs four jobs in parallel and every push to `main` re-runs the same
+matrix as a regression catch. Branch protection consumes each job's
+status as a required check (per
+`branches/main/protection.required_status_checks.contexts` —
+re-verified after the 2026-05-20 #698 promotion of the integration
+lane, the structural corrective to the v0.2 / G3.4 green-but-hollow
+incidents #634 / #697).
 
 ### Matrix
 
 | Job | Surface | Steps |
 | --- | --- | --- |
-| `python-lint-test` | `backend/` | `uv sync --locked --all-groups` -> `ruff check` -> `ruff format --check` -> `mypy --strict` -> `pytest -x --cov` -> upload `python-coverage` artefact |
-| `go-lint-test` | `cli/` | `golangci-lint` (v6 action, v1.64.8 binary) -> `go build ./...` -> `go test -race -cover ./...` |
-| `helm-lint-template` | `deploy/charts/meho/` | `helm lint` -> `helm template` -> `kubeconform --strict --kubernetes-version 1.28.0` |
+| `python-lint-test` (`Python (ruff + mypy + pytest)`) | `backend/` unit + acceptance subtree | `uv sync --locked --all-groups` -> `ruff check` -> `ruff format --check` -> `mypy --strict` -> `pytest -x --cov` (excludes `tests/integration/`) -> upload `python-coverage` artefact |
+| `python-integration` (`Python (integration testcontainers)`) | `backend/tests/integration/` | `uv sync --locked --all-groups` -> `pytest tests/integration/` against pgvector / valkey / k3d / vcsim / vault testcontainers via DinD. **Required merge gate (#698)** so the lane that exercises real connector dispatch can no longer ship red. |
+| `go-lint-test` (`Go (golangci-lint + go test)`) | `cli/` | `golangci-lint` (v6 action) -> `go build ./...` -> `go test -race -cover ./...` |
+| `helm-lint-template` (`Helm (lint + template + kubeconform)`) | `deploy/charts/meho/` | `helm lint` -> `helm template` -> `kubeconform --strict --kubernetes-version 1.28.0` |
 
-Each job runs on its own `meho-runners` runner with a 10-minute
-`timeout-minutes`. Wall-clock for a green PR comes in well under the
-Goal #11 10-minute budget because the three jobs never block each other
-— the slowest job is the workflow's elapsed time.
+Each job runs on its own `meho-runners` runner. `python-lint-test`,
+`go-lint-test`, and `helm-lint-template` carry a 10-minute
+`timeout-minutes`; `python-integration` carries 60 minutes for the
+container-pull + DinD spin-up + testcontainers sweep (xdist
+loadgroup parallelisation to bring it well under cap tracked in #564).
+Wall-clock for a green PR is the slowest job's elapsed time because
+the four jobs never block each other — `python-integration` typically
+dominates and is the dispatch surface for the Goal #11 budget
+conversation.
 
 ### Fail-loud posture
 


### PR DESCRIPTION
Follow-up to #698 (already executed via `gh api POST branches/main/protection/required_status_checks/contexts` — promoted `Python (integration testcontainers)` to a required check on 2026-05-20). Two stale notes still claimed otherwise:

- **`.github/workflows/ci.yml`** — `python-integration` block's comment said *"This job is NOT yet in the branch-protection required-check set"*. Updated to record the promotion + reference #634/#697 as the corrective rationale.
- **`docs/codebase/devops.md`** — PR-level CI matrix listed three jobs and treated the workflow's overall status as the gate. Now lists four jobs with each status-check context, explicit `Required merge gate (#698)` annotation on `python-integration`, and the 10-min vs 60-min timeout split + Goal #11 budget framing.

Docs-only. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow: Python integration testing is now a required merge gate as of 2026-05-20.

* **Documentation**
  * Updated CI documentation to reflect four parallel test jobs (python-lint-test, python-integration, go-lint-test, helm-lint-template), with integration testing as a mandatory status check.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->