### PR TITLE
feat(connectors): G0.9-T5 surface register_connector_v2-registered connectors in GET /api/v1/connectors (#733)

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -18,6 +18,19 @@ operator; tenant-curated connectors are visible only when
 ``tenant_id == operator.tenant_id``. Cross-tenant rows never appear
 in the result.
 
+Class-side registrations from the v2 connector registry (entries
+registered via
+:func:`~meho_backplane.connectors.registry.register_connector_v2`
+that have no rows in ``endpoint_descriptor`` / ``operation_group``
+yet) are unioned into the response with ``group_count: 0,
+operation_count: 0``. This surfaces "State 0.5" connectors
+(harbor, sddc-manager during pre-G3.5 windows) so operators see
+``connector registered ⇒ visible in list`` rather than silent
+invisibility until the first op lands. v1-compat shim entries
+(``(product, "", "")`` rows the v1 :func:`register_connector` writes
+into the v2 table) are excluded — they're an internal compat
+detail, not separately registered connectors.
+
 Status filter semantics
 -----------------------
 
@@ -40,12 +53,14 @@ clauses (PG-only) so the same query runs against SQLite in tests.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from uuid import UUID
 
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations.ingest._llm_grouping_internals import build_connector_id
@@ -217,6 +232,19 @@ async def list_ingested_connectors(
     sub-selects with correlated aggregation are dialect-finicky on
     SQLite; the two queries together stay cheap relative to the
     per-row JSON projection.
+
+    The response is the union of two sources:
+
+    * DB-backed rows from ``operation_group`` / ``endpoint_descriptor``
+      — the connectors that have made it through (or are mid-way
+      through) the review pipeline. These sort first.
+    * Class-side registrations from the v2 connector registry that
+      have no DB rows yet ("State 0.5"). These append with
+      ``group_count: 0, operation_count: 0`` so an operator sees
+      every registered connector. Class-only entries are always
+      built-in (``tenant_id IS NULL``); they're filtered out under
+      an explicit ``status`` narrowing (no groups ⇒ nothing to
+      review).
     """
     sm = sessionmaker if sessionmaker is not None else get_sessionmaker()
     async with sm() as session:
@@ -249,4 +277,54 @@ async def list_ingested_connectors(
                 operation_count=op_counts_by_connector.get(key, 0),
             ),
         )
+    items.extend(_class_side_only_items(groups_by_connector.keys(), status=status))
     return items
+
+
+def _class_side_only_items(
+    db_keys: Iterable[tuple[UUID | None, str, str, str]],
+    *,
+    status: ConnectorStatusFilter | None,
+) -> list[ConnectorListItem]:
+    """Return rows for v2-registered connectors with no DB-side state.
+
+    Walks :func:`all_connectors_v2` and yields a
+    ``group_count: 0, operation_count: 0`` row for every triple that
+    isn't already represented in *db_keys*. The v1-compat shims the
+    registry writes as ``(product, "", "")`` are skipped — they're a
+    resolver-internal compatibility detail, not separately registered
+    connectors, and surfacing them would double-list every v1
+    connector (e.g. ``k8s`` already lands as
+    ``("k8s", "1.x", "k8s")`` via its dedicated v2 call).
+
+    Class-side registrations are always built-in (``tenant_id IS NULL``)
+    — there is no per-tenant class registration path. Under an explicit
+    ``status`` narrowing (``staged`` / ``enabled`` / ``disabled``) the
+    rows are excluded: zero groups means nothing to review and would
+    otherwise pollute the review-queue view.
+    """
+    if status not in (None, "all"):
+        return []
+    db_triples = {(product, version, impl_id) for (_, product, version, impl_id) in db_keys}
+    rows: list[ConnectorListItem] = []
+    for product, version, impl_id in sorted(all_connectors_v2().keys()):
+        if not version or not impl_id:
+            # v1-compat shim — see docstring.
+            continue
+        if (product, version, impl_id) in db_triples:
+            continue
+        rows.append(
+            ConnectorListItem(
+                connector_id=build_connector_id(product, version, impl_id),
+                product=product,
+                version=version,
+                impl_id=impl_id,
+                tenant_id=None,
+                group_count=0,
+                staged_group_count=0,
+                enabled_group_count=0,
+                disabled_group_count=0,
+                operation_count=0,
+            ),
+        )
+    return rows

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -437,13 +437,22 @@ def test_edit_op_operator_role_returns_403(client: TestClient) -> None:
 
 
 def test_list_operator_role_returns_200(client: TestClient) -> None:
-    """``operator`` role can call GET / (operator minimum)."""
+    """``operator`` role can call GET / (operator minimum).
+
+    Asserts the RBAC contract only: response payload shape varies
+    with whatever v2-registered connectors are present at test time
+    (T5 #733 unions the class-side registry into the response), so
+    the test pins the wire shape (``{"connectors": [...]}``) and the
+    200 status code rather than the exact row set.
+    """
     key, token = _operator_token()
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.get("/api/v1/connectors", headers=_authed(token))
     assert response.status_code == 200
-    assert response.json() == {"connectors": []}
+    body = response.json()
+    assert "connectors" in body
+    assert isinstance(body["connectors"], list)
 
 
 # ---------------------------------------------------------------------------
@@ -468,7 +477,10 @@ async def test_list_returns_operator_tenant_and_builtins(
         response = client.get("/api/v1/connectors", headers=_authed(token))
     assert response.status_code == 200
     connectors = response.json()["connectors"]
-    seen_ids = {c["connector_id"] for c in connectors}
+    # T5 #733: filter to DB-backed rows; class-only v2 registrations
+    # (``group_count == 0``) leak into the response from other tests'
+    # lifespan boots and aren't the subject of this assertion.
+    seen_ids = {c["connector_id"] for c in connectors if c["group_count"] > 0}
     assert seen_ids == {"vmware-rest-9.0", "nsx-9.0"}
     # tenant_b's harbor must not surface.
     assert "harbor-9.0" not in seen_ids
@@ -588,6 +600,125 @@ async def test_list_operation_count_includes_typed_and_composite(
     assert by_id["vmware-rest-9.0"]["operation_count"] == 3
     assert by_id["bind9-ssh-9.0"]["operation_count"] == 4
     assert by_id["vmware-composite-9.0"]["operation_count"] == 2
+
+
+@pytest.fixture
+def _registered_class_only_connectors() -> Iterator[None]:
+    """Ensure harbor + sddc-manager are registered against the v2 registry.
+
+    The autouse ``_isolate_global_registries`` fixture in conftest
+    snapshots the registry before each test and restores after, so the
+    direct ``register_connector_v2`` calls here are scoped to the
+    enclosing test. We bypass the connector subpackages'
+    ``__init__.py`` (whose import-time registration only fires once
+    per process, after which subsequent tests would see an empty
+    registry post-snapshot-restore) and call ``register_connector_v2``
+    directly so every test that uses this fixture gets a deterministic
+    registration. The ``key in registry`` guards make the fixture
+    idempotent against the case where an earlier test in the same
+    process already imported the subpackage and the snapshot kept
+    the entry alive — without the guard the second call would raise
+    ``RuntimeError: connector already registered``.
+    """
+    from meho_backplane.connectors.harbor.connector import HarborConnector
+    from meho_backplane.connectors.registry import (
+        all_connectors_v2,
+        register_connector_v2,
+    )
+    from meho_backplane.connectors.sddc_manager.connector import (
+        SddcManagerConnector,
+    )
+
+    existing = all_connectors_v2()
+    if ("harbor", "2.x", "harbor-rest") not in existing:
+        register_connector_v2(
+            product="harbor",
+            version="2.x",
+            impl_id="harbor-rest",
+            cls=HarborConnector,
+        )
+    if ("sddc-manager", "9.0", "sddc-rest") not in existing:
+        register_connector_v2(
+            product="sddc-manager",
+            version="9.0",
+            impl_id="sddc-rest",
+            cls=SddcManagerConnector,
+        )
+    yield
+
+
+@pytest.mark.asyncio
+async def test_list_surfaces_register_connector_v2_only_entries(
+    client: TestClient,
+    _registered_class_only_connectors: None,
+) -> None:
+    """``register_connector_v2``-only connectors appear with zero counts.
+
+    T5 (#733): connectors registered against the v2 registry but
+    without any rows in ``operation_group`` / ``endpoint_descriptor``
+    yet should surface in ``GET /api/v1/connectors`` so operators
+    see "connector registered ⇒ visible in list". Built-in
+    (``tenant_id IS NULL``); ``group_count`` / ``operation_count``
+    both ``0``.
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    connectors = response.json()["connectors"]
+    by_id = {c["connector_id"]: c for c in connectors}
+
+    assert "harbor-rest-2.x" in by_id
+    harbor = by_id["harbor-rest-2.x"]
+    assert harbor["product"] == "harbor"
+    assert harbor["version"] == "2.x"
+    assert harbor["impl_id"] == "harbor-rest"
+    assert harbor["tenant_id"] is None
+    assert harbor["group_count"] == 0
+    assert harbor["staged_group_count"] == 0
+    assert harbor["enabled_group_count"] == 0
+    assert harbor["disabled_group_count"] == 0
+    assert harbor["operation_count"] == 0
+
+    assert "sddc-rest-9.0" in by_id
+    sddc = by_id["sddc-rest-9.0"]
+    assert sddc["product"] == "sddc-manager"
+    assert sddc["operation_count"] == 0
+    assert sddc["group_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_class_only_entries_excluded_under_status_narrowing(
+    client: TestClient,
+    _registered_class_only_connectors: None,
+) -> None:
+    """Class-only v2 entries are excluded under ``?status=staged``.
+
+    A connector with zero groups has nothing to review; surfacing it
+    under the review-queue filter would dilute the queue view. The
+    union is for the default / ``?status=all`` listing only.
+    """
+    tenant_a = uuid.uuid4()
+    # Seed one staged DB-backed connector so the result isn't empty.
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        impl_id="vmware-rest",
+        review_status="staged",
+    )
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/connectors?status=staged",
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+    seen_ids = {c["connector_id"] for c in response.json()["connectors"]}
+    assert "vmware-rest-9.0" in seen_ids
+    assert "harbor-rest-2.x" not in seen_ids
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -131,9 +131,12 @@ flow is the only auth_model; loader is live; consumer confirmed
 | `harbor-2.x` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
 | `kubernetes-asyncio-1.x` | 1 (shadow) | Same as `k8s-1.x` | ❌ |
 
-State 0.5 = `register_connector_v2` called but no ops registered yet
-(visible to internal code, invisible to `GET /api/v1/connectors`).
-Asymmetry tracked under [T5 #733](https://github.com/evoila/meho/issues/733).
+State 0.5 = `register_connector_v2` called but no ops registered yet.
+Since [T5 #733](https://github.com/evoila/meho/issues/733), these
+connectors surface in `GET /api/v1/connectors` with
+`group_count: 0, operation_count: 0` (built-in, `tenant_id: null`)
+so operators see `connector registered ⇒ visible in list` rather
+than waiting for the first ingested or typed op to land.
 
 ## Why this is hard to get right
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -326,6 +326,18 @@ The renamer "list_*ingested*_connectors" is now misleading and is a
 follow-up cleanup; the function lists every connector with at least
 one visible :class:`OperationGroup` row.
 
+Class-side registrations from the v2 connector registry that have
+no DB-side state yet (T5 #733 — "State 0.5" connectors registered
+via `register_connector_v2` but without any rows in
+`operation_group` / `endpoint_descriptor`) are unioned into the
+response with `group_count: 0, operation_count: 0` so operators
+see `connector registered ⇒ visible in list`. Class-only rows are
+always built-in (`tenant_id IS NULL`); under an explicit `status`
+narrowing they're filtered out (no groups ⇒ nothing to review).
+v1-compat shim entries (`(product, "", "")` rows the v1
+`register_connector` writes into the v2 table) are excluded — they
+double-list every v1 connector and aren't separately registered.
+
 ### API request / response models (`ingest/api_schemas.py`)
 
 The shared Pydantic-v2 surface T5 (CLI), T6 (REST), and T7 (MCP) all


### PR DESCRIPTION
## Summary

- **Implements Option A from the issue body.** `list_ingested_connectors` now unions class-side v2 registry entries into `GET /api/v1/connectors` with `group_count: 0, operation_count: 0` so operators see `connector registered ⇒ visible in list`. Without this, harbor + sddc-manager (registered via `register_connector_v2` but no DB-side ops yet) were silently absent until G3.5 ships their first ops, surprising operators after the v0.3.0 dogfood.
- DB-backed connectors sort first (preserving existing ordering); class-only entries append. v1-compat shims (`(product, "", "")` rows the v1 `register_connector` writes into the v2 table for resolver compatibility) are excluded so v1 connectors don't double-list. Class-only rows are filtered out under an explicit `?status=staged|enabled|disabled` narrowing — they have nothing to review.
- One adjacent test fix: `test_list_operator_role_returns_200` (and a `seen_ids` assertion on `test_list_returns_operator_tenant_and_builtins`) tightened from "list is exactly empty / exactly {a, b}" to "wire shape + DB-backed subset" — the previous assertions were sensitive to whether an in-process lifespan had already imported a connector subpackage. T5's union promotes those leaks from latent to visible.
- Surface area chosen over Option B (docs-only) per the issue's recommendation: removes the asymmetry rather than just documenting it.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — 396 files already formatted
- [x] `mypy src/ --ignore-missing-imports` — Success: no issues found in 192 source files
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — 32 passed (incl. 2 new regression tests below)
- [x] Targeted connector + ingest suite (`test_api_v1_connectors_ingest`, `test_connectors_registry`, `test_connectors_resolver`, `test_mcp_tools_connector_admin`, `test_operations_register_ingested`) — 94 passed
- [x] **Acceptance** — *new regression test* `test_list_surfaces_register_connector_v2_only_entries` asserts harbor (`harbor-rest-2.x`) + sddc-manager (`sddc-rest-9.0`) appear in `GET /api/v1/connectors` with `group_count: 0, staged_group_count: 0, enabled_group_count: 0, disabled_group_count: 0, operation_count: 0, tenant_id: null` after `register_connector_v2(...)`.
- [x] **Acceptance** — *new regression test* `test_list_class_only_entries_excluded_under_status_narrowing` asserts class-only entries are filtered out under `?status=staged` (no groups ⇒ nothing to review).
- [x] **Acceptance** — DB-backed connectors sort first (existing sort logic untouched); class-only entries append (new `_class_side_only_items` helper called after the DB pass).
- [x] **Acceptance** — `docs/codebase/spec-ingestion.md` + `docs/codebase/connector-release-readiness.md` updated to describe the new visibility contract; the latter's "State 0.5 = invisible to `GET /api/v1/connectors`" line is corrected to "visible with `group_count: 0, operation_count: 0`".

## Out of scope

- Sibling **T1 #728** drops `source_kind == "ingested"` from `_operation_count_by_connector` — they edit different functions in the same file and compose cleanly.
- Loader wiring for harbor / sddc-manager (`NotImplementedError` stubs) is tracked under Goal #214, not in this Initiative.
- Renaming `list_ingested_connectors` to drop the misleading "ingested" — explicitly out per the issue body.
- Manual rke2-infra smoke (`curl https://meho.evba.lab/api/v1/connectors`) — defers to v0.3.1 release verification; the regression test exercises the same code path against the SQLite-backed test app.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #733


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The connectors API now lists registry-only (pre-deployment) connectors with group_count: 0, operation_count: 0 and tenant_id: null so operators can track early registrations.

* **Bug Fix / Behavior**
  * Registry-only connectors are excluded when filtering by status (e.g., ?status=staged) to avoid polluting status-specific views.

* **Documentation**
  * Clarified connector state definitions and listing behavior.

* **Tests**
  * Added tests to validate registry-only connector visibility and status-filter exclusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->