### PR TITLE
fix(connectors): G0.9-T1 count typed+composite ops in /api/v1/connectors rollup (#728)

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -152,11 +152,21 @@ async def _operation_count_by_connector(
 ) -> dict[tuple[UUID | None, str, str, str], int]:
     """Aggregate :class:`EndpointDescriptor` rows by connector triple.
 
-    Source-kind filter excludes typed-connector rows (G3.x hand-
-    coded ops) -- this endpoint lists *ingested* connectors only,
-    per the G0.7 review-queue contract; typed connectors live in
-    the v2 registry and operators don't drive them through the
-    review state machine.
+    Counts every ``source_kind`` -- ``"ingested"`` (G0.7 spec-driven),
+    ``"typed"`` (G3.x hand-coded via :func:`register_typed_operation`),
+    and ``"composite"`` (G3.x orchestration via
+    :func:`register_composite_operation`). The visibility driver for
+    this endpoint is :func:`_aggregate_groups_by_connector`, which has
+    never carried a source-kind filter -- a typed connector (e.g.
+    ``bind9-ssh-9.x`` with 11 typed ops) surfaces because its
+    :class:`OperationGroup` rows are visible. The op-count rollup
+    used to filter ``source_kind == "ingested"`` (an artefact of the
+    G0.7-only era when this endpoint only listed ingested
+    connectors), which left typed-connector rows visible with
+    ``operation_count: 0`` -- the asymmetry between the two paired
+    queries was the bug (Signal #4 in the v0.3.0 RDC dogfood), fixed
+    by dropping the filter so both queries count the same universe
+    of rows.
     """
     stmt = (
         select(
@@ -167,7 +177,6 @@ async def _operation_count_by_connector(
             func.count(EndpointDescriptor.id).label("op_count"),
         )
         .where(
-            EndpointDescriptor.source_kind == "ingested",
             (EndpointDescriptor.tenant_id.is_(None))
             | (EndpointDescriptor.tenant_id == operator_tenant_id),
         )

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -232,9 +232,19 @@ async def _seed_connector(
     ops_per_group: int = 3,
     review_status: str = "staged",
     op_is_enabled: bool = False,
+    source_kind: str = "ingested",
 ) -> list[uuid.UUID]:
-    """Seed an ingested connector with *group_count* groups + ops per group."""
+    """Seed a connector with *group_count* groups + ops per group.
+
+    ``source_kind`` defaults to ``"ingested"`` (the G0.7 spec-driven
+    path the bulk of these tests exercise); pass ``"typed"`` or
+    ``"composite"`` to seed a G3.x typed / composite connector. For
+    typed/composite rows ``method`` / ``path`` are left ``None`` (per
+    the dispatcher contract -- those columns are populated for ingested
+    rows only).
+    """
     sessionmaker = get_sessionmaker()
+    is_ingested = source_kind == "ingested"
     group_ids: list[uuid.UUID] = []
     async with sessionmaker() as session:
         for g_index in range(group_count):
@@ -262,9 +272,9 @@ async def _seed_connector(
                         version=version,
                         impl_id=impl_id,
                         op_id=f"GET:/api/v1/{group_key}/{o_index}",
-                        source_kind="ingested",
-                        method="GET",
-                        path=f"/api/v1/{group_key}/{o_index}",
+                        source_kind=source_kind,
+                        method="GET" if is_ingested else None,
+                        path=f"/api/v1/{group_key}/{o_index}" if is_ingested else None,
                         group_id=group_id,
                         summary=f"Operation {o_index} in {group_key}",
                         is_enabled=op_is_enabled,
@@ -523,6 +533,61 @@ async def test_list_status_enabled_requires_uniform_state(
     assert item["connector_id"] == "vmware-rest-9.0"
     assert item["enabled_group_count"] == item["group_count"]
     assert item["operation_count"] == 6  # 2 groups x 3 ops
+
+
+@pytest.mark.asyncio
+async def test_list_operation_count_includes_typed_and_composite(
+    client: TestClient,
+) -> None:
+    """The ``operation_count`` rollup counts typed + composite rows, not only ingested.
+
+    Regression for Signal #4 in the 2026-05-20 RDC v0.3.0 dogfood (#728):
+    ``_operation_count_by_connector`` used to filter ``source_kind ==
+    "ingested"``, so typed connectors like ``bind9-ssh-9.x`` /
+    ``k8s-1.x`` / ``vault-1.x`` -- whose groups surface (the groups
+    aggregator has no source-kind filter) -- rolled up to
+    ``operation_count: 0`` while their groups reported the real op
+    counts. The paired queries must count the same universe of rows.
+
+    Seeds one connector per ``source_kind`` value -- ingested (3 ops),
+    typed (4 ops), composite (2 ops) -- and asserts each connector's
+    ``operation_count`` matches the seeded total.
+    """
+    tenant_a = uuid.uuid4()
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        impl_id="vmware-rest",
+        group_count=1,
+        ops_per_group=3,
+        source_kind="ingested",
+    )
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="bind9",
+        impl_id="bind9-ssh",
+        group_count=2,
+        ops_per_group=2,
+        source_kind="typed",
+    )
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        impl_id="vmware-composite",
+        group_count=1,
+        ops_per_group=2,
+        source_kind="composite",
+    )
+
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    by_id = {c["connector_id"]: c for c in response.json()["connectors"]}
+    assert by_id["vmware-rest-9.0"]["operation_count"] == 3
+    assert by_id["bind9-ssh-9.0"]["operation_count"] == 4
+    assert by_id["vmware-composite-9.0"]["operation_count"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -293,11 +293,16 @@ uniform), or `all` (no filter). The implementation uses portable
 only `FILTER` clauses so the same query runs against SQLite in
 tests.
 
-Source-kind filter excludes typed-connector rows from the operation
-count — this endpoint lists *ingested* connectors only, per the
-G0.7 review-queue contract; typed connectors live in the v2
-registry and operators don't drive them through the review state
-machine.
+The op-count rollup counts every `source_kind` (`ingested`,
+`typed`, `composite`) — the visibility driver is the paired groups
+query, which has never filtered on `source_kind`. The earlier
+filter that excluded typed/composite rows from the count (G0.7-era
+artefact) was the cause of Signal #4 in the 2026-05-20 RDC dogfood:
+typed connectors surfaced with `group_count > 0` but
+`operation_count: 0`, the asymmetry between the two paired queries.
+The renamer "list_*ingested*_connectors" is now misleading and is a
+follow-up cleanup; the function lists every connector with at least
+one visible :class:`OperationGroup` row.
 
 ### API request / response models (`ingest/api_schemas.py`)
 


### PR DESCRIPTION
## Summary

- Drop the stale `source_kind == "ingested"` filter on `_operation_count_by_connector` so the rollup matches the paired groups query (which has never filtered on `source_kind`). Typed connectors (`bind9-ssh-9.x`, `k8s-1.x`, `vault-1.x`, `vmware-rest-9.0`) now report their real op count instead of always rolling up to `operation_count: 0`.
- Update the function docstring + `docs/codebase/spec-ingestion.md` paragraph that justified the (now-removed) filter; both said "ingested only", both contradicted the groups query that has always been multi-kind.
- Add `test_list_operation_count_includes_typed_and_composite` regression test seeding one connector per `source_kind` (3 ingested, 4 typed, 2 composite) and asserting every row's `operation_count` matches its seeded total.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` on changed files — clean
- [x] `mypy src/meho_backplane/operations/` — Success: no issues found in 32 source files
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — 29 passed (includes the new regression test)
- [x] `pytest tests/test_api_v1_connectors_ingest.py tests/test_mcp_tools_connector_admin.py tests/test_operations_meta_tools.py tests/test_operations_register_ingested.py tests/test_api_v1_operations.py` — 86 passed
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] AC: `list_connectors.py:170` no longer filters `source_kind`
- [x] AC: typed connector returns expected `operation_count` via `list_ingested_connectors()` (covered by the new test for typed, plus a composite variant)
- [x] AC: existing ingested-connector tests still pass (verified — the existing `test_list_status_enabled_requires_uniform_state` still asserts `operation_count == 6`)
- [ ] AC: manual smoke against rke2-infra — runtime verification, runs in CI / post-merge dogfood

## Out of scope

- Sibling task #733 (T5): surface `register_connector_v2`-registered connectors with no ops yet. Orthogonal — touches the same file but along a different axis (additive query to merge in the v2 registry).
- Renaming `list_ingested_connectors` to reflect that it now lists all source_kinds (per issue body, deferred follow-up).
- Loader wiring for the per-target-credential typed connectors (tracked under open Goal #214).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #728


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the connectors list API to properly count operations from all connector types (typed, composite, and ingested). Previously, typed and composite connectors incorrectly displayed zero operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->