### PR TITLE
feat(mcp): G6.3-T5 admin MCP meta-tools meho.broadcast.overrides.{list,set,remove} (#382)

### DIFF
--- a/backend/src/meho_backplane/api/v1/broadcast_overrides.py
+++ b/backend/src/meho_backplane/api/v1/broadcast_overrides.py
@@ -235,21 +235,24 @@ def _bind_remove_audit(*, override_id: uuid.UUID) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Handlers
+# Implementation functions
 # ---------------------------------------------------------------------------
+#
+# Extracted from the route handlers so the G6.3-T5 admin MCP tools
+# (``meho.broadcast.overrides.list|set|remove``) can call into the same
+# code path in-process. The route handlers below are thin wrappers
+# around these; the MCP tools call them with a transient session +
+# concrete :class:`Operator`. Same RBAC (every call site is gated by
+# ``require_role(TENANT_ADMIN)``), same audit + cache-invalidation
+# hooks, same :class:`HTTPException` shapes (the MCP tool wraps those
+# into ``McpInvalidParamsError`` for the JSON-RPC envelope).
 
 
-@router.get("", response_model=list[BroadcastOverrideRead])
-async def list_overrides(
-    operator: Annotated[Operator, _require_tenant_admin],
-    session: Annotated[AsyncSession, Depends(get_session)],
-    op_id_pattern: Annotated[
-        str | None,
-        Query(
-            max_length=128,
-            description="Exact-match filter on op_id_pattern (not a glob match).",
-        ),
-    ] = None,
+async def list_overrides_impl(
+    *,
+    operator: Operator,
+    session: AsyncSession,
+    op_id_pattern: str | None = None,
 ) -> list[BroadcastOverride]:
     """List override rules owned by the operator's tenant.
 
@@ -271,15 +274,11 @@ async def list_overrides(
     return list(result.scalars().all())
 
 
-@router.post(
-    "",
-    response_model=BroadcastOverrideRead,
-    status_code=status.HTTP_201_CREATED,
-)
-async def create_override(
+async def create_override_impl(
+    *,
     payload: BroadcastOverrideCreate,
-    operator: Annotated[Operator, _require_tenant_admin],
-    session: Annotated[AsyncSession, Depends(get_session)],
+    operator: Operator,
+    session: AsyncSession,
 ) -> BroadcastOverride:
     """Create an override rule; broadcasts as ``op_class=write``.
 
@@ -307,13 +306,20 @@ async def create_override(
         # propagate so a genuine corruption surfaces as a 500 rather
         # than a misleading "already exists" message.
         #
-        # PG: ``UniqueViolation`` carries ``pgcode == "23505"`` (per
-        # PEP 249's psycopg shape). SQLite: the
+        # PG via asyncpg: ``PostgresError`` exposes the SQLSTATE code
+        # through ``orig.sqlstate`` -- asyncpg's exceptions/_base.py
+        # field map binds character ``'C'`` to ``sqlstate`` (not
+        # ``pgcode``). The earlier ``pgcode`` check was inherited from
+        # the psycopg2 shape and silently returned ``None`` against
+        # asyncpg; SQLite tests passed only via the substring fallback
+        # below. The ``pgcode`` fallback survives in case a future
+        # psycopg-based wiring shows up. SQLite: the
         # ``UNIQUE constraint failed`` substring is the documented
         # form (sqlite.org/lang_conflict.html). Both dialects covered.
-        pgcode = getattr(getattr(exc, "orig", None), "pgcode", None)
-        orig_msg = str(getattr(exc, "orig", exc))
-        is_unique_violation = pgcode == "23505" or "UNIQUE constraint failed" in orig_msg
+        orig = getattr(exc, "orig", None)
+        sqlstate = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+        orig_msg = str(orig or exc)
+        is_unique_violation = sqlstate == "23505" or "UNIQUE constraint failed" in orig_msg
         if is_unique_violation:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -333,11 +339,11 @@ async def create_override(
     return row
 
 
-@router.delete("/{override_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_override(
+async def delete_override_impl(
+    *,
     override_id: uuid.UUID,
-    operator: Annotated[Operator, _require_tenant_admin],
-    session: Annotated[AsyncSession, Depends(get_session)],
+    operator: Operator,
+    session: AsyncSession,
 ) -> None:
     """Delete an override rule owned by the operator's tenant.
 
@@ -367,3 +373,60 @@ async def delete_override(
         )
     _bind_remove_audit(override_id=override_id)
     invalidate_tenant_cache(operator.tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Route handlers
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=list[BroadcastOverrideRead])
+async def list_overrides(
+    operator: Annotated[Operator, _require_tenant_admin],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    op_id_pattern: Annotated[
+        str | None,
+        Query(
+            max_length=128,
+            description="Exact-match filter on op_id_pattern (not a glob match).",
+        ),
+    ] = None,
+) -> list[BroadcastOverride]:
+    """List override rules owned by the operator's tenant."""
+    return await list_overrides_impl(
+        operator=operator,
+        session=session,
+        op_id_pattern=op_id_pattern,
+    )
+
+
+@router.post(
+    "",
+    response_model=BroadcastOverrideRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_override(
+    payload: BroadcastOverrideCreate,
+    operator: Annotated[Operator, _require_tenant_admin],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> BroadcastOverride:
+    """Create an override rule; broadcasts as ``op_class=write``."""
+    return await create_override_impl(
+        payload=payload,
+        operator=operator,
+        session=session,
+    )
+
+
+@router.delete("/{override_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_override(
+    override_id: uuid.UUID,
+    operator: Annotated[Operator, _require_tenant_admin],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> None:
+    """Delete an override rule owned by the operator's tenant."""
+    await delete_override_impl(
+        override_id=override_id,
+        operator=operator,
+        session=session,
+    )

--- a/backend/src/meho_backplane/mcp/tools/broadcast_overrides.py
+++ b/backend/src/meho_backplane/mcp/tools/broadcast_overrides.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Admin MCP tools for the broadcast-override CRUD surface.
+
+G6.3-T5 (#382) — three ``meho.broadcast.overrides.*`` tools that
+mirror the T4 (#381) REST surface (``/api/v1/broadcast/overrides``)
+onto the MCP transport:
+
+* ``meho.broadcast.overrides.list`` — list the operator's tenant's
+  rules. Optional ``op_id_pattern`` arg (exact match).
+* ``meho.broadcast.overrides.set`` — create a rule. Args mirror
+  T4's :class:`BroadcastOverrideCreate` Pydantic model.
+* ``meho.broadcast.overrides.remove`` — delete a rule by id.
+
+All three are ``tenant_admin``-required. RBAC enforcement happens at
+two layers: the registry filter (``required_role=TENANT_ADMIN``
+hides the tool from ``tools/list`` for non-admins) and the
+dispatcher's call-time re-check (``handle_tools_call`` raises
+``McpInvalidParamsError`` with ``"forbidden"`` if a non-admin
+somehow knows the name). The tools cite Initiative #376 so an
+agent calling them can read the broader contract.
+
+In-process call into T4
+=======================
+
+Each tool's handler opens a transient :class:`AsyncSession` via
+:func:`get_sessionmaker`, calls the matching ``*_impl`` function
+T4 exposes
+(:func:`~meho_backplane.api.v1.broadcast_overrides.list_overrides_impl`,
+:func:`~meho_backplane.api.v1.broadcast_overrides.create_override_impl`,
+:func:`~meho_backplane.api.v1.broadcast_overrides.delete_override_impl`),
+and translates the result into the MCP wire shape:
+
+* List → ``{"overrides": [<row dict>, ...]}``.
+* Set → ``{"override": <row dict>}``.
+* Remove → ``{"removed": true}`` (204-equivalent).
+
+:class:`HTTPException` raised by the impl (409 on duplicate, 404 on
+delete-not-found) is caught and re-raised as
+:class:`McpInvalidParamsError` so the MCP dispatcher emits a
+``-32602`` JSON-RPC error with the FastAPI detail string. This is
+the conservative mapping — the MCP spec doesn't have a clean
+analogue for "conflict" or "not found", and INVALID_PARAMS
+("the call's params can't be satisfied") is the closest
+spec-blessed shape for both.
+
+Audit + broadcast inheritance
+=============================
+
+The ``*_impl`` functions bind the same audit-side contextvars
+T4's REST handlers do (``audit_op_id``,
+``audit_op_class="write"``, override-diff fragment). The chassis
+MCP audit middleware reads these on the response side, so a
+mutation MCP call produces an audit row + broadcast event identical
+in shape to the REST call's row (modulo ``method="MCP"`` vs
+``"POST"``/``"DELETE"`` and the synthetic
+``/mcp/tools/call/meho.broadcast.overrides.set`` path).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import structlog
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from meho_backplane.api.v1.broadcast_overrides import (
+    BroadcastOverrideCreate,
+    BroadcastOverrideRead,
+    create_override_impl,
+    delete_override_impl,
+    list_overrides_impl,
+)
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+_log = structlog.get_logger(__name__)
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    """Serialise a :class:`BroadcastOverride` ORM row through Pydantic.
+
+    The MCP wire shape is a JSON dict. The Pydantic
+    :class:`BroadcastOverrideRead` model is the single source of
+    truth for which columns are exposed; using it here keeps the
+    MCP surface and the REST surface in lock-step (any future
+    response-model change in T4 propagates here automatically).
+    """
+    return BroadcastOverrideRead.model_validate(row).model_dump(mode="json")
+
+
+def _http_to_mcp(exc: HTTPException) -> McpInvalidParamsError:
+    """Translate a route-side ``HTTPException`` to the MCP wire-error.
+
+    The MCP dispatcher maps :class:`McpInvalidParamsError` to
+    JSON-RPC ``-32602`` Invalid Params. 409 / 404 from the impl
+    functions both surface here: there is no MCP analogue for
+    "conflict" or "not found", but "the call's params can't be
+    satisfied" is the closest spec-blessed shape.
+
+    The raw FastAPI ``detail`` token is preserved verbatim --
+    REST and MCP callers see the same identifier
+    (``broadcast_override_already_exists`` /
+    ``broadcast_override_not_found``). The HTTP status code is
+    intentionally NOT embedded in the message; the JSON-RPC
+    envelope already carries ``-32602`` and the audit row's
+    ``status_code`` column records the upstream HTTP code for
+    forensics. Pattern matches :mod:`~meho_backplane.mcp.tools.audit`'s
+    ``McpInvalidParamsError(str(exc))`` shape.
+    """
+    detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+    return McpInvalidParamsError(detail)
+
+
+# ---------------------------------------------------------------------------
+# meho.broadcast.overrides.list
+# ---------------------------------------------------------------------------
+
+
+async def _list_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    op_id_pattern = arguments.get("op_id_pattern")
+    if op_id_pattern is not None and not isinstance(op_id_pattern, str):
+        raise McpInvalidParamsError("op_id_pattern must be a string when provided")
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        rows = await list_overrides_impl(
+            operator=operator,
+            session=session,
+            op_id_pattern=op_id_pattern,
+        )
+        return {"overrides": [_row_to_dict(r) for r in rows]}
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.broadcast.overrides.list",
+        description=(
+            "List broadcast-detail override rules for the operator's "
+            "tenant (Initiative #376). Tenant-admin only. Optional "
+            "op_id_pattern argument filters by exact-match pattern "
+            "(not a glob match against an op_id). Returns "
+            "{overrides: [row, ...]}."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "op_id_pattern": {
+                    "type": "string",
+                    "maxLength": 128,
+                    "description": (
+                        "Exact-match filter on the rule's stored "
+                        "op_id_pattern. Omit to list every rule."
+                    ),
+                },
+            },
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class="read",
+    ),
+    handler=_list_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# meho.broadcast.overrides.set
+# ---------------------------------------------------------------------------
+
+
+async def _set_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    # Re-validate through Pydantic so the same scope-pair invariant
+    # and glob-not-regex blacklist run for MCP as for REST. The
+    # inputSchema does first-pass shape checks; Pydantic runs the
+    # cross-field validators.
+    try:
+        payload = BroadcastOverrideCreate.model_validate(arguments)
+    except ValidationError as exc:
+        raise McpInvalidParamsError(f"invalid arguments: {exc}") from exc
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        try:
+            row = await create_override_impl(
+                payload=payload,
+                operator=operator,
+                session=session,
+            )
+        except HTTPException as exc:
+            raise _http_to_mcp(exc) from exc
+        return {"override": _row_to_dict(row)}
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.broadcast.overrides.set",
+        description=(
+            "Create a broadcast-detail override rule for the operator's "
+            "tenant (Initiative #376). Tenant-admin only. op_id_pattern "
+            "accepts globs (* + literals; regex chars are rejected). "
+            "scope_field/scope_value must both be set (scoped rule) or "
+            "both omitted (op-wide rule). detail is one of "
+            "full|aggregate. A duplicate (same pattern + scope triple) "
+            "returns an error with detail "
+            "'broadcast_override_already_exists'."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "op_id_pattern": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": (
+                        "op_id glob (e.g. 'vault.kv.*' or "
+                        "'k8s.configmap.info'). Regex chars rejected."
+                    ),
+                },
+                "scope_field": {
+                    "type": ["string", "null"],
+                    "enum": ["namespace", "target_name", None],
+                    "description": (
+                        "Scope key. Null for an op-wide rule; non-null requires scope_value."
+                    ),
+                },
+                "scope_value": {
+                    "type": ["string", "null"],
+                    "maxLength": 128,
+                    "description": (
+                        "Scope value (e.g. 'kube-system'). Required when scope_field is non-null."
+                    ),
+                },
+                "detail": {
+                    "type": "string",
+                    "enum": ["full", "aggregate"],
+                    "description": "Override detail.",
+                },
+            },
+            "required": ["op_id_pattern", "detail"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class="write",
+    ),
+    handler=_set_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# meho.broadcast.overrides.remove
+# ---------------------------------------------------------------------------
+
+
+async def _remove_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    raw_id = arguments.get("override_id")
+    if not isinstance(raw_id, str):
+        raise McpInvalidParamsError("override_id must be a string UUID")
+    try:
+        override_id = uuid.UUID(raw_id)
+    except (TypeError, ValueError) as exc:
+        raise McpInvalidParamsError(f"override_id is not a valid UUID: {raw_id!r}") from exc
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        try:
+            await delete_override_impl(
+                override_id=override_id,
+                operator=operator,
+                session=session,
+            )
+        except HTTPException as exc:
+            raise _http_to_mcp(exc) from exc
+        return {"removed": True}
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.broadcast.overrides.remove",
+        description=(
+            "Delete a broadcast-detail override rule by id for the "
+            "operator's tenant (Initiative #376). Tenant-admin only. "
+            "Returns {removed: true} on success. A 404-equivalent "
+            "error (detail 'broadcast_override_not_found') surfaces "
+            "both 'id doesn't exist' and 'id belongs to another "
+            "tenant' -- existence is not leaked across tenant "
+            "boundaries."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "override_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Override row UUID.",
+                },
+            },
+            "required": ["override_id"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class="write",
+    ),
+    handler=_remove_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -141,6 +141,7 @@ def isolated_registry() -> Iterator[None]:
     from meho_backplane.mcp.resources import tenant_feed, tenant_info
     from meho_backplane.mcp.tools import (
         audit,
+        broadcast_overrides,
         connector_admin,
         knowledge,
         meho_status,
@@ -154,6 +155,7 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(operations)
     importlib.reload(connector_admin)
     importlib.reload(audit)
+    importlib.reload(broadcast_overrides)
     importlib.reload(knowledge)
     importlib.reload(topology)
     importlib.reload(memory_tools)

--- a/backend/tests/test_mcp_broadcast_overrides_tools.py
+++ b/backend/tests/test_mcp_broadcast_overrides_tools.py
@@ -1,0 +1,779 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G6.3-T5 admin MCP override-CRUD tools.
+
+Coverage matrix (Task #382 acceptance criteria):
+
+* All three tools (``meho.broadcast.overrides.list/set/remove``) are
+  registered with ``required_role=TENANT_ADMIN`` -- visible in
+  ``tools/list`` only for tenant_admin operators.
+* ``operator``-role JWTs see ``tools/list`` without the three tools
+  (registry filter), AND a direct ``tools/call`` against
+  ``meho.broadcast.overrides.set`` is rejected by the dispatcher's
+  call-time re-check.
+* Tenant-admin happy paths: list / set / remove round-trip in-process
+  through the T4 ``*_impl`` functions, producing the same DB rows the
+  REST surface would.
+* ``set`` Pydantic validation (regex chars, half-set scope pair, invalid
+  detail) surfaces as ``-32602`` Invalid Params.
+* ``set`` duplicate maps to Invalid Params with the
+  ``broadcast_override_already_exists`` detail string.
+* ``remove`` 404 (cross-tenant or unknown id) maps to Invalid Params
+  with the ``broadcast_override_not_found`` detail.
+* Mutation MCP calls produce audit rows identical in shape to the REST
+  surface (modulo ``method="MCP"`` + the synthetic
+  ``/mcp/tools/call/...`` path).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.overrides import (
+    _TENANT_CACHE,
+    reset_overrides_cache_for_testing,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, BroadcastOverride
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+    seeded_operator_tenant,  # noqa: F401 — pytest-discovered fixture
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_resolver_cache() -> Iterator[None]:
+    """T2's per-tenant cache is module-level; wipe between cases."""
+    reset_overrides_cache_for_testing()
+    yield
+    reset_overrides_cache_for_testing()
+
+
+def _result_dict(response: Any) -> dict[str, Any]:
+    """Extract the JSON-decoded tool result from a JSON-RPC response."""
+    body = response.json()
+    assert "error" not in body, body
+    content = body["result"]["content"]
+    # The dispatcher wraps the handler's return value in a single
+    # text content block carrying the JSON-serialised dict.
+    return json.loads(content[0]["text"])
+
+
+async def _audit_rows() -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).order_by(AuditLog.occurred_at),
+        )
+        return list(result.scalars().all())
+
+
+async def _override_rows() -> list[BroadcastOverride]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(BroadcastOverride).order_by(BroadcastOverride.created_at),
+        )
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Registration shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_tools_list_exposes_three_override_tools_to_admin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Tenant-admin sees all three ``meho.broadcast.overrides.*`` tools."""
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {t["name"] for t in body["result"]["tools"]}
+    assert "meho.broadcast.overrides.list" in names
+    assert "meho.broadcast.overrides.set" in names
+    assert "meho.broadcast.overrides.remove" in names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.READ_ONLY, TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_hides_override_tools_from_non_admin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Non-admin roles (``read_only`` + ``operator``) do NOT see the three tools.
+
+    AC 6 explicitly names ``operator`` -- parametrising both
+    non-admin roles closes the literal AC text and covers the
+    boundary where the registry filter draws the line.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {t["name"] for t in body["result"]["tools"]}
+    assert "meho.broadcast.overrides.list" not in names
+    assert "meho.broadcast.overrides.set" not in names
+    assert "meho.broadcast.overrides.remove" not in names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.READ_ONLY, TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_non_admin_tools_call_set_is_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A direct ``tools/call`` from a non-admin (knows the name) is rejected.
+
+    The registry filter hides the tool from ``tools/list`` (verified
+    above), but a malicious / curious client could still POST a
+    ``tools/call`` with the literal tool name. The dispatcher's
+    call-time RBAC re-check is the load-bearing second gate.
+    AC 6 explicitly names ``operator``; the ``read_only`` parametrize
+    covers the lower role for defence in depth.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.set",
+                "arguments": {
+                    "op_id_pattern": "vault.kv.*",
+                    "detail": "aggregate",
+                },
+            },
+        },
+    )
+    body = resp.json()
+    assert "error" in body
+    # The dispatcher emits ``-32602`` Invalid Params for role denials
+    # on a known tool name (the same shape as an unknown-tool 404).
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tenant-admin happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_set_creates_row_returns_override_dict(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.set",
+                "arguments": {
+                    "op_id_pattern": "k8s.configmap.info",
+                    "scope_field": "namespace",
+                    "scope_value": "kube-system",
+                    "detail": "aggregate",
+                },
+            },
+        },
+    )
+    assert resp.status_code == 200
+    result = _result_dict(resp)
+    override = result["override"]
+    assert override["op_id_pattern"] == "k8s.configmap.info"
+    assert override["detail"] == "aggregate"
+    assert uuid.UUID(override["id"])
+    rows = await _override_rows()
+    assert len(rows) == 1
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_list_returns_own_tenant_rows(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    # Seed two rows via set.
+    for pattern in ("vault.kv.*", "audit.*"):
+        post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "meho.broadcast.overrides.set",
+                    "arguments": {"op_id_pattern": pattern, "detail": "aggregate"},
+                },
+            },
+        )
+    # List them back.
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.list",
+                "arguments": {},
+            },
+        },
+    )
+    result = _result_dict(resp)
+    patterns = {row["op_id_pattern"] for row in result["overrides"]}
+    assert patterns == {"vault.kv.*", "audit.*"}
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_remove_deletes_row(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    create_resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.set",
+                "arguments": {"op_id_pattern": "vault.kv.*", "detail": "aggregate"},
+            },
+        },
+    )
+    override_id = _result_dict(create_resp)["override"]["id"]
+
+    remove_resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.remove",
+                "arguments": {"override_id": override_id},
+            },
+        },
+    )
+    result = _result_dict(remove_resp)
+    assert result == {"removed": True}
+    rows = await _override_rows()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Error mapping -- HTTPException → McpInvalidParamsError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_set_duplicate_maps_to_invalid_params_409(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    # The composite unique constraint includes NULL-able ``scope_field``
+    # / ``scope_value`` columns; under SQL's default NULL-distinct
+    # semantics, two rows with both NULL collide-by-design but the
+    # constraint declares them distinct. Use a fully-scoped pair so
+    # the second insert deterministically triggers the unique
+    # violation across PG + SQLite. Mirrors T4's REST duplicate test
+    # body in ``tests/test_api_v1_broadcast_overrides.py``.
+    client, _op = client_with_operator
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "meho.broadcast.overrides.set",
+            "arguments": {
+                "op_id_pattern": "k8s.configmap.info",
+                "scope_field": "namespace",
+                "scope_value": "kube-system",
+                "detail": "aggregate",
+            },
+        },
+    }
+    post_mcp(client, body)  # first call: success
+    resp = post_mcp(client, body)  # second call: duplicate
+    err = resp.json()["error"]
+    assert err["code"] == INVALID_PARAMS
+    assert "broadcast_override_already_exists" in err["message"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_remove_unknown_id_maps_to_invalid_params_404(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.remove",
+                "arguments": {"override_id": str(uuid.uuid4())},
+            },
+        },
+    )
+    err = resp.json()["error"]
+    assert err["code"] == INVALID_PARAMS
+    assert "broadcast_override_not_found" in err["message"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_set_regex_chars_rejected_by_pydantic(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """``op_id_pattern`` with regex syntax is rejected by Pydantic."""
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.set",
+                "arguments": {
+                    "op_id_pattern": "vault\\.kv\\..+",
+                    "detail": "aggregate",
+                },
+            },
+        },
+    )
+    err = resp.json()["error"]
+    assert err["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_remove_with_malformed_uuid_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.remove",
+                "arguments": {"override_id": "not-a-uuid"},
+            },
+        },
+    )
+    err = resp.json()["error"]
+    assert err["code"] == INVALID_PARAMS
+    assert "uuid" in err["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Audit-row equivalence with REST
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_set_via_mcp_writes_audit_row_with_override_diff(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """The MCP set tool produces the same audit-row diff as the REST POST.
+
+    Specifically: ``audit_log.payload`` carries ``op_id=meho.broadcast.overrides.set``,
+    ``op_class=write``, and the override-diff fragment
+    (``override_op="set"`` / ``override_id`` / ``override_pattern`` /
+    ``override_detail``) -- the contextvar binding in
+    :func:`~meho_backplane.api.v1.broadcast_overrides._bind_set_audit`
+    fires inside the impl function regardless of REST vs MCP caller.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.set",
+                "arguments": {"op_id_pattern": "vault.kv.*", "detail": "full"},
+            },
+        },
+    )
+    assert resp.status_code == 200
+    override_id = _result_dict(resp)["override"]["id"]
+    rows = await _audit_rows()
+    # The MCP envelope writes one row with ``method="MCP"`` and path
+    # ``/mcp/tools/call/meho.broadcast.overrides.set``.
+    mcp_rows = [
+        r
+        for r in rows
+        if r.method == "MCP" and r.path == "/mcp/tools/call/meho.broadcast.overrides.set"
+    ]
+    assert len(mcp_rows) == 1
+    payload = mcp_rows[0].payload
+    assert payload["op_id"] == "meho.broadcast.overrides.set"
+    assert payload["op_class"] == "write"
+    assert payload["override_op"] == "set"
+    assert payload["override_id"] == override_id
+    assert payload["override_pattern"] == "vault.kv.*"
+    assert payload["override_detail"] == "full"
+
+
+# ---------------------------------------------------------------------------
+# Tenant-scoping invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_list_returns_only_own_tenant_rows(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """A row owned by a different tenant must not appear in this operator's list."""
+    # Seed a row directly into the DB for a foreign tenant.
+    foreign_tenant_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        from meho_backplane.db.models import Tenant
+
+        session.add(
+            Tenant(id=foreign_tenant_id, slug="foreign", name="Foreign Tenant"),
+        )
+        await session.flush()
+        session.add(
+            BroadcastOverride(
+                tenant_id=foreign_tenant_id,
+                op_id_pattern="vault.kv.*",
+                detail="aggregate",
+                created_by_sub="foreign-op",
+            ),
+        )
+
+    # The operator's MCP list call should return nothing.
+    assert foreign_tenant_id != OPERATOR_TENANT_ID  # sanity
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.list",
+                "arguments": {},
+            },
+        },
+    )
+    result = _result_dict(resp)
+    assert result == {"overrides": []}
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation -- AC 9
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_set_via_mcp_invalidates_tenant_override_cache(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """``set`` over MCP invalidates T2's per-tenant cache (AC 9).
+
+    Mirrors ``test_post_invalidates_resolver_cache`` in the T4 REST
+    suite: pre-seed the cache with a long-TTL empty sentinel and a
+    matching tenant scope, then issue the set call. The
+    ``create_override_impl`` function calls
+    :func:`invalidate_tenant_cache` on success, so the post-call
+    cache state must NOT carry the pre-seeded sentinel under this
+    tenant's slot.
+    """
+    import time as time_module
+
+    client, _op = client_with_operator
+    # Sentinel: empty rule set under a far-future TTL. Any rule
+    # mutation that fails to call ``invalidate_tenant_cache`` would
+    # leave this sentinel in place; the test catches that regression.
+    _TENANT_CACHE[OPERATOR_TENANT_ID] = ([], time_module.monotonic() + 600.0)
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.set",
+                "arguments": {
+                    "op_id_pattern": "vault.kv.*",
+                    "detail": "aggregate",
+                },
+            },
+        },
+    )
+    assert resp.status_code == 200
+    # Post-call: the sentinel slot must be evicted. Whether the
+    # post-route audit publish path re-hydrates the slot with FRESH
+    # rows or leaves it empty for the next lookup is implementation
+    # detail; the load-bearing invariant is "the empty sentinel that
+    # would have served stale 'no overrides' verdicts is gone".
+    entry = _TENANT_CACHE.get(OPERATOR_TENANT_ID)
+    if entry is not None:
+        cached_rules, _expires_at = entry
+        # If the cache was re-hydrated, the new entry must carry the
+        # rule we just created (not the empty sentinel).
+        patterns = {r.op_id_pattern for r in cached_rules}
+        assert "vault.kv.*" in patterns, "post-set cache still holds the pre-seeded empty sentinel"
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_remove_via_mcp_invalidates_tenant_override_cache(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """``remove`` over MCP invalidates T2's per-tenant cache (AC 9).
+
+    Same shape as the ``set`` cache-invalidation test. A removed rule
+    must NOT linger in the cache under this tenant's slot.
+    """
+    import time as time_module
+
+    client, _op = client_with_operator
+    # Seed a real rule via the MCP set call.
+    create_resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.set",
+                "arguments": {"op_id_pattern": "audit.*", "detail": "aggregate"},
+            },
+        },
+    )
+    override_id = _result_dict(create_resp)["override"]["id"]
+    # Pin a stale-cache sentinel containing the just-created rule
+    # under a long TTL. The remove call below must evict the slot.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(BroadcastOverride).where(
+                BroadcastOverride.tenant_id == OPERATOR_TENANT_ID,
+            ),
+        )
+        rows = list(result.scalars().all())
+    _TENANT_CACHE[OPERATOR_TENANT_ID] = (rows, time_module.monotonic() + 600.0)
+    assert len(_TENANT_CACHE[OPERATOR_TENANT_ID][0]) == 1
+    remove_resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.remove",
+                "arguments": {"override_id": override_id},
+            },
+        },
+    )
+    assert remove_resp.status_code == 200
+    entry = _TENANT_CACHE.get(OPERATOR_TENANT_ID)
+    if entry is not None:
+        cached_rules, _ = entry
+        cached_ids = {r.id for r in cached_rules}
+        assert uuid.UUID(override_id) not in cached_ids, (
+            "post-remove cache still holds the deleted rule"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pydantic cross-field validation -- half-set scope pair
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_set_half_set_scope_pair_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """``scope_field`` without ``scope_value`` fails Pydantic's after-validator.
+
+    The dispatcher's jsonschema check permits both fields to be
+    optional and the half-set combination passes the schema layer.
+    ``BroadcastOverrideCreate._scope_pair_must_be_consistent`` is
+    the load-bearing invariant: it raises ``ValueError`` →
+    Pydantic ValidationError → ``McpInvalidParamsError`` → -32602.
+    Verifies the MCP set handler runs T4's Pydantic re-validation
+    rather than skipping straight into the impl.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.broadcast.overrides.set",
+                "arguments": {
+                    "op_id_pattern": "k8s.configmap.info",
+                    "scope_field": "namespace",
+                    # scope_value deliberately omitted -- half-set pair.
+                    "detail": "aggregate",
+                },
+            },
+        },
+    )
+    err = resp.json()["error"]
+    assert err["code"] == INVALID_PARAMS
+    # The Pydantic ValueError message threads through to the wire
+    # error; the substring "scope_field and scope_value" pins the
+    # validator-message identity so a future rewording surfaces here.
+    assert "scope_field" in err["message"]
+    assert "scope_value" in err["message"]
+
+
+# ---------------------------------------------------------------------------
+# inputSchema strictness -- matches connector_admin precedent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_input_schemas_are_strict_draft_2020_12(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Every override tool's inputSchema is JSON-Schema 2020-12 + strict.
+
+    Matches the ``connector_admin`` precedent's schema-strictness
+    pattern: schema itself validates as Draft 2020-12, every schema
+    sets ``additionalProperties: false`` (so a typo'd kwarg fails at
+    the dispatcher's jsonschema gate rather than landing as a silent
+    no-op), and MEHO-internal fields (``required_role`` /
+    ``op_class``) are stripped from the wire shape per
+    :meth:`ToolDefinition.to_wire`.
+    """
+    import jsonschema
+
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    tools = {t["name"]: t for t in resp.json()["result"]["tools"]}
+    for name in (
+        "meho.broadcast.overrides.list",
+        "meho.broadcast.overrides.set",
+        "meho.broadcast.overrides.remove",
+    ):
+        schema = tools[name]["inputSchema"]
+        assert schema["type"] == "object"
+        assert schema["additionalProperties"] is False, (
+            f"{name}: missing additionalProperties=false"
+        )
+        jsonschema.Draft202012Validator.check_schema(schema)
+        # MEHO-internal fields must not leak onto the wire.
+        assert "required_role" not in tools[name]
+        assert "op_class" not in tools[name]

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -264,6 +264,33 @@ this stage it exposes:
   `--json` output, `--op-id-pattern` filter on list, and the same
   scope-pair check applied client-side so operators get an
   immediate error rather than a remote 422 round-trip.
+* Admin MCP override-CRUD tools (G6.3-T5 #382) — three
+  `tenant_admin` admin tools `meho.broadcast.overrides.list|set|remove`
+  in `src/meho_backplane/mcp/tools/broadcast_overrides.py` that mirror
+  T4's REST surface onto MCP. Each handler opens a transient
+  `AsyncSession` via `get_sessionmaker()` and calls into the same `*_impl`
+  functions T4 extracted from its route handlers
+  (`list_overrides_impl` / `create_override_impl` /
+  `delete_override_impl`), so audit-row binding, cache
+  invalidation, and the cross-tenant 404 invariant behave
+  identically across the REST and MCP transports.
+  `HTTPException` raised by the impl (409 duplicate, 404 not
+  found) translates to `McpInvalidParamsError` → JSON-RPC
+  `-32602` "Invalid params" with the FastAPI detail string
+  preserved (`broadcast_override_already_exists` /
+  `broadcast_override_not_found`). The set handler re-runs
+  arguments through `BroadcastOverrideCreate.model_validate` so
+  the scope-pair invariant and the glob-not-regex blacklist run
+  for MCP callers identically to REST callers. RBAC is enforced
+  at two layers — `required_role=TenantRole.TENANT_ADMIN` hides
+  the three tools from `tools/list` for non-admin operators via
+  `registry.py::all_tools_for`, and `handlers.py::handle_tools_call`
+  re-checks at call time so a non-admin that knows the literal
+  tool name still gets `-32602` with detail `forbidden: …
+  requires a higher role`. The override-management surface is
+  deliberately outside the narrow-waist agent surface per
+  CLAUDE.md postulate 5; pattern matches the existing
+  `connector_admin.py` admin-namespace precedent.
 * Operation dispatch (G0.6-T8 #399) —
   `src/meho_backplane/api/v1/operations.py` exposes
   `POST /api/v1/operations/call` plus the discovery routes


### PR DESCRIPTION
## Summary
- Three `tenant_admin`-only admin MCP tools (`meho.broadcast.overrides.{list,set,remove}`) mirror T4's REST CRUD onto the MCP transport via in-process calls into the `*_impl` helpers extracted from `backend/src/meho_backplane/api/v1/broadcast_overrides.py` — same audit binding, same per-tenant cache invalidation, same cross-tenant 404 invariant.
- `HTTPException(409)` and `HTTPException(404)` from the impl translate to `McpInvalidParamsError` → JSON-RPC `-32602` with FastAPI detail strings preserved (`broadcast_override_already_exists` / `broadcast_override_not_found`). `BroadcastOverrideCreate.model_validate` runs at the tool boundary so the scope-pair invariant + glob-not-regex blacklist fire for MCP callers identically to REST callers.
- RBAC is two-layered: `required_role=TenantRole.TENANT_ADMIN` hides the three tools from `tools/list` for non-admin operators (registry filter), and the dispatcher's call-time re-check returns `-32602 "forbidden"` if a non-admin knows the literal tool name.
- Per `CLAUDE.md` postulate 5 the override-management surface stays outside the narrow-waist agent tool list; pattern matches the existing `meho_backplane/mcp/tools/connector_admin.py` admin-namespace precedent.

## Test plan
- [ ] `pytest backend/tests/test_mcp_broadcast_overrides_tools.py` — 18 tests covering registration, `tools/list` RBAC filtering for `read_only` + `operator`, dispatcher RBAC denial for `read_only` + `operator`, happy paths (`set` / `list` / `remove`), duplicate → `-32602`, unknown id → `-32602`, regex-chars Pydantic rejection, malformed UUID rejection, half-set scope-pair Pydantic rejection, audit-row diff parity, cross-tenant list returns empty, set + remove cache invalidation, inputSchema strictness (`Draft202012Validator.check_schema` + `additionalProperties: false`).
- [ ] `pytest backend/tests/test_api_v1_broadcast_overrides.py` — regression gate for the `*_impl` extraction (behaviour-preserving refactor of T4's route handlers).
- [ ] `pytest backend/tests/test_mcp_tools_connector_admin.py backend/tests/test_mcp_registry.py backend/tests/test_mcp_server.py backend/tests/test_mcp_audit.py` — sibling MCP-admin regression.
- [ ] `ruff check` + `ruff format --check` over the touched files.
- [ ] `mypy backend/src/meho_backplane/mcp/tools/broadcast_overrides.py backend/src/meho_backplane/api/v1/broadcast_overrides.py`.

## Verification status
Local pytest verification was deferred to CI at the author's request — the pre-commit hook gates (ruff / mypy / fast unit lane) still ran on this push. Branch base is 10 commits behind `origin/main`; verified no intervening commit touches any file in scope, so the diff applies cleanly.

## Acceptance criteria proof (#382)
- ✅ Module `backend/src/meho_backplane/mcp/tools/broadcast_overrides.py` exists with three `ToolDefinition`s carrying `required_role=TenantRole.TENANT_ADMIN`, `op_class="write"` (set/remove) and `"read"` (list).
- ✅ All three tools register via `register_mcp_tool()` at module top level; no edit to `mcp/registry.py`.
- ✅ `meho.broadcast.overrides.list` happy path — `test_list_returns_own_tenant_rows`.
- ✅ `meho.broadcast.overrides.set` happy path + 409 → `-32602` — `test_set_creates_row_returns_override_dict` + `test_set_duplicate_maps_to_invalid_params_409`.
- ✅ `meho.broadcast.overrides.remove` happy path + 404 → `-32602` — `test_remove_deletes_row` + `test_remove_unknown_id_maps_to_invalid_params_404`.
- ✅ Dispatcher RBAC denial for `operator`-role JWT — `test_non_admin_tools_call_set_is_rejected[operator]`.
- ✅ `tools/list` RBAC filtering for `operator`-role JWT — `test_tools_list_hides_override_tools_from_non_admin[operator]`.
- ✅ Audit row parity (op_id, op_class, override-diff fragment) — `test_set_via_mcp_writes_audit_row_with_override_diff`.
- ✅ `set` + `remove` invalidate per-tenant cache — `test_set_via_mcp_invalidates_tenant_override_cache` + `test_remove_via_mcp_invalidates_tenant_override_cache`.
- ✅ `docs/codebase/backend.md` carries the new "Admin MCP override-CRUD tools (G6.3-T5 #382)" entry.

## Out of scope
- T6 (#383) — E2E + load test + cross-repo docs.
- Initiative #376 checklist tick for T5 — left for review-bot / merge automation.

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant administrators can manage broadcast overrides via three MCP tools: list, set, and remove.

* **Bug Fixes / Behavior**
  * Tenant-scoped listing/deletion enforced, duplicate/not-found cases return consistent errors, and tenant override cache is invalidated after changes.

* **Tests**
  * End-to-end tests cover RBAC, CRUD, validation, error mapping, audit logging, and cache invalidation.

* **Documentation**
  * Added docs describing the admin MCP override CRUD tools, validation, and authorization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->