### PR TITLE
docs(cross-repo): T6 — Goal #214 body reframe (dual-layer connector model)

### DIFF
--- a/docs/cross-repo/goal-214-reframe-2026-05-20.md
+++ b/docs/cross-repo/goal-214-reframe-2026-05-20.md
@@ -1,0 +1,354 @@
+# Goal #214 reframe — curated composites + generic-ingested raw REST (dual-layer connector model)
+
+**Date:** 2026-05-20
+**Source task:** [#734 (T6 — Goal #214 body reframe)](https://github.com/evoila/meho/issues/734)
+**Initiative:** [#737 (G0.9 v0.3.1 dogfood hardening)](https://github.com/evoila/meho/issues/737)
+**Goal amended:** [#214 (Connector parity with ClaudeVCF wrapper set)](https://github.com/evoila/meho/issues/214)
+
+This file is the verification artifact for [#734](https://github.com/evoila/meho/issues/734).
+It records the exact wording applied to Goal [#214](https://github.com/evoila/meho/issues/214)'s
+body on 2026-05-20 plus the architectural verification that justifies the
+reframe. Reviewers diff this file against the live Goal #214 body to
+confirm the edit landed as intended.
+
+## Why the reframe
+
+After the v0.3.0 in-lab dogfood (2026-05-20), the RDC operator team
+asked: *"is meho's connector model deliberately curated composite ops,
+not raw-API binding?"* — reading Goal #214's *"connector parity with
+ClaudeVCF wrapper set"* framing as *"1:1 binding parity with the
+underlying vendor API."*
+
+That reading is **wrong** in both directions. The architecture is
+**dual-shaped**, verified in code:
+
+- **Layer 1 — Hand-coded composites.** First-class hand-curated
+  multi-step governed workflows. Per-op `safety_level` +
+  `requires_approval`. The agent's primary surface.
+- **Layer 2 — Generic-ingested raw REST.** Operator ingests the
+  vendor's OpenAPI spec via `POST /api/v1/connectors/ingest`; the G0.7
+  review state machine ([state machine in
+  `backend/src/meho_backplane/operations/ingest/`](../../backend/src/meho_backplane/operations/ingest/))
+  stages ops; operator reviews + enables; ops become dispatchable via
+  the same `search_operations` / `call_operation` agent surface.
+
+The reason the consumer saw only 13 vmware ops in v0.3.0 is not that
+MEHO refuses to ship raw-REST — it is that ingest is operator-driven,
+per-tenant, and ingest has not been run against their deploy. When it
+is, hundreds of ops land in `endpoint_descriptor` with
+`review_status='staged'`.
+
+**bind9-ssh-9.x is the exception** — no OpenAPI spec exists for the
+bind9 control surface, so bind9 is composites-only by necessity. Every
+other tier-1 / tier-2 / tier-3 generic-ingestible connector is
+dual-shaped.
+
+## Architectural verification (code citations)
+
+The dual-shape model is observable in the code that ships in v0.3.0:
+
+- **Layer 1 — composites registrar:**
+  [`backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py`](../../backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py)
+  — `_COMPOSITES` tuple (lines 128–402) contains exactly 13
+  `_CompositeSpec` entries (5 read + 8 write) in the
+  `vmware.composite.*` namespace, each carrying `safety_level` +
+  `requires_approval` per-row.
+- **Layer 2 — generic-ingestion helper:**
+  [`backend/src/meho_backplane/operations/ingest/register_ingested.py`](../../backend/src/meho_backplane/operations/ingest/register_ingested.py)
+  — `register_ingested_operations()` is the bulk upsert that persists
+  parsed-OpenAPI output to `endpoint_descriptor` with
+  `source_kind='ingested'`, `is_enabled=False`,
+  `review_status='staged'`. Same table both layers write to.
+- **Layer 2 — review state machine:**
+  [`backend/src/meho_backplane/operations/ingest/`](../../backend/src/meho_backplane/operations/ingest/)
+  — staged → enabled transition; `search_operations` hides staged ops
+  until the operator reviews + enables a group.
+- **Layer 2 canary test:**
+  [`backend/tests/acceptance/test_g07_vsphere_canary.py`](../../backend/tests/acceptance/test_g07_vsphere_canary.py)
+  — exercises ingest of `vcenter.yaml` + `vi-json.yaml` against the
+  same `(product="vmware", version="9.0", impl_id="vmware-rest")`
+  connector triple.
+
+Per-connector typed-op counts confirmed at the 2026-05-20 review:
+
+| Connector | Typed/composite op_id namespace | Count (v0.3.0) |
+|---|---|---|
+| `vmware-rest-9.0` | `vmware.composite.*` | 13 composites |
+| `vault-1.x` | `vault.kv.* / vault.sys.* / vault.auth.*` | 13 typed ops |
+| `k8s-1.x` | `k8s.*` | 14 typed ops |
+| `bind9-ssh-9.x` | `bind9.*` | 11 typed ops |
+
+These are layer-1 counts. Layer-2 ingest produces hundreds-to-thousands
+of additional ops per connector once the operator runs ingest (vSphere
+alone publishes >2,000 paths across `vcenter.yaml` + `vi-json.yaml`).
+
+## The applied Goal #214 body
+
+The full new body wording follows. It is what `gh issue edit 214 …`
+applied on 2026-05-20.
+
+---
+
+## Goal
+
+Ship MEHO connectors that cover the operations the RDC team uses most
+often in `claude-rdc-hetzner-dc`'s `scripts/*.sh` wrappers, in tiers
+ordered by usage frequency, so the team can progressively retire local
+wrappers in favour of `meho <connector> <op>` calls — without losing
+the existing capabilities, audit trail, or operator UX.
+
+## The connector model: dual-shaped by design (clarifying note added 2026-05-20)
+
+**MEHO connectors are dual-shaped.** Both layers ship through the same
+operation registry, the same dispatcher, the same audit-tree, and the
+same agent surface — adopters who treat MEHO as "curated composites
+only" miss half the architecture and the half that gives them long-tail
+vendor-API coverage on day 1.
+
+**Layer 1 — Hand-coded composites.** First-class, curated,
+operator-oriented multi-step governed workflows. Hand-authored Python
+handlers that orchestrate multiple sub-ops via the dispatcher's
+recursive `dispatch(...)` call. Each composite carries per-op
+`safety_level` + `requires_approval` annotations and an LLM-friendly
+`description`. The v0.3.0 vmware connector ships 13 composite ops
+(`vmware.composite.host.evacuate`, `vmware.composite.vm.snapshot.revert`,
+`vmware.composite.cluster.patch`, …) that wrap multi-step flows the
+raw vendor API can't express in one call. This is the agent's
+first-class surface and where governance lives.
+
+**Layer 2 — Generic-ingested raw vendor API.** Operators ingest the
+vendor's OpenAPI spec via `POST /api/v1/connectors/ingest` (or the
+upcoming `meho connector ingest --catalog vmware/9.0` per [#743](https://github.com/evoila/meho/issues/743)),
+review the LLM-summarised operation groups, and enable the ones their
+workflows need. Ingested rows land in the same `endpoint_descriptor`
+table with `source_kind='ingested'`, `is_enabled=False`, and
+`review_status='staged'`; the [G0.7 review state machine](backend/src/meho_backplane/operations/ingest/)
+flips them to `enabled` once the operator vets the group. Enabled
+operations become dispatchable via the same `search_operations` /
+`call_operation` agent surface as the typed/composite layer — the
+agent does not see the difference.
+
+**Adopters value MEHO's vmware connector for *both* axes**:
+
+- **Layer 1's governance** — audit + safety + approval gating on the
+  composite workflows that orchestrate multi-step operator intent.
+- **Layer 2's coverage** — full vSphere REST surface (`vcenter.yaml` +
+  `vi-json.yaml` together carry >2,000 paths) once the operator runs
+  ingest + reviews the groups.
+
+**The exception:** `bind9-ssh-9.x` has no OpenAPI spec to ingest — the
+bind9 control surface is configuration-file + `rndc` reload, not REST
+— so bind9 is **composites-only by necessity**. Every other tier-1 /
+tier-2 / tier-3 connector below is dual-shaped.
+
+## Wrapper-retirement: two axes, adopter chooses
+
+Adopters retire wrappers on two axes:
+
+1. **Composites land** for high-value multi-step governed workflows
+   each MEHO release covers (the G3.x roadmap, one composite batch per
+   connector per release).
+2. **Operators ingest** the vendor's OpenAPI spec via [#743 (curated
+   catalog)](https://github.com/evoila/meho/issues/743) — or directly
+   via `POST /api/v1/connectors/ingest` against any
+   operator-supplied spec — review the LLM-summarised groups, and
+   enable the raw-REST surface their workflows actually need. Enabled
+   ops become visible to `search_operations` immediately.
+
+The retire-clock advances on **whichever axis the adopter chooses**.
+Adopters don't wait for MEHO to ship more composites for long-tail
+single-call shape — they ingest + review.
+
+## Connector typology (per-tier dual-shape state)
+
+| Connector | Layer 1 (composites / typed ops) | Layer 2 (ingestable raw API) |
+|---|---|---|
+| `vmware-rest-9.0` | 13 composites shipped (5 read + 8 write) | `vcenter.yaml` + `vi-json.yaml` ingestable |
+| `vault-1.x` | 13 typed ops shipped (kv + sys + auth) | Vault HTTP API ingestable (no v0.3 catalog entry yet) |
+| `k8s-1.x` | 14 typed ops shipped (pod/deployment/configmap/svc/ingress/event/…) | `kubernetes_asyncio`'s spec surface per Kubernetes minor version (per-product spec — catalog investigation under [#743](https://github.com/evoila/meho/issues/743)) |
+| `bind9-ssh-9.x` | 11 typed ops shipped | **no spec exists** — composites-only by necessity |
+| `harbor-2.x` | 0 ops yet — class registered (State 0.5), ops pending | Harbor swagger ingestable |
+| `sddc-manager-9.0` | 0 ops yet — class registered (State 0.5), ops pending | SDDC Manager OpenAPI ingestable |
+| `nsx-4.2` | 0 ops yet — class registered (State 0.5), ops pending | NSX OpenAPI ingestable |
+
+The "State" column references the three-state release-readiness rubric
+in [docs/codebase/connector-release-readiness.md](docs/codebase/connector-release-readiness.md):
+State 0.5 = class registered, no ops yet, loader stubbed; State 1 =
+dispatch + catalog only (loader stubbed); State 2 = loader-wired,
+single auth_model live; State 3 = full production execution.
+
+Layer-2 ingest is independent of layer-1 state — an operator can
+ingest `vcenter.yaml` against a `vmware-rest-9.0` connector at State
+1 (which v0.3.0 ships at, against real operator targets) by running
+`POST /api/v1/connectors/ingest` and reviewing the groups; the raw-REST
+ops then dispatch through the same code path the composites use.
+
+## Why
+
+The chassis (Goal #11) gives us a deployable MEHO and Goal #59 closes
+one wrapper end-to-end. To close the dogfood loop *at scale*, we need
+parity with the working set of wrappers — not all at once, but in a
+usage-ordered sequence that lets operators migrate piece-by-piece
+while keeping the old wrappers as fallback during transition.
+
+This is the consumer-side "I want to *work* through MEHO" thread
+(Thread A in the consumer-needs framing). Without it the chassis is
+real but unused; with it MEHO becomes the primary tool for daily ops.
+
+## Architecture (the load-bearing model)
+
+Per [CLAUDE.md](CLAUDE.md) postulates 1-5: every connector is one of
+two kinds, both first-class, both versioned, both dispatching through
+the G0.6 (#388) operation registry + dispatcher substrate:
+
+- **Generic connectors** (`vmware-rest-9.0`, `nsx-4.2`,
+  `sddc-manager-9.0`, `harbor-2.x`, `vcf-operations-9.0`,
+  `vcf-logs-9.0`, `vcf-fleet-9.0`, `vcf-automation-9.0`, `gcloud-?`
+  if discovery-doc-parsed, `hetzner-robot-2026-04`) — get their
+  operations from the G0.7 (#389) spec ingestion pipeline ingesting
+  the vendor's OpenAPI spec into the `endpoint_descriptor` table.
+  Operator reviews the LLM-summarised groups + when-to-use hints;
+  enables the connector; ops become dispatchable via the agent's
+  `search_operations` + `call_operation` meta-tools.
+- **Typed connectors** (`vault-1.x`, `kubernetes-asyncio` per
+  decision #8, `bind9-ssh`, `pfsense-ssh`, `holodeck-ssh`, plus
+  `gcloud` if wrapped via `google-cloud-python`) — register
+  hand-coded operations into the same `endpoint_descriptor` table at
+  connector init via `register_typed_operation()`. Dispatched through
+  the same path; the agent does not see the difference.
+
+Both kinds also support **composite operations** (third operation kind
+within a connector): hand-authored Python handlers that orchestrate
+multiple sub-ops via the dispatcher's recursive `dispatch(...)` call.
+Tier-1 generic connectors are expected to ship ~10–15 composites for
+common workflows (e.g. `vm.create` orchestrates 5 atomic vCenter calls;
+see consumer-side analysis on govc parity).
+
+**No per-op MCP tools.** Per CLAUDE.md postulate 5, the agent surface
+is ~17 meta-tools registered by #226 G0.5. Connector ops reach the
+agent through `search_operations(connector_id, query, group?)` +
+`call_operation(connector_id, operation_id, target?, params)`.
+
+## Done-when (testable from the consumer)
+
+- **Tier-1 connectors** (`vmware-rest` 9.0 + `vault` + `bind9-ssh`)
+  shipped through MEHO. vSphere generic-ingested (both `vcenter.yaml`
+  + `vi-json.yaml`); Vault + bind9 typed.
+- **Tier-2 connectors** (`nsx-4.2` + `harbor-2.x` +
+  `sddc-manager-9.0`) shipped, all generic-ingested.
+- ≥1 operator on the RDC team has stopped using local wrappers for
+  tier-1 ops for ≥ 2 consecutive weeks (the empirical dogfood test).
+- Tier-3 and 4 connectors filed as follow-up Goals/Initiatives
+  (lower-frequency: vcf-* family, pfsense, gcloud, hetzner-robot,
+  holodeck).
+
+## Out of scope (explicit)
+
+- Tier-3/4 connectors — separate follow-up Goals when prioritised.
+- Policy-engine integration, runbooks — separate Goals on the v0.2
+  roadmap.
+- Real JSONFlux reduction logic (set-shaped response handles +
+  MinIO/S3 spill). G0.6 ships the `Reducer` ABC hook only; v0.2
+  default is pass-through.
+- The full operation surface of any connector — generic connectors
+  index everything the spec carries; operator-enabled subsets land
+  incrementally per real usage.
+
+## References
+
+The canonical context with priority-tier breakdown, per-connector
+contract notes, and the open question on identity model per system is
+in the consumer-needs doc at
+https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/docs/meho-coordination/consumer-needs.md
+(§ G3). Read first; this Goal body intentionally stays at the
+requirements level.
+
+- Consumer-needs doc (canonical context):
+  https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/docs/meho-coordination/consumer-needs.md
+- v0.1 spec (architecture):
+  https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/docs/meho-coordination/v0.1-spec.md
+- Existing wrapper inventory (the source-of-truth for "what we use
+  today"): https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/tree/main/scripts
+- Predecessors: Goal #11 (chassis), Goal #59 (first connector + first
+  wrapper)
+- **Release-readiness rubric (three-state model):**
+  [docs/codebase/connector-release-readiness.md](docs/codebase/connector-release-readiness.md)
+  — distinguishes State 0.5 (class registered) / State 1 (catalog
+  only) / State 2 (loader-wired) / State 3 (full production execution).
+- **Consumer-facing reframe note:**
+  [docs/cross-repo/goal-214-reframe-2026-05-20.md](docs/cross-repo/goal-214-reframe-2026-05-20.md)
+  — explains the layer-2 ingest path for adopters reading "only 13
+  vmware ops" out of v0.3.0.
+- **Operationalising tickets** (the v0.3.1 hardening that makes
+  layer-2 actually onboardable for operators):
+  - [#740 (T8 — spec ↔ label validation)](https://github.com/evoila/meho/issues/740)
+  - [#741 (T9 — label ↔ class pre-flight)](https://github.com/evoila/meho/issues/741)
+  - [#743 (T10 — curated spec catalog)](https://github.com/evoila/meho/issues/743)
+- **Architectural-reality verification source:** Task
+  [#734](https://github.com/evoila/meho/issues/734) (T6) — the
+  2026-05-20 dogfood triage that surfaced the framing question and
+  drove this Goal body amendment.
+
+## Execution Initiatives
+
+All G3 Initiatives depend on [#388 G0.6](https://github.com/evoila/meho/issues/388)
+(operation registry + dispatcher) and (for generic-ingested connectors)
+[#389 G0.7](https://github.com/evoila/meho/issues/389) (spec ingestion
+pipeline).
+
+- [ ] #227 — G3.1 `vmware-rest-9.0` tier-1 connector — **generic**:
+  ingest `vcenter.yaml` + `vi-json.yaml` via G0.7; ~10–15 hand-authored
+  composites for common govc-parity workflows (vm.create, vm.clone,
+  host.evac, cluster.patch); the connector-ABC canary
+- [x] #320 — G3.2 `kubernetes-asyncio` connector — **typed** per
+  decision #8: 13 ops registered via `register_typed_operation()`;
+  kubeconfig-from-Vault; k3d CI; replaces kubectl-vcf.sh
+- [x] #366 — G3.3 `vault-1.x` op surface — **typed** (Vault publishes
+  OpenAPI but the shipped chassis VaultConnector is already hand-coded;
+  keep typed per minimum-disruption call); KV-v2 + sys + auth read/list
+  ops; G6 credential_read classifier exerciser
+- [x] #367 — G3.4 `bind9-ssh` connector — **typed-SSH** (no spec
+  exists); first SshConnector tier-1 child; atomic-apply discipline;
+  replaces bind9-dns.sh
+- [ ] #368 — G3.5 tier-2 batch — **all generic**: `nsx-4.2` +
+  `sddc-manager-9.0` + `harbor-2.x` (each ingests its vendor OpenAPI
+  via G0.7)
+- [ ] #369 — G3.6 tier-3 VCF management plane — **all generic**:
+  `vcf-operations-9.0` + `vcf-logs-9.0` + `vcf-fleet-9.0` +
+  `vcf-automation-9.0` (each ingests its vendor OpenAPI; auth diverges
+  per product, transport stays REST)
+- [ ] #370 — G3.7 tier-3 standalone — **mixed**: `pfsense-ssh`
+  (typed), `gcloud` (TBD: generic via Google discovery docs vs typed
+  via google-cloud-python), `hetzner-robot-2026-04` (generic;
+  no-retry-on-401)
+- [ ] #371 — G3.8 `holodeck-ssh` tier-4 connector — **typed-SSH**
+  (PowerShell-over-SSH; no REST exists); closes the G3
+  wrapper-retirement story
+
+## Numbering note (2026-05-13)
+
+The original parenthetical drafted G3.2 = Vault op surface. After
+[#320](https://github.com/evoila/meho/issues/320) filed Kubernetes as
+G3.2 (per decision #8 in
+[v0.2-decisions.md](docs/planning/v0.2-decisions.md) —
+kubernetes_asyncio locked before Phase-1 K8s work), the rest of the G3
+sequence shifted by one: Vault → G3.3, bind9 → G3.4, tier-2 batch →
+G3.5, tier-3 VCF mgmt → G3.6, tier-3 standalone → G3.7, tier-4
+Holodeck → G3.8. The frequency-tier mapping in consumer-needs.md §G3
+is unchanged.
+
+## Body amendment log
+
+- **2026-05-20 (T6 [#734](https://github.com/evoila/meho/issues/734))** —
+  Added the "dual-shaped by design" clarifying section + the
+  wrapper-retirement two-axis reframe + the connector-typology table +
+  cross-links to [#740](https://github.com/evoila/meho/issues/740) /
+  [#741](https://github.com/evoila/meho/issues/741) /
+  [#743](https://github.com/evoila/meho/issues/743) /
+  [release-readiness rubric](docs/codebase/connector-release-readiness.md).
+  Driven by the RDC operator team's framing question after the
+  v0.3.0 in-lab dogfood: *"is meho's connector model deliberately
+  curated composite ops, not raw-API binding?"* The authoritative
+  answer — **no, both layers ship; layer 2 is operator-driven ingest
+  on the same agent surface** — needed to be in the Goal body so
+  adopters can plan wrapper-retirement honestly.


### PR DESCRIPTION
## Summary

- **Goal [#214](https://github.com/evoila/meho/issues/214)'s body is now authoritative on the dual-layer connector model.** The v0.3.0 dogfood surfaced a framing question from the RDC operator team: *"is meho's connector model deliberately curated composite ops, not raw-API binding?"* The new body answers that authoritatively: **no — both layers ship; Layer 2 is operator-driven ingest on the same agent surface.**
- **Adds [`docs/cross-repo/goal-214-reframe-2026-05-20.md`](docs/cross-repo/goal-214-reframe-2026-05-20.md)** as the verification artifact: records the exact wording applied to Goal #214, the architectural verification against code (composite registrar + ingest helper + per-connector op counts), and explains the Layer-2 ingest path for adopters who read "only 13 vmware ops" in v0.3.0.
- **The live Goal #214 body was updated in the same session** via `gh api repos/evoila/meho/issues/214 -X PATCH -F body=@…` (the documented workaround for the broken `gh issue edit --body-file` projectCards-deprecation path). Reviewers can diff the live body against the artifact's "applied Goal #214 body" section.

## Architectural reality (verified in code, 2026-05-20)

The dual-shape model is observable in the v0.3.0 tree:

- **Layer 1 — composites registrar:** [`backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py`](backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py) — `_COMPOSITES` tuple holds exactly 13 `_CompositeSpec` entries (5 read + 8 write) in the `vmware.composite.*` namespace, each with `safety_level` + `requires_approval` per-row.
- **Layer 2 — generic-ingestion helper:** [`backend/src/meho_backplane/operations/ingest/register_ingested.py`](backend/src/meho_backplane/operations/ingest/register_ingested.py) — `register_ingested_operations()` persists parsed OpenAPI to the same `endpoint_descriptor` table with `source_kind='ingested'`, `is_enabled=False`, `review_status='staged'`. Same table both layers write to.
- **Layer 2 — review state machine:** [`backend/src/meho_backplane/operations/ingest/`](backend/src/meho_backplane/operations/ingest/) — staged → enabled transition; `search_operations` hides staged ops until the operator vets the group.
- **Layer 2 canary test:** [`backend/tests/acceptance/test_g07_vsphere_canary.py`](backend/tests/acceptance/test_g07_vsphere_canary.py) — exercises ingest of `vcenter.yaml` + `vi-json.yaml` against the same `(product="vmware", version="9.0", impl_id="vmware-rest")` triple.

Per-connector typed/composite op_id counts (grep'd at 2026-05-20):

| Connector | Namespace | Count | Matches Goal #214 body |
|---|---|---|---|
| `vmware-rest-9.0` | `vmware.composite.*` | 13 composites | ✓ |
| `vault-1.x` | `vault.kv.* / vault.sys.* / vault.auth.*` | 13 typed ops | ✓ |
| `k8s-1.x` | `k8s.*` | 14 typed ops | ✓ |
| `bind9-ssh-9.x` | `bind9.*` | 11 typed ops | ✓ |

**`bind9-ssh-9.x` is the documented exception** — no OpenAPI spec exists for the bind9 control surface, so bind9 is composites-only by necessity. Every other tier-1 / tier-2 / tier-3 generic-ingestible connector is dual-shaped.

## Test plan

This is a docs-only + GitHub-issue-body change. No code paths touched; no Python / frontend gates apply.

- [x] **Pre-commit hygiene passed** — `trailing-whitespace`, `end-of-file-fixer`, `detect-private-key`, secret-scan, conventional-commit lint all green (see commit hook output).
- [x] **Goal #214 body updated on GitHub** — verified via `gh issue view 214 --repo evoila/meho --json body --jq .body | grep '^##'`; produces the 12 expected headings including the three new ones:
  - `## The connector model: dual-shaped by design (clarifying note added 2026-05-20)`
  - `## Wrapper-retirement: two axes, adopter chooses`
  - `## Connector typology (per-tier dual-shape state)`
- [x] **Acceptance criteria mapping:**
  - Dual-layer model statement (top-section paragraph) — present.
  - Wrapper-retirement reframe (two-axis paragraph) — present.
  - Connector-typology table (7-row table) — present.
  - Cross-refs to [#740](https://github.com/evoila/meho/issues/740) / [#741](https://github.com/evoila/meho/issues/741) / [#743](https://github.com/evoila/meho/issues/743) + [`docs/codebase/connector-release-readiness.md`](docs/codebase/connector-release-readiness.md) — present.
  - Consumer-facing reframe note cross-link — points to this PR's `docs/cross-repo/goal-214-reframe-2026-05-20.md` artifact.
- [x] **Body amendment log appended** — Goal #214 now carries a `## Body amendment log` section recording the 2026-05-20 T6 amendment so future readers see the diff history without spelunking issue events.

## Out of scope

- Implementing more composites (the v0.4+ G3.x roadmap continues independently).
- Renaming the `vmware.composite.*` namespace.
- Catalog content itself ([#743](https://github.com/evoila/meho/issues/743) handles the curated reference catalog).
- Auto-ingesting Layer 2 at chart install (Shape C in the catalog design — separate Initiative if pursued).
- Loader-wiring (the State 1 → State 2 work for `k8s-1.x` and `vmware-rest-9.0` tracks under the open Goal #214 itself, not under this Initiative).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #734


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive Goal `#214` reframe verification documentation with architectural details, including the dual-shaped connector model clarification, wrapper-retirement reframe specifications, connector typology definitions, release-readiness state criteria, execution guidelines, and implementation checklist for adopter planning and reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->