### PR TITLE
ci(runner-smoke): matrix over both runner pools (meho-runners + meho-runners-ci) for the migration window

### DIFF
--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -1,17 +1,25 @@
 name: meho-runners smoke
-# Verifies the meho-runners self-hosted runner pool can:
-#   1. Pick up + run a job (original scope, claude-rdc-hetzner-dc#262).
+# Verifies BOTH the meho-runners self-hosted runner pools can:
+#   1. Pick up + run a job (original scope, claude-rdc-hetzner-dc#262 +
+#      claude-rdc-hetzner-dc#610 for the rke2-ci-side meho-runners-ci pool).
 #   2. Pull Docker Hub images through the Harbor pull-through cache at
 #      harbor.evba.lab/dockerhub-proxy via the explicit project-prefixed
 #      URL form (the Harbor-supported pull pattern — see
 #      evoila-bosnia/meho-internal#75 + MEHO.HelmCharts#20 for the
 #      "transparent-mirror doesn't work with Harbor" finding).
 #
-# Runs on every push to main + workflow_dispatch. After a week of green
-# runs, the cleanup follow-up on the meho-internal#67 Initiative rewrites
-# the workflows that currently pull `library/<image>` to use the
-# `harbor.evba.lab/dockerhub-proxy/library/<image>` form, and retires the
-# tactical Docker Hub auth shims on security-scan.yml + ci.yml.
+# Runs on every push to main + workflow_dispatch. Matrix over both pools:
+#   - meho-runners        (rke2-meho cluster; chart gha-runner-scale-set@0.9.3)
+#   - meho-runners-ci     (rke2-ci  cluster; chart gha-runner-scale-set@0.14.1)
+# Both pools coexist during the migration window (claude-rdc-hetzner-dc#604
+# Initiative / ADR 0001). The rke2-meho-side `meho-runners` pool retires
+# in claude-rdc-hetzner-dc#611 after 5+ green PRs on the rke2-ci pool —
+# at which point this matrix collapses back to a single pool.
+#
+# After a week of green runs, the cleanup follow-up on the meho-internal#67
+# Initiative rewrites the workflows that currently pull `library/<image>`
+# to use the `harbor.evba.lab/dockerhub-proxy/library/<image>` form, and
+# retires the tactical Docker Hub auth shims on security-scan.yml + ci.yml.
 on:
   push:
     branches: [main]
@@ -27,11 +35,19 @@ env:
 
 jobs:
   smoke:
-    runs-on: meho-runners
+    name: smoke (${{ matrix.pool }})
+    strategy:
+      fail-fast: false
+      matrix:
+        pool:
+          - meho-runners      # rke2-meho; retired in claude-rdc-hetzner-dc#611
+          - meho-runners-ci   # rke2-ci; added in claude-rdc-hetzner-dc#610
+    runs-on: ${{ matrix.pool }}
     timeout-minutes: 10
     steps:
       - name: Identify the runner
         run: |
+          echo "pool: ${{ matrix.pool }}"
           echo "host: $(hostname)"
           echo "uname: $(uname -a)"
           echo "os:"
@@ -45,8 +61,8 @@ jobs:
       - name: Assert Docker daemon is reachable
         # The dind sidecar shares /var/run/docker.sock via emptyDir; runner
         # container has DOCKER_HOST=unix:///var/run/docker.sock. If the
-        # hand-rolled template.spec in MEHO.HelmCharts regressed, this
-        # prints docker daemon version OR fails loudly.
+        # hand-rolled template.spec in MEHO.HelmCharts / rdc-gitops regressed,
+        # this prints docker daemon version OR fails loudly.
         run: |
           set -euo pipefail
           echo "== docker version =="
@@ -72,7 +88,7 @@ jobs:
         #
         # Fail-mode: TLS error means the CA mount or update-ca-certificates
         # step regressed (likely a chart upgrade that overwrote the
-        # hand-rolled command: in MEHO.HelmCharts values.yaml).
+        # hand-rolled command: in MEHO.HelmCharts / rdc-gitops values.yaml).
         run: |
           set -euo pipefail
           # Just grep the bundle for our CA's CN. Empirically verified
@@ -93,7 +109,7 @@ jobs:
             # only as defence-in-depth: if it is reached, the runner-side
             # CA wiring regressed (chart drift) — the pull step below still
             # exercises dockerd's TLS path as a last-resort signal.
-            echo "Note: runner-side CA bundle check did not match; relying on the pull step below for TLS validation (investigate MEHO.HelmCharts runner-container CA mount — meho-internal#80)."
+            echo "Note: runner-side CA bundle check did not match; relying on the pull step below for TLS validation (investigate ${{ matrix.pool }}'s runner-container CA mount — meho-internal#80)."
           fi
           echo "✓ Bundle check complete."
 
@@ -142,7 +158,8 @@ jobs:
         # `--insecure` / `--cacert` — proving TLS to Harbor works is the
         # whole point of this step. A `curl: (60) SSL certificate problem`
         # here means the runner-side CA wiring regressed in
-        # MEHO.HelmCharts (see that repo's runner-smoke debugging notes).
+        # MEHO.HelmCharts / rdc-gitops (see that repo's runner-smoke
+        # debugging notes).
         run: |
           set -euo pipefail
           ARTIFACTS_URL="$HARBOR_API_URL/projects/${HARBOR_REPO_PATH%%/*}/repositories/$(echo "${HARBOR_REPO_PATH#*/}" | sed 's|/|%2F|g')/artifacts"
@@ -159,7 +176,7 @@ jobs:
             echo "         the project-prefix path regressed). Check:"
             echo "         - kubectl exec <pod> -c dind -- docker info"
             echo "         - kubectl logs <pod> -c dind | grep -iE 'harbor|tls|x509'"
-            echo "         - the hand-rolled template.spec in MEHO.HelmCharts"
+            echo "         - the hand-rolled template.spec in MEHO.HelmCharts / rdc-gitops"
             exit 1
           fi
           echo "✓ Cache populated."


### PR DESCRIPTION
Cross-link: [evoila-bosnia/claude-rdc-hetzner-dc#610](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/610) (the runner-pool migration task; part of Initiative #604 / ADR 0001 — dedicated general-purpose CI runner cluster on rke2-ci).

## What

`.github/workflows/runner-smoke.yml` now matrices over both runner pools:

- `meho-runners` — on the existing rke2-meho cluster, chart `gha-runner-scale-set@0.9.3`. Active since claude-rdc-hetzner-dc#262.
- `meho-runners-ci` — on the new rke2-ci cluster, chart `gha-runner-scale-set@0.14.1`. Added by claude-rdc-hetzner-dc#610 (this push proves it).

Every push to `main` + every `workflow_dispatch` now produces TWO runs (one per pool). `fail-fast: false` so a regression on one pool doesn't mask another.

## Why

The new `rke2-ci` cluster is a dedicated CI runner host (ADR 0001 — gets evoila/meho's runners off the shared `rke2-meho` cluster that runs the prod-ida workload). Migration is incremental:

1. **#610 (this PR's counterpart on the rdc side)** — bring up `meho-runners-ci` alongside `meho-runners`. Both pools serve `evoila/meho` simultaneously. **← we are here**
2. **#611 (next)** — after 5+ green smoke runs (i.e., a week of pushes), retire the rke2-meho-side `meho-runners` pool entirely.

This matrix is the smoke during the migration window. When #611 lands, this matrix collapses back to a single pool — either re-using the original name `meho-runners` after rename, or simplifying to `meho-runners-ci`.

## Why matrix instead of a separate workflow

Single source of truth for the smoke logic. The 5 steps (identify runner, docker version, CA trust, harbor cache pull, harbor API artifact check) are functionally identical between pools — no point duplicating. The matrix dimension makes the per-pool tagging explicit in run history.

## Verified before opening this PR

The new `meho-runners-ci` pool is registered with GitHub on this repo's settings:

- ARC controller `arc-gha-rs-controller` on rke2-ci, chart `gha-rs-controller-0.14.1` ([claude-rdc-hetzner-dc#609](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/609))
- AutoscalingRunnerSet `meho-runners-ci` (id=2 in this repo's actions runner registry), min=1/max=3
- Listener pod `meho-runners-ci-784fdb49-listener` Running on rke2-ci
- Runner pod `meho-runners-ci-rzmr8-runner-bkz55` Running on rke2-ci-wk-03 (`status: online`, `busy: false` per `GET /repos/evoila/meho/actions/runners`)

After this PR merges + the next workflow run, the `smoke (meho-runners-ci)` matrix cell will exercise the new pool end-to-end (docker pull from Harbor cache + CA trust + artifact assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests & CI/CD**
  * Smoke test workflow expanded to validate against multiple self-hosted runner pools using a matrix strategy
  * Job naming and runtime output updated to clearly identify the selected runner pool
  * Top-level verification text and inline guidance revised for the expanded scope
  * Diagnostic messaging refined for CA bundle checks and Harbor cache assertion failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->