### PR TITLE
fix(test): topology-annotate use in-vocab graph_node.kind (unblock #698 gate)

### DIFF
--- a/backend/tests/integration/test_topology_annotate.py
+++ b/backend/tests/integration/test_topology_annotate.py
@@ -387,7 +387,16 @@ async def _seed_incompatible_kinds_fixture(
     persist with bidirectional ``conflicts_with`` markers.
     """
     svc = await _seed_node(tenant_id=tenant_id, kind="service", name="svc")
-    db = await _seed_node(tenant_id=tenant_id, kind="database", name="db")
+    # ``volume`` is the closest in-vocabulary kind to "stateful storage
+    # node" for this scenario; the closed v0.2 ``_GRAPH_NODE_KINDS``
+    # (mirrored in migration 0007's ``_NODE_KINDS``) does not include
+    # ``database``. Widening the vocabulary is a coordinated DB + model
+    # migration scoped to G9.2's curated extensions, not a test-only
+    # change. The variable name stays ``db`` because the test scenario
+    # narrates "service routes through the database-shaped node" — the
+    # *kind* slot just needs an in-vocab member; the conflict logic
+    # under test is edge-kind-driven, not node-kind-driven.
+    db = await _seed_node(tenant_id=tenant_id, kind="volume", name="db")
     auto_edge = await _seed_auto_edge(
         tenant_id=tenant_id,
         from_id=svc,
@@ -627,7 +636,10 @@ async def test_conflict_incompatible_kinds_persists_both_rows_with_bidirectional
                 json={
                     "from": {"name": "svc", "kind": "service"},
                     "kind": "depends-on",
-                    "to": {"name": "db", "kind": "database"},
+                    # ``volume`` matches the seed in
+                    # :func:`_seed_incompatible_kinds_fixture`; ``database``
+                    # is not in the closed v0.2 ``_GRAPH_NODE_KINDS``.
+                    "to": {"name": "db", "kind": "volume"},
                 },
                 headers=_authed(token),
             )


### PR DESCRIPTION
## Summary

The `Python (integration testcontainers)` lane has been RED on `main`
since #708 / #698 made it a required merge gate (promoted yesterday).
Single failing test:

```
FAILED tests/integration/test_topology_annotate.py::test_conflict_incompatible_kinds_persists_both_rows_with_bidirectional_markers
asyncpg.exceptions.CheckViolationError:
  new row for relation "graph_node" violates check constraint "ck_graph_node_kind"
DETAIL: Failing row contains (..., kind='database', ...).
```

## Root cause

The G9.2-T9 conflict test (#657, merged 2026-05-18) seeded a `graph_node`
row with `kind="database"` in `_seed_incompatible_kinds_fixture`, then
sent the same kind through the annotate API. `"database"` is **not** in
the closed v0.2 `_GRAPH_NODE_KINDS` vocabulary
([backend/src/meho_backplane/db/models.py:1130-1144](backend/src/meho_backplane/db/models.py#L1130-L1144),
mirrored in migration 0007's `_NODE_KINDS` at
[backend/alembic/versions/0007_create_topology_graph.py:183-197](backend/alembic/versions/0007_create_topology_graph.py#L183-L197)),
so the migration's `ck_graph_node_kind` CHECK constraint rejected the
insert.

The fault only became visible after #698 promoted the integration lane
to a required merge gate yesterday — exactly the green-but-hollow class
that gate is intended to backstop. #657 went green pre-#698 because the
lane was advisory.

## Fix

Switch the seeded and annotated `to` node to `kind="volume"` — the
closest in-vocabulary kind for a "stateful storage node" (K8s
PersistentVolume semantics).

The test variable name stays `db` because the scenario narrates
"service depends on the database-shaped node" — the *kind* slot just
needs an in-vocab member, since the conflict logic under test is
edge-kind-driven (`depends-on` vs `routes-through` over the same node
pair), not node-kind-driven.

**No widening of `_GRAPH_NODE_KINDS`.** That would be a coordinated DB +
model migration scoped to G9.2's curated extensions, not a test-only
change. The closed v0.2 vocabulary already encodes the lock-step DB +
ORM invariant that the test was implicitly violating.

## Verification

- `tests/integration/test_topology_annotate.py::test_conflict_incompatible_kinds_persists_both_rows_with_bidirectional_markers` — PASS locally
- Full `tests/integration/test_topology_annotate.py` (7 tests) — PASS locally
- `ruff check` on the touched file — clean

## v0.3 ship-readiness context

This unblocks the `Python (integration testcontainers)` gate on every
open PR (#710, #709, #706, #705), and is a prerequisite for closing
[#697](https://github.com/evoila/meho/issues/697) → [#367](https://github.com/evoila/meho/issues/367) (G3.4 bind9) — the only remaining v0.3 Initiative blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test fixtures and payloads to ensure consistent test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->