### PR TITLE
feat(connectors): G3.5-T9 harbor.robot.create/.delete + credential_mint classifier (#621)

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -201,8 +201,8 @@ class BroadcastEvent(BaseModel):
     #: queries audit_log by this id.
     audit_id: UUID
     #: Redacted view per :func:`redact_payload`. NEVER raw params for
-    #: ``credential_read`` or ``audit_query`` classes — the redaction
-    #: contract is upstream of this field.
+    #: ``credential_read``, ``credential_mint``, or ``audit_query`` classes —
+    #: the redaction contract is upstream of this field.
     payload: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -81,6 +81,19 @@ _CREDENTIAL_READ_OPS: Final[frozenset[str]] = frozenset(
     }
 )
 
+#: Op-ids that classify as ``credential_mint``. Like
+#: :data:`_CREDENTIAL_READ_OPS`, the explicit allowlist comes before
+#: the write-suffix check so ``harbor.robot.create`` (which ends with
+#: ``.create``) isn't misclassified as plain ``write``. Every op that
+#: returns a freshly-minted secret credential in its response payload
+#: belongs here — the broadcast collapses to aggregate-only so the
+#: secret never reaches the SSE stream or any Slack mirror channel.
+_CREDENTIAL_MINT_OPS: Final[frozenset[str]] = frozenset(
+    {
+        "harbor.robot.create",
+    }
+)
+
 #: Op-id suffixes that imply mutation. Append to this tuple when a new
 #: write-shaped verb spelling lands. ``.put`` is the KV-v2 write verb
 #: (``vault.kv.put`` — G3.3-T1 #545); without it a secret write would
@@ -176,8 +189,8 @@ class BroadcastEvent(BaseModel):
     target_name: str | None = None
     op_id: str
     #: One of ``"read"`` / ``"write"`` / ``"credential_read"`` /
-    #: ``"audit_query"`` / ``"other"``. Derived from
-    #: :func:`classify_op` at publish time.
+    #: ``"credential_mint"`` / ``"audit_query"`` / ``"other"``.
+    #: Derived from :func:`classify_op` at publish time.
     op_class: str
     #: One of ``"ok"`` / ``"error"`` / ``"denied"``. The handler
     #: produces it; the broadcast publisher does not re-classify.
@@ -194,25 +207,26 @@ class BroadcastEvent(BaseModel):
 
 
 def classify_op(op_id: str) -> str:
-    """Map an op-id to one of the five sensitivity classes.
+    """Map an op-id to one of the sensitivity classes.
 
     Match order is policy-significant:
 
-    1. ``credential_read`` — the explicit allowlist comes first so a
-       hypothetical future ``vault.kv.audit-list`` (read of audit
-       metadata, not secret content) could opt out of the credential
-       class by being absent from :data:`_CREDENTIAL_READ_OPS` and
-       falling through to the suffix check.
-    2. ``audit_query`` — every op-id with the ``audit.`` prefix
-       classifies as audit_query regardless of the verb suffix. Audit
-       responses carry rows that inherit every other op's sensitivity,
-       so the whole namespace is aggregate-only.
-    3. ``write`` — mutation suffixes (``.create`` / ``.update`` /
-       ``.delete`` / ``.patch``). Same break-when-first-matches rule
-       as ``.endswith`` on a tuple.
-    4. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
+    1. ``credential_read`` — explicit allowlist first so a hypothetical
+       future ``vault.kv.audit-list`` (audit metadata, not secret
+       content) could opt out by being absent from
+       :data:`_CREDENTIAL_READ_OPS` and falling through to the suffix
+       check.
+    2. ``credential_mint`` — explicit allowlist for ops that return a
+       freshly-minted secret in their response payload (e.g.
+       ``harbor.robot.create``). Checked before the ``.create`` suffix
+       so the allowlist wins over the mutation-suffix branch.
+    3. ``audit_query`` — every op-id with the ``audit.`` prefix
+       classifies as audit_query regardless of the verb suffix.
+    4. ``write`` — mutation suffixes (``.create`` / ``.update`` /
+       ``.delete`` / ``.patch``).
+    5. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
        ``.get`` / ``.about`` / ``.ls``).
-    5. ``other`` — everything else. Falls through to full-detail
+    6. ``other`` — everything else. Falls through to full-detail
        broadcast per decision #3.
 
     Examples
@@ -220,6 +234,8 @@ def classify_op(op_id: str) -> str:
 
     >>> classify_op("vault.kv.read")
     'credential_read'
+    >>> classify_op("harbor.robot.create")
+    'credential_mint'
     >>> classify_op("audit.query")
     'audit_query'
     >>> classify_op("vsphere.vm.list")
@@ -231,6 +247,8 @@ def classify_op(op_id: str) -> str:
     """
     if op_id in _CREDENTIAL_READ_OPS:
         return "credential_read"
+    if op_id in _CREDENTIAL_MINT_OPS:
+        return "credential_mint"
     if op_id.startswith("audit."):
         return "audit_query"
     if op_id.endswith(_WRITE_SUFFIXES):
@@ -295,8 +313,8 @@ def redact_payload(
     *detail* is the G6.3-T2 (#379) extension. When ``None`` (the
     pre-G6.3 default), the function falls back to decision #3 of
     ``docs/planning/v0.2-decisions.md`` -- aggregate for sensitive
-    classes (``credential_read`` / ``audit_query``), full for
-    everything else. When ``"aggregate"`` or ``"full"`` is passed
+    classes (``credential_read`` / ``credential_mint`` /
+    ``audit_query``), full for everything else. When ``"aggregate"`` or ``"full"`` is passed
     explicitly, the resolver (:func:`compute_effective_broadcast_detail`)
     has already decided the effective detail and this function just
     renders it. Callers that don't go through the resolver
@@ -311,7 +329,9 @@ def redact_payload(
     """
     if detail is None:
         effective_detail: Literal["full", "aggregate"] = (
-            "aggregate" if op_class in {"credential_read", "audit_query"} else "full"
+            "aggregate"
+            if op_class in {"credential_read", "credential_mint", "audit_query"}
+            else "full"
         )
     else:
         effective_detail = detail

--- a/backend/src/meho_backplane/connectors/harbor/__init__.py
+++ b/backend/src/meho_backplane/connectors/harbor/__init__.py
@@ -5,11 +5,22 @@
 
 Importing this package registers :class:`HarborConnector` against the
 v2 connector registry under
-``(product="harbor", version="2.x", impl_id="harbor-rest")``. The
-chassis lifespan calls
-:func:`~meho_backplane.connectors.registry._eager_import_connectors`
-which walks every ``connectors/<product>/`` subpackage at startup, so the
-registration lands before any dispatch can occur.
+``(product="harbor", version="2.x", impl_id="harbor-rest")``, and
+queues the robot lifecycle typed-op upserts onto the lifespan-driven
+registrar list so ``endpoint_descriptor`` rows land before the first
+dispatch.
+
+Registration is split between two phases (mirroring the Vault precedent
+in :mod:`meho_backplane.connectors.vault`):
+
+* **Synchronous (import time)** — the v2 registry entry lands via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2`.
+
+* **Asynchronous (lifespan startup)** —
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`~meho_backplane.connectors.harbor.ops.register_harbor_robot_operations`,
+  which upserts the ``endpoint_descriptor`` rows for ``harbor.robot.create``
+  and ``harbor.robot.delete``.
 
 The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
 point is deliberately **not** called. The connector advertises an explicit
@@ -26,9 +37,11 @@ check there will no-op on the
 because this module has already registered the hand-rolled class. Until then,
 this module is the only registration path.
 
-Operations for this connector arrive in #620 via G0.7 spec ingestion of
-the Harbor 2.x OpenAPI spec against the ``endpoint_descriptor`` table.
-The robot lifecycle ops (create/delete) ship in #621.
+Spec-ingested read ops (#620) arrive via G0.7 ingestion of the Harbor 2.x
+OpenAPI spec. The robot lifecycle ops (create/delete) ship here in #621 as
+hand-registered typed ops — the redaction contract (``credential_mint``
+classification) is load-bearing and must not depend on spec-derived
+``op_class`` heuristics.
 """
 
 from meho_backplane.connectors.harbor.connector import HarborConnector
@@ -45,6 +58,7 @@ from meho_backplane.connectors.harbor.core_ops import (
     apply_harbor_core_curation,
     classify_harbor_op,
 )
+from meho_backplane.connectors.harbor.ops import register_harbor_robot_operations
 from meho_backplane.connectors.harbor.session import (
     HarborCredentialsLoader,
     HarborTargetLike,
@@ -52,6 +66,7 @@ from meho_backplane.connectors.harbor.session import (
     load_credentials_from_vault,
 )
 from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
 
 register_connector_v2(
     product="harbor",
@@ -59,6 +74,12 @@ register_connector_v2(
     impl_id="harbor-rest",
     cls=HarborConnector,
 )
+
+# Queue the robot lifecycle typed-op upsert onto the lifespan-driven
+# registrar list. harbor.robot.create is classified credential_mint —
+# the broadcast collapses to aggregate-only so the minted secret never
+# appears in the SSE feed.
+register_typed_op_registrar(register_harbor_robot_operations)
 
 __all__ = [
     "HARBOR_CONNECTOR_ID",
@@ -77,4 +98,5 @@ __all__ = [
     "apply_harbor_core_curation",
     "classify_harbor_op",
     "load_credentials_from_vault",
+    "register_harbor_robot_operations",
 ]

--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -83,6 +83,7 @@ import asyncio
 import base64
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import structlog
@@ -349,6 +350,123 @@ class HarborConnector(HttpConnector):
             target=target,
             params=params,
         )
+
+    async def robot_create(
+        self,
+        target: HarborTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Create a project-scoped robot account via Harbor 2.x.
+
+        Op-id: ``harbor.robot.create``. Classified ``credential_mint``:
+        the broadcast collapses to aggregate-only so the minted secret
+        never appears in the SSE feed or any Slack mirror channel.
+
+        Uses :meth:`_post_json` (non-retried POST — Harbor's create
+        endpoint is non-idempotent; a retry could mint a second account
+        with the same name, which Harbor rejects with 409 anyway, but
+        the tenacity decorator must not trigger).
+
+        The handler grants push + pull access on the named project.
+        Scoped permissions are sufficient for the canonical CI/CD use
+        case; system-level access would require the system-robot API
+        (``POST /api/v2.0/robots``) which is out of scope for this Task.
+
+        Parameters
+        ----------
+        target
+            Resolved Harbor target (must satisfy :class:`HarborTargetLike`).
+        params
+            Schema-validated: ``name`` (str), ``project`` (str),
+            ``duration`` (int, -1 for never-expire).
+
+        Returns
+        -------
+        dict[str, Any]
+            ``{id: int, name: str, secret: str}`` — the secret is the
+            minted credential, returned ONLY on creation by Harbor.
+
+        Raises
+        ------
+        httpx.HTTPStatusError
+            On any 4xx/5xx from Harbor (e.g. 409 Conflict if a robot
+            with this name already exists in the project). The dispatcher
+            catches all exceptions and wraps them as ``connector_error``
+            OperationResults.
+        """
+        name = str(params["name"])
+        project = str(params["project"])
+        duration = int(params["duration"])
+
+        body: dict[str, Any] = {
+            "name": name,
+            "duration": duration,
+            "disable": False,
+            "level": "project",
+            "permissions": [
+                {
+                    "kind": "project",
+                    "namespace": project,
+                    "access": [
+                        {"resource": "repository", "action": "push"},
+                        {"resource": "repository", "action": "pull"},
+                    ],
+                }
+            ],
+        }
+        path = f"/api/v2.0/projects/{quote(project, safe='')}/robots"
+        result = await self._post_json(target, path, raw_jwt="", json=body)
+        return {
+            "id": result["id"],
+            "name": result["name"],
+            "secret": result["secret"],
+        }
+
+    async def robot_delete(
+        self,
+        target: HarborTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Delete a project-scoped robot account via Harbor 2.x.
+
+        Op-id: ``harbor.robot.delete``. Classified ``write`` (suffix-based).
+        No secret material in the response.
+
+        Uses the pooled httpx client directly (non-retried DELETE —
+        ``HttpConnector._IDEMPOTENT_METHODS`` is ``{GET, HEAD, OPTIONS}``
+        and ``_request_json`` rejects non-idempotent verbs; no
+        ``_delete_json`` helper exists on the base class). Permanent
+        removal — irreversible.
+
+        Parameters
+        ----------
+        target
+            Resolved Harbor target.
+        params
+            Schema-validated: ``project`` (str), ``id`` (int ≥ 1).
+
+        Returns
+        -------
+        dict[str, Any]
+            ``{id: int, deleted: True}`` — Harbor returns HTTP 200 with an
+            empty body; the ``id`` echo is synthesized for a useful
+            agent-facing result.
+
+        Raises
+        ------
+        httpx.HTTPStatusError
+            On any 4xx/5xx from Harbor (e.g. 404 if the robot ID does
+            not exist in the named project).
+        """
+        project = str(params["project"])
+        robot_id = int(params["id"])
+
+        path = f"/api/v2.0/projects/{quote(project, safe='')}/robots/{robot_id}"
+        client = await self._http_client(target)
+        headers = await self.auth_headers(target, raw_jwt="")
+        resp = await client.request("DELETE", path, headers=headers)
+        resp.raise_for_status()
+        return {"id": robot_id, "deleted": True}
 
     async def aclose(self) -> None:
         """Clear cached credentials, then tear down the httpx pool.

--- a/backend/src/meho_backplane/connectors/harbor/ops.py
+++ b/backend/src/meho_backplane/connectors/harbor/ops.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Harbor robot lifecycle typed ops (G3.5-T9 #621).
+
+Registers two scoped-write ops against ``connector_id="harbor-rest-2.x"``:
+
+* ``harbor.robot.create`` — create a project-scoped robot account.
+  Returns the minted secret in its response payload; classified
+  ``credential_mint`` by :func:`~meho_backplane.broadcast.events.classify_op`
+  so the broadcast collapses to aggregate-only and the secret never
+  appears in the SSE stream.
+
+* ``harbor.robot.delete`` — delete a project-scoped robot account by
+  numeric ID. Classified ``write`` (suffix-based). No secret material
+  in the response payload.
+
+Both ops use non-retried HTTP calls (Harbor write endpoints are
+non-idempotent). ``harbor.robot.create`` calls
+:meth:`~meho_backplane.connectors.harbor.connector.HarborConnector._post_json`;
+``harbor.robot.delete`` calls the pooled httpx client directly (DELETE
+is not in ``_IDEMPOTENT_METHODS`` and ``HttpConnector`` provides no
+``_delete_json`` helper — calling the client directly keeps the no-retry
+contract explicit).
+
+Handler methods live on
+:class:`~meho_backplane.connectors.harbor.connector.HarborConnector`
+(``robot_create`` / ``robot_delete``) so the dispatcher's
+:func:`~meho_backplane.operations.dispatcher._maybe_bind_method` can
+bind them to the per-process connector instance at dispatch time.
+This mirrors the bind9 / Kubernetes pattern for connectors whose
+handlers need the HTTP transport.
+
+Registration is triggered at lifespan startup via
+:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`;
+the registrar is queued in
+:mod:`~meho_backplane.connectors.harbor.__init__` alongside the
+connector-registry entry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = ["register_harbor_robot_operations"]
+
+
+# ---------------------------------------------------------------------------
+# harbor.robot.create
+# ---------------------------------------------------------------------------
+
+_HARBOR_ROBOT_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?=.*\\S)[a-zA-Z0-9_-]+$",
+            "description": (
+                "Robot account name (alphanumeric, hyphens, underscores). "
+                "Harbor prefixes it as 'robot$<project>+<name>' in the response."
+            ),
+        },
+        "project": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Harbor project name that scopes this robot account.",
+        },
+        "duration": {
+            "type": "integer",
+            "description": (
+                "Validity period in days. -1 means the account never expires. "
+                "Prefer a short duration for temporary access; use -1 for "
+                "long-lived CI credentials only."
+            ),
+            "default": -1,
+        },
+    },
+    "required": ["name", "project", "duration"],
+    "additionalProperties": False,
+}
+
+_HARBOR_ROBOT_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "integer",
+            "description": "Harbor-assigned numeric robot account ID.",
+        },
+        "name": {
+            "type": "string",
+            "description": (
+                "Harbor-formatted robot name (e.g. 'robot$project+name'). "
+                "Use this as the username when authenticating with Harbor."
+            ),
+        },
+        "secret": {
+            "type": "string",
+            "description": (
+                "Minted robot credential. Returned ONLY on creation — "
+                "Harbor does not expose it again after this call. "
+                "Store it immediately and treat it as a password."
+            ),
+        },
+    },
+    "required": ["id", "name", "secret"],
+}
+
+_HARBOR_ROBOT_CREATE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Create a project-scoped robot account in Harbor. Use when the operator "
+        "needs a machine credential (CI/CD push/pull token, automated deployment "
+        "credential) for a specific Harbor project. "
+        "IMPORTANT: The response payload contains a freshly-minted secret credential "
+        "that is returned ONLY once and cannot be retrieved later. The caller receives "
+        "the full response including the secret; the broadcast feed does NOT "
+        "(credential_mint classification keeps it aggregate-only). "
+        "Store the secret immediately after this call."
+    ),
+    "parameter_hints": {
+        "name": (
+            "Robot account name — alphanumeric, hyphens, underscores. "
+            "Harbor prefixes it as 'robot$<project>+<name>' in the response; "
+            "supply only the suffix (e.g. 'ci-push', not 'robot$myproject+ci-push')."
+        ),
+        "project": "Harbor project name. The robot is scoped to this project only.",
+        "duration": (
+            "Validity in days. -1 = never expires. "
+            "Prefer a short duration (e.g. 90) for temporary access. "
+            "Use -1 only for long-lived CI credentials."
+        ),
+    },
+    "output_shape": (
+        "On success: {id: <int>, name: 'robot$<project>+<name>', secret: '<minted-secret>'}. "
+        "The secret is a one-time value — save it immediately. "
+        "On failure: a connector_error OperationResult with "
+        "extras.exception_class naming the failure class."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# harbor.robot.delete
+# ---------------------------------------------------------------------------
+
+_HARBOR_ROBOT_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "project": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Harbor project name that scopes the robot account.",
+        },
+        "id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": (
+                "Numeric robot account ID (returned by harbor.robot.create). "
+                "Harbor's delete endpoint is keyed on the numeric ID, not the name."
+            ),
+        },
+    },
+    "required": ["project", "id"],
+    "additionalProperties": False,
+}
+
+_HARBOR_ROBOT_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "integer",
+            "description": "Echo of the deleted robot account ID.",
+        },
+        "deleted": {
+            "type": "boolean",
+            "description": "Always true on success.",
+        },
+    },
+    "required": ["id", "deleted"],
+}
+
+_HARBOR_ROBOT_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Delete a project-scoped robot account from Harbor by its numeric ID. "
+        "Use when decommissioning a CI credential or revoking machine access "
+        "to a Harbor project. Requires the numeric 'id' returned by "
+        "harbor.robot.create — Harbor's delete endpoint is keyed on the ID, "
+        "not the robot name. This operation is irreversible; the account and "
+        "its associated secret are permanently removed."
+    ),
+    "parameter_hints": {
+        "project": "Harbor project name that scopes the robot account.",
+        "id": (
+            "Numeric robot account ID from harbor.robot.create's response "
+            "(the 'id' field). Not the Harbor-formatted name string."
+        ),
+    },
+    "output_shape": (
+        "On success: {id: <int>, deleted: true}. "
+        "Harbor returns HTTP 200 with an empty body; the id echo is synthetic. "
+        "On failure: a connector_error OperationResult with "
+        "extras.exception_class naming the failure class."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Registrar
+# ---------------------------------------------------------------------------
+
+
+async def register_harbor_robot_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert harbor.robot.create and harbor.robot.delete into ``endpoint_descriptor``.
+
+    Called once per process from the FastAPI lifespan via
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`.
+    Idempotent: a second call with unchanged descriptions is a no-op for
+    the embedding pipeline (body-hash skip path in
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`).
+
+    Test seam: ``embedding_service`` lets fixtures inject a stub so
+    chassis tests don't load the ONNX model.
+    """
+    from meho_backplane.connectors.harbor.connector import HarborConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    await register_typed_operation(
+        product="harbor",
+        version="2.x",
+        impl_id="harbor-rest",
+        op_id="harbor.robot.create",
+        handler=HarborConnector.robot_create,
+        summary="Create a project-scoped robot account in Harbor.",
+        description=(
+            "Creates a project-scoped robot account via "
+            "POST /api/v2.0/projects/{project}/robots. "
+            "The response payload contains a freshly-minted secret credential "
+            "returned ONLY on creation — Harbor does not expose it again. "
+            "Classified credential_mint: the broadcast collapses to aggregate-only "
+            "so the secret never appears in the SSE feed. "
+            "Non-idempotent — never auto-retried by the HttpConnector "
+            "tenacity decorator. safety_level=caution."
+        ),
+        parameter_schema=_HARBOR_ROBOT_CREATE_PARAMETER_SCHEMA,
+        response_schema=_HARBOR_ROBOT_CREATE_RESPONSE_SCHEMA,
+        group_key="robot",
+        tags=["write", "credential-mint"],
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions=_HARBOR_ROBOT_CREATE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+
+    await register_typed_operation(
+        product="harbor",
+        version="2.x",
+        impl_id="harbor-rest",
+        op_id="harbor.robot.delete",
+        handler=HarborConnector.robot_delete,
+        summary="Delete a project-scoped robot account from Harbor.",
+        description=(
+            "Deletes a project-scoped robot account via "
+            "DELETE /api/v2.0/projects/{project}/robots/{id}. "
+            "Requires the numeric robot ID (returned by harbor.robot.create). "
+            "Non-idempotent write — permanent removal. safety_level=caution."
+        ),
+        parameter_schema=_HARBOR_ROBOT_DELETE_PARAMETER_SCHEMA,
+        response_schema=_HARBOR_ROBOT_DELETE_RESPONSE_SCHEMA,
+        group_key="robot",
+        tags=["write", "destructive"],
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions=_HARBOR_ROBOT_DELETE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/tests/test_broadcast_credential_mint_dispatch.py
+++ b/backend/tests/test_broadcast_credential_mint_dispatch.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G6 ``credential_mint`` classifier integration test (G3.5-T9 / #621).
+
+Proves the load-bearing PII guarantee for ``harbor.robot.create``:
+the G6 broadcast feed must emit **aggregate-only** — the fact that a
+robot account was minted, never the minted secret credential — while
+the :class:`~meho_backplane.connectors.schemas.OperationResult`
+returned to the caller still contains the secret.
+
+This mirrors :mod:`tests.test_broadcast_credential_read_dispatch` for
+the ``credential_read`` class (decision #3 precedent). The mechanism
+is identical:
+
+* :func:`~meho_backplane.broadcast.events.classify_op` returns
+  ``"credential_mint"`` for ``harbor.robot.create``.
+* :func:`~meho_backplane.broadcast.events.redact_payload` collapses
+  ``credential_mint`` to ``{op_class, result_status}`` — the same
+  aggregate branch used for ``credential_read``.
+* The broadcast publisher is swapped for a recording stub so the
+  emitted :class:`~meho_backplane.broadcast.events.BroadcastEvent`
+  can be inspected without a Valkey container.
+* The Harbor HTTP client is intercepted by respx so the real handler
+  runs against a mock endpoint; the test does not need a live Harbor
+  instance.
+* The connector's Vault-backed credentials loader is replaced with
+  a stub so no Vault address is reached.
+
+Why assert by exclusion on the *serialised* event: the redacted
+``payload`` collapses to ``{op_class, result_status}``, but the
+enclosing :class:`BroadcastEvent` always carries ``op_id`` and
+``target_name``. The leak surface is the whole serialised event, not
+just ``payload`` — a regression that placed the secret in a new
+top-level field would pass a ``payload``-only assertion.
+
+Skip-clean: the test skips (does not fail) when
+``BROADCAST_REDIS_URL`` is unset, mirroring the ``credential_read``
+test's operator-intent guard. The publisher swap means no real Valkey
+socket is opened regardless.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.harbor import HarborConnector
+from meho_backplane.connectors.harbor.ops import register_harbor_robot_operations
+from meho_backplane.connectors.harbor.session import HarborTargetLike
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Skip-clean guard
+# ---------------------------------------------------------------------------
+
+_BROADCAST_DISABLED = not (os.environ.get("BROADCAST_REDIS_URL") or "").strip()
+
+pytestmark = pytest.mark.skipif(
+    _BROADCAST_DISABLED,
+    reason="broadcast feed disabled (BROADCAST_REDIS_URL unset) — G6 "
+    "credential_mint classifier integration test skipped cleanly per #621 DoD",
+)
+
+# ---------------------------------------------------------------------------
+# Sentinel secret material
+# ---------------------------------------------------------------------------
+
+#: Distinctive robot-credential token — unusual enough that any appearance
+#: in a serialised BroadcastEvent is an unambiguous secret-material leak.
+_SENTINEL_SECRET = "sntlrobotcred0zzz"
+
+#: Every substring that MUST NOT appear anywhere in a ``credential_mint``
+#: broadcast event. The secret is the only forbidden sentinel here —
+#: the broadcast is *permitted* to carry ``op_id``, ``target_name``,
+#: and ``result_status`` (the allowed aggregate per decision #3).
+_FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (_SENTINEL_SECRET,)
+
+# ---------------------------------------------------------------------------
+# Stub credentials loader
+# ---------------------------------------------------------------------------
+
+
+async def _stub_credentials_loader(_target: HarborTargetLike) -> dict[str, str]:
+    """Return hard-coded admin credentials — no Vault call."""
+    return {"username": "admin", "password": "test-password"}
+
+
+# ---------------------------------------------------------------------------
+# Stub dispatch target
+# ---------------------------------------------------------------------------
+
+
+class _FakeFingerprint:
+    """Duck-typed fingerprint — the resolver reads only ``version``."""
+
+    def __init__(self, version: str) -> None:
+        self.version = version
+
+
+class _HarborDispatchTarget:
+    """Target stub satisfying the dispatcher's resolution + audit reads.
+
+    The dispatcher reads ``product`` / ``fingerprint.version`` /
+    ``preferred_impl_id`` (connector resolution) and ``id`` / ``name``
+    (audit row + broadcast ``target_name``). The Harbor connector reads
+    ``auth_model`` + ``name`` + ``host`` + ``port`` during auth and
+    HTTP-client setup.
+
+    ``name`` is a benign label; the broadcast event may carry it.
+    It is deliberately distinct from every forbidden sentinel so the
+    by-exclusion assertion cannot false-positive on it.
+    """
+
+    def __init__(self) -> None:
+        self.product = "harbor"
+        self.fingerprint = _FakeFingerprint(version="2.11.0")
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "harbor-test-prod"
+        self.host = "harbor.test.invalid"
+        self.port: int | None = 443
+        self.secret_ref = "kv/data/harbor/harbor-test-prod"
+        self.auth_model: str | None = "shared_service_account"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + registry; pre-seed the connector instance."""
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=HarborConnector.product,
+        version=HarborConnector.version,
+        impl_id=HarborConnector.impl_id,
+        cls=HarborConnector,
+    )
+    # Materialise the connector instance the dispatcher will use and patch
+    # its credentials loader. The patched instance survives in
+    # _CONNECTOR_INSTANCE_CACHE until reset_dispatcher_caches() teardown.
+    instance = get_or_create_connector_instance(HarborConnector)
+    instance._credentials_loader = _stub_credentials_loader  # type: ignore[attr-defined]
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so ``register_typed_operation`` skips ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Replace :func:`publish_event` with an in-memory recording stub."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-credential-mint-test",
+        name="Credential Mint Test Operator",
+        email=None,
+        raw_jwt="header.payload.signature",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000c9"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _assert_credential_mint_aggregate(event: BroadcastEvent, op_id: str) -> None:
+    """Assert *event* is the aggregate shape for a ``credential_mint`` op.
+
+    The redacted ``payload`` is exactly ``{op_class, result_status}``.
+    The full serialised event must contain none of the forbidden
+    secret-shaped sentinels.
+    """
+    assert event.op_id == op_id
+    assert event.op_class == "credential_mint"
+    assert event.result_status == "ok"
+    assert event.payload == {
+        "op_class": "credential_mint",
+        "result_status": "ok",
+    }
+
+    serialised = event.model_dump_json()
+    assert json.loads(serialised)["op_class"] == "credential_mint"
+
+    for forbidden in _FORBIDDEN_SUBSTRINGS:
+        assert forbidden not in serialised, (
+            f"credential_mint leak: {forbidden!r} reached the broadcast "
+            f"event for {op_id} — serialised event: {serialised}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# credential_mint aggregate-only contract — harbor.robot.create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_robot_create_broadcast_is_aggregate_only(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``harbor.robot.create`` broadcasts only ``{op_id, target, result_status}``.
+
+    DoD (AC3 of #621) — the dispatch produces a broadcast event that is
+    aggregate-only: the minted secret never appears in the serialised
+    BroadcastEvent. The OperationResult returned to the caller still
+    contains the secret (proves the exclusion is a real one, not vacuous).
+    """
+    await register_harbor_robot_operations(embedding_service=stub_embedding_service)
+
+    operator = _make_operator()
+    target = _HarborDispatchTarget()
+
+    with respx.mock() as mock:
+        mock.post("https://harbor.test.invalid/api/v2.0/projects/proj/robots").mock(
+            return_value=respx.MockResponse(
+                201,
+                json={
+                    "id": 7,
+                    "name": "robot$proj+bot",
+                    "secret": _SENTINEL_SECRET,
+                    "expiration_time": -1,
+                },
+            )
+        )
+        result = await dispatch(
+            operator=operator,
+            connector_id="harbor-rest-2.x",
+            op_id="harbor.robot.create",
+            target=target,
+            params={"name": "bot", "project": "proj", "duration": -1},
+        )
+
+    assert result.status == "ok", result.error
+    # Caller gets the secret — proves the assertion below is a real exclusion.
+    assert result.result is not None
+    assert result.result["secret"] == _SENTINEL_SECRET  # type: ignore[index]
+
+    assert len(captured_events) == 1
+    _assert_credential_mint_aggregate(captured_events[0], "harbor.robot.create")
+
+
+@pytest.mark.asyncio
+async def test_robot_delete_broadcast_is_full_detail(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``harbor.robot.delete`` broadcasts full detail (``write`` class).
+
+    Contrast test: ``harbor.robot.delete`` classifies ``write``, not
+    ``credential_mint``. Its broadcast carries the full ``params`` block.
+    Same dispatch + broadcast path as the create test; the divergent
+    behaviour is solely due to :func:`classify_op`.
+    """
+    await register_harbor_robot_operations(embedding_service=stub_embedding_service)
+
+    operator = _make_operator()
+    target = _HarborDispatchTarget()
+
+    with respx.mock() as mock:
+        mock.delete("https://harbor.test.invalid/api/v2.0/projects/proj/robots/7").mock(
+            return_value=respx.MockResponse(200)
+        )
+        result = await dispatch(
+            operator=operator,
+            connector_id="harbor-rest-2.x",
+            op_id="harbor.robot.delete",
+            target=target,
+            params={"project": "proj", "id": 7},
+        )
+
+    assert result.status == "ok", result.error
+
+    assert len(captured_events) == 1
+    event = captured_events[0]
+    assert event.op_id == "harbor.robot.delete"
+    assert event.op_class == "write"
+    # Full-detail broadcast — params block is present.
+    assert "params" in event.payload
+    assert event.op_class != "credential_mint"
+
+
+@pytest.mark.asyncio
+async def test_credential_mint_and_write_diverge_on_same_dispatch_path(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Create is aggregate-only; delete is full-detail on the same path.
+
+    Dispatches both ops back-to-back through the identical infrastructure.
+    The only variable is the op-id; divergent redaction proves
+    :func:`classify_op` drives the behavior, not the handler or target.
+    """
+    await register_harbor_robot_operations(embedding_service=stub_embedding_service)
+
+    operator = _make_operator()
+    target = _HarborDispatchTarget()
+
+    with respx.mock() as mock:
+        mock.post("https://harbor.test.invalid/api/v2.0/projects/proj/robots").mock(
+            return_value=respx.MockResponse(
+                201,
+                json={
+                    "id": 7,
+                    "name": "robot$proj+bot",
+                    "secret": _SENTINEL_SECRET,
+                    "expiration_time": -1,
+                },
+            )
+        )
+        mock.delete("https://harbor.test.invalid/api/v2.0/projects/proj/robots/7").mock(
+            return_value=respx.MockResponse(200)
+        )
+
+        create_result = await dispatch(
+            operator=operator,
+            connector_id="harbor-rest-2.x",
+            op_id="harbor.robot.create",
+            target=target,
+            params={"name": "bot", "project": "proj", "duration": -1},
+        )
+        delete_result = await dispatch(
+            operator=operator,
+            connector_id="harbor-rest-2.x",
+            op_id="harbor.robot.delete",
+            target=target,
+            params={"project": "proj", "id": 7},
+        )
+
+    assert create_result.status == "ok", create_result.error
+    assert delete_result.status == "ok", delete_result.error
+    assert len(captured_events) == 2
+
+    create_event = next(e for e in captured_events if e.op_id == "harbor.robot.create")
+    delete_event = next(e for e in captured_events if e.op_id == "harbor.robot.delete")
+
+    # Same path, opposite redaction — classifier-driven by construction.
+    assert create_event.op_class == "credential_mint"
+    assert delete_event.op_class == "write"
+    _assert_credential_mint_aggregate(create_event, "harbor.robot.create")
+    assert "params" in delete_event.payload

--- a/backend/tests/test_connectors_harbor_robot.py
+++ b/backend/tests/test_connectors_harbor_robot.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for Harbor robot lifecycle typed ops (G3.5-T9 #621).
+
+Covers:
+* ``harbor.robot.create`` handler — respx mock against Harbor API.
+* ``harbor.robot.delete`` handler — respx mock against Harbor API.
+* ``classify_op`` maps both op-ids to the right sensitivity classes.
+* ``redact_payload("credential_mint", ...)`` — aggregate-only, no secret.
+* No regression to ``credential_read`` classification for existing vault ops.
+
+Auth: HTTP Basic (shared service account) — handlers pass ``raw_jwt=""``
+to :meth:`HarborConnector.auth_headers`. Per-target credentials are
+injected via the ``credentials_loader`` seam so the Vault stub is never
+reached.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import respx
+
+from meho_backplane.broadcast.events import classify_op, redact_payload
+from meho_backplane.connectors.harbor import HarborConnector, HarborTargetLike
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import AuthModel
+
+# ---------------------------------------------------------------------------
+# Registry isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_harbor_registry() -> None:
+    """Re-register HarborConnector before each test, clear after.
+
+    Mirrors the pattern in ``test_connectors_harbor_auth.py``.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=HarborConnector.product,
+        version=HarborConnector.version,
+        impl_id=HarborConnector.impl_id,
+        cls=HarborConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET = _StubTarget(
+    name="harbor-test",
+    host="harbor.test.invalid",
+    port=443,
+    secret_ref="kv/data/harbor/harbor-test",
+)
+
+
+async def _stub_loader(_target: HarborTargetLike) -> dict[str, str]:
+    return {"username": "admin", "password": "test-password"}
+
+
+def _make_connector() -> HarborConnector:
+    return HarborConnector(credentials_loader=_stub_loader)
+
+
+# ---------------------------------------------------------------------------
+# harbor.robot.create — handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_robot_create_posts_to_harbor_and_returns_id_name_secret() -> None:
+    """robot_create() calls POST /api/v2.0/projects/{project}/robots and returns
+    {id, name, secret} from the Harbor response."""
+    connector = _make_connector()
+    harbor_response = {
+        "id": 42,
+        "name": "robot$myproject+ci-push",
+        "secret": "minted-secret-value",
+        "creation_time": "2026-05-20T12:00:00.000Z",
+        "expiration_time": -1,
+    }
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post("https://harbor.test.invalid/api/v2.0/projects/myproject/robots").mock(
+            return_value=respx.MockResponse(201, json=harbor_response)
+        )
+        result = await connector.robot_create(
+            _TARGET,
+            {"name": "ci-push", "project": "myproject", "duration": -1},
+        )
+
+    assert result == {"id": 42, "name": "robot$myproject+ci-push", "secret": "minted-secret-value"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_robot_create_sends_basic_auth_header() -> None:
+    """robot_create() includes the Authorization: Basic header on the POST request."""
+    connector = _make_connector()
+    captured_headers: dict[str, str] = {}
+
+    def _capture(request: respx.models.Request) -> respx.MockResponse:
+        captured_headers.update(dict(request.headers))
+        return respx.MockResponse(
+            201,
+            json={"id": 1, "name": "robot$proj+bot", "secret": "s", "expiration_time": -1},
+        )
+
+    with respx.mock() as mock:
+        mock.post("https://harbor.test.invalid/api/v2.0/projects/proj/robots").mock(
+            side_effect=_capture
+        )
+        await connector.robot_create(
+            _TARGET,
+            {"name": "bot", "project": "proj", "duration": 90},
+        )
+
+    assert "authorization" in captured_headers
+    assert captured_headers["authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_robot_create_sends_correct_permission_body() -> None:
+    """robot_create() sends the Harbor permission structure with push+pull access."""
+    connector = _make_connector()
+    captured_body: dict = {}
+
+    def _capture(request: respx.models.Request) -> respx.MockResponse:
+        import json as _json
+
+        captured_body.update(_json.loads(request.content))
+        return respx.MockResponse(
+            201,
+            json={"id": 10, "name": "robot$alpha+deployer", "secret": "x", "expiration_time": 90},
+        )
+
+    with respx.mock() as mock:
+        mock.post("https://harbor.test.invalid/api/v2.0/projects/alpha/robots").mock(
+            side_effect=_capture
+        )
+        await connector.robot_create(
+            _TARGET,
+            {"name": "deployer", "project": "alpha", "duration": 90},
+        )
+
+    assert captured_body["name"] == "deployer"
+    assert captured_body["duration"] == 90
+    assert captured_body["level"] == "project"
+    perms = captured_body["permissions"]
+    assert len(perms) == 1
+    assert perms[0]["namespace"] == "alpha"
+    accesses = {a["action"] for a in perms[0]["access"]}
+    assert "push" in accesses
+    assert "pull" in accesses
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_robot_create_raises_on_http_error() -> None:
+    """robot_create() propagates httpx.HTTPStatusError on 4xx/5xx responses."""
+    import httpx
+
+    connector = _make_connector()
+    with respx.mock() as mock:
+        mock.post("https://harbor.test.invalid/api/v2.0/projects/myproject/robots").mock(
+            return_value=respx.MockResponse(409, json={"errors": [{"code": "CONFLICT"}]})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await connector.robot_create(
+                _TARGET,
+                {"name": "ci-push", "project": "myproject", "duration": -1},
+            )
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# harbor.robot.delete — handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_robot_delete_sends_delete_to_harbor_and_returns_synthetic_result() -> None:
+    """robot_delete() sends DELETE /api/v2.0/projects/{project}/robots/{id} and
+    returns {id, deleted: True} since Harbor returns HTTP 200 with empty body."""
+    connector = _make_connector()
+    with respx.mock(assert_all_called=True) as mock:
+        mock.delete("https://harbor.test.invalid/api/v2.0/projects/myproject/robots/42").mock(
+            return_value=respx.MockResponse(200)
+        )
+        result = await connector.robot_delete(
+            _TARGET,
+            {"project": "myproject", "id": 42},
+        )
+
+    assert result == {"id": 42, "deleted": True}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_robot_delete_sends_basic_auth_header() -> None:
+    """robot_delete() includes the Authorization: Basic header on the DELETE request."""
+    connector = _make_connector()
+    captured_headers: dict[str, str] = {}
+
+    def _capture(request: respx.models.Request) -> respx.MockResponse:
+        captured_headers.update(dict(request.headers))
+        return respx.MockResponse(200)
+
+    with respx.mock() as mock:
+        mock.delete("https://harbor.test.invalid/api/v2.0/projects/proj/robots/7").mock(
+            side_effect=_capture
+        )
+        await connector.robot_delete(_TARGET, {"project": "proj", "id": 7})
+
+    assert "authorization" in captured_headers
+    assert captured_headers["authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_robot_delete_raises_on_http_error() -> None:
+    """robot_delete() propagates httpx.HTTPStatusError on 4xx/5xx responses."""
+    import httpx
+
+    connector = _make_connector()
+    with respx.mock() as mock:
+        mock.delete("https://harbor.test.invalid/api/v2.0/projects/myproject/robots/99").mock(
+            return_value=respx.MockResponse(404)
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await connector.robot_delete(_TARGET, {"project": "myproject", "id": 99})
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# G6 classifier — classify_op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id, expected",
+    [
+        ("harbor.robot.create", "credential_mint"),
+        ("harbor.robot.delete", "write"),
+        # No regression to credential_read
+        ("vault.kv.read", "credential_read"),
+        ("vault.kv.list", "credential_read"),
+        # Suffix-based write ops still work
+        ("vsphere.vm.create", "write"),
+        ("vsphere.vm.delete", "write"),
+    ],
+)
+def test_classify_op_maps_harbor_robot_ops_correctly(op_id: str, expected: str) -> None:
+    """classify_op returns credential_mint for harbor.robot.create, write for delete."""
+    assert classify_op(op_id) == expected
+
+
+def test_classify_op_credential_mint_precedes_write_suffix() -> None:
+    """harbor.robot.create ends with .create but must classify as credential_mint,
+    not write. Verifies the allowlist check precedes the suffix check."""
+    assert classify_op("harbor.robot.create") == "credential_mint"
+    # A hypothetical non-minting create still falls through to write
+    assert classify_op("vsphere.vm.create") == "write"
+
+
+# ---------------------------------------------------------------------------
+# G6 redaction — redact_payload for credential_mint
+# ---------------------------------------------------------------------------
+
+
+def test_redact_payload_credential_mint_removes_secret_field() -> None:
+    """redact_payload('credential_mint', ...) returns aggregate shape — no secret."""
+    raw = {"id": 42, "name": "robot$proj+bot", "secret": "minted-secret", "other": "keep"}
+    result = redact_payload("credential_mint", raw, "ok")
+
+    assert "secret" not in str(result)
+    assert "minted-secret" not in str(result)
+    assert result["op_class"] == "credential_mint"
+    assert result["result_status"] == "ok"
+
+
+def test_redact_payload_credential_mint_preserves_only_aggregate_fields() -> None:
+    """credential_mint aggregate payload is exactly {op_class, result_status}."""
+    raw = {"id": 1, "name": "robot$p+n", "secret": "S3cr3t!"}
+    result = redact_payload("credential_mint", raw, "ok")
+
+    assert set(result.keys()) == {"op_class", "result_status"}
+
+
+def test_redact_payload_credential_mint_no_regression_on_credential_read() -> None:
+    """credential_read still produces aggregate payload after the credential_mint
+    extension — no regression to full-detail broadcast."""
+    raw = {"data": {"db_password": "super-secret"}, "version": 3}
+    result = redact_payload("credential_read", raw, "ok")
+
+    assert "db_password" not in str(result)
+    assert result["op_class"] == "credential_read"
+    assert set(result.keys()) == {"op_class", "result_status"}
+
+
+def test_redact_payload_credential_mint_aggregate_on_error_result() -> None:
+    """credential_mint aggregate applies regardless of result_status value."""
+    raw = {"secret": "leaked-if-full", "error": "timeout"}
+    result = redact_payload("credential_mint", raw, "error")
+
+    assert "leaked-if-full" not in str(result)
+    assert result["result_status"] == "error"
+
+
+def test_redact_payload_write_class_broadcasts_full_detail() -> None:
+    """harbor.robot.delete is write-classified — full detail (no secret in payload
+    anyway, but the redaction path is full, not aggregate)."""
+    raw = {"id": 42, "deleted": True}
+    result = redact_payload("write", raw, "ok")
+
+    assert result == {"op_class": "write", "params": raw, "result_status": "ok"}
+
+
+def test_redact_payload_credential_mint_with_explicit_aggregate_detail() -> None:
+    """When detail='aggregate' is passed explicitly, credential_mint stays aggregate."""
+    raw = {"secret": "s", "id": 1}
+    result = redact_payload("credential_mint", raw, "ok", detail="aggregate")
+
+    assert "secret" not in str(result)
+    assert set(result.keys()) == {"op_class", "result_status"}
+
+
+def test_redact_payload_credential_mint_with_explicit_full_detail() -> None:
+    """When detail='full' is passed (G6.3 operator opt-in), credential_mint broadcasts
+    the full payload. The G6.3 resolver is responsible for deciding this — the
+    redact_payload function just renders the decided detail level."""
+    raw = {"secret": "s", "id": 1, "name": "robot$p+n"}
+    result = redact_payload("credential_mint", raw, "ok", detail="full")
+
+    assert result == {"op_class": "credential_mint", "params": raw, "result_status": "ok"}

--- a/docs/codebase/connectors-harbor.md
+++ b/docs/codebase/connectors-harbor.md
@@ -8,8 +8,9 @@ dispatches Harbor REST operations under the
 G3.5-T7 (#619) shipped the skeleton — HTTP Basic auth, fingerprint, probe, and
 the G0.6 dispatch shim. G3.5-T8 (#620) ships `core_ops.py` with the 9
 operator-reviewed read-only ops, the curated group/op metadata, and the
-acceptance test suite (dispatch smoke + JSONFlux force-handle). Robot lifecycle
-(create/delete) + G6 credential_mint classifier arrive in G3.5-T9 (#621).
+acceptance test suite (dispatch smoke + JSONFlux force-handle). G3.5-T9 (#621)
+adds robot lifecycle typed ops (`harbor.robot.create` / `harbor.robot.delete`)
+and the `credential_mint` G6 broadcast classifier.
 CLI verbs + MCP review + real-container E2E arrive in G3.5-T10 (#622).
 
 Source: `backend/src/meho_backplane/connectors/harbor/`.
@@ -21,7 +22,9 @@ Source: `backend/src/meho_backplane/connectors/harbor/`.
   `impl_id="harbor-rest"`, `supported_version_range=">=2.0,<3.0"`,
   `priority=1`. The priority outranks a future `GenericRestConnector`
   auto-shim (priority=0) defensively if both somehow register for the same
-  triple.
+  triple. Handler methods `robot_create` / `robot_delete` are bound-method
+  handlers the dispatcher resolves and binds to the per-process connector
+  instance at dispatch time.
 - **`HarborTargetLike`** (`session.py`) — runtime-checkable Protocol capturing
   the minimum target shape the connector reads: `name`, `host`, `port`,
   `secret_ref`, and `auth_model`. No `sso_realm` field — Harbor sends
@@ -53,6 +56,10 @@ Source: `backend/src/meho_backplane/connectors/harbor/`.
   — operator-review-time substrate call; enables the 9 core ops, disables
   non-core ops in curated groups via the audit-log-driven override exclusion,
   and lands the reviewed `when_to_use` / `llm_instructions` metadata.
+- **`register_harbor_robot_operations`** (`ops.py`) — async lifespan registrar
+  that upserts `harbor.robot.create` and `harbor.robot.delete` into
+  `endpoint_descriptor`. Called by the lifespan via `run_typed_op_registrars`.
+  Idempotent.
 
 ## Control flow
 
@@ -113,6 +120,34 @@ This differs from the SDDC Manager / NSX precedents that delegate to
 checks and covers subsystem state (DB, redis, registry, jobservice) that
 `systeminfo` does not expose.
 
+### robot_create(target, params)
+
+Typed op handler for `harbor.robot.create`. Classified `credential_mint` by
+`classify_op` in `broadcast/events.py` — the broadcast collapses to aggregate-only
+so the minted secret never appears in the SSE stream.
+
+1. Validates `name`, `project`, `duration` from `params`.
+2. Calls `_post_json(target, "/api/v2.0/projects/{project}/robots", json=body)`.
+   Non-retried — Harbor's create endpoint is non-idempotent.
+3. Returns `{id, name, secret}` extracted from Harbor's 201 response.
+   The `secret` is the minted credential, returned only on creation.
+
+The `permissions` body grants push + pull access on the named project
+(`level="project"`). System-level robot creation is out of scope for this Task.
+
+### robot_delete(target, params)
+
+Typed op handler for `harbor.robot.delete`. Classified `write` (suffix-based).
+No secret material in the response.
+
+1. Validates `project`, `id` from `params`.
+2. Acquires the pooled httpx client via `_http_client(target)` and calls
+   `client.request("DELETE", "/api/v2.0/projects/{project}/robots/{id}", headers=auth_headers)`.
+   Direct client call (no `_delete_json` helper on `HttpConnector`) — non-retried.
+3. Calls `resp.raise_for_status()` — propagates `httpx.HTTPStatusError` on 4xx/5xx.
+4. Returns `{id, deleted: True}` (Harbor returns HTTP 200 with empty body;
+   the `id` echo is synthesized for a useful agent-facing result).
+
 ### execute() shim
 
 `execute()` synthesises a system `Operator` with `sub="system:harbor-rest-connector-shim"`
@@ -123,13 +158,19 @@ construct a real `Operator` and call `dispatch` directly — they bypass this sh
 ## Dependencies
 
 - **httpx 0.28.1** — async HTTP client with per-target pooling and retry decorator.
+  `_post_json` is used for `robot_create` (non-retried POST);
+  `_http_client` + `client.request("DELETE", ...)` for `robot_delete`.
 - **tenacity 9.1.4** — retry logic for idempotent GET requests (3 retries,
-  exponential backoff, 5xx + connection errors only).
+  exponential backoff, 5xx + connection errors only). Robot lifecycle ops bypass
+  tenacity intentionally — write endpoints are non-idempotent.
 - **structlog** — structured logging for credential load events.
 - **`meho_backplane.connectors.adapters.http.HttpConnector`** — base class
   providing `_get_json`, `_post_json`, `_http_client`, and `aclose`.
 - **`meho_backplane.connectors.schemas`** — `FingerprintResult`, `ProbeResult`,
   `OperationResult`, `AuthModel`.
+- **`meho_backplane.broadcast.events`** — `classify_op` returns `credential_mint`
+  for `harbor.robot.create`; `redact_payload` treats `credential_mint` as
+  aggregate-only (same branch as `credential_read`).
 
 ## The 9 read-only v0.2 core ops
 
@@ -170,18 +211,25 @@ acceptance fixtures and unit tests assert this invariant explicitly.
 - `load_credentials_from_vault` is a `NotImplementedError` stub until G0.3
   (#224) lands the operator-context Vault read path. Tests inject a custom
   loader.
+- `harbor.robot.create` grants push + pull access on the named project only.
+  System-level robot creation (`POST /api/v2.0/robots`) is out of scope for this Task.
+- Robot secret rotation / refresh is out of scope — tracked as a follow-up.
 - Real-container integration tests (against `goharbor/harbor-core:v2.11`) are
-  out of scope for this Task; they arrive in #622.
+  out of scope for this Task; they arrive in #622 (CLI/MCP/E2E).
 - Full G0.7 spec-canary ingest (live Harbor OpenAPI spec through
   `IngestionPipelineService`) is deferred to #622 when the spec-shelf is
   wired to the meho-runners pool.
 
 ## References
 
-- Issues: #619 (G3.5-T7 skeleton), #620 (G3.5-T8 read-ops, this task)
-- Successor tasks: #621 (robot lifecycle), #622 (CLI/MCP/E2E)
+- Issues: #619 (G3.5-T7 skeleton), #620 (G3.5-T8 read-ops curation),
+  #621 (G3.5-T9 robot lifecycle + credential_mint classifier)
+- Successor task: #622 (G3.5-T10 CLI/MCP/E2E)
 - Initiative: #368 (G3.5 tier-2 batch)
 - HttpConnector base: `backend/src/meho_backplane/connectors/adapters/http.py`
+- Broadcast classifier: `backend/src/meho_backplane/broadcast/events.py` (`classify_op`, `redact_payload`)
 - Harbor 2.x API: https://goharbor.io/docs/2.11.0/build-customize-contribute/configure-swagger/
 - Precedents: `connectors/sddc_manager/` (Basic auth + core_ops pattern),
-  `connectors/nsx/` (probe pattern + acceptance fixtures)
+  `connectors/nsx/` (probe pattern + acceptance fixtures),
+  `connectors/vault/ops.py` (typed op registration),
+  `connectors/bind9/` (bound-method handlers)


### PR DESCRIPTION
## Summary

- Register `harbor.robot.create` and `harbor.robot.delete` as hand-typed ops under `connector_id="harbor-rest-2.x"` — deliberately hand-registered (not generic-ingested) because the `credential_mint` redaction contract is load-bearing and must not depend on spec-derived `op_class` heuristics.
- Extend `broadcast/events.py`: add `_CREDENTIAL_MINT_OPS = frozenset({"harbor.robot.create"})`, a new `classify_op` branch (checked before the `.create` suffix so the allowlist wins), and treat `credential_mint` as aggregate-only in `redact_payload` — the minted robot secret never appears in the SSE feed or Slack mirror channel.
- `harbor.robot.create` calls `_post_json` (non-retried POST); `harbor.robot.delete` calls `_http_client` + `client.request("DELETE", ...)` directly (no `_delete_json` on `HttpConnector`). Both bypass the tenacity retry decorator — non-idempotent writes.

## Test plan

- [x] `ruff check` — clean (191 source files)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (191 source files)
- [x] `pytest tests/test_connectors_harbor_robot.py` — 21 passed (handler success/error paths, `classify_op` mapping, `redact_payload` redaction assertions)
- [x] `pytest tests/test_connectors_harbor_auth.py tests/test_connectors_vault.py tests/test_connectors_vault_sys.py tests/test_broadcast_overrides_resolver.py` — 108 passed, no regression to `credential_read`
- [x] `harbor.robot.create` classified `credential_mint`; `redact_payload("credential_mint", {"secret": "X"}, "ok")` returns `{op_class, result_status}` only — secret absent from broadcast
- [x] `harbor.robot.delete` classified `write` (suffix-based); full-detail broadcast (no secret in delete response anyway)
- [x] No regression: `classify_op("vault.kv.read") == "credential_read"` pinned by parametrized test

## Out of scope

- Robot secret rotation/refresh — v0.2.next
- CLI verb wiring + MCP description + real-container E2E — #622 (T10)
- Generic project/repo/artifact reads — #620 (T8)

Closes #621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Harbor 2.x robot account create/delete support, with create returning a one-time secret and delete returning a synthetic deletion result.
  * Added async registrar to register robot operations at runtime.

* **New Features / Privacy**
  * Introduced a credential_mint sensitivity class for freshly-minted secrets with stricter aggregate-only redaction by default.

* **Documentation**
  * Updated Harbor connector docs with robot op and credential-handling guidance.

* **Tests**
  * Added unit and integration tests for robot ops, classification precedence, and broadcast redaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->