### PR TITLE
docs(cross-repo): RDC team reply — verified dual-layer connector model + ingest path

### DIFF
--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -1,0 +1,216 @@
+# Connector release readiness
+
+How to honestly describe a connector's ship state in release notes, the
+operator kb, and Goal-tracker bodies — distinguishing the three layers
+that have to land before a connector executes end-to-end against a real
+operator's target in production.
+
+This document is the lasting artifact from the v0.3.0 consumer-feedback
+triage. The triage caught a consumer-side kb mis-supersede that was
+shipped in the morning and corrected the same afternoon, by exactly the
+"read the source per connector" discipline the consumer's own kb had
+distilled the day before. The lesson belongs upstream too.
+
+## The three states
+
+A connector ships through three layers. **Release notes / kb / Goal-tracker
+text must say which layer the release ships, not the next layer up.**
+
+### State 1 — Dispatch + catalog only
+
+What's shipped:
+
+- Connector class registered via `register_connector_v2(...)` in
+  [connectors/registry.py](../../backend/src/meho_backplane/connectors/registry.py).
+- Operations register into `endpoint_descriptor` (typed: via
+  [`register_typed_operation`](../../backend/src/meho_backplane/operations/typed_register.py);
+  ingested: via the G0.7 review pipeline). `operation_group` rows
+  written alongside, indexed by the hybrid BM25 + cosine search.
+- `search_operations(connector_id, query)`, `list_operation_groups(connector_id)`,
+  and `call_operation(connector_id, op_id, target, params)` all return
+  cataloged ops.
+- Per-op `description`, `safety_level`, `requires_approval`,
+  `llm_instructions` metadata is curated and surfaces through the MCP +
+  REST API.
+- Integration tests (testcontainers / k3d / mock-loader) exercise the
+  dispatch path against an **injected loader** — not against real
+  per-target credentials.
+
+What's NOT shipped at this state:
+
+- The default loader (e.g. `load_kubeconfig_from_vault`,
+  `load_session_credentials_from_vault`, `load_credentials_from_vault`)
+  is a `NotImplementedError` stub.
+- `operations/call <op_id> target=...` against a real operator-context
+  Vault path raises `NotImplementedError` in production.
+
+How to verify a connector is at this state (and not further along):
+
+```bash
+# 1. Class registered:
+rg "register_connector_v2.*product=.<connector-name>" backend/src/
+# 2. Ops registered:
+rg "op_id=.<connector-name>\." backend/src/meho_backplane/connectors/<connector-name>/
+# 3. Loader stubbed:
+rg "raise NotImplementedError" backend/src/meho_backplane/connectors/<connector-name>/
+```
+
+**v0.3.0 examples at this state:** `k8s-1.x`, `vmware-rest-9.0`.
+
+**Honest release-notes language:**
+
+> *"Kubernetes typed connector dispatch + catalog (13 ops indexed; loader
+> wiring tracked under [#214](https://github.com/evoila/meho/issues/214))."*
+
+**Dishonest release-notes language** (the v0.3.0 mistake — fixed in [T7
+amendment #735](https://github.com/evoila/meho/issues/735)):
+
+> *"Kubernetes typed connector (13 ops, k3d CI)."*
+
+This reads as "production-ready" because k3d CI is a strong signal and
+"13 ops" doesn't include the qualifier. Adopters who read this and ran
+`operations/call k8s.namespace.list target=<their-vault-backed-target>`
+got `NotImplementedError`, not the operator inventory they expected.
+
+### State 2 — Loader-wired, single auth model
+
+What's shipped (on top of State 1):
+
+- The default loader reads real operator-context per-target Vault
+  credentials for **one** `auth_model` (e.g. `shared_service_account`).
+- Production dispatch path `operations/call <op_id> target=...`
+  executes end-to-end for targets with that auth_model.
+- Tests exercise the live loader against a real Vault dev-mode harness
+  (not just a mock).
+
+What's NOT shipped:
+
+- Other auth_models (`per_user`, `impersonation`) still raise a clear
+  boundary error.
+
+**v0.3.0 examples at this state:** `bind9-ssh-9.x` (the SSH transport
+loads credentials inline in the connector — no separate `session.py`
+stub; the credential read for `shared_service_account` is live). The
+consumer correctly noted this as the "closest to parity" connector.
+
+**Honest release-notes language:**
+
+> *"bind9 typed-SSH connector — 11 ops, atomic-apply discipline.
+> `shared_service_account` auth model live; `per_user` tracked under
+> #N."*
+
+### State 3 — Full production execution
+
+What's shipped (on top of State 2):
+
+- All advertised `auth_model`s are wired and execute.
+- The connector's full op catalog is in production rotation for the
+  operator workflows it covers.
+- Operator onboarding doc at `docs/cross-repo/<connector>-onboarding.md`
+  has been written, reviewed, and validates against a real deploy.
+
+**v0.3.0 examples at this state:** `vault-1.x` (the JWT-federated auth
+flow is the only auth_model; loader is live; consumer confirmed
+`operations/call vault.kv.read target={"name":"rdc-vault"} ...` returns
+`status: ok` in 66–80 ms via both REST and MCP).
+
+**Honest release-notes language:**
+
+> *"vault-1.x typed op surface ready for production
+> (`jwt-federated` auth model, full ops catalog)."*
+
+## State map of the v0.3.0 connectors
+
+| Connector | State | Loader | Production-execute? |
+|---|---|---|---|
+| `vault-1.x` | 3 | JWT-federated, live | ✅ |
+| `bind9-ssh-9.x` | 2-3 | `shared_service_account` inline | ✅ |
+| `k8s-1.x` | 1 | [`load_kubeconfig_from_vault`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py#L86) — `NotImplementedError` | ❌ (mock loader in test only) |
+| `vmware-rest-9.0` (composites) | 1 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L107) — `NotImplementedError` | ❌ (mock loader in test only) |
+| `sddc-manager-9.0` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
+| `harbor-2.x` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
+| `kubernetes-asyncio-1.x` | 1 (shadow) | Same as `k8s-1.x` | ❌ |
+
+State 0.5 = `register_connector_v2` called but no ops registered yet
+(visible to internal code, invisible to `GET /api/v1/connectors`).
+Asymmetry tracked under [T5 #733](https://github.com/evoila/meho/issues/733).
+
+## Why this is hard to get right
+
+The k3d / testcontainers test pattern injects an `override_loader` at
+test boundary. Tests pass. CI is green. The release-notes writer sees
+"13 ops + k3d CI" and writes "13 ops, k3d CI" in the release body. An
+adopter reads "k3d CI" as a production-execute signal. The catalog
+indexes the op. `search_operations` finds it. `call_operation` dispatches
+to the loader. The default loader raises `NotImplementedError`. The
+adopter is surprised.
+
+This isn't carelessness on anyone's part — it's the inherent shape of a
+catalog-first connector architecture. The fix is **vocabulary discipline**
+in the release-notes, kb, and Goal-tracker layers. Naming the three
+states explicitly (and citing the open Goal that tracks the next-layer
+work) lets adopters read "what state is this in?" off the release-notes
+language directly.
+
+## The release-notes convention going forward
+
+Every connector-related entry in `CHANGELOG.md` cites the state and the
+live auth_models. Examples:
+
+- *"feat(connectors): G3.X — Foo typed connector dispatch + catalog (N
+  ops indexed; loader wiring tracked under #M)."*
+- *"feat(connectors): Foo typed connector — `service_account` auth
+  model live; `per_user` tracked under #M."*
+- *"feat(connectors): Foo typed connector ready for production (all
+  advertised auth models live)."*
+
+Codified in [CHANGELOG.md](../../CHANGELOG.md) under "How entries are
+added" by [T7 #735](https://github.com/evoila/meho/issues/735).
+
+## How the consumer-feedback triage caught the gap (2026-05-20)
+
+The RDC operator team:
+
+1. Deployed `meho:v0.3.0` to their `rke2-infra/meho` lab the day it
+   shipped (REV 22→23, chart digest `sha256:08c934d6…`, git_sha
+   `602ab880…`).
+2. Ran a full read-only smoke; all 6 of 6 checks green.
+3. Read the v0.3.0 release notes. The framing *"G3.2 Kubernetes typed
+   connector (13 ops, k3d CI)"* + the apparent +31/-23 line delta on
+   `connectors/kubernetes/kubeconfig.py` between the v0.2.1 and v0.3.0
+   tags led to the natural conclusion *"the loader is wired upstream
+   now; the v0.2.1 'binary by auth model' framing is no longer true."*
+4. Shipped a kb supersede on that conclusion (consumer PR #637 at
+   12:50 UTC).
+5. Around 14:30 UTC, source-read the actual loader. Found it was still
+   a `NotImplementedError` stub; the line delta was a docstring +
+   error-message refactor, not a wire-up.
+6. Corrected the kb supersede the same afternoon (consumer PR #643).
+7. Filed the consolidated v0.3.0 feedback report to the meho team.
+
+The recursion (their own kb caught their own assumption-from-release-notes
+within hours) is the discipline working — *"the hook finds the error
+fast"*, not *"the error never happens"*.
+
+This doc captures the upstream half: making the vocabulary so explicit
+that the assumption isn't there to make.
+
+## References
+
+- Consumer feedback report dated 2026-05-20 from
+  `evoila-bosnia/claude-rdc-hetzner-dc`
+- [CHANGELOG.md](../../CHANGELOG.md) — the v0.3.0 section + the
+  convention codified by [T7 #735](https://github.com/evoila/meho/issues/735)
+- [Goal #214 (Connector parity)](https://github.com/evoila/meho/issues/214)
+  — the open Goal that loader-wiring tracks under (T6 #734 amends the
+  body to reframe the curated-composite-ops model)
+- Tickets from this triage:
+  - [#728 (T1)](https://github.com/evoila/meho/issues/728) — operation_count rollup bug
+  - [#729 (T2)](https://github.com/evoila/meho/issues/729) — schema hardening
+  - [#730 (T3)](https://github.com/evoila/meho/issues/730) — uvicorn proxy-headers
+  - [#731 (T4a)](https://github.com/evoila/meho/issues/731) — kill auto-derive `when_to_use` default
+  - [#732 (T4b)](https://github.com/evoila/meho/issues/732) — curate group strings
+  - [#733 (T5)](https://github.com/evoila/meho/issues/733) — surface State-0.5 connectors
+  - [#734 (T6)](https://github.com/evoila/meho/issues/734) — Goal #214 body reframe
+  - [#735 (T7)](https://github.com/evoila/meho/issues/735) — CHANGELOG amendment + convention
+  - [#727 (S1)](https://github.com/evoila/meho/pull/727) — sddc-manager + harbor stub-message fix (the small PR shipped during this triage)

--- a/docs/cross-repo/v0.3.0-feedback-reply-vmware-13-ops.md
+++ b/docs/cross-repo/v0.3.0-feedback-reply-vmware-13-ops.md
@@ -1,0 +1,218 @@
+# Reply to the RDC team — *"only 13 vmware ops?"*
+
+Operator-facing note for the
+[`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)
+team, written 2026-05-20 in response to their broad v0.3.0 in-lab dogfood
+feedback. Covers the framing question — *"is meho's connector model
+deliberately curated composite ops, not raw-API binding?"* — that drove
+their kb mis-supersede + correction the same day.
+
+Pairs with the maintainer-side artifact at
+[docs/codebase/connector-release-readiness.md](../codebase/connector-release-readiness.md)
+(which defines the three-state catalog/dispatch/loader rubric) and the
+Goal #214 body reframe filed under [#734](https://github.com/evoila/meho/issues/734).
+
+## The short answer
+
+**MEHO's connector model is NOT curated-composites-only.** It's
+**dual-shaped by design** — and the long-tail raw-REST coverage your
+team is missing is an *operator action* away, not a *MEHO release* away.
+
+## What v0.3.0 actually ships for vmware
+
+Layer 1 — **hand-coded composites** registered at startup:
+
+| Layer 1 ops (13) | Class |
+|---|---|
+| `vmware.composite.cluster.drs_recommendations` | read |
+| `vmware.composite.event.tail` | read |
+| `vmware.composite.performance.summary` | read |
+| `vmware.composite.datastore.usage` | read |
+| `vmware.composite.network.portgroup.audit` | read |
+| `vmware.composite.vm.create` | write + approval |
+| `vmware.composite.vm.clone` | write + approval |
+| `vmware.composite.vm.snapshot.revert` | write + approval |
+| `vmware.composite.vm.migrate` | write + approval |
+| `vmware.composite.vm.power.bulk` | write + approval |
+| `vmware.composite.host.evacuate` | write + approval |
+| `vmware.composite.host.detach_from_vds` | write + approval |
+| `vmware.composite.cluster.patch` | write + approval |
+
+These are governed multi-step workflows the raw REST API can't express
+in one call. The 8 writes carry `requires_approval: true` annotations
+so an agent can never run them without a human signing off. This is
+the layer 1 *governance* surface — the part that makes MEHO different
+from a thin RPC shim.
+
+Layer 2 — **operator-ingested raw REST** (NOT visible in your deploy
+*yet*, because the ingest hasn't been run):
+
+```
+vSphere REST API (vcenter.yaml + vi-json.yaml)
+  → hundreds of paths, thousands of ops
+  → ingested via POST /api/v1/connectors/ingest
+  → registered into endpoint_descriptor with review_status='staged'
+  → operator reviews per group (LLM-summarised "when to use" + safety)
+  → operator transitions groups to review_status='enabled'
+  → visible to search_operations + call_operation on the agent surface
+```
+
+The ingest path is real and tested
+([backend/tests/acceptance/test_g07_vsphere_canary.py](../../backend/tests/acceptance/test_g07_vsphere_canary.py)).
+What's missing is operator action against your deploy.
+
+## The wrapper-retirement story, honestly framed
+
+`govc.sh`, `kubectl-vcf.sh`, and `vault.sh` retire on **two axes**:
+
+1. **Composite axis** — each MEHO release lands composites for
+   high-value multi-step governed workflows. v0.3.0 ships 13 vmware
+   composites. v0.4+ adds more per the G3.x roadmap. You wait on MEHO
+   for these.
+2. **Ingest axis** — you ingest the vendor's OpenAPI spec, review the
+   groups, enable the ones covering your wrapper's basic shape
+   (`vm.list`, `cluster.info`, `datacenter.list`, etc.). You don't wait
+   on MEHO for these. The infrastructure shipped in v0.2 with G0.7 and
+   has been tested against the vSphere two-spec ingest since.
+
+Your kb's *"the wrapper-retirement story rolls forward one composite
+per release"* framing was correct for axis 1 but missed axis 2 entirely.
+The corrected framing: **both axes roll forward; the ingest axis is
+operator-driven and can cover the long-tail single-call shape as fast
+as your team wants to review-and-enable.**
+
+## How to drive layer 2 against your deploy (current path, v0.3.0)
+
+```bash
+# 1. Fetch vSphere 9.0's OpenAPI specs from Broadcom's developer portal:
+#    https://developer.broadcom.com/xapis/vsphere-automation-api/latest/
+#    Download:
+#      - vcenter.yaml (the modern REST API)
+#      - vi-json.yaml (the legacy vi-json bridge for ops not in vcenter.yaml)
+
+# 2. Ingest under the existing vmware-rest-9.0 connector_id:
+curl -X POST https://meho.evba.lab/api/v1/connectors/ingest \
+  -H "Authorization: Bearer $MEHO_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "product": "vmware",
+    "version": "9.0",
+    "impl_id": "vmware-rest",
+    "specs": [
+      {"uri": "file:///path/to/vcenter.yaml"},
+      {"uri": "file:///path/to/vi-json.yaml"}
+    ],
+    "base_url": "https://your-vcenter.example.com",
+    "dry_run": true
+  }'
+# dry_run=true validates the parse + reports counts; nothing commits.
+
+# 3. Re-run with dry_run=false to actually register the ops.
+
+# 4. List the ingested groups:
+curl https://meho.evba.lab/api/v1/connectors/vmware-rest-9.0/review \
+  -H "Authorization: Bearer $MEHO_ACCESS_TOKEN"
+# Shows the LLM-grouped operations, each in review_status='staged'.
+
+# 5. Review + enable the groups your workflows need:
+curl -X POST https://meho.evba.lab/api/v1/connectors/vmware-rest-9.0/enable \
+  -H "Authorization: Bearer $MEHO_ACCESS_TOKEN" \
+  -d '{"group_keys": ["cluster", "datacenter", "vm", "host"]}'
+# Now those groups' ops are visible via search_operations + call_operation.
+```
+
+## What v0.3.1 adds for the ingest path
+
+Three filed Tasks under the v0.3.1 dogfood-hardening Initiative
+[#737](https://github.com/evoila/meho/issues/737) tighten the ingest
+ergonomics directly because of feedback like yours:
+
+- [#740 (T8)](https://github.com/evoila/meho/issues/740) — validate
+  `spec.info.version` against the operator-supplied `version` label.
+  Catches the "I labelled a vCenter-9 spec under `version=8.0`" silent
+  mismatch class.
+- [#741 (T9)](https://github.com/evoila/meho/issues/741) — pre-flight
+  that the operator's `version` label is covered by *some* registered
+  connector class's `supported_version_range`. Catches "ingested ops
+  that can never dispatch" orphan class.
+- [#743 (T10)](https://github.com/evoila/meho/issues/743) — curated
+  reference catalog at `docs/connector-specs/catalog.yaml`. The above
+  curl will become `meho connector ingest --catalog vmware/9.0` —
+  catalog knows the right URLs, the right version label, the right
+  class, fast-paths T8/T9 validation. **This is the operator on-ramp
+  your team was missing in v0.3.0.**
+
+## Version coexistence (because you'll ask)
+
+The connector class `VmwareRestConnector` ships with
+`supported_version_range = ">=8.5,<10.0"`
+([backend/src/meho_backplane/connectors/vmware_rest/connector.py:229](../../backend/src/meho_backplane/connectors/vmware_rest/connector.py#L229)).
+Your vCenter 9.x targets dispatch through it. If you have vCenter 7.x
+*also*, you need either:
+
+- A separate class advertising `>=7.0,<8.5` (typed connector — the
+  CLAUDE.md `vmware-pyvmomi-7.0` pattern, not shipped today)
+- OR widen the existing class's range (only if the v8.5+ REST surface
+  is backwards-compatible with v7.x, which it largely isn't)
+
+The version-resolver's tie-break ladder
+([backend/src/meho_backplane/connectors/resolver.py:294-333](../../backend/src/meho_backplane/connectors/resolver.py#L294-L333))
+picks the most-specific-match-then-priority winner per target. Multiple
+classes for the same `product` coexist via separate `supported_version_range`s.
+
+## Same dual-shape applies to vault + k8s
+
+- **vault-1.x**: 13 typed ops shipped at startup (KV-v2 + sys + auth).
+  The full Vault HTTP API is ingestable. No catalog entry yet under
+  #743 — but the same pattern applies once a Vault OpenAPI spec is
+  picked.
+- **k8s-1.x**: 14 typed ops shipped at startup (all read).
+  `kubernetes_asyncio`'s full surface is ingestable; the kubernetes
+  team publishes per-version Swagger that #743 can catalog. Same
+  ingest-and-review path.
+- **bind9-ssh-9.x**: the exception — no OpenAPI spec exists for bind9.
+  Composites-only by necessity. 11 ops shipped covers your
+  `bind9-dns.sh` wrapper directly.
+
+## The framing question itself, answered
+
+> *"Is meho's connector model deliberately curated composite ops, not
+> raw-API binding?"*
+
+**Both.** Composites are the agent's first-class governance surface;
+raw-API is the operator's per-tenant long-tail coverage surface; same
+`call_operation` endpoint, same `endpoint_descriptor` table, same
+audit trail, different sources. The retirement clock for your local
+wrappers advances on whichever axis you choose to push on next.
+
+This framing will land in Goal #214's body once
+[#734 (T6)](https://github.com/evoila/meho/issues/734) closes; it's
+captured here in advance because your team needs the answer now, not
+when the issue closes.
+
+## Recapping the corrections from this triage
+
+What I (the meho team's agent voice) got wrong before the deep-dive,
+and what the verified picture is:
+
+| Triage v1 (wrong) | Verified v2 (correct) |
+|---|---|
+| "Curated composites only, parity over many releases" | Dual-shaped: composites + operator-ingested raw REST |
+| "Adopters keep local wrappers indefinitely for the long tail" | Adopters retire wrappers via ingest + review-and-enable; no need to wait for MEHO |
+| Goal #214 framing should say composites-by-design | Goal #214 should say dual-layer; ingest is the operator on-ramp |
+
+Your kb's discipline arc (*"read the source per connector"*) caught
+your own assumption-from-release-notes in hours. The same discipline
+would have caught mine before I drafted T6's first version. **The
+upstream lesson and the consumer lesson are the same one** —
+release-notes claims need to be source-verified, by the writer and by
+the reader.
+
+## Thanks
+
+Genuinely thank you for the broad in-lab dogfood + the report. The
+audit-trail + per-op governance + `query_audit` working end-to-end is
+exactly what we want MEHO to feel like; the surface gaps you surfaced
+are tractable and will land in v0.3.1.
+
+— @damir-topic, meho maintainer


### PR DESCRIPTION
## Summary

Operator-facing follow-up to the 2026-05-20 RDC v0.3.0 in-lab dogfood feedback. Documents the verified dual-layer connector model (composites at startup + operator-ingested raw REST via G0.7) that the original triage's T6 framing got wrong before the architectural code-walk.

## What's in the note

- The 13 vmware composite ops (layer 1) + the full vSphere REST surface ingestable via existing G0.7 pipeline (layer 2)
- The exact curl recipe to drive the layer-2 ingest against their deploy today (no MEHO release needed)
- What v0.3.1 adds: [#740 (T8)](https://github.com/evoila/meho/issues/740) spec validation, [#741 (T9)](https://github.com/evoila/meho/issues/741) class pre-flight, [#743 (T10)](https://github.com/evoila/meho/issues/743) curated catalog
- Version coexistence via `supported_version_range` tie-break ladder
- Same dual-shape pattern for vault + k8s; bind9 the exception
- Honest v1-vs-v2 framing corrections the deep-dive surfaced

## Pairs with

- [docs/codebase/connector-release-readiness.md](docs/codebase/connector-release-readiness.md) (merged via [PR #736](https://github.com/evoila/meho/pull/736))
- [#734 (T6)](https://github.com/evoila/meho/issues/734) — Goal #214 body reframe (body updated this session to match the dual-layer model)
- [G0.9 #737](https://github.com/evoila/meho/issues/737) — v0.3.1 dogfood hardening Initiative (now parents 11 child Tasks including T8-T10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added connector readiness state definitions and standardized release-notes conventions
  * Added operator guide for connector ingestion workflows and model architecture
  * Documented connector version coexistence and management behavior across services

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->