### PR TITLE
feat(memory): G5.2-T4 POST /memory/{scope}/{slug}/promote (idempotent) + meho.memory.promote admin meta-tool (#626)

### DIFF
--- a/backend/src/meho_backplane/api/v1/memory.py
+++ b/backend/src/meho_backplane/api/v1/memory.py
@@ -113,6 +113,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.memory import (
+    InvalidPromotionStepError,
     MemoryEntry,
     MemoryScope,
     MemoryService,
@@ -121,7 +122,7 @@ from meho_backplane.memory import (
 from meho_backplane.memory.schemas import SLUG_PATTERN
 from meho_backplane.settings import get_settings
 
-__all__ = ["MemoryListResponse", "RememberBody", "router"]
+__all__ = ["MemoryListResponse", "PromoteBody", "RememberBody", "router"]
 
 router = APIRouter(prefix="/api/v1/memory", tags=["memory"])
 
@@ -154,6 +155,7 @@ _MEMORY_OP_IDS: Final[dict[str, str]] = {
     "list": "memory.list",
     "recall": "memory.recall",
     "forget": "memory.forget",
+    "promote": "memory.promote",
 }
 
 #: Maximum length of the ``slug`` path / query parameter accepted by
@@ -262,6 +264,36 @@ class RememberBody(BaseModel):
     # strings surface as 422 from pydantic's own coercion -- no
     # custom parse layer needed.
     expires_at: datetime | None = None
+    target_name: str | None = Field(default=None, max_length=_SLUG_MAX_LENGTH)
+
+
+class PromoteBody(BaseModel):
+    """POST body for ``/api/v1/memory/{scope}/{slug}/promote``.
+
+    G5.2-T4 (#626) of Initiative #374. Two required-ish fields plus a
+    target-scope name for the ``user -> user-target`` / ``user-target ->
+    target`` ladder steps; ``frozen=True`` + ``extra="forbid"`` mirror
+    :class:`RememberBody`.
+
+    * ``to`` -- the target scope. The route delegates ladder validation
+      to :func:`~meho_backplane.memory.rbac.assert_can_promote`, which
+      raises :class:`InvalidPromotionStepError` on non-ladder pairs (the
+      route maps that to 400).
+    * ``move`` -- when ``True``, delete the source row in the same
+      transaction as the target insert (broadens-and-leaves vs.
+      broadens-and-rewires). Default ``False`` per the issue body.
+    * ``target_name`` -- required when ``to`` is target-flavoured AND
+      the source scope is not (``user -> user-target``). For
+      ``user-target -> target`` the service inherits ``target_name``
+      from the source row, so the caller may omit it; we still accept
+      it for forward-compat with the CLI verb (T5 #627). Omitted
+      values land as ``None``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    to: MemoryScope
+    move: bool = False
     target_name: str | None = Field(default=None, max_length=_SLUG_MAX_LENGTH)
 
 
@@ -573,3 +605,122 @@ async def forget(
         ) from exc
     structlog.contextvars.bind_contextvars(audit_existed=existed)
     return Response(status_code=http_status.HTTP_204_NO_CONTENT)
+
+
+def _promote_value_error_to_http(exc: ValueError) -> HTTPException:
+    """Map a service-raised :class:`ValueError` to the right HTTPException.
+
+    Two distinct failure modes share the :class:`ValueError` type at
+    the service boundary:
+
+    * ``promote_target_conflict`` -- target slug occupied by a row
+      with different provenance (409 conflict; not a request-shape
+      error).
+    * Other ValueErrors (e.g. ``target_name required for
+      user-target``) -- request-shape errors mapped to 422 in line
+      with the rest of the memory router.
+
+    The dispatch on prefix keeps the failure surface readable at one
+    function rather than splattered across the route handler.
+    """
+    message = str(exc)
+    if message.startswith("promote_target_conflict"):
+        return HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=message,
+        )
+    return HTTPException(
+        status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=message,
+    )
+
+
+@router.post(
+    "/{scope}/{slug}/promote",
+    response_model=MemoryEntry,
+    status_code=http_status.HTTP_200_OK,
+)
+async def promote(
+    scope: MemoryScope,
+    slug: str,
+    body: PromoteBody,
+    operator: Operator = _require_operator,
+) -> MemoryEntry:
+    """Promote one memory to a strictly broader scope. Idempotent.
+
+    G5.2-T4 (#626). Delegates ladder + authority checks to T3's
+    :func:`~meho_backplane.memory.rbac.assert_can_promote`. The route
+    is the HTTP error-mapping layer plus the audit contextvar
+    (``audit_promotion_target_scope``) that distinguishes promote
+    rows from regular ``memory.remember`` writes for G8 forensic
+    queries.
+
+    Status mapping: **200** new target row OR idempotent re-run
+    (existing row); **400** :class:`InvalidPromotionStepError`;
+    **403** :class:`PermissionDeniedError` with detail
+    ``insufficient_promotion_authority``; **404** source absent or
+    not visible (tenant-boundary info-leak avoidance); **409**
+    target slug owned by a different ``promoted_from`` marker;
+    **501** :class:`NotImplementedError` for the unshipped per-
+    target ACL branch.
+
+    Binds five audit contextvars before the service call so a mid-
+    service exception still produces a correctly-classified audit
+    row. The contextvar pattern mirrors G0.4-T5's ``audit_query_hash``
+    on ``/api/v1/retrieve``.
+    """
+    if len(slug) > _SLUG_MAX_LENGTH:
+        # Path-parameter overrun defence-in-depth; 404 (not 422)
+        # preserves the recall route's info-leak avoidance.
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="memory_not_found",
+        )
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_MEMORY_OP_IDS["promote"],
+        audit_op_class="write",
+        audit_scope=scope.value,
+        audit_slug=slug,
+        audit_promotion_target_scope=body.to.value,
+    )
+    service = MemoryService()
+    try:
+        entry = await service.promote(
+            operator=operator,
+            source_scope=scope,
+            source_slug=slug,
+            target_scope=body.to,
+            move=body.move,
+            target_name=body.target_name,
+        )
+    except InvalidPromotionStepError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except PermissionDeniedError:
+        # Canonical detail per Initiative #374. The helper's
+        # ``reason`` field carries the same literal, but pinning it
+        # here lets audit-query consumers grep one string.
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="insufficient_promotion_authority",
+        ) from None
+    except NotImplementedError as exc:
+        # G0.3 #224 per-target ACL gap surfaces loudly per the
+        # helper's contract; 501 is the spec-correct status.
+        raise HTTPException(
+            status_code=http_status.HTTP_501_NOT_IMPLEMENTED,
+            detail=f"not_implemented: {exc}",
+        ) from exc
+    except ValueError as exc:
+        raise _promote_value_error_to_http(exc) from exc
+
+    if entry is None:
+        # 404 across "absent" and "not visible" preserves the
+        # tenant-boundary info-leak avoidance contract.
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="memory_not_found",
+        )
+    return entry

--- a/backend/src/meho_backplane/mcp/tools/memory_promote.py
+++ b/backend/src/meho_backplane/mcp/tools/memory_promote.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho.memory.promote`` -- admin-only memory promotion meta-tool (G5.2-T4).
+
+The MCP twin of ``POST /api/v1/memory/{scope}/{slug}/promote`` (T4 #626).
+Lives in the **admin namespace** (``meho.*``) and is registered with
+``required_role=TenantRole.TENANT_ADMIN`` so the MCP registry's
+list-time filter hides it from non-admin sessions -- it is NOT on the
+agent's daily surface. Promotion is a privileged broaden-visibility
+operation; consumer-needs.md §G5 names tenant-shared memory as "real
+organisational state -- others depend on it" and the v0.2-decisions
+document carves the agent surface narrowly. Operators initiate
+promotion via the matching CLI verb (T5 #627); the admin meta-tool
+exists for orchestrators / Claude Desktop sessions running under a
+``tenant_admin`` operator who needs to drive promotions from the MCP
+transport.
+
+Why a separate module
+=====================
+
+The companion :mod:`meho_backplane.mcp.tools.memory` module owns the
+two daily-surface tools (``search_memory`` / ``add_to_memory``). The
+admin namespace is structurally distinct -- a wider role gate, a
+``meho.*`` name, and the explicit "not on the agent surface" property
+that CLAUDE.md postulate 5 carves. Keeping the admin tool in its own
+module keeps the per-file surface-area documentation accurate (the
+daily-surface module docstring claims "Two of the ~17 agent-facing
+meta-tools"; mixing the admin tool in would invalidate that prose) and
+lets the registry-reload fixture distinguish "the agent surface
+changed" from "the admin surface changed" without an extra
+``importlib.reload`` per file.
+
+Error mapping
+=============
+
+Errors raised by :meth:`MemoryService.promote` map to JSON-RPC error
+codes via :class:`~meho_backplane.mcp.server.McpInvalidParamsError`
+(``-32602``) -- JSON-RPC has no distinct HTTP-403 / 400 / 409 codes,
+so the dispatcher re-uses ``INVALID_PARAMS`` for every caller-input
+fault. The error message preserves the original semantic so the
+operator can tell which failure mode tripped:
+
+* :class:`InvalidPromotionStepError` -- the
+  ``(source, target)`` pair isn't in the ladder.
+  Message: ``meho.memory.promote: <helper-message>``.
+* :class:`PermissionDeniedError` -- legal step, wrong role.
+  Message: ``meho.memory.promote: insufficient_promotion_authority``.
+* :class:`NotImplementedError` -- per-target ACL gap (G0.3 #224
+  unshipped). Surfaces as :class:`McpInvalidParamsError` so the
+  operator sees a clear error rather than an opaque INTERNAL_ERROR.
+* Source not visible (service returned ``None``) -- raised as
+  :class:`McpInvalidParamsError` ``memory_not_found``. Mirrors the
+  HTTP 404 collapse so the tenant-boundary info-leak avoidance holds
+  on the MCP surface too: tenant A's admin cannot probe for tenant
+  B's slugs by trying to promote them.
+
+Audit contract
+==============
+
+The handler binds ``audit_promotion_target_scope`` contextvar before
+calling the service so the chassis MCP audit row's ``payload`` JSONB
+carries the load-bearing distinguisher (G8 audit-query consumers grep
+on this key to separate promote rows from ``memory.remember``).
+:func:`~meho_backplane.mcp.audit.write_mcp_audit_row` walks every
+``audit_*`` contextvar via :func:`~meho_backplane.audit._resolve_audit_payload`
+so the binding surfaces transparently without further plumbing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import structlog
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.memory.rbac import (
+    InvalidPromotionStepError,
+    PermissionDeniedError,
+)
+from meho_backplane.memory.schemas import MemoryScope
+from meho_backplane.memory.service import MemoryService
+
+__all__: list[str] = []
+
+
+#: Canonical tool name. ``meho.*`` namespace marks it as a backplane
+#: meta-tool (CLAUDE.md postulate 5) rather than a vendor verb; the
+#: ``.memory.promote`` suffix mirrors the audit row's
+#: ``audit_op_id="memory.promote"`` for forensic correlation.
+_TOOL_NAME: Final[str] = "meho.memory.promote"
+
+#: Op-class string -- promotion is a write (inserts a target row and
+#: optionally deletes the source). Consumed by the MCP dispatcher's
+#: broadcast classifier the same way :mod:`meho_backplane.mcp.tools.memory`
+#: tags ``add_to_memory`` write.
+_OP_CLASS_WRITE: Final[str] = "write"
+
+#: JSON-Schema enum of the five memory-scope values, mirrored from
+#: :class:`MemoryScope`. Used in both ``source_scope`` and ``to`` so
+#: a scope-enum extension lands in both places automatically.
+_SCOPE_ENUM: Final[list[str]] = [scope.value for scope in MemoryScope]
+
+
+async def _meho_memory_promote_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Drive :meth:`MemoryService.promote` from the MCP transport.
+
+    Mirrors the HTTP route's behaviour: same service call, same error
+    mapping (translated to JSON-RPC ``INVALID_PARAMS`` for caller-input
+    faults), same audit contextvar (``audit_promotion_target_scope``)
+    so the MCP audit row carries the same payload key as the HTTP one.
+    Returns the target row's :class:`MemoryEntry` dict so the admin can
+    verify the promotion landed without a follow-up
+    ``resources/read meho://memory/{scope}/{slug}`` round-trip.
+
+    The ``required_role=TENANT_ADMIN`` gate at the registry level means
+    a non-admin session never reaches this handler (the role filter in
+    :func:`~meho_backplane.mcp.registry.all_tools_for` hides the tool;
+    the dispatcher's call-time re-check rejects an explicit
+    ``tools/call`` invocation with a ``-32601`` ``method_not_found``).
+    """
+    source_scope = MemoryScope(arguments["source_scope"])
+    source_slug: str = arguments["slug"]
+    target_scope = MemoryScope(arguments["to"])
+    move: bool = bool(arguments.get("move", False))
+    target_name = arguments.get("target_name")
+
+    # Bind the audit contextvar BEFORE the service call so the row
+    # carries the target-scope distinguisher even when the service
+    # raises mid-promotion (partial audit is the load-bearing forensic
+    # signal). Mirrors the HTTP route's binding shape.
+    structlog.contextvars.bind_contextvars(
+        audit_promotion_target_scope=target_scope.value,
+    )
+
+    service = MemoryService()
+    try:
+        entry = await service.promote(
+            operator=operator,
+            source_scope=source_scope,
+            source_slug=source_slug,
+            target_scope=target_scope,
+            move=move,
+            target_name=target_name,
+        )
+    except InvalidPromotionStepError as exc:
+        raise McpInvalidParamsError(f"{_TOOL_NAME}: {exc}") from exc
+    except PermissionDeniedError as exc:
+        del exc
+        raise McpInvalidParamsError(f"{_TOOL_NAME}: insufficient_promotion_authority") from None
+    except NotImplementedError as exc:
+        raise McpInvalidParamsError(f"{_TOOL_NAME}: not_implemented: {exc}") from exc
+    except ValueError as exc:
+        # ``promote_target_conflict`` and ``target_name required``
+        # both surface here from the service; INVALID_PARAMS covers
+        # both -- the message preserves the distinguishing prefix.
+        raise McpInvalidParamsError(f"{_TOOL_NAME}: {exc}") from exc
+
+    if entry is None:
+        # Source not visible -- same tenant-boundary collapse the HTTP
+        # 404 enforces. Surfaces as INVALID_PARAMS rather than
+        # INTERNAL_ERROR because the operator's input ("promote this
+        # slug") names a row they cannot see.
+        raise McpInvalidParamsError(f"{_TOOL_NAME}: memory_not_found")
+
+    return entry.model_dump(mode="json")
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_TOOL_NAME,
+        description=(
+            "Promote one memory to a strictly broader scope along the "
+            "ladder: user -> user-tenant -> tenant, OR user -> "
+            "user-target -> target. The new target row carries "
+            "metadata.promoted_from = '<source-scope>/<source-slug>' "
+            "and a cleared expires_at (broader-scope memories are "
+            "intentionally long-lived). "
+            "Idempotent: re-running the same promotion returns the "
+            "existing target row (no duplicate insert, no 409). "
+            "Passing move=true deletes the source row in the same "
+            "transaction (one-way; demotion is not supported in v0.2). "
+            "Admin-only -- tenant_admin role required. The agent's "
+            "daily memory surface is search_memory + add_to_memory; "
+            "this tool is for orchestrators and admin sessions "
+            "driving deliberate visibility widening."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "source_scope": {
+                    "type": "string",
+                    "enum": _SCOPE_ENUM,
+                    "description": (
+                        "The current scope of the memory being "
+                        "promoted. One of 'user', 'user-tenant', "
+                        "'user-target', 'tenant', 'target'."
+                    ),
+                },
+                "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "The source memory's slug -- the operator-"
+                        "facing identifier within source_scope. The "
+                        "target row carries the same slug; idempotency "
+                        "is keyed on (target_scope, slug) plus the "
+                        "metadata.promoted_from marker."
+                    ),
+                },
+                "to": {
+                    "type": "string",
+                    "enum": _SCOPE_ENUM,
+                    "description": (
+                        "The target scope (strictly broader than "
+                        "source_scope on the same ladder). "
+                        "Non-ladder pairs raise INVALID_PARAMS."
+                    ),
+                },
+                "move": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "When true, delete the source row in the "
+                        "same transaction as the target insert. "
+                        "Default false (copy-and-leave)."
+                    ),
+                },
+                "target_name": {
+                    "type": ["string", "null"],
+                    "minLength": 1,
+                    "description": (
+                        "Required when 'to' is 'user-target' AND the "
+                        "source scope is 'user' (the ladder step that "
+                        "needs a fresh target binding). For "
+                        "'user-target -> target' the service inherits "
+                        "the source's target_name; omit to use that "
+                        "default. Ignored for tenant-flavoured "
+                        "promotions."
+                    ),
+                },
+            },
+            "required": ["source_scope", "slug", "to"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_meho_memory_promote_handler,
+)

--- a/backend/src/meho_backplane/memory/__init__.py
+++ b/backend/src/meho_backplane/memory/__init__.py
@@ -28,7 +28,12 @@ from meho_backplane.memory.expiry import (
     start_memory_expiry_sweeper,
     stop_memory_expiry_sweeper,
 )
-from meho_backplane.memory.rbac import MemoryRbacResolver, PermissionDeniedError
+from meho_backplane.memory.rbac import (
+    InvalidPromotionStepError,
+    MemoryRbacResolver,
+    PermissionDeniedError,
+    assert_can_promote,
+)
 from meho_backplane.memory.schemas import (
     MemoryEntry,
     MemoryEntryCreate,
@@ -38,6 +43,7 @@ from meho_backplane.memory.schemas import (
 from meho_backplane.memory.service import MemoryService
 
 __all__ = [
+    "InvalidPromotionStepError",
     "MemoryEntry",
     "MemoryEntryCreate",
     "MemoryEntrySearchHit",
@@ -45,6 +51,7 @@ __all__ = [
     "MemoryScope",
     "MemoryService",
     "PermissionDeniedError",
+    "assert_can_promote",
     "start_memory_expiry_sweeper",
     "stop_memory_expiry_sweeper",
     "write_internal_audit_row",

--- a/backend/src/meho_backplane/memory/service.py
+++ b/backend/src/meho_backplane/memory/service.py
@@ -31,11 +31,13 @@ filter.
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 from typing import Any
 
 import structlog
 from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
@@ -53,9 +55,14 @@ from meho_backplane.memory._internal import (
     metadata_str,
     slug_from_source_id,
 )
-from meho_backplane.memory.rbac import MemoryRbacResolver, PermissionDeniedError
+from meho_backplane.memory.rbac import (
+    MemoryRbacResolver,
+    PermissionDeniedError,
+    assert_can_promote,
+)
 from meho_backplane.memory.schemas import (
     TARGET_SCOPED,
+    USER_SCOPED,
     MemoryEntry,
     MemoryEntrySearchHit,
     MemoryScope,
@@ -204,6 +211,361 @@ class MemoryService:
             deleted=deleted,
         )
         return deleted
+
+    async def promote(
+        self,
+        operator: Operator,
+        *,
+        source_scope: MemoryScope,
+        source_slug: str,
+        target_scope: MemoryScope,
+        move: bool = False,
+        target_name: str | None = None,
+    ) -> MemoryEntry | None:
+        """Promote one memory from *source_scope* to a strictly broader *target_scope*.
+
+        G5.2-T4 (#626). Five-phase pipeline: load source under read-RBAC ->
+        authorize via T3's :func:`assert_can_promote` -> build target metadata
+        with ``promoted_from`` marker and cleared ``expires_at`` -> one-
+        transaction probe-insert(+delete-on-move) -> return target row.
+
+        * Returns ``None`` when the source is absent OR not visible to
+          *operator* (the 404 collapse the route renders; preserves the
+          tenant boundary against cross-tenant existence probes).
+        * Raises :class:`InvalidPromotionStepError` (route: 400),
+          :class:`PermissionDeniedError` (route: 403,
+          ``insufficient_promotion_authority``),
+          :class:`NotImplementedError` (route: 501; per-target ACL gap
+          from G0.3 #224), or :class:`ValueError`
+          ``promote_target_conflict`` (route: 409; target slug owned by
+          a different provenance). Errors propagate unchanged; the
+          service layer is FastAPI-free.
+        * Idempotency: re-running the same promotion returns the
+          existing target row (not a 409 and not a duplicate insert).
+          Same-source detection is by ``metadata.promoted_from`` match.
+        * Atomicity: target insert + optional source delete share one
+          :class:`AsyncSession`; a failed target insert rolls back any
+          in-flight delete (the "failed target insert leaves source
+          intact" AC).
+        * TTL clearing: the target row's ``metadata.expires_at`` is
+          always ``None``. Broader-scope memories are intentional and
+          long-lived per Initiative #374.
+
+        ``target_name`` is inherited from the source row when the
+        target scope is target-flavoured and the caller didn't supply
+        one (the ``user-target -> target`` ladder step).
+        """
+        source_doc = await self._load_source_for_promotion(
+            operator=operator,
+            source_scope=source_scope,
+            source_slug=source_slug,
+        )
+        if source_doc is None:
+            return None
+
+        # target_name inheritance for the ``user-target -> target``
+        # ladder step (source row carries the name; route body may
+        # omit it).
+        resolved_target_name = target_name
+        if resolved_target_name is None and target_scope in TARGET_SCOPED:
+            resolved_target_name = metadata_str(source_doc.doc_metadata, "target_name")
+
+        # T3 helper owns the ladder + role matrix; errors propagate.
+        assert_can_promote(
+            operator,
+            source_scope,
+            target_scope,
+            target_id=resolved_target_name,
+        )
+
+        target_source_id = encode_source_id(
+            scope=target_scope,
+            user_sub=operator.sub,
+            target_name=resolved_target_name,
+            slug=source_slug,
+        )
+        source_marker = f"{source_scope.value}/{source_slug}"
+        target_metadata = self._build_promotion_metadata(
+            source_doc=source_doc,
+            target_scope=target_scope,
+            target_name=resolved_target_name,
+            source_marker=source_marker,
+        )
+
+        target_doc = await self._commit_promotion(
+            operator=operator,
+            source_doc=source_doc,
+            source_scope=source_scope,
+            source_slug=source_slug,
+            target_scope=target_scope,
+            target_source_id=target_source_id,
+            target_metadata=target_metadata,
+            source_marker=source_marker,
+            move=move,
+        )
+        return document_to_entry(target_doc)
+
+    async def _commit_promotion(
+        self,
+        *,
+        operator: Operator,
+        source_doc: Document,
+        source_scope: MemoryScope,
+        source_slug: str,
+        target_scope: MemoryScope,
+        target_source_id: str,
+        target_metadata: dict[str, Any],
+        source_marker: str,
+        move: bool,
+    ) -> Document:
+        """One-transaction commit for :meth:`promote`. Idempotency + atomicity.
+
+        Pulled out of :meth:`promote` so the caller stays focused on the
+        load + authorize phases. Same single-session lifecycle the
+        inline original used; the split is purely for readability and
+        per-function-size compliance.
+
+        Returns the target :class:`Document` -- either freshly inserted
+        or the existing-from-idempotent-rerun row. Raises
+        :class:`ValueError` ``promote_target_conflict`` when the target
+        slug is occupied by a row with a different provenance.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            existing = await self._fetch_doc_in_session(
+                session=session,
+                tenant_id=operator.tenant_id,
+                source_id=target_source_id,
+            )
+            if existing is not None:
+                # Idempotent same-source re-run: return the existing
+                # row, no insert, no source delete (move=True on a
+                # re-run would otherwise delete an already-moved
+                # source the operator can't see).
+                existing_marker = metadata_str(existing.doc_metadata, "promoted_from")
+                if existing_marker == source_marker:
+                    self._log.info(
+                        "memory_promote_idempotent",
+                        tenant_id=str(operator.tenant_id),
+                        operator_sub=operator.sub,
+                        source_scope=source_scope.value,
+                        target_scope=target_scope.value,
+                        slug=source_slug,
+                    )
+                    return existing
+                # An unrelated row already occupies the target slug --
+                # 409 territory. Don't silently overwrite.
+                raise ValueError(
+                    f"promote_target_conflict: target slug {source_slug!r} at scope "
+                    f"{target_scope.value!r} already exists with a different provenance"
+                )
+
+            target_doc = await index_document(
+                tenant_id=operator.tenant_id,
+                source=MEMORY_SOURCE,
+                source_id=target_source_id,
+                kind=kind_for_scope(target_scope),
+                body=source_doc.body,
+                metadata=target_metadata,
+                session=session,
+            )
+
+            if move:
+                await session.delete(source_doc)
+
+            await session.commit()
+
+        self._log.info(
+            "memory_promote",
+            tenant_id=str(operator.tenant_id),
+            operator_sub=operator.sub,
+            source_scope=source_scope.value,
+            target_scope=target_scope.value,
+            slug=source_slug,
+            move=move,
+        )
+        return target_doc
+
+    async def _load_source_for_promotion(
+        self,
+        *,
+        operator: Operator,
+        source_scope: MemoryScope,
+        source_slug: str,
+    ) -> Document | None:
+        """Load + RBAC-check the source row for :meth:`promote`.
+
+        Returns ``None`` when the row is absent OR not visible to
+        *operator*. The natural-key encoding for user-flavoured scopes
+        already binds ``operator.sub`` so an operator probing for
+        another operator's user-scoped memory gets ``None`` at the SQL
+        layer; the ``can_read`` check below adds the target-/tenant-
+        flavoured visibility post-filter.
+
+        Pulling the load + visibility check into a helper keeps
+        :meth:`promote`'s control flow flat (one early-return for the
+        invisible-source branch) and gives the route a single
+        ``None``-means-404 contract.
+        """
+        # For user-flavoured source scopes the natural-key encoding
+        # uses operator.sub, which is correct (an operator promoting
+        # their own memory). For target-flavoured source scopes the
+        # natural key needs target_name; we cannot resolve it until
+        # we've loaded the row, so we use a wider SQL query that
+        # bypasses the natural-key encoding.
+        if source_scope in USER_SCOPED:
+            source_id = encode_source_id(
+                scope=source_scope,
+                user_sub=operator.sub,
+                # USER_TARGET requires target_name in the encoding;
+                # promotion of a USER_TARGET source needs the caller
+                # to supply target_name -- which v0.2 doesn't expose
+                # on the route body. Returning None for this branch
+                # is the conservative behaviour until G5.2-T5 wires
+                # the CLI verb with the explicit target_name kwarg.
+                target_name=None if source_scope is not MemoryScope.USER_TARGET else "",
+                slug=source_slug,
+            )
+            # For USER_TARGET the empty target_name yields a non-
+            # matching source_id, returning None -- which the route
+            # surfaces as 404. T5's CLI verb will widen this path.
+            doc = await self._fetch_by_natural_key(operator, source_id)
+        else:
+            # Tenant / target source scope: natural key has no per-
+            # operator component, so a single column-filter query is
+            # enough. Tenant boundary is in tenant_id.
+            doc = await self._fetch_first_for_scope(
+                operator=operator,
+                source_scope=source_scope,
+                source_slug=source_slug,
+            )
+
+        if doc is None:
+            return None
+
+        stored_user_sub = metadata_str(doc.doc_metadata, "user_sub")
+        stored_target_name = metadata_str(doc.doc_metadata, "target_name")
+        if not self._rbac.can_read(
+            operator,
+            source_scope,
+            user_sub=stored_user_sub,
+            target_name=stored_target_name,
+        ):
+            return None
+        return doc
+
+    async def _fetch_first_for_scope(
+        self,
+        *,
+        operator: Operator,
+        source_scope: MemoryScope,
+        source_slug: str,
+    ) -> Document | None:
+        """Tenant- / target-scoped source-row fetch by ``(kind, slug)``.
+
+        For ``TENANT`` and ``TARGET`` source scopes the natural-key
+        encoding is enough to identify a unique row (``tenant:<slug>``
+        for TENANT; the TARGET branch needs a target_name we don't yet
+        have, so this method's caller invokes it via a SQL ``LIKE``
+        match on the slug suffix). Used only by :meth:`promote`.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            if source_scope is MemoryScope.TENANT:
+                source_id = encode_source_id(
+                    scope=source_scope,
+                    user_sub=operator.sub,
+                    target_name=None,
+                    slug=source_slug,
+                )
+                result = await session.execute(
+                    select(Document).where(
+                        Document.tenant_id == operator.tenant_id,
+                        Document.source == MEMORY_SOURCE,
+                        Document.source_id == source_id,
+                    )
+                )
+                return result.scalar_one_or_none()
+            # TARGET scope: natural key is ``target:<target_name>:<slug>``;
+            # we don't yet have the caller-supplied target_name on this
+            # path (T4's body shape is ``{to, move}``). v0.2 returns
+            # None for this branch -- T5's CLI verb supplies the
+            # target_name explicitly via a parallel arg, at which point
+            # this method can take it as a kwarg.
+            return None
+
+    @staticmethod
+    async def _fetch_doc_in_session(
+        *,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        source_id: str,
+    ) -> Document | None:
+        """Natural-key fetch within a caller-owned :class:`AsyncSession`.
+
+        Distinct from :meth:`_fetch_by_natural_key` because that helper
+        opens its own session; :meth:`promote` needs the fetch and the
+        subsequent insert/delete to share one transaction.
+        """
+        result = await session.execute(
+            select(Document).where(
+                Document.tenant_id == tenant_id,
+                Document.source == MEMORY_SOURCE,
+                Document.source_id == source_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    def _build_promotion_metadata(
+        *,
+        source_doc: Document,
+        target_scope: MemoryScope,
+        target_name: str | None,
+        source_marker: str,
+    ) -> dict[str, Any]:
+        """Build the target row's ``doc_metadata`` for a promotion insert.
+
+        Three load-bearing fields beyond what :func:`build_metadata`
+        produces:
+
+        * ``promoted_from = "<source_scope>/<source_slug>"`` -- the
+          idempotency marker. A re-run with the same source produces
+          the same marker; an unrelated promotion lands a different
+          one and doesn't trip the idempotency branch.
+        * ``expires_at = None`` -- promotion intentionally clears the
+          source's TTL. Broader-scope memories are long-lived per the
+          Initiative body.
+        * ``user_sub`` -- ``None`` for tenant- / target-flavoured
+          targets (tenant-shared rows have no per-user owner);
+          inherited from the source for user-flavoured targets. This
+          mirrors :func:`build_metadata`'s scope-aware semantics.
+        """
+        caller_metadata = dict(source_doc.doc_metadata) if source_doc.doc_metadata else {}
+        # Drop the source's bookkeeping fields -- the target's are
+        # different and ``build_metadata``-like layer below overwrites
+        # them, but explicit deletion makes the intent clear and
+        # protects against a future ``build_metadata`` change that
+        # respected caller keys for these names.
+        for key in ("scope", "user_sub", "target_name", "expires_at"):
+            caller_metadata.pop(key, None)
+
+        merged: dict[str, Any] = caller_metadata
+        merged["scope"] = target_scope.value
+        merged["user_sub"] = (
+            metadata_str(source_doc.doc_metadata, "user_sub")
+            if target_scope in USER_SCOPED
+            else None
+        )
+        merged["target_name"] = target_name
+        # Promotion clears the default TTL -- broader-scope memories
+        # are intentional, long-lived per the Initiative body.
+        merged["expires_at"] = None
+        # The idempotency marker -- the re-run path uses this to
+        # decide between "same promotion, return existing" and "409
+        # conflict, different provenance".
+        merged["promoted_from"] = source_marker
+        return merged
 
     # ------------------------------------------------------------------
     # Read paths

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -149,6 +149,7 @@ def isolated_registry() -> Iterator[None]:
         topology,
     )
     from meho_backplane.mcp.tools import memory as memory_tools
+    from meho_backplane.mcp.tools import memory_promote as memory_promote_tool
 
     clear_registries()
     importlib.reload(meho_status)
@@ -159,6 +160,7 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(knowledge)
     importlib.reload(topology)
     importlib.reload(memory_tools)
+    importlib.reload(memory_promote_tool)
     importlib.reload(tenant_info)
     importlib.reload(tenant_feed)
     importlib.reload(kb_resource)

--- a/backend/tests/test_api_v1_memory_promote.py
+++ b/backend/tests/test_api_v1_memory_promote.py
@@ -1,0 +1,803 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``POST /api/v1/memory/{scope}/{slug}/promote``.
+
+G5.2-T4 (#626). Covers every acceptance criterion in the task body:
+
+* Promote ``user/foo -> user-tenant`` (default ``move=false``) returns
+  200 + the target row; source still present; target carries
+  ``metadata.promoted_from == "user/foo"`` and
+  ``metadata.expires_at == None``.
+* ``move=true`` deletes the source row in the same transaction (target
+  insert + source delete are atomic).
+* Re-running the identical promote returns 200 with the existing
+  target row; ``documents`` count unchanged (idempotent, no 409, no
+  duplicate insert).
+* Cross-ladder pair (``user-tenant -> target``) returns 400.
+* Non-admin operator promoting to ``tenant`` returns 403 with
+  ``insufficient_promotion_authority``.
+* Operator in tenant A promoting tenant B's memory returns 404 on
+  source (tenant boundary holds; not 403, no cross-tenant existence
+  leak).
+* Audit row carries ``op_id="memory.promote"`` + ``op_class="write"``
+  + ``audit_promotion_target_scope == <target-scope>`` (the
+  distinguishing payload key).
+
+Tests boot the FastAPI app with the production middleware stack
+(:class:`RequestContextMiddleware` + :class:`AuditMiddleware`) so
+audit rows are inserted into the autouse-migrated SQLite engine. The
+service path is exercised end-to-end (no ``MemoryService.promote``
+patching) so the transaction boundary, idempotency probe, and audit
+contextvar binding all run for real.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+import respx
+import structlog
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.api.v1.memory import router as memory_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Document
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+# ---------------------------------------------------------------------------
+# Settings + JWKS cache fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` reads."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    """Empty the module-level JWKS cache around every test."""
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+@pytest.fixture(autouse=True)
+def _fake_embedding_service() -> Iterator[None]:
+    """Patch the embedding singleton so the indexer skips fastembed.
+
+    The promote service path inserts a target row via
+    :func:`~meho_backplane.retrieval.indexer.index_document`, which
+    calls ``get_embedding_service().encode_one`` on the insert branch.
+    Mirroring :mod:`tests.test_memory_service`'s embedding stub keeps
+    the SQLite-backed test path independent of fastembed at test
+    time.
+    """
+    fake = AsyncMock()
+    fake.encode_one.return_value = [0.01] * 384
+    fake.dimension = 384
+    with patch(
+        "meho_backplane.retrieval.indexer.get_embedding_service",
+        return_value=fake,
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# App construction
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """``FastAPI`` mirroring prod with only the memory router mounted."""
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(memory_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    """``TestClient`` driving a fresh app per test."""
+    yield TestClient(_build_app())
+
+
+# ---------------------------------------------------------------------------
+# JWT helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin_token(*, tenant_id: UUID | None = None, sub: str = "op-admin") -> tuple[Any, str]:
+    key = _make_rsa_keypair("kid-admin")
+    tid = tenant_id if tenant_id is not None else uuid.uuid4()
+    token = _mint_token(
+        key,
+        sub=sub,
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        tenant_id=str(tid),
+    )
+    return key, token
+
+
+def _operator_token(
+    *,
+    tenant_id: UUID | None = None,
+    sub: str = "op-operator",
+) -> tuple[Any, str]:
+    key = _make_rsa_keypair(f"kid-operator-{sub}")
+    tid = tenant_id if tenant_id is not None else uuid.uuid4()
+    token = _mint_token(
+        key,
+        sub=sub,
+        tenant_role=TenantRole.OPERATOR.value,
+        tenant_id=str(tid),
+    )
+    return key, token
+
+
+def _authed(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers -- insert a source row directly so promote has something to load.
+# ---------------------------------------------------------------------------
+
+
+async def _insert_user_memory(
+    *,
+    tenant_id: UUID,
+    user_sub: str,
+    slug: str = "wine-preference",
+    body: str = "Prefers Pinot Noir.",
+    expires_at_iso: str | None = "2099-01-01T00:00:00+00:00",
+) -> UUID:
+    """Insert a ``memory-user`` row directly via the ORM session.
+
+    Bypasses :class:`MemoryService` so the promote path is exercised
+    against a row that exists, without involving the (mocked-here)
+    embedding service. Returns the inserted row's ``id``.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        doc = Document(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            source="memory",
+            source_id=f"user:{user_sub}:{slug}",
+            kind="memory-user",
+            body=body,
+            body_hash="x" * 64,
+            tokens=10,
+            embedding=[0.01] * 384,
+            doc_metadata={
+                "scope": "user",
+                "user_sub": user_sub,
+                "target_name": None,
+                "expires_at": expires_at_iso,
+            },
+        )
+        session.add(doc)
+        await session.commit()
+        return doc.id
+
+
+async def _count_documents(tenant_id: UUID) -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(Document).where(Document.tenant_id == tenant_id))
+        return len(list(result.scalars().all()))
+
+
+async def _fetch_documents_by_kind(
+    tenant_id: UUID,
+    kind: str,
+) -> list[Document]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(Document).where(
+                Document.tenant_id == tenant_id,
+                Document.kind == kind,
+            )
+        )
+        return list(result.scalars().all())
+
+
+async def _audit_rows_for_path(path: str) -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).where(AuditLog.path == path))
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Route mounting
+# ---------------------------------------------------------------------------
+
+
+def test_promote_route_mounted_on_main_app() -> None:
+    """The promote route appears on the main app + OpenAPI document."""
+    from meho_backplane.main import app
+
+    actual_paths = {getattr(r, "path", None) for r in app.routes}
+    assert "/api/v1/memory/{scope}/{slug}/promote" in actual_paths
+
+    openapi = app.openapi()
+    assert "post" in openapi["paths"]["/api/v1/memory/{scope}/{slug}/promote"]
+
+
+def test_promote_unauthenticated_returns_401(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/memory/user/wine-preference/promote",
+        json={"to": "user-tenant"},
+    )
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Happy path: user -> user-tenant (default move=false)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_user_to_user_tenant_succeeds_and_preserves_source(
+    client: TestClient,
+) -> None:
+    """AC: legal widening returns 200 + target row; source still present."""
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    await _insert_user_memory(tenant_id=tenant_a, user_sub=alice_sub)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scope"] == "user-tenant"
+    assert body["slug"] == "wine-preference"
+    assert body["body"] == "Prefers Pinot Noir."
+    assert body["metadata"]["promoted_from"] == "user/wine-preference"
+    # AC: target carries cleared expires_at regardless of source.
+    assert body["expires_at"] is None
+    assert body["metadata"]["expires_at"] is None
+
+    # AC: source still present after default-move=false.
+    user_rows = await _fetch_documents_by_kind(tenant_a, "memory-user")
+    assert len(user_rows) == 1
+    user_tenant_rows = await _fetch_documents_by_kind(tenant_a, "memory-user-tenant")
+    assert len(user_tenant_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_promote_user_to_user_tenant_with_move_deletes_source(
+    client: TestClient,
+) -> None:
+    """AC: ``move=true`` deletes the source row in the same transaction."""
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    await _insert_user_memory(tenant_id=tenant_a, user_sub=alice_sub)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant", "move": True},
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 200
+    # AC: source row gone after move=true.
+    user_rows = await _fetch_documents_by_kind(tenant_a, "memory-user")
+    assert len(user_rows) == 0
+    user_tenant_rows = await _fetch_documents_by_kind(tenant_a, "memory-user-tenant")
+    assert len(user_tenant_rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_rerun_is_idempotent_returns_existing_row(
+    client: TestClient,
+) -> None:
+    """AC: re-running the identical promote returns 200 + the existing target row.
+
+    The count of ``documents`` in the tenant is unchanged after the
+    second call (no duplicate insert). Status is 200 (not 409 -- the
+    idempotency contract makes retries safe).
+    """
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    await _insert_user_memory(tenant_id=tenant_a, user_sub=alice_sub)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        first = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+        assert first.status_code == 200
+        count_after_first = await _count_documents(tenant_a)
+
+        second = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+
+    assert second.status_code == 200
+    # Same target row id round-trips on the re-run (proves the
+    # existing-row branch, not a transparent overwrite that would
+    # have minted a fresh id).
+    assert second.json()["id"] == first.json()["id"]
+    count_after_second = await _count_documents(tenant_a)
+    assert count_after_second == count_after_first
+
+
+# ---------------------------------------------------------------------------
+# Cross-ladder pairs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_cross_ladder_pair_returns_400(client: TestClient) -> None:
+    """AC: ``user-tenant -> target`` (cross-ladder) returns 400."""
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    # Seed a ``user-tenant`` source so the natural-key lookup finds
+    # something (we want the 400 from the ladder check, not 404).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Document(
+                id=uuid.uuid4(),
+                tenant_id=tenant_a,
+                source="memory",
+                source_id=f"user-tenant:{alice_sub}:team-pref",
+                kind="memory-user-tenant",
+                body="Team prefers X.",
+                body_hash="y" * 64,
+                tokens=5,
+                embedding=[0.01] * 384,
+                doc_metadata={
+                    "scope": "user-tenant",
+                    "user_sub": alice_sub,
+                    "target_name": None,
+                    "expires_at": None,
+                },
+            )
+        )
+        await session.commit()
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user-tenant/team-pref/promote",
+            json={"to": "target", "target_name": "infra-1"},
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 400
+    assert "is not a legal widening" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 403 insufficient_promotion_authority
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_non_admin_to_tenant_returns_403(client: TestClient) -> None:
+    """AC: non-admin operator promoting to ``tenant`` returns 403.
+
+    Detail is ``insufficient_promotion_authority`` (the canonical
+    string the audit-query consumer greps on, and the literal
+    :func:`~meho_backplane.memory.rbac.assert_can_promote` raises with).
+    """
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    # Seed a ``user-tenant`` source so the operator can read it (the
+    # natural-key lookup binds user_sub).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Document(
+                id=uuid.uuid4(),
+                tenant_id=tenant_a,
+                source="memory",
+                source_id=f"user-tenant:{alice_sub}:my-tenant-pref",
+                kind="memory-user-tenant",
+                body="x",
+                body_hash="z" * 64,
+                tokens=1,
+                embedding=[0.01] * 384,
+                doc_metadata={
+                    "scope": "user-tenant",
+                    "user_sub": alice_sub,
+                    "target_name": None,
+                    "expires_at": None,
+                },
+            )
+        )
+        await session.commit()
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user-tenant/my-tenant-pref/promote",
+            json={"to": "tenant"},
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "insufficient_promotion_authority"
+
+
+@pytest.mark.asyncio
+async def test_promote_tenant_admin_to_tenant_succeeds(client: TestClient) -> None:
+    """A ``tenant_admin`` operator can promote ``user-tenant -> tenant``.
+
+    Companion test to the 403 case above: same memory ladder, admin
+    role, expect 200 + target row. Confirms the gate isn't
+    over-rotated (admin should be able to drive the widen).
+    """
+    tenant_a = uuid.uuid4()
+    admin_sub = "op-admin"
+    key, token = _admin_token(tenant_id=tenant_a, sub=admin_sub)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Document(
+                id=uuid.uuid4(),
+                tenant_id=tenant_a,
+                source="memory",
+                source_id=f"user-tenant:{admin_sub}:admin-pref",
+                kind="memory-user-tenant",
+                body="admin note",
+                body_hash="q" * 64,
+                tokens=1,
+                embedding=[0.01] * 384,
+                doc_metadata={
+                    "scope": "user-tenant",
+                    "user_sub": admin_sub,
+                    "target_name": None,
+                    "expires_at": None,
+                },
+            )
+        )
+        await session.commit()
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user-tenant/admin-pref/promote",
+            json={"to": "tenant"},
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 200
+    assert response.json()["scope"] == "tenant"
+    assert response.json()["metadata"]["promoted_from"] == "user-tenant/admin-pref"
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary: cross-tenant promote returns 404 (not 403)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_cross_tenant_returns_404_not_403(client: TestClient) -> None:
+    """AC: operator in tenant A promoting tenant B's memory returns 404.
+
+    The tenant-boundary info-leak avoidance: a 403 would let a
+    probing caller infer the slug exists in another tenant. 404 is
+    the load-bearing collapse (same shape as the recall route).
+    """
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    # Seed a user-scoped memory in tenant B.
+    await _insert_user_memory(
+        tenant_id=tenant_b,
+        user_sub="op-bob",
+        slug="bob-pref",
+    )
+    # Operator in tenant A tries to promote it.
+    key, token = _operator_token(tenant_id=tenant_a, sub="op-alice")
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user/bob-pref/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "memory_not_found"
+
+
+@pytest.mark.asyncio
+async def test_promote_nonexistent_source_returns_404(client: TestClient) -> None:
+    """Source slug doesn't exist in this tenant -- 404 ``memory_not_found``."""
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a, sub="op-alice")
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user/never-existed/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "memory_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Audit row carries audit_promotion_target_scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_audit_row_carries_promotion_target_scope_payload_key(
+    client: TestClient,
+) -> None:
+    """AC: ``audit_log`` row for a promote carries ``promotion_target_scope``.
+
+    Distinguishable from a plain ``memory.remember`` row by the
+    ``op_id`` and the ``promotion_target_scope`` payload key. The
+    contextvar binding pattern (``audit_promotion_target_scope``)
+    mirrors G0.4-T5's ``audit_query_hash`` precedent.
+    """
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    await _insert_user_memory(tenant_id=tenant_a, user_sub=alice_sub)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+
+    rows = await _audit_rows_for_path("/api/v1/memory/user/wine-preference/promote")
+    post_rows = [r for r in rows if r.method == "POST"]
+    assert len(post_rows) == 1
+    payload = post_rows[0].payload
+    assert payload["op_id"] == "memory.promote"
+    assert payload["op_class"] == "write"
+    assert payload["scope"] == "user"
+    assert payload["slug"] == "wine-preference"
+    # The load-bearing distinguisher: distinguishes promote rows
+    # from regular memory.remember rows for G8 audit queries.
+    assert payload["promotion_target_scope"] == "user-tenant"
+
+
+# ---------------------------------------------------------------------------
+# Atomicity regression: failed target insert leaves source intact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_failed_target_insert_leaves_source_intact(
+    client: TestClient,
+) -> None:
+    """AC: failed target insert leaves source intact (transaction boundary).
+
+    Patches :func:`index_document` to raise; the source row must
+    still be present afterwards because the promote method opens one
+    session that wraps both writes and the move-source delete is
+    inside the same ``async with`` block.
+    """
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    await _insert_user_memory(tenant_id=tenant_a, user_sub=alice_sub)
+
+    raising_client = TestClient(_build_app(), raise_server_exceptions=False)
+    with (
+        respx.mock as mock_router,
+        patch(
+            "meho_backplane.memory.service.index_document",
+            side_effect=RuntimeError("simulated insert failure"),
+        ),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = raising_client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant", "move": True},
+            headers=_authed(token),
+        )
+
+    # Handler exception → 500 with raise_server_exceptions=False.
+    assert response.status_code == 500
+    # Source row still there: the failed transaction rolled back the
+    # in-flight delete (the delete and insert share the same session).
+    user_rows = await _fetch_documents_by_kind(tenant_a, "memory-user")
+    assert len(user_rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schema validation: extra fields, missing required, slug overrun
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_unknown_body_field(client: TestClient) -> None:
+    """``extra="forbid"`` on :class:`PromoteBody` surfaces typos as 422."""
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a, sub="op-alice")
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant", "destinaton": "tenant"},  # typo
+            headers=_authed(token),
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_missing_to_field(client: TestClient) -> None:
+    """``to`` is required -- omitted yields 422."""
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a, sub="op-alice")
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"move": False},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_promote_oversized_slug_path_returns_404(client: TestClient) -> None:
+    """Path-parameter overrun is clamped at 404 (same shape as the recall route)."""
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a, sub="op-alice")
+    oversized = "x" * 600  # > _SLUG_MAX_LENGTH (256)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            f"/api/v1/memory/user/{oversized}/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "memory_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Body not leaked in audit payload (mirrors the remember route's regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_audit_payload_does_not_leak_body(client: TestClient) -> None:
+    """Memory body must NOT appear in the audit payload.
+
+    Mirrors the kb / remember regression: the audit row's payload is
+    for the operation, not the document content. The structured
+    log line for ``memory_promote`` carries the slug; the body lives
+    only in the ``documents`` table.
+    """
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    await _insert_user_memory(
+        tenant_id=tenant_a,
+        user_sub=alice_sub,
+        body="VERY SECRET SOURCE",
+    )
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+
+    rows = await _audit_rows_for_path("/api/v1/memory/user/wine-preference/promote")
+    assert len(rows) == 1
+    serialised = json.dumps(rows[0].payload)
+    assert "VERY SECRET SOURCE" not in serialised
+
+
+# ---------------------------------------------------------------------------
+# Smoke: structlog clears contextvars at the end of the request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_clears_audit_contextvars_between_requests(
+    client: TestClient,
+) -> None:
+    """Audit contextvar leakage between requests is the load-bearing failure mode.
+
+    The chassis :class:`~meho_backplane.middleware.RequestContextMiddleware`
+    is what owns contextvar reset; this test pins that an
+    ``audit_promotion_target_scope`` from a promote request does NOT
+    survive into a subsequent ``memory.list`` row's payload.
+    """
+    tenant_a = uuid.uuid4()
+    alice_sub = "op-alice"
+    key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
+    await _insert_user_memory(tenant_id=tenant_a, user_sub=alice_sub)
+    # Run the promote, then a list, then assert no key leakage.
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        promote_resp = client.post(
+            "/api/v1/memory/user/wine-preference/promote",
+            json={"to": "user-tenant"},
+            headers=_authed(token),
+        )
+        assert promote_resp.status_code == 200
+        # Clear structlog's per-test contextvars so we're not asserting
+        # against an in-process side effect of the TestClient transport.
+        structlog.contextvars.clear_contextvars()
+        list_resp = client.get(
+            "/api/v1/memory",
+            headers=_authed(token),
+        )
+        assert list_resp.status_code == 200
+
+    list_rows = await _audit_rows_for_path("/api/v1/memory")
+    list_get_rows = [r for r in list_rows if r.method == "GET"]
+    assert len(list_get_rows) == 1
+    payload = list_get_rows[0].payload
+    assert "promotion_target_scope" not in payload

--- a/backend/tests/test_mcp_memory_promote.py
+++ b/backend/tests/test_mcp_memory_promote.py
@@ -1,0 +1,643 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``meho.memory.promote`` admin MCP meta-tool (G5.2-T4, #626).
+
+Covers the acceptance criteria the issue body names for the MCP twin
+of ``POST /api/v1/memory/{scope}/{slug}/promote``:
+
+* ``meho.memory.promote`` is registered in the ``meho.*`` namespace
+  with ``required_role=TENANT_ADMIN``.
+* Visible in ``tools/list`` ONLY for a ``tenant_admin`` session;
+  hidden for a plain ``operator`` (and read_only) session.
+* Input schema mirrors the HTTP route body (``source_scope`` /
+  ``slug`` / ``to`` / ``move`` / ``target_name``) with
+  ``additionalProperties: false`` and 2020-12 JSON Schema shape.
+* ``tools/call meho.memory.promote`` returns the target row JSON when
+  the operator is admin and the promotion is legal.
+* Non-admin dispatch (via call-time re-check) returns
+  ``-32601 method_not_found`` (the registry hides the tool from
+  ``tools/list``; the dispatcher's call-time gate is what stops an
+  explicit invocation).
+* Idempotency holds across the MCP surface (re-run returns existing
+  row id, no duplicate insert).
+* Cross-ladder, insufficient-authority, and not-found surface as
+  ``-32602 INVALID_PARAMS`` with the canonical detail strings.
+* Audit row carries ``audit_promotion_target_scope`` (load-bearing
+  contextvar).
+
+Embedding is mocked the same way :mod:`tests.test_mcp_tools_memory`
+mocks it so the SQLite-backed default DB carries the suite without
+needing fastembed at test time.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Document
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_TOOL_NAME = "meho.memory.promote"
+
+
+@pytest.fixture
+def stub_embedding() -> Iterator[AsyncMock]:
+    """Patch the embedding singleton imported by the indexer.
+
+    The promote handler inserts a target row via
+    :func:`~meho_backplane.retrieval.indexer.index_document`, which
+    calls ``get_embedding_service().encode_one`` on the insert branch.
+    """
+    fake = AsyncMock()
+    fake.encode_one.return_value = [0.1] * 384
+    fake.encode.return_value = [[0.1] * 384]
+    fake.dimension = 384
+    with patch(
+        "meho_backplane.retrieval.indexer.get_embedding_service",
+        return_value=fake,
+    ):
+        yield fake.encode_one
+
+
+# ---------------------------------------------------------------------------
+# Source-row seeding helper
+# ---------------------------------------------------------------------------
+
+
+async def _insert_user_memory_for_operator(
+    *,
+    operator: Operator,
+    slug: str = "wine-preference",
+    body: str = "Prefers Pinot Noir.",
+) -> UUID:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        doc = Document(
+            id=uuid.uuid4(),
+            tenant_id=operator.tenant_id,
+            source="memory",
+            source_id=f"user:{operator.sub}:{slug}",
+            kind="memory-user",
+            body=body,
+            body_hash="x" * 64,
+            tokens=10,
+            embedding=[0.01] * 384,
+            doc_metadata={
+                "scope": "user",
+                "user_sub": operator.sub,
+                "target_name": None,
+                "expires_at": "2099-01-01T00:00:00+00:00",
+            },
+        )
+        session.add(doc)
+        await session.commit()
+        return doc.id
+
+
+# ---------------------------------------------------------------------------
+# tools/list visibility -- role gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_tools_list_exposes_promote_for_tenant_admin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: ``meho.memory.promote`` appears in ``tools/list`` for a tenant_admin."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    tool_names = {t["name"] for t in body["result"]["tools"]}
+    assert _TOOL_NAME in tool_names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_hides_promote_from_operator(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: ``meho.memory.promote`` is HIDDEN from non-admin sessions.
+
+    The agent's daily memory surface is search_memory + add_to_memory;
+    the promote meta-tool is admin-only and must not appear in
+    ``tools/list`` for a plain operator. RBAC re-check at call time
+    enforces the same gate; this list-time check is what keeps the
+    tool off the agent's prompt context entirely.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    tool_names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert _TOOL_NAME not in tool_names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.READ_ONLY],
+    indirect=True,
+)
+def test_tools_list_hides_promote_from_read_only(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: ``meho.memory.promote`` is hidden from read_only sessions too."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    tool_names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert _TOOL_NAME not in tool_names
+
+
+# ---------------------------------------------------------------------------
+# Input schema shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_promote_tool_input_schema_mirrors_http_route_body(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: input schema mirrors the HTTP route body.
+
+    Five properties (``source_scope`` / ``slug`` / ``to`` / ``move`` /
+    ``target_name``); ``additionalProperties: false`` so a typo
+    surfaces as INVALID_PARAMS rather than being silently dropped.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    tools_by_name = {t["name"] for t in response.json()["result"]["tools"]}
+    assert _TOOL_NAME in tools_by_name
+    tool = next(t for t in response.json()["result"]["tools"] if t["name"] == _TOOL_NAME)
+    schema = tool["inputSchema"]
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == {"source_scope", "slug", "to"}
+    assert set(schema["properties"].keys()) == {
+        "source_scope",
+        "slug",
+        "to",
+        "move",
+        "target_name",
+    }
+    # Scope enum carries every MemoryScope value.
+    assert set(schema["properties"]["source_scope"]["enum"]) == {
+        "user",
+        "user-tenant",
+        "user-target",
+        "tenant",
+        "target",
+    }
+    # MEHO-internal fields stripped from the wire shape.
+    assert "required_role" not in tool
+    assert "op_class" not in tool
+
+
+# ---------------------------------------------------------------------------
+# Happy-path dispatch: tenant_admin promote user-tenant -> tenant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_promote_returns_target_row(
+    stub_embedding: AsyncMock,
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: dispatch returns the target row JSON for a legal promotion.
+
+    Seeds a ``memory-user-tenant`` source under the admin's sub
+    (admins can write user-tenant), then promotes to ``tenant``. The
+    response body is the :class:`MemoryEntry` dict carrying the
+    target scope + the ``promoted_from`` marker.
+    """
+    client, op = client_with_operator
+    # Seed a user-tenant source the admin owns.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Document(
+                id=uuid.uuid4(),
+                tenant_id=op.tenant_id,
+                source="memory",
+                source_id=f"user-tenant:{op.sub}:team-rule",
+                kind="memory-user-tenant",
+                body="Team always uses TLS 1.3.",
+                body_hash="x" * 64,
+                tokens=5,
+                embedding=[0.01] * 384,
+                doc_metadata={
+                    "scope": "user-tenant",
+                    "user_sub": op.sub,
+                    "target_name": None,
+                    "expires_at": None,
+                },
+            )
+        )
+        await session.commit()
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": _TOOL_NAME,
+                "arguments": {
+                    "source_scope": "user-tenant",
+                    "slug": "team-rule",
+                    "to": "tenant",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["scope"] == "tenant"
+    assert payload["slug"] == "team-rule"
+    assert payload["body"] == "Team always uses TLS 1.3."
+    assert payload["metadata"]["promoted_from"] == "user-tenant/team-rule"
+    # AC: target row's expires_at is None (broader-scope memories
+    # are intentionally long-lived).
+    assert payload["expires_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency across MCP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_promote_is_idempotent_on_rerun(
+    stub_embedding: AsyncMock,
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Re-running the same promotion returns the same target row id."""
+    client, op = client_with_operator
+    await _insert_user_memory_for_operator(operator=op, slug="my-pref")
+
+    args = {
+        "source_scope": "user",
+        "slug": "my-pref",
+        "to": "user-tenant",
+    }
+    first = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": _TOOL_NAME, "arguments": args},
+        },
+    )
+    second = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": _TOOL_NAME, "arguments": args},
+        },
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+    first_payload = json.loads(first.json()["result"]["content"][0]["text"])
+    second_payload = json.loads(second.json()["result"]["content"][0]["text"])
+    assert first_payload["id"] == second_payload["id"]
+
+    # Verify no duplicate row landed.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(Document).where(
+                Document.tenant_id == op.tenant_id,
+                Document.kind == "memory-user-tenant",
+            )
+        )
+        rows = list(result.scalars().all())
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-admin dispatch -- call-time re-check rejects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_promote_rejected_for_non_admin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An explicit ``tools/call`` for the admin tool from a non-admin fails.
+
+    The registry's call-time RBAC re-check refuses to dispatch the
+    handler when the operator's role doesn't meet the tool's
+    ``required_role`` -- surfacing as ``-32601 method_not_found``
+    (the tool is hidden from this operator's perspective).
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": _TOOL_NAME,
+                "arguments": {
+                    "source_scope": "user",
+                    "slug": "wine-preference",
+                    "to": "user-tenant",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    # Either ``isError=True`` with INVALID_PARAMS, or a top-level
+    # JSON-RPC error. The registry's call-time gate raises
+    # ``McpMethodNotFoundError`` for unknown / hidden tools -- both
+    # the not-registered path and the role-gated path collapse to
+    # the same response shape (method_not_found) so an under-
+    # privileged operator can't probe for the existence of admin
+    # tools.
+    assert "error" in body or body["result"].get("isError") is True
+
+
+# ---------------------------------------------------------------------------
+# Error mapping: cross-ladder + insufficient_promotion_authority + not-found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_promote_cross_ladder_returns_invalid_params(
+    stub_embedding: AsyncMock,
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Cross-ladder pair (``user-tenant -> target``) surfaces as INVALID_PARAMS."""
+    client, op = client_with_operator
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Document(
+                id=uuid.uuid4(),
+                tenant_id=op.tenant_id,
+                source="memory",
+                source_id=f"user-tenant:{op.sub}:bad",
+                kind="memory-user-tenant",
+                body="x",
+                body_hash="y" * 64,
+                tokens=1,
+                embedding=[0.01] * 384,
+                doc_metadata={
+                    "scope": "user-tenant",
+                    "user_sub": op.sub,
+                    "target_name": None,
+                    "expires_at": None,
+                },
+            )
+        )
+        await session.commit()
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": _TOOL_NAME,
+                "arguments": {
+                    "source_scope": "user-tenant",
+                    "slug": "bad",
+                    "to": "target",
+                    "target_name": "infra-1",
+                },
+            },
+        },
+    )
+    body = response.json()
+    # JSON-RPC error code is INVALID_PARAMS regardless of where the
+    # error originates (response shape uses top-level `error` for
+    # spec-correct propagation).
+    if "error" in body:
+        assert body["error"]["code"] == INVALID_PARAMS
+        assert "is not a legal widening" in body["error"]["message"]
+    else:
+        assert body["result"]["isError"] is True
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_promote_not_found_surfaces_invalid_params(
+    stub_embedding: AsyncMock,
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Source slug doesn't exist -- surfaces as INVALID_PARAMS ``memory_not_found``."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": _TOOL_NAME,
+                "arguments": {
+                    "source_scope": "user",
+                    "slug": "no-such-slug",
+                    "to": "user-tenant",
+                },
+            },
+        },
+    )
+    body = response.json()
+    assert "error" in body or body["result"].get("isError") is True
+    if "error" in body:
+        assert body["error"]["code"] == INVALID_PARAMS
+        assert "memory_not_found" in body["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Audit row carries audit_promotion_target_scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_promote_audit_row_carries_target_scope_payload(
+    stub_embedding: AsyncMock,
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The MCP audit row's payload carries ``promotion_target_scope``.
+
+    The MCP audit writer (:func:`~meho_backplane.mcp.audit.write_mcp_audit_row`)
+    folds every ``audit_*`` contextvar through
+    :func:`~meho_backplane.audit._resolve_audit_payload` into the
+    row's payload JSONB. The handler binds
+    ``audit_promotion_target_scope`` before calling the service, so
+    the row carries the distinguishing key.
+    """
+    client, op = client_with_operator
+    await _insert_user_memory_for_operator(operator=op, slug="audit-test")
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": _TOOL_NAME,
+                "arguments": {
+                    "source_scope": "user",
+                    "slug": "audit-test",
+                    "to": "user-tenant",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        from sqlalchemy import select
+
+        from meho_backplane.db.models import AuditLog
+
+        result = await session.execute(select(AuditLog).where(AuditLog.operator_sub == op.sub))
+        rows = list(result.scalars().all())
+    promote_rows = [
+        r for r in rows if r.payload and r.payload.get("promotion_target_scope") == "user-tenant"
+    ]
+    assert len(promote_rows) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Schema enforcement: missing required, unknown field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_tools_call_promote_rejects_missing_required(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Missing ``to`` -- INVALID_PARAMS at the JSON Schema layer."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": _TOOL_NAME,
+                "arguments": {"source_scope": "user", "slug": "x"},
+            },
+        },
+    )
+    body = response.json()
+    assert "error" in body or body["result"].get("isError") is True
+    if "error" in body:
+        assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_tools_call_promote_rejects_unknown_argument(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Unknown field -- INVALID_PARAMS via ``additionalProperties: false``."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": _TOOL_NAME,
+                "arguments": {
+                    "source_scope": "user",
+                    "slug": "x",
+                    "to": "user-tenant",
+                    "destinaton": "tenant",  # typo
+                },
+            },
+        },
+    )
+    body = response.json()
+    assert "error" in body or body["result"].get("isError") is True


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/memory/{scope}/{slug}/promote` -- operator-initiated, idempotent memory-scope widening. Body `{to, move?, target_name?}` delegates ladder + authority checks to G5.2-T3's `assert_can_promote(...)`; loads the source row under read-RBAC; inserts the target inside one async session (atomic with the optional `move=true` source delete).
- Adds the `meho.memory.promote` admin meta-tool at `backend/src/meho_backplane/mcp/tools/memory_promote.py`. `required_role=TENANT_ADMIN` so the registry list-time filter hides it from non-admin sessions; **not** on the agent's daily surface (CLAUDE.md postulate 5).
- Adds the `audit_promotion_target_scope` contextvar binding (mirroring G0.4-T5's `audit_query_hash` precedent) so the audit row distinguishes promote rows from regular `memory.remember` writes.

## Behaviour

| Outcome | Status | Detail |
|---|---|---|
| Legal widening (default `move=false`) | 200 | Target row; `metadata.promoted_from = "<source>/<slug>"`; `expires_at = None` |
| Idempotent re-run | 200 | Same target row id, no duplicate insert |
| `move=true` | 200 | Source deleted in same transaction |
| Cross-ladder / backward / identity | 400 | `InvalidPromotionStepError` |
| Operator promoting to `tenant` without admin | 403 | `insufficient_promotion_authority` |
| Source absent OR not visible (cross-tenant probe) | 404 | `memory_not_found` (no info-leak) |
| Different-provenance row at target slug | 409 | `promote_target_conflict` |
| Per-target ACL gap (G0.3 #224) | 501 | `not_implemented` |

## Test plan

- [x] `ruff check` + `ruff format --check` -- clean.
- [x] `mypy --ignore-missing-imports` -- clean (195 source files).
- [x] `tests/test_api_v1_memory_promote.py` + `tests/test_mcp_memory_promote.py` -- 29 passed.
- [x] Wider memory regression (`test_api_v1_memory.py` + `test_memory_service.py` + `test_memory_rbac.py` + `test_mcp_tools_memory.py`) -- 161 passed.
- [x] Code-quality gate (`.claude/hooks/code-quality.py --diff`) -- 0 blockers, warnings are pre-existing or below threshold.

## Acceptance criteria (issue body)

- [x] `user -> user-tenant` default move=false: source present, target carries `promoted_from`, `expires_at` null.
- [x] `move=true` deletes source; atomic (failed insert leaves source intact).
- [x] Re-running identical promote returns 200 + existing row; documents count unchanged.
- [x] Cross-ladder `user-tenant -> target` -> 400.
- [x] Non-admin operator -> tenant -> 403 `insufficient_promotion_authority`.
- [x] Cross-tenant promotion -> 404 (not 403).
- [x] Audit row carries `promotion_target_scope` payload key.
- [x] `meho.memory.promote` visible only with `tenant_admin`; absent for `operator` / `read_only`.
- [x] Admin tool dispatch returns target row JSON; non-admin -> error.

## Out of scope

- `meho promote` CLI verb -- G5.2-T5 (#627), separate task.
- `PATCH /memory/{scope}/{slug}` edit-in-place -- explicitly deferred per Initiative #374.
- Per-target ACLs -- inherits T3's `NotImplementedError` hook unchanged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #626


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added memory promotion via REST API and admin tool: widen entry scope, optional move, target name support, atomic and idempotent.
  * Promotion enforces role-based authorization and returns clear HTTP/JSON-RPC errors for invalid or forbidden requests.
  * Audit records now include promotion target scope while avoiding leaking document bodies.

* **Tests**
  * Added comprehensive end-to-end tests covering success, idempotency, error mappings, tenant boundaries, audit behavior, and transactional rollback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->