### PR TITLE
fix(ingest): G0.9-T9 pre-flight that version label is covered by a registered connector class (#741)

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -62,6 +62,11 @@ The service-layer exceptions map to HTTP status codes uniformly:
 
 * :class:`ConnectorNotFoundError` → 404.
 * :class:`InvalidStateTransitionError` → 409 Conflict.
+* :class:`UncoveredVersionLabel` (G0.9-T9 #741 ingest pre-flight:
+  the ``version`` label is outside every registered class's
+  ``supported_version_range``) → 422 Unprocessable Entity. Caught
+  before the generic ValueError-family below so the more-specific
+  status code wins.
 * :class:`InvalidSpecError` / :class:`UnsupportedSpecError` /
   :class:`InvalidSchemaError` / :class:`OpIdCollision` /
   :class:`LlmOutputInvalid` → 400 Bad Request (with the structured
@@ -133,6 +138,7 @@ from meho_backplane.operations.ingest import (
     LlmOutputInvalid,
     OpIdCollision,
     ReviewService,
+    UncoveredVersionLabel,
     UnsupportedSpecError,
     VersionMismatchError,
     default_llm_client_factory,
@@ -286,13 +292,26 @@ async def _run_ingest_with_http_mapping(
             detail=str(exc),
         ) from exc
     except VersionMismatchError as exc:
-        # 422 (not 400) because the request was syntactically valid
-        # but semantically refuses the spec-vs-label cross-check.
-        # The structured detail names both versions so the operator's
-        # error message tells them exactly what to fix.
+        # G0.9-T8 (#740). 422 (not 400) because the request was
+        # syntactically valid but semantically refuses the spec-vs-label
+        # cross-check. The structured detail names both versions so the
+        # operator's error message tells them exactly what to fix.
         raise HTTPException(
             status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=_version_mismatch_detail(exc),
+        ) from exc
+    except UncoveredVersionLabel as exc:
+        # G0.9-T9 (#741). The request body parsed fine (Pydantic
+        # accepted shape + length bounds), but the operator's
+        # ``version`` label is semantically outside every registered
+        # connector class's ``supported_version_range`` for the
+        # ``(product, impl_id)`` pair — orphan-at-ingest. 422
+        # Unprocessable Entity is the right code: structurally valid,
+        # semantically rejected. Listed BEFORE the generic ValueError-
+        # family catch below so the more-specific exception wins.
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
         ) from exc
     except (
         InvalidSpecError,

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -30,6 +30,7 @@ from meho_backplane.operations.ingest.api_schemas import (
 )
 from meho_backplane.operations.ingest.connector_registration import (
     GenericRestConnector,
+    check_version_covered_by_registered_class,
     ensure_connector_class_registered,
 )
 from meho_backplane.operations.ingest.exceptions import (
@@ -39,6 +40,7 @@ from meho_backplane.operations.ingest.exceptions import (
     InvalidStateTransitionError,
     LlmOutputInvalid,
     OpIdCollision,
+    UncoveredVersionLabel,
     UnsupportedSpecError,
     VersionMismatchError,
 )
@@ -113,8 +115,10 @@ __all__ = [
     "ReviewService",
     "SafetyLevel",
     "SpecSource",
+    "UncoveredVersionLabel",
     "UnsupportedSpecError",
     "VersionMismatchError",
+    "check_version_covered_by_registered_class",
     "default_llm_client_factory",
     "detect_spec_format",
     "ensure_connector_class_registered",

--- a/backend/src/meho_backplane/operations/ingest/connector_registration.py
+++ b/backend/src/meho_backplane/operations/ingest/connector_registration.py
@@ -54,6 +54,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.base import Connector
@@ -63,9 +65,11 @@ from meho_backplane.connectors.schemas import (
     OperationResult,
     ProbeResult,
 )
+from meho_backplane.operations.ingest.exceptions import UncoveredVersionLabel
 
 __all__ = [
     "GenericRestConnector",
+    "check_version_covered_by_registered_class",
     "derive_supported_version_range",
     "ensure_connector_class_registered",
 ]
@@ -351,3 +355,157 @@ def ensure_connector_class_registered(
         base_url=base_url,
     )
     return True
+
+
+def check_version_covered_by_registered_class(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> None:
+    """Pre-flight check that the ``version`` label is dispatchable.
+
+    G0.9-T9 (#741). The dispatch resolver
+    (:func:`~meho_backplane.connectors.resolver.resolve_connector`)
+    walks :func:`~meho_backplane.connectors.registry.all_connectors_v2`
+    and matches a target's fingerprinted version against each class's
+    PEP 440 ``supported_version_range``. The ingest pipeline keys
+    its rows on ``(product, version, impl_id)`` as a free-form
+    natural-key triple. Without a pre-flight, an operator can ingest
+    under ``(vmware, "7.0", vmware-rest)`` even though the only
+    registered class (``VmwareRestConnector`` with
+    ``supported_version_range=">=8.5,<10.0"``) cannot dispatch a 7.x
+    target — the catalog shows the ops but every call fails with
+    :exc:`NoMatchingConnector` at runtime, far from the ingest call
+    site.
+
+    This helper runs at ingest time **before**
+    :func:`ensure_connector_class_registered` synthesises the auto-
+    shim (the auto-shim's ``supported_version_range`` is derived
+    from the operator's own ``version`` label so it would always
+    "match" and make the check vacuous).
+
+    Behaviour by registry state:
+
+    * **At least one class registered for ``(product, impl_id)``** —
+      every such class is checked. If **none** advertises a range
+      that accepts the operator's ``version``, raise
+      :exc:`UncoveredVersionLabel`. The exception carries every
+      candidate class so the operator-facing 422 detail names
+      exactly which advertised ranges the label fell outside of.
+
+    * **No class registered for ``(product, impl_id)``** — log
+      ``connector_ingest_orphaned_class`` at info level and return.
+      This is the v0.4-staging path where ops land before the
+      hand-coded subclass exists; the dispatcher will surface the
+      gap clearly at the first ``call_operation`` and the warning
+      log is the upstream signal at ingest time.
+
+    The check intentionally filters by ``(product, impl_id)`` and
+    not the full triple — the goal is to confirm the operator's
+    ``version`` label is dispatchable against at least one of the
+    classes already known for that ``impl_id``, not to require a
+    class registered under the same triple. A real subclass at
+    ``(vmware, "9.0", vmware-rest)`` advertising
+    ``">=8.5,<10.0"`` accepts an ingest at
+    ``(vmware, "8.5.1", vmware-rest)`` because the subclass already
+    advertises support for the 8.5.x line; the auto-shim then
+    registers under the new triple to give the ingest its
+    resolvable identity.
+
+    Args:
+        product, version, impl_id: The connector triple the operator
+            submitted. The triple matches the natural-key shape on
+            :class:`~meho_backplane.db.models.EndpointDescriptor`.
+
+    Raises:
+        UncoveredVersionLabel: At least one registered class exists
+            for ``(product, impl_id)`` but none accepts ``version``.
+    """
+    # Local import — the v2 registry helper lives in a sibling
+    # package; deferring import to call-time mirrors
+    # :func:`ensure_connector_class_registered` and avoids a
+    # top-of-module dependency that would also be loaded at every
+    # import of this subpackage.
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    try:
+        parsed_version = Version(version)
+    except InvalidVersion:
+        # PEP 440 cannot parse the operator's label. We cannot
+        # decide range membership — log + proceed so the operator
+        # is not blocked by a label-parsing quirk the resolver
+        # itself tolerates (the resolver also catches
+        # InvalidVersion and falls through). T8 (#740) validates
+        # the label format against the spec's info.version; this
+        # pre-flight is specifically about range coverage and
+        # should not over-reach into label-shape validation.
+        _log.info(
+            "connector_ingest_version_unparseable",
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+        return
+
+    candidates: list[tuple[str, str, str, str]] = []
+    accepted_by: tuple[str, str, str, str] | None = None
+    for (entry_product, entry_version, entry_impl_id), cls in all_connectors_v2().items():
+        if entry_product != product or entry_impl_id != impl_id:
+            continue
+        spec_str = cls.supported_version_range
+        candidate = (entry_version, entry_impl_id, cls.__name__, spec_str or "")
+        candidates.append(candidate)
+        if not spec_str:
+            # ``None`` / empty range = "accepts any version" per the
+            # resolver's conventions (v1-style entries register here
+            # with ``version=""`` and no range). One such class is
+            # enough to cover any label.
+            accepted_by = candidate
+            break
+        try:
+            if parsed_version in SpecifierSet(spec_str):
+                accepted_by = candidate
+                break
+        except InvalidSpecifier:
+            # An unparseable advertisement is the connector author's
+            # bug, not the operator's. The resolver logs it at
+            # dispatch time and skips that class; mirror the
+            # behaviour here so a typo in one class does not block
+            # an ingest the other classes would have accepted.
+            _log.warning(
+                "connector_specifier_invalid_at_ingest_preflight",
+                product=entry_product,
+                version=entry_version,
+                impl_id=entry_impl_id,
+                cls=cls.__name__,
+                supported_version_range=spec_str,
+            )
+            continue
+
+    if not candidates:
+        # v0.4-staging path: ops land before the class exists.
+        _log.info(
+            "connector_ingest_orphaned_class",
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+        return
+
+    if accepted_by is None:
+        raise UncoveredVersionLabel(
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            candidates=candidates,
+        )
+
+    _log.debug(
+        "connector_ingest_version_covered",
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        accepted_by_cls=accepted_by[2],
+        accepted_by_range=accepted_by[3],
+    )

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -95,6 +95,7 @@ __all__ = [
     "InvalidStateTransitionError",
     "LlmOutputInvalid",
     "OpIdCollision",
+    "UncoveredVersionLabel",
     "UnsupportedSpecError",
     "VersionMismatchError",
 ]
@@ -304,6 +305,79 @@ class LlmOutputInvalid(Exception):  # noqa: N818 -- Task #404 API contract pins 
         super().__init__(
             f"LLM output failed validation in pass {pass_name!r}: "
             f"{parse_error!r}; raw_output={preview!r}",
+        )
+
+
+class UncoveredVersionLabel(ValueError):  # noqa: N818 -- Task #741 names this verbatim
+    """The operator's ``version`` label is outside every registered class's range.
+
+    Raised by the ingest pre-flight check (G0.9-T9, #741) before any
+    DB write when at least one connector class for the
+    ``(product, impl_id)`` pair is already registered against the v2
+    registry but none advertises a ``supported_version_range`` that
+    accepts the operator-supplied ``version``. Dispatch would later
+    raise :exc:`~meho_backplane.connectors.resolver.NoMatchingConnector`
+    on the first ``call_operation`` against the orphan rows — the
+    pre-flight catches the misconfiguration at the ingest call site
+    where the operator can correct it immediately.
+
+    Conditions for raising:
+
+    * **At least one** class with matching ``(product, impl_id)`` is
+      registered against the v2 registry.
+    * **None** of those classes accepts the operator's ``version``
+      label per its PEP 440 ``supported_version_range``.
+
+    The "no class registered for ``(product, impl_id)``" case is the
+    v0.4-staging path (ops land before the class exists); the pre-
+    flight logs ``connector_ingest_orphaned_class`` and proceeds
+    rather than raising — the dispatcher will surface the orphan
+    clearly later, and the warning is the upstream signal.
+
+    Attributes
+    ----------
+    product, version, impl_id:
+        The connector triple the operator submitted; surfaced on the
+        exception so the CLI / REST layer can render a complete
+        operator-facing error without re-threading them from the
+        call site.
+    candidates:
+        Sorted list of ``(version, impl_id, class_name, supported_version_range)``
+        tuples — one per existing registered class for the
+        ``(product, impl_id)`` pair. Surfaces in the exception
+        message so the operator sees exactly which advertised ranges
+        the label fell outside of.
+
+    Inherits from :class:`ValueError` so callers that already catch
+    ingest-shaped errors via ``except ValueError`` keep working. The
+    REST router maps this exception onto HTTP 422 Unprocessable
+    Entity — the request body is structurally valid (Pydantic
+    accepted it) but semantically rejected at the service layer.
+    """
+
+    def __init__(
+        self,
+        *,
+        product: str,
+        version: str,
+        impl_id: str,
+        candidates: list[tuple[str, str, str, str]],
+    ) -> None:
+        self.product = product
+        self.version = version
+        self.impl_id = impl_id
+        self.candidates = sorted(candidates)
+        rendered_candidates = ", ".join(
+            f"{cls_name} (version={cand_version!r}, impl_id={cand_impl_id!r}, "
+            f"supported_version_range={spec!r})"
+            for cand_version, cand_impl_id, cls_name, spec in self.candidates
+        )
+        super().__init__(
+            f"version={version!r} is not covered by any registered "
+            f"connector class for product={product!r}, impl_id={impl_id!r}; "
+            f"registered: [{rendered_candidates}]. Either register a class "
+            f"with a compatible supported_version_range or pick a version "
+            f"inside an existing class's range."
         )
 
 

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -85,6 +85,9 @@ from meho_backplane.operations.ingest.api_schemas import (
     IngestionResultModel,
     SpecSource,
 )
+from meho_backplane.operations.ingest.connector_registration import (
+    check_version_covered_by_registered_class,
+)
 from meho_backplane.operations.ingest.exceptions import VersionMismatchError
 from meho_backplane.operations.ingest.llm_groups import (
     GroupingResult,
@@ -538,6 +541,18 @@ class IngestionPipelineService:
 
         if dry_run:
             log.info("ingestion_pipeline_dry_run_start")
+            # G0.9-T9 (#741) — pre-flight runs in dry-run too so the
+            # operator validating a spec sees the same 422 they would
+            # see on the real path; the check is cheap (one v2-registry
+            # snapshot walk) and parallels the dispatcher's resolver
+            # contract. ``register_ingested_operations`` (the real-path
+            # caller) re-invokes the same helper before the auto-shim
+            # is synthesised; the duplicate call is idempotent.
+            check_version_covered_by_registered_class(
+                product=product,
+                version=version,
+                impl_id=impl_id,
+            )
             return await self._run_dry_run(
                 product=product,
                 version=version,

--- a/backend/src/meho_backplane/operations/ingest/register_ingested.py
+++ b/backend/src/meho_backplane/operations/ingest/register_ingested.py
@@ -109,6 +109,7 @@ from meho_backplane.operations.ingest._upsert import (
     upsert_one_operation,
 )
 from meho_backplane.operations.ingest.connector_registration import (
+    check_version_covered_by_registered_class,
     ensure_connector_class_registered,
 )
 from meho_backplane.operations.ingest.exceptions import OpIdCollision
@@ -302,6 +303,20 @@ async def register_ingested_operations(
     """
     _detect_op_id_collisions(
         operations,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+    )
+    # G0.9-T9 (#741) — pre-flight that the operator's ``version`` label
+    # is dispatchable against at least one already-registered class for
+    # ``(product, impl_id)``. Runs **before** the auto-shim is
+    # synthesised: the shim's ``supported_version_range`` is derived
+    # from the operator's own ``version`` so a post-shim check would
+    # always pass vacuously. Raises :exc:`UncoveredVersionLabel` (mapped
+    # to HTTP 422 by the REST router) when a class is registered but
+    # none accepts the label; logs ``connector_ingest_orphaned_class``
+    # and proceeds when no class is registered yet (v0.4-staging path).
+    check_version_covered_by_registered_class(
         product=product,
         version=version,
         impl_id=impl_id,

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -54,6 +54,7 @@ from meho_backplane.api.v1.connectors_ingest import (
 from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.base import Connector
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
     AuditLog,
@@ -1196,6 +1197,152 @@ def test_set_llm_client_factory_returns_previous_and_restores(
     assert previous is default_llm_client_factory
     restored = set_llm_client_factory(previous)
     assert restored is custom_factory
+
+
+# ---------------------------------------------------------------------------
+# G0.9-T9 (#741) — version label coverage pre-flight at the HTTP layer
+# ---------------------------------------------------------------------------
+
+
+class _RangedTestConnector(Connector):
+    """Hand-rolled :class:`Connector` for the 422 pre-flight HTTP tests.
+
+    Pinned ``supported_version_range`` mirrors the real
+    ``VmwareRestConnector`` shape so the operator-facing 422 detail
+    looks like what a real misconfigured ingest produces.
+    """
+
+    product = "t9-vmware"
+    version = "9.0"
+    impl_id = "t9-vmware-rest"
+    supported_version_range = ">=8.5,<10.0"
+    priority = 1
+
+    async def fingerprint(self, target: Any) -> Any:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> Any:
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def _registered_ranged_connector() -> Iterator[None]:
+    """Register :class:`_RangedTestConnector` for the duration of the test.
+
+    The v2 registry has no per-entry unregister API; this fixture
+    inspects the underlying dict and pops the entry on teardown so
+    the registration is scoped to the test rather than leaking into
+    later cases. The product / impl_id are namespaced (``t9-…``) to
+    avoid colliding with any prior auto-shim a happy-path ingest
+    test may have left behind.
+    """
+    from meho_backplane.connectors import registry as _registry_mod
+    from meho_backplane.connectors.registry import register_connector_v2
+
+    register_connector_v2(
+        product="t9-vmware",
+        version="9.0",
+        impl_id="t9-vmware-rest",
+        cls=_RangedTestConnector,
+    )
+    try:
+        yield
+    finally:
+        _registry_mod._REGISTRY_V2.pop(("t9-vmware", "9.0", "t9-vmware-rest"), None)
+
+
+def test_ingest_returns_422_when_version_outside_registered_class_range(
+    client: TestClient,
+    tmp_path: Any,
+    stub_embedding_service: AsyncMock,
+    _registered_ranged_connector: None,
+) -> None:
+    """A registered class with ``">=8.5,<10.0"`` + label ``"7.0"`` → 422.
+
+    The pre-flight raises :exc:`UncoveredVersionLabel` (mapped to
+    422); the response detail names the existing class so the
+    operator can see exactly which range the label fell outside of.
+    """
+    spec_path = tmp_path / "vcenter.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: vcenter
+  version: '7.0'
+paths:
+  /api/vcenter/cluster:
+    get:
+      summary: list clusters
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "t9-vmware",
+                "version": "7.0",
+                "impl_id": "t9-vmware-rest",
+                "specs": [{"uri": str(spec_path)}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert "version='7.0'" in detail
+    assert ">=8.5,<10.0" in detail
+    assert "_RangedTestConnector" in detail
+
+
+def test_ingest_dry_run_returns_422_when_version_outside_registered_class_range(
+    client: TestClient,
+    tmp_path: Any,
+    _registered_ranged_connector: None,
+) -> None:
+    """``dry_run=true`` runs the same pre-flight → 422.
+
+    Catches the orphan-at-ingest mistake during validation so
+    operators don't ship a misconfigured ingest by trusting a
+    successful dry-run.
+    """
+    spec_path = tmp_path / "vcenter.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: vcenter
+  version: '7.0'
+paths:
+  /api/vcenter/cluster:
+    get:
+      summary: list clusters
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "t9-vmware",
+                "version": "7.0",
+                "impl_id": "t9-vmware-rest",
+                "specs": [{"uri": str(spec_path)}],
+                "dry_run": True,
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    assert "version='7.0'" in response.json()["detail"]
 
 
 # Silence unused-import lints on test seams reserved for sibling tasks.

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -50,10 +50,16 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+import structlog.testing
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from meho_backplane.connectors.registry import all_connectors_v2, clear_registry
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor
 from meho_backplane.operations.ingest import (
@@ -61,6 +67,8 @@ from meho_backplane.operations.ingest import (
     GenericRestConnector,
     IngestionResult,
     OpIdCollision,
+    UncoveredVersionLabel,
+    check_version_covered_by_registered_class,
     parse_openapi,
     register_ingested_operations,
 )
@@ -763,3 +771,221 @@ async def test_caller_owned_session_defers_commit(
             )
         ).scalar_one_or_none()
     assert post_rollback is None
+
+
+# ---------------------------------------------------------------------------
+# G0.9-T9 (#741) — version label coverage pre-flight
+# ---------------------------------------------------------------------------
+
+
+class _FakeRangedConnector(Connector):
+    """Hand-rolled connector class for pre-flight tests.
+
+    Stands in for the kind of subclass an operator would register at
+    G3.x — pinned ``supported_version_range`` mirrors the real
+    :class:`VmwareRestConnector` shape (``">=8.5,<10.0"``) and the
+    methods are no-op stubs so the ABC is concrete.
+    """
+
+    product = "vmware"
+    version = "9.0"
+    impl_id = "vmware-rest"
+    supported_version_range = ">=8.5,<10.0"
+    priority = 1
+
+    async def fingerprint(self, target: Any) -> Any:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> Any:
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> Any:
+        raise NotImplementedError
+
+
+def test_check_version_covered_passes_when_label_inside_range() -> None:
+    """A class advertising ``">=8.5,<10.0"`` accepts label ``"8.6"`` — no raise."""
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_FakeRangedConnector,
+    )
+    # Inside the range → silent pass.
+    check_version_covered_by_registered_class(
+        product="vmware",
+        version="8.6",
+        impl_id="vmware-rest",
+    )
+
+
+def test_check_version_covered_raises_when_label_outside_range() -> None:
+    """A class with non-matching range → :exc:`UncoveredVersionLabel` with detail."""
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_FakeRangedConnector,
+    )
+    with pytest.raises(UncoveredVersionLabel) as excinfo:
+        check_version_covered_by_registered_class(
+            product="vmware",
+            version="7.0",
+            impl_id="vmware-rest",
+        )
+    err = excinfo.value
+    assert err.product == "vmware"
+    assert err.version == "7.0"
+    assert err.impl_id == "vmware-rest"
+    # The exception names the existing class + its range so the
+    # operator can see what to fix.
+    assert err.candidates == [("9.0", "vmware-rest", "_FakeRangedConnector", ">=8.5,<10.0")]
+    detail = str(err)
+    assert "version='7.0'" in detail
+    assert ">=8.5,<10.0" in detail
+    assert "_FakeRangedConnector" in detail
+
+
+def test_check_version_covered_logs_orphan_when_no_class_registered() -> None:
+    """No class for ``(product, impl_id)`` → log ``connector_ingest_orphaned_class``; no raise."""
+    # Registry is empty (autouse fixture cleared it).
+    with structlog.testing.capture_logs() as captured:
+        check_version_covered_by_registered_class(
+            product="brand-new-vendor",
+            version="1.0",
+            impl_id="brand-new-impl",
+        )
+    events = [
+        entry for entry in captured if entry.get("event") == "connector_ingest_orphaned_class"
+    ]
+    assert len(events) == 1
+    assert events[0]["product"] == "brand-new-vendor"
+    assert events[0]["version"] == "1.0"
+    assert events[0]["impl_id"] == "brand-new-impl"
+
+
+def test_check_version_covered_ignores_other_impls_of_same_product() -> None:
+    """Class for ``(product, impl_id_A)`` does not constrain ingest under ``impl_id_B``.
+
+    The pre-flight filters by the full ``(product, impl_id)`` pair, so
+    a coexisting class on the same product but a different impl
+    (``vmware-pyvmomi`` vs ``vmware-rest``) leaves the ``impl_id_B``
+    pre-flight in the no-class-registered branch and proceeds with
+    the orphan warning.
+    """
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_FakeRangedConnector,
+    )
+    with structlog.testing.capture_logs() as captured:
+        check_version_covered_by_registered_class(
+            product="vmware",
+            version="7.0",
+            impl_id="vmware-pyvmomi",
+        )
+    orphan_events = [
+        entry for entry in captured if entry.get("event") == "connector_ingest_orphaned_class"
+    ]
+    assert len(orphan_events) == 1
+    assert orphan_events[0]["impl_id"] == "vmware-pyvmomi"
+
+
+@pytest.mark.asyncio
+async def test_register_ingested_blocks_when_version_outside_existing_class_range(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """End-to-end: ingest under ``(vmware, 7.0, vmware-rest)`` with a
+    registered ``VmwareRestConnector``-shaped class → 422-mapped
+    :exc:`UncoveredVersionLabel`; no rows persisted.
+    """
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_FakeRangedConnector,
+    )
+    with pytest.raises(UncoveredVersionLabel):
+        await register_ingested_operations(
+            product="vmware",
+            version="7.0",
+            impl_id="vmware-rest",
+            spec_source="vcenter.yaml",
+            operations=[_proto("GET:/api/vcenter/cluster", path="/api/vcenter/cluster")],
+            embedding_service=stub_embedding_service,
+        )
+    # No rows persisted — the pre-flight raised before any upsert.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.product == "vmware")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
+    # The embedding pipeline was not invoked.
+    assert stub_embedding_service.encode_one.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_register_ingested_warns_and_proceeds_when_no_class_registered(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """No class for ``(product, impl_id)`` → ingest proceeds and emits
+    ``connector_ingest_orphaned_class``.
+    """
+    # Registry empty for ``(unknown-vendor, brand-new-impl)``.
+    with structlog.testing.capture_logs() as captured:
+        result = await register_ingested_operations(
+            product="unknown-vendor",
+            version="1.0",
+            impl_id="brand-new-impl",
+            spec_source="vendor.yaml",
+            operations=[_proto("GET:/things", path="/things")],
+            embedding_service=stub_embedding_service,
+        )
+    assert result.inserted_count == 1
+    # The orphan event is logged with the full triple.
+    orphan_events = [
+        entry for entry in captured if entry.get("event") == "connector_ingest_orphaned_class"
+    ]
+    assert len(orphan_events) == 1
+    event = orphan_events[0]
+    assert event["product"] == "unknown-vendor"
+    assert event["version"] == "1.0"
+    assert event["impl_id"] == "brand-new-impl"
+    # The auto-shim is registered after the orphan log (the ingest
+    # proceeded — that's the warn-but-proceed semantics).
+    assert ("unknown-vendor", "1.0", "brand-new-impl") in all_connectors_v2()
+
+
+@pytest.mark.asyncio
+async def test_register_ingested_passes_pre_flight_for_compatible_version(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Operator-supplied version inside a registered class's range → success path."""
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_FakeRangedConnector,
+    )
+    result = await register_ingested_operations(
+        # Inside the ``>=8.5,<10.0`` range advertised by the existing class.
+        product="vmware",
+        version="9.0.3",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto("GET:/api/vcenter/cluster", path="/api/vcenter/cluster")],
+        embedding_service=stub_embedding_service,
+    )
+    assert result.inserted_count == 1
+    # A NEW auto-shim is registered under the (vmware, 9.0.3, vmware-rest) triple
+    # alongside the pre-existing (vmware, 9.0, vmware-rest) entry — the pre-flight
+    # checks coverage, it does not require the triple to already exist.
+    assert ("vmware", "9.0.3", "vmware-rest") in all_connectors_v2()

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -254,6 +254,33 @@ subclass that adds the auth path. The shim makes the connector
 resolvable through the v2 registry so spec ingestion can proceed
 before the per-product Initiative work lands.
 
+### `check_version_covered_by_registered_class()` (`ingest/connector_registration.py`)
+
+G0.9-T9 (#741) pre-flight that the operator's `version` label is
+dispatchable against at least one already-registered class for
+`(product, impl_id)`. Mirrors the
+`resolver.resolve_connector` PEP 440 `SpecifierSet` check at ingest
+time so orphan-at-ingest is caught at the operator's call site,
+not at the first `call_operation` against the resulting orphan
+rows. Two branches:
+
+* **At least one class registered** for `(product, impl_id)` but
+  none accepts the label → raise `UncoveredVersionLabel` (mapped
+  to HTTP 422 in the REST router). The exception names every
+  candidate class and its advertised range so the operator-facing
+  detail tells them exactly what to fix.
+* **No class registered** for `(product, impl_id)` → log
+  `connector_ingest_orphaned_class` at info level and proceed.
+  This is the v0.4-staging path where ops land before the class
+  exists; the dispatcher will surface the gap at the first
+  `call_operation` and the ingest-time warning is the upstream
+  signal.
+
+Called from `register_ingested_operations` (real path) and from
+`IngestionPipelineService._run_dry_run` (dry-run path) so an
+operator's `dry_run=True` validation sees the same 422 the real
+path would.
+
 ### `IngestionPipelineService` (`ingest/pipeline.py`)
 
 End-to-end orchestrator that bundles the parse → register_ingested →
@@ -413,6 +440,13 @@ dispatcher's concern (G0.6-T5 + T2's tracking of `components.schemas`).
 ```text
 register_ingested_operations
 ├─ _detect_op_id_collisions    # set scan; raise OpIdCollision (within-batch) before DB writes
+├─ check_version_covered_by_registered_class    # G0.9-T9 (#741) pre-flight
+│  ├─ all_connectors_v2()       # snapshot v2 registry
+│  ├─ filter by (product, impl_id) # version label is the thing being checked
+│  ├─ for each class: Version(label) in SpecifierSet(supported_version_range)?
+│  ├─ no class for (product, impl_id) → log connector_ingest_orphaned_class, proceed
+│  ├─ class(es) exist but none accepts label → raise UncoveredVersionLabel (→ HTTP 422)
+│  └─ at least one accepts → return
 ├─ ensure_connector_class_registered
 │  ├─ all_connectors_v2()       # check v2 registry for (product, version, impl_id)
 │  ├─ type(cls_name, ...)       # synthesise GenericRestConnector subclass
@@ -429,6 +463,14 @@ register_ingested_operations
       ├─ re-embed path          # row exists, embedding text changed
       └─ first-register path    # brand-new row, embedding computed
 ```
+
+The pre-flight runs **before** `ensure_connector_class_registered`
+on purpose: the auto-shim's `supported_version_range` is derived
+from the operator's own `version` label (via
+`derive_supported_version_range`), so a post-shim check would
+always pass vacuously. The dry-run path in `IngestionPipelineService`
+calls the same helper so an operator validating a spec sees the
+422 they would see on the real path.
 
 The skip-re-embed path is the operationally critical branch on spec
 re-ingest: an unchanged 3,000-op vCenter spec must not re-embed


### PR DESCRIPTION
## Summary

- At ingest time, check that the operator-supplied `(product, impl_id, version)` triple is dispatchable against at least one registered connector class's `supported_version_range` — mirroring `resolver.resolve_connector`'s PEP 440 `SpecifierSet` math at the call site so orphan-at-ingest doesn't surface as `NoMatchingConnector` at the first `call_operation`.
- Block ingest with HTTP 422 (`UncoveredVersionLabel` → REST mapper) when at least one class for `(product, impl_id)` exists but none accepts the label; warn-and-proceed with structured log `connector_ingest_orphaned_class` when no class is registered (v0.4-staging path).
- Pre-flight runs before `ensure_connector_class_registered` (auto-shim would otherwise vacuously match) and in both the real and `dry_run=True` paths.

## Test plan

- [x] `ruff check` — clean on touched files
- [x] `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — Success: no issues found in 6 source files
- [x] `pytest tests/test_operations_register_ingested.py` — 21 passed (added 7 new pre-flight tests)
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — 30 passed (added 2 new 422 + dry-run tests)
- [x] `pytest tests/ -k "ingest or connector_registration or resolver or registry"` — 271 passed, 9 skipped
- [x] Acceptance criterion (a) version inside range succeeds — `test_register_ingested_passes_pre_flight_for_compatible_version`
- [x] Acceptance criterion (b) version outside range → 422 — `test_ingest_returns_422_when_version_outside_registered_class_range`
- [x] Acceptance criterion (c) `dry_run=True` outside range → 422 — `test_ingest_dry_run_returns_422_when_version_outside_registered_class_range`
- [x] Acceptance criterion (d) no class registered → warn-proceed with structured event — `test_register_ingested_warns_and_proceeds_when_no_class_registered`
- [x] Acceptance criterion: 422 detail names parsed version + advertised range + class — asserted in `test_check_version_covered_raises_when_label_outside_range` + HTTP test
- [x] `Python (ruff + mypy + pytest)` lane will run on the PR; integration testcontainers lane will run too.

## Out of scope

- Validating `spec.info.version` against the supplied label — that's sibling task T8 (#740) being implemented in parallel; the two share adjacent code in `api_schemas.py` / `pipeline.py` but T8 covers spec ↔ label and this PR covers label ↔ connector-class.
- Auto-registering a connector class when ingest references a `(product, impl_id)` with no class — explicitly called out as a feature (not hardening) in the issue body.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #741


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added version-compatibility validation for connector ingestion; requests with unsupported version labels now return HTTP 422 with operator-facing details about acceptable ranges.

* **Bug Fixes**
  * Dry-run ingestion now enforces the same version checks as real ingest, ensuring consistent failure behavior.

* **Tests**
  * Added tests covering successful/failed version checks and 422 responses for both real and dry-run ingests.

* **Documentation**
  * Updated ingestion docs to describe the pre-flight version validation and resulting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->