### PR TITLE
fix(memory): G0.9.1-T3 share default-TTL resolver between REST and MCP

### DIFF
--- a/backend/src/meho_backplane/api/v1/memory.py
+++ b/backend/src/meho_backplane/api/v1/memory.py
@@ -101,7 +101,7 @@ is the single source of truth for the safe-URL alphabet so a typo
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime
 from typing import Any, Final
 
 import structlog
@@ -119,7 +119,7 @@ from meho_backplane.memory import (
     PermissionDeniedError,
 )
 from meho_backplane.memory.schemas import SLUG_PATTERN
-from meho_backplane.settings import get_settings
+from meho_backplane.memory.ttl import resolve_default_expires_at
 
 __all__ = ["MemoryListResponse", "RememberBody", "router"]
 
@@ -175,19 +175,18 @@ _LIST_LIMIT_MAX: Final[int] = 500
 def _resolve_default_ttl(body: RememberBody) -> datetime | None:
     """Return the effective ``expires_at`` for a ``remember`` write.
 
-    G5.2-T2 (#624). Implements the default-TTL injection contract for
-    ``POST /api/v1/memory``:
+    Thin REST-side adapter over
+    :func:`meho_backplane.memory.ttl.resolve_default_expires_at`. The
+    shared resolver carries the G5.2-T2 (#624) policy; this wrapper's
+    only job is to translate Pydantic's ``model_fields_set`` view of
+    "field absent from JSON" vs "field present with value null" into
+    the primitives shape the resolver expects.
 
-    * :attr:`MemoryScope.USER` scope **and** ``expires_at`` field
-      absent from the request body → ``now(UTC) +
-      Settings.memory_user_default_ttl_days``.
-    * Any other scope (``user-tenant`` / ``user-target`` / ``tenant``
-      / ``target``) → :attr:`RememberBody.expires_at` unchanged
-      (which is ``None`` when omitted, mirroring G5.1 behaviour).
-    * Explicit ``"expires_at": null`` on ``user`` scope → ``None``
-      (the CLI ``--persist`` opt-out shape: persist forever).
-    * Explicit ``"expires_at": "<ISO-8601>"`` on ``user`` scope → that
-      datetime verbatim (the caller picked a cutoff; no override).
+    G0.9.1-T3 (#775) introduced the shared resolver so the MCP
+    ``add_to_memory`` tool applies the same default-TTL discrimination
+    -- previously the MCP path always passed ``expires_at`` explicitly
+    to :meth:`MemoryService.remember` and the default never fired on
+    that surface, producing a silent divergence between REST and MCP.
 
     The "field absent" vs "explicit null" discrimination uses
     :attr:`BaseModel.model_fields_set` (pydantic v2): the set carries
@@ -199,30 +198,12 @@ def _resolve_default_ttl(body: RememberBody) -> datetime | None:
     path. Verified against the installed pydantic 2.13.4 (`uv run
     python -c "from pydantic import BaseModel; ..."` -- explicit
     ``b=None`` is in ``model_fields_set``, absent ``b`` is not).
-
-    Why only ``MemoryScope.USER``: consumer-needs.md §G5's
-    "session-scoped hints expire by default" rule targets the per-
-    operator-only scope (``kind="memory-user"``); ``user-tenant`` and
-    ``user-target`` rows are team-shared coordinates the consumer
-    spec leaves operator-controlled. The Task body pins this to
-    ``kind == "memory-user"`` -- not the broader "any user-* scope"
-    -- so the surface stays narrow until a future Task widens it
-    with an explicit hierarchy decision.
     """
-    if "expires_at" in body.model_fields_set:
-        # Caller supplied the field (either an ISO timestamp or
-        # explicit null); honour their intent verbatim. This branch
-        # is the CLI ``--persist`` opt-out path when the value is
-        # ``None``.
-        return body.expires_at
-    if body.scope is not MemoryScope.USER:
-        # Default only fires on the ``memory-user`` kind per #624.
-        # Other scopes fall through to the G5.1 baseline (no auto-TTL,
-        # row persists until an operator deletes it or G5.2's
-        # promote/expire verbs touch it).
-        return None
-    settings = get_settings()
-    return datetime.now(UTC) + timedelta(days=settings.memory_user_default_ttl_days)
+    return resolve_default_expires_at(
+        body.scope,
+        expires_at_was_set="expires_at" in body.model_fields_set,
+        explicit_expires_at=body.expires_at,
+    )
 
 
 class RememberBody(BaseModel):

--- a/backend/src/meho_backplane/mcp/tools/memory.py
+++ b/backend/src/meho_backplane/mcp/tools/memory.py
@@ -87,12 +87,20 @@ TTL semantics
 The handler parses it into a concrete ``expires_at`` timestamp before
 calling the service so the storage layer sees the same wall-clock
 shape it accepts on the REST surface (T2 #422). A missing ``ttl`` on
-a user-scope write picks up the **default 7-day TTL** that G5.2 #374
-will inject when its background expiry executor lands; for G5.1 the
-metadata column simply stores ``None`` and the read-side filter
-treats it as "never expires". The tool description names this
-contract explicitly so an agent that wants a specific lifetime knows
-to set ``ttl``, and an agent that wants the default knows to omit it.
+a user-scope write picks up the **default TTL** from
+``MEMORY_USER_DEFAULT_TTL_DAYS`` (7 days at the
+``Settings.memory_user_default_ttl_days`` default) via the shared
+:func:`~meho_backplane.memory.ttl.resolve_default_expires_at` resolver
+the REST handler uses. An explicit ``null`` (the CLI ``--persist``
+opt-out) bypasses the default and persists the row forever; non-user
+scopes never see the default. G0.9.1-T3 (#775) lifted the resolver
+into a shared helper so both surfaces stay in sync -- previously the
+MCP path bypassed the discrimination, producing a silent regression
+where user-scope memories written via MCP never expired. The tool
+description names this contract explicitly so an agent that wants a
+specific lifetime knows to set ``ttl``, an agent that wants
+persistence knows to pass ``null``, and an agent that wants the
+default knows to omit it.
 """
 
 from __future__ import annotations
@@ -106,6 +114,7 @@ from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.memory.rbac import PermissionDeniedError
 from meho_backplane.memory.schemas import MemoryScope
 from meho_backplane.memory.service import MemoryService
+from meho_backplane.memory.ttl import resolve_default_expires_at
 
 __all__: list[str] = []
 
@@ -269,10 +278,13 @@ async def _add_to_memory_handler(
       surfaces as JSON-Schema validation failure (``-32602``) before
       this handler runs.
     * Parsing the optional ``ttl`` ISO 8601 duration into an absolute
-      ``expires_at``. The service stores the parsed timestamp in
-      ``doc_metadata.expires_at`` and the read-side filter uses it
-      directly; G5.2's expiry executor reaps rows whose ``expires_at``
-      has passed.
+      ``expires_at`` and resolving the G5.2-T2 (#624) default-TTL
+      contract via :func:`resolve_default_expires_at` so a user-scope
+      write with ``ttl`` omitted injects ``now(UTC) +
+      memory_user_default_ttl_days`` (parity with the REST surface).
+      G0.9.1-T3 (#775) closed the divergence -- previously this
+      handler always passed ``expires_at`` to the service, defeating
+      the surface-layer "set vs unset" split.
     * Catching :class:`PermissionDeniedError` from the service's RBAC
       matrix (most commonly: an ``operator`` role attempting a
       ``TENANT`` write) and re-raising as
@@ -297,13 +309,28 @@ async def _add_to_memory_handler(
     # it up uniformly across MCP and REST writes.
     metadata: dict[str, Any] | None = {"tags": list(tags)} if tags is not None else None
 
-    expires_at: datetime | None = None
-    ttl_raw = arguments.get("ttl")
-    if ttl_raw is not None:
-        try:
-            expires_at = _parse_iso_duration(ttl_raw)
-        except ValueError as exc:
-            raise McpInvalidParamsError(f"add_to_memory: {exc}") from exc
+    # Discriminate "ttl absent from JSON" from "ttl explicitly null".
+    # The MCP dispatcher's JSON-Schema gate (additionalProperties:
+    # false) already rejects unknown keys, so ``"ttl" in arguments``
+    # is the canonical set-vs-unset signal for this surface -- the
+    # exact analogue of pydantic's ``model_fields_set`` on the REST
+    # side. Without this split, ``arguments.get("ttl")`` returning
+    # ``None`` collapses the ``--persist`` opt-out into the default
+    # path and the divergence #775 fixes reappears.
+    ttl_was_set = "ttl" in arguments
+    explicit_expires_at: datetime | None = None
+    if ttl_was_set:
+        ttl_raw = arguments["ttl"]
+        if ttl_raw is not None:
+            try:
+                explicit_expires_at = _parse_iso_duration(ttl_raw)
+            except ValueError as exc:
+                raise McpInvalidParamsError(f"add_to_memory: {exc}") from exc
+    expires_at = resolve_default_expires_at(
+        scope,
+        expires_at_was_set=ttl_was_set,
+        explicit_expires_at=explicit_expires_at,
+    )
 
     service = MemoryService()
     try:
@@ -428,10 +455,11 @@ register_mcp_tool(
             "prefer extending its body (re-add with same slug, body-hash "
             "short-circuit updates in place). "
             "TTL is optional, formatted as ISO 8601 duration ('P7D' = "
-            "7 days, 'PT1H' = 1 hour). Omit to accept the backend "
-            "default (G5.2 #374 will inject a 7-day TTL on user-scope "
-            "writes; tenant- and target-scope writes default to no "
-            "expiry). "
+            "7 days, 'PT1H' = 1 hour). Omit on a 'user'-scope write to "
+            "accept the backend default (7-day expiry from "
+            "MEMORY_USER_DEFAULT_TTL_DAYS); pass explicit null to "
+            "persist forever; tenant- and target-scope writes default "
+            "to no expiry. "
             "Do NOT use this for durable, generalizable team knowledge — "
             "that belongs in `add_to_knowledge`. Memory is for shorter-"
             "lived, operator/tenant/target-scoped state."
@@ -465,10 +493,11 @@ register_mcp_tool(
                     "description": (
                         "Optional ISO 8601 duration ('P7D', 'PT1H', "
                         "'PT30M'). Months and years are not accepted "
-                        "(variable-length). Omit to accept the backend "
-                        "default — G5.2 #374 will inject a 7-day TTL on "
-                        "user-scope writes; tenant/target writes default "
-                        "to no expiry."
+                        "(variable-length). Omit on a 'user'-scope write "
+                        "to accept the backend default (7 days from "
+                        "MEMORY_USER_DEFAULT_TTL_DAYS); pass null to "
+                        "persist forever (the CLI --persist opt-out); "
+                        "tenant/target writes default to no expiry."
                     ),
                 },
                 "target_name": {

--- a/backend/src/meho_backplane/memory/ttl.py
+++ b/backend/src/meho_backplane/memory/ttl.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared default-TTL resolver for the memory write surfaces.
+
+G5.2-T2 (#624) introduced default-TTL injection on user-scope memory
+writes: when the caller omits ``expires_at`` and the scope is
+:attr:`MemoryScope.USER`, the surface layer injects
+``now(UTC) + Settings.memory_user_default_ttl_days``. Two opt-outs
+remain explicit:
+
+* explicit ``null`` (the CLI ``--persist`` shape) → ``None``.
+* explicit ISO-8601 timestamp → honoured verbatim.
+
+G0.9.1-T3 (#775) lifted this resolver out of
+:mod:`meho_backplane.api.v1.memory` so both the REST handler **and**
+the MCP ``add_to_memory`` tool consume the same discrimination. Prior
+to that, the MCP handler always passed ``expires_at`` explicitly to
+:meth:`MemoryService.remember` -- defeating the "set vs unset" split
+the REST layer modelled with :attr:`BaseModel.model_fields_set`.
+
+Why a primitives-shape signature
+================================
+
+The resolver takes the raw triple ``(scope, expires_at_was_set,
+explicit_expires_at)`` rather than a Pydantic model so the MCP entry
+point -- which receives plain ``dict[str, Any]`` arguments and has no
+Pydantic shell on the inbound shape -- can call it without
+synthesising a fake model. Each caller decides locally what "the
+field was set" means:
+
+* The REST handler uses :attr:`RememberBody.model_fields_set` -- the
+  pydantic-v2-canonical way to discriminate "field absent from JSON"
+  from "field present with value null".
+* The MCP handler uses ``"ttl" in arguments`` -- the dispatcher
+  populates ``arguments`` only with the keys the inbound JSON-RPC
+  payload carried (the JSON-Schema ``additionalProperties: false``
+  guard already rejects unknown keys upstream), so membership is the
+  same set-vs-unset discriminant.
+
+The policy itself lives here -- one place to change the default
+windowing, one place to widen the gate to other scopes, one place
+the test suite pins.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from meho_backplane.memory.schemas import MemoryScope
+from meho_backplane.settings import get_settings
+
+__all__ = ["resolve_default_expires_at"]
+
+
+def resolve_default_expires_at(
+    scope: MemoryScope,
+    *,
+    expires_at_was_set: bool,
+    explicit_expires_at: datetime | None,
+) -> datetime | None:
+    """Return the effective ``expires_at`` for a memory write.
+
+    Parameters
+    ----------
+    scope
+        The memory scope being written. Only :attr:`MemoryScope.USER`
+        is in scope for the default-TTL gate per #624.
+    expires_at_was_set
+        ``True`` when the caller supplied ``expires_at`` (REST) or
+        ``ttl`` (MCP) explicitly -- including an explicit ``null`` /
+        omitted-duration shape. ``False`` when the field was absent
+        from the inbound payload.
+    explicit_expires_at
+        The caller-supplied value when ``expires_at_was_set`` is
+        ``True``; ignored otherwise.
+
+    Returns
+    -------
+    datetime | None
+        * ``explicit_expires_at`` verbatim when the caller set the
+          field (the CLI ``--persist`` opt-out path returns ``None``
+          here).
+        * ``None`` when the scope is not :attr:`MemoryScope.USER`
+          (per #624's narrow gate).
+        * ``now(UTC) + memory_user_default_ttl_days`` otherwise.
+    """
+    if expires_at_was_set:
+        return explicit_expires_at
+    if scope is not MemoryScope.USER:
+        return None
+    settings = get_settings()
+    return datetime.now(UTC) + timedelta(days=settings.memory_user_default_ttl_days)

--- a/backend/tests/test_mcp_tools_memory.py
+++ b/backend/tests/test_mcp_tools_memory.py
@@ -519,6 +519,175 @@ async def test_tools_call_add_to_memory_applies_ttl(
     assert delta < 60, f"expected ~7 days from {before}, got {parsed} (delta={delta}s)"
 
 
+# ---------------------------------------------------------------------------
+# G0.9.1-T3 (#775): default-TTL injection on the MCP add_to_memory path
+# ---------------------------------------------------------------------------
+#
+# The MCP handler delegates the default-TTL decision to the same
+# :func:`meho_backplane.memory.ttl.resolve_default_expires_at` resolver
+# the REST handler uses. The discrimination on the MCP side is
+# ``"ttl" in arguments`` (the dispatcher only carries keys the inbound
+# JSON-RPC payload supplied, gated by ``additionalProperties: false``);
+# the canonical opt-outs match the REST surface:
+#
+# * ``ttl`` omitted on user-scope → ``now + 7d`` default (load-bearing
+#   parity with REST's ``model_fields_set`` branch on the same shape).
+# * Explicit ``"ttl": null`` on user-scope → no expiry (CLI ``--persist``
+#   parity).
+# * Non-user scopes (``user-tenant`` etc.) → no default even with ``ttl``
+#   omitted, mirroring #624's narrow gate.
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_user_scope_no_ttl_injects_default(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC #1: omitted ``ttl`` on ``user`` scope → ``expires_at ~ now + 7d``.
+
+    Closes the regression #775 documents: prior to G0.9.1 the MCP path
+    always passed ``expires_at`` explicitly to ``service.remember``
+    (including ``None`` when ``ttl`` was absent), defeating the
+    surface-layer "set vs unset" split and silently producing memories
+    with ``expires_at=null`` -- so user-scope MCP writes lived forever
+    despite the documented 7-day default.
+
+    Tolerance window mirrors the existing ``applies_ttl`` test:
+    ``parsed`` should land within ±60 s of ``before + 7 d`` so a slow
+    test machine never flakes.
+    """
+    client, _op = client_with_operator
+
+    before = datetime.now(UTC)
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Operator-scope note that should age out.",
+                    "scope": "user",
+                    "slug": "default-ttl-user",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    # The persisted row carries the injected default. Without the fix
+    # this would be ``None``.
+    assert payload["expires_at"] is not None, (
+        "user-scope MCP write with omitted ttl must inject the default "
+        f"expires_at; got payload={payload}"
+    )
+    parsed = datetime.fromisoformat(payload["expires_at"])
+    expected = before + timedelta(days=7)
+    delta = abs((parsed - expected).total_seconds())
+    assert delta < 60, f"expected ~7 days from {before}, got {parsed} (delta={delta}s)"
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_user_scope_explicit_null_ttl_persists(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC #2: explicit ``"ttl": null`` on ``user`` scope → no expiry.
+
+    Load-bearing opt-out parity with the REST surface: the CLI
+    ``--persist`` flag emits ``"expires_at": null`` and the agent
+    surface mirrors it with ``"ttl": null``. Discrimination is
+    ``"ttl" in arguments`` -- ``arguments.get("ttl") is None`` would
+    collapse this branch into the default path and silently override
+    the operator's pin-forever intent.
+    """
+    client, _op = client_with_operator
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Pin this note forever (CLI --persist parity).",
+                    "scope": "user",
+                    "slug": "persist-forever-user",
+                    "ttl": None,
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False, body
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["expires_at"] is None, (
+        f"explicit ttl=null must opt out of the default; got payload={payload}"
+    )
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_user_tenant_scope_no_default_ttl(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC #3: non-``user`` scopes bypass the default even with ``ttl`` omitted.
+
+    #624 narrows the default to ``kind == "memory-user"``. Pinning the
+    ``user-tenant`` scope here prevents a future refactor that widened
+    the gate to ``USER_SCOPED`` from silently expiring team-shared
+    memories on the MCP path. Parity with the equivalent REST test
+    ``test_remember_user_tenant_scope_no_default_ttl``.
+    """
+    client, _op = client_with_operator
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Team-shared note in this tenant.",
+                    "scope": "user-tenant",
+                    "slug": "team-note-mcp",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False, body
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["expires_at"] is None, (
+        f"non-user scope must not get the default ttl; got payload={payload}"
+    )
+
+
 @pytest.mark.parametrize(
     "client_with_operator",
     [TenantRole.OPERATOR],

--- a/docs/codebase/memory.md
+++ b/docs/codebase/memory.md
@@ -1,0 +1,120 @@
+# `memory/` — server-side memory layer
+
+> Durable map of the memory write surface — REST `/api/v1/memory*`,
+> MCP `add_to_memory` / `search_memory`, CLI `meho memory remember`.
+> Update in lock-step with code changes; stale entries are bugs.
+
+## Overview
+
+`backend/src/meho_backplane/memory/` exposes the five-scope memory
+layer consumer-needs.md §G5 defines (`user` / `user-tenant` /
+`user-target` / `tenant` / `target`) on top of the G0.4 documents
+table. Three transports — the REST router under `/api/v1/memory`, the
+MCP `add_to_memory` / `search_memory` meta-tools, and the CLI `meho
+memory` verb — all funnel through a single tenant-scoped
+`MemoryService` that owns the RBAC matrix and the substrate I/O.
+
+## Key types
+
+| Symbol | Module | What it is |
+|---|---|---|
+| `MemoryService.remember(...)` | `memory/service.py` | Tenant-scoped write entry. Persists one row via `index_document`; RBAC matrix and slug validation run here. |
+| `MemoryScope` | `memory/schemas.py` | Five-value `StrEnum`: `user`, `user-tenant`, `user-target`, `tenant`, `target`. |
+| `MemoryRbacResolver` | `memory/rbac.py` | Per-scope write/read matrix. `tenant` writes require `tenant_admin`. |
+| `RememberBody` | `api/v1/memory.py` | Pydantic v2 frozen model, `extra="forbid"`. REST request shape. |
+| `_add_to_memory_handler` | `mcp/tools/memory.py` | MCP write handler. Receives `dict[str, Any]` arguments from the dispatcher. |
+| `resolve_default_expires_at` | `memory/ttl.py` | Shared default-TTL resolver. Called by both REST and MCP write paths. |
+
+## Control flow — write path (default-TTL contract)
+
+The default-TTL policy (G5.2-T2 #624: omitted `expires_at` on a
+`user`-scope write injects `now + memory_user_default_ttl_days`) lives
+in **one** place — `memory/ttl.py:resolve_default_expires_at`. Both
+surface layers consume it.
+
+```
+REST POST /api/v1/memory
+    body: RememberBody (pydantic)
+    │
+    └─> _resolve_default_ttl(body)
+        │   expires_at_was_set = "expires_at" in body.model_fields_set
+        │   explicit_expires_at = body.expires_at
+        └─> resolve_default_expires_at(scope, ...)
+                │
+                └─> MemoryService.remember(expires_at=...)
+
+MCP tools/call add_to_memory
+    arguments: dict[str, Any]
+    │
+    │   ttl_was_set = "ttl" in arguments
+    │   explicit_expires_at = _parse_iso_duration(arguments["ttl"])
+    │       (when ttl_was_set and value is not None)
+    │
+    └─> resolve_default_expires_at(scope, ...)
+            │
+            └─> MemoryService.remember(expires_at=...)
+```
+
+The discrimination on each side picks a surface-native "field absent
+from the payload" signal:
+
+* REST uses **pydantic v2's `model_fields_set`** — the set carries
+  every field the constructor saw, even when the value was `null`.
+  Verified against pydantic 2.13.4: explicit `b=None` is in
+  `model_fields_set`; absent `b` is not.
+* MCP uses **dict membership (`"ttl" in arguments`)** — the JSON-RPC
+  dispatcher only populates `arguments` with keys the inbound payload
+  carried, and `additionalProperties: false` on the tool's
+  `inputSchema` already rejected unknown keys upstream.
+
+The three semantic branches are:
+
+| Caller shape | `expires_at_was_set` | `explicit_expires_at` | Resolver returns |
+|---|---|---|---|
+| Field omitted, `scope=user` | `False` | (n/a) | `now + memory_user_default_ttl_days` |
+| Field omitted, non-`user` scope | `False` | (n/a) | `None` |
+| Field present, value `null` (CLI `--persist`) | `True` | `None` | `None` |
+| Field present, value `<ISO-8601>` | `True` | the parsed datetime | the parsed datetime |
+
+Why this matters: before G0.9.1-T3 (#775) the MCP path always passed
+`expires_at` explicitly to `MemoryService.remember` — including
+`None` when the caller omitted `ttl` — so the surface-layer "set vs
+unset" split was defeated and user-scope memories written via MCP
+never expired (silent data-retention regression in v0.3.1). The fix
+lifts the resolver into a shared helper both layers call with their
+own set-vs-unset signal.
+
+## Dependencies
+
+* **`meho_backplane.retrieval.indexer.index_document`** — the
+  substrate write the service wraps. Owns the actual SQL.
+* **`meho_backplane.settings.Settings.memory_user_default_ttl_days`** —
+  env-var-controlled (`MEMORY_USER_DEFAULT_TTL_DAYS`), default 7. The
+  shared resolver is the only reader; widening the default-TTL gate
+  to other scopes is a one-line change in `memory/ttl.py`.
+* **`meho_backplane.mcp.tools.memory._parse_iso_duration`** — parses
+  the wire-string ISO 8601 duration ("P7D", "PT1H") into an absolute
+  `datetime`. Months/years rejected (variable-length).
+
+## Known issues
+
+* The MCP `add_to_memory` schema names the body field `content` while
+  the REST + KB schemas use `body` — sibling task #779 (G0.9.1-T7)
+  closes that asymmetry separately. Out of scope here.
+* Non-`user` scopes have no default-TTL gate by design (per #624's
+  narrow scope). A future Task widening it should change the
+  `scope is not MemoryScope.USER` branch in `memory/ttl.py` and add
+  matching tests on both surfaces.
+
+## References
+
+* Goal #221 — Foundational substrate; parents the v0.3.x stream.
+* Initiative #772 — G0.9.1 v0.3.2 dogfood hardening; this Task ships
+  as part of it.
+* Task #775 — apply default-TTL injection on the MCP `add_to_memory`
+  path (the work this doc captures).
+* Task #624 (G5.2-T2) — original default-TTL contract for the REST
+  surface.
+* Best-practices: `python_best_practices.md` (don't duplicate
+  validation logic across entry points — one canonical resolver;
+  pydantic set-vs-unset is the idiomatic discriminator).


### PR DESCRIPTION
## Summary
- Lift the user-scope default-TTL resolver from `api/v1/memory.py` into a new shared `memory/ttl.py` so both the REST handler and the MCP `add_to_memory` tool consume the same `(scope, set?, value)` discrimination.
- Fixes the v0.3.1 dogfood regression (Signal #10): the MCP path silently bypassed the default-TTL gate, producing user-scope memories with `expires_at=null` despite the documented 7-day default. REST behaviour is unchanged.
- MCP set-vs-unset signal is `"ttl" in arguments` -- the JSON-RPC dispatcher only populates `arguments` with keys the inbound payload carried (`additionalProperties: false` upstream), which is the dict-membership analogue of pydantic's `model_fields_set` on the REST side.
- Adds `docs/codebase/memory.md` documenting the shared write surface and the per-layer discriminants.

## Test plan
- [x] `ruff check` -- clean (changed files)
- [x] `ruff format --check` -- clean (post-format)
- [x] `mypy backend/src/meho_backplane/api/v1/memory.py backend/src/meho_backplane/mcp/tools/memory.py backend/src/meho_backplane/memory/ttl.py` -- clean
- [x] `pytest tests/test_mcp_tools_memory.py tests/test_api_v1_memory.py -x -q` -- 60 passed
- [x] `pytest tests/test_memory_service.py tests/test_memory_rbac.py tests/test_memory_expiry.py tests/test_mcp_resources_memory.py -x -q` -- 131 passed (no behaviour drift in the surrounding memory layer)
- [x] `code-quality.py --diff` -- 0 blockers; 5 pre-existing legacy warnings on file/function sizes in `api/v1/memory.py` and `mcp/tools/memory.py` (not introduced by this change)

Acceptance criteria from the issue:

- [x] MCP `add_to_memory` with `scope=user` and no `ttl` -> `expires_at ~= now + memory_user_default_ttl_days` (`test_tools_call_add_to_memory_user_scope_no_ttl_injects_default`).
- [x] MCP `add_to_memory` with `scope=user` and explicit `"ttl": null` -> `expires_at = null` (`test_tools_call_add_to_memory_user_scope_explicit_null_ttl_persists`).
- [x] MCP `add_to_memory` with an explicit ISO-8601 `ttl` -> that expiry (existing `test_tools_call_add_to_memory_applies_ttl`, unchanged).
- [x] REST behaviour unchanged -- existing G5.2-T2 (#624) tests still pass verbatim.

## Out of scope
- The `content` -> `body` rename on the MCP `add_to_memory` schema is sibling task #779 (G0.9.1-T7); merging may cause a rebase here.
- Widening the default-TTL gate beyond `MemoryScope.USER` -- #624 deliberately narrowed it; future widening is a one-line change in `memory/ttl.py` with matching tests.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #775


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User-scoped memory items now default to 7-day expiration when time-to-live is not specified
  * Explicit null values prevent automatic expiration across all APIs
  * Memory expiration behavior is now consistent across REST and MCP interfaces

* **Documentation**
  * Added comprehensive documentation explaining memory scopes and time-to-live behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->