### PR TITLE
fix(cli): gofmt sddc-manager domain.go + network_pool.go (#709 regression)

### DIFF
--- a/cli/internal/cmd/sddc-manager/domain.go
+++ b/cli/internal/cmd/sddc-manager/domain.go
@@ -35,7 +35,7 @@ func newDomainListCmd() *cobra.Command {
 		Short: "List VCF domains (management + workload)",
 		Long: "list dispatches GET:/v1/domains against connector_id=\"sddc-rest-9.0\".\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager domain list --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager domain list --target rdc-sddc-manager",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -95,7 +95,7 @@ func newDomainInfoCmd() *cobra.Command {
 		Long: "info dispatches GET:/v1/domains/{id} against connector_id=\"sddc-rest-9.0\".\n" +
 			"Requires a domain id from `sddc-manager domain list`.\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager domain info domain-mgmt --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager domain info domain-mgmt --target rdc-sddc-manager",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -129,15 +129,15 @@ func printDomainInfo(w io.Writer, r *CallResult) {
 		return
 	}
 	var d struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-		Type string `json:"type"`
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Type     string `json:"type"`
 		VCenters []struct {
 			ID   string `json:"id"`
 			FQDN string `json:"fqdn"`
 		} `json:"vcenters"`
 		NsxtCluster *struct {
-			ID     string `json:"id"`
+			ID      string `json:"id"`
 			VipFQDN string `json:"vipFqdn"`
 		} `json:"nsxtCluster"`
 		Clusters []struct {

--- a/cli/internal/cmd/sddc-manager/network_pool.go
+++ b/cli/internal/cmd/sddc-manager/network_pool.go
@@ -34,7 +34,7 @@ func newNetworkPoolListCmd() *cobra.Command {
 		Short: "List VCF network pools (IP ranges and VLANs for host commission)",
 		Long: "list dispatches GET:/v1/network-pools against connector_id=\"sddc-rest-9.0\".\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager network-pool list --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager network-pool list --target rdc-sddc-manager",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,


### PR DESCRIPTION
## Summary

Restores `Go (golangci-lint)` gate on main. Two files from [#709 (G3.5-T6 sddc-manager)](https://github.com/evoila/meho/pull/709) needed gofmt — struct-field alignment in [domain.go](cli/internal/cmd/sddc-manager/domain.go) and example-field alignment in [network_pool.go](cli/internal/cmd/sddc-manager/network_pool.go). The PR-level Go lane was green at #709 merge time (likely a race against [#698](https://github.com/evoila/meho/pull/698)'s required-gate promotion), so the gofmt drift only surfaced after main re-ran the gate.

## What

`gofmt -w cli/internal/cmd/sddc-manager/domain.go cli/internal/cmd/sddc-manager/network_pool.go` — pure mechanical whitespace reformat. No semantic change.

## Verification

- `cd cli && go build ./...` — clean
- The remaining cli/ Go files are already gofmt-clean

## Why surgical

Two files, 7 insertions / 7 deletions. Only the alignment columns moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text and command examples for domain management (list, info) and network pool list CLI commands to enhance clarity and improve readability for command-line interface users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->