### PR TITLE
fix(mcp): write_mcp_audit_row merges audit_* contextvars into payload (#710 regression)

### DIFF
--- a/backend/src/meho_backplane/mcp/audit.py
+++ b/backend/src/meho_backplane/mcp/audit.py
@@ -59,6 +59,7 @@ from typing import Any
 
 import structlog
 
+from meho_backplane.audit import _resolve_audit_payload
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
@@ -105,6 +106,21 @@ async def write_mcp_audit_row(
     explicitly keeps the audit row's tenant attribution auditable at
     the call site rather than buried in a contextvar resolver.
 
+    The final ``payload`` written to the row is the caller's explicit
+    payload **merged on top of** any ``audit_*`` contextvars routed
+    through :func:`~meho_backplane.audit._resolve_audit_payload`. This
+    matches the REST middleware's behaviour
+    (:func:`~meho_backplane.audit.AuditMiddleware.dispatch` reads the
+    same helper at audit-write time) and lets MCP-side handlers enrich
+    the row by binding ``audit_*`` contextvars without the envelope
+    having to know about every per-handler field. Caller-supplied
+    keys win on collision (``op_id`` / ``op_class`` / ``params_hash``
+    / ``broadcast_detail_*`` are load-bearing identity and must not
+    be overwritten by stale contextvars from an earlier call on the
+    same task). #710's ``meho.broadcast.overrides.set`` (REST + MCP
+    parity) is the v0.2 caller; future MCP meta-tools that bind
+    ``audit_*`` contextvars inherit the same surfacing automatically.
+
     Raises any DB-side exception verbatim — the caller's ``finally``
     block converts it into a JSON-RPC ``-32603`` so the client sees
     the operation as failed and the audit-write failure is the
@@ -122,6 +138,15 @@ async def write_mcp_audit_row(
     audit id used for the row so the dispatch call site can plumb it
     through to ``publish_event`` either way.
     """
+    # Merge ``audit_*`` contextvars into the row payload — same
+    # surfacing the REST middleware does. Caller's payload wins on
+    # collision so the MCP envelope's load-bearing identity keys
+    # (``op_id`` / ``op_class`` / ``params_hash``) are never
+    # overwritten by stale contextvars.
+    contextvar_payload = _resolve_audit_payload()
+    if contextvar_payload:
+        payload = {**contextvar_payload, **payload}
+
     log = structlog.get_logger(__name__)
     if audit_id is None:
         audit_id = uuid.uuid4()


### PR DESCRIPTION
## Summary

Restores `Python (ruff + mypy + pytest)` lane on main. [#710 (G6.3-T5 broadcast overrides)](https://github.com/evoila/meho/pull/710) merged with a `_bind_set_audit` handler-side contextvar binding that the MCP envelope's audit-row writer never read.

## Root cause

[#710](https://github.com/evoila/meho/pull/710) added [`_bind_set_audit`](backend/src/meho_backplane/api/v1/broadcast_overrides.py) which binds `audit_override_op`, `audit_override_id`, `audit_override_pattern`, and `audit_override_detail` into structlog contextvars before the handler returns. The expectation: the audit-row writer reads every `audit_*` contextvar at write time, strips the prefix, and merges the result into `audit_log.payload` — same pattern the REST middleware has used since the chassis era.

The REST middleware does this at [audit.py:613](backend/src/meho_backplane/audit.py#L613): `payload = _resolve_audit_payload()` seeds the row from contextvars, then the explicit broadcast-detail keys are added on top.

The **MCP envelope's** audit-write path ([mcp/audit.py](backend/src/meho_backplane/mcp/audit.py) `write_mcp_audit_row`) took the caller's explicit payload literally and never merged contextvars in. So when the same handler ran through the MCP transport (`meho.broadcast.overrides.set` tool call), the audit_log row landed without the override-diff fragment, and the `test_set_via_mcp_writes_audit_row_with_override_diff[tenant_admin]` test failed with `KeyError: 'override_op'` on the unit lane.

This is the direct parallel of [#704 (audit contextvar fix for the dispatcher)](https://github.com/evoila/meho/pull/704) one architecture-layer over: same root-cause class — explicit-payload writer that ignored `audit_*` contextvars and bypassed a binding the handler relied on.

## Fix

[`write_mcp_audit_row`](backend/src/meho_backplane/mcp/audit.py) reads `_resolve_audit_payload()` and merges the result into the row payload **before** the `AuditLog` insert. Caller-supplied keys win on collision — the MCP envelope's load-bearing identity fields (`op_id` / `op_class` / `params_hash` / `broadcast_detail_origin` / `broadcast_detail_effective`) are authoritative and must not be overwritten by stale contextvars from an earlier call on the same task.

## Verification

- `tests/test_mcp_broadcast_overrides_tools.py::test_set_via_mcp_writes_audit_row_with_override_diff[tenant_admin]` — **PASS** (was FAIL on main)
- `ruff check` + `ruff format --check` + `mypy --strict` all clean on touched file

## Unblocks

- `Python (ruff + mypy + pytest)` lane on main (currently FAIL since #710 merged at 10:50Z)
- [PR #713 (handler_ref registration guard)](https://github.com/evoila/meho/pull/713) inherits the unit failure from main; this PR is its sibling unblocker

## Refs

- Regression source: [#710](https://github.com/evoila/meho/pull/710) (G6.3-T5)
- Architectural sibling: [#704](https://github.com/evoila/meho/pull/704) (dispatcher-side audit contextvar fix)
- v0.3 ship gating: [#367](https://github.com/evoila/meho/issues/367) (G3.4 bind9) closes after this lands + #713 merges + #697 closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit logs now automatically incorporate context variable values during write operations, ensuring all contextual data is properly captured without requiring manual payload specification.

* **Documentation**
  * Updated audit logging documentation to clarify how audit payloads are composed through merging, with caller-supplied values taking precedence to preserve identity fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->