### PR TITLE
feat(memory): G5.2-T2 default 7-day TTL injection + CLI --persist (#624)

### DIFF
--- a/backend/src/meho_backplane/api/v1/memory.py
+++ b/backend/src/meho_backplane/api/v1/memory.py
@@ -101,7 +101,7 @@ is the single source of truth for the safe-URL alphabet so a typo
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, Final
 
 import structlog
@@ -119,6 +119,7 @@ from meho_backplane.memory import (
     PermissionDeniedError,
 )
 from meho_backplane.memory.schemas import SLUG_PATTERN
+from meho_backplane.settings import get_settings
 
 __all__ = ["MemoryListResponse", "RememberBody", "router"]
 
@@ -169,6 +170,59 @@ _SLUG_MAX_LENGTH: Final[int] = 256
 #: 200)``); capping at 500 at the API surface keeps a single page
 #: from materialising more than ~2000 rows server-side.
 _LIST_LIMIT_MAX: Final[int] = 500
+
+
+def _resolve_default_ttl(body: RememberBody) -> datetime | None:
+    """Return the effective ``expires_at`` for a ``remember`` write.
+
+    G5.2-T2 (#624). Implements the default-TTL injection contract for
+    ``POST /api/v1/memory``:
+
+    * :attr:`MemoryScope.USER` scope **and** ``expires_at`` field
+      absent from the request body → ``now(UTC) +
+      Settings.memory_user_default_ttl_days``.
+    * Any other scope (``user-tenant`` / ``user-target`` / ``tenant``
+      / ``target``) → :attr:`RememberBody.expires_at` unchanged
+      (which is ``None`` when omitted, mirroring G5.1 behaviour).
+    * Explicit ``"expires_at": null`` on ``user`` scope → ``None``
+      (the CLI ``--persist`` opt-out shape: persist forever).
+    * Explicit ``"expires_at": "<ISO-8601>"`` on ``user`` scope → that
+      datetime verbatim (the caller picked a cutoff; no override).
+
+    The "field absent" vs "explicit null" discrimination uses
+    :attr:`BaseModel.model_fields_set` (pydantic v2): the set carries
+    every field name the constructor saw in the input, regardless of
+    its value. Without this discrimination, an explicit
+    ``"expires_at": null`` would round-trip to ``body.expires_at is
+    None`` and be indistinguishable from the field being missing --
+    which would collapse the ``--persist`` opt-out into the default
+    path. Verified against the installed pydantic 2.13.4 (`uv run
+    python -c "from pydantic import BaseModel; ..."` -- explicit
+    ``b=None`` is in ``model_fields_set``, absent ``b`` is not).
+
+    Why only ``MemoryScope.USER``: consumer-needs.md §G5's
+    "session-scoped hints expire by default" rule targets the per-
+    operator-only scope (``kind="memory-user"``); ``user-tenant`` and
+    ``user-target`` rows are team-shared coordinates the consumer
+    spec leaves operator-controlled. The Task body pins this to
+    ``kind == "memory-user"`` -- not the broader "any user-* scope"
+    -- so the surface stays narrow until a future Task widens it
+    with an explicit hierarchy decision.
+    """
+    if "expires_at" in body.model_fields_set:
+        # Caller supplied the field (either an ISO timestamp or
+        # explicit null); honour their intent verbatim. This branch
+        # is the CLI ``--persist`` opt-out path when the value is
+        # ``None``.
+        return body.expires_at
+    if body.scope is not MemoryScope.USER:
+        # Default only fires on the ``memory-user`` kind per #624.
+        # Other scopes fall through to the G5.1 baseline (no auto-TTL,
+        # row persists until an operator deletes it or G5.2's
+        # promote/expire verbs touch it).
+        return None
+    settings = get_settings()
+    return datetime.now(UTC) + timedelta(days=settings.memory_user_default_ttl_days)
 
 
 class RememberBody(BaseModel):
@@ -264,12 +318,48 @@ async def remember(
     omits it -- binding before would leave ``audit_slug=None`` in
     that path; the post-call rebind carries the actually-persisted
     slug.
+
+    Default-TTL injection (G5.2-T2 #624)
+    ------------------------------------
+
+    When ``body.scope`` is :attr:`MemoryScope.USER` *and* the request
+    omitted ``expires_at`` entirely, the handler injects
+    ``expires_at = now(UTC) + Settings.memory_user_default_ttl_days``
+    so session-scoped hints expire by default (consumer-needs.md §G5:
+    "session-scoped hints expire after 7 days unless re-pinned").
+    The G5.2-T1 expiry sweeper (#623) reaps these rows once
+    ``expires_at`` passes.
+
+    Two opt-outs are deliberately distinguished from "field omitted":
+
+    * Explicit ``"expires_at": null`` in the JSON body → no default;
+      the row persists forever. The CLI's ``--persist`` flag emits
+      this shape.
+    * Explicit ``"expires_at": "<ISO-8601>"`` → that value is honoured
+      verbatim (no override).
+
+    The discrimination uses :attr:`BaseModel.model_fields_set`
+    (pydantic v2) rather than ``body.expires_at is None``: the former
+    distinguishes "field absent from JSON" from "field present with
+    value null", which is the load-bearing semantics for the CLI's
+    ``--persist`` opt-out. The default is applied *only* to the
+    user-only :attr:`MemoryScope.USER` kind (the one consumer-needs
+    targets); ``user-tenant`` / ``user-target`` are not in scope per
+    the issue ("``kind == 'memory-user'``").
     """
     structlog.contextvars.bind_contextvars(
         audit_op_id=_MEMORY_OP_IDS["remember"],
         audit_op_class="write",
         audit_scope=body.scope.value,
     )
+    # Resolve the effective ``expires_at`` *before* calling the service
+    # so the audit row, the broadcast payload, and the persisted
+    # ``doc_metadata.expires_at`` all see the same value. ``service``
+    # itself is the storage substrate; the default-TTL contract is a
+    # surface-layer policy (G5.2-T2 #624) bolted onto the
+    # ``/api/v1/memory`` route, not :class:`MemoryService` proper --
+    # MCP / direct callers stay unaffected.
+    expires_at = _resolve_default_ttl(body)
     service = MemoryService()
     try:
         entry = await service.remember(
@@ -278,7 +368,7 @@ async def remember(
             body=body.body,
             slug=body.slug,
             metadata=body.metadata,
-            expires_at=body.expires_at,
+            expires_at=expires_at,
             target_name=body.target_name,
         )
     except PermissionDeniedError as exc:

--- a/backend/tests/test_api_v1_memory.py
+++ b/backend/tests/test_api_v1_memory.py
@@ -531,6 +531,221 @@ def test_remember_accepts_expires_at_iso_string(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# G5.2-T2 (#624): default-TTL injection on ``memory-user`` writes
+# ---------------------------------------------------------------------------
+#
+# The handler computes ``expires_at = now(UTC) +
+# memory_user_default_ttl_days`` when the request omits ``expires_at``
+# AND ``body.scope == MemoryScope.USER``. Two opt-outs:
+#
+# * explicit ``"expires_at": null`` in the request body → no default
+#   (the CLI ``--persist`` shape). Detection uses
+#   :attr:`BaseModel.model_fields_set`, not ``body.expires_at is None``.
+# * non-``user`` scopes (``user-tenant`` / ``user-target`` / ``tenant``
+#   / ``target``) → no default per #624's narrow scope ("``kind ==
+#   'memory-user'``").
+#
+# Tests assert the value the handler passes to ``MemoryService.remember``
+# via the ``expires_at`` kwarg -- the storage layer is the substrate's
+# concern; the surface contract is what this route sends downstream.
+
+
+def test_remember_user_scope_no_expires_at_injects_default_7_days(
+    client: TestClient,
+) -> None:
+    """Omitted ``expires_at`` on ``user`` scope → default ``now + 7d``.
+
+    Acceptance criterion: stored row has ``metadata.expires_at ~ now
+    + MEMORY_USER_DEFAULT_TTL_DAYS`` (within tolerance for clock drift
+    between the test invocation and the handler's ``datetime.now``).
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    fake_remember = AsyncMock(
+        return_value=_make_entry(scope=MemoryScope.USER, slug="auto-default"),
+    )
+    before = datetime.now(UTC)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.memory.MemoryService.remember", fake_remember),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory",
+            json={"scope": "user", "body": "default-ttl note"},
+            headers=_authed(token),
+        )
+    after = datetime.now(UTC)
+    assert response.status_code == 201
+    call_kwargs = fake_remember.await_args.kwargs
+    expires_at = call_kwargs["expires_at"]
+    # Default is 7 days from the ``Settings`` ``memory_user_default_ttl_days``
+    # field's own default; verifying the value lies in ``[before+7d,
+    # after+7d]`` covers clock-drift tolerance between the test's
+    # ``datetime.now`` reads and the handler's call without coupling
+    # the assertion to a fixed-second cutoff.
+    assert expires_at is not None
+    assert isinstance(expires_at, datetime)
+    assert before + timedelta(days=7) <= expires_at <= after + timedelta(days=7)
+
+
+def test_remember_user_scope_explicit_null_skips_default(
+    client: TestClient,
+) -> None:
+    """Explicit ``"expires_at": null`` → no default; row persists forever.
+
+    Load-bearing opt-out semantics: the discrimination must be on
+    :attr:`BaseModel.model_fields_set` (pydantic v2), not
+    ``body.expires_at is None`` -- otherwise the CLI ``--persist`` flag
+    (which emits ``"expires_at": null``) would collapse into the default
+    path and the operator's pin-forever intent would be silently
+    overridden.
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    fake_remember = AsyncMock(
+        return_value=_make_entry(scope=MemoryScope.USER, slug="persisted"),
+    )
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.memory.MemoryService.remember", fake_remember),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory",
+            json={"scope": "user", "body": "pin forever", "expires_at": None},
+            headers=_authed(token),
+        )
+    assert response.status_code == 201
+    call_kwargs = fake_remember.await_args.kwargs
+    assert call_kwargs["expires_at"] is None
+
+
+def test_remember_user_scope_explicit_expires_at_honoured_verbatim(
+    client: TestClient,
+) -> None:
+    """Explicit ISO-8601 ``expires_at`` is honoured (no override)."""
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    future = datetime(2027, 6, 1, 12, 0, 0, tzinfo=UTC)
+    fake_remember = AsyncMock(
+        return_value=_make_entry(scope=MemoryScope.USER, slug="explicit", expires_at=future),
+    )
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.memory.MemoryService.remember", fake_remember),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory",
+            json={
+                "scope": "user",
+                "body": "expires-on-jun-1",
+                "expires_at": future.isoformat(),
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 201
+    call_kwargs = fake_remember.await_args.kwargs
+    assert call_kwargs["expires_at"] == future
+
+
+def test_remember_user_tenant_scope_no_default_ttl(client: TestClient) -> None:
+    """``user-tenant`` scope is *not* in scope for the default TTL.
+
+    #624 narrows the default to ``kind == "memory-user"`` (i.e.
+    :attr:`MemoryScope.USER`). The ``USER_TENANT`` /
+    ``USER_TARGET`` / ``TENANT`` / ``TARGET`` scopes pass
+    ``expires_at`` through unchanged when omitted (i.e. ``None``).
+    Pinning this prevents a future refactor that widened the gate
+    to ``USER_SCOPED`` from silently expiring team-shared memories.
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    fake_remember = AsyncMock(
+        return_value=_make_entry(scope=MemoryScope.USER_TENANT, slug="team-note"),
+    )
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.memory.MemoryService.remember", fake_remember),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory",
+            json={"scope": "user-tenant", "body": "team note"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 201
+    call_kwargs = fake_remember.await_args.kwargs
+    assert call_kwargs["expires_at"] is None
+
+
+def test_remember_tenant_scope_no_default_ttl(client: TestClient) -> None:
+    """``tenant`` scope (admin-only write) also bypasses the default.
+
+    Tenant-shared memory is an explicitly operator-managed coordinate
+    -- defaulting a 7-day expiry on the tenant admin's note would
+    surprise the operator. The route mints a ``tenant_admin`` token
+    here so the service-layer RBAC matrix doesn't 403 the call.
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _admin_token(tenant_id=tenant_a)
+    fake_remember = AsyncMock(
+        return_value=_make_entry(scope=MemoryScope.TENANT, slug="tenant-note"),
+    )
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.memory.MemoryService.remember", fake_remember),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory",
+            json={"scope": "tenant", "body": "team policy"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 201
+    call_kwargs = fake_remember.await_args.kwargs
+    assert call_kwargs["expires_at"] is None
+
+
+def test_remember_user_scope_default_ttl_honours_settings_override(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Custom ``MEMORY_USER_DEFAULT_TTL_DAYS`` env var changes the cutoff.
+
+    Pins the env-var → ``Settings`` → handler dataflow so a future
+    refactor that hardcoded the 7-day default (instead of reading
+    :class:`Settings`) would surface here. The fixture clears
+    ``get_settings.cache_clear()`` so the env-var change actually
+    takes effect for this test.
+    """
+    monkeypatch.setenv("MEMORY_USER_DEFAULT_TTL_DAYS", "30")
+    get_settings.cache_clear()
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    fake_remember = AsyncMock(
+        return_value=_make_entry(scope=MemoryScope.USER, slug="custom-ttl"),
+    )
+    before = datetime.now(UTC)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.memory.MemoryService.remember", fake_remember),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory",
+            json={"scope": "user", "body": "30-day note"},
+            headers=_authed(token),
+        )
+    after = datetime.now(UTC)
+    assert response.status_code == 201
+    call_kwargs = fake_remember.await_args.kwargs
+    expires_at = call_kwargs["expires_at"]
+    assert expires_at is not None
+    assert before + timedelta(days=30) <= expires_at <= after + timedelta(days=30)
+
+
+# ---------------------------------------------------------------------------
 # GET / -- list
 # ---------------------------------------------------------------------------
 

--- a/cli/internal/cmd/memory/memory.go
+++ b/cli/internal/cmd/memory/memory.go
@@ -171,13 +171,86 @@ type RetrieveResponse struct {
 // rememberRequest mirrors the backend `RememberBody` pydantic model
 // (`backend/src/meho_backplane/api/v1/memory.py` L174-211). Fields
 // without JSON `omitempty` are mandatory at the wire level.
+//
+// `Persist` is a tri-state escape-hatch for the `expires_at` field
+// the backend's G5.2-T2 (#624) default-TTL injection key on:
+//
+//   - Persist=false, ExpiresAt="" → field is OMITTED from the JSON;
+//     the backend's :func:`_resolve_default_ttl` sees the field as
+//     absent from :attr:`BaseModel.model_fields_set` and injects
+//     “now + memory_user_default_ttl_days“ on “memory-user“ writes.
+//   - Persist=false, ExpiresAt="<RFC3339>" → field is sent verbatim;
+//     the backend honours it as the explicit cutoff.
+//   - Persist=true → field is emitted as explicit JSON `null`; the
+//     backend sees the field as present in
+//     :attr:`BaseModel.model_fields_set` with value None and skips
+//     the default. This is the wire shape `meho remember --persist`
+//     uses to opt out of the auto-TTL and pin the memory forever.
+//
+// The marshaling can't ride on Go's `,omitempty` semantics alone
+// because `*string`+`omitempty` collapses nil-pointer and empty-
+// string into "omit", whereas the backend's contract distinguishes
+// "absent field" (default fires) from "explicit null" (default
+// skipped). The custom :func:`MarshalJSON` below is the load-bearing
+// gate for the three-state discipline.
 type rememberRequest struct {
-	Scope      Scope          `json:"scope"`
-	Body       string         `json:"body"`
-	Slug       string         `json:"slug,omitempty"`
-	Metadata   map[string]any `json:"metadata,omitempty"`
-	ExpiresAt  string         `json:"expires_at,omitempty"`
-	TargetName string         `json:"target_name,omitempty"`
+	Scope      Scope
+	Body       string
+	Slug       string
+	Metadata   map[string]any
+	ExpiresAt  string
+	TargetName string
+	// Persist, when true, emits ``"expires_at": null`` on the wire
+	// even when ExpiresAt is empty. Mutually exclusive with a non-
+	// empty ExpiresAt in practice; the verb-level CLI gate refuses
+	// `--persist` + `--ttl` together so the operator's intent is
+	// unambiguous. The struct doesn't enforce that mutual exclusion
+	// itself (callers do) -- when both are set, ExpiresAt wins
+	// because emitting "null" alongside a real timestamp would be
+	// nonsensical.
+	Persist bool
+}
+
+// MarshalJSON renders rememberRequest with explicit handling for the
+// G5.2-T2 (#624) tri-state “expires_at“ contract. See the type-level
+// docstring for the three states and their wire shapes.
+//
+// Implementation notes:
+//
+//   - Uses a positional emit (json.Marshal over a map[string]any)
+//     rather than struct tags so the `expires_at` rendering can branch
+//     on the Persist bool without leaking into the public field set.
+//   - The map ordering does not affect JSON correctness; the backend
+//     parses fields by key, not position.
+//   - "Persist + ExpiresAt set" lets ExpiresAt win (we already wrote
+//     the operator's intent to a clock-aligned cutoff at the
+//     parseTTLFlag stage; emitting `null` would silently override
+//     their `--ttl` value). The verb-level mutual-exclusion gate is
+//     where this collision is reported back to the operator.
+func (r rememberRequest) MarshalJSON() ([]byte, error) {
+	out := map[string]any{
+		"scope": r.Scope,
+		"body":  r.Body,
+	}
+	if r.Slug != "" {
+		out["slug"] = r.Slug
+	}
+	if r.Metadata != nil {
+		out["metadata"] = r.Metadata
+	}
+	if r.TargetName != "" {
+		out["target_name"] = r.TargetName
+	}
+	switch {
+	case r.ExpiresAt != "":
+		out["expires_at"] = r.ExpiresAt
+	case r.Persist:
+		// Explicit JSON `null` so backend's
+		// :func:`_resolve_default_ttl` sees "expires_at" in
+		// :attr:`BaseModel.model_fields_set` and skips the default.
+		out["expires_at"] = nil
+	}
+	return json.Marshal(out)
 }
 
 // retrieveRequest mirrors the backend `RetrieveRequest` pydantic

--- a/cli/internal/cmd/memory/memory_test.go
+++ b/cli/internal/cmd/memory/memory_test.go
@@ -646,6 +646,172 @@ func TestRunRememberSendsExpiresAtFromTTL(t *testing.T) {
 	}
 }
 
+// G5.2-T2 (#624): --persist flag tests.
+//
+// The wire contract this verb must satisfy:
+//
+//   - --persist alone → request body carries explicit "expires_at":
+//     null (so the backend's _resolve_default_ttl sees the field in
+//     model_fields_set and skips the default-7-day injection).
+//   - --persist absent + no --ttl → "expires_at" key OMITTED entirely
+//     (backend's model_fields_set is empty, default fires on user
+//     scope).
+//   - --persist + --ttl → CLI-side error (mutually exclusive).
+//
+// The "explicit null vs absent" assertion uses json.RawMessage so the
+// test sees the literal wire bytes, not the decoded map (which would
+// collapse both shapes to a Go nil interface).
+
+func TestRunRememberPersistEmitsExplicitNullExpiresAt(t *testing.T) {
+	var rawBody json.RawMessage
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		rawBody = json.RawMessage(b)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "persisted"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runRemember(cmd, rememberOptions{
+		BodyArg: "pin-forever", ScopeArg: "user",
+		Persist: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runRemember --persist: %v", err)
+	}
+	// Decode into a map[string]json.RawMessage so we can see whether
+	// "expires_at" was present at all (key in map) and, if so,
+	// whether its value was the four bytes `null`.
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rawBody, &fields); err != nil {
+		t.Fatalf("decode raw body: %v; body=%s", err, rawBody)
+	}
+	raw, present := fields["expires_at"]
+	if !present {
+		t.Fatalf("expected expires_at to be present (as JSON null) when --persist is set; body=%s", rawBody)
+	}
+	if string(raw) != "null" {
+		t.Errorf("expected expires_at to be literal JSON null; got %q (body=%s)", raw, rawBody)
+	}
+}
+
+func TestRunRememberOmitsExpiresAtWhenNoPersistAndNoTTL(t *testing.T) {
+	var rawBody json.RawMessage
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		rawBody = json.RawMessage(b)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "auto"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "user", BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runRemember: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rawBody, &fields); err != nil {
+		t.Fatalf("decode raw body: %v", err)
+	}
+	if _, present := fields["expires_at"]; present {
+		t.Errorf("expected expires_at absent when neither --persist nor --ttl is set; body=%s", rawBody)
+	}
+}
+
+func TestRunRememberPersistAndTTLAreMutuallyExclusive(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "user", TTLArg: "1d", Persist: true,
+		BackplaneOverride: "https://meho.test",
+	})
+	if err == nil {
+		t.Fatalf("expected error when --persist and --ttl are both set")
+	}
+	if !strings.Contains(stderr.String(), "mutually exclusive") {
+		t.Errorf("expected mutually-exclusive message; got %q", stderr.String())
+	}
+}
+
+func TestRememberRequestMarshalPersistTriState(t *testing.T) {
+	// Direct unit test of the MarshalJSON tri-state contract; the
+	// higher-level runRemember tests above pin the wire shape end-to-
+	// end, but the struct-level test is what a future refactor would
+	// touch first.
+	cases := []struct {
+		name        string
+		req         rememberRequest
+		wantPresent bool
+		wantNull    bool
+		wantString  string
+	}{
+		{
+			name:        "absent when neither set",
+			req:         rememberRequest{Scope: ScopeUser, Body: "x"},
+			wantPresent: false,
+		},
+		{
+			name:        "null when persist=true",
+			req:         rememberRequest{Scope: ScopeUser, Body: "x", Persist: true},
+			wantPresent: true,
+			wantNull:    true,
+		},
+		{
+			name:        "string when ExpiresAt set",
+			req:         rememberRequest{Scope: ScopeUser, Body: "x", ExpiresAt: "2027-01-01T00:00:00Z"},
+			wantPresent: true,
+			wantString:  "2027-01-01T00:00:00Z",
+		},
+		{
+			name:        "ExpiresAt wins over Persist when both set",
+			req:         rememberRequest{Scope: ScopeUser, Body: "x", ExpiresAt: "2027-01-01T00:00:00Z", Persist: true},
+			wantPresent: true,
+			wantString:  "2027-01-01T00:00:00Z",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.req)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(b, &fields); err != nil {
+				t.Fatalf("re-decode: %v", err)
+			}
+			raw, present := fields["expires_at"]
+			if present != tc.wantPresent {
+				t.Errorf("expires_at presence: got %v want %v (body=%s)", present, tc.wantPresent, b)
+			}
+			if !present {
+				return
+			}
+			if tc.wantNull && string(raw) != "null" {
+				t.Errorf("expected literal null; got %s", raw)
+			}
+			if tc.wantString != "" {
+				var s string
+				if err := json.Unmarshal(raw, &s); err != nil {
+					t.Fatalf("decode string: %v (raw=%s)", err, raw)
+				}
+				if s != tc.wantString {
+					t.Errorf("expires_at string: got %q want %q", s, tc.wantString)
+				}
+			}
+		})
+	}
+}
+
 func TestRunRememberTargetScopeRequiresTargetFlag(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	cmd.SetIn(bytes.NewBufferString(""))

--- a/cli/internal/cmd/memory/remember.go
+++ b/cli/internal/cmd/memory/remember.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -17,7 +18,7 @@ import (
 
 // NewRememberCmd returns the top-level `meho remember` command.
 //
-// CLI shape (per issue #424):
+// CLI shape (per issue #424; --persist added by G5.2-T2 #624):
 //
 //	meho remember "body text" \
 //	  [--scope user|user-tenant|user-target|tenant|target] \
@@ -25,6 +26,7 @@ import (
 //	  [--target TARGET_NAME] \
 //	  [--tag T] \
 //	  [--ttl 7d] \
+//	  [--persist] \
 //	  [--json] \
 //	  [--backplane <url>]
 //
@@ -37,6 +39,15 @@ import (
 // a flag there because the slug is the positional. Here the body is
 // the positional and `--slug` is a flag, so we use `-` as the
 // in-band stdin marker.)
+//
+// `--persist` opts out of the G5.2-T2 (#624) backend default-TTL
+// injection: the verb emits “"expires_at": null“ on the wire so
+// the backend's :func:`_resolve_default_ttl` sees the field as
+// explicitly present-and-null and refuses to inject the default 7-
+// day cutoff. Mutually exclusive with `--ttl`: passing both surfaces
+// a CLI-side error before the HTTP round-trip (`--ttl` already
+// computes an absolute cutoff; emitting `null` alongside it would
+// be self-contradictory).
 //
 // Role: any authenticated operator (`read_only` excluded at the
 // FastAPI gate). The service-layer MemoryRbacResolver further
@@ -56,6 +67,7 @@ func NewRememberCmd() *cobra.Command {
 		targetFlag        string
 		tagsFlag          []string
 		ttlFlag           string
+		persistFlag       bool
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -96,6 +108,7 @@ func NewRememberCmd() *cobra.Command {
 				TargetArg:         targetFlag,
 				TagsArg:           tagsFlag,
 				TTLArg:            ttlFlag,
+				Persist:           persistFlag,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
@@ -111,6 +124,8 @@ func NewRememberCmd() *cobra.Command {
 		"tag to attach to the memory; repeat for multiple tags")
 	cmd.Flags().StringVar(&ttlFlag, "ttl", "",
 		"time-to-live shorthand (e.g. `7d`, `36h`, `30m`) — set expires_at")
+	cmd.Flags().BoolVar(&persistFlag, "persist", false,
+		"persist forever — opt out of the backend's default-7-day TTL on memory-user writes (sends expires_at=null)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit raw Entry JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -119,12 +134,17 @@ func NewRememberCmd() *cobra.Command {
 }
 
 type rememberOptions struct {
-	BodyArg           string
-	ScopeArg          string
-	SlugArg           string
-	TargetArg         string
-	TagsArg           []string
-	TTLArg            string
+	BodyArg   string
+	ScopeArg  string
+	SlugArg   string
+	TargetArg string
+	TagsArg   []string
+	TTLArg    string
+	// Persist is the wire-shape flag for the G5.2-T2 (#624) backend
+	// default-TTL opt-out: when true and TTLArg is empty, the
+	// request emits ``"expires_at": null`` so the backend skips
+	// the default 7-day injection and the memory persists forever.
+	Persist           bool
 	JSONOut           bool
 	BackplaneOverride string
 }
@@ -138,6 +158,16 @@ func runRemember(cmd *cobra.Command, opts rememberOptions) error {
 	if err := requireTargetForScope(scope, opts.TargetArg); err != nil {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	// `--persist` opts out of the backend default TTL; `--ttl` sets
+	// an explicit cutoff. Both at once is self-contradictory (the
+	// operator wants "never expire" and "expire on X" simultaneously),
+	// so refuse client-side rather than letting the JSON marshaler
+	// silently let ExpiresAt win and discard --persist's intent.
+	if opts.Persist && strings.TrimSpace(opts.TTLArg) != "" {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("--persist and --ttl are mutually exclusive: --persist means \"never expire\", --ttl sets a finite cutoff"),
+			opts.JSONOut)
 	}
 	body, err := loadBody(cmd, opts.BodyArg)
 	if err != nil {
@@ -160,6 +190,7 @@ func runRemember(cmd *cobra.Command, opts rememberOptions) error {
 		Slug:       opts.SlugArg,
 		ExpiresAt:  expiresAt,
 		TargetName: opts.TargetArg,
+		Persist:    opts.Persist,
 	}
 	if tags := parseTagsFlag(opts.TagsArg); tags != nil {
 		// `tags` lands under `metadata.tags` per consumer-needs.md

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -83,7 +83,7 @@ The `TARGET` scope's "any operator in the tenant" RBAC is a v0.2 placeholder. Th
 
 `expires_at` is stored in `documents.metadata` rather than as a dedicated column — the substrate is shared with G4 kb (no expiry concept), and adding a NULL-able expiry column for one consumer would pollute the schema. The read paths (`recall` / `list_memories` / `search_memories`) filter out rows whose stored `expires_at` lies in the past unless the caller opts in via `include_expired=True`. G5.1 ships only this read-side filter; G5.2 #374's daily background task is what *deletes* expired rows and writes the `INTERNAL/memory.expire` audit row.
 
-The default-7-day-TTL injection on user-scoped writes (when the caller omits `expires_at`) is also G5.2 — G5.1 stores `None` in `metadata.expires_at` and the read-side filter treats it as "never expires". The `--persist` flag at the CLI and explicit `expires_at: null` at the API are the opt-outs G5.2 will respect.
+The default-7-day-TTL injection on user-scoped writes (when the caller omits `expires_at`) lands in [G5.2-T2 #624](https://github.com/evoila/meho/issues/624): the `POST /api/v1/memory` handler resolves `expires_at = now(UTC) + Settings.memory_user_default_ttl_days` (env-var `MEMORY_USER_DEFAULT_TTL_DAYS`, default 7, range 1-365 days) when the request body **omits** the field and `scope == MemoryScope.USER`. The "omitted-vs-null" discrimination uses Pydantic v2's `BaseModel.model_fields_set` (the set carries every field name the constructor saw in the input, regardless of value): explicit `"expires_at": null` in the request body opts out and the row persists forever. The CLI's `--persist` flag is exactly that wire shape — it sends `expires_at: null` (rather than omitting the field) so the backend takes the explicit-null branch. Default-TTL only fires on `MemoryScope.USER` (the `memory-user` kind); `user-tenant`, `user-target`, `tenant`, and `target` scopes are team-shared coordinates that stay operator-controlled.
 
 ## The four surfaces
 
@@ -113,7 +113,7 @@ Every route binds two contextvars **before** the service call so the chassis [`A
 
 `forget` and `list` are **deliberately absent** from the agent surface (CLAUDE.md postulate 5 carves the agent surface narrow). An agent reaches list-style queries via `search_memory(scope=...)`; `forget` is a deliberate-write op normally driven by operators, not by the agent without explicit confirmation.
 
-The tool descriptions are load-bearing agent UX — `add_to_memory` is called by every agent session that learns something worth retaining. The descriptions name the lifecycle contract (default 7-day TTL on user scope when G5.2 ships, `--persist` opt-out) so an agent learns it from the tool definition itself rather than guessing.
+The tool descriptions are load-bearing agent UX — `add_to_memory` is called by every agent session that learns something worth retaining. The descriptions name the lifecycle contract (default 7-day TTL on user scope per [G5.2-T2 #624](https://github.com/evoila/meho/issues/624), `--persist` opt-out at the CLI / explicit `expires_at: null` at the API) so an agent learns it from the tool definition itself rather than guessing.
 
 ### MCP resource (T3 #423)
 
@@ -127,7 +127,7 @@ The URI template is a v0.2 simple-expansion shape — `target_name` is **not** i
 
 | Verb | Backend call | Role |
 |---|---|---|
-| `meho remember "body" [--scope SCOPE] [--slug SLUG] [--target NAME] [--tag T] [--ttl 7d] [--json]` | `POST /api/v1/memory` | `operator` |
+| `meho remember "body" [--scope SCOPE] [--slug SLUG] [--target NAME] [--tag T] [--ttl 7d] [--persist] [--json]` | `POST /api/v1/memory` | `operator` |
 | `meho recall <scope>/<slug> [--target NAME] [--json]` | `GET /api/v1/memory/{scope}/{slug}` | `operator` |
 | `meho recall --query "search terms" [--scope SCOPE] [--limit N] [--json]` | `POST /api/v1/retrieve` (`source="memory"` pinned) | `operator` |
 | `meho forget <scope>/<slug> [--target NAME] [--confirm] [--json]` | `DELETE /api/v1/memory/{scope}/{slug}` | `operator` |
@@ -135,7 +135,9 @@ The URI template is a v0.2 simple-expansion shape — `target_name` is **not** i
 
 The verbs are **top-level** (not nested under `meho memory ...`) per the consumer-needs.md §G5 ergonomic shape — "I prefer kubectl over k9s" is a user-scoped `meho remember`, not a `meho memory remember`. The `meho list` verb takes the bare-word slot the issue's acceptance criterion names verbatim (`meho list --scope user`).
 
-`--ttl 7d` is parsed CLI-side into an RFC 3339 `expires_at` and POSTed as `expires_at` in the body; the shorthand accepts `s` / `m` / `h` / `d` suffixes (`time.ParseDuration` doesn't accept `d`, so days are handled explicitly). Empty `--ttl` defers to the backplane default (none in G5.1; default 7 days on `memory-user` writes when G5.2 ships).
+`--ttl 7d` is parsed CLI-side into an RFC 3339 `expires_at` and POSTed as `expires_at` in the body; the shorthand accepts `s` / `m` / `h` / `d` suffixes (`time.ParseDuration` doesn't accept `d`, so days are handled explicitly). Empty `--ttl` defers to the backplane default: G5.1 left this as "never expires"; [G5.2-T2 #624](https://github.com/evoila/meho/issues/624) injects the default 7-day cutoff on `memory-user` writes when the field is omitted.
+
+`--persist` is the explicit opt-out: the verb emits `"expires_at": null` on the wire so the backend's `_resolve_default_ttl` takes the explicit-null branch and skips the default-TTL injection. The flag is mutually exclusive with `--ttl` (passing both surfaces a CLI-side error before the HTTP round-trip; `--persist` means "never expire", `--ttl` sets a finite cutoff). Use `--persist` for memories you intentionally want to retain across the 7-day window — durable user-scoped preferences like `kubectl-preference` or `editor-preference`.
 
 `meho remember "body"` accepts inline text by default; the bare hyphen `-` reads stdin (`echo "body text" | meho remember -`) so piped migration works.
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -132,7 +132,7 @@ cli/
     │   │   └── delete_test.go    # confirm-prompt + idempotent-204 + --json envelope tests.
     │   ├── memory/           # G5.1-T4 #424 — top-level `meho remember/recall/forget/list` (no parent).
     │   │   ├── memory.go         # Scope enum + Entry/ListResponse/RetrievalHit + shared HTTP/auth helpers + parseScope/parseTTL/parseTags/parseScopeSlugArg/loadBody/confirmPrompt.
-    │   │   ├── remember.go       # `meho remember <body> [--scope --slug --target --tag --ttl --json]` (POST /api/v1/memory).
+    │   │   ├── remember.go       # `meho remember <body> [--scope --slug --target --tag --ttl --persist --json]` (POST /api/v1/memory). `--persist` (G5.2-T2 #624) sends explicit `expires_at: null` to opt out of the backend's default-7-day TTL on `memory-user` writes.
     │   │   ├── recall.go         # `meho recall <scope>/<slug>` or `meho recall --query` (GET /api/v1/memory/{scope}/{slug} or POST /api/v1/retrieve, source="memory").
     │   │   ├── forget.go         # `meho forget <scope>/<slug> [--confirm --target --json]` (DELETE /api/v1/memory/{scope}/{slug}).
     │   │   ├── list.go           # `meho list [--scope --tag --slug-pattern --include-expired --limit --json]` (GET /api/v1/memory).

--- a/docs/cross-repo/memory-migration.md
+++ b/docs/cross-repo/memory-migration.md
@@ -110,16 +110,17 @@ meho recall user/kubectl-preference                              # exact natural
 
 A `meho recall user/missing-slug` returns 404 (CLI exit code 4) by design — the route deliberately conflates "not found" and "no access" so an operator can't probe for slugs they shouldn't see.
 
-## Default TTL behavior (when G5.2 ships)
+## Default TTL behavior
 
-[#374 G5.2](https://github.com/evoila/meho/issues/374) ships a default 7-day TTL injection on `memory-user` writes that omit `expires_at`. When G5.2 lands:
+[#624 G5.2-T2](https://github.com/evoila/meho/issues/624) ships the default 7-day TTL injection on `memory-user` writes that omit `expires_at`. Concretely:
 
-- Every `meho remember --scope user "..."` without `--ttl` will land with `expires_at = now + 7d`. The entry is invisible to reads after the cutoff (read-side filter on `expires_at`) and physically deleted by the daily reap.
+- Every `meho remember --scope user "..."` without `--ttl` lands with `expires_at = now + Settings.memory_user_default_ttl_days` (default 7, range 1-365 via the `MEMORY_USER_DEFAULT_TTL_DAYS` env var / Helm `memory.userDefaultTtlDays`). The entry is invisible to reads after the cutoff (read-side filter on `expires_at`) and physically deleted by the G5.2-T1 [#623](https://github.com/evoila/meho/issues/623) daily reap.
 - Pass `--ttl 30d` (or `--ttl 12h`, `--ttl 36m`) to set a specific lifetime. The shorthand accepts `s` / `m` / `h` / `d` suffixes.
-- Pass `--persist` to opt out of the default TTL (the entry never expires until you `meho forget` it). Use this for memories you intentionally want to retain across the 7-day window — typically the durable preferences (`kubectl-preference`, `editor-preference`).
+- Pass `--persist` to opt out of the default TTL (the entry never expires until you `meho forget` it). Use this for memories you intentionally want to retain across the 7-day window — typically the durable preferences (`kubectl-preference`, `editor-preference`). `--persist` is mutually exclusive with `--ttl`: passing both surfaces a CLI-side error before the HTTP round-trip.
 - `user-tenant`, `user-target`, `tenant`, `target` scopes do **not** receive the default TTL — only `user` does. Tenant / target memories are intentionally long-lived; user-scoped is the "what I'm investigating today" cadence.
+- Direct REST callers (not `meho remember`) can opt out by sending `"expires_at": null` in the JSON body. The handler distinguishes "field omitted" from "field present with value null" via Pydantic v2's `BaseModel.model_fields_set` — the former triggers the default, the latter is the explicit-persist shape `--persist` emits.
 
-Until G5.2 ships, every memory written without `--ttl` is persistent (G5.1 stores `None` in `metadata.expires_at` and the read-side filter treats it as "never expires"). Plan migration accordingly: bulk-migrating an old laptop directory under G5.1 means everything is persistent until you `meho forget` it; under G5.2 the user-scoped subset will start expiring on a rolling 7-day window.
+Plan migration accordingly: under G5.2 the user-scoped subset of a bulk migration starts expiring on a rolling 7-day window unless you pass `--persist` per row. Pre-existing rows written under G5.1 (before #624 landed) keep their stored value — only **new** writes go through the default-injection path.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary

- `POST /api/v1/memory` now injects `expires_at = now(UTC) + Settings.memory_user_default_ttl_days` (default 7) when the request omits `expires_at` AND `scope == MemoryScope.USER`. Other scopes pass through unchanged.
- Discrimination between "field omitted" and "field present with value null" uses Pydantic v2's `BaseModel.model_fields_set` — explicit `"expires_at": null` opts out of the default and pins the memory forever.
- `meho remember` gains `--persist`, a verb-level flag that emits `expires_at: null` on the wire (struct-level `MarshalJSON` is the load-bearing tri-state gate; Go's `omitempty` can't express explicit-null). Mutually exclusive with `--ttl`.
- Consumes the `MEMORY_USER_DEFAULT_TTL_DAYS` Setting landed by G5.2-T1 (#623); no redefinition. G5.2-T1's sweeper reaps the rows; T2 populates the `expires_at` field they reap on.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — Success: no issues found in 192 source files
- [x] `pytest tests/test_api_v1_memory.py tests/test_memory_expiry.py tests/test_memory_service.py tests/test_memory_rbac.py` — 126 passed
- [x] `go test -count=1 ./internal/cmd/memory/...` — ok
- [x] Acceptance: `POST /api/v1/memory` `scope=user` no `expires_at` → row has `expires_at ≈ now+7d` (within tolerance for clock drift)
- [x] Acceptance: explicit `expires_at: null` on user scope → no default applied
- [x] Acceptance: explicit ISO `expires_at` → stored verbatim
- [x] Acceptance: non-`user` scopes (user-tenant, tenant) with no `expires_at` → no default applied
- [x] Acceptance: `meho remember … --persist` test asserts wire body has literal `"expires_at": null`
- [x] Acceptance: `MEMORY_USER_DEFAULT_TTL_DAYS=30` env override → row has `expires_at ≈ now+30d`

## Files touched

- `backend/src/meho_backplane/api/v1/memory.py` — added `_resolve_default_ttl` helper + handler hook + docstring updates.
- `backend/tests/test_api_v1_memory.py` — 5 new pytest cases covering the default-TTL contract end-to-end at the handler boundary.
- `cli/internal/cmd/memory/memory.go` — `rememberRequest` gains a `Persist` field + custom `MarshalJSON` that emits explicit null when `Persist=true` and `ExpiresAt` is empty.
- `cli/internal/cmd/memory/remember.go` — `--persist` flag wired through `rememberOptions`; mutual-exclusion check vs `--ttl`.
- `cli/internal/cmd/memory/memory_test.go` — 4 new Go tests: `--persist` emits explicit null, absence omits the key, mutual exclusion, MarshalJSON tri-state unit test.
- `docs/architecture/memory.md`, `docs/codebase/cli.md`, `docs/cross-repo/memory-migration.md` — updated to describe the shipped behavior (no longer "when G5.2 ships").

## Out of scope

- The expiry sweeper itself — G5.2-T1 #623, already merged.
- Promotion logic (`assert_can_promote`, `_PROMOTION_LADDER`) — G5.2-T3 #625.
- Promotion clearing the TTL — G5.2-T4 #626.
- The `meho promote` CLI verb — G5.2-T5 #627.

## Adjacent findings

- `backend/src/meho_backplane/api/v1/memory.py` is 576 lines (warn at 400) and the `remember` / `forget` handlers are 95 / 78 lines after docstring growth. Pre-existing legacy debt; out of scope for #624.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #624


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--persist` flag to `meho remember` command to opt out of automatic memory expiration
  * User-scoped memories now expire after 7 days by default (previously never expired); configurable via environment settings

* **Documentation**
  * Updated memory architecture and migration guides to reflect new default TTL behavior and `--persist` usage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->