### PR TITLE
feat(operations): registration-time handler_ref resolvability guard (#697 AC #3)

### DIFF
--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -1,5 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: load-bearing registration surface. The three
+# helpers (register_typed_operation, register_composite_operation,
+# _register_in_session) are sequential phase pipelines — validate,
+# derive handler_ref, fail-closed checks, resolve group, body-hash
+# skip, embed, upsert. They share a 17-19-arg natural key + per-op
+# metadata surface that the dispatcher and search_operations meta-tool
+# read. Splitting them by phase forces every caller to thread the
+# same args through a coordinator + four sub-helpers, which makes the
+# upsert state machine harder to read, not easier. The two public
+# helpers + the private upsert path stay colocated for that reason.
 
 """``register_typed_operation()`` / ``register_composite_operation()`` -- async upsert helpers.
 
@@ -128,6 +138,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations._handler_resolve import import_handler
 from meho_backplane.operations.embed import (
     build_embedding_text,
     compute_embedding_text_hash,
@@ -424,6 +435,64 @@ def validate_composite_handler_signature(handler: Any) -> None:
         )
 
 
+def _assert_handler_ref_resolvable(
+    handler_ref: str,
+    *,
+    op_id: str,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> None:
+    """Fail-closed: ``handler_ref`` MUST resolve via the dispatcher's import walk.
+
+    The dispatcher resolves ``handler_ref`` at dispatch time via
+    :func:`~meho_backplane.operations._handler_resolve.import_handler`
+    (``importlib.import_module`` + chained :func:`getattr`). A connector
+    that registers an op whose ``handler_ref`` cannot resolve produces
+    a ``handler_unreachable`` error at first dispatch -- which closed
+    the bind9 G3.4 Initiative #367 green-but-hollow (#697): the
+    integration lane was advisory, the per-op meta-tool test failed,
+    and the Initiative closed anyway. #699 fixed the *binding* layer
+    (MRO-aware :func:`is_unbound_method`); this guard fills the
+    parallel #697 AC #3 line at the *resolvability* layer so a future
+    connector cannot ship green with an unreachable handler_ref.
+
+    Catches at registration time:
+
+    * Typos / stale entries -- handler removed but registrar entry
+      still references the dotted path.
+    * Module path changes ``derive_handler_ref``'s ``{module}.{qualname}``
+      shape doesn't anticipate (submodule re-exports, decorator wrapping).
+    * Non-callable resolution -- e.g. a refactor that replaces an
+      ``async def`` with a class attribute.
+
+    Does **not** catch the precise #697 root cause (the resolver's
+    MRO-aware unbound-method binding -- that's a runtime-binding
+    question upstream of resolution). #699 fixed that at the binding
+    layer; this guard is the parallel registration-time backstop.
+
+    Raises
+    ------
+    HandlerRefError
+        ``handler_ref`` does not resolve to a callable via
+        :func:`import_handler`. Subclass of :class:`ValueError`; the
+        registrar surfaces the original :exc:`ImportError` /
+        :exc:`TypeError` as ``__cause__``.
+    """
+    try:
+        import_handler(handler_ref)
+    except (ImportError, TypeError) as exc:
+        raise HandlerRefError(
+            f"register_typed_operation: handler_ref {handler_ref!r} "
+            f"(op_id={op_id!r}, product={product!r}, version={version!r}, "
+            f"impl_id={impl_id!r}) does not resolve to a callable via "
+            f"import_handler -- the dispatcher would surface this as "
+            f"handler_unreachable at dispatch. Fail-closed at "
+            f"registration so the connector cannot ship green with an "
+            f"unreachable handler (#697 / #699)."
+        ) from exc
+
+
 def _reject_composite_handler(handler: Any) -> None:
     """Symmetric: typed registrations reject composite-shaped handlers.
 
@@ -690,6 +759,13 @@ async def register_typed_operation(
     _validate_safety_level(safety_level)
     _reject_composite_handler(handler)
     handler_ref = derive_handler_ref(handler)
+    _assert_handler_ref_resolvable(
+        handler_ref,
+        op_id=op_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+    )
 
     tags_list = list(tags) if tags is not None else []
 
@@ -862,6 +938,13 @@ async def register_composite_operation(
     _validate_safety_level(safety_level)
     validate_composite_handler_signature(handler)
     handler_ref = derive_handler_ref(handler)
+    _assert_handler_ref_resolvable(
+        handler_ref,
+        op_id=op_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+    )
 
     tags_list = list(tags) if tags is not None else []
 

--- a/backend/tests/test_operations_typed_register.py
+++ b/backend/tests/test_operations_typed_register.py
@@ -695,9 +695,7 @@ async def test_register_accepts_module_level_handler_via_import_round_trip(
                 select(EndpointDescriptor).where(EndpointDescriptor.op_id == "vault.kv.read")
             )
         ).scalar_one()
-        assert (
-            row.handler_ref == "tests.test_operations_typed_register.sample_module_level_handler"
-        )
+        assert row.handler_ref == "tests.test_operations_typed_register.sample_module_level_handler"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_operations_typed_register.py
+++ b/backend/tests/test_operations_typed_register.py
@@ -600,6 +600,151 @@ async def test_register_rejects_closure_handler(
 
 
 # ---------------------------------------------------------------------------
+# Registration-time handler_ref resolvability guard (#697 AC #3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_unreachable_handler_ref_via_import_round_trip(
+    stub_embedding_service: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Handler whose derived ``handler_ref`` does not import-walk is rejected.
+
+    Fail-closed at registration. Simulates the green-but-hollow case
+    that #697 caught after the fact (#367 bind9 ``about`` op closed
+    green with a handler unreachable through ``call_operation``):
+    after ``derive_handler_ref`` succeeds on the in-memory callable,
+    point the handler's ``__module__`` at a non-existent module so the
+    dispatcher's :func:`import_handler` walk fails. Without the guard,
+    the row would commit and the connector would close green; with
+    the guard, registration raises :class:`HandlerRefError` and the
+    upsert never runs.
+    """
+    from meho_backplane.operations import _handler_resolve
+
+    _handler_resolve.reset_handler_cache()
+
+    # Use a module-level handler so ``derive_handler_ref`` (which
+    # rejects ``<locals>``-bearing qualnames before any other check)
+    # accepts it; then point ``__module__`` at a non-existent module
+    # so :func:`import_handler`'s walk fails. That isolates this test
+    # to the resolution-time guard, not the closure-rejection path
+    # exercised separately above.
+    monkeypatch.setattr(
+        sample_module_level_handler,
+        "__module__",
+        "definitely_not_a_real_module_xyzzy",
+    )
+
+    with pytest.raises(HandlerRefError, match="handler_unreachable at dispatch"):
+        await register_typed_operation(
+            product="vault",
+            version="1.x",
+            impl_id="vault",
+            op_id="vault.kv.read",
+            handler=sample_module_level_handler,
+            summary="x",
+            description="x",
+            parameter_schema={"type": "object"},
+            embedding_service=stub_embedding_service,
+        )
+
+    # No row committed: the guard fires before _register_in_session.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        result = await fresh.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.op_id == "vault.kv.read")
+        )
+        assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_register_accepts_module_level_handler_via_import_round_trip(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A real module-level handler imports cleanly and registers.
+
+    Pairs with the rejection test above so the guard's positive path
+    is also pinned: ``sample_module_level_handler`` lives in this test
+    module, ``derive_handler_ref`` produces the dotted path
+    ``tests.test_operations_typed_register.sample_module_level_handler``,
+    and :func:`import_handler` round-trips that ref to the same
+    callable -- the registration proceeds normally.
+    """
+    from meho_backplane.operations import _handler_resolve
+
+    _handler_resolve.reset_handler_cache()
+
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.read",
+        handler=sample_module_level_handler,
+        summary="x",
+        description="x",
+        parameter_schema={"type": "object"},
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(EndpointDescriptor.op_id == "vault.kv.read")
+            )
+        ).scalar_one()
+        assert (
+            row.handler_ref == "tests.test_operations_typed_register.sample_module_level_handler"
+        )
+
+
+@pytest.mark.asyncio
+async def test_register_accepts_bound_method_handler_via_import_round_trip(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Bound-method handlers (the typed-connector shape) round-trip too.
+
+    The bind9 / vault / kubernetes connectors all register ops via
+    ``register_typed_operation(handler=self.<method>, ...)``. The
+    dispatcher's resolver returns the *unbound* function for those
+    refs (``getattr(Cls, 'method')`` is unbound in Py3); the guard's
+    :func:`import_handler` call MUST accept that same shape so the
+    typed-connector pattern keeps working. Pins the binding contract
+    for #699 (MRO-aware ``is_unbound_method``).
+    """
+    from meho_backplane.operations import _handler_resolve
+
+    _handler_resolve.reset_handler_cache()
+    instance = SampleHandlerClass()
+
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.read",
+        handler=instance.bound_method_handler,
+        summary="x",
+        description="x",
+        parameter_schema={"type": "object"},
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(EndpointDescriptor.op_id == "vault.kv.read")
+            )
+        ).scalar_one()
+        assert (
+            row.handler_ref
+            == "tests.test_operations_typed_register.SampleHandlerClass.bound_method_handler"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Caller-owned session
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes [#697](https://github.com/evoila/meho/issues/697) AC #3 (the
"registration-time guard for handler_ref resolvability" line). #699
fixed the *binding* layer; this PR adds the parallel *resolvability*
layer guard so a connector cannot ship green with an unreachable
handler_ref.

## What

* `_assert_handler_ref_resolvable` in [backend/src/meho_backplane/operations/typed_register.py](backend/src/meho_backplane/operations/typed_register.py) calls the dispatcher's own [import_handler](backend/src/meho_backplane/operations/_handler_resolve.py) on the derived ref and re-raises `ImportError` / `TypeError` as `HandlerRefError` with `op_id` / `product` / `version` / `impl_id` context.
* Wired into both `register_typed_operation` and `register_composite_operation`, immediately after `derive_handler_ref` returns. Same pattern as the existing `_reject_composite_handler` / `validate_composite_handler_signature` registration-time checks.
* Three new tests in [backend/tests/test_operations_typed_register.py](backend/tests/test_operations_typed_register.py):
  - Negative path: `__module__` monkeypatched to a non-existent module → derived ref is shape-valid, the import walk fails, `HandlerRefError` fires, no DB row commits.
  - Positive path (module-level handler).
  - Positive path (bound-method handler) — locks #699's MRO-aware `is_unbound_method` contract from the registration side.

## Why this is the right level

Connector registration runs at FastAPI lifespan start. Failing here surfaces in deploy / smoke / unit logs with the offending ref + `op_id`, not as a runtime `handler_unreachable` at first `call_operation`. This is the "fail-closed at registration so the connector cannot close green with an unreachable handler" structural backstop #697 AC #3 calls for.

## What it does NOT catch

The precise #697 root cause (the resolver's MRO-aware unbound-method binding — runtime binding, upstream of resolution). #699 fixed that at the binding layer. This guard is the parallel registration-time backstop, not a replacement.

## Scope note

`typed_register.py` gets a `code-quality-allow` header. The file is 1136 lines because `register_typed_operation` + `register_composite_operation` + `_register_in_session` are sequential phase pipelines sharing a 17–19-arg natural-key + per-op metadata surface. Splitting them by phase forces every caller through a coordinator + four sub-helpers, which makes the upsert state machine harder to read, not easier. Refactor is out of scope for closing #697.

## Verification

- `tests/test_operations_typed_register.py` — 25 passed (3 new + 22 pre-existing)
- `tests/test_operations_handler_resolve.py` — 8 passed
- `tests/test_operations_composite_register.py` — 22 passed
- bind9 + k8s + vault connector unit suites — **272 passed** (connector registration through the new guard works)
- `ruff` + `mypy` clean on touched files

## Refs

- Task [#697](https://github.com/evoila/meho/issues/697) — AC #3 (this PR closes it)
- Initiative [#367](https://github.com/evoila/meho/issues/367) — G3.4 bind9
- Sister binding fix [#699](https://github.com/evoila/meho/pull/699)
- Required-gate promotion [#698](https://github.com/evoila/meho/pull/698)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fail-closed validation for operation registration: unresolvable handler references are now detected and rejected at registration time to prevent invalid registrations.

* **Tests**
  * Added tests covering handler-resolution failures and successful resolution scenarios to ensure registration behaves correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->