### PR TITLE
feat(connectors): HarborConnector skeleton — HTTP Basic + fingerprint + probe + registry v2 (G3.5-T7 #619)

### DIFF
--- a/backend/src/meho_backplane/connectors/harbor/__init__.py
+++ b/backend/src/meho_backplane/connectors/harbor/__init__.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.harbor — HarborConnector package.
+
+Importing this package registers :class:`HarborConnector` against the
+v2 connector registry under
+``(product="harbor", version="2.x", impl_id="harbor-rest")``. The
+chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+which walks every ``connectors/<product>/`` subpackage at startup, so the
+registration lands before any dispatch can occur.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
+point is deliberately **not** called. The connector advertises an explicit
+``(version="2.x", impl_id="harbor-rest")`` key; the v1 entry would land as
+``("harbor", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s tie-break
+ladder. Same pattern :mod:`meho_backplane.connectors.sddc_manager` and
+:mod:`meho_backplane.connectors.nsx` established.
+
+Once G0.7-T8 (#408) lands its
+:func:`ensure_connector_class_registered` auto-shim in main, the idempotency
+check there will no-op on the
+``(product="harbor", version="2.x", impl_id="harbor-rest")`` triple
+because this module has already registered the hand-rolled class. Until then,
+this module is the only registration path.
+
+Operations for this connector arrive in #620 via G0.7 spec ingestion of
+the Harbor 2.x OpenAPI spec against the ``endpoint_descriptor`` table.
+The robot lifecycle ops (create/delete) ship in #621.
+"""
+
+from meho_backplane.connectors.harbor.connector import HarborConnector
+from meho_backplane.connectors.harbor.session import (
+    HarborCredentialsLoader,
+    HarborTargetLike,
+    SessionCredentials,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.registry import register_connector_v2
+
+register_connector_v2(
+    product="harbor",
+    version="2.x",
+    impl_id="harbor-rest",
+    cls=HarborConnector,
+)
+
+__all__ = [
+    "HarborConnector",
+    "HarborCredentialsLoader",
+    "HarborTargetLike",
+    "SessionCredentials",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""HarborConnector — hand-rolled HttpConnector subclass for Harbor 2.x.
+
+Skeleton-only — auth + fingerprint + probe + the G0.6 dispatch shim.
+Operations arrive in #620 via G0.7 spec ingestion against the Harbor 2.x
+OpenAPI spec into the ``endpoint_descriptor`` table.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.harbor.__init__`. The G0.7 auto-shim's
+idempotency check (in
+:func:`~meho_backplane.operations.ingest.connector_registration.ensure_connector_class_registered`
+once #408's pipeline lands in main) no-ops on subsequent ingests against the
+same ``(product="harbor", version="2.x", impl_id="harbor-rest")`` triple.
+
+Auth
+----
+
+Harbor uses HTTP Basic auth sent on every request — no session cookie or
+XSRF token is established. The connector caches the raw service-account
+credentials (loaded once from Vault via an injectable loader) and computes
+the ``Authorization: Basic`` header on each :meth:`auth_headers` call.
+
+Harbor supports two account forms:
+
+* **Admin account**: plain username (e.g. ``"admin"``).
+* **Robot account**: Harbor-formatted username (e.g. ``"robot$project+name"``
+  for a project-scoped robot or ``"robot$name"`` for a system-level robot).
+
+Both forms are stored verbatim in Vault under the target's ``secret_ref``
+path. No reformatting is applied; the stored username is sent as-is.
+
+This differs from the SDDC Manager precedent in that no ``sso_realm`` suffix
+is appended — Harbor's Basic auth header carries ``username:password`` directly.
+
+Auth model gating
+-----------------
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` (or
+``None`` for pre-G0.3 targets where the column hasn't been populated yet).
+:meth:`auth_headers` rejects any other ``target.auth_model`` value with a
+clear :exc:`NotImplementedError` naming both the target and the requested mode.
+
+Fingerprint
+-----------
+
+``GET /api/v2.0/systeminfo`` returns a ``GeneralInfo`` object. The
+``harbor_version`` field carries the full version string (e.g.
+``"v2.11.0-abc1234"``); the connector splits on the first ``-`` to extract
+separate ``version`` (``"v2.11.0"``) and ``build`` (``"abc1234"``) values.
+``extras["auth_mode"]`` carries the Harbor auth mode (e.g. ``"db_auth"``,
+``"ldap_auth"``, ``"oidc_auth"``).
+
+Probe
+-----
+
+``GET /api/v2.0/health`` is Harbor's own composite healthcheck covering DB,
+redis, registry, jobservice, and related subsystems. The connector maps the
+per-component ``status`` fields to a single ``ok`` boolean + a ``reason``
+string listing any unhealthy component names.
+
+This differs from the SDDC Manager / NSX precedents that delegate ``probe()``
+to ``fingerprint()``. Harbor's health endpoint is purpose-built for
+reachability checks and covers subsystem state that ``systeminfo`` does not
+expose, making the dedicated endpoint the better choice.
+
+Operations
+----------
+
+This module ships zero operations — the G0.6 dispatch shim :meth:`execute`
+exists for ABC compatibility but operations land in the ``endpoint_descriptor``
+table via #620's spec ingestion. Until then, the connector is registered and
+discoverable but ``execute(target, op_id, ...)`` against any ``op_id``
+resolves to "unknown operation" at the dispatcher layer — which is the correct
+behaviour for a registered-but-empty connector at this Task's stage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.harbor.session import (
+    HarborCredentialsLoader,
+    HarborTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["HarborConnector"]
+
+_log = structlog.get_logger(__name__)
+
+
+def _is_acceptable_auth_model(value: Any) -> bool:
+    """Return ``True`` iff *value* is the SHARED_SERVICE_ACCOUNT mode or unset.
+
+    Accepts the enum member, the equivalent string, and ``None`` (the
+    "auth_model column not yet populated" sentinel for pre-G0.3 targets).
+    Any other value is rejected by the caller. Same predicate the SDDC
+    Manager and NSX precedents use; lifted into this module to keep
+    connectors decoupled.
+    """
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+def _basic_auth_header(username: str, password: str) -> str:
+    """Compute the ``Authorization: Basic`` header value for *username*:*password*."""
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+def _parse_harbor_version(harbor_version: str) -> tuple[str | None, str | None]:
+    """Split ``harbor_version`` into (version, build).
+
+    ``harbor_version`` from ``GET /api/v2.0/systeminfo`` is typically
+    ``"v2.11.0-abc1234"`` (version + git hash) or bare ``"v2.11.0"``.
+    Returns ``(version_str, build_str)`` where ``build_str`` is ``None``
+    when no ``-`` separator is present.
+    """
+    if not harbor_version:
+        return None, None
+    if "-" in harbor_version:
+        version_str, build_str = harbor_version.split("-", 1)
+        return version_str or None, build_str or None
+    return harbor_version, None
+
+
+class HarborConnector(HttpConnector):
+    """Harbor 2.x REST connector with HTTP Basic auth.
+
+    Per-target credentials cached in :attr:`_creds_cache` (loaded once via
+    the injectable :class:`HarborCredentialsLoader`). HTTP Basic auth is sent
+    on every request via ``Authorization: Basic <base64>`` — no session
+    token is established and no 401-driven re-login is needed.
+
+    The :attr:`priority` is set to ``1`` so a future
+    ``GenericRestConnector`` auto-shim that somehow registers for the same
+    triple loses the registry's tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"harbor-rest-2.x"`` -> (``"harbor"``, ``"2.x"``, ``"harbor-rest"``).
+    product = "harbor"
+    version = "2.x"
+    impl_id = "harbor-rest"
+    supported_version_range = ">=2.0,<3.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: HarborCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._creds_cache: dict[str, dict[str, str]] = {}
+        self._creds_lock = asyncio.Lock()
+        self._credentials_loader: HarborCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+
+    async def auth_headers(self, target: HarborTargetLike, raw_jwt: str) -> dict[str, str]:
+        """Return ``{"Authorization": "Basic ..."}`` for the request.
+
+        Loads credentials from Vault on first call against *target*, caches
+        them, and reuses the cached values on subsequent calls. ``raw_jwt``
+        is accepted for ABC-signature compatibility but unused —
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
+        Vault-sourced service account, not the operator's OIDC token.
+
+        The Basic auth username is sent verbatim from the Vault-loaded
+        credentials — no ``sso_realm`` suffix is appended. Both admin
+        usernames (``"admin"``) and robot account usernames
+        (``"robot$project+name"``) are passed through unchanged.
+
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is
+        anything other than ``shared_service_account`` or ``None``.
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT mode does not forward operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not _is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"HarborConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        creds = await self._load_credentials(target)
+        return {"Authorization": _basic_auth_header(creds["username"], creds["password"])}
+
+    async def _load_credentials(self, target: HarborTargetLike) -> dict[str, str]:
+        """Return the cached credentials for *target*, loading from Vault on first use.
+
+        The lock serialises concurrent first-use callers for the same target;
+        subsequent calls take the fast path under the same lock. The loaded
+        dict must contain ``"username"`` and ``"password"`` keys; missing
+        keys raise a :exc:`RuntimeError` naming the target and the missing
+        key so operators can identify a misconfigured Vault path.
+        """
+        async with self._creds_lock:
+            cached = self._creds_cache.get(target.name)
+            if cached is not None:
+                return cached
+            raw = await self._credentials_loader(target)
+            try:
+                _ = raw["username"]
+                _ = raw["password"]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"harbor credentials loader for target {target.name!r} returned "
+                    f"a dict missing required key {exc.args[0]!r}; need "
+                    "{'username': str, 'password': str}"
+                ) from exc
+            self._creds_cache[target.name] = raw
+            _log.info(
+                "harbor_credentials_loaded",
+                target=target.name,
+                host=target.host,
+            )
+            return raw
+
+    async def fingerprint(self, target: HarborTargetLike) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /api/v2.0/systeminfo``.
+
+        The ``harbor_version`` field is split on the first ``-`` to produce
+        separate ``version`` and ``build`` values. ``extras["auth_mode"]``
+        carries the Harbor auth mode (``"db_auth"``, ``"ldap_auth"``, etc.).
+
+        On transport or status failure, returns a non-reachable
+        :class:`FingerprintResult` whose ``extras["error"]`` carries the
+        exception class + message — same pattern the SDDC Manager and NSX
+        connectors established.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            payload = await self._get_json(target, "/api/v2.0/systeminfo", raw_jwt="")
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="harbor",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="GET /api/v2.0/systeminfo",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        harbor_version = payload.get("harbor_version") or ""
+        version_str, build_str = _parse_harbor_version(harbor_version)
+        return FingerprintResult(
+            vendor="vmware",
+            product="harbor",
+            version=version_str,
+            build=build_str,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="GET /api/v2.0/systeminfo",
+            extras={
+                "auth_mode": payload.get("auth_mode"),
+                "registry_url": payload.get("registry_url"),
+                "external_url": payload.get("external_url"),
+            },
+        )
+
+    async def probe(self, target: HarborTargetLike) -> ProbeResult:
+        """Composite reachability check via ``GET /api/v2.0/health``.
+
+        Harbor's health endpoint covers DB, redis, registry, jobservice, and
+        related subsystems. The connector maps per-component ``status`` fields
+        to a single ``ok`` boolean; when any component is unhealthy, ``reason``
+        lists the unhealthy component names.
+
+        Unlike the SDDC Manager / NSX precedents that delegate to
+        ``fingerprint()``, Harbor's dedicated health endpoint is the
+        purpose-built reachability surface — it checks subsystem state that
+        ``systeminfo`` does not expose.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            payload = await self._get_json(target, "/api/v2.0/health", raw_jwt="")
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return ProbeResult(
+                ok=False,
+                reason=f"{type(exc).__name__}: {exc}",
+                probed_at=probed_at,
+            )
+        overall = payload.get("status", "unknown")
+        if overall == "healthy":
+            return ProbeResult(ok=True, probed_at=probed_at)
+        components = payload.get("components") or []
+        unhealthy = [c.get("name", "unknown") for c in components if c.get("status") != "healthy"]
+        reason = (
+            f"unhealthy components: {', '.join(unhealthy)}" if unhealthy else f"status={overall!r}"
+        )
+        return ProbeResult(ok=False, reason=reason, probed_at=probed_at)
+
+    async def execute(
+        self,
+        target: HarborTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`SddcManagerConnector.execute`'s shape. Post-G0.6
+        callers (``/api/v1/operations/call``, MCP ``call_operation``, the CLI
+        verbs once #622 lands) construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly — they don't
+        reach this method.
+
+        The connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``'s contract:
+        ``"harbor-rest-2.x"`` → (product=``"harbor"``,
+        version=``"2.x"``, impl_id=``"harbor-rest"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:harbor-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached credentials, then tear down the httpx pool.
+
+        No server-side session to revoke — HTTP Basic is stateless.
+        The credential cache is cleared so a post-aclose reuse of the same
+        connector instance (e.g. a test that builds one connector across two
+        contexts) starts clean.
+        """
+        async with self._creds_lock:
+            self._creds_cache.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/harbor/session.py
+++ b/backend/src/meho_backplane/connectors/harbor/session.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading for the harbor connector.
+
+The hand-rolled :class:`~meho_backplane.connectors.harbor.connector.HarborConnector`
+reads service-account credentials from the target's Vault path and sends
+them as HTTP Basic auth on every request — no session token is established;
+the ``Authorization: Basic`` header is recomputed from the cached credentials
+on each call.
+
+The credential fetch (Vault path → ``{"username": ..., "password": ...}``
+dict) is split out behind a narrow :class:`HarborCredentialsLoader` callable
+so:
+
+* Production deploys override the default loader at construction time once
+  G0.3 (#224) lands the operator-context Vault read path.
+* Unit tests inject their own (mock) loader returning a pre-built dict.
+* Integration tests pass a loader that yields the appropriate service-account
+  credentials.
+
+The default loader, :func:`load_credentials_from_vault`, raises
+:exc:`NotImplementedError` until G0.3 (#224) merges. Mirrors the shape
+:func:`~meho_backplane.connectors.sddc_manager.session.load_credentials_from_vault`
+established for :class:`SddcManagerConnector`.
+
+Harbor supports two account forms:
+
+* **Admin account**: plain username (e.g. ``"admin"``).
+* **Robot account**: Harbor-formatted username (e.g. ``"robot$project+name"``
+  for a project-scoped robot or ``"robot$name"`` for a system-level robot).
+
+Both forms are stored verbatim in Vault under the target's ``secret_ref``
+path. The connector sends the stored username as-is in the Basic auth header;
+no reformatting is applied here.
+
+The :class:`HarborTargetLike` Protocol captures the minimum target shape the
+connector reads: ``name`` (for the per-target credential cache key), ``host``,
+``port`` (forwarded to :meth:`HttpConnector._base_url`), ``secret_ref`` (the
+Vault path the loader resolves), and ``auth_model`` (checked at the
+boundary). Unlike the SDDC Manager protocol, no ``sso_realm`` field is
+needed — Harbor's Basic auth header carries ``username:password`` directly
+with no realm suffix.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "HarborCredentialsLoader",
+    "HarborTargetLike",
+    "SessionCredentials",
+    "load_credentials_from_vault",
+]
+
+
+class SessionCredentials(Protocol):
+    """The dict shape :class:`HarborCredentialsLoader` returns.
+
+    Captured as a Protocol so the type checker can flag a loader that
+    forgets a key. The two values map to the Basic auth components the
+    connector sends on every Harbor API request.
+    """
+
+    username: str
+    password: str
+
+
+@runtime_checkable
+class HarborTargetLike(Protocol):
+    """Minimum target shape :class:`HarborConnector` reads.
+
+    Structural Protocol — once G0.3 (#224) lands the concrete ``Target``
+    model in :mod:`meho_backplane.targets`, that model satisfies this
+    Protocol unchanged. ``auth_model`` is checked at the boundary so a
+    target tagged ``per_user`` or ``impersonation`` raises a clear error
+    rather than silently authenticating as the shared service account.
+
+    ``secret_ref`` is the Vault path the loader resolves to a
+    :class:`SessionCredentials`-shaped dict. ``port`` is optional —
+    Harbor defaults to 443 and :meth:`HttpConnector._base_url` already
+    handles the ``port is None or 443`` case correctly.
+
+    No ``sso_realm`` field — Harbor sends ``username:password`` as-is;
+    no realm suffix is appended.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+
+
+HarborCredentialsLoader = Callable[[HarborTargetLike], Awaitable[dict[str, str]]]
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+The connector's :meth:`HarborConnector._load_credentials` invokes the
+loader exactly once per target (first-use), caching the resulting dict under
+``target.name``. The return type is the looser ``dict[str, str]`` (not
+:class:`SessionCredentials`) because Python :class:`Protocol` instances
+aren't runtime-constructible without a matching class — production code
+returns a plain dict and the connector reads ``creds["username"]`` /
+``creds["password"]`` by key.
+"""
+
+
+async def load_credentials_from_vault(
+    target: HarborTargetLike,
+) -> dict[str, str]:
+    """Default credential loader — Vault read by ``target.secret_ref``.
+
+    Stubbed until G0.3 (#224) lands the ``Target`` model and the
+    operator-context Vault read path. Mirrors
+    :func:`~meho_backplane.connectors.sddc_manager.session.load_credentials_from_vault`'s
+    ``NotImplementedError`` stub so the wiring shape is stable: a production
+    caller without an explicit loader override receives a clear error rather
+    than a silent fallback or a hallucinated credential pair.
+
+    Once G0.3 lands, this function becomes the live implementation that reads
+    the ``harbor/<target.name>`` Vault path and returns the parsed
+    ``{"username": ..., "password": ...}`` dict. Until then, tests and any
+    acceptance harness inject a custom :class:`HarborCredentialsLoader` on
+    connector construction.
+    """
+    raise NotImplementedError(
+        "load_credentials_from_vault requires G0.3 Target model + "
+        f"operator-context Vault read; target={target.name!r} "
+        f"secret_ref={target.secret_ref!r}. Inject a custom credentials_loader "
+        "on HarborConnector until G0.3 lands."
+    )

--- a/backend/tests/test_connectors_harbor_auth.py
+++ b/backend/tests/test_connectors_harbor_auth.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`HarborConnector` auth + fingerprint/probe (G3.5-T7 #619).
+
+Exercises HTTP Basic auth with admin and robot-account username forms,
+per-target credential isolation, the auth_model boundary gate, and the
+fingerprint/probe shapes against mocked Harbor 2.x endpoints.
+
+Auth: no session token — HTTP Basic sent on every request. Credentials
+cached per target so Vault is only queried once per target per connector
+instance lifetime. No sso_realm suffix; username passed as-is from Vault
+(supports both ``"admin"`` and robot forms like ``"robot$project+name"``).
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+import respx
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.harbor import (
+    HarborConnector,
+    HarborTargetLike,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+
+
+@pytest.fixture(autouse=True)
+def _clean_harbor_registry() -> Iterator[None]:
+    """Re-register HarborConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that
+    calls :func:`clear_registry` between tests. Re-register before every
+    test in this module and clear after — same pattern
+    :mod:`tests.test_connectors_sddc_manager_auth` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=HarborConnector.product,
+        version=HarborConnector.version,
+        impl_id=HarborConnector.impl_id,
+        cls=HarborConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies HarborTargetLike Protocol structurally.
+# Replaced by the real Target model when G0.3 (#224) lands.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET_A = _StubTarget(
+    name="harbor-a",
+    host="harbor-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/harbor/harbor-a",
+)
+_TARGET_B = _StubTarget(
+    name="harbor-b",
+    host="harbor-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/harbor/harbor-b",
+)
+
+
+async def _stub_loader(_target: HarborTargetLike) -> dict[str, str]:
+    """Return canned admin credentials regardless of the target."""
+    return {"username": "admin", "password": "stub-password"}
+
+
+async def _stub_robot_loader(_target: HarborTargetLike) -> dict[str, str]:
+    """Return canned robot-account credentials."""
+    return {"username": "robot$myproject+myrobot", "password": "robot-secret"}
+
+
+def _make_connector() -> HarborConnector:
+    return HarborConnector(credentials_loader=_stub_loader)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_harbor_connector_subclasses_http_connector() -> None:
+    assert issubclass(HarborConnector, HttpConnector)
+    assert HarborConnector.product == "harbor"
+    assert HarborConnector.version == "2.x"
+    assert HarborConnector.impl_id == "harbor-rest"
+    assert HarborConnector.supported_version_range == ">=2.0,<3.0"
+    assert HarborConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("harbor", "2.x", "harbor-rest")
+    assert key in registry
+    assert registry[key] is HarborConnector
+
+
+def test_default_credentials_loader_raises_until_g03_lands() -> None:
+    import asyncio
+
+    from meho_backplane.connectors.harbor.session import load_credentials_from_vault
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"G0\.3"):
+            await load_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# HTTP Basic auth — admin account
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_sends_basic_auth_for_admin_account() -> None:
+    """auth_headers() produces Authorization: Basic with plain admin username."""
+    connector = _make_connector()
+    headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "Authorization" in headers
+    assert headers["Authorization"].startswith("Basic ")
+    username, password = _decode_basic_auth(headers["Authorization"])
+    assert username == "admin"
+    assert password == "stub-password"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# HTTP Basic auth — robot account username form
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_sends_basic_auth_for_robot_account_username_form() -> None:
+    """robot$project+name username is passed as-is in the Basic auth header."""
+    connector = HarborConnector(credentials_loader=_stub_robot_loader)
+    headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    username, password = _decode_basic_auth(headers["Authorization"])
+    assert username == "robot$myproject+myrobot"
+    assert password == "robot-secret"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-invoke the loader."""
+    call_count = 0
+
+    async def _counting_loader(_target: HarborTargetLike) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "admin", "password": "stub-password"}
+
+    connector = HarborConnector(credentials_loader=_counting_loader)
+    h1 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h2 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert h1 == h2
+    assert call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Per-target isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_credentials_separate() -> None:
+    """Two targets get two distinct credential cache entries; no cross-target leakage."""
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: HarborTargetLike) -> dict[str, str]:
+        call_log.append(target.name)
+        return {"username": f"svc-{target.name}", "password": "pass"}
+
+    connector = HarborConnector(credentials_loader=_tracking_loader)
+    h_a = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h_b = await connector.auth_headers(_TARGET_B, raw_jwt="")
+
+    username_a, _ = _decode_basic_auth(h_a["Authorization"])
+    username_b, _ = _decode_basic_auth(h_b["Authorization"])
+    assert username_a == "svc-harbor-a"
+    assert username_b == "svc-harbor-b"
+    assert call_log == ["harbor-a", "harbor-b"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential loading failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: HarborTargetLike) -> dict[str, str]:
+        return {"username": "admin"}  # type: ignore[return-value]
+
+    connector = HarborConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"password") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "harbor-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_username_key_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: HarborTargetLike) -> dict[str, str]:
+        return {"password": "stub-password"}  # type: ignore[return-value]
+
+    connector = HarborConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"username") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "harbor-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="harbor-per-user",
+        host="harbor.test.invalid",
+        port=443,
+        secret_ref="kv/data/harbor/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="")
+
+    assert "harbor-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="harbor-pre-g03",
+        host="harbor.test.invalid",
+        port=443,
+        secret_ref="kv/data/harbor/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="harbor-enum",
+        host="harbor.test.invalid",
+        port=443,
+        secret_ref="kv/data/harbor/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against mocked GET /api/v2.0/systeminfo returns canonical shape."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://harbor-a.test.invalid") as mock:
+        mock.get("/api/v2.0/systeminfo").respond(
+            200,
+            json={
+                "harbor_version": "v2.11.0-abc1234def",
+                "auth_mode": "db_auth",
+                "registry_url": "harbor-a.test.invalid",
+                "external_url": "https://harbor-a.test.invalid",
+                "self_registration": False,
+                "has_ca_root": False,
+                "with_notary": False,
+            },
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "harbor"
+    assert fp.version == "v2.11.0"
+    assert fp.build == "abc1234def"
+    assert fp.reachable is True
+    assert fp.probe_method == "GET /api/v2.0/systeminfo"
+    assert fp.extras["auth_mode"] == "db_auth"
+    assert fp.extras["registry_url"] == "harbor-a.test.invalid"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_version_without_build_hash() -> None:
+    """A bare harbor_version string (no - separator) leaves build=None."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://harbor-a.test.invalid") as mock:
+        mock.get("/api/v2.0/systeminfo").respond(
+            200,
+            json={"harbor_version": "v2.11.0", "auth_mode": "ldap_auth"},
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.version == "v2.11.0"
+    assert fp.build is None
+    assert fp.reachable is True
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_returns_reachable_false_with_structured_error() -> None:
+    """Transport/status failure returns reachable=False with extras['error']."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://harbor-a.test.invalid") as mock:
+        mock.get("/api/v2.0/systeminfo").respond(401, json={"errors": [{"code": "UNAUTHORIZED"}]})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "harbor"
+    assert fp.reachable is False
+    assert fp.probe_method == "GET /api/v2.0/systeminfo"
+    error = fp.extras["error"]
+    assert "HTTPStatusError" in error or "401" in error
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_when_all_components_healthy() -> None:
+    """probe() returns ok=True when Harbor's health endpoint reports all healthy."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://harbor-a.test.invalid") as mock:
+        mock.get("/api/v2.0/health").respond(
+            200,
+            json={
+                "status": "healthy",
+                "components": [
+                    {"name": "database", "status": "healthy"},
+                    {"name": "jobservice", "status": "healthy"},
+                    {"name": "redis", "status": "healthy"},
+                    {"name": "registry", "status": "healthy"},
+                ],
+            },
+        )
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_with_reason_for_unhealthy_component() -> None:
+    """probe() returns ok=False with reason listing unhealthy component names."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://harbor-a.test.invalid") as mock:
+        mock.get("/api/v2.0/health").respond(
+            200,
+            json={
+                "status": "unhealthy",
+                "components": [
+                    {"name": "database", "status": "healthy"},
+                    {"name": "jobservice", "status": "unhealthy", "error": "connection refused"},
+                    {"name": "redis", "status": "unhealthy", "error": "timeout"},
+                    {"name": "registry", "status": "healthy"},
+                ],
+            },
+        )
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    assert "jobservice" in result.reason
+    assert "redis" in result.reason
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_on_transport_error() -> None:
+    """probe() returns ok=False + reason on transport failure."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://harbor-a.test.invalid") as mock:
+        mock.get("/api/v2.0/health").respond(503)
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_credential_cache_and_pool() -> None:
+    """aclose() clears the in-memory credential cache and tears down the httpx pool."""
+    connector = _make_connector()
+    await connector.auth_headers(_TARGET_A, raw_jwt="")
+    assert "harbor-a" in connector._creds_cache
+    await connector.aclose()
+    assert connector._creds_cache == {}
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_with_no_cached_credentials_is_a_noop() -> None:
+    """A fresh connector with no credentials established closes cleanly."""
+    connector = _make_connector()
+    await connector.aclose()
+    assert connector._clients == {}
+    assert connector._creds_cache == {}

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -274,3 +274,24 @@ def test_sddc_manager_connector_registered_under_v2_triple() -> None:
     key = ("sddc-manager", "9.0", "sddc-rest")
     assert key in snapshot
     assert snapshot[key] is SddcManagerConnector
+
+
+def test_harbor_connector_registered_under_v2_triple() -> None:
+    """HarborConnector package registers under (harbor, 2.x, harbor-rest) at import.
+
+    The autouse _clean_registry fixture clears the registry before this test,
+    so we manually re-register using the class attributes to assert the triple
+    resolves correctly. Same pattern as the SDDC Manager test above.
+    """
+    from meho_backplane.connectors.harbor import HarborConnector
+
+    register_connector_v2(
+        product=HarborConnector.product,
+        version=HarborConnector.version,
+        impl_id=HarborConnector.impl_id,
+        cls=HarborConnector,
+    )
+    snapshot = all_connectors_v2()
+    key = ("harbor", "2.x", "harbor-rest")
+    assert key in snapshot
+    assert snapshot[key] is HarborConnector

--- a/docs/codebase/connectors-harbor.md
+++ b/docs/codebase/connectors-harbor.md
@@ -1,0 +1,131 @@
+# Connector: harbor (Harbor 2.x)
+
+## Overview
+
+The `harbor` connector is the hand-rolled `HttpConnector` subclass that
+dispatches Harbor REST operations under the
+`(product="harbor", version="2.x", impl_id="harbor-rest")` registry triple.
+G3.5-T7 (#619) shipped the skeleton — HTTP Basic auth, fingerprint, probe, and
+the G0.6 dispatch shim. G3.5-T8 (#620) adds spec ingestion + operator-review
+curation + ~8 read-only ops (project/repo/artifact lists). Robot lifecycle
+(create/delete) + G6 credential_mint classifier arrive in G3.5-T9 (#621).
+CLI verbs + MCP review + real-container E2E arrive in G3.5-T10 (#622).
+
+Source: `backend/src/meho_backplane/connectors/harbor/`.
+
+## Key types
+
+- **`HarborConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="harbor"`, `version="2.x"`,
+  `impl_id="harbor-rest"`, `supported_version_range=">=2.0,<3.0"`,
+  `priority=1`. The priority outranks a future `GenericRestConnector`
+  auto-shim (priority=0) defensively if both somehow register for the same
+  triple.
+- **`HarborTargetLike`** (`session.py`) — runtime-checkable Protocol capturing
+  the minimum target shape the connector reads: `name`, `host`, `port`,
+  `secret_ref`, and `auth_model`. No `sso_realm` field — Harbor sends
+  `username:password` as-is; no realm suffix is appended. Replaced by the
+  concrete `Target` model once G0.3 (#224) lands.
+- **`HarborCredentialsLoader`** (`session.py`) — async callable type resolving
+  a target to `{"username": ..., "password": ...}`. Injectable on connector
+  construction (`HarborConnector(credentials_loader=...)`) so unit tests,
+  integration tests, and pre-G0.3 production deploys override the default
+  Vault loader.
+- **`load_credentials_from_vault`** (`session.py`) — default loader, stubbed
+  `NotImplementedError` until G0.3 lands the operator-context Vault read path.
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()` in
+   `meho_backplane/connectors/registry.py`, which walks every
+   `connectors/<product>/` subpackage in name-sorted order.
+2. Importing `meho_backplane.connectors.harbor` triggers the module-level
+   `register_connector_v2(product="harbor", version="2.x", impl_id="harbor-rest", cls=HarborConnector)`
+   call.
+3. The registry's v2 table now resolves `("harbor", "2.x", "harbor-rest")`
+   to `HarborConnector`. The G0.7 auto-shim's idempotency check (in
+   `ensure_connector_class_registered`, once #408's pipeline lands in main)
+   no-ops on subsequent ingests against the same triple.
+
+### Per-target credentials + HTTP Basic auth
+
+Harbor uses HTTP Basic auth — no session cookie or XSRF token is established.
+Two account forms are supported:
+
+- **Admin account**: plain username (e.g. `"admin"`).
+- **Robot account**: Harbor-formatted username (e.g. `"robot$project+name"`
+  for a project-scoped robot or `"robot$name"` for a system-level robot).
+
+Both forms are stored verbatim in Vault under `target.secret_ref`. The
+connector passes the stored username through unchanged in the Basic auth header.
+
+1. `HarborConnector.auth_headers(target)` is called.
+2. `_load_credentials(target)` acquires the per-instance `asyncio.Lock`,
+   checks the `_creds_cache` dict (keyed on `target.name`), and calls the
+   loader on miss.
+3. The loader (default: `load_credentials_from_vault`, injected in tests)
+   returns `{"username": ..., "password": ...}`.
+4. The result is cached under `target.name` and a `harbor_credentials_loaded`
+   log event is emitted.
+5. `_basic_auth_header(username, password)` returns `"Basic <base64>"`.
+6. `auth_headers` returns `{"Authorization": "Basic <base64>"}`.
+
+### fingerprint()
+
+`GET /api/v2.0/systeminfo` → `GeneralInfo` object. The `harbor_version` field
+(e.g. `"v2.11.0-abc1234"`) is split on the first `-` to extract separate
+`version` (`"v2.11.0"`) and `build` (`"abc1234"`) values. `extras["auth_mode"]`
+carries the Harbor auth mode (`"db_auth"`, `"ldap_auth"`, `"oidc_auth"`).
+
+On transport or status error, returns `FingerprintResult(reachable=False,
+extras={"error": "<ExcType>: <message>"})`.
+
+### probe()
+
+`GET /api/v2.0/health` → `OverallHealthStatus`. The connector checks each
+`component.status` field; if all are `"healthy"`, returns `ProbeResult(ok=True)`.
+If any component is unhealthy, `reason` lists the unhealthy component names.
+
+This differs from the SDDC Manager / NSX precedents that delegate to
+`fingerprint()`. Harbor's health endpoint is purpose-built for reachability
+checks and covers subsystem state (DB, redis, registry, jobservice) that
+`systeminfo` does not expose.
+
+### execute() shim
+
+`execute()` synthesises a system `Operator` with `sub="system:harbor-rest-connector-shim"`
+and delegates to `meho_backplane.operations.dispatch(connector_id="harbor-rest-2.x", ...)`.
+Post-G0.6 callers (CLI verbs, MCP `call_operation`, `/api/v1/operations/call`)
+construct a real `Operator` and call `dispatch` directly — they bypass this shim.
+
+## Dependencies
+
+- **httpx 0.28.1** — async HTTP client with per-target pooling and retry decorator.
+- **tenacity 9.1.4** — retry logic for idempotent GET requests (3 retries,
+  exponential backoff, 5xx + connection errors only).
+- **structlog** — structured logging for credential load events.
+- **`meho_backplane.connectors.adapters.http.HttpConnector`** — base class
+  providing `_get_json`, `_post_json`, `_http_client`, and `aclose`.
+- **`meho_backplane.connectors.schemas`** — `FingerprintResult`, `ProbeResult`,
+  `OperationResult`, `AuthModel`.
+
+## Known issues
+
+- `load_credentials_from_vault` is a `NotImplementedError` stub until G0.3
+  (#224) lands the operator-context Vault read path. Tests inject a custom
+  loader.
+- Operations are not yet registered — `execute()` will produce "unknown
+  operation" at the dispatcher layer until G0.7 spec ingestion lands in #620.
+- Real-container integration tests (against `goharbor/harbor-core:v2.11`) are
+  out of scope for this Task; they arrive in #622.
+
+## References
+
+- Issue: #619 (G3.5-T7)
+- Initiative: #368 (G3.5 tier-2 batch)
+- Successor tasks: #620 (read-ops ingestion), #621 (robot lifecycle), #622 (CLI/MCP/E2E)
+- HttpConnector base: `backend/src/meho_backplane/connectors/adapters/http.py`
+- Harbor 2.x API: https://goharbor.io/docs/2.11.0/build-customize-contribute/configure-swagger/
+- Precedents: `connectors/sddc_manager/` (Basic auth), `connectors/nsx/` (probe pattern)


### PR DESCRIPTION
## Summary

- Adds `connectors/harbor/` package (`__init__.py`, `connector.py`, `session.py`) with `HarborConnector(HttpConnector)` registered under `(product="harbor", version="2.x", impl_id="harbor-rest")` via `register_connector_v2`.
- Auth: HTTP Basic with verbatim username (admin or `robot$project+name` robot accounts), credentials cached per-target from injectable Vault loader — same pattern as SDDC Manager but without `sso_realm` suffix.
- `fingerprint()` hits `GET /api/v2.0/systeminfo`; splits `harbor_version` (e.g. `"v2.11.0-abc123"`) into separate `version` + `build`. `probe()` uses Harbor's dedicated `GET /api/v2.0/health` composite healthcheck (DB, redis, registry, jobservice) rather than delegating to `fingerprint()`.
- Ships `docs/codebase/connectors-harbor.md` and extends `test_connectors_registry_v2.py` with the harbor triple assertion (per AC).

## Test plan

- [x] `ruff check src/ tests/` — clean (pre-existing bind9 E501 unrelated)
- [x] `mypy src/ --ignore-missing-imports` — no issues in 189 source files
- [x] `pytest tests/test_connectors_harbor_auth.py` — 22 passed (all ACs covered)
- [x] `pytest tests/test_connectors_registry_v2.py::test_harbor_connector_registered_under_v2_triple` — passed
- [x] Basic auth admin account — correct `Authorization: Basic` header
- [x] Basic auth robot account (`robot$project+name` form) — passed through verbatim
- [x] Per-target credential isolation — loader called once per target
- [x] Vault loader missing key → `RuntimeError` naming target
- [x] `auth_model="per_user"` → `NotImplementedError` naming target + mode
- [x] `fingerprint()` canonical shape + version/build split
- [x] `fingerprint()` unreachable → `reachable=False` + `extras["error"]`
- [x] `probe()` all components healthy → `ok=True`
- [x] `probe()` unhealthy component → `ok=False` + reason listing names
- [x] `probe()` transport error → `ok=False` + reason

## Out of scope

- Harbor read ops (project/repo/artifact lists) — #620
- Harbor robot lifecycle (robot.create/delete) + G6 credential_mint classifier — #621
- CLI verbs + MCP review + real-container E2E — #622

Closes #619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Harbor 2.x container registry connector now available, featuring HTTP Basic authentication, per-target credential caching with isolation, system health checks, and version fingerprinting capabilities.
  * Connector is automatically registered and ready for immediate deployment across integrated systems.

* **Documentation**
  * Added Harbor 2.x connector documentation covering architecture, credential handling, authentication mechanisms, and API integration patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->