### PR TITLE
docs(release): G0.9-T7 v0.3.0 breaking-changes + connector release-notes convention (#735)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,43 @@ shipped and why it matters — not a dump of commit subjects.
   - **Removed** — features removed in this release.
   - **Fixed** — bug fixes.
   - **Security** — vulnerability fixes; flag CVE / advisory.
+  - **Breaking changes** — schema renames, body-shape changes, removed
+    endpoints, or any other contract change that requires adopters to
+    update their client code. Each bullet includes a migration recipe
+    (the smallest concrete edit a v(N-1) client makes to keep working
+    on v(N)). Surfaces above `Added` in the release section so
+    adopters reading top-to-bottom see migrations before features.
+
+**Connector release-notes convention.** Distinguish three connector
+ship states; release-notes / kb / Goal-tracker text must say which
+state the release ships, not the next state up. Full rubric in
+[`docs/codebase/connector-release-readiness.md`](docs/codebase/connector-release-readiness.md).
+
+- **Dispatch + catalog landed.** Connector class registered, ops
+  register into `endpoint_descriptor`, `search_operations` indexes
+  them, per-op `description` / `safety_level` / `requires_approval`
+  metadata is curated, integration tests with **injected loaders**
+  pass. Production execution against real per-target Vault
+  credentials does NOT yet work. Language: *"Kubernetes typed
+  connector dispatch + catalog (13 ops indexed; loader wiring tracked
+  under #214)."*
+- **Loader wired (single auth model).** As above, plus the default
+  loader reads real operator-context per-target Vault credentials for
+  one `auth_model`. Production dispatch executes end-to-end for
+  targets with that auth_model. Language: *"Kubernetes typed
+  connector — `service_account` auth model live; `per_user` auth
+  model tracked under #N."*
+- **Ops curated for production.** All advertised auth_models live;
+  per-op descriptions + safety annotations make the op
+  LLM-discoverable; onboarding doc validates against a real deploy.
+  Language: *"vault-1.x typed op surface ready for production
+  (`jwt-federated` auth model, full ops catalog)."*
+
+The k3d / testcontainers / mock-loader integration test does not
+promote a connector across these states. Promotion is per-auth-model
+and requires the loader to read real Vault per real-target
+credentials. Mention the live auth-model set explicitly on every
+connector-related release-notes line.
 
 ## [Unreleased]
 
@@ -61,6 +98,69 @@ landed against the green-but-hollow class of failure that surfaced
 during the closure push: dispatcher MRO-aware binding, registration-
 time `handler_ref` resolvability guard, and the `Python (integration
 testcontainers)` lane is now a required merge gate.
+
+> **What v0.3.0 ships for the new connectors (k8s / bind9-ssh / vault / vmware-rest):**
+> dispatch + catalog + per-op metadata + safety annotations + `search_operations` indexing
+> + integration-test coverage (against injected loaders for k8s + vmware-rest, against
+> real Vault for the existing `vault-1.x` connector). The bind9-ssh connector executes
+> end-to-end against a real bind9 SSH target.
+>
+> **What v0.3.0 does NOT ship for the per-target-credential connectors (k8s + vmware-rest):**
+> the loader that reads operator-context per-target Vault credentials. Both
+> `load_kubeconfig_from_vault` and `load_session_credentials_from_vault` remain
+> `NotImplementedError` stubs in production, tracked under the open
+> [Goal #214 (Connector parity)](https://github.com/evoila/meho/issues/214).
+>
+> Adopters running a v0.3.0 deploy with `operations/call k8s.namespace.list target=...`
+> against a real Vault-backed target will receive `NotImplementedError` — not
+> "the connector works." The catalog is real and indexed; production execution
+> needs Goal #214 to land per-connector. See
+> [`docs/codebase/connector-release-readiness.md`](docs/codebase/connector-release-readiness.md)
+> for the three-state rubric (dispatch + catalog / loader wired / ops curated).
+
+### Breaking changes
+
+Amended 2026-05-20 ([#735](https://github.com/evoila/meho/issues/735)) after the
+RDC operator-team dogfood surfaced two v0.2.1 → v0.3.0 schema changes
+that shipped without CHANGELOG coverage. Both affect adopters who
+authored v0.2.1 client code against the public REST surface.
+
+- **`POST /api/v1/operations/call` — `target` field shape.** Changed
+  from bare string to object descriptor. A v0.2.1 client encoding
+  `target: "rdc-vault"` now gets HTTP 422 (`dict_type`) on first call
+  after upgrade.
+
+  Migration (one-character change per call site):
+
+  ```diff
+  - {"op_id": "vault.kv.read", "target": "rdc-vault", "params": {...}}
+  + {"op_id": "vault.kv.read", "target": {"name": "rdc-vault"}, "params": {...}}
+  ```
+
+  The new shape accepts the full target descriptor — `name`, `id`, or
+  fingerprint-match — via the G0.3 target-resolver. The old bare-string
+  shape is not aliased; aliasing was considered and rejected (see
+  [#729 (T2)](https://github.com/evoila/meho/issues/729) which tightens
+  `extra="forbid"` across all v1 schemas — extending an alias would
+  cut against that direction).
+
+- **`POST /api/v1/retrieve` — field renames.** `q` → `query`;
+  `top_k` → `limit`. A v0.2.1 client sending the old names will receive
+  HTTP 422 once [#729 (T2 — `extra="forbid"`)](https://github.com/evoila/meho/issues/729)
+  lands; until then the old names silently fall back to defaults
+  (`query=""`, `limit=10`) and the retrieve call returns unrelated results.
+
+  Migration:
+
+  ```diff
+  - {"q": "vault rotation", "top_k": 20}
+  + {"query": "vault rotation", "limit": 20}
+  ```
+
+  `query` aligns the retrieve surface with the agent-facing
+  `search_operations(connector_id, query)` vocabulary already used
+  through MCP; `limit` is the Keep-a-REST convention for pagination
+  size and aligns with the `list_operations` / `list_targets` surfaces.
 
 ### Added
 


### PR DESCRIPTION
## Summary

- **CHANGELOG.md `[0.3.0]` "Breaking changes" subsection** documents the two v0.2.1 → v0.3.0 schema changes that shipped without coverage: `POST /api/v1/operations/call` `target` shape (`str` → `dict`) and `POST /api/v1/retrieve` field renames (`q` → `query`, `top_k` → `limit`). Each with a copy-paste migration recipe.
- **"What v0.3.0 ships … what does NOT ship" call-out** at the top of `[0.3.0]` so adopters see the catalog/dispatch-vs-loader-wired distinction before they read the per-Initiative bullets — the upstream half of the consumer-team's "13 ops, k3d CI" misread.
- **Connector release-notes convention** under "How entries are added" codifies the three-state vocabulary (dispatch + catalog landed / loader wired / ops curated) so future release-notes writers cite the state explicitly. Cross-linked to the deeper rubric at [`docs/codebase/connector-release-readiness.md`](https://github.com/evoila/meho/blob/main/docs/codebase/connector-release-readiness.md) (shipped in #736).
- New **"Breaking changes" category** added to "How entries are added" so the schema-rename / body-shape gap doesn't recur — surfaces above `Added` in each release so adopters read migrations first.

## Test plan

- [x] `pre-commit run --files CHANGELOG.md` — all hooks pass (trailing-whitespace, end-of-file, gitleaks, check-yaml/json, mixed-line-ending)
- [x] Code change claims verified against source: `RetrieveRequest` ([`backend/src/meho_backplane/api/v1/retrieve.py:117-120`](https://github.com/evoila/meho/blob/main/backend/src/meho_backplane/api/v1/retrieve.py#L117-L120)) uses `query` + `limit`; `CallOperationBody.target: dict[str, Any] | None` ([`backend/src/meho_backplane/operations/meta_tools.py:229`](https://github.com/evoila/meho/blob/main/backend/src/meho_backplane/operations/meta_tools.py#L229))
- [x] No code paths touched — CHANGELOG-only diff; `Helm (lint + template + kubeconform)` + per-PR CI surface should run green on the same admin-merge pattern as #721
- [x] Cross-link to [`docs/codebase/connector-release-readiness.md`](https://github.com/evoila/meho/blob/main/docs/codebase/connector-release-readiness.md) confirmed — that doc already cites this CHANGELOG section as the codification

## Acceptance criteria

- [x] CHANGELOG.md `[0.3.0]` gets the "Breaking changes" subsection with both shape changes + migration recipes
- [x] CHANGELOG.md `[0.3.0]` gets the "What v0.3.0 ships … what does NOT ship" call-out near the top
- [x] CHANGELOG.md "How entries are added" gets the connector release-notes convention (three-state vocabulary)
- [x] A pointer in `docs/codebase/` cites the convention as the upstream rule — satisfied by the existing `connector-release-readiness.md` which already cross-references this CHANGELOG section by issue number; reference now holds (was a forward-link, becomes a back-reference once this merges)
- [x] PR ships the amendment + convention as one commit

## Out of scope

- Republishing the v0.3.0 GitHub Release with the amended notes — release-notes generation reads CHANGELOG.md at tag time; this amendment is for adopters reading the file going forward + for v0.3.1 release-body extraction (per the issue body's explicit out-of-scope item).
- Aliasing the renamed fields (`q` → `query`, `top_k` → `limit`, `target: str` → `target: dict`) — separate triage decision; tracked under #729 (T2 `extra="forbid"`) which cuts against any alias direction.
- A new `[0.3.1]` section header — this Initiative ships the patch; the release-cutting PR moves bullets and adds the header.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #735


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added connector release-notes conventions defining three connector ship states and clarifying feature availability.
  * Documented per-target credential Vault loader as pending implementation.

* **Breaking Changes**
  * `POST /api/v1/operations/call`: `target` parameter changes from string to object `{ name }`.
  * `POST /api/v1/retrieve`: Request fields renamed (`q` → `query`, `top_k` → `limit`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->