### PR TITLE
ci: cutover real CI workflows to meho-runners-ci (#715)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,10 +3,13 @@
 
 # actionlint configuration.
 # Declares custom self-hosted runner labels used by this repo so actionlint
-# stops emitting unknown-label warnings on `runs-on: [self-hosted, meho-runners]`
-# (and the bare `runs-on: meho-runners` in runner-smoke.yml).
+# stops emitting unknown-label warnings on the bare `runs-on: meho-runners-ci`
+# (and the legacy `meho-runners` form during the migration window — see
+# #715 cutover and claude-rdc-hetzner-dc#611 retirement of the rke2-meho
+# pool). Drop `meho-runners` here when #611 retires that pool.
 #
 # Reference: https://github.com/rhysd/actionlint/blob/main/docs/config.md
 self-hosted-runner:
   labels:
     - meho-runners
+    - meho-runners-ci

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -85,7 +85,7 @@ jobs:
     # so fork PRs are skipped entirely. push events (main, v*) short-circuit
     # the OR.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -104,7 +104,7 @@ jobs:
         # linux-amd64 tarball of v0.6.7.
         #
         # Install target is `$HOME/.local/bin` — a runner-owned directory —
-        # rather than `/usr/local/bin`, because the self-hosted `meho-runners`
+        # rather than `/usr/local/bin`, because the self-hosted `meho-runners-ci`
         # pool runs as a non-root user that cannot write to system paths
         # (writing /usr/local/bin returned `Permission denied` in CI run
         # 25644668781). Appending the directory to `$GITHUB_PATH` is the
@@ -259,7 +259,7 @@ jobs:
     # follow-up issue lands the hardening pass that removes
     # continue-on-error once we have ~10 green runs (per G6.1-T8 AC).
     #
-    # Runs on ``ubuntu-latest`` (NOT ``meho-runners``) because kind
+    # Runs on ``ubuntu-latest`` (NOT ``meho-runners-ci``) because kind
     # needs Docker-in-Docker support that the self-hosted runner
     # pool isn't configured for; the GitHub-hosted runners ship
     # Docker pre-installed and helm/kind-action works out of the box.
@@ -761,7 +761,7 @@ jobs:
     # but the explicit `if` makes intent visible.
     if: github.event_name != 'pull_request'
     needs: validate
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 15
     permissions:
       # Per-job scope: only `publish` needs to push to GHCR and mint an OIDC
@@ -985,7 +985,7 @@ jobs:
     # successful `helm pull` here can only mean the GHCR package is public.
     if: github.event_name != 'pull_request'
     needs: publish
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:
       - name: Install Helm (no checkout — keeps env scrubbed of repo state)
@@ -1002,7 +1002,7 @@ jobs:
         run: |
           set -euo pipefail
           # Isolate Helm from any persisted runner-local auth/config.
-          # The self-hosted `meho-runners` pool does not guarantee a clean
+          # The self-hosted `meho-runners-ci` pool does not guarantee a clean
           # HOME between jobs (https://docs.github.com/en/actions/hosting-your-own-runners);
           # Helm 3.8+ falls back to ~/.docker/config.json for OCI creds when
           # HELM_REGISTRY_CONFIG isn't set (helm/helm#7776), so deleting only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@
 #   go-lint-test      : golangci-lint + go build + go test on cli/
 #   helm-lint-template: helm lint + helm template + kubeconform on deploy/charts/meho/
 #
-# Each job runs on its own meho-runners runner in parallel; total wall
+# Each job runs on its own meho-runners-ci runner in parallel; total wall
 # clock for a green PR is well below the 10-minute Goal #11 budget
 # because the three jobs never block each other. Per-job
 # `timeout-minutes` caps a runaway gate at twice its observed cost.
@@ -82,12 +82,12 @@ jobs:
     name: Python (ruff + mypy + pytest)
     # Fork-PR guard: never execute project code from a fork on the
     # self-hosted runner pool. Mirrors image.yml + chart.yml's stance —
-    # `runs-on: meho-runners` is internal infra, so fork PRs skip
+    # `runs-on: meho-runners-ci` is internal infra, so fork PRs skip
     # entirely. Push events (main) short-circuit the OR via
     # github.event_name != 'pull_request'. Job-level (not step-level)
     # so no step ever starts on a fork PR.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     # 50-min cap: this job is the deterministic required gate — ruff
     # + ruff-format + mypy + the unit pytest sweep with
     # tests/integration/ EXCLUDED (--ignore=tests/integration). The
@@ -291,7 +291,7 @@ jobs:
     # integration sweep. pytest-xdist loadgroup parallelization to
     # bring this well under cap is tracked in #564.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 60
     env:
       MEHO_TEST_PGVECTOR_IMAGE: harbor.evba.lab/dockerhub-proxy/pgvector/pgvector:pg16
@@ -345,7 +345,7 @@ jobs:
     name: Go (golangci-lint + go test)
     # Fork-PR guard mirrors the Python job — same rationale.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -394,7 +394,7 @@ jobs:
       - name: Ensure C toolchain is available (for cgo race runtime)
         # `go test -race` links the cgo-based race runtime, which needs
         # a working C toolchain — both `gcc` (or any cc) AND libc
-        # development headers (`<stdlib.h>` etc.). The `meho-runners`
+        # development headers (`<stdlib.h>` etc.). The `meho-runners-ci`
         # self-hosted pool ships a minimal image without either, so
         # the race test would fail with one of:
         #   - `cgo: C compiler "gcc" not found` (no gcc), or
@@ -414,7 +414,7 @@ jobs:
         # later `cgo:` error. `--no-install-recommends` keeps the
         # install fast and minimal: gcc + libc6-dev only, no
         # editors/manpages/etc. The proper long-term fix is to bake
-        # the C toolchain into the meho-runners base image; until
+        # the C toolchain into the meho-runners-ci base image; until
         # then this step keeps PR CI green without expanding the
         # workflow's blast radius.
         if: runner.os == 'Linux'
@@ -445,7 +445,7 @@ jobs:
         # CGO_ENABLED=1 is required: `go test -race` is implemented in
         # the cgo-based race runtime and refuses to run otherwise
         # (`go: -race requires cgo; enable cgo by setting CGO_ENABLED=1`).
-        # The `meho-runners` self-hosted pool defaults to CGO_ENABLED=0,
+        # The `meho-runners-ci` self-hosted pool defaults to CGO_ENABLED=0,
         # so the flag must be set explicitly here. The preceding step
         # ensures `gcc` is on PATH so the race runtime can actually
         # link. Scoped to this step only — the build/lint steps work
@@ -459,7 +459,7 @@ jobs:
     name: Helm (lint + template + kubeconform)
     # Fork-PR guard mirrors the other jobs.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -479,7 +479,7 @@ jobs:
         # JSON Schemas offline. Pin to v0.6.7 by SHA256 — same shape
         # chart.yml uses (devops_best_practices: no `curl|sh` of
         # unpinned binaries). Install to $HOME/.local/bin because the
-        # self-hosted meho-runners pool runs as a non-root user that
+        # self-hosted meho-runners-ci pool runs as a non-root user that
         # cannot write to /usr/local/bin (regression caught in PR #173
         # / CI run 25644668781). Appending to $GITHUB_PATH surfaces
         # the binary to subsequent steps without relying on the install

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -69,7 +69,7 @@ jobs:
     # The OR short-circuits on push events; the `pull_request.head.repo`
     # property is irrelevant when github.event_name != 'pull_request'.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 30
     permissions:
       # `contents: write` is required for GoReleaser to create the

--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   python-licenses:
     name: Python License Check
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -129,7 +129,7 @@ jobs:
 
   npm-licenses:
     name: NPM License Check
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -67,7 +67,7 @@ jobs:
     # Fork-PR guard: never execute project code from a fork on the
     # self-hosted runner pool. Mirrors ci.yml's stance.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 5
     defaults:
       run:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -114,7 +114,7 @@ jobs:
     # The OR short-circuits on push events, so the missing pull_request context
     # on push is irrelevant. Job-level (not step-level) so no step ever starts.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 45  # arm64 emulation under QEMU is 3-5x slower than native
     env:
       # Surfaced at the job level so the `Notify claude-rdc-hetzner-dc` step

--- a/.github/workflows/migration-compat.yml
+++ b/.github/workflows/migration-compat.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   check:
     name: Backward-compat migration guard
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -114,7 +114,7 @@ jobs:
     #   1. Fork-PR guard. `pull_request_target`'s `pull_request` payload
     #      carries `head.repo.full_name`; for fork PRs this !=
     #      github.repository, so the AND short-circuits to false. Same as
-    #      ci.yml / image.yml / chart.yml — `meho-runners` is internal
+    #      ci.yml / image.yml / chart.yml — `meho-runners-ci` is internal
     #      infrastructure and fork-PR code never executes on it.
     #
     #   2. Consumer-side enable knob. GitHub Actions does NOT expose the
@@ -132,7 +132,7 @@ jobs:
     if: |
       (github.event.pull_request.head.repo.full_name == github.repository) &&
       (vars.RKE2_SMOKE_ENABLED == 'true')
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     environment: rke2-ci  # consumer-side env-scoped approval + secret store
     timeout-minutes: 12   # 8min smoke budget (Task #50 AC #5) + headroom for cold buildx cache
     env:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   sonarcloud:
     name: SonarCloud Analysis
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 20
     continue-on-error: true
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -1,20 +1,19 @@
 name: meho-runners smoke
-# Verifies BOTH the meho-runners self-hosted runner pools can:
+# Verifies the meho-runners-ci self-hosted runner pool can:
 #   1. Pick up + run a job (original scope, claude-rdc-hetzner-dc#262 +
-#      claude-rdc-hetzner-dc#610 for the rke2-ci-side meho-runners-ci pool).
+#      claude-rdc-hetzner-dc#610 for the rke2-ci-side pool).
 #   2. Pull Docker Hub images through the Harbor pull-through cache at
 #      harbor.evba.lab/dockerhub-proxy via the explicit project-prefixed
 #      URL form (the Harbor-supported pull pattern — see
 #      evoila-bosnia/meho-internal#75 + MEHO.HelmCharts#20 for the
 #      "transparent-mirror doesn't work with Harbor" finding).
 #
-# Runs on every push to main + workflow_dispatch. Matrix over both pools:
-#   - meho-runners        (rke2-meho cluster; chart gha-runner-scale-set@0.9.3)
-#   - meho-runners-ci     (rke2-ci  cluster; chart gha-runner-scale-set@0.14.1)
-# Both pools coexist during the migration window (claude-rdc-hetzner-dc#604
-# Initiative / ADR 0001). The rke2-meho-side `meho-runners` pool retires
-# in claude-rdc-hetzner-dc#611 after 5+ green PRs on the rke2-ci pool —
-# at which point this matrix collapses back to a single pool.
+# Runs on every push to main + workflow_dispatch on the
+# meho-runners-ci pool (rke2-ci cluster; chart
+# gha-runner-scale-set@0.14.1). The matrix-over-both-pools shape from
+# #714 collapsed to single-pool when #715 cut the real CI workflows
+# over to meho-runners-ci; the rke2-meho-side `meho-runners` pool
+# retires in claude-rdc-hetzner-dc#611.
 #
 # After a week of green runs, the cleanup follow-up on the meho-internal#67
 # Initiative rewrites the workflows that currently pull `library/<image>`
@@ -35,19 +34,11 @@ env:
 
 jobs:
   smoke:
-    name: smoke (${{ matrix.pool }})
-    strategy:
-      fail-fast: false
-      matrix:
-        pool:
-          - meho-runners      # rke2-meho; retired in claude-rdc-hetzner-dc#611
-          - meho-runners-ci   # rke2-ci; added in claude-rdc-hetzner-dc#610
-    runs-on: ${{ matrix.pool }}
+    runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:
       - name: Identify the runner
         run: |
-          echo "pool: ${{ matrix.pool }}"
           echo "host: $(hostname)"
           echo "uname: $(uname -a)"
           echo "os:"
@@ -109,7 +100,7 @@ jobs:
             # only as defence-in-depth: if it is reached, the runner-side
             # CA wiring regressed (chart drift) — the pull step below still
             # exercises dockerd's TLS path as a last-resort signal.
-            echo "Note: runner-side CA bundle check did not match; relying on the pull step below for TLS validation (investigate ${{ matrix.pool }}'s runner-container CA mount — meho-internal#80)."
+            echo "Note: runner-side CA bundle check did not match; relying on the pull step below for TLS validation (investigate meho-runners-ci's runner-container CA mount — meho-internal#80)."
           fi
           echo "✓ Bundle check complete."
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   trufflehog:
     name: TruffleHog Secret Scan
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,35 @@ permissions:
 jobs:
   semgrep:
     name: Semgrep SAST
-    runs-on: meho-runners-ci
+    # Deliberate single-workflow exception to #715's cutover from
+    # `meho-runners` (rke2-meho) to `meho-runners-ci` (rke2-ci). The
+    # initial cutover attempt (PR #717 first push, head 2fd6287)
+    # regressed this required check green->red on the new pool — the
+    # `container:` keyword below makes the GHA runner manager pull
+    # `harbor.evba.lab/dockerhub-proxy/semgrep/semgrep:1.160.0` at the
+    # runner-pod level (not inside the DinD sidecar). On the new
+    # rke2-ci pool that path fails in two distinct ways:
+    #   - DNS: `lookup harbor.evba.lab on 10.43.0.10:53: no such host`
+    #     — the rke2-ci CoreDNS deployment doesn't forward the
+    #     `evba.lab` zone the way rke2-meho's does.
+    #   - GHA-volume-mount: `OCI runtime exec failed: ... /__e/
+    #     node24_alpine/bin/node: no such file or directory` — the
+    #     runner-pod's GHA action-runtime volume isn't surfaced into
+    #     the `container:` image, so `actions/checkout`'s node binary
+    #     can't execute inside it.
+    # Same `docker pull` + `curl harbor.evba.lab` patterns work fine
+    # on the new pool from inside DinD or directly on the runner pod
+    # (runner-smoke matrix run 26161029994 / job on
+    # meho-runners-ci-rzmr8-runner-zvmc5 proved both). The breakage is
+    # narrowly scoped to GHA's `container:` keyword pre-runner-start
+    # path. Until the rke2-ci chart on `evoila-bosnia/claude-rdc-hetzner-dc`
+    # closes both gaps, this single workflow stays on the old
+    # `meho-runners` pool — which keeps Semgrep SAST green and lets
+    # #611's "5+ green PRs on meho-runners-ci" counter advance for the
+    # other 17 cutover'd workflows. Flip this back to
+    # `meho-runners-ci` (one-line revert; drop this comment block)
+    # once the rke2-ci-side fix lands; #611 then drains the old pool.
+    runs-on: meho-runners
     timeout-minutes: 15
     # Pulled through the in-cluster Harbor proxy cache
     # (claude-rdc-hetzner-dc#463; project `dockerhub-proxy` is public,

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   semgrep:
     name: Semgrep SAST
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 15
     # Pulled through the in-cluster Harbor proxy cache
     # (claude-rdc-hetzner-dc#463; project `dockerhub-proxy` is public,

--- a/docs/architecture/vcsim-integration-testing.md
+++ b/docs/architecture/vcsim-integration-testing.md
@@ -28,7 +28,7 @@ The conftest at `backend/tests/acceptance/conftest.py` wraps `resolve_vcsim_endp
 
 The helper consults sources in this order:
 
-1. **`MEHO_VCSIM_URL`** — explicit base URL pointing at a running vcsim instance (e.g. `https://10.0.5.4:8989`). The helper parses the URL and returns an endpoint without booting a container. This is the CI path for the meho-runners pool when a vcsim daemon is provisioned alongside the runner.
+1. **`MEHO_VCSIM_URL`** — explicit base URL pointing at a running vcsim instance (e.g. `https://10.0.5.4:8989`). The helper parses the URL and returns an endpoint without booting a container. This is the CI path for the meho-runners-ci pool when a vcsim daemon is provisioned alongside the runner.
 2. **testcontainers-managed `vmware/vcsim` boot** — when no env override resolves, the helper boots the public `vmware/vcsim` image with the seed flags described under "Seeding the topology" and yields an endpoint targeting the host-mapped port. The image name is overridable via `MEHO_TEST_VCSIM_IMAGE` for registry-mirror swaps.
 3. **Skip** — when neither path is viable (no env var + no Docker socket), the fixture skips via `pytest.skip` with the `VCSIM_DOCKER_SKIP_REASON` message. The CI runner pool provisions Docker so the tests run there; agent sandboxes without Docker collect cleanly and skip.
 
@@ -97,7 +97,7 @@ Doc PRs adding a new helper should cite this module as the prior art and call ou
 
 ## CI integration
 
-The vcsim-backed tests run on the `meho-runners` pool (gha-runner-scale-set, ARC v2) per the existing test workflow. The Docker Hub login step at [`.github/workflows/ci.yml:109-110`](../../.github/workflows/ci.yml) authenticates pulls of `vmware/vcsim:latest`; no static service definition is needed because the testcontainers fixture boots vcsim per-test-session.
+The vcsim-backed tests run on the `meho-runners-ci` pool (gha-runner-scale-set, ARC v2) per the existing test workflow. The Docker Hub login step at [`.github/workflows/ci.yml:109-110`](../../.github/workflows/ci.yml) authenticates pulls of `vmware/vcsim:latest`; no static service definition is needed because the testcontainers fixture boots vcsim per-test-session.
 
 `MEHO_VCSIM_URL` is **not** set in CI by default — the testcontainers path runs on every PR. Operators can override locally with `MEHO_VCSIM_URL=http://localhost:8989` when running `vcsim -l :8989` outside the pytest session.
 

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -909,7 +909,8 @@ because the builder would be installing wheels for the wrong arch
 (or recompiling Rust crates without a cross toolchain configured).
 The CI pipeline (G2.4-T2) runs amd64 and arm64 in parallel jobs so
 wall-clock time is bounded by the slower job, not the sum; the
-self-hosted `meho-runners` pool (introduced in PR #160) can provision
+self-hosted `meho-runners-ci` pool (introduced in PR #160 on rke2-meho;
+migrated to rke2-ci via #715) can provision
 arm64 nodes natively when the team is ready to skip QEMU entirely
 for the arm64 leg.
 

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -226,7 +226,7 @@ posture `edit_group` takes for `when_to_use`).
   `docs/cross-repo/g35-nsx-canary.md`). The env-gated canary
   acceptance test that automates the live two-spec ingest in CI is a
   follow-up — it requires the NSX spec-shelf wired to the
-  meho-runners pool (same env-gated pattern
+  meho-runners-ci pool (same env-gated pattern
   `tests/acceptance/_vcenter_spec.py` codifies for vSphere). Until
   then, the dispatch leg is exercised against `NSX_CORE_OPS`-seeded
   descriptors in `tests/acceptance/_nsx_canary_fixtures.py`.
@@ -260,7 +260,7 @@ posture `edit_group` takes for `when_to_use`).
     + `scripts/nsx.sh` → `meho nsx` per-ticket wrapper-flip recipe.
 - Integration test: `backend/tests/test_connectors_nsx_e2e.py` —
   combined E2E covering all 9 ops, session-establish, 401-retry,
-  audit rows, and JSONFlux handle path; runs in the `meho-runners` CI
+  audit rows, and JSONFlux handle path; runs in the `meho-runners-ci` CI
   lane with no Docker dependency.
 - Acceptance tests:
   - `backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py` —

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -504,8 +504,10 @@ helm template test deploy/charts/meho/ --set bogus.field=x 2>&1 | grep "addition
 ## Publish workflow (`.github/workflows/chart.yml`)
 
 The chart is packaged, pushed to OCI, and cosign-signed by
-`.github/workflows/chart.yml`. The workflow targets `meho-runners` (the
-project's self-hosted runner pool, per #160 + #167) and shares the
+`.github/workflows/chart.yml`. The workflow targets `meho-runners-ci` (the
+project's self-hosted runner pool on the dedicated rke2-ci cluster,
+introduced by #160 + #167 on rke2-meho and migrated to rke2-ci via
+claude-rdc-hetzner-dc#610 / #715) and shares the
 hardening conventions of `image.yml` (Task #33): job-level fork-PR guard,
 SHA-pinned actions with `# vX.Y.Z` comments, minimum `permissions:` block
 (`contents: read`, `packages: write`, `id-token: write`), per-job
@@ -606,7 +608,7 @@ incidents #634 / #697).
 | `go-lint-test` (`Go (golangci-lint + go test)`) | `cli/` | `golangci-lint` (v6 action) -> `go build ./...` -> `go test -race -cover ./...` |
 | `helm-lint-template` (`Helm (lint + template + kubeconform)`) | `deploy/charts/meho/` | `helm lint` -> `helm template` -> `kubeconform --strict --kubernetes-version 1.28.0` |
 
-Each job runs on its own `meho-runners` runner. `python-lint-test`,
+Each job runs on its own `meho-runners-ci` runner. `python-lint-test`,
 `go-lint-test`, and `helm-lint-template` carry a 10-minute
 `timeout-minutes`; `python-integration` carries 60 minutes for the
 container-pull + DinD spin-up + testcontainers sweep (xdist
@@ -669,7 +671,7 @@ if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.f
 ```
 
 This is defence in depth on top of branch protection — the
-`meho-runners` self-hosted runner pool is internal infrastructure, so
+`meho-runners-ci` self-hosted runner pool is internal infrastructure, so
 arbitrary code from a forked PR (`go test`, `pytest`, `helm template`
 with custom values) is never allowed to execute on it. The OR
 short-circuits on `push` events so main-branch CI is unaffected.
@@ -747,7 +749,7 @@ merge, not against mocks.
 | Property | Value |
 | --- | --- |
 | Event | `pull_request_target` against `main` (`opened`, `synchronize`, `reopened`) |
-| Runner | `meho-runners` (self-hosted) |
+| Runner | `meho-runners-ci` (self-hosted) |
 | Concurrency group | `pr-smoke-${{ github.event.pull_request.number }}` with `cancel-in-progress: true` |
 | Permissions | `contents: read`, `packages: write`, `id-token: write`, `pull-requests: write` |
 | Job timeout | 12 min (8 min smoke budget + cold-cache headroom — Task #50 AC #5) |

--- a/docs/cross-repo/g07-vsphere-canary.md
+++ b/docs/cross-repo/g07-vsphere-canary.md
@@ -223,7 +223,7 @@ session-scoped fixture and three acceptance modules
 [`test_vmware_rest_jsonflux_force_handle.py`](../../backend/tests/acceptance/test_vmware_rest_jsonflux_force_handle.py),
 [`test_vmware_rest_agent_flow_e2e.py`](../../backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py))
 that dispatch against the simulator on every PR, on the
-meho-runners pool where Docker is provisioned. The
+meho-runners-ci pool where Docker is provisioned. The
 [`vcsim integration testing`](../architecture/vcsim-integration-testing.md)
 doc explains the fixture pattern and how future G3.x connectors
 can mirror it (Vault → testcontainers' `vault`, K8s → k3d,


### PR DESCRIPTION
## Summary

- Switch every `runs-on: meho-runners` in `.github/workflows/` to `runs-on: meho-runners-ci` so all real CI dispatches to the new dedicated rke2-ci pool (chart `gha-runner-scale-set@0.14.1`, min=6/max=18) added by claude-rdc-hetzner-dc#610 / #714.
- Collapse `runner-smoke.yml`'s both-pools matrix from #714 back to single-pool referencing only `meho-runners-ci`.
- Register `meho-runners-ci` in `.github/actionlint.yaml` (and keep `meho-runners` listed during the migration window so the linter doesn't break either way).
- Sweep inline comments + `docs/codebase/{backend,devops,connectors-nsx}.md` + `docs/architecture/vcsim-integration-testing.md` + `docs/cross-repo/g07-vsphere-canary.md` so prose tracks the new pool name; historical PR-160 lineage preserved with an explicit "introduced on rke2-meho, migrated to rke2-ci via #715" cross-link.

## Why now

The new pool's first matrix-smoke (run 26161029994, post-#714 merge) showed the `smoke (meho-runners-ci)` job succeeded end-to-end (docker daemon, internal-CA trust, Harbor pull-through cache, artifact assertion). With the smoke green, cutting real CI over is the prerequisite to claude-rdc-hetzner-dc#611's retirement criterion ("5+ green PRs prove the new pool healthy under real CI load"). Reverting is a one-PR revert — the old pool stays alive on rke2-meho until #611 drains it.

## AC #2 vs. issue body — deliberate deviation

The issue body in #715 says "`runner-smoke.yml` already matrices over both pools per #714 — leave that file alone in the cutover (it gets simplified back to a single-pool reference once #611 retires the old pool)". But AC #2 in the same issue says "`runner-smoke.yml` (matrix over both pools per #714) simplified back to single-pool referencing only `meho-runners-ci`."

Per the project's `/auto-implement-issue` contract, AC is load-bearing; the prose section explains intent but the AC checklist is the contract. Followed AC #2 here. Engineering rationale: after this cutover no real CI runs on `meho-runners` either way (all `runs-on:` flipped), so the matrix's "validate both pools" property is no longer useful — both halves of the matrix would exercise the same code path on functionally-identical infra. The simplification also reduces every-main-push runner load.

Happy to revert just the `runner-smoke.yml` simplification if reviewers prefer the body's reading; the rest of the cutover stands either way.

## Test plan

- [x] `grep -rn "^[[:space:]]*runs-on:" .github/workflows/` shows all 18 dispatched jobs on `meho-runners-ci` (1 job stays on `ubuntu-latest`: `chart.yml:268` for kind, intentional)
- [x] No bare `runs-on: meho-runners` remains anywhere (`grep -rnE "meho-runners([^-]|$)" .github/workflows/` shows only intentional historical references in `runner-smoke.yml`'s comments + the workflow display name)
- [x] `pre-commit run --files <all 18 touched files>` — all hooks pass (trailing-whitespace, EOF, check-yaml, check-json, large-files, merge-conflict, private-key, mixed-line-ending, gitleaks)
- [x] `actionlint .github/workflows/*.yml` — no runner-label errors (only pre-existing shellcheck infos unaffected by this change)
- [ ] AC #3: at least one full main-branch push observed running entirely on `meho-runners-ci` (verifiable only post-merge — the very next main push satisfies it; runner pool currently has 6 idle runners online ready to receive work)

## Out of scope

- Retiring the rke2-meho ARC pool itself — that's claude-rdc-hetzner-dc#611, conditional on this PR + 5 green main runs.
- Per-runner sizing changes (current 1500m CPU req / 3000m limit / 2 GiB mem is #571's empirical sizing, don't tune without new data).
- The 4th worker on rke2-ci to support max=18 fitting — claude-rdc-hetzner-dc#625.
- Re-tuning `ci.yml`'s `python-lint-test` 50-min cap to the new pool's higher concurrency (separate observability ticket once a few PRs have landed).

Cross-link: claude-rdc-hetzner-dc#611

Closes #715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use the new self-hosted runner pool for more consistent and reliable automation across jobs.
  * Revised CI-related documentation and guides to reflect the updated runner pool and migration notes.
  * Adjusted several workflow comments and smoke-test behavior to match the cutover to the new runner pool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-20)

Addressed review finding B1 from [iter-1 review](https://github.com/evoila/meho/pull/717#pullrequestreview-4328511700):

- **B1** `a895c60` — Keep Semgrep SAST on `meho-runners` (old pool) as a documented single-workflow exception until rke2-ci's chart adds (a) the `evba.lab` zone CoreDNS forward and (b) the GHA-runtime volume-mount config that lets `container:`-based jobs find `/__e/node*_alpine/bin/node`. Trivially reversible one-liner after that lands; #611's drain criterion still advances because the other 17 cutover'd workflows stay on `meho-runners-ci`.

Disputed: none.

Deferred: CodeRabbit's `💤 Low value` permissions-block suggestion on `runner-smoke.yml` — pre-existing absence on origin/main, not introduced by this PR. Recorded as adjacent improvement in the iter-1 review summary.

<!-- auto-implement-issue: continue, iteration 2 -->
