### PR TITLE
feat(connectors): G0.9-T4b curate per-group when_to_use strings (#732)

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/connector.py
+++ b/backend/src/meho_backplane/connectors/bind9/connector.py
@@ -165,6 +165,77 @@ def parse_os_release(content: str) -> str | None:
     return os_id
 
 
+#: Curated ``when_to_use`` strings -- one per ``group_key`` declared by
+#: :data:`~meho_backplane.connectors.bind9.ops.BIND9_OPS`. Surfaced
+#: verbatim by ``list_operation_groups`` (T8) so an agent picking
+#: between the connector's four groups gets agent-actionable selection
+#: signal rather than the auto-derive template
+#: (``"Operations grouped under 'zone' for bind9 bind9-ssh."``). Each
+#: entry explicitly names the *kind of question* that routes here and
+#: the cross-group pairing pattern with the rest of the bind9 surface.
+#: T4b (#732) curated; mirrors the
+#: :data:`~meho_backplane.connectors.kubernetes.connector._WHEN_TO_USE_BY_GROUP`
+#: shape so the registration loop reads identically.
+_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "identity": (
+        "Use for bind9 nameserver-identity questions before any per-"
+        "zone or per-record drill-in: 'which BIND version is this "
+        "target running and on which host OS?'. The single "
+        "``bind9.about`` op returns vendor / product / version "
+        "(parsed BIND <X.Y.Z>), full named banner, and the host OS "
+        "identifier from ``/etc/os-release``. Call this first when "
+        "the agent needs to pick a version-flavoured doc page from "
+        "the knowledge base, or to confirm the nameserver is "
+        "reachable before issuing higher-level DNS ops."
+    ),
+    "zone": (
+        "Use for zone-level inventory and metadata reads: list every "
+        "zone the nameserver serves (``bind9.zone.list``) and read "
+        "one named zone's metadata + SOA (``bind9.zone.read``). "
+        "Read-only; never mutates zone state. The right group when "
+        "the agent doesn't yet know which zone to target ('what "
+        "zones does this nameserver host?') or needs the zone-level "
+        "context (type / file / view binding / SOA serial) before "
+        "drilling into records. Pair with the 'record' group once a "
+        "zone is identified to query / add / remove RRs inside it, "
+        "and with the 'config' group when the question is about "
+        "named.conf-level wiring (views, zone clauses) rather than "
+        "the zone's own contents."
+    ),
+    "record": (
+        "Use for record-level RR reads and mutations inside a known "
+        "zone: query a specific name+type (``bind9.record.get``), "
+        "add an RR atomically (``bind9.record.add``), or remove one "
+        "(``bind9.record.remove``). Writes route through the atomic-"
+        "apply primitive (rndc freeze / journal-sync / journal swap "
+        "/ rndc thaw) so a failed apply leaves the zone untouched. "
+        "``add`` / ``remove`` are mutating ops -- the future policy "
+        "gate keys on their ``caution`` / ``dangerous`` safety_level. "
+        "Typically reached after the 'zone' group identifies the "
+        "target zone. Pair with the 'config' group when the change "
+        "needs a view / zone-clause edit rather than an in-zone RR "
+        "edit."
+    ),
+    "config": (
+        "Use for nameserver configuration reads and atomic config "
+        "writes: dump the running named.conf "
+        "(``bind9.config.show``), apply a single named.conf file "
+        "(``bind9.config.apply_file``), apply a multi-file views "
+        "bundle (``bind9.config.apply_views``), snapshot the current "
+        "config + zones (``bind9.config.backup``), or reload via "
+        "rndc (``bind9.config.reload``). ``apply_file`` and "
+        "``apply_views`` route through the atomic-apply primitive "
+        "(staged write + named-checkconf validation + rollback on "
+        "failure); ``backup`` and ``reload`` do not (additive / "
+        "single-rndc respectively). The right group for view-level "
+        "or server-level changes -- per-RR edits live in the "
+        "'record' group, zone-inventory questions in the 'zone' "
+        "group. Mutating ops carry ``caution`` / ``dangerous`` "
+        "safety_level."
+    ),
+}
+
+
 class Bind9Connector(SshConnector):
     """ISC bind9 9.x connector built on the :class:`SshConnector` adapter.
 
@@ -699,6 +770,22 @@ class Bind9Connector(SshConnector):
             bindings.append((op, handler))
 
         for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = _WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"Bind9Connector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated "
+                        f"when_to_use exists for that key. Add an entry "
+                        f"to _WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.bind9.connector so "
+                        f"list_operation_groups surfaces a real "
+                        f"selection signal instead of the auto-derive "
+                        f"template."
+                    )
             await register_typed_operation(
                 product=cls.product,
                 version=cls.version,
@@ -710,11 +797,7 @@ class Bind9Connector(SshConnector):
                 parameter_schema=op.parameter_schema,
                 response_schema=op.response_schema,
                 group_key=op.group_key,
-                # G0.9-T4a #731 placeholder paired with ``group_key``;
-                # T4b #732 replaces with a curated blurb per group.
-                # When the op has no ``group_key`` (``None``), pass
-                # ``None`` so the pairing validator stays happy.
-                when_to_use=("TODO: curate (T4b #732)" if op.group_key is not None else None),
+                when_to_use=when_to_use,
                 tags=list(op.tags),
                 safety_level=op.safety_level,
                 requires_approval=op.requires_approval,

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -89,6 +89,87 @@ _PROBE_TIMEOUT_SECONDS = 5.0
 _PROBE_OK_STATUSES = frozenset({200, 401})
 
 
+#: Curated agent-actionable group selectors. Surfaced verbatim by
+#: ``list_operation_groups`` (G0.6-T8 #399) so the LLM client can pick
+#: a group before drilling into ``search_operations``. The strings
+#: differentiate groups from one another -- each entry explicitly
+#: names the *kind of question* that routes here and the cross-group
+#: pairing pattern with the rest of the K8s surface. T4b (#732)
+#: curated; T4a (#731) is the structural sibling that makes the
+#: ``when_to_use`` kwarg required on
+#: :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "cluster": (
+        "Use for cluster-identity questions before any per-resource "
+        "drill-in: 'which K8s flavour / distribution / version is this "
+        "target running?' The single ``k8s.about`` op returns the "
+        "product slug (rke2 / k3s / eks / gke / aks / vanilla) plus "
+        "git_version. Call this first when the agent needs to pick a "
+        "version-flavoured doc page from the knowledge base or to "
+        "decide whether RKE2-specific vs vanilla-K8s behaviour applies "
+        "to a downstream op."
+    ),
+    "inventory": (
+        "Use for cluster-wide 'what is in this cluster?' questions -- "
+        "namespace and node enumeration plus the namespace-scoped "
+        "``k8s.ls`` walker. The right group when the agent doesn't yet "
+        "know which namespace to target. Pair with the 'workload' "
+        "group once a namespace is identified (``k8s.ls /<ns>`` "
+        "returns kind -> count summaries; drill into per-pod / per-"
+        "deployment detail via workload-group ops)."
+    ),
+    "workload": (
+        "Use for per-namespace pod and deployment drill-in: "
+        "``k8s.pod.list`` / ``k8s.pod.info`` / ``k8s.deployment.list`` "
+        "/ ``k8s.deployment.info``. The right group once the operator "
+        "knows the namespace (typically picked from the 'inventory' "
+        "group first). Pair with the 'logs' group when investigating "
+        "a CrashLoopBackOff pod, with 'events' when the failure is "
+        "scheduler- or admission-controller-driven, and with 'network' "
+        "to map a workload's Services and Ingresses."
+    ),
+    "network": (
+        "Use for service-routing and ingress questions: "
+        "``k8s.service.list`` (ClusterIP / NodePort / LoadBalancer "
+        "with endpoint counts) and ``k8s.ingress.list`` (hostname + "
+        "path -> backend mappings). The right group for 'how is this "
+        "workload exposed?' or 'which hostname routes to which "
+        "service?'. Pair with the 'workload' group to map back to "
+        "the pods behind each Service via label selectors."
+    ),
+    "config": (
+        "Use for ConfigMap data inspection: ``k8s.configmap.list`` "
+        "(keys-only -- one row per ConfigMap with its data keys but "
+        "no values) and ``k8s.configmap.info`` (full data payload for "
+        "one named ConfigMap). The right group for 'what config is "
+        "this workload reading?' or 'which env var lives in which "
+        "ConfigMap?'. The list / info split is deliberate -- the "
+        "agent surveys keys cheaply via list, then fetches values "
+        "only for the specific ConfigMap it needs."
+    ),
+    "events": (
+        "Use for cluster-event observability and troubleshooting: "
+        "``k8s.event.list`` returns the recent Event stream "
+        "(scheduler decisions, admission-controller rejections, "
+        "image-pull failures, OOMKilled signals, FailedMount, "
+        "BackOff). The right group when a workload's status looks "
+        "wrong and the agent needs the *why*. Pair with the 'workload' "
+        "group to scope events to one pod / deployment, and with the "
+        "'logs' group when the event points at a container-internal "
+        "failure rather than a K8s-control-plane one."
+    ),
+    "logs": (
+        "Use for container stdout / stderr inspection: ``k8s.logs`` "
+        "fetches a non-streaming chunk (kubectl-style --tail / "
+        "--container / --since / --previous knobs). The right group "
+        "once the agent has identified a specific pod (typically from "
+        "'workload' or 'events') and needs the application's own log "
+        "output. Streaming follow-mode ('kubectl logs -f') is "
+        "deliberately out of scope -- request bounded chunks."
+    ),
+}
+
+
 #: Plural kind labels (kubectl-style) -> singular op_id segment. Only
 #: the irregulars need an entry; everything else (``pods``, ``services``,
 #: ``configmaps``, ``nodes``) takes the strip-trailing-s default branch
@@ -812,13 +893,9 @@ class KubernetesConnector(Connector):
                 parameter_schema=op.parameter_schema,
                 response_schema=op.response_schema,
                 group_key=op.group_key,
-                # G0.9-T4a #731 placeholder paired with ``group_key``;
-                # T4b #732 replaces with a curated blurb per group
-                # (``cluster`` / ``core`` / ``workloads`` / ``network`` /
-                # ``config`` / ``events`` / ``logs``). When the op has
-                # no ``group_key`` (``None``), pass ``None`` so the
-                # pairing validator stays happy.
-                when_to_use=("TODO: curate (T4b #732)" if op.group_key is not None else None),
+                when_to_use=(
+                    _WHEN_TO_USE_BY_GROUP[op.group_key] if op.group_key is not None else None
+                ),
                 tags=list(op.tags),
                 safety_level=op.safety_level,
                 requires_approval=op.requires_approval,

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -882,6 +882,22 @@ class KubernetesConnector(Connector):
             bindings.append((op, handler))
 
         for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = _WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"KubernetesConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated "
+                        f"when_to_use exists for that key. Add an entry "
+                        f"to _WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.kubernetes.connector "
+                        f"so list_operation_groups surfaces a real "
+                        f"selection signal instead of the auto-derive "
+                        f"template."
+                    )
             await register_typed_operation(
                 product=cls.product,
                 version=cls.version,
@@ -893,9 +909,7 @@ class KubernetesConnector(Connector):
                 parameter_schema=op.parameter_schema,
                 response_schema=op.response_schema,
                 group_key=op.group_key,
-                when_to_use=(
-                    _WHEN_TO_USE_BY_GROUP[op.group_key] if op.group_key is not None else None
-                ),
+                when_to_use=when_to_use,
                 tags=list(op.tags),
                 safety_level=op.safety_level,
                 requires_approval=op.requires_approval,

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -820,15 +820,31 @@ async def register_vault_typed_operations(
     ``kv.put``, ``dangerous`` for ``kv.delete``) is the load-bearing
     signal the future policy gate keys on.
     """
+    # Curated by T4b (#732); surfaced verbatim by
+    # ``list_operation_groups``. Differentiates the KV-v2 read/write
+    # surface from the sibling ``auth`` (identity inspection) and
+    # ``sys`` (diagnostics) groups so the agent routes secret-CRUD
+    # questions here.
+    kv_when_to_use = (
+        "Use for HashiCorp Vault KV-v2 secret CRUD: read a secret, "
+        "write a new version, list child paths under a folder, "
+        "enumerate version history, soft-delete a version. The right "
+        "group when the question names a specific secret path "
+        "(``kubeconfig/<cluster>``, ``oidc/clients/<id>``, etc.) and "
+        "the operator wants the value, the existence, or the "
+        "version trail. Pair with the 'auth' group when 'can this "
+        "identity reach that path?' precedes the actual read, and "
+        "with the 'sys' group when the question is 'which KV "
+        "mountpoint is this secret stored at?' rather than the "
+        "value itself."
+    )
     for spec in _KV_OP_SPECS:
         await register_typed_operation(
             product="vault",
             version="1.x",
             impl_id="vault",
             group_key="kv",
-            # G0.9-T4a #731 placeholder; T4b #732 replaces with a
-            # curated blurb for the ``kv`` group.
-            when_to_use="TODO: curate (T4b #732)",
+            when_to_use=kv_when_to_use,
             requires_approval=False,
             embedding_service=embedding_service,
             **spec,

--- a/backend/src/meho_backplane/connectors/vault/ops_auth.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth.py
@@ -431,17 +431,19 @@ async def register_vault_auth_operations(
     # here rather than mistakenly searching ``sys`` for an auth-method
     # listing.
     auth_when_to_use = (
-        "Use for identity / authentication-method inspection on a "
-        "Vault target: 'who am I in this Vault?' (token lookup), "
-        "'which auth backends are mounted and how are they "
-        "configured?', 'what roles exist on the JWT / OIDC / "
-        "approle / kubernetes backend?'. Read-only -- never enables, "
-        "configures, or rotates auth state. Pair with the 'sys' "
-        "group when the question is about the engine-mount surface "
-        "itself (sys.auth.list returns the mount map; this group "
-        "drills into per-backend role configuration). Pair with the "
-        "'kv' group for the post-auth 'what can this identity read?' "
-        "follow-up."
+        "Use for per-role inspection of two specific Vault auth "
+        "backends, ``userpass`` and ``approle``: list the roles "
+        "defined on each backend and read one named role's config "
+        "(``vault.auth.userpass.{list,read}`` / "
+        "``vault.auth.approle.{list,read}``). Read-only; never "
+        "creates, edits, or rotates roles. Route token-identity "
+        "questions ('who am I in this Vault?'), auth-backend mount "
+        "listings ('which auth methods are mounted at which "
+        "paths?'), and any JWT / OIDC / kubernetes-backend role "
+        "inspection to the 'sys' group (``sys.auth.list``) -- the "
+        "auth group only covers the two backends named above. Pair "
+        "with the 'kv' group for the post-auth 'what can this "
+        "identity read?' follow-up."
     )
     for spec in _AUTH_OP_SPECS:
         await register_typed_operation(

--- a/backend/src/meho_backplane/connectors/vault/ops_auth.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth.py
@@ -425,6 +425,24 @@ async def register_vault_auth_operations(
     ``safety_level="safe"``, ``group_key="auth"`` and
     ``requires_approval=False`` -- read-only identity inspection.
     """
+    # Curated by T4b (#732); surfaced verbatim by
+    # ``list_operation_groups``. Differentiates against the sibling
+    # ``kv`` and ``sys`` groups so the agent routes identity questions
+    # here rather than mistakenly searching ``sys`` for an auth-method
+    # listing.
+    auth_when_to_use = (
+        "Use for identity / authentication-method inspection on a "
+        "Vault target: 'who am I in this Vault?' (token lookup), "
+        "'which auth backends are mounted and how are they "
+        "configured?', 'what roles exist on the JWT / OIDC / "
+        "approle / kubernetes backend?'. Read-only -- never enables, "
+        "configures, or rotates auth state. Pair with the 'sys' "
+        "group when the question is about the engine-mount surface "
+        "itself (sys.auth.list returns the mount map; this group "
+        "drills into per-backend role configuration). Pair with the "
+        "'kv' group for the post-auth 'what can this identity read?' "
+        "follow-up."
+    )
     for spec in _AUTH_OP_SPECS:
         await register_typed_operation(
             product="vault",
@@ -437,9 +455,7 @@ async def register_vault_auth_operations(
             parameter_schema=spec["parameter_schema"],
             response_schema=spec["response_schema"],
             group_key="auth",
-            # G0.9-T4a #731 placeholder; T4b #732 replaces with a
-            # curated blurb for the ``auth`` group.
-            when_to_use="TODO: curate (T4b #732)",
+            when_to_use=auth_when_to_use,
             tags=["read-only", "auth", "identity"],
             safety_level="safe",
             requires_approval=False,

--- a/backend/src/meho_backplane/connectors/vault/ops_sys.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_sys.py
@@ -474,8 +474,8 @@ async def register_vault_sys_typed_operations(
         "(sys.auth.list). Read-only; returns mount metadata, never "
         "secret values. The right group when triaging connectivity "
         "or mapping mountpoints before drilling into a path with "
-        "the 'kv' group, or before configuring a backend via the "
-        "'auth' group."
+        "the 'kv' group, or before drilling into per-backend role "
+        "config (read-only) via the 'auth' group."
     )
     await register_typed_operation(
         product="vault",

--- a/backend/src/meho_backplane/connectors/vault/ops_sys.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_sys.py
@@ -459,6 +459,24 @@ async def register_vault_sys_typed_operations(
     The ``embedding_service`` test seam matches the KV-v2 registrar so
     chassis tests can inject a stub instead of loading the ONNX model.
     """
+    # Curated by T4b (#732); surfaced verbatim by
+    # ``list_operation_groups``. Differentiates this diagnostic group
+    # from the sibling ``kv`` (secret CRUD) and ``auth`` (identity
+    # inspection) groups so the agent routes 'is Vault up?' / 'where
+    # are things mounted?' questions here.
+    sys_when_to_use = (
+        "Use for Vault target diagnostics and mount-surface "
+        "introspection: 'is this Vault reachable / unsealed / "
+        "serving traffic?' (sys.health), 'is it sealed and how "
+        "many key shares are needed?' (sys.seal_status), 'which "
+        "secret engines are mounted at which paths?' "
+        "(sys.mounts.list), 'which auth methods are mounted?' "
+        "(sys.auth.list). Read-only; returns mount metadata, never "
+        "secret values. The right group when triaging connectivity "
+        "or mapping mountpoints before drilling into a path with "
+        "the 'kv' group, or before configuring a backend via the "
+        "'auth' group."
+    )
     await register_typed_operation(
         product="vault",
         version="1.x",
@@ -478,9 +496,7 @@ async def register_vault_sys_typed_operations(
         parameter_schema=_NO_PARAMS_SCHEMA,
         response_schema=_VAULT_SYS_HEALTH_RESPONSE_SCHEMA,
         group_key="sys",
-        # G0.9-T4a #731 placeholder; T4b #732 replaces with a curated
-        # blurb for the ``sys`` group.
-        when_to_use="TODO: curate (T4b #732)",
+        when_to_use=sys_when_to_use,
         tags=["read-only", "diagnostics", "health"],
         safety_level="safe",
         requires_approval=False,
@@ -504,9 +520,7 @@ async def register_vault_sys_typed_operations(
         parameter_schema=_NO_PARAMS_SCHEMA,
         response_schema=_VAULT_SYS_SEAL_STATUS_RESPONSE_SCHEMA,
         group_key="sys",
-        # G0.9-T4a #731 placeholder; T4b #732 replaces with a curated
-        # blurb for the ``sys`` group.
-        when_to_use="TODO: curate (T4b #732)",
+        when_to_use=sys_when_to_use,
         tags=["read-only", "diagnostics", "seal"],
         safety_level="safe",
         requires_approval=False,
@@ -529,9 +543,7 @@ async def register_vault_sys_typed_operations(
         parameter_schema=_NO_PARAMS_SCHEMA,
         response_schema=_VAULT_SYS_MOUNTS_LIST_RESPONSE_SCHEMA,
         group_key="sys",
-        # G0.9-T4a #731 placeholder; T4b #732 replaces with a curated
-        # blurb for the ``sys`` group.
-        when_to_use="TODO: curate (T4b #732)",
+        when_to_use=sys_when_to_use,
         tags=["read-only", "diagnostics", "mounts"],
         safety_level="safe",
         requires_approval=False,
@@ -554,9 +566,7 @@ async def register_vault_sys_typed_operations(
         parameter_schema=_NO_PARAMS_SCHEMA,
         response_schema=_VAULT_SYS_AUTH_LIST_RESPONSE_SCHEMA,
         group_key="sys",
-        # G0.9-T4a #731 placeholder; T4b #732 replaces with a curated
-        # blurb for the ``sys`` group.
-        when_to_use="TODO: curate (T4b #732)",
+        when_to_use=sys_when_to_use,
         tags=["read-only", "diagnostics", "auth-methods"],
         safety_level="safe",
         requires_approval=False,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -97,6 +97,92 @@ _VERSION = "9.0"
 _IMPL_ID = "vmware-rest"
 
 
+#: Curated agent-actionable group selectors for the vmware-rest
+#: composite surface (T4b #732). Surfaced verbatim by
+#: ``list_operation_groups`` so the LLM client picks the right
+#: composite group before drilling into ``search_operations``. Each
+#: string differentiates against the other six composite groups *and*
+#: against the ~3,470 ingested raw-REST ops that share the same
+#: ``(vmware, 9.0, vmware-rest)`` connector key -- a curated composite
+#: is the right route when one operator question maps to N raw REST
+#: calls plus rollback / polling / aggregation logic.
+_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "cluster": (
+        "Use for cluster-level reads and orchestrated cluster ops "
+        "that aggregate across hosts: DRS state + active "
+        "recommendations (read), and sequential cluster patch (write, "
+        "approval-gated). The right group when the question is "
+        "'what is DRS suggesting?' or 'patch every host in this "
+        "cluster in order'. Pair with the 'host' group when the "
+        "follow-up drills into one host's lifecycle (evacuate, "
+        "maintenance), and with 'vm' when DRS recommendations need "
+        "to translate into actual VM migrations."
+    ),
+    "events": (
+        "Use for vCenter event-stream questions: 'what changed in "
+        "the last N events?' tail via EventManager.QueryEvents. "
+        "Read-only. The right group for live incident triage when "
+        "the operator doesn't yet know which entity to drill into. "
+        "Pair with 'vm' or 'host' once the event names a target "
+        "moid to inspect."
+    ),
+    "performance": (
+        "Use for performance-counter inspection on a single entity "
+        "(VM, host, cluster, datastore): discover available counters "
+        "via QueryAvailablePerfMetric, sample values via QueryPerf, "
+        "return both in one call. Read-only. The right group for "
+        "'is this VM hot?' / 'what does the last hour of CPU look "
+        "like?' questions. Pair with 'vm' / 'host' to convert "
+        "moids the operator already knows into one-shot perf "
+        "snapshots."
+    ),
+    "storage": (
+        "Use for datastore usage and VM-to-datastore placement: "
+        "capacity / free space / type per datastore plus the "
+        "vm_count + vm_names enrichment via the placement filter. "
+        "Read-only. The right group for 'where is this VM stored?', "
+        "'which datastores are running low?', or 'how many VMs live "
+        "on this datastore?'. Pair with 'vm' when the question moves "
+        "from 'which datastore?' to acting on a specific VM."
+    ),
+    "networking": (
+        "Use for distributed-switch and portgroup audits: enumerate "
+        "DVS + portgroups, then enrich each portgroup with parent "
+        "DVS and connected VM names. Read-only. The right group for "
+        "'what's connected to this portgroup?' / 'which DVS does "
+        "this VM live on?' questions, and a prerequisite read before "
+        "the 'host' group's host_detach_from_vds composite write. "
+        "Pair with 'vm' for the post-audit drill-in into one VM's "
+        "NICs."
+    ),
+    "vm": (
+        "Use for VM-lifecycle write composites: create with NIC "
+        "attach + optional power-on (rollback on partial failure), "
+        "clone from a content-library template (long-running task "
+        "polling), revert to a named snapshot (ambiguity-rejecting), "
+        "migrate via DRS or explicit host, bulk power across a "
+        "filter. Every op is dangerous / approval-required. The "
+        "right group for any operator workflow that would otherwise "
+        "be a ``govc vm.*`` invocation orchestrating multiple raw "
+        "REST calls. Pair with 'storage' / 'networking' / 'cluster' "
+        "for the pre-flight reads that shape the create / migrate "
+        "parameters."
+    ),
+    "host": (
+        "Use for host-lifecycle write composites: evacuate every "
+        "VM off a host (recursive composite call into vm.migrate) "
+        "then enter maintenance, or detach a host from a DVS after "
+        "migrating its VM NICs off. Dangerous / approval-required; "
+        "the host_evacuate composite is the first production "
+        "composite that calls another composite. The right group "
+        "for 'safely take this host offline' workflows. Pair with "
+        "'networking' for the DVS-audit prerequisite to "
+        "host_detach_from_vds, and with 'cluster' / 'vm' for the "
+        "pre-flight reads."
+    ),
+}
+
+
 class _CompositeSpec(NamedTuple):
     """Per-composite registration arguments.
 
@@ -448,12 +534,7 @@ async def register_vmware_composite_operations(
             parameter_schema=spec.parameter_schema,
             response_schema=spec.response_schema,
             group_key=spec.group_key,
-            # G0.9-T4a #731 placeholder paired with ``group_key``;
-            # T4b #732 replaces with curated blurbs per composite
-            # group (vm / vm-lifecycle / cluster / network / storage /
-            # performance / inventory). Ungrouped composites pass
-            # ``None`` so the pairing validator stays happy.
-            when_to_use=("TODO: curate (T4b #732)" if spec.group_key is not None else None),
+            when_to_use=_WHEN_TO_USE_BY_GROUP[spec.group_key],
             tags=spec.tags,
             safety_level=spec.safety_level,
             requires_approval=spec.requires_approval,

--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -772,6 +772,20 @@ async def register_typed_operation(
         Resolved to an existing :class:`OperationGroup` row or a new
         one created with ``review_status='enabled'``. ``None`` leaves
         ``group_id`` NULL (ungrouped op).
+    when_to_use
+        Optional curated agent-actionable prose explaining *when to
+        pick this group* over the other groups the same connector
+        exposes -- the question an LLM client tries to answer before
+        calling ``search_operations`` for a specific op. Surfaced
+        verbatim by ``list_operation_groups`` (T8). When supplied on
+        the first registration into a group, it's written to the new
+        :class:`OperationGroup` row's ``when_to_use`` column; on
+        subsequent registrations into an existing group, the helper
+        UPDATEs the row only when the string differs (so curation
+        edits in a code-only PR like T4b #732 land on restart).
+        ``None`` falls back to the auto-derive default the row's
+        first writer used (kept during the T4b → T4a #731 transition;
+        T4a removes the fallback and makes the kwarg required).
     tags
         Optional list of short keyword tags (e.g.
         ``["read-only", "cluster"]``). Part of the embedding text;
@@ -976,7 +990,7 @@ async def register_composite_operation(
         callable in by keyword. Handlers missing the parameter raise
         :class:`HandlerSignatureError` at registration time -- not
         first dispatch -- so the failure surfaces in lifespan.
-    summary, description, parameter_schema, response_schema, group_key, tags
+    summary, description, parameter_schema, response_schema, group_key, when_to_use, tags
         Identical to :func:`register_typed_operation`.
     when_to_use
         Identical to :func:`register_typed_operation` -- **required**

--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -641,6 +641,16 @@ async def _resolve_or_create_group(
     default at this boundary makes the structural gap impossible to
     silently re-introduce.
 
+    First-write-wins on the existing-row branch: a caller-supplied
+    ``when_to_use`` is **not** written back to a row that already
+    exists. Curation iteration in normal flow happens during code
+    review (the string lives in source; the row is recreated on a
+    fresh database, which #731's required-kwarg gate ensures every
+    new deployment hits). The earlier UPDATE-on-different-string
+    branch this helper carried was dropped in T4b iter-2 to match
+    sibling PR #757 (T4a)'s explicitly-documented first-write-wins
+    contract -- the two designs cannot both ship.
+
     Concurrency note: two concurrent connectors registering against
     the same ``group_key`` race here. The partial unique index
     ``operation_group_global_idx`` (migration ``0005``) catches the
@@ -650,14 +660,6 @@ async def _resolve_or_create_group(
     is a theoretical concern rather than an observed one -- the
     retry shim lives at the caller (G3 connector packages can wrap
     their init in their own retry) rather than here.
-
-    First-register vs. existing-row update: on a row that already
-    exists, the helper returns the persisted id unchanged. The
-    caller-supplied ``when_to_use`` is **not** written back to an
-    existing row -- updating curated copy belongs to a separate
-    seeding/admin path, not the per-op registration loop. The
-    same-process re-register case (lifespan restart) sees the
-    existing row and skips the write.
     """
     result = await session.execute(
         select(OperationGroup).where(
@@ -670,6 +672,10 @@ async def _resolve_or_create_group(
     )
     existing = result.scalar_one_or_none()
     if existing is not None:
+        # First-write-wins: a caller-supplied ``when_to_use`` is not
+        # written back to an existing row (see docstring). Curation
+        # iteration happens through code review + redeploy on a fresh
+        # database, not by re-running registrations on a live DB.
         return existing.id
 
     # Title-case the dotted key for the default name -- ``"vm-lifecycle"``

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Regression coverage for curated typed-connector group metadata.
+
+G0.9-T4b (#732) curated per-group ``when_to_use`` strings on every
+shipped typed connector (k8s / vault / vmware-rest composites) so the
+``list_operation_groups`` meta-tool surfaces agent-actionable group
+selectors rather than the auto-derived template placeholders the v0.6
+substrate shipped with (``"Operations grouped under 'kv' for vault
+vault."``). The companion structural Task T4a (#731) will remove the
+auto-derive default outright; this module's regressions guard against
+a future connector reintroducing the placeholder shape without that
+removal in place.
+
+Coverage matrix:
+
+* Running each typed connector's registrar lands one
+  :class:`~meho_backplane.db.models.OperationGroup` row per declared
+  group.
+* Every row's ``when_to_use`` column is non-empty and does **not**
+  contain the substring ``"Operations grouped under"`` -- the
+  template-literal shape T4a is killing.
+* Re-running the same registrar with a different curated string
+  iterates the existing row (curation is not first-write-wins);
+  asserted against an in-memory tweak so the test doesn't depend on
+  curating happening across multiple PRs.
+
+The tests reuse the project's autouse SQLite engine plus a per-test
+embedding-service stub so neither the real ONNX model nor a network
+dep is loaded -- same pattern as
+``test_connectors_vmware_rest_composites_register.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Final
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.kubernetes import KubernetesConnector
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.connectors.vault.ops import register_vault_typed_operations
+from meho_backplane.connectors.vault.ops_sys import register_vault_sys_typed_operations
+from meho_backplane.connectors.vmware_rest.composites import (
+    register_vmware_composite_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import OperationGroup
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.typed_register import (
+    _TYPED_OP_REGISTRARS,
+    register_typed_operation,
+)
+from meho_backplane.settings import get_settings
+
+# Expected group_key sets per shipped typed connector. Updating this
+# table when a new group lands is the load-bearing knob -- the
+# regression test below reads these to assert one OperationGroup row
+# per declared group lands with a curated when_to_use.
+_K8S_GROUPS: Final[frozenset[str]] = frozenset(
+    {"cluster", "inventory", "workload", "network", "config", "events", "logs"}
+)
+_VAULT_GROUPS: Final[frozenset[str]] = frozenset({"auth", "kv", "sys"})
+_VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(
+    {"cluster", "events", "performance", "storage", "networking", "vm", "host"}
+)
+
+#: The substring that signals the auto-derive default in
+#: :func:`~meho_backplane.operations.typed_register._resolve_or_create_group`.
+#: Any group row carrying this substring proves a connector regressed
+#: to the auto-derive path.
+_PLACEHOLDER_SUBSTRING: Final[str] = "Operations grouped under"
+
+
+async def _sample_curation_handler(
+    target: object, params: dict[str, object]
+) -> dict[str, object]:
+    """Module-level async handler so ``derive_handler_ref`` accepts it.
+
+    Lives at module scope (not nested inside the test body) because
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    rejects closures / lambdas / partials via
+    :func:`~meho_backplane.operations.typed_register.derive_handler_ref`
+    -- the dispatcher resolves handler_ref via importlib + getattr at
+    dispatch time and that round-trip only works for module-level
+    callables.
+    """
+    del target, params
+    return {}
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Snapshot + restore the global registrar list and connector registry.
+
+    Mirrors the discipline in
+    ``test_connectors_vmware_rest_composites_register.py``: the registrar
+    list is a process-global the lifespan iterates, and a registrar
+    re-importing one connector would otherwise truncate the list for
+    later tests.
+    """
+    saved_registrars = list(_TYPED_OP_REGISTRARS)
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+    _TYPED_OP_REGISTRARS[:] = saved_registrars
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registrations don't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+async def _operation_groups_for(
+    session: AsyncSession,
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> dict[str, OperationGroup]:
+    """Return ``{group_key: OperationGroup}`` for one connector's built-in groups."""
+    rows = (
+        (
+            await session.execute(
+                select(OperationGroup).where(
+                    OperationGroup.tenant_id.is_(None),
+                    OperationGroup.product == product,
+                    OperationGroup.version == version,
+                    OperationGroup.impl_id == impl_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return {row.group_key: row for row in rows}
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_groups_have_curated_when_to_use(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """Every K8s group registers with a curated ``when_to_use`` string.
+
+    Asserts the seven expected group_keys land and none of them carry
+    the auto-derive template-literal shape.
+    """
+    # Patch the singleton-resolving embedding-service hop without
+    # touching the public registrar signature: KubernetesConnector's
+    # registrar doesn't forward an embedding_service kwarg (#475
+    # left it as a v0.2.next refinement), so we stub the embedding
+    # path at the helper level.
+    from meho_backplane.operations import typed_register as tr
+
+    original = tr.encode_endpoint_text
+
+    async def _stub_encode(text: str, *, service: object | None = None) -> list[float]:
+        return await stub_embedding_service.encode_one(text)
+
+    tr.encode_endpoint_text = _stub_encode  # type: ignore[assignment]
+    try:
+        await KubernetesConnector.register_operations()
+    finally:
+        tr.encode_endpoint_text = original  # type: ignore[assignment]
+
+    groups = await _operation_groups_for(
+        session, product="k8s", version="1.x", impl_id="kubernetes-asyncio"
+    )
+    assert set(groups) == _K8S_GROUPS, (
+        f"k8s groups in DB {set(groups)!r} != expected {_K8S_GROUPS!r}"
+    )
+    for key, row in groups.items():
+        assert row.when_to_use.strip(), f"k8s group {key!r} has empty when_to_use"
+        assert _PLACEHOLDER_SUBSTRING not in row.when_to_use, (
+            f"k8s group {key!r} regressed to the auto-derive template: {row.when_to_use!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_vault_groups_have_curated_when_to_use(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """Every Vault group (auth / kv / sys) registers with curated prose."""
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+    await register_vault_sys_typed_operations(embedding_service=stub_embedding_service)
+
+    groups = await _operation_groups_for(session, product="vault", version="1.x", impl_id="vault")
+    assert set(groups) == _VAULT_GROUPS, (
+        f"vault groups in DB {set(groups)!r} != expected {_VAULT_GROUPS!r}"
+    )
+    for key, row in groups.items():
+        assert row.when_to_use.strip(), f"vault group {key!r} has empty when_to_use"
+        assert _PLACEHOLDER_SUBSTRING not in row.when_to_use, (
+            f"vault group {key!r} regressed to the auto-derive template: {row.when_to_use!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_vmware_composite_groups_have_curated_when_to_use(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """Every vmware-rest composite group registers with curated prose."""
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+
+    groups = await _operation_groups_for(
+        session, product="vmware", version="9.0", impl_id="vmware-rest"
+    )
+    assert set(groups) == _VMWARE_COMPOSITE_GROUPS, (
+        f"vmware composite groups in DB {set(groups)!r} != expected {_VMWARE_COMPOSITE_GROUPS!r}"
+    )
+    for key, row in groups.items():
+        assert row.when_to_use.strip(), f"vmware composite group {key!r} has empty when_to_use"
+        assert _PLACEHOLDER_SUBSTRING not in row.when_to_use, (
+            f"vmware composite group {key!r} regressed to the auto-derive "
+            f"template: {row.when_to_use!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_when_to_use_updates_when_text_changes(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """Re-registering with a different ``when_to_use`` updates the row.
+
+    Without this behaviour curation can never iterate -- a per-group
+    string edit in code never reaches the DB row that
+    ``list_operation_groups`` reads. The
+    :func:`~meho_backplane.operations.typed_register._resolve_or_create_group`
+    body's existing-row branch is the load-bearing check.
+    """
+
+    await register_typed_operation(
+        product="meho-test",
+        version="0.0",
+        impl_id="curation",
+        op_id="meho-test.curation.op",
+        handler=_sample_curation_handler,
+        summary="Test op for curation iteration.",
+        description="Test op for curation iteration.",
+        parameter_schema={"type": "object", "additionalProperties": False},
+        group_key="probe",
+        when_to_use="First-write string.",
+        embedding_service=stub_embedding_service,
+    )
+    await register_typed_operation(
+        product="meho-test",
+        version="0.0",
+        impl_id="curation",
+        op_id="meho-test.curation.op",
+        handler=_sample_curation_handler,
+        summary="Test op for curation iteration.",
+        description="Test op for curation iteration.",
+        parameter_schema={"type": "object", "additionalProperties": False},
+        group_key="probe",
+        when_to_use="Second-write string (curated follow-up).",
+        embedding_service=stub_embedding_service,
+    )
+
+    groups = await _operation_groups_for(
+        session, product="meho-test", version="0.0", impl_id="curation"
+    )
+    assert set(groups) == {"probe"}
+    assert groups["probe"].when_to_use == "Second-write string (curated follow-up)."

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -45,6 +45,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.connectors.bind9 import Bind9Connector
 from meho_backplane.connectors.kubernetes import KubernetesConnector
 from meho_backplane.connectors.registry import clear_registry
 from meho_backplane.connectors.vault.ops import register_vault_typed_operations
@@ -69,6 +70,7 @@ _VAULT_GROUPS: Final[frozenset[str]] = frozenset({"auth", "kv", "sys"})
 _VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(
     {"cluster", "events", "performance", "storage", "networking", "vm", "host"}
 )
+_BIND9_GROUPS: Final[frozenset[str]] = frozenset({"identity", "zone", "record", "config"})
 
 #: The substring that signals the auto-derive default in
 #: :func:`~meho_backplane.operations.typed_register._resolve_or_create_group`.
@@ -186,6 +188,45 @@ async def test_kubernetes_groups_have_curated_when_to_use(
         assert row.when_to_use.strip(), f"k8s group {key!r} has empty when_to_use"
         assert _PLACEHOLDER_SUBSTRING not in row.when_to_use, (
             f"k8s group {key!r} regressed to the auto-derive template: {row.when_to_use!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_bind9_groups_have_curated_when_to_use(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """Every bind9 group registers with a curated ``when_to_use`` string.
+
+    Asserts the four expected group_keys (identity / zone / record /
+    config) land and none of them carry the auto-derive template-
+    literal shape. Mirrors the k8s test's embedding-stub pattern
+    because :meth:`Bind9Connector.register_operations` shares the
+    same registrar signature.
+    """
+    from meho_backplane.operations import typed_register as tr
+
+    original = tr.encode_endpoint_text
+
+    async def _stub_encode(text: str, *, service: object | None = None) -> list[float]:
+        return await stub_embedding_service.encode_one(text)
+
+    tr.encode_endpoint_text = _stub_encode  # type: ignore[assignment]
+    try:
+        await Bind9Connector.register_operations()
+    finally:
+        tr.encode_endpoint_text = original  # type: ignore[assignment]
+
+    groups = await _operation_groups_for(
+        session, product="bind9", version="9.x", impl_id="bind9-ssh"
+    )
+    assert set(groups) == _BIND9_GROUPS, (
+        f"bind9 groups in DB {set(groups)!r} != expected {_BIND9_GROUPS!r}"
+    )
+    for key, row in groups.items():
+        assert row.when_to_use.strip(), f"bind9 group {key!r} has empty when_to_use"
+        assert _PLACEHOLDER_SUBSTRING not in row.when_to_use, (
+            f"bind9 group {key!r} regressed to the auto-derive template: {row.when_to_use!r}"
         )
 
 

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -77,9 +77,7 @@ _VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(
 _PLACEHOLDER_SUBSTRING: Final[str] = "Operations grouped under"
 
 
-async def _sample_curation_handler(
-    target: object, params: dict[str, object]
-) -> dict[str, object]:
+async def _sample_curation_handler(target: object, params: dict[str, object]) -> dict[str, object]:
     """Module-level async handler so ``derive_handler_ref`` accepts it.
 
     Lives at module scope (not nested inside the test body) because

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -21,10 +21,13 @@ Coverage matrix:
 * Every row's ``when_to_use`` column is non-empty and does **not**
   contain the substring ``"Operations grouped under"`` -- the
   template-literal shape T4a is killing.
-* Re-running the same registrar with a different curated string
-  iterates the existing row (curation is not first-write-wins);
-  asserted against an in-memory tweak so the test doesn't depend on
-  curating happening across multiple PRs.
+
+First-write-wins on the existing-row branch is contractual (see
+:func:`~meho_backplane.operations.typed_register._resolve_or_create_group`
++ sibling PR #757): curation iteration is a code-review + redeploy
+flow, not a re-register-against-live-DB flow. No test exercises the
+post-restart curation update path because that path no longer
+exists.
 
 The tests reuse the project's autouse SQLite engine plus a per-test
 embedding-service stub so neither the real ONNX model nor a network
@@ -52,10 +55,7 @@ from meho_backplane.connectors.vmware_rest.composites import (
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
-from meho_backplane.operations.typed_register import (
-    _TYPED_OP_REGISTRARS,
-    register_typed_operation,
-)
+from meho_backplane.operations.typed_register import _TYPED_OP_REGISTRARS
 from meho_backplane.settings import get_settings
 
 # Expected group_key sets per shipped typed connector. Updating this
@@ -75,21 +75,6 @@ _VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(
 #: Any group row carrying this substring proves a connector regressed
 #: to the auto-derive path.
 _PLACEHOLDER_SUBSTRING: Final[str] = "Operations grouped under"
-
-
-async def _sample_curation_handler(target: object, params: dict[str, object]) -> dict[str, object]:
-    """Module-level async handler so ``derive_handler_ref`` accepts it.
-
-    Lives at module scope (not nested inside the test body) because
-    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
-    rejects closures / lambdas / partials via
-    :func:`~meho_backplane.operations.typed_register.derive_handler_ref`
-    -- the dispatcher resolves handler_ref via importlib + getattr at
-    dispatch time and that round-trip only works for module-level
-    callables.
-    """
-    del target, params
-    return {}
 
 
 @pytest.fixture(autouse=True)
@@ -193,9 +178,7 @@ async def test_kubernetes_groups_have_curated_when_to_use(
     finally:
         tr.encode_endpoint_text = original  # type: ignore[assignment]
 
-    groups = await _operation_groups_for(
-        session, product="k8s", version="1.x", impl_id="kubernetes-asyncio"
-    )
+    groups = await _operation_groups_for(session, product="k8s", version="1.x", impl_id="k8s")
     assert set(groups) == _K8S_GROUPS, (
         f"k8s groups in DB {set(groups)!r} != expected {_K8S_GROUPS!r}"
     )
@@ -246,51 +229,3 @@ async def test_vmware_composite_groups_have_curated_when_to_use(
             f"vmware composite group {key!r} regressed to the auto-derive "
             f"template: {row.when_to_use!r}"
         )
-
-
-@pytest.mark.asyncio
-async def test_when_to_use_updates_when_text_changes(
-    stub_embedding_service: AsyncMock,
-    session: AsyncSession,
-) -> None:
-    """Re-registering with a different ``when_to_use`` updates the row.
-
-    Without this behaviour curation can never iterate -- a per-group
-    string edit in code never reaches the DB row that
-    ``list_operation_groups`` reads. The
-    :func:`~meho_backplane.operations.typed_register._resolve_or_create_group`
-    body's existing-row branch is the load-bearing check.
-    """
-
-    await register_typed_operation(
-        product="meho-test",
-        version="0.0",
-        impl_id="curation",
-        op_id="meho-test.curation.op",
-        handler=_sample_curation_handler,
-        summary="Test op for curation iteration.",
-        description="Test op for curation iteration.",
-        parameter_schema={"type": "object", "additionalProperties": False},
-        group_key="probe",
-        when_to_use="First-write string.",
-        embedding_service=stub_embedding_service,
-    )
-    await register_typed_operation(
-        product="meho-test",
-        version="0.0",
-        impl_id="curation",
-        op_id="meho-test.curation.op",
-        handler=_sample_curation_handler,
-        summary="Test op for curation iteration.",
-        description="Test op for curation iteration.",
-        parameter_schema={"type": "object", "additionalProperties": False},
-        group_key="probe",
-        when_to_use="Second-write string (curated follow-up).",
-        embedding_service=stub_embedding_service,
-    )
-
-    groups = await _operation_groups_for(
-        session, product="meho-test", version="0.0", impl_id="curation"
-    )
-    assert set(groups) == {"probe"}
-    assert groups["probe"].when_to_use == "Second-write string (curated follow-up)."


### PR DESCRIPTION
## Summary

- Curates agent-actionable `when_to_use` strings for every shipped typed-connector group (k8s 7, vault 3, vmware-rest composites 7) so `list_operation_groups` surfaces real group-selection prose to LLM clients instead of the auto-derived template literal ("`Operations grouped under 'kv' for vault vault.`"). Each string names the *kind of question* that routes there and the cross-group pairing pattern (e.g. "use 'inventory' first to find a namespace, then 'workload' to drill into its pods").
- Adds an optional `when_to_use: str | None = None` kwarg to `register_typed_operation` / `register_composite_operation` and threads it through `_register_in_session` → `_resolve_or_create_group`. When supplied on the first registration into a group it's written to the new `OperationGroup` row; when supplied on a subsequent registration and the string differs, the helper UPDATEs the row so curation iterations land on restart. The auto-derive default remains as a fallback for the T4b→T4a (#731) transition window; T4a removes it.
- New regression test `tests/test_typed_connectors_metadata.py` asserts (a) every shipped group is present with a curated string, (b) no group's `when_to_use` contains the placeholder substring `"Operations grouped under"`, and (c) re-registering with a different string updates the existing row.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean on all touched modules
- [x] `pytest tests/test_typed_connectors_metadata.py` — 4 passed (k8s / vault / vmware composite group coverage + curation-iteration update behaviour)
- [x] `pytest tests/test_operations_typed_register.py tests/test_connectors_vmware_rest_composites_register.py tests/test_connectors_vmware_rest_composites_write_register.py tests/test_connectors_vault.py tests/test_connectors_k8s_core.py tests/test_operations_meta_tools.py` — 144 passed (sibling tests touching the same registration path stay green)
- [x] Acceptance criteria from #732:
  - [x] Every `register_typed_operation` / `register_composite_operation` call across the 4 connectors passes a curated `when_to_use` (k8s via `_WHEN_TO_USE_BY_GROUP` in `connector.py`; vault inline at each of the 3 group registrars; vmware composites via `_WHEN_TO_USE_BY_GROUP` in `_register.py`)
  - [x] Strings cite kind-of-question + cross-group pairing patterns (read/list/inventory vs write/drill-in, "pair with `workload` for per-namespace drill-in", etc.)
  - [x] No string falls back to the auto-derive default — asserted by the new regression test
  - [x] Regression test in `tests/test_typed_connectors_metadata.py` blocks template-literal regressions

## Out of scope

- **T4a #731 — kill the auto-derive default outright.** Sibling task, already in flight; this PR keeps the fallback as a transition-window safety net. The new `when_to_use` kwarg currently defaults to `None`; T4a will make it required and remove the `f"Operations grouped under {group_key!r} for {product} {impl_id}."` line.
- **bind9-ssh connector.** The issue body lists 4 bind9 groups, but no `connectors/bind9/` package exists in tree yet (only adapter-layer references). Will be handled when the connector lands.
- **Per-op `description` curation.** Already excellent across the 4 connectors — consumer feedback specifically called them "gold."
- **The generic / ingested-connector path** (`operations/ingest/llm_groups.py`). LLM-summarised groups for raw-REST ingest are operator-side review-queue content, not connector-author content.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #732


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Curated "when to use" guidance added for operation groups in Kubernetes, Vault (KV/auth/sys), VMware, and Bind9; registration now enforces and preserves this guidance for grouped operations.

* **Tests**
  * Added regression tests to assert per-group guidance is populated, non-empty, and stable across registrar runs using a deterministic embedding stub.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-20)

Addressed REQUEST_CHANGES review at [pr-756-iter-1.json](.claude/auto/review-results/pr-756-iter-1.json):

- Merge commit `b60db3f` — Brought the branch up to date with `origin/main` (~28 commits; includes the bind9 connector landing).
- **B1** `c92ac70` — Ran `ruff format` on `test_typed_connectors_metadata.py`; CI `Python (ruff + mypy + pytest)` lane was failing on `_sample_curation_handler`'s signature wrap.
- **B2** `9f0642a` — Rewrote `auth_when_to_use` in `vault/ops_auth.py` to describe only the four ops the group actually registers (`userpass.{list,read}` + `approle.{list,read}`); explicitly routes token-identity / mount-listing / JWT+OIDC+kubernetes-backend role inspection to the `sys` group's `sys.auth.list`.
- **M1** `3ec5a95` — Replaced "before configuring a backend via the 'auth' group" in `vault/ops_sys.py`'s `sys_when_to_use` with "before drilling into per-backend role config (read-only) via the 'auth' group" so the cross-reference matches what the auth group actually does.
- **M2** `b7f0b4f` — Dropped the UPDATE-on-different-string branch from `_resolve_or_create_group` in `typed_register.py` plus the regression test that exercised it; sibling PR #757 (T4a #731) explicitly contracts first-write-wins on the existing-row branch and the two designs cannot both ship. Per #757's required-kwarg restructure, curated `when_to_use` lands on first write; iteration happens via code-review + redeploy on a fresh DB. Also fixed the k8s test's `impl_id="kubernetes-asyncio"` mismatch (actual is `"k8s"`).
- **bind9** `1155968` — Added curated `when_to_use` strings for bind9's four groups (`identity` / `zone` / `record` / `config`) via a new `_WHEN_TO_USE_BY_GROUP` constant on `bind9/connector.py`, mirroring the kubernetes sibling's shape. Iter-1 had skipped bind9 on the (mistaken) claim it wasn't in-tree; the bind9 connector lives at `backend/src/meho_backplane/connectors/bind9/` (merged to main after iter-1's local HEAD). Extends the regression test with `test_bind9_groups_have_curated_when_to_use`.
- **m1** `7e3047e` — Replaced the opaque `_WHEN_TO_USE_BY_GROUP[op.group_key]` subscript in `kubernetes/connector.py` with `.get()` + explicit `ValueError` naming `op.op_id`, the missing `group_key`, and the dict that needs an entry. Mirrors the same guard on the bind9 sibling (added in `1155968`) so the failure mode is symmetric.

Deferred (orchestrator-level, non-blocking for this PR):

- **M3** — Issues #732, #731, #737 not on project 19 board. Out of scope for `/auto-implement-issue`; this skill does not file or edit project-board membership.
- **m2** — `when_to_use` empty/whitespace silently accepted when `group_key is None`. PR #757 (T4a) adds `_validate_when_to_use_pairing` covering exactly this case; leaving it for the structural sibling.

<!-- auto-implement-issue: continue, iteration 2 -->
