### PR TITLE
perf(ci): pin pytest-xdist -n 3 + skip --cov on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,27 @@ jobs:
         # the container-heavy subtree runs in the sibling
         # `python-integration` job. Coverage is the unit sweep only;
         # combined cov is #564.
-        run: uv run pytest -n 3 --dist loadscope --maxfail=1 --ignore=tests/integration --cov=meho_backplane --cov-report=xml --cov-report=term tests/
+        # Coverage gated to push events only (push-to-main): pytest-cov
+        # instrumentation is the unit job's dominant cost — run
+        # 26164020459 clocked ~27min on 2678 items, and coverage tracing
+        # adds an empirical 30-60% wall-time tax on xdist suites. PRs
+        # skip --cov entirely so the merge gate stays fast; main pushes
+        # still produce coverage.xml for quality-gate.yml's SonarCloud
+        # workflow_run consumer. SonarCloud's Clean-as-You-Code semantics
+        # tolerate coverage updating one merge later — main always
+        # carries fresh data, and quality-gate.yml is whole-job
+        # continue-on-error so missing PR coverage never blocks merge.
+        # Trade-off accepted: PR-level Sonar coverage decoration goes
+        # quiet (the new-code coverage widget shows "no data" on PRs).
+        # --cov-report=term dropped regardless — purely cosmetic and
+        # serializes through xdist workers.
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            uv run pytest -n 3 --dist loadscope --maxfail=1 --ignore=tests/integration \
+              --cov=meho_backplane --cov-report=xml tests/
+          else
+            uv run pytest -n 3 --dist loadscope --maxfail=1 --ignore=tests/integration tests/
+          fi
 
       - name: Upload Python coverage artifact
         # Consumed by quality-gate.yml (`workflow_run` -> SonarCloud).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,16 @@ jobs:
         # `-n auto --dist loadscope` 2007/0/0 — identical, empty
         # failure set; local wall-clock serial 10:18 → xdist 6:14
         # (limited by core count; CI multi-core gets the ~49→~10 min).
-        # -n auto: one worker per core. --dist loadscope: a module's
+        # -n 3: pinned. -n auto was inconsistent on these ARC pods —
+        # run 26164020459 (main, 2026-05-20 12:57Z) reported 4 workers,
+        # a later same-day PR push reported 8. The variance points at
+        # cgroup-aware CPU detection mismatches (or pod-size drift);
+        # either way, pinning removes the ambiguity and the context-
+        # switch tax `-n auto` was silently paying. 3 reserves headroom
+        # for the xdist coordinator + the DinD daemon (testcontainers
+        # pgvector/valkey fire from unit-suite tests too, not just the
+        # integration job — see MEHO_TEST_PGVECTOR_IMAGE env above).
+        # --dist loadscope: a module's
         # tests stay on one worker so module-/session-scoped fixtures
         # (testcontainers PG, embedding service) instantiate per
         # worker, not per test. --maxfail=1 preserves the old `-x`
@@ -253,7 +262,7 @@ jobs:
         # the container-heavy subtree runs in the sibling
         # `python-integration` job. Coverage is the unit sweep only;
         # combined cov is #564.
-        run: uv run pytest -n auto --dist loadscope --maxfail=1 --ignore=tests/integration --cov=meho_backplane --cov-report=xml --cov-report=term tests/
+        run: uv run pytest -n 3 --dist loadscope --maxfail=1 --ignore=tests/integration --cov=meho_backplane --cov-report=xml --cov-report=term tests/
 
       - name: Upload Python coverage artifact
         # Consumed by quality-gate.yml (`workflow_run` -> SonarCloud).


### PR DESCRIPTION
## Summary

Two-commit performance fix for the `python-lint-test` unit job, which the most recent successful main run (26164020459, 2026-05-20 12:57Z) clocked at **~27 min** on 2678 items.

- **`perf(ci): pin pytest-xdist to -n 3 (was -n auto)`** — `-n auto` was reporting inconsistent worker counts across runs on `meho-runners-ci` ARC pods (4 workers on 26164020459, 8 on a later same-day PR push). Either cgroup-aware CPU detection mismatch or pod-size drift; either way, pinning removes the ambiguity and the context-switch tax. `-n 3` reserves headroom for the xdist coordinator and the DinD daemon — testcontainers pgvector/valkey fire from unit-suite tests too (`test_db_engine`, `test_db_models`, `test_broadcast_client`), not only from the sibling `python-integration` job.

- **`perf(ci): skip --cov on pull_request events (push-to-main only)`** — pytest-cov instrumentation is the unit job's dominant cost (30-60% wall-time tax empirically on xdist suites). Gate `--cov=meho_backplane --cov-report=xml` on `github.event_name == 'push'`; PRs take the fast path. `main` pushes still emit `coverage.xml` for [`quality-gate.yml`](.github/workflows/quality-gate.yml)'s SonarCloud `workflow_run` consumer. Also drops `--cov-report=term` (cosmetic, serializes through xdist workers).

## Trade-off accepted

PR-level Sonar coverage decoration will go quiet — the new-code coverage widget on PR comments will show "no data". The merge gate itself never blocked on Sonar ([`quality-gate.yml:42`](.github/workflows/quality-gate.yml#L42) is whole-job `continue-on-error`, with `continue-on-error` also on the artifact-download step at [`quality-gate.yml:56`](.github/workflows/quality-gate.yml#L56)), so missing PR coverage never blocks merge. `main` always carries fresh coverage data from push-mode runs.

If the team misses PR-level coverage decoration after a few merges, layering a `COVERAGE_CORE=sysmon` swap (py3.12's `sys.monitoring` backend on coverage.py 7.4+) typically halves the coverage overhead and can re-enable PR-mode coverage.

## Expected wall-time delta

The PR-mode runs (this very PR will be the first data point) should show ~30-50% reduction vs. the current ~27min unit-job wall. Push-mode runs (after merge) stay similar to current. We'll get a clean before/after once this PR's CI lights up.

## Test plan

- [ ] CI on this PR runs in PR mode (no `--cov`) — verify the `Pytest (unit + coverage)` step output omits coverage instrumentation
- [ ] CI step reports `created: 3/3 workers` (was 4/8 variable on `-n auto`)
- [ ] First push-to-main run after merge produces the `python-coverage` artifact
- [ ] `quality-gate.yml` (`workflow_run`) succeeds on that push and updates SonarCloud
- [ ] Compare unit-job wall: PR-mode (this PR's CI) vs current ~27min baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline test execution and coverage reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->