### PR TITLE
perf(ci): python-lint-test on meho-runners-ci-heavy + -n 6 (#761 Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,13 @@ jobs:
     # github.event_name != 'pull_request'. Job-level (not step-level)
     # so no step ever starts on a fork PR.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: meho-runners-ci
+    # Dedicated heavy ARC scale set (6000m requests=limits, max 5 pods)
+    # for the unit suite only — #761. The other jobs (Go, Helm,
+    # integration) stay on the 4-core `meho-runners-ci` pool; only the
+    # pytest sweep is CPU-bound enough to want the extra cores. Heavy
+    # pool scales from 0, so an idle period costs one cold-start on the
+    # next run. Provisioned RDC-side in rdc-gitops#55.
+    runs-on: meho-runners-ci-heavy
     # 50-min cap: this job is the deterministic required gate — ruff
     # + ruff-format + mypy + the unit pytest sweep with
     # tests/integration/ EXCLUDED (--ignore=tests/integration). The
@@ -245,16 +251,22 @@ jobs:
         # `-n auto --dist loadscope` 2007/0/0 — identical, empty
         # failure set; local wall-clock serial 10:18 → xdist 6:14
         # (limited by core count; CI multi-core gets the ~49→~10 min).
-        # -n 3: pinned. -n auto was inconsistent on these ARC pods —
-        # run 26164020459 (main, 2026-05-20 12:57Z) reported 4 workers,
-        # a later same-day PR push reported 8. The variance points at
-        # cgroup-aware CPU detection mismatches (or pod-size drift);
-        # either way, pinning removes the ambiguity and the context-
-        # switch tax `-n auto` was silently paying. 3 reserves headroom
-        # for the xdist coordinator + the DinD daemon (testcontainers
-        # pgvector/valkey fire from unit-suite tests too, not just the
-        # integration job — see MEHO_TEST_PGVECTOR_IMAGE env above).
-        # --dist loadscope: a module's
+        # -n 6: pinned, matched to the dedicated `meho-runners-ci-heavy`
+        # scale set's 6000m guaranteed cores (#761). History: -n auto
+        # was inconsistent on the shared 4-core pool (run 26164020459
+        # reported 4 workers, a later same-day push reported 8 — cgroup
+        # detection drift), so #726 pinned -n 3 (N-1, leaving a core for
+        # the coordinator + DinD on the burstable 4-core pool). The heavy
+        # pool is QoS Guaranteed (requests=limits=6000m), so the
+        # host-core-detection ambiguity is gone and the headroom math
+        # changes: 6 workers fully subscribe the pod. The xdist
+        # coordinator is mostly IPC-blocked and DinD is near-idle during
+        # pure-CPU test execution (testcontainers pgvector/valkey only
+        # burst at spin-up — see MEHO_TEST_PGVECTOR_IMAGE env above), so
+        # full subscription is the intended trade. If the #761 wall/
+        # variance measurement shows oversubscription symptoms (high
+        # variance, wall not improving vs -n 3), drop to -n 5 (N-1) as
+        # the fallback. --dist loadscope: a module's
         # tests stay on one worker so module-/session-scoped fixtures
         # (testcontainers PG, embedding service) instantiate per
         # worker, not per test. --maxfail=1 preserves the old `-x`
@@ -293,10 +305,10 @@ jobs:
         # not yet on the CI's Python) does not apply.
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            COVERAGE_CORE=sysmon uv run pytest -n 3 --dist loadscope --maxfail=1 --ignore=tests/integration \
+            COVERAGE_CORE=sysmon uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration \
               --cov=meho_backplane --cov-report=xml tests/
           else
-            uv run pytest -n 3 --dist loadscope --maxfail=1 --ignore=tests/integration tests/
+            uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration tests/
           fi
 
       - name: Upload Python coverage artifact


### PR DESCRIPTION
## Summary

Phase 2 of #761. Switches the `python-lint-test` job to the dedicated `meho-runners-ci-heavy` ARC scale set and bumps the unit pytest sweep `-n 3` → `-n 6`.

- **`runs-on: meho-runners-ci` → `meho-runners-ci-heavy`** for `python-lint-test` only. Other three jobs (Go, Helm, `python-integration`) stay on the dense 4-core `meho-runners-ci` pool.
- **`-n 3` → `-n 6`** in both the push-mode (`COVERAGE_CORE=sysmon ... --cov`) and PR-mode branches of the pytest invocation.

Phase 1 (the heavy scale set, 6000m requests=limits, max 5 pods) landed RDC-side via [rdc-gitops#55](https://github.com/evoila-bosnia/rdc-gitops/pull/55) and is registered + healthy against evoila/meho (confirmed on #761 at 2026-05-20T21:36Z).

## Worker-count note (`-n 6` vs `-n 5`)

#726 pinned `-n 3` (N−1) on the burstable 4-core pool to leave a core for the xdist coordinator + DinD, and to dodge the `-n auto` host-core-detection drift (4-vs-8 workers run to run). The heavy pool is QoS **Guaranteed** (requests=limits=6000m), so that detection ambiguity is gone. `-n 6` fully subscribes the pod — the coordinator is IPC-blocked and DinD is near-idle during pure-CPU test execution, so full subscription is the intended trade. **Documented fallback: if #761's wall/variance measurement shows oversubscription (high variance, wall not beating `-n 3`), drop to `-n 5`.**

## Test plan

- [x] YAML valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Only `python-lint-test` switched pools; Go / Helm / integration jobs confirmed unchanged on `meho-runners-ci`
- [x] Local smoke: `pytest -n 6 --dist loadscope` spawns 6 workers cleanly, 43/43 passed on a two-file subset
- [ ] CI green on this PR (first PR-mode wall data point on the heavy pool)
- [ ] **Post-merge measurement (per #761 AC):** report first 3 PR-mode walls + first 3 push-mode walls back on #761; confirm variance ≤ 4min and walls ≤ 14min before declaring the heavy pool earns its place

## Note

This PR's own CI is the first real measurement of the heavy pool under PR-mode. The heavy pool scales from 0, so this run pays a one-time cold-start for the first pod.

Refs #761


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to use heavier test runners and increase parallel test workers (6) for faster, more reliable test execution while preserving existing test selection and failure handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->