### PR TITLE
ci(security-scan): runs-on meho-runners → meho-runners-ci; drop exception block

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,35 +40,7 @@ permissions:
 jobs:
   semgrep:
     name: Semgrep SAST
-    # Deliberate single-workflow exception to #715's cutover from
-    # `meho-runners` (rke2-meho) to `meho-runners-ci` (rke2-ci). The
-    # initial cutover attempt (PR #717 first push, head 2fd6287)
-    # regressed this required check green->red on the new pool — the
-    # `container:` keyword below makes the GHA runner manager pull
-    # `harbor.evba.lab/dockerhub-proxy/semgrep/semgrep:1.160.0` at the
-    # runner-pod level (not inside the DinD sidecar). On the new
-    # rke2-ci pool that path fails in two distinct ways:
-    #   - DNS: `lookup harbor.evba.lab on 10.43.0.10:53: no such host`
-    #     — the rke2-ci CoreDNS deployment doesn't forward the
-    #     `evba.lab` zone the way rke2-meho's does.
-    #   - GHA-volume-mount: `OCI runtime exec failed: ... /__e/
-    #     node24_alpine/bin/node: no such file or directory` — the
-    #     runner-pod's GHA action-runtime volume isn't surfaced into
-    #     the `container:` image, so `actions/checkout`'s node binary
-    #     can't execute inside it.
-    # Same `docker pull` + `curl harbor.evba.lab` patterns work fine
-    # on the new pool from inside DinD or directly on the runner pod
-    # (runner-smoke matrix run 26161029994 / job on
-    # meho-runners-ci-rzmr8-runner-zvmc5 proved both). The breakage is
-    # narrowly scoped to GHA's `container:` keyword pre-runner-start
-    # path. Until the rke2-ci chart on `evoila-bosnia/claude-rdc-hetzner-dc`
-    # closes both gaps, this single workflow stays on the old
-    # `meho-runners` pool — which keeps Semgrep SAST green and lets
-    # #611's "5+ green PRs on meho-runners-ci" counter advance for the
-    # other 17 cutover'd workflows. Flip this back to
-    # `meho-runners-ci` (one-line revert; drop this comment block)
-    # once the rke2-ci-side fix lands; #611 then drains the old pool.
-    runs-on: meho-runners
+    runs-on: meho-runners-ci
     timeout-minutes: 15
     # Pulled through the in-cluster Harbor proxy cache
     # (claude-rdc-hetzner-dc#463; project `dockerhub-proxy` is public,


### PR DESCRIPTION
Reverts the single-workflow exception introduced in #717's [`a895c60`](https://github.com/evoila/meho/commit/a895c60) that kept Semgrep SAST on the old `meho-runners` pool (rke2-meho) because GHA's `container:` keyword failed two distinct ways on the new `meho-runners-ci` pool (rke2-ci).

## What changed

- `.github/workflows/security-scan.yml`: `runs-on: meho-runners` → `runs-on: meho-runners-ci`
- Dropped the 26-line exception header comment block (no longer relevant)

Net: 1 line changed, 29 lines removed, 0 lines added.

## Why now

Both cluster-side gaps closed by [`evoila-bosnia/rdc-gitops#52`](https://github.com/evoila-bosnia/rdc-gitops/pull/52) + the [`#53`](https://github.com/evoila-bosnia/rdc-gitops/pull/53) hot-fix, tracked at [`claude-rdc-hetzner-dc#630`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/630). Verified live 2026-05-20T15:08-15:16Z on `meho-runners-ci-g26ts-runner-4jccc`:

```
$ kubectl -n arc-runners exec ... -c runner -- getent hosts harbor.evba.lab
10.5.61.31  harbor.evba.lab

$ kubectl -n arc-runners exec ... -c runner -- curl -ks https://harbor.evba.lab/v2/ -o /dev/null -w "HTTP %{http_code}\n"
HTTP 401                                                # Harbor auth required; TLS handshake succeeded

$ kubectl -n arc-runners exec ... -c dind -- ls -la /home/runner/externals/node24_alpine/bin/node
-rwxr-xr-x 1 1001 1001 130700432 May 20 15:08 /home/runner/externals/node24_alpine/bin/node

$ kubectl -n arc-runners describe pod meho-runners-ci-g26ts-runner-4jccc | grep -A 2 init-dind-externals
  init-dind-externals: ...
    State: Terminated  Reason: Completed  Exit Code: 0
```

DNS resolves + GHA action runtime is bind-mountable inside `container:` images. The exact failures from #717's iter-1 are not reachable on the current pool any more.

## Test plan

- [x] Pre-commit hooks pass (trailing-whitespace, EOF, check-yaml, gitleaks, mixed-line-ending, secret-detect, conventional-commit)
- [ ] Workflow runs once on `meho-runners-ci-*` runners after merge
- [ ] Semgrep SAST returns SUCCESS (Code Scanning SARIF upload step is `continue-on-error: true`, so the relevant signal is the Semgrep step itself)

## Cross-link to #611

After this merges and one main-branch run lands Semgrep green on `meho-runners-ci`, the old `meho-runners` pool has no remaining real-CI consumers — [`claude-rdc-hetzner-dc#611`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/611)'s rke2-meho ARC retirement becomes unblocked (pending the agreed quiet period of organic green-PR signal on the new pool).

Refs: [claude-rdc-hetzner-dc#630](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/630), [#717](https://github.com/evoila/meho/pull/717) (the cutover that surfaced the gap), [claude-rdc-hetzner-dc#611](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/611) (downstream unblock).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning infrastructure configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->