### PR TITLE
Adding flag to not verify its installation binary

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -55,6 +55,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true  # coverage artifact may not exist yet (no tests)
 
+      - name: Ensure dirmngr is available (for sonar-scanner GPG verify)
+        run: |
+          set -euo pipefail
+          if ! command -v dirmngr >/dev/null 2>&1; then
+            sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -y
+            sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends dirmngr
+          fi
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995  # v8.1.0
         with: 

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -65,7 +65,5 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995  # v8.1.0
-        with: 
-          skipSignatureVerification: true
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -57,5 +57,7 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995  # v8.1.0
+        with: 
+          skipSignatureVerification: true
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->
<!-- Copyright (c) 2026 evoila Group -->

## Description

<!-- What and why -->

## Related issue

<!-- Closes #N -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] CI / build / chore

## Checklist

- [ ] Conventional Commits format on every commit
- [ ] Every commit has a `Signed-off-by:` line (DCO; `git commit -s`)
- [ ] Tests added/updated where applicable
- [ ] Documentation updated where applicable
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated: code-quality scan configured to skip signature verification for the scanning step.
  * CI workflow adds a pre-scan step to ensure a required system package is present on runners.
  * No user-facing functionality or public interfaces were modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->