### PR TITLE
chore(cli): gofmt -w sddc-manager domain.go + network_pool.go

### DIFF
--- a/cli/internal/cmd/sddc-manager/domain.go
+++ b/cli/internal/cmd/sddc-manager/domain.go
@@ -35,7 +35,7 @@ func newDomainListCmd() *cobra.Command {
 		Short: "List VCF domains (management + workload)",
 		Long: "list dispatches GET:/v1/domains against connector_id=\"sddc-rest-9.0\".\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager domain list --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager domain list --target rdc-sddc-manager",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -95,7 +95,7 @@ func newDomainInfoCmd() *cobra.Command {
 		Long: "info dispatches GET:/v1/domains/{id} against connector_id=\"sddc-rest-9.0\".\n" +
 			"Requires a domain id from `sddc-manager domain list`.\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager domain info domain-mgmt --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager domain info domain-mgmt --target rdc-sddc-manager",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -129,15 +129,15 @@ func printDomainInfo(w io.Writer, r *CallResult) {
 		return
 	}
 	var d struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-		Type string `json:"type"`
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Type     string `json:"type"`
 		VCenters []struct {
 			ID   string `json:"id"`
 			FQDN string `json:"fqdn"`
 		} `json:"vcenters"`
 		NsxtCluster *struct {
-			ID     string `json:"id"`
+			ID      string `json:"id"`
 			VipFQDN string `json:"vipFqdn"`
 		} `json:"nsxtCluster"`
 		Clusters []struct {

--- a/cli/internal/cmd/sddc-manager/network_pool.go
+++ b/cli/internal/cmd/sddc-manager/network_pool.go
@@ -34,7 +34,7 @@ func newNetworkPoolListCmd() *cobra.Command {
 		Short: "List VCF network pools (IP ranges and VLANs for host commission)",
 		Long: "list dispatches GET:/v1/network-pools against connector_id=\"sddc-rest-9.0\".\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
-		Example: "  meho sddc-manager network-pool list --target rdc-sddc-manager",
+		Example:       "  meho sddc-manager network-pool list --target rdc-sddc-manager",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,


### PR DESCRIPTION
Pure formatting fix. `#709` (`feat(cli): meho sddc-manager verb tree for sddc-rest-9.0`) introduced two sddc-manager files without running `gofmt`; golangci-lint on `main` has been red since:

```
##[error]/home/runner/_work/meho/meho/cli/internal/cmd/sddc-manager/domain.go:38:1: File is not properly formatted (gofmt)
##[error]/home/runner/_work/meho/meho/cli/internal/cmd/sddc-manager/network_pool.go:37:1: File is not properly formatted (gofmt)
```

One-shot `gofmt -w cli/internal/cmd/sddc-manager/*.go`. Diff is the struct-field alignment + `Example:` spacing that gofmt enforces.

Surfaced while investigating CI failures on [#714](https://github.com/evoila/meho/pull/714) (the matrix runner-smoke change) — both failures were pre-existing on main. This PR addresses the Go failure; the Python failure (`KeyError: 'override_op'` in `test_set_via_mcp_writes_audit_row_with_override_diff`) is a separate audit-payload mismatch I haven't touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed formatting and whitespace in CLI command examples and help text for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->