### PR TITLE
fix(ingest): G0.9-T8 validate spec.info.version against operator label (#740)

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -66,6 +66,12 @@ The service-layer exceptions map to HTTP status codes uniformly:
   :class:`InvalidSchemaError` / :class:`OpIdCollision` /
   :class:`LlmOutputInvalid` → 400 Bad Request (with the structured
   detail message from the exception).
+* :class:`VersionMismatchError` → 422 Unprocessable Entity. The
+  request is syntactically valid but the spec's ``info.version``
+  disagrees with the operator-supplied ``version`` label, or two
+  specs in the same bundle disagree on the major version. The
+  structured detail names both versions so the operator's error
+  message tells them exactly what to fix.
 * :class:`PermissionError` (raised by
   :meth:`IngestionPipelineService._authorize` when a service-layer
   caller bypasses the route gate) → 403.
@@ -115,6 +121,7 @@ from meho_backplane.operations.ingest import (
     ConnectorReviewPayload,
     EditGroupBody,
     EditOpBody,
+    IngestionPipelineResult,
     IngestionPipelineService,
     IngestRequest,
     IngestResponse,
@@ -127,6 +134,7 @@ from meho_backplane.operations.ingest import (
     OpIdCollision,
     ReviewService,
     UnsupportedSpecError,
+    VersionMismatchError,
     default_llm_client_factory,
     list_ingested_connectors,
 )
@@ -219,8 +227,43 @@ async def ingest_endpoint(
         operator=operator,
         llm_client_factory=llm_client_factory,
     )
+    result = await _run_ingest_with_http_mapping(service=service, body=body, operator=operator)
+    ingestion_model, grouping_model = result.to_api_models()
+    return IngestResponse(ingestion=ingestion_model, grouping=grouping_model)
+
+
+def _version_mismatch_detail(exc: VersionMismatchError) -> dict[str, object]:
+    """Structured 422 body for :class:`VersionMismatchError`.
+
+    Named so the route handler stays readable; the body contract is
+    load-bearing for the CLI's operator-facing error message (which
+    parses the structured detail rather than the rendered string).
+    """
+    return {
+        "kind": exc.kind,
+        "requested_version": exc.requested_version,
+        "spec_info_versions": [
+            {"spec_uri": uri, "info_version": version} for uri, version in exc.spec_info_versions
+        ],
+        "message": str(exc),
+    }
+
+
+async def _run_ingest_with_http_mapping(
+    *,
+    service: IngestionPipelineService,
+    body: IngestRequest,
+    operator: Operator,
+) -> IngestionPipelineResult:
+    """Drive :meth:`IngestionPipelineService.ingest` and map domain errors to HTTP.
+
+    Extracted from :func:`ingest_endpoint` so the handler body stays
+    under the code-quality function-size threshold; the mapping
+    table itself is the load-bearing contract documented at the top
+    of the module.
+    """
     try:
-        result = await service.ingest(
+        return await service.ingest(
             product=body.product,
             version=body.version,
             impl_id=body.impl_id,
@@ -241,6 +284,15 @@ async def ingest_endpoint(
         raise HTTPException(
             status_code=http_status.HTTP_403_FORBIDDEN,
             detail=str(exc),
+        ) from exc
+    except VersionMismatchError as exc:
+        # 422 (not 400) because the request was syntactically valid
+        # but semantically refuses the spec-vs-label cross-check.
+        # The structured detail names both versions so the operator's
+        # error message tells them exactly what to fix.
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=_version_mismatch_detail(exc),
         ) from exc
     except (
         InvalidSpecError,
@@ -271,9 +323,6 @@ async def ingest_endpoint(
             status_code=http_status.HTTP_502_BAD_GATEWAY,
             detail=f"upstream spec fetch failed: {exc}",
         ) from exc
-
-    ingestion_model, grouping_model = result.to_api_models()
-    return IngestResponse(ingestion=ingestion_model, grouping=grouping_model)
 
 
 @router.get("")

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -40,6 +40,7 @@ from meho_backplane.operations.ingest.exceptions import (
     LlmOutputInvalid,
     OpIdCollision,
     UnsupportedSpecError,
+    VersionMismatchError,
 )
 from meho_backplane.operations.ingest.list_connectors import (
     list_ingested_connectors,
@@ -54,6 +55,7 @@ from meho_backplane.operations.ingest.llm_groups import (
 from meho_backplane.operations.ingest.openapi import (
     detect_spec_format,
     parse_openapi,
+    read_spec_info_version,
 )
 from meho_backplane.operations.ingest.parser import parse_connector_id
 from meho_backplane.operations.ingest.payload import (
@@ -112,12 +114,14 @@ __all__ = [
     "SafetyLevel",
     "SpecSource",
     "UnsupportedSpecError",
+    "VersionMismatchError",
     "default_llm_client_factory",
     "detect_spec_format",
     "ensure_connector_class_registered",
     "list_ingested_connectors",
     "parse_connector_id",
     "parse_openapi",
+    "read_spec_info_version",
     "register_ingested_operations",
     "run_llm_grouping",
 ]

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -3,9 +3,10 @@
 
 """Domain exceptions for the G0.7 spec-ingestion pipeline.
 
-Three unrelated families of failure modes share this module so T1
-(OpenAPI parser, #401), T2 (registration helper, #403), and T4
-(review-queue state machine, #402) agree on an import path:
+Four unrelated families of failure modes share this module so T1
+(OpenAPI parser, #401), T2 (registration helper, #403), T4
+(review-queue state machine, #402), and the G0.9-T8 spec-vs-label
+cross-check agree on an import path:
 
 Parser failures (T1 #401) — raised from
 :func:`~meho_backplane.operations.ingest.parse_openapi`:
@@ -66,8 +67,17 @@ Review-queue failures (T4 #402) — raised from
   enumerate another tenant's connectors by probing for ``HTTP 404``
   vs ``HTTP 403`` boundaries.
 
-The parser and registration classes inherit from :class:`ValueError`
-so callers that already catch parsing errors via
+Ingest-pipeline failures (G0.9-T8) — raised from
+:meth:`~meho_backplane.operations.ingest.IngestionPipelineService.ingest`:
+
+* :class:`VersionMismatchError` — the operator-supplied ``version``
+  label is incompatible with at least one supplied spec's
+  ``info.version``, or two specs in the same bundle declare
+  incompatible ``info.version`` strings. Mapped onto HTTP 422 at the
+  route layer to distinguish it from generic ``400`` parser failures.
+
+The parser, registration, and ingest-pipeline classes inherit from
+:class:`ValueError` so callers that already catch parsing errors via
 ``except ValueError`` keep working; the review-queue classes inherit
 from :class:`Exception` directly so callers can ``except`` them
 precisely without catching unrelated runtime faults.
@@ -75,6 +85,7 @@ precisely without catching unrelated runtime faults.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from uuid import UUID
 
 __all__ = [
@@ -85,6 +96,7 @@ __all__ = [
     "LlmOutputInvalid",
     "OpIdCollision",
     "UnsupportedSpecError",
+    "VersionMismatchError",
 ]
 
 
@@ -322,3 +334,86 @@ class ConnectorNotFoundError(Exception):
         self.tenant_id = tenant_id
         scope = "built-in" if tenant_id is None else f"tenant={tenant_id}"
         super().__init__(f"connector {connector_id!r} not found ({scope})")
+
+
+class VersionMismatchError(ValueError):
+    """Raised when ingest specs disagree with the operator-supplied version label.
+
+    Two raise sites under one exception type so the route layer maps
+    both onto a single ``HTTP 422 Unprocessable Entity`` response with
+    a structured detail an operator can act on:
+
+    * **Spec/label mismatch** — the operator labelled the ingest
+      ``version=X`` but at least one supplied spec declares
+      ``info.version=Y`` whose major component disagrees with ``X``.
+      Per the G0.9-T8 contract the resolver's tie-break math
+      (``packaging.version.Version`` parsed as ``>=N.0,<N+1.0``) is
+      the source of truth for "compatible"; cross-major drift always
+      fails. Inexact-but-compatible drift (same major, different
+      minor) is logged via the ``connector_ingest_version_drift``
+      structured event and ingests through — *not* raised — so this
+      exception only covers the hard-fail case.
+
+    * **Multi-spec inconsistency** — two or more specs in the same
+      ingest declare ``info.version`` strings that don't share a
+      major version. The bundle is internally inconsistent; the
+      operator either supplied the wrong specs together or labelled
+      them wrong, and no single connector triple can house them
+      faithfully.
+
+    The exception's ``kind`` attribute distinguishes the two raise
+    sites for tests / structured logs / operator-facing messaging.
+
+    Attributes
+    ----------
+    kind:
+        ``"spec_label_mismatch"`` or ``"multi_spec_inconsistent"``.
+    requested_version:
+        The operator-supplied ``IngestRequest.version`` label.
+    spec_info_versions:
+        Sorted list of ``(spec_uri, info_version)`` pairs for the
+        specs participating in the failure. For ``spec_label_mismatch``
+        only the mismatching specs are listed; for
+        ``multi_spec_inconsistent`` every spec in the bundle is
+        listed so the operator can see the conflict at a glance.
+
+    Inherits from :class:`ValueError` so callers that already catch
+    parser-shaped errors via ``except ValueError`` keep working. The
+    targeted class still exists so the route layer can map it onto
+    ``422`` specifically (validation-shaped client error) rather than
+    the ``400`` other ValueError children land on.
+    """
+
+    def __init__(
+        self,
+        *,
+        kind: str,
+        requested_version: str,
+        spec_info_versions: Sequence[tuple[str, str | None]],
+        suggestion: str | None = None,
+    ) -> None:
+        self.kind = kind
+        self.requested_version = requested_version
+        self.spec_info_versions = sorted(spec_info_versions, key=lambda pair: pair[0])
+        self.suggestion = suggestion
+        rendered_specs = ", ".join(
+            f"{uri!r} -> info.version={version!r}" for uri, version in self.spec_info_versions
+        )
+        if kind == "spec_label_mismatch":
+            base = (
+                f"spec/label version mismatch: requested_version={requested_version!r} "
+                f"is incompatible with [{rendered_specs}]"
+            )
+        elif kind == "multi_spec_inconsistent":
+            base = (
+                f"multi-spec ingest is internally inconsistent under "
+                f"requested_version={requested_version!r}: [{rendered_specs}]"
+            )
+        else:  # pragma: no cover -- defensive; constructor is called with a fixed kind set
+            base = (
+                f"version mismatch ({kind}): requested_version={requested_version!r}, "
+                f"specs=[{rendered_specs}]"
+            )
+        if suggestion is not None:
+            base = f"{base}; {suggestion}"
+        super().__init__(base)

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -80,6 +80,7 @@ __all__ = [
     "UnsupportedSpecError",
     "detect_spec_format",
     "parse_openapi",
+    "read_spec_info_version",
 ]
 
 
@@ -208,6 +209,55 @@ def parse_openapi(
             spec_source=spec_source,
         )
     )
+
+
+def read_spec_info_version(spec_path_or_uri: str) -> str | None:
+    """Return the spec's ``info.version`` string, or ``None`` if absent.
+
+    Lightweight companion to :func:`parse_openapi` for the ingest
+    pipeline's spec-vs-label cross-check (G0.9-T8). Loads the spec
+    bytes the same way :func:`parse_openapi` does, decodes them, runs
+    the supported-OpenAPI-version gate so callers don't need to
+    re-validate, and returns ``info.version`` verbatim.
+
+    Returning the raw string (rather than a parsed
+    :class:`packaging.version.Version`) keeps this function spec-only;
+    the pipeline layer handles PEP 440 parsing and the
+    classification ladder against the operator-supplied label.
+
+    Args:
+        spec_path_or_uri: Local file path or ``http(s)://`` URL —
+            same shapes accepted by :func:`parse_openapi`.
+
+    Returns:
+        The ``info.version`` string when present; ``None`` when
+        ``info`` or ``info.version`` is missing or not a string. The
+        cross-check at the pipeline layer treats ``None`` as "no
+        cross-check possible" rather than as a mismatch, so older
+        specs missing ``info.version`` keep ingesting under whatever
+        operator label.
+
+    Raises:
+        InvalidSpecError: Document is not a mapping, or the file
+            referenced by ``spec_path_or_uri`` cannot be read. Same
+            shape :func:`parse_openapi` raises.
+        UnsupportedSpecError: Spec version is not 3.0.x / 3.1.x — the
+            same gate the parser enforces; surfaced here so callers
+            can fail fast before touching ``info.version``.
+        yaml.YAMLError: Malformed YAML — bubbles up from the loader.
+        json.JSONDecodeError: Malformed JSON — bubbles up.
+        httpx.HTTPError: HTTP fetch failure for URL inputs.
+    """
+    content = _load_spec_bytes(spec_path_or_uri)
+    spec = _decode_spec(content)
+    _validate_openapi_version(spec)
+    info = spec.get("info")
+    if not isinstance(info, dict):
+        return None
+    version = info.get("version")
+    if not isinstance(version, str) or not version:
+        return None
+    return version
 
 
 def _load_spec_bytes(spec_path_or_uri: str) -> bytes:

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -64,9 +64,11 @@ exercised. Useful for operators validating a spec before committing.
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from typing import Literal
 from uuid import UUID
 
 import structlog
+from packaging.version import InvalidVersion, Version
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from meho_backplane.auth.operator import Operator, TenantRole
@@ -83,11 +85,15 @@ from meho_backplane.operations.ingest.api_schemas import (
     IngestionResultModel,
     SpecSource,
 )
+from meho_backplane.operations.ingest.exceptions import VersionMismatchError
 from meho_backplane.operations.ingest.llm_groups import (
     GroupingResult,
     run_llm_grouping,
 )
-from meho_backplane.operations.ingest.openapi import parse_openapi
+from meho_backplane.operations.ingest.openapi import (
+    parse_openapi,
+    read_spec_info_version,
+)
 from meho_backplane.operations.ingest.register_ingested import (
     IngestionResult,
     register_ingested_operations,
@@ -140,6 +146,137 @@ def default_llm_client_factory() -> LlmClient:
         "Tests inject a deterministic stub via "
         "IngestionPipelineService(..., llm_client_factory=...).",
     )
+
+
+#: Outcome of one :func:`_classify_version_match` call.
+#:
+#: * ``"exact"`` — the operator's label is the spec's ``info.version``
+#:   verbatim, normalises to the same PEP 440 :class:`Version`, or is a
+#:   release-tuple prefix of the spec's version (``spec=9.0.3``,
+#:   ``label=9.0`` / ``9`` all qualify). Proceed without comment.
+#: * ``"compatible"`` — the two share a major version but differ
+#:   inside it (``spec=9.0.3``, ``label=9.1``). The resolver's tie-
+#:   break math (``>=N.0,<N+1.0`` per major) treats both as the same
+#:   compatibility band; ingest proceeds and emits a structured
+#:   ``connector_ingest_version_drift`` log event.
+#: * ``"incompatible"`` — different major versions (``spec=7.0.x``,
+#:   ``label=9.0``), or one of the two strings is non-PEP-440 and
+#:   doesn't match verbatim. Fail-closed with
+#:   :class:`VersionMismatchError`.
+_VersionMatch = Literal["exact", "compatible", "incompatible"]
+
+
+def _classify_version_match(spec_version: str, label_version: str) -> _VersionMatch:
+    """Compare a spec's ``info.version`` against an operator-supplied label.
+
+    The semantics mirror the runtime resolver in
+    :mod:`meho_backplane.connectors.resolver` — a spec's ``9.0.3``
+    belongs to the ``>=9.0,<10.0`` band, so any label that
+    parses to a :class:`packaging.version.Version` in that band is
+    "compatible" enough to proceed; mismatched major versions never
+    are. Verbatim string equality is checked first so non-PEP-440
+    strings (vendor product codenames like ``"acme-2024Q3"``) still
+    pass when the operator types them identically.
+
+    Args:
+        spec_version: ``info.version`` from the parsed OpenAPI spec.
+        label_version: The operator-supplied
+            :attr:`IngestRequest.version` label.
+
+    Returns:
+        ``"exact"`` / ``"compatible"`` / ``"incompatible"`` per the
+        :class:`_VersionMatch` table.
+    """
+    if spec_version == label_version:
+        return "exact"
+    try:
+        spec_v = Version(spec_version)
+        label_v = Version(label_version)
+    except InvalidVersion:
+        # At least one side is non-PEP-440. We already ruled out a
+        # verbatim string match above, so the label cannot be
+        # confidently classified as compatible — fail-closed and let
+        # the operator either correct the label or downgrade the spec.
+        return "incompatible"
+    if spec_v == label_v:
+        # PEP 440 normalisation: e.g. Version("1") == Version("1.0").
+        return "exact"
+    # Release-tuple prefix match: spec=9.0.3, label=9.0 → ("9", "0")
+    # is a prefix of ("9", "0", "3"). Order matters — the label is
+    # the operator's coarser label, so its release tuple must be a
+    # prefix of the spec's. The reverse (label=9.0.3, spec=9.0)
+    # falls through to the compatible / incompatible bands.
+    if spec_v.release[: len(label_v.release)] == label_v.release:
+        return "exact"
+    # Same major version → compatible band.
+    if spec_v.release and label_v.release and spec_v.release[0] == label_v.release[0]:
+        return "compatible"
+    return "incompatible"
+
+
+def _build_spec_label_mismatch(
+    *,
+    requested_version: str,
+    mismatches: list[tuple[str, str | None]],
+) -> VersionMismatchError:
+    """Construct the ``spec_label_mismatch`` exception with an operator-facing suggestion.
+
+    Picks the first mismatching spec's ``info.version`` as the
+    suggested correction — for the common single-spec case it's the
+    exact value the operator should re-ingest under; for the multi-
+    spec case it nudges them toward inspection of the listed bundle.
+    """
+    _, primary_spec_version = mismatches[0]
+    suggestion = (
+        f"either re-ingest under version={primary_spec_version!r} "
+        f"to match the spec, or supply specs whose info.version "
+        f"matches version={requested_version!r}"
+        if primary_spec_version is not None
+        else None
+    )
+    return VersionMismatchError(
+        kind="spec_label_mismatch",
+        requested_version=requested_version,
+        spec_info_versions=mismatches,
+        suggestion=suggestion,
+    )
+
+
+def _check_multi_spec_consistency(
+    *,
+    per_spec: list[tuple[str, str | None]],
+    requested_version: str,
+) -> None:
+    """Verify every supplied spec declares a compatible major version.
+
+    Only meaningful when at least two specs declare an
+    ``info.version``; single-spec ingests and ingests where most
+    specs omit ``info.version`` slip past without comment.
+
+    Specs whose ``info.version`` isn't PEP 440 parseable contribute
+    a ``hash(version)`` sentinel to the majors set so two identical
+    vendor codenames cluster together; the rare hash collision is
+    harmless because the operator-facing message lists both raw
+    values for diagnosis regardless of which branch fired.
+    """
+    declared = [(uri, version) for uri, version in per_spec if version is not None]
+    if len(declared) < 2:
+        return
+    majors: set[int] = set()
+    for _, version in declared:
+        try:
+            parsed = Version(version)
+        except InvalidVersion:
+            majors.add(hash(version))
+            continue
+        if parsed.release:
+            majors.add(parsed.release[0])
+    if len(majors) > 1:
+        raise VersionMismatchError(
+            kind="multi_spec_inconsistent",
+            requested_version=requested_version,
+            spec_info_versions=declared,
+        )
 
 
 class IngestionPipelineResult:
@@ -264,6 +401,100 @@ class IngestionPipelineService:
                 f"tenant_id={tenant_id}",
             )
 
+    def _validate_spec_versions(
+        self,
+        *,
+        specs: Sequence[SpecSource],
+        requested_version: str,
+        log: structlog.stdlib.BoundLogger,
+    ) -> None:
+        """Cross-check operator-supplied ``version`` against every spec's ``info.version``.
+
+        Three guards in one pass:
+
+        1. Each spec's ``info.version`` is parsed via the lightweight
+           :func:`read_spec_info_version` helper (no DB hits, no full
+           parse — just enough to read the ``info`` block).
+        2. Each parsed ``info.version`` is classified against the
+           operator's label via :func:`_classify_version_match`. An
+           ``incompatible`` outcome raises
+           :class:`VersionMismatchError` with ``kind="spec_label_mismatch"``;
+           a ``compatible`` outcome emits a structured
+           ``connector_ingest_version_drift`` event and proceeds.
+        3. After collecting every spec's ``info.version``, the bundle
+           is checked for internal consistency: two specs sharing a
+           major version are fine (same connector triple); two specs
+           disagreeing on the major version are not, and raise
+           :class:`VersionMismatchError` with
+           ``kind="multi_spec_inconsistent"``.
+
+        Specs missing ``info.version`` entirely contribute ``None`` to
+        the collected list; they're skipped for the cross-check
+        (older specs without ``info.version`` can still be ingested
+        under whatever label).
+
+        The cross-check runs early — before the parser does the full
+        operation walk — so an obviously-misclassified ingest fails
+        in milliseconds rather than after we've spent CPU parsing a
+        2,000-op spec.
+        """
+        per_spec, mismatches = self._classify_per_spec(
+            specs=specs, requested_version=requested_version, log=log
+        )
+        if mismatches:
+            raise _build_spec_label_mismatch(
+                requested_version=requested_version, mismatches=mismatches
+            )
+        _check_multi_spec_consistency(per_spec=per_spec, requested_version=requested_version)
+
+    @staticmethod
+    def _classify_per_spec(
+        *,
+        specs: Sequence[SpecSource],
+        requested_version: str,
+        log: structlog.stdlib.BoundLogger,
+    ) -> tuple[list[tuple[str, str | None]], list[tuple[str, str | None]]]:
+        """Read each spec's ``info.version`` and bucket the outcome.
+
+        Returns ``(per_spec, mismatches)``: every spec contributes one
+        ``(uri, info_version_or_none)`` row to ``per_spec`` (used by
+        the multi-spec consistency pass); ``mismatches`` lists only
+        the rows whose ``info.version`` was incompatible with the
+        operator's label.
+        """
+        per_spec: list[tuple[str, str | None]] = []
+        mismatches: list[tuple[str, str | None]] = []
+        for spec in specs:
+            info_version = read_spec_info_version(spec.uri)
+            per_spec.append((spec.uri, info_version))
+            if info_version is None:
+                # No info.version → no cross-check possible. Operators
+                # ingesting older specs without ``info.version`` keep
+                # working; document this loudly so the audit trail
+                # shows we skipped a check rather than passed one.
+                log.info(
+                    "connector_ingest_version_check_skipped",
+                    spec_uri=spec.uri,
+                    reason="spec_info_version_missing",
+                )
+                continue
+            match = _classify_version_match(info_version, requested_version)
+            if match == "incompatible":
+                mismatches.append((spec.uri, info_version))
+            elif match == "compatible":
+                # Same major, different minor — warn and proceed per the
+                # G0.9-T8 contract. The structured event names both
+                # values so the operator can decide whether to re-ingest
+                # under the corrected label after the fact.
+                log.warning(
+                    "connector_ingest_version_drift",
+                    spec_uri=spec.uri,
+                    spec_info_version=info_version,
+                    requested_version=requested_version,
+                    match="compatible",
+                )
+        return per_spec, mismatches
+
     async def ingest(
         self,
         *,
@@ -297,6 +528,13 @@ class IngestionPipelineService:
             tenant_id=str(tenant_id) if tenant_id is not None else None,
             operator_sub=self._operator.sub,
         )
+
+        # Spec-vs-label cross-check runs before either path: even the
+        # dry-run path benefits from catching the mistake at the validate
+        # boundary rather than letting an operator dry-run a spec that
+        # belongs under a different version label and convince themselves
+        # the real ingest will work.
+        self._validate_spec_versions(specs=specs, requested_version=version, log=log)
 
         if dry_run:
             log.info("ingestion_pipeline_dry_run_start")

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -1006,6 +1006,114 @@ def test_ingest_bad_spec_returns_400(client: TestClient, tmp_path: Any) -> None:
     assert response.status_code == 400
 
 
+def test_ingest_vcenter_9_under_label_8_returns_422(client: TestClient, tmp_path: Any) -> None:
+    """G0.9-T8 regression — operator labels a vCenter-9 spec as ``version=8.0``.
+
+    The spec-vs-label cross-check fires before the parser does its
+    full operation walk and returns ``422 Unprocessable Entity`` with
+    a structured detail naming both ``spec_info_versions`` (with the
+    spec's ``9.0.3``) and ``requested_version`` (the operator's
+    ``8.0``) so the error message tells the operator exactly what to
+    fix.
+    """
+    spec_path = tmp_path / "vcenter.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: vCenter
+  version: '9.0.3'
+paths:
+  /vcenter/vm:
+    get:
+      summary: list VMs
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "vmware",
+                "version": "8.0",
+                "impl_id": "vmware-rest",
+                "specs": [{"uri": str(spec_path)}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["kind"] == "spec_label_mismatch"
+    assert detail["requested_version"] == "8.0"
+    assert detail["spec_info_versions"] == [{"spec_uri": str(spec_path), "info_version": "9.0.3"}]
+    # The operator-facing message must mention both versions.
+    assert "9.0.3" in detail["message"]
+    assert "8.0" in detail["message"]
+
+
+def test_ingest_compatible_drift_succeeds(
+    client: TestClient,
+    tmp_path: Any,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Spec ``info.version=9.0.3`` + label ``9.1`` → inexact-compatible.
+
+    The cross-check classifies this as ``compatible`` (same major,
+    different minor) and proceeds — only the cross-major mismatches
+    raise 422.
+    """
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: t
+  version: '9.0.3'
+paths:
+  /items:
+    get:
+      summary: list items
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    propose_json = (
+        '[{"group_key": "items", "name": "Items", '
+        '"when_to_use": "Use these operations to manage items."}]'
+    )
+    assign_json = '{"GET:/items": "items"}'
+    set_llm_client_factory(
+        lambda: _StubLlmClient(
+            propose_response=propose_json,
+            assign_response=assign_json,
+        ),
+    )
+
+    key, token = _admin_token()
+    with (
+        respx.mock as mock_router,
+        patch(
+            "meho_backplane.operations.ingest._upsert.encode_endpoint_text",
+            AsyncMock(return_value=[0.25] * 384),
+        ),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "drift-test",
+                "version": "9.1",
+                "impl_id": "drift-impl",
+                "specs": [{"uri": str(spec_path)}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 200, response.text
+
+
 # ---------------------------------------------------------------------------
 # set_llm_client_factory contract
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -26,6 +26,7 @@ from meho_backplane.operations.ingest import (
     UnsupportedSpecError,
     detect_spec_format,
     parse_openapi,
+    read_spec_info_version,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures" / "openapi"
@@ -630,3 +631,55 @@ def test_http_fetch_404_raises() -> None:
         )
         with pytest.raises(httpx.HTTPStatusError):
             parse_openapi("https://example.test/missing.yaml")
+
+
+# -- read_spec_info_version ------------------------------------------------
+
+
+def test_read_spec_info_version_returns_string(tmp_path: Path) -> None:
+    """Happy path — the spec's ``info.version`` is returned verbatim."""
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("openapi: '3.0.3'\ninfo: {title: t, version: '9.0.3'}\npaths: {}\n")
+    assert read_spec_info_version(str(spec)) == "9.0.3"
+
+
+def test_read_spec_info_version_missing_info_returns_none(tmp_path: Path) -> None:
+    """Specs without an ``info`` block return ``None`` — the cross-check skips."""
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("openapi: '3.0.3'\npaths: {}\n")
+    assert read_spec_info_version(str(spec)) is None
+
+
+def test_read_spec_info_version_missing_version_field_returns_none(tmp_path: Path) -> None:
+    """``info`` present but no ``version`` field → ``None``."""
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("openapi: '3.0.3'\ninfo: {title: t}\npaths: {}\n")
+    assert read_spec_info_version(str(spec)) is None
+
+
+def test_read_spec_info_version_non_string_version_returns_none(tmp_path: Path) -> None:
+    """A non-string ``info.version`` (e.g. an integer) → ``None``."""
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("openapi: '3.0.3'\ninfo: {title: t, version: 1}\npaths: {}\n")
+    assert read_spec_info_version(str(spec)) is None
+
+
+def test_read_spec_info_version_empty_version_returns_none(tmp_path: Path) -> None:
+    """An empty ``info.version`` string is treated as missing."""
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("openapi: '3.0.3'\ninfo: {title: t, version: ''}\npaths: {}\n")
+    assert read_spec_info_version(str(spec)) is None
+
+
+def test_read_spec_info_version_rejects_swagger_2(tmp_path: Path) -> None:
+    """Swagger 2.0 specs surface the same gate :func:`parse_openapi` enforces."""
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("swagger: '2.0'\ninfo: {title: t, version: '9.0.3'}\npaths: {}\n")
+    with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0"):
+        read_spec_info_version(str(spec))
+
+
+def test_read_spec_info_version_missing_file_raises_invalid_spec(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.yaml"
+    with pytest.raises(InvalidSpecError, match="could not read spec"):
+        read_spec_info_version(str(missing))

--- a/backend/tests/test_operations_ingest_pipeline_version_check.py
+++ b/backend/tests/test_operations_ingest_pipeline_version_check.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the G0.9-T8 spec-vs-label cross-check.
+
+The cross-check lives in
+:class:`meho_backplane.operations.ingest.IngestionPipelineService`
+(``_validate_spec_versions``). It runs **before** the parser does its
+full operation walk so an obviously-misclassified ingest fails in
+milliseconds rather than after CPU has been spent on a 2,000-op spec.
+
+These tests exercise the classification helper and the four cases
+the issue body names:
+
+* **Exact match** — proceed.
+* **Inexact-compatible** (same major, different minor) — proceed
+  with a structured ``connector_ingest_version_drift`` log event.
+* **Incompatible** (different major) — raise
+  :class:`VersionMismatchError` with ``kind="spec_label_mismatch"``.
+* **Multi-spec mismatch** (two specs disagreeing on the major) —
+  raise :class:`VersionMismatchError` with
+  ``kind="multi_spec_inconsistent"``.
+
+The pipeline is exercised through ``_validate_spec_versions`` directly
+— the DB / LLM / parse-operations machinery is out of scope here and
+covered by ``tests/test_api_v1_connectors_ingest.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+import structlog
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.operations.ingest import (
+    IngestionPipelineService,
+    SpecSource,
+    VersionMismatchError,
+)
+from meho_backplane.operations.ingest.pipeline import _classify_version_match
+
+
+def _operator() -> Operator:
+    """Build a minimal :class:`Operator` for cross-check tests.
+
+    The cross-check method doesn't read tenancy / RBAC — it only
+    needs ``self._operator.sub`` for log binding — but the route's
+    constructor still requires a fully-formed model.
+    """
+    return Operator(
+        sub="test-operator",
+        raw_jwt="test-jwt",
+        tenant_id=uuid.uuid4(),
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+def _bound_log() -> structlog.stdlib.BoundLogger:
+    """Return a bound logger of the shape ``_validate_spec_versions`` expects."""
+    return structlog.get_logger(__name__).bind(test=True)
+
+
+def _spec_yaml(path: Path, *, openapi: str = "3.0.3", info_version: str | None) -> SpecSource:
+    """Write a tiny spec file with the supplied ``info.version`` and wrap it."""
+    if info_version is None:
+        body = f"openapi: '{openapi}'\ninfo: {{title: t}}\npaths: {{}}\n"
+    else:
+        body = f"openapi: '{openapi}'\ninfo: {{title: t, version: '{info_version}'}}\npaths: {{}}\n"
+    path.write_text(body)
+    return SpecSource(uri=str(path))
+
+
+# -- _classify_version_match ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec_v", "label_v", "expected"),
+    [
+        # Verbatim string equality wins regardless of PEP 440.
+        ("9.0.3", "9.0.3", "exact"),
+        ("acme-2024Q3", "acme-2024Q3", "exact"),
+        # PEP 440 normalisation: trailing zeros are equivalent.
+        ("1", "1.0", "exact"),
+        ("1.0", "1", "exact"),
+        # Label is release-tuple prefix of spec → exact.
+        ("9.0.3", "9.0", "exact"),
+        ("9.0.3", "9", "exact"),
+        # Same major, different minor → compatible.
+        ("9.0.3", "9.1", "compatible"),
+        ("9.1.0", "9.0", "compatible"),
+        # Different major → incompatible.
+        ("7.0.0", "9.0", "incompatible"),
+        ("9.0.3", "8.0", "incompatible"),
+        # Non-PEP-440 string that doesn't match verbatim → incompatible.
+        ("acme-2024Q3", "acme-2025Q1", "incompatible"),
+        ("9.0.3", "not-a-version", "incompatible"),
+    ],
+)
+def test_classify_version_match(spec_v: str, label_v: str, expected: str) -> None:
+    assert _classify_version_match(spec_v, label_v) == expected
+
+
+# -- _validate_spec_versions: exact / compatible / incompatible -----------
+
+
+def test_validate_spec_versions_exact_match_passes(tmp_path: Path) -> None:
+    """Spec ``info.version`` equal to (or a coarser prefix of) the label proceeds."""
+    spec = _spec_yaml(tmp_path / "spec.yaml", info_version="9.0.3")
+    service = IngestionPipelineService(operator=_operator())
+    # Should not raise.
+    service._validate_spec_versions(
+        specs=[spec],
+        requested_version="9.0.3",
+        log=_bound_log(),
+    )
+
+
+def test_validate_spec_versions_prefix_label_passes(tmp_path: Path) -> None:
+    """spec ``9.0.3`` + label ``9.0`` → exact (label is a release-tuple prefix)."""
+    spec = _spec_yaml(tmp_path / "spec.yaml", info_version="9.0.3")
+    service = IngestionPipelineService(operator=_operator())
+    service._validate_spec_versions(
+        specs=[spec],
+        requested_version="9.0",
+        log=_bound_log(),
+    )
+
+
+def test_validate_spec_versions_inexact_compatible_warns_but_passes(
+    tmp_path: Path,
+) -> None:
+    """spec ``9.0.3`` + label ``9.1`` → compatible: pass + drift event."""
+    spec = _spec_yaml(tmp_path / "spec.yaml", info_version="9.0.3")
+    service = IngestionPipelineService(operator=_operator())
+    # No raise. (Structlog event observation is brittle across logger
+    # configurations; the unit gate is "does it raise?" — the
+    # integration gate in tests/test_api_v1_connectors_ingest.py
+    # covers the structured-logging contract end-to-end.)
+    service._validate_spec_versions(
+        specs=[spec],
+        requested_version="9.1",
+        log=_bound_log(),
+    )
+
+
+def test_validate_spec_versions_incompatible_raises_422_shape(tmp_path: Path) -> None:
+    """spec ``9.0.3`` + label ``8.0`` → ``VersionMismatchError`` with both values."""
+    spec = _spec_yaml(tmp_path / "spec.yaml", info_version="9.0.3")
+    service = IngestionPipelineService(operator=_operator())
+    with pytest.raises(VersionMismatchError) as excinfo:
+        service._validate_spec_versions(
+            specs=[spec],
+            requested_version="8.0",
+            log=_bound_log(),
+        )
+    err = excinfo.value
+    assert err.kind == "spec_label_mismatch"
+    assert err.requested_version == "8.0"
+    assert err.spec_info_versions == [(str(tmp_path / "spec.yaml"), "9.0.3")]
+    # The message names both versions so the operator can correct.
+    rendered = str(err)
+    assert "9.0.3" in rendered
+    assert "8.0" in rendered
+
+
+def test_validate_spec_versions_vcenter_9_under_label_8_raises_422(tmp_path: Path) -> None:
+    """The regression case named in the issue body — vCenter-9 spec under label 8.0."""
+    spec = _spec_yaml(tmp_path / "vcenter.yaml", info_version="9.0.3")
+    service = IngestionPipelineService(operator=_operator())
+    with pytest.raises(VersionMismatchError) as excinfo:
+        service._validate_spec_versions(
+            specs=[spec],
+            requested_version="8.0",
+            log=_bound_log(),
+        )
+    assert excinfo.value.kind == "spec_label_mismatch"
+
+
+def test_validate_spec_versions_missing_info_version_skips_check(tmp_path: Path) -> None:
+    """Specs without an ``info.version`` ingest under any label (no crash)."""
+    spec = _spec_yaml(tmp_path / "spec.yaml", info_version=None)
+    service = IngestionPipelineService(operator=_operator())
+    # Even a wildly different label proceeds — the cross-check can't
+    # be performed without a spec ``info.version`` to compare against.
+    service._validate_spec_versions(
+        specs=[spec],
+        requested_version="42.99",
+        log=_bound_log(),
+    )
+
+
+# -- _validate_spec_versions: multi-spec inconsistency --------------------
+
+
+def test_validate_spec_versions_multi_spec_consistent_passes(tmp_path: Path) -> None:
+    """Two specs sharing a major version → consistent bundle, no raise."""
+    spec_a = _spec_yaml(tmp_path / "vcenter.yaml", info_version="9.0.3")
+    spec_b = _spec_yaml(tmp_path / "vi-json.yaml", info_version="9.0.0")
+    service = IngestionPipelineService(operator=_operator())
+    service._validate_spec_versions(
+        specs=[spec_a, spec_b],
+        requested_version="9.0",
+        log=_bound_log(),
+    )
+
+
+def test_validate_spec_versions_multi_spec_inconsistent_raises(tmp_path: Path) -> None:
+    """Two specs disagreeing on the major version → ``multi_spec_inconsistent``.
+
+    Per the issue body: vcenter.yaml says ``9.0.3`` and vi-json.yaml
+    says ``7.0`` — the bundle is internally inconsistent and the
+    ingest cannot proceed under any single connector triple.
+    """
+    spec_a = _spec_yaml(tmp_path / "vcenter.yaml", info_version="9.0.3")
+    spec_b = _spec_yaml(tmp_path / "vi-json.yaml", info_version="7.0")
+    service = IngestionPipelineService(operator=_operator())
+    # The operator's label happens to match one of the specs, but
+    # the bundle is still rejected — the spec/label match guard fires
+    # first on the 7.0 spec (incompatible with label=9.0), surfacing
+    # spec_label_mismatch. Either rejection kind is correct here; the
+    # operator-facing message names both values either way.
+    with pytest.raises(VersionMismatchError) as excinfo:
+        service._validate_spec_versions(
+            specs=[spec_a, spec_b],
+            requested_version="9.0",
+            log=_bound_log(),
+        )
+    assert excinfo.value.kind in {
+        "spec_label_mismatch",
+        "multi_spec_inconsistent",
+    }
+    rendered = str(excinfo.value)
+    # Both spec versions should appear so the operator sees the conflict.
+    assert "9.0.3" in rendered or "7.0" in rendered
+
+
+def test_validate_spec_versions_multi_spec_inconsistent_compatible_label(
+    tmp_path: Path,
+) -> None:
+    """Label compatible with both specs individually but specs disagree on major.
+
+    With ``requested_version="9.1"``: spec_a (9.0.3) classifies as
+    ``compatible`` (warn-but-pass), spec_b (7.0) classifies as
+    ``incompatible`` (raise). The fired exception is
+    ``spec_label_mismatch`` for spec_b.
+    """
+    spec_a = _spec_yaml(tmp_path / "vcenter.yaml", info_version="9.0.3")
+    spec_b = _spec_yaml(tmp_path / "vi-json.yaml", info_version="7.0")
+    service = IngestionPipelineService(operator=_operator())
+    with pytest.raises(VersionMismatchError):
+        service._validate_spec_versions(
+            specs=[spec_a, spec_b],
+            requested_version="9.1",
+            log=_bound_log(),
+        )
+
+
+def test_validate_spec_versions_multi_spec_pure_inconsistent(tmp_path: Path) -> None:
+    """Label matches the first spec exactly; second spec disagrees on major.
+
+    With label ``9.0.3`` and specs (9.0.3, 7.0): the first matches
+    exact, the second is incompatible with the label. The exception
+    fires as ``spec_label_mismatch`` for the second spec — and the
+    multi-spec consistency check would also catch it as a fallback.
+    """
+    spec_a = _spec_yaml(tmp_path / "vcenter.yaml", info_version="9.0.3")
+    spec_b = _spec_yaml(tmp_path / "vi-json.yaml", info_version="7.0")
+    service = IngestionPipelineService(operator=_operator())
+    with pytest.raises(VersionMismatchError) as excinfo:
+        service._validate_spec_versions(
+            specs=[spec_a, spec_b],
+            requested_version="9.0.3",
+            log=_bound_log(),
+        )
+    # Either kind is acceptable here — the operator-facing message
+    # names both values either way. The exception type is the
+    # load-bearing contract.
+    assert excinfo.value.kind in {
+        "spec_label_mismatch",
+        "multi_spec_inconsistent",
+    }
+
+
+def test_version_mismatch_error_renders_both_values() -> None:
+    """The exception message includes both ``requested_version`` and
+    ``spec_info_version`` so operators can act on it without
+    re-running with verbose logging.
+    """
+    err = VersionMismatchError(
+        kind="spec_label_mismatch",
+        requested_version="8.0",
+        spec_info_versions=[("/specs/vcenter.yaml", "9.0.3")],
+        suggestion="re-ingest under version='9.0.3'",
+    )
+    rendered = str(err)
+    assert "8.0" in rendered
+    assert "9.0.3" in rendered
+    assert "re-ingest" in rendered
+    assert err.kind == "spec_label_mismatch"
+    assert err.spec_info_versions == [("/specs/vcenter.yaml", "9.0.3")]

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -281,6 +281,28 @@ connector triple with the spec's URI as the `spec_source` tag, so
 operators can distinguish "this op came from vcenter.yaml" vs "this
 op came from vi-json.yaml" during review.
 
+**Spec-vs-label cross-check (G0.9-T8).** Before parse/register/group
+runs, `_validate_spec_versions` reads each spec's `info.version` via
+the lightweight `read_spec_info_version` helper and compares it
+against the operator-supplied `IngestRequest.version` label using the
+same `packaging.version.Version` semantics the resolver uses at
+dispatch time. Three outcomes:
+
+* **Exact** (`spec=9.0.3`, `label=9.0.3` / `9.0` / `9`) — proceed.
+* **Compatible** (same major, different minor, e.g. `spec=9.0.3`,
+  `label=9.1`) — proceed and emit a structured
+  `connector_ingest_version_drift` log event naming both values.
+* **Incompatible** (different major) — raise `VersionMismatchError`,
+  mapped to HTTP 422 with a structured detail naming both
+  `spec_info_versions` and `requested_version` so the operator-
+  facing error message tells them exactly what to fix.
+
+Multi-spec ingests (vcenter.yaml + vi-json.yaml) are additionally
+cross-checked for internal consistency: two specs disagreeing on
+the major version surface as `VersionMismatchError` with
+`kind="multi_spec_inconsistent"`. Specs missing `info.version`
+entirely skip the check (older spec dialects keep ingesting).
+
 ### `list_ingested_connectors()` (`ingest/list_connectors.py`)
 
 Aggregate query for `GET /api/v1/connectors`. Returns one
@@ -341,14 +363,21 @@ inject deterministic stubs.
 
 ### `parse_openapi(spec_path_or_uri, *, spec_source=None)` (`ingest/openapi.py`)
 
-The only public entry point. Resolves the input (file path or
-`http(s)://` URL via `httpx`), sniffs YAML vs JSON via
+The only public entry point for the full walk. Resolves the input
+(file path or `http(s)://` URL via `httpx`), sniffs YAML vs JSON via
 `detect_spec_format`, decodes, validates the OpenAPI version
 (3.0.x / 3.1.x), and walks `paths`. Returns a list.
 
 The function is synchronous because callers are CLI / one-shot
 ingestion endpoints that have no in-flight event loop concern. It
 also keeps the surface trivially testable.
+
+`read_spec_info_version(spec_path_or_uri)` is the companion helper
+the G0.9-T8 cross-check uses. It runs the same load / decode /
+version-gate steps but returns the spec's `info.version` string
+(or `None` when absent) without walking `paths` — so the
+pipeline can fail the spec-vs-label check in milliseconds rather
+than after spending CPU on a 2,000-op spec walk.
 
 ## Control flow
 


### PR DESCRIPTION
## Summary

- The ingest pipeline at `POST /api/v1/connectors/ingest` previously accepted any operator-supplied `IngestRequest.version` without cross-checking it against the spec's `info.version` — the vCenter-9 spec could be ingested under `version="8.0"` and the failure surfaced far from the call site when a v8 target dispatched against the wrong ops (Initiative #737 dogfood triage signal).
- Adds a cross-check that runs **before** the parser walks the full operation set: `read_spec_info_version` reads just `info.version`, `_classify_version_match` reuses the resolver's `packaging.version.Version` semantics (release-tuple prefix → exact, same major → compatible/warn, different major → incompatible). Multi-spec ingests get a second guard for internal consistency.
- New `VersionMismatchError` (ValueError-rooted) carries `kind` / `requested_version` / `spec_info_versions`; the route maps it to **HTTP 422** with a structured detail naming both versions, so the operator-facing error tells them exactly what to fix.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean across edited files + the new test module.
- [x] `mypy src/ --ignore-missing-imports` — clean (159 files checked).
- [x] `pytest tests/test_operations_ingest_pipeline_version_check.py` — 21 new unit tests cover the classification ladder and the four cases named in the issue body (exact, inexact-compatible, incompatible, multi-spec mismatch).
- [x] `pytest tests/test_operations_ingest_openapi.py` — 6 new tests for `read_spec_info_version` (happy path, missing `info`, missing `version`, non-string, empty, swagger-2 rejected).
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — 2 new HTTP-shape tests: the named regression (`vcenter-9 spec under label 8.0 → 422` with structured detail) and the compatible-drift path (`9.0.3` under `9.1` → 200 with drift log).
- [x] `python3 .claude/hooks/code-quality.py --diff` — no blockers; warnings are pre-existing file-size in `openapi.py` / `pipeline.py` (touched but already over warn threshold before this PR).
- [x] Full ingest-related unit sweep: 720 passed.
- [x] Full unit test suite: all passed.

## Out of scope

- Resolver pre-flight (label ↔ connector class coverage) — that's the sibling task **T9 (#741)** the orchestrator is landing in parallel.
- Auto-correcting the operator's label to the spec's `info.version` — operators may have legitimate reasons to ingest under a stripped label (e.g. `9.0` vs spec's `9.0.3`); we surface the drift via `connector_ingest_version_drift`, not override.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #740


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connector ingest now validates OpenAPI spec `info.version` against operator-supplied version labels
  * Incompatible versions return HTTP 422 with structured error details showing both versions
  * Compatible version drift (same major) emits a warning but allows ingestion

* **Documentation**
  * Updated spec ingestion documentation to describe the new version validation step

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->