### PR TITLE
feat(api): G0.9-T2 extra="forbid" on every public v1 request schema (#729)

### DIFF
--- a/backend/src/meho_backplane/api/v1/audit.py
+++ b/backend/src/meho_backplane/api/v1/audit.py
@@ -173,9 +173,10 @@ async def query(
 
     Body fields mirror :class:`AuditQueryFilters` except ``since`` /
     ``until`` are duration strings (``"24h"`` / ``"7d"`` / ISO-8601)
-    parsed at the router layer. Client-supplied ``tenant_id`` in the
-    body is silently dropped per Pydantic v2's default
-    ``extra="ignore"``; the route always passes
+    parsed at the router layer. Client-supplied ``tenant_id`` (or any
+    other unknown field) in the body is rejected at 422
+    ``extra_forbidden`` per :class:`AuditQueryRequest`'s
+    ``extra="forbid"`` config; the route always passes
     ``operator.tenant_id`` to the substrate.
     """
     _bind_audit_overrides()

--- a/backend/src/meho_backplane/api/v1/audit.py
+++ b/backend/src/meho_backplane/api/v1/audit.py
@@ -22,9 +22,10 @@ Tenant scoping
 Every route passes ``operator.tenant_id`` (lifted from the JWT by
 :func:`~meho_backplane.auth.rbac.require_role`) to ``query_audit`` as
 the mandatory keyword-only ``tenant_id`` argument. Client-supplied
-``tenant_id`` in the POST body is silently dropped — Pydantic v2's
-default ``extra="ignore"`` policy means a field absent from
-:class:`AuditQueryRequest` never reaches the router. Cross-tenant
+``tenant_id`` (or any other unknown field) in the POST body is
+rejected at 422 ``extra_forbidden`` per
+:class:`AuditQueryRequest`'s ``extra="forbid"`` config (G0.9-T2 /
+#729); the route never reads tenant from the body. Cross-tenant
 queries are impossible by construction.
 
 Audit-on-audit-query (decision #3, ``docs/planning/v0.2-decisions.md``)

--- a/backend/src/meho_backplane/api/v1/audit_models.py
+++ b/backend/src/meho_backplane/api/v1/audit_models.py
@@ -18,13 +18,14 @@ surfaces them under the audit-query tag without duplicating the schema.
 Tenant scoping by construction
 ==============================
 
-:class:`AuditQueryRequest` deliberately has **no** ``tenant_id`` field.
-Pydantic v2's default ``extra="ignore"`` policy means a client that
-puts ``tenant_id`` in the body has the value silently dropped; the
-router never reads from the body for the tenant boundary — it injects
-``operator.tenant_id`` from the JWT into the T1 handler call. The
-substrate's mandatory keyword-only ``tenant_id`` argument enforces the
-invariant on its side.
+:class:`AuditQueryRequest` deliberately has **no** ``tenant_id`` field
+and sets ``extra="forbid"`` (G0.9-T2 / #729) so a client that puts
+``tenant_id`` in the body fails 422 ``extra_forbidden`` instead of
+having the value silently dropped. The router never reads from the
+body for the tenant boundary — it injects ``operator.tenant_id`` from
+the JWT into the T1 handler call. The substrate's mandatory
+keyword-only ``tenant_id`` argument enforces the invariant on its side.
+The fail-loud posture matches every other public v1 request schema.
 """
 
 from __future__ import annotations
@@ -51,9 +52,14 @@ class AuditQueryRequest(BaseModel):
     layer. All other fields pass through to the substrate filter
     object unchanged. The empty body shape ``{}`` is the no-filter
     case — every field defaults to None or the substrate-side default.
+
+    ``extra="forbid"`` rejects unknown fields with 422
+    ``extra_forbidden`` so a typo or a client passing ``tenant_id``
+    in the body fails loud at the framework boundary — the route
+    always uses ``operator.tenant_id`` from the JWT, never the body.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     target: str | None = Field(default=None, max_length=256)
     principal: str | None = Field(default=None, max_length=256)

--- a/backend/src/meho_backplane/api/v1/retrieve.py
+++ b/backend/src/meho_backplane/api/v1/retrieve.py
@@ -110,9 +110,15 @@ class RetrieveRequest(BaseModel):
     free-form operator queries; operators with longer payloads
     should use the embedding pipeline directly via G4 / G5 ingestion
     paths.
+
+    ``extra="forbid"`` rejects unknown fields at 422 with
+    ``extra_forbidden`` detail so a v0.2.1 client still sending the
+    pre-rename ``q`` / ``top_k`` keys fails loud instead of silently
+    running with the defaults (Signal #2 from the 2026-05-20 RDC
+    dogfood). Same posture as every public v1 request schema.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     query: str = Field(min_length=1, max_length=2000)
     source: str | None = Field(default=None, max_length=64)

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -15,6 +15,15 @@ The shapes are deliberately conservative:
 * ``frozen=True`` on every model — responses flow read-only and any
   in-place mutation surfaces as a Pydantic error rather than a
   silently-modified payload.
+* ``extra="forbid"`` on every **request** body (G0.9-T2 / #729):
+  :class:`IngestRequest`, :class:`SpecSource`, :class:`EditGroupBody`,
+  :class:`EditOpBody`. Unknown fields fail 422 ``extra_forbidden`` at
+  the framework boundary instead of being silently dropped, so a v0.2.1
+  client mis-spelling ``impl_id`` as ``implementation_id`` (or the
+  RDC-team-style ``q`` / ``top_k`` carryover) hears about it
+  immediately rather than seeing a confusing required-field error or
+  silent default. Response models keep the pydantic default
+  (``extra="ignore"``) — they aren't validated against client input.
 * ``IngestRequest.specs`` is a list of :class:`SpecSource` objects with
   one ``uri`` field so future per-spec knobs (auth headers, dialect
   pinning) can land without breaking the wire contract.
@@ -88,10 +97,13 @@ class SpecSource(BaseModel):
 
     Wrapped in its own model so future per-spec knobs (auth headers,
     dialect pinning, content-type override) can land without
-    reshaping :class:`IngestRequest`.
+    reshaping :class:`IngestRequest`. ``extra="forbid"`` rejects
+    unknown fields (per the request-schema-strictness rule) so a
+    typo in a nested ``specs[*]`` entry fails 422 at the body parse
+    instead of being silently dropped.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     uri: str = Field(min_length=1, max_length=2048)
 
@@ -116,9 +128,14 @@ class IngestRequest(BaseModel):
     registered :class:`GenericRestConnector` shim; ``None`` leaves
     the shim unconfigured (the connector's eventual hand-coded
     subclass at G3.x will set its own base URL).
+
+    ``extra="forbid"`` rejects unknown body fields with 422
+    ``extra_forbidden`` (G0.9-T2 / #729) — silent-drop on a typo
+    would otherwise mean the pipeline runs with the wrong impl_id
+    and the operator only finds out at review-time.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     product: str = Field(min_length=1, max_length=64)
     version: str = Field(min_length=1, max_length=64)
@@ -245,9 +262,15 @@ class EditGroupBody(BaseModel):
     :class:`OperationGroup.name` columns. Empty strings are
     rejected — operators that want to "clear" the field should
     re-run grouping rather than blank it.
+
+    ``extra="forbid"`` (G0.9-T2 / #729) means an unknown field —
+    e.g. a client mis-spelling ``when_to_use`` as ``whentouse`` —
+    fails 422 instead of being silently dropped (which would
+    surface as a confusing 400 "at least one field must be set"
+    from the route layer).
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     when_to_use: str | None = Field(default=None, min_length=1, max_length=2048)
     name: str | None = Field(default=None, min_length=1, max_length=128)
@@ -274,9 +297,13 @@ class EditOpBody(BaseModel):
     that the agent surfaces in place of the upstream spec's
     ``description`` field; capped at 4096 chars to keep audit-log
     payloads bounded.
+
+    ``extra="forbid"`` (G0.9-T2 / #729) rejects unknown fields with
+    422 ``extra_forbidden`` — same fail-loud posture as every other
+    public v1 request schema.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     custom_description: str | None = Field(default=None, min_length=1, max_length=4096)
     safety_level: Literal["safe", "caution", "dangerous"] | None = None

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -202,7 +202,18 @@ class CallOperationBody(BaseModel):
     :func:`~meho_backplane.targets.resolver.resolve_target`; ``None``
     means the operation does not need a target (typed handlers that
     don't read it; composite handlers that do their own resolution).
+
+    ``extra="forbid"`` (G0.9-T2 / #729) rejects unknown fields with
+    422 ``extra_forbidden`` — a v0.2.1 client still sending ``target:
+    str`` (the pre-rename single-name shape) or a typo in
+    ``connector_id`` now fails loud at the framework boundary instead
+    of silently dispatching with the defaults. ``params`` itself is a
+    free-form ``dict`` because per-op parameter shape is enforced by
+    the descriptor's ``parameter_schema`` further down the dispatch
+    path; only the meta-tool body's own fields are constrained here.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     connector_id: str = Field(min_length=1)
     op_id: str = Field(min_length=1)

--- a/backend/tests/test_api_audit_routes.py
+++ b/backend/tests/test_api_audit_routes.py
@@ -270,8 +270,22 @@ def test_post_query_since_24h_parses_to_datetime(client: TestClient) -> None:
     assert filters.since <= (after - timedelta(hours=24) + timedelta(seconds=1))
 
 
-def test_post_query_body_tenant_id_is_silently_dropped(client: TestClient) -> None:
-    """AC7: a tenant-A operator with ``tenant_id=<B>`` in the body still gets tenant-A scoping."""
+def test_post_query_body_tenant_id_is_rejected_with_extra_forbidden(
+    client: TestClient,
+) -> None:
+    """AC7 (G0.9-T2 / #729): ``tenant_id`` in the body is rejected at 422.
+
+    Pre-#729 the value was silently dropped (Pydantic v2's default
+    ``extra="ignore"``) and the route still ran under
+    ``operator.tenant_id`` from the JWT — the test asserted "JWT
+    wins". With ``extra="forbid"`` on :class:`AuditQueryRequest`,
+    the framework now rejects the field at 422 with
+    ``extra_forbidden``, making the cross-tenant-attempt visible to
+    the caller and to the audit log instead of silently mapping it
+    to own-tenant. The tenant boundary is still enforced — by
+    construction the substrate is never reached for a body that
+    fails validation.
+    """
     key = make_rsa_keypair("kid-A")
     token = _token(key, tenant_id=_TENANT_A)
     mock_query = AsyncMock(return_value=_empty_result())
@@ -285,9 +299,13 @@ def test_post_query_body_tenant_id_is_silently_dropped(client: TestClient) -> No
             json={"tenant_id": str(_TENANT_B)},
             headers={"Authorization": f"Bearer {token}"},
         )
-    assert resp.status_code == 200
-    kwargs = mock_query.await_args.kwargs
-    assert kwargs["tenant_id"] == _TENANT_A  # JWT wins
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert any(
+        d.get("type") == "extra_forbidden" and tuple(d.get("loc", ())) == ("body", "tenant_id")
+        for d in detail
+    ), detail
+    mock_query.assert_not_awaited()  # Substrate never reached.
 
 
 def test_post_query_bad_duration_returns_400(client: TestClient) -> None:

--- a/backend/tests/test_api_audit_routes.py
+++ b/backend/tests/test_api_audit_routes.py
@@ -20,8 +20,12 @@ Coverage matrix (#466 acceptance criteria):
   rows (the cross-tenant probe case — the substrate's tenant WHERE
   clause produces zero rows for a row in another tenant, and the
   route surfaces 404, not 403, so existence is never leaked).
-* AC7 — Body-supplied ``tenant_id`` is silently dropped; the route
-  always passes ``operator.tenant_id`` to the substrate.
+* AC7 — Body-supplied ``tenant_id`` (or any unknown field) is
+  rejected with 422 ``extra_forbidden`` per
+  :class:`AuditQueryRequest`'s ``extra="forbid"`` config (G0.9-T2 /
+  #729); the substrate is never reached on validation failure. The
+  route always passes ``operator.tenant_id`` from the JWT to the
+  substrate for the valid-body branch.
 * AC8 — Every call binds ``audit_op_id="meho.audit.query"`` +
   ``audit_op_class="audit_query"`` contextvars before the substrate
   call, so the audit row written by :class:`AuditMiddleware` carries

--- a/backend/tests/test_api_v1_schema_extras.py
+++ b/backend/tests/test_api_v1_schema_extras.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Regression tests for ``extra="forbid"`` on every public v1 request schema.
+
+G0.9-T2 (#729) of Initiative #737. Surfaced by the 2026-05-20 RDC
+in-lab dogfood as "Signal #2": a v0.2.1 client posting the
+pre-rename ``q`` / ``top_k`` keys to ``/api/v1/retrieve`` saw the
+fields silently dropped (Pydantic v2 default ``extra="ignore"``) and
+got either a confusing required-field error or a request that ran
+with the defaults. The fix: every public v1 **request** schema sets
+``model_config = ConfigDict(extra="forbid", ...)`` so unknown keys
+surface as 422 ``extra_forbidden`` at the framework boundary.
+
+Two complementary layers of coverage:
+
+1. **Schema-level tests** — pure Pydantic ``model_validate`` calls
+   against every touched request model, asserting that an extra
+   field raises a :class:`ValidationError` with a
+   ``type == "extra_forbidden"`` detail. These are fast and don't
+   depend on the FastAPI test harness or the JWT mock; they are the
+   regression line that catches a future drop of ``extra="forbid"``
+   from any one schema.
+2. **Integration test against ``/api/v1/retrieve``** — exercises the
+   exact signal #2 payload (``{"q": "vault", "top_k": 3}``) through
+   the route and asserts a 422 with ``extra_forbidden`` in the
+   detail, not a 400 or a silent 200. This is the contract the
+   consumer dogfood report named — the schema-level test alone
+   would not catch a route-layer middleware mis-mapping the error.
+
+Inventory covered (every request-body ``BaseModel`` backing a public
+v1 POST / PATCH / PUT, plus :class:`CallOperationBody` outside
+``api/v1/`` per the issue scope):
+
+* :class:`meho_backplane.api.v1.retrieve.RetrieveRequest`
+* :class:`meho_backplane.api.v1.audit_models.AuditQueryRequest`
+* :class:`meho_backplane.api.v1.retrieve_eval.EvalRequest`
+* :class:`meho_backplane.api.v1.retrieve_retire.RetireChecklistRequest`
+* :class:`meho_backplane.api.v1.kb.KbEntryCreate`
+* :class:`meho_backplane.api.v1.kb.IngestKbRequest`
+* :class:`meho_backplane.targets.schemas.TargetCreate`
+* :class:`meho_backplane.targets.schemas.TargetUpdate`
+* :class:`meho_backplane.operations.ingest.api_schemas.IngestRequest`
+* :class:`meho_backplane.operations.ingest.api_schemas.SpecSource`
+  (nested in ``IngestRequest.specs``)
+* :class:`meho_backplane.operations.ingest.api_schemas.EditGroupBody`
+* :class:`meho_backplane.operations.ingest.api_schemas.EditOpBody`
+* :class:`meho_backplane.operations.meta_tools.CallOperationBody`
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import respx
+import structlog
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, ValidationError
+
+from meho_backplane.api.v1.audit_models import AuditQueryRequest
+from meho_backplane.api.v1.kb import IngestKbRequest, KbEntryCreate
+from meho_backplane.api.v1.retrieve import RetrieveRequest
+from meho_backplane.api.v1.retrieve import router as retrieve_router
+from meho_backplane.api.v1.retrieve_eval import EvalRequest
+from meho_backplane.api.v1.retrieve_retire import RetireChecklistRequest
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.operations.ingest.api_schemas import (
+    EditGroupBody,
+    EditOpBody,
+    IngestRequest,
+    SpecSource,
+)
+from meho_backplane.operations.meta_tools import CallOperationBody
+from meho_backplane.settings import get_settings
+from meho_backplane.targets.schemas import TargetCreate, TargetUpdate
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+# ---------------------------------------------------------------------------
+# Schema-level coverage — one parametrised test per request model
+# ---------------------------------------------------------------------------
+
+#: (model, minimal-valid-payload) for every public v1 request schema.
+#:
+#: The minimal-valid-payload satisfies each model's required fields so
+#: the only thing distinguishing the test from a happy construction is
+#: the addition of one unknown key. Future schemas should append here
+#: rather than copy-paste a new parametrised case.
+_REQUEST_MODELS: list[tuple[type[BaseModel], dict[str, Any]]] = [
+    (RetrieveRequest, {"query": "vault"}),
+    (AuditQueryRequest, {}),
+    (EvalRequest, {}),
+    (RetireChecklistRequest, {}),
+    (KbEntryCreate, {"slug": "k8s-ingress", "body": "Ingress runbook"}),
+    (IngestKbRequest, {"directory": "/tmp/kb"}),
+    (
+        TargetCreate,
+        {"name": "rdc-vcenter", "product": "vsphere", "host": "vc.example.lab"},
+    ),
+    (TargetUpdate, {"host": "vc-2.example.lab"}),
+    (
+        IngestRequest,
+        {
+            "product": "vsphere",
+            "version": "8.0",
+            "impl_id": "vmware-rest",
+            "specs": [{"uri": "/abs/spec.yaml"}],
+        },
+    ),
+    (SpecSource, {"uri": "/abs/spec.yaml"}),
+    (EditGroupBody, {"when_to_use": "for vCenter VM ops"}),
+    (EditOpBody, {"safety_level": "safe"}),
+    (
+        CallOperationBody,
+        {"connector_id": "vmware-rest-8.0", "op_id": "vm.list"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    _REQUEST_MODELS,
+    ids=[m.__name__ for m, _ in _REQUEST_MODELS],
+)
+def test_request_schema_rejects_unknown_field_with_extra_forbidden(
+    model: type[BaseModel],
+    payload: dict[str, Any],
+) -> None:
+    """Every public v1 request schema rejects an unknown field at 422.
+
+    The chosen unknown key (``__unexpected__``) is deliberately not a
+    legitimate field on any of the touched models — a future rename
+    that happens to land on this name would surface as a test failure,
+    which is the desired signal.
+
+    Asserting on ``type == "extra_forbidden"`` (rather than just
+    "any ValidationError") pins the **shape** of the failure, not
+    just its existence. A schema accidentally dropping
+    ``extra="forbid"`` and gaining a different constraint that
+    happens to fail on the unknown key would still pass a bare
+    ``pytest.raises(ValidationError)``; the explicit type check
+    catches that drift.
+    """
+    valid = model.model_validate(payload)
+    assert valid is not None
+
+    with pytest.raises(ValidationError) as exc_info:
+        model.model_validate({**payload, "__unexpected__": "value"})
+
+    errors = exc_info.value.errors()
+    extra_forbidden = [e for e in errors if e["type"] == "extra_forbidden"]
+    assert extra_forbidden, (
+        f"{model.__name__} did not raise extra_forbidden on unknown field; errors={errors!r}"
+    )
+    assert extra_forbidden[0]["loc"] == ("__unexpected__",)
+
+
+def test_ingest_request_nested_spec_source_also_forbids_unknown_fields() -> None:
+    """``IngestRequest.specs[*]`` is a :class:`SpecSource` — nested forbid.
+
+    The schema-level test above proves :class:`SpecSource` in
+    isolation; this case proves the constraint cascades when the
+    nested model is constructed via the parent's validator. A future
+    refactor that re-shapes ``specs`` (e.g. inlines the field shape
+    back into :class:`IngestRequest`) must not regress the nested
+    strictness — the dogfood signal hit nested keys too.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        IngestRequest.model_validate(
+            {
+                "product": "vsphere",
+                "version": "8.0",
+                "impl_id": "vmware-rest",
+                "specs": [{"uri": "/abs/spec.yaml", "__unexpected__": "x"}],
+            },
+        )
+    errors = exc_info.value.errors()
+    extra_forbidden = [e for e in errors if e["type"] == "extra_forbidden"]
+    assert extra_forbidden
+    assert extra_forbidden[0]["loc"] == ("specs", 0, "__unexpected__")
+
+
+# ---------------------------------------------------------------------------
+# Integration test — exercises the signal-#2 payload through the route
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` reads, around every test.
+
+    Mirrors :mod:`tests.test_api_v1_retrieve` so the integration case
+    boots the same way the existing route tests do.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    """Empty the module-level JWKS cache around every test."""
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def _log_buffer() -> Iterator[io.StringIO]:
+    """Redirect structlog into an in-memory buffer for the integration test.
+
+    Without this fixture the AuditMiddleware logs would land on stdout
+    and pollute the pytest output. Same shape as
+    :func:`tests.test_api_v1_retrieve.log_buffer`.
+    """
+    buf = io.StringIO()
+    structlog.reset_defaults()
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=buf),
+        cache_logger_on_first_use=False,
+    )
+    yield buf
+    structlog.reset_defaults()
+
+
+@pytest.fixture
+def _retrieve_client(_log_buffer: io.StringIO) -> Iterator[TestClient]:
+    """``TestClient`` driving a FastAPI app with the retrieve route mounted."""
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(retrieve_router)
+    yield TestClient(app)
+
+
+def test_retrieve_route_rejects_signal_2_payload_with_422_extra_forbidden(
+    _retrieve_client: TestClient,
+) -> None:
+    """``POST /api/v1/retrieve`` rejects the exact dogfood Signal #2 payload.
+
+    The 2026-05-20 RDC report's reproducer was a v0.2.1 client still
+    sending ``q`` (the pre-rename field) and ``top_k`` (renamed to
+    ``limit``) — that payload used to be silently dropped, producing
+    a 422 missing-``query`` error and an apparent "request worked
+    with weird defaults" experience. The fix: 422 with one
+    ``extra_forbidden`` error per unknown field, surfacing the
+    actual problem to the caller.
+
+    Patches :func:`retrieve` so the test never touches the substrate
+    even though it should never get past validation either — the
+    patch is defence-in-depth in case the route's order of checks
+    drifts (the goal is failing validation before retrieval is
+    attempted).
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-extras", tenant_role=TenantRole.OPERATOR.value)
+    fake_retrieve = AsyncMock(return_value=[])
+
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.retrieve.retrieve", new=fake_retrieve),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = _retrieve_client.post(
+            "/api/v1/retrieve",
+            json={"q": "vault", "top_k": 3},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert isinstance(detail, list)
+    extra_forbidden = [d for d in detail if d.get("type") == "extra_forbidden"]
+    # Both unknown fields should be flagged so the caller sees both at once
+    # rather than playing whack-a-mole through repeated re-submissions.
+    flagged = {tuple(d["loc"]) for d in extra_forbidden}
+    assert ("body", "q") in flagged
+    assert ("body", "top_k") in flagged
+
+    # The retrieval substrate must not be invoked when validation fails
+    # — the framework rejects the body before the handler body runs.
+    fake_retrieve.assert_not_awaited()

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -117,7 +117,7 @@ substrate's tenant-scoping invariant is enforced one layer up.
 
 | Route | Filter shape | Notes |
 |---|---|---|
-| `POST /api/v1/audit/query` | Body is `AuditQueryRequest`; `since` / `until` are strings parsed at the router via `parse_duration` (`"24h"` / `"7d"` / ISO-8601). Client-supplied `tenant_id` is silently dropped by Pydantic's default `extra="ignore"` — the route never reads tenant from the body. | Full-filter surface. |
+| `POST /api/v1/audit/query` | Body is `AuditQueryRequest`; `since` / `until` are strings parsed at the router via `parse_duration` (`"24h"` / `"7d"` / ISO-8601). Client-supplied `tenant_id` (or any other unknown field) is rejected with 422 `extra_forbidden` (`AuditQueryRequest.model_config` sets `extra="forbid"`, G0.9-T2 / #729); the route never reads tenant from the body — it always passes `operator.tenant_id` from the JWT to the substrate. | Full-filter surface. |
 | `GET /api/v1/audit/who-touched/{target}` | Path param becomes `filters.target`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
 | `GET /api/v1/audit/my-recent` | `filters.principal = operator.sub`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
 | `GET /api/v1/audit/show/{audit_id}` | `filters.audit_id = <path>`, `limit=1`. Substrate returns 0 rows for cross-tenant lookups → router raises **404** (not 403) so existence never leaks. | Single-row fetch. |


### PR DESCRIPTION
## Summary

- Flips every public v1 **request** schema to `model_config = ConfigDict(extra="forbid", ...)` so unknown keys fail 422 `extra_forbidden` at the framework boundary instead of being silently dropped (Pydantic v2's default `extra="ignore"`).
- Fixes Signal #2 from the 2026-05-20 RDC in-lab dogfood: a v0.2.1 client sending `{"q": "vault", "top_k": 3}` to `/api/v1/retrieve` used to get a confusing missing-`query` error; now it gets a clear 422 with one `extra_forbidden` per unknown field.
- Adds a layered regression test (`tests/test_api_v1_schema_extras.py`): parametrised schema-level coverage for every touched request model + an integration test exercising the exact Signal #2 payload through `/api/v1/retrieve`.

## Inventory of v1 request schemas

Every `BaseModel` backing a public v1 POST/PATCH/PUT body, plus `CallOperationBody` outside `api/v1/` per the issue's "any other request-body schema" line:

| Schema | File | Pre-existing | This PR |
| --- | --- | --- | --- |
| `RetrieveRequest` | `backend/src/meho_backplane/api/v1/retrieve.py` | `frozen=True` | + `extra="forbid"` |
| `AuditQueryRequest` | `backend/src/meho_backplane/api/v1/audit_models.py` | `frozen=True` | + `extra="forbid"` |
| `CallOperationBody` | `backend/src/meho_backplane/operations/meta_tools.py` | (none) | new `ConfigDict(extra="forbid")` |
| `IngestRequest` | `backend/src/meho_backplane/operations/ingest/api_schemas.py` | `frozen=True` | + `extra="forbid"` |
| `SpecSource` (nested in `IngestRequest.specs`) | same | `frozen=True` | + `extra="forbid"` |
| `EditGroupBody` | same | `frozen=True` | + `extra="forbid"` |
| `EditOpBody` | same | `frozen=True` | + `extra="forbid"` |
| `EvalRequest` | `backend/src/meho_backplane/api/v1/retrieve_eval.py` | `frozen=True, extra="forbid"` | unchanged ✓ |
| `RetireChecklistRequest` | `backend/src/meho_backplane/api/v1/retrieve_retire.py` | `frozen=True, extra="forbid"` | unchanged ✓ |
| `KbEntryCreate` | `backend/src/meho_backplane/api/v1/kb.py` | `frozen=True, extra="forbid"` | unchanged ✓ |
| `IngestKbRequest` | `backend/src/meho_backplane/api/v1/kb.py` | `frozen=True, extra="forbid"` | unchanged ✓ |
| `TargetCreate` | `backend/src/meho_backplane/targets/schemas.py` | `extra="forbid"` | unchanged ✓ |
| `TargetUpdate` | `backend/src/meho_backplane/targets/schemas.py` | `extra="forbid"` | unchanged ✓ |

Response schemas (e.g. `RetrieveResponse`, `IngestResponse`, `Target`, `OperationDescriptor`) are deliberately **not** touched — they're not validated against client input, so `extra="forbid"` would add no value.

Routes that take no JSON body (`POST /api/v1/targets/{name}/probe`, `POST /api/v1/connectors/{id}/enable|disable`, `POST /api/v1/topology/refresh/{target_name}`) are out of scope by construction.

`mcp/server.py`'s JSON-RPC handler is a different transport surface (not v1 REST) and out of scope per the issue body's `api/v1/` scope.

## Test plan

- [x] `ruff check src/ tests/` — `All checks passed!`
- [x] `ruff format --check src/ tests/` — all 317 files formatted
- [x] `mypy src/ --ignore-missing-imports` — `Success: no issues found in 159 source files`
- [x] `pytest tests/test_api_v1_schema_extras.py` — 15 passed (13 parametrised + nested-cascade + integration)
- [x] `pytest tests/test_api_v1_retrieve.py tests/test_api_v1_kb.py tests/test_api_v1_operations.py tests/test_api_v1_connectors_ingest.py tests/test_api_v1_targets.py tests/test_api_audit_routes.py tests/test_api_v1_retrieve_eval.py tests/test_audit_query_schemas.py tests/test_targets_schemas.py tests/test_kb_schemas.py tests/test_operations_meta_tools.py tests/test_operations_ingest_review.py tests/test_api_v1_schema_extras.py` — 258 passed (post-update of `test_post_query_body_tenant_id_*`)
- [x] `code-quality.py --diff` — 0 blockers, 3 pre-existing legacy warnings on `meta_tools.py` (file 503 lines, two pre-existing 70+-line functions); not introduced by this PR

### Acceptance criteria

- [x] Every `BaseModel` backing a POST/PATCH/PUT body in `backend/src/meho_backplane/api/v1/` has `model_config = ConfigDict(extra="forbid", ...)` — proven by the parametrised schema-level test
- [x] `CallOperationBody` in `meta_tools.py` (outside `api/v1/`) covered — proven by the same parametrised test
- [x] `tests/test_api_v1_schema_extras.py` asserts `{"q": "x", "top_k": 3}` returns 422 with `extra_forbidden` against `/api/v1/retrieve` — `test_retrieve_route_rejects_signal_2_payload_with_422_extra_forbidden`
- [x] One representative regression test per touched endpoint — parametrised over the 13 request models, asserting `type == "extra_forbidden"` on the unknown-field branch
- [x] `Python (ruff + mypy + pytest)` — green locally; CI will re-run
- [ ] Manual smoke against rke2-infra (curl `/api/v1/retrieve` with `{"q": "vault"}`) — operator-only step; orchestrator/operator runs against the staged deploy after merge

## Behaviour change / out of scope

- **Behaviour change** for clients passing previously-silently-dropped unknown fields — they now get 422 instead of either a missing-required-field 422 or a default-driven 200. Triage chose fail-loud over alias-then-deprecate (rename window already past); CHANGELOG `[0.3.1]` will call this out per #735.
- **Out of scope:** adding aliases (`q` → `query`, `top_k` → `limit`) — explicitly rejected in the issue body. Out-of-scope adjacent finding: `meta_tools.py` carries pre-existing code-quality warnings (file 503 lines, two ~76-line functions); independent refactor opportunity.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #729


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API endpoints (audit query, retrieve, ingest, connector/meta operations) now reject unknown or unexpected request-body fields with HTTP 422 (validation error) instead of silently ignoring them.
* **Documentation**
  * Updated audit-query docs to reflect that tenant scoping is derived from authentication and client-supplied tenant_id in the body is rejected.
* **Tests**
  * Added/updated tests to assert the new validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-20)

Addressed review findings from /auto-review-pr iteration 1 (REQUEST_CHANGES; result file `.claude/auto/review-results/pr-746-iter-1.json`):

- **B1** `2ac85f7` — docs/codebase/audit_query.md routes-matrix row for `POST /api/v1/audit/query` now reflects `extra="forbid"` on `AuditQueryRequest` (422 `extra_forbidden`, never reads body tenant_id).
- **M1** `adfbaaf` — `backend/src/meho_backplane/api/v1/audit.py` module-level "Tenant scoping" docstring brought into agreement with the new `extra="forbid"` contract and the route docstring on the same file.
- **M2** `8f9af33` — `backend/tests/test_api_audit_routes.py` AC7 coverage-matrix entry now matches the renamed assertion (422 + `extra_forbidden` + `assert_not_awaited`).

Disputed: none.

Deferred: none.

Verification (post-fix): `ruff check` clean / `ruff format --check` clean / `mypy src/` clean (159 files) / `pytest` 204 passed across the 10 affected suites / `code-quality.py --diff` clean.

<!-- auto-implement-issue: continue, iteration 2 -->
