### PR TITLE
fix(connectors): reconcile GET /api/v1/connectors with the dispatcher resolve path (#773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed
+
+- Reconcile `GET /api/v1/connectors` with the dispatcher resolve path
+  so no listed `connector_id` is unresolvable. Drops stale-rename DB
+  rows (e.g. pre-`k8s` `kubernetes-asyncio-1.x` survivors from G3.2
+  #320) whose emitted `connector_id` cannot round-trip through
+  `parse_connector_id` + `connector_exists`. Adds `ConnectorListItem.state`
+  (`"ingested"` for DB-backed dispatchable rows, `"registered"` for
+  class-side-only opless entries) so an agent / operator browsing the
+  catalog distinguishes a connector the dispatcher will resolve from one
+  that's registered but not yet dispatchable. De-circularises the
+  `UnknownConnectorError` message to no longer point at the listing as
+  the remediation for a listed-but-unresolvable id. Closes Signal #6
+  from the 2026-05-21 RDC v0.3.1 dogfood
+  ([#773](https://github.com/evoila/meho/issues/773)).
+
 ## [0.3.1] - 2026-05-21
 
 **v0.3.0 dogfood-hardening patch.** No new headline features — this

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -63,6 +63,7 @@ from pydantic import BaseModel, ConfigDict, Field
 __all__ = [
     "ConnectorListItem",
     "ConnectorListResponse",
+    "ConnectorState",
     "ConnectorStatusFilter",
     "EditGroupBody",
     "EditOpBody",
@@ -204,6 +205,33 @@ class IngestResponse(BaseModel):
     grouping: GroupingResultModel | None = None
 
 
+#: Lifecycle state of a row in the ``GET /api/v1/connectors`` response.
+#:
+#: G0.9.1-T1 (#773). Splits the two operator-meaningful states the listing
+#: surfaces:
+#:
+#: * ``"ingested"`` — the connector has at least one row in
+#:   ``operation_group`` / ``endpoint_descriptor`` and the dispatcher can
+#:   resolve it via :func:`~meho_backplane.operations._lookup.connector_exists`.
+#:   ``call_operation`` / ``list_operation_groups`` / ``search_operations``
+#:   will return data (or a documented empty) for this ``connector_id``.
+#: * ``"registered"`` — the connector class is registered in the v2 registry
+#:   (via :func:`~meho_backplane.connectors.registry.register_connector_v2`)
+#:   but no descriptor / group rows exist yet. The dispatcher cannot
+#:   resolve it; ``list_operation_groups`` / ``search_operations`` /
+#:   ``call_operation`` return ``UnknownConnectorError`` (REST → 404).
+#:   The state is *visible-but-not-dispatchable*: operators see the
+#:   connector exists, but know not to call it until the ingest /
+#:   typed-op registration lands rows under it.
+#:
+#: Rows whose ``connector_id`` round-trips through
+#: :func:`parse_connector_id` to a triple the dispatcher cannot resolve
+#: (stale-rename DB rows, class-side-only entries whose v2-registry
+#: product disagrees with the parser's derived product) are dropped
+#: before the listing returns — they have no operator-meaningful state.
+ConnectorState = Literal["ingested", "registered"]
+
+
 class ConnectorListItem(BaseModel):
     """One row in the ``GET /api/v1/connectors`` response.
 
@@ -220,6 +248,20 @@ class ConnectorListItem(BaseModel):
     ``operation_count`` is the sum of operations across all groups
     in scope. Useful for the CLI's
     ``meho connector list --status staged`` summary view.
+
+    ``state`` (G0.9.1-T1 / #773) distinguishes *dispatchable* rows
+    (``"ingested"`` — DB-backed, resolves through the dispatcher) from
+    *registered-but-empty* rows (``"registered"`` — v2-registry entries
+    without descriptor rows yet). Rows that wouldn't round-trip
+    through the resolver at all (stale-impl_id DB rows, v2 entries
+    whose registry product disagrees with the parser's derived
+    product) are filtered out before the response is built;
+    ``connector_id``s the listing emits are guaranteed to resolve
+    through :func:`~meho_backplane.operations._lookup.connector_exists`
+    when ``state == "ingested"``, and explicitly labelled
+    not-yet-dispatchable when ``state == "registered"``. Defaults to
+    ``"ingested"`` so existing call sites (tests, MCP fakes)
+    construct rows without breakage.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -234,6 +276,7 @@ class ConnectorListItem(BaseModel):
     enabled_group_count: int
     disabled_group_count: int
     operation_count: int
+    state: ConnectorState = "ingested"
 
 
 class ConnectorListResponse(BaseModel):

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from uuid import UUID
 
+import structlog
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -63,6 +64,7 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations._lookup import connector_exists, parse_connector_id
 from meho_backplane.operations.ingest._llm_grouping_internals import build_connector_id
 from meho_backplane.operations.ingest.api_schemas import (
     ConnectorListItem,
@@ -70,6 +72,8 @@ from meho_backplane.operations.ingest.api_schemas import (
 )
 
 __all__ = ["list_ingested_connectors"]
+
+_log = structlog.get_logger(__name__)
 
 
 def _matches_status_filter(
@@ -237,14 +241,37 @@ async def list_ingested_connectors(
 
     * DB-backed rows from ``operation_group`` / ``endpoint_descriptor``
       — the connectors that have made it through (or are mid-way
-      through) the review pipeline. These sort first.
+      through) the review pipeline. These sort first and carry
+      ``state="ingested"``.
     * Class-side registrations from the v2 connector registry that
       have no DB rows yet ("State 0.5"). These append with
-      ``group_count: 0, operation_count: 0`` so an operator sees
-      every registered connector. Class-only entries are always
+      ``group_count: 0, operation_count: 0`` and ``state="registered"``
+      so an operator sees every registered connector but knows the
+      dispatcher won't resolve a call against it until ingestion /
+      typed-op registration lands rows. Class-only entries are always
       built-in (``tenant_id IS NULL``); they're filtered out under
       an explicit ``status`` narrowing (no groups ⇒ nothing to
       review).
+
+    G0.9.1-T1 (#773) listing-integrity contract
+    -------------------------------------------
+
+    Every ``connector_id`` this function returns is guaranteed to
+    round-trip through the dispatcher resolve path: for ``state ==
+    "ingested"`` rows,
+    :func:`~meho_backplane.operations._lookup.connector_exists` returns
+    ``True`` for
+    :func:`~meho_backplane.operations._lookup.parse_connector_id` of
+    the emitted ``connector_id``. Rows whose emitted ``connector_id``
+    would not round-trip (stale-rename DB rows whose ``impl_id`` no
+    longer appears under any registered class, v2-registry entries
+    whose registry ``product`` disagrees with what the parser derives
+    from ``impl_id``) are dropped before the response is built and a
+    structured ``dropped_unresolvable_connector_id`` log event is
+    emitted per drop. This closes Signal #6 from the 2026-05-21 RDC
+    v0.3.1 dogfood: an LLM browsing the catalog can no longer pick a
+    listed ``connector_id`` only to have every downstream call return
+    ``HTTP 404`` / ``-32603 UnknownConnectorError``.
     """
     sm = sessionmaker if sessionmaker is not None else get_sessionmaker()
     async with sm() as session:
@@ -263,6 +290,16 @@ async def list_ingested_connectors(
         if not _matches_status_filter(row, status):
             continue
         connector_id = build_connector_id(product, version, impl_id)
+        if not await _resolves_through_dispatcher(
+            operator=operator,
+            connector_id=connector_id,
+            source_product=product,
+            source_version=version,
+            source_impl_id=impl_id,
+            tenant_uuid=tenant_uuid,
+            source="db",
+        ):
+            continue
         items.append(
             ConnectorListItem(
                 connector_id=connector_id,
@@ -275,6 +312,7 @@ async def list_ingested_connectors(
                 enabled_group_count=row["enabled"],
                 disabled_group_count=row["disabled"],
                 operation_count=op_counts_by_connector.get(key, 0),
+                state="ingested",
             ),
         )
     items.extend(_class_side_only_items(groups_by_connector.keys(), status=status))
@@ -302,29 +340,168 @@ def _class_side_only_items(
     ``status`` narrowing (``staged`` / ``enabled`` / ``disabled``) the
     rows are excluded: zero groups means nothing to review and would
     otherwise pollute the review-queue view.
+
+    G0.9.1-T1 (#773): the emitted ``product`` / ``connector_id`` are
+    derived from the parser's interpretation of the v2-registry
+    ``impl_id``, not the registry's ``product`` field, so the
+    ``connector_id`` round-trips losslessly through
+    :func:`parse_connector_id`. For SDDC the v2 registry stores
+    ``product="sddc-manager"`` but the listing emits ``product="sddc"``
+    (consistent with what the dispatcher will derive from
+    ``parse_connector_id("sddc-rest-9.0")`` and what
+    ``SDDC_PRODUCT="sddc"`` already writes into ``endpoint_descriptor``
+    rows). When DB rows eventually land under the same row-product the
+    parser derives, the listing transitions cleanly from
+    ``state="registered"`` to ``state="ingested"`` without a
+    ``connector_id`` change. Entries whose ``connector_id`` cannot
+    round-trip at all (parser-incompatible ``impl_id`` shape) are
+    dropped with a structured log line.
     """
     if status not in (None, "all"):
         return []
+    # Dedupe against the DB-emitted set using the row-side natural key
+    # (the dispatcher's parsed triple). This keeps the SDDC case clean:
+    # the v2 registry holds ``("sddc-manager", "9.0", "sddc-rest")`` but
+    # DB rows live under ``("sddc", ...)``; matching on the registry
+    # triple would miss the dedupe and emit two rows for the same
+    # connector (one ``ingested`` from the DB loop, one ``registered``
+    # here). Comparing against the parser-derived triple — the same
+    # triple the DB loop emits — drops the duplicate cleanly.
     db_triples = {(product, version, impl_id) for (_, product, version, impl_id) in db_keys}
     rows: list[ConnectorListItem] = []
     for product, version, impl_id in sorted(all_connectors_v2().keys()):
         if not version or not impl_id:
             # v1-compat shim — see docstring.
             continue
-        if (product, version, impl_id) in db_triples:
+        connector_id = build_connector_id(product, version, impl_id)
+        try:
+            parsed_product, parsed_version, parsed_impl_id = parse_connector_id(connector_id)
+        except ValueError:
+            _log.warning(
+                "dropped_unresolvable_connector_id",
+                source="v2_registry",
+                connector_id=connector_id,
+                registry_product=product,
+                registry_version=version,
+                registry_impl_id=impl_id,
+                reason="parse_connector_id_raised",
+            )
+            continue
+        if (parsed_version, parsed_impl_id) != (version, impl_id):
+            # The parser cannot recover the (version, impl_id) the
+            # registry advertises; even if a DB row eventually lands
+            # under the registry's natural key, the dispatcher will
+            # parse this connector_id to a different triple and fail
+            # to resolve. Drop and log — there is no clean
+            # remediation from inside the listing.
+            _log.warning(
+                "dropped_unresolvable_connector_id",
+                source="v2_registry",
+                connector_id=connector_id,
+                registry_product=product,
+                registry_version=version,
+                registry_impl_id=impl_id,
+                parsed_product=parsed_product,
+                parsed_version=parsed_version,
+                parsed_impl_id=parsed_impl_id,
+                reason="impl_id_or_version_not_recoverable_from_connector_id",
+            )
+            continue
+        if (parsed_product, parsed_version, parsed_impl_id) in db_triples:
+            # DB rows already represent this connector under the
+            # parser-derived natural key; the DB-loop emitted the
+            # ingested row, so skip the class-only ``registered`` row
+            # to avoid duplication. Covers both the trivial case
+            # (registry product == parsed product) and the SDDC case
+            # (registry product "sddc-manager" vs parsed "sddc").
             continue
         rows.append(
             ConnectorListItem(
-                connector_id=build_connector_id(product, version, impl_id),
-                product=product,
-                version=version,
-                impl_id=impl_id,
+                connector_id=connector_id,
+                product=parsed_product,
+                version=parsed_version,
+                impl_id=parsed_impl_id,
                 tenant_id=None,
                 group_count=0,
                 staged_group_count=0,
                 enabled_group_count=0,
                 disabled_group_count=0,
                 operation_count=0,
+                state="registered",
             ),
         )
     return rows
+
+
+async def _resolves_through_dispatcher(
+    *,
+    operator: Operator,
+    connector_id: str,
+    source_product: str,
+    source_version: str,
+    source_impl_id: str,
+    tenant_uuid: UUID | None,
+    source: str,
+) -> bool:
+    """Return whether *connector_id* round-trips through the dispatcher resolve path.
+
+    Parses ``connector_id`` the same way the dispatcher's
+    :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
+    /
+    :func:`~meho_backplane.operations.meta_tools.search_operations`
+    /
+    :func:`~meho_backplane.operations.meta_tools.call_operation`
+    would, then probes existence with the same tenant-visibility
+    filter
+    :func:`~meho_backplane.operations._lookup.connector_exists`
+    enforces. Returns ``True`` only when the dispatcher would also
+    return ``True``.
+
+    Drops + structured-logs every miss so operators / observability
+    surface every stale-rename row and every v2-registry
+    misalignment in the audit trail. The log line carries both the
+    source-row triple and the parsed triple so the
+    remediation is obvious from a single log fetch (delete the
+    stale row, or correct the v2 registration's ``product``).
+    """
+    try:
+        parsed_product, parsed_version, parsed_impl_id = parse_connector_id(connector_id)
+    except ValueError:
+        _log.warning(
+            "dropped_unresolvable_connector_id",
+            source=source,
+            connector_id=connector_id,
+            row_product=source_product,
+            row_version=source_version,
+            row_impl_id=source_impl_id,
+            row_tenant_id=str(tenant_uuid) if tenant_uuid is not None else None,
+            reason="parse_connector_id_raised",
+        )
+        return False
+    # Visibility-scope probe via the same helper the dispatcher
+    # uses. The tenant scope is the operator's; the source row's
+    # tenant_id is logged for the audit trail but not used to
+    # widen the visibility filter (cross-tenant stale rows
+    # should not surface either way).
+    exists = await connector_exists(
+        tenant_id=operator.tenant_id,
+        product=parsed_product,
+        version=parsed_version,
+        impl_id=parsed_impl_id,
+    )
+    if not exists:
+        _log.warning(
+            "dropped_unresolvable_connector_id",
+            source=source,
+            connector_id=connector_id,
+            row_product=source_product,
+            row_version=source_version,
+            row_impl_id=source_impl_id,
+            row_tenant_id=str(tenant_uuid) if tenant_uuid is not None else None,
+            parsed_product=parsed_product,
+            parsed_version=parsed_version,
+            parsed_impl_id=parsed_impl_id,
+            reason="dispatcher_resolve_path_missed_parsed_triple",
+        )
+        return False
+    return True

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -278,7 +278,10 @@ async def list_operation_groups(
     ):
         raise UnknownConnectorError(
             f"unknown connector_id {connector_id!r} — expected <impl_id>-<version> "
-            f"(e.g. 'vmware-rest-9.0', 'vault-1.x'); see GET /api/v1/connectors"
+            f"(e.g. 'vmware-rest-9.0', 'vault-1.x'). If this id appeared in "
+            f"GET /api/v1/connectors, the listing is inconsistent with the "
+            f"dispatcher's resolve path — please file a bug report; otherwise "
+            f"the id is mistyped or the connector is not registered on this deploy"
         )
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -386,7 +389,10 @@ async def search_operations(
     ):
         raise UnknownConnectorError(
             f"unknown connector_id {connector_id!r} — expected <impl_id>-<version> "
-            f"(e.g. 'vmware-rest-9.0', 'vault-1.x'); see GET /api/v1/connectors"
+            f"(e.g. 'vmware-rest-9.0', 'vault-1.x'). If this id appeared in "
+            f"GET /api/v1/connectors, the listing is inconsistent with the "
+            f"dispatcher's resolve path — please file a bug report; otherwise "
+            f"the id is mistyped or the connector is not registered on this deploy"
         )
     started = time.monotonic()
     sessionmaker = get_sessionmaker()

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -661,6 +661,23 @@ async def test_list_surfaces_register_connector_v2_only_entries(
     see "connector registered ⇒ visible in list". Built-in
     (``tenant_id IS NULL``); ``group_count`` / ``operation_count``
     both ``0``.
+
+    G0.9.1-T1 (#773) extends T5 with two refinements:
+
+    * Class-side-only rows carry ``state="registered"`` so an LLM /
+      operator browsing the catalog distinguishes
+      *registered-but-not-yet-dispatchable* from *ingested-and-ready*.
+    * The emitted ``product`` is what
+      :func:`~meho_backplane.operations._lookup.parse_connector_id`
+      derives from the ``connector_id``, not the v2 registry's
+      ``product`` field. For SDDC the registry stores
+      ``product="sddc-manager"`` but the listing emits ``"sddc"`` —
+      consistent with what the dispatcher derives from
+      ``parse_connector_id("sddc-rest-9.0")`` and with
+      ``SDDC_PRODUCT="sddc"`` writing into ``endpoint_descriptor``
+      rows. When DB rows land under the parser-derived product the
+      row transitions cleanly from ``state="registered"`` to
+      ``state="ingested"`` without a ``connector_id`` change.
     """
     tenant_a = uuid.uuid4()
     key, token = _operator_token(tenant_id=tenant_a)
@@ -682,12 +699,18 @@ async def test_list_surfaces_register_connector_v2_only_entries(
     assert harbor["enabled_group_count"] == 0
     assert harbor["disabled_group_count"] == 0
     assert harbor["operation_count"] == 0
+    assert harbor["state"] == "registered"
 
     assert "sddc-rest-9.0" in by_id
     sddc = by_id["sddc-rest-9.0"]
-    assert sddc["product"] == "sddc-manager"
+    # The listing emits the parser-derived product ("sddc"), not the
+    # v2 registry's "sddc-manager" — see test docstring for rationale.
+    assert sddc["product"] == "sddc"
+    assert sddc["impl_id"] == "sddc-rest"
+    assert sddc["version"] == "9.0"
     assert sddc["operation_count"] == 0
     assert sddc["group_count"] == 0
+    assert sddc["state"] == "registered"
 
 
 @pytest.mark.asyncio
@@ -720,6 +743,309 @@ async def test_list_class_only_entries_excluded_under_status_narrowing(
     seen_ids = {c["connector_id"] for c in response.json()["connectors"]}
     assert "vmware-rest-9.0" in seen_ids
     assert "harbor-rest-2.x" not in seen_ids
+
+
+# ---------------------------------------------------------------------------
+# G0.9.1-T1 (#773) listing-integrity contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_drops_stale_impl_id_rows_whose_connector_id_will_not_resolve(
+    client: TestClient,
+) -> None:
+    """A stale-rename row that won't round-trip is filtered out.
+
+    G0.9.1-T1 (#773) regression for Signal #6 in the 2026-05-21 RDC
+    v0.3.1 dogfood. The consumer deploy carried ``operation_group`` /
+    ``endpoint_descriptor`` rows under ``impl_id="kubernetes-asyncio"``
+    from the G3.2 (#320) ship, but the connector now registers under
+    ``impl_id="k8s"``. ``GET /api/v1/connectors`` emitted
+    ``"kubernetes-asyncio-1.x"`` for the stale rows; every dispatcher
+    call against that id then returned ``HTTP 404 UnknownConnector``
+    because the parser derives ``product="kubernetes"`` from
+    ``connector_id``, but the seeded rows are under
+    ``product="k8s"``. Round-trip lost.
+
+    The fix: drop any DB-backed row whose emitted ``connector_id``
+    doesn't round-trip through
+    :func:`~meho_backplane.operations._lookup.connector_exists`. The
+    listing now never advertises an id the dispatcher cannot resolve.
+    """
+    tenant_a = uuid.uuid4()
+    # Stale-rename row matching the consumer's deploy: rows live under
+    # product="k8s" but with the pre-rename impl_id="kubernetes-asyncio".
+    # build_connector_id emits "kubernetes-asyncio-1.x"; parse_connector_id
+    # derives product="kubernetes", which connector_exists won't find.
+    await _seed_connector(
+        tenant_id=None,
+        product="k8s",
+        version="1.x",
+        impl_id="kubernetes-asyncio",
+        group_count=1,
+        ops_per_group=2,
+        source_kind="typed",
+    )
+    # Healthy control row so the listing isn't empty.
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        group_count=1,
+        ops_per_group=1,
+    )
+
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    connectors = response.json()["connectors"]
+    seen_ids = {c["connector_id"] for c in connectors}
+
+    assert "vmware-rest-9.0" in seen_ids
+    assert "kubernetes-asyncio-1.x" not in seen_ids
+
+
+@pytest.mark.asyncio
+async def test_list_every_connector_id_round_trips_through_dispatcher(
+    client: TestClient,
+    _registered_class_only_connectors: None,
+) -> None:
+    """Every emitted ``connector_id`` resolves through ``connector_exists``.
+
+    G0.9.1-T1 (#773) acceptance criterion #2 (verbatim):
+
+        every ``connector_id`` returned by ``list_ingested_connectors``
+        resolves true through
+        ``connector_exists(parse_connector_id(connector_id))`` —
+        asserted over a seeded DB that includes a stale-impl_id row
+        and a class-side-only opless connector.
+
+    Seeds a stale-rename row (filtered out), a healthy DB-backed row
+    (kept, ``state="ingested"``), and exercises the class-side-only
+    registered-but-empty path via the ``_registered_class_only_connectors``
+    fixture (kept, ``state="registered"``). The assertion: for every
+    row the listing returns where ``state == "ingested"``, the
+    dispatcher's
+    :func:`~meho_backplane.operations._lookup.connector_exists` returns
+    ``True`` for the parsed triple. ``state == "registered"`` rows are
+    explicitly *not* dispatchable yet; they're surfaced as a discovery
+    signal, and the operator / agent reads ``state`` to know they
+    can't call ops against them.
+    """
+    from meho_backplane.auth.operator import Operator, TenantRole
+    from meho_backplane.operations._lookup import (
+        connector_exists,
+        parse_connector_id,
+    )
+
+    tenant_a = uuid.uuid4()
+    # Stale-rename row — dispatcher cannot resolve emitted connector_id.
+    await _seed_connector(
+        tenant_id=None,
+        product="k8s",
+        version="1.x",
+        impl_id="kubernetes-asyncio",
+        group_count=1,
+        ops_per_group=1,
+        source_kind="typed",
+    )
+    # Healthy ingested row — dispatcher resolves cleanly.
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        group_count=1,
+        ops_per_group=2,
+    )
+
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    connectors = response.json()["connectors"]
+    operator = Operator(
+        sub="op-roundtrip",
+        name="Round-Trip Probe",
+        email=None,
+        raw_jwt="header.payload.signature",
+        tenant_id=tenant_a,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+    # Stale id must not surface.
+    seen_ids = {c["connector_id"] for c in connectors}
+    assert "kubernetes-asyncio-1.x" not in seen_ids
+    # Healthy ingested row must surface as ingested.
+    by_id = {c["connector_id"]: c for c in connectors}
+    assert by_id["vmware-rest-9.0"]["state"] == "ingested"
+    # Class-only registered rows must surface as registered.
+    assert by_id["harbor-rest-2.x"]["state"] == "registered"
+
+    # Round-trip every emitted id through the dispatcher resolve path.
+    # ``state="ingested"`` rows must resolve through connector_exists;
+    # ``state="registered"`` rows are documented not-yet-dispatchable
+    # and the assertion below pins that contract too.
+    for item in connectors:
+        parsed = parse_connector_id(item["connector_id"])
+        product, version, impl_id = parsed
+        exists = await connector_exists(
+            tenant_id=operator.tenant_id,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+        if item["state"] == "ingested":
+            assert exists, (
+                f"ingested row {item['connector_id']!r} did not round-trip — "
+                f"parsed={parsed}, but connector_exists returned False"
+            )
+        else:
+            assert item["state"] == "registered"
+            assert not exists, (
+                f"registered (class-only) row {item['connector_id']!r} "
+                f"unexpectedly resolves through connector_exists — the "
+                f"row should be ingested, not registered"
+            )
+
+
+@pytest.fixture
+def _every_v2_connector_registered() -> Iterator[None]:
+    """Register every production v2 connector for the round-trip test.
+
+    Each production connector subpackage performs its
+    ``register_connector_v2`` call at import time, but the autouse
+    ``_isolate_global_registries`` fixture snapshots-and-restores the
+    registry around each test, so only the entries present at session
+    start (i.e. none, post-restore) survive. Re-register the full
+    production set directly so the round-trip test sees every entry
+    rather than a partial slice.
+    """
+    from meho_backplane.connectors.bind9.connector import Bind9Connector
+    from meho_backplane.connectors.harbor.connector import HarborConnector
+    from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
+    from meho_backplane.connectors.nsx.connector import NsxConnector
+    from meho_backplane.connectors.registry import (
+        all_connectors_v2,
+        register_connector_v2,
+    )
+    from meho_backplane.connectors.sddc_manager.connector import (
+        SddcManagerConnector,
+    )
+    from meho_backplane.connectors.vault.connector import VaultConnector
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+
+    existing = all_connectors_v2()
+    entries: tuple[tuple[str, str, str, type], ...] = (
+        ("bind9", "9.x", "bind9-ssh", Bind9Connector),
+        ("harbor", "2.x", "harbor-rest", HarborConnector),
+        ("k8s", "1.x", "k8s", KubernetesConnector),
+        ("nsx", "4.2", "nsx-rest", NsxConnector),
+        ("sddc-manager", "9.0", "sddc-rest", SddcManagerConnector),
+        ("vault", "1.x", "vault", VaultConnector),
+        ("vmware", "9.0", "vmware-rest", VmwareRestConnector),
+    )
+    for product, version, impl_id, cls in entries:
+        if (product, version, impl_id) not in existing:
+            register_connector_v2(
+                product=product,
+                version=version,
+                impl_id=impl_id,
+                cls=cls,
+            )
+    yield
+
+
+@pytest.mark.asyncio
+async def test_register_connector_v2_round_trip_lossless_for_every_entry(
+    _every_v2_connector_registered: None,
+) -> None:
+    """The build/parse round-trip is lossless for every registered v2 entry.
+
+    G0.9.1-T1 (#773) acceptance criterion #1 (verbatim):
+
+        Round-trip unit test:
+        ``parse_connector_id(build_connector_id(p, v, i)) == (p, v, i)``
+        holds for every connector registered via ``register_connector_v2``
+        / typed registration, including a case where
+        ``product != impl_id.split("-")[0]``.
+
+    The check is *operationally* strict: we don't require the parser
+    to recover the registry's friendly ``product`` (SDDC is the
+    canonical exception: registry ``product="sddc-manager"``, but the
+    dispatcher derives ``"sddc"`` from ``impl_id="sddc-rest"``). What
+    must hold is that:
+
+    * the parser recovers ``(version, impl_id)`` losslessly — these
+      are the natural-key columns the dispatcher matches on; and
+    * when the registry's ``product`` differs from the parser's
+      derived ``product``, the registry's ``product`` matches what
+      :func:`~meho_backplane.connectors.kubernetes.SDDC_PRODUCT`-style
+      constants write into ``endpoint_descriptor`` rows — i.e., the
+      dispatcher's parsed product matches the DB row product, so a
+      DB-backed row lookup succeeds.
+
+    Concretely: ``product != impl_id.split("-")[0]`` is allowed when
+    the v2-registry product is purely a friendly resolver-key label
+    and DB writes use the parser-derived product (the documented SDDC
+    convention). It is *not* allowed when the registry product would
+    also be the DB-row product, because then the dispatcher's parse
+    would miss every row. The class-side-only listing path
+    (``_class_side_only_items``) enforces this by emitting the
+    parser-derived ``product`` on each class-only row.
+
+    This test exhaustively enumerates ``all_connectors_v2()`` and
+    pins the property; new connectors added to the registry are
+    automatically covered.
+    """
+    from meho_backplane.connectors.registry import all_connectors_v2
+    from meho_backplane.operations._lookup import parse_connector_id
+    from meho_backplane.operations.ingest._llm_grouping_internals import (
+        build_connector_id,
+    )
+
+    registry = all_connectors_v2()
+    # Sanity-check the registry actually has the SDDC entry that
+    # exercises the product != impl_id.split("-")[0] case the
+    # acceptance criterion calls out explicitly.
+    assert ("sddc-manager", "9.0", "sddc-rest") in registry, (
+        "SDDC v2 registration missing — the test relies on it as the "
+        "canonical product != impl_id.split('-')[0] case"
+    )
+
+    for (product, version, impl_id), _cls in registry.items():
+        if not version or not impl_id:
+            # v1-compat shim (e.g. ("vault", "", "")) — not separately
+            # registered, see _class_side_only_items docstring.
+            continue
+        connector_id = build_connector_id(product, version, impl_id)
+        parsed_product, parsed_version, parsed_impl_id = parse_connector_id(
+            connector_id,
+        )
+        # (version, impl_id) must round-trip losslessly — these are
+        # the dispatcher's natural-key columns.
+        assert parsed_version == version, (
+            f"version round-trip lost for {(product, version, impl_id)}: "
+            f"build={connector_id!r} parsed_version={parsed_version!r}"
+        )
+        assert parsed_impl_id == impl_id, (
+            f"impl_id round-trip lost for {(product, version, impl_id)}: "
+            f"build={connector_id!r} parsed_impl_id={parsed_impl_id!r}"
+        )
+        # product is allowed to differ from the registry's friendly
+        # name only when the parser's derivation matches what DB
+        # writes use (the SDDC convention). Catch any future registration
+        # that quietly breaks this contract.
+        derived_product = impl_id.split("-")[0]
+        assert parsed_product == derived_product, (
+            f"parser-derived product disagrees with impl_id-prefix "
+            f"convention for {(product, version, impl_id)}: "
+            f"derived={derived_product!r} parsed={parsed_product!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -357,13 +357,55 @@ Class-side registrations from the v2 connector registry that have
 no DB-side state yet (T5 #733 — "State 0.5" connectors registered
 via `register_connector_v2` but without any rows in
 `operation_group` / `endpoint_descriptor`) are unioned into the
-response with `group_count: 0, operation_count: 0` so operators
-see `connector registered ⇒ visible in list`. Class-only rows are
-always built-in (`tenant_id IS NULL`); under an explicit `status`
-narrowing they're filtered out (no groups ⇒ nothing to review).
-v1-compat shim entries (`(product, "", "")` rows the v1
-`register_connector` writes into the v2 table) are excluded — they
-double-list every v1 connector and aren't separately registered.
+response with `group_count: 0, operation_count: 0` and
+`state: "registered"` so operators see `connector registered ⇒
+visible in list` but the agent knows the dispatcher won't resolve
+calls against them yet. Class-only rows are always built-in
+(`tenant_id IS NULL`); under an explicit `status` narrowing they're
+filtered out (no groups ⇒ nothing to review). v1-compat shim
+entries (`(product, "", "")` rows the v1 `register_connector`
+writes into the v2 table) are excluded — they double-list every v1
+connector and aren't separately registered.
+
+#### Listing-integrity contract (G0.9.1-T1 / #773)
+
+Every `connector_id` the function emits is guaranteed to round-trip
+through the dispatcher's resolve path: for every row with `state:
+"ingested"`,
+`connector_exists(*parse_connector_id(connector_id))` returns
+`True`; for rows with `state: "registered"`, `connector_exists`
+returns `False` honestly (no descriptor rows yet) and the agent
+reads `state` to know it cannot dispatch. Rows whose emitted
+`connector_id` would not round-trip at all are dropped before the
+response is built and a structured
+`dropped_unresolvable_connector_id` log line is emitted per drop —
+two shapes:
+
+* **Stale-rename DB rows.** `endpoint_descriptor` / `operation_group`
+  rows survived an `impl_id` rename (G3.2 #320's
+  `kubernetes-asyncio → k8s` rename) but no migration cleaned them
+  up. `build_connector_id` emits e.g. `"kubernetes-asyncio-1.x"`,
+  `parse_connector_id` derives `product="kubernetes"`, and
+  `connector_exists` cannot find the row because the rows now live
+  under `product="k8s"`. The listing drops the stale row and the
+  log line names both the row's natural-key triple and the parsed
+  triple so the operator can clean up with a single SQL `DELETE`.
+* **v2-registry product disagreement.** A class-side-only entry
+  registered with `product != impl_id.split("-")[0]` whose
+  `connector_id` parses to a different `(version, impl_id)` than
+  the registry advertises is dropped (impossible to recover from
+  inside the listing). The SDDC case — registry
+  `product="sddc-manager"`, parser derives `product="sddc"` — is
+  *not* dropped because `(version, impl_id)` survives the round-
+  trip and `SDDC_PRODUCT="sddc"` already writes DB rows the
+  dispatcher reaches via the parsed product; the listing emits
+  `product="sddc"` (parser-derived) so the wire shape is
+  consistent with what the dispatcher will derive.
+
+Regression test:
+`tests/test_api_v1_connectors_ingest.py::test_list_every_connector_id_round_trips_through_dispatcher`
+asserts the contract over a seeded DB that includes a stale-rename
+row and a class-side-only opless connector.
 
 ### API request / response models (`ingest/api_schemas.py`)
 
@@ -377,7 +419,10 @@ consume so the wire contract is defined once:
 * `ConnectorListItem` / `ConnectorListResponse` — one row per
   visible connector + the wrapper for the list endpoint. The wrapper
   keeps the JSON shape stable when future paging / cursor fields
-  land.
+  land. `ConnectorListItem.state` (G0.9.1-T1 / #773) is `"ingested"`
+  for DB-backed rows the dispatcher can resolve and `"registered"`
+  for class-side-only rows the dispatcher cannot resolve yet — see
+  the listing-integrity contract section above.
 * `EditGroupBody` / `EditOpBody` — PATCH bodies for the per-group
   and per-op edit verbs. Pydantic enforces the bounded enum for
   `safety_level` and the empty-body rejection lands as a service-


### PR DESCRIPTION
## Summary

- G0.9.1-T1 (#773) — Signal #6 regression from the 2026-05-21 RDC v0.3.1 dogfood. `GET /api/v1/connectors` emitted `connector_id`s the dispatcher could not resolve (`kubernetes-asyncio-1.x` stale-rename rows; `nsx-rest-4.2` / `sddc-rest-9.0` class-side-only opless rows), and the resolve-failure message circularly pointed the operator back at the same listing.
- Makes the listing a single source of truth for what the dispatcher will resolve: every emitted `connector_id` round-trips losslessly through `parse_connector_id` + `connector_exists`. Stale-rename DB rows are dropped (with a structured `dropped_unresolvable_connector_id` log line per drop). Class-side-only registry entries carry a new `ConnectorListItem.state="registered"` so an agent distinguishes registered-but-not-yet-dispatchable from ingested-and-ready.
- For class-side-only items the emitted `product` is the parser-derived one (consistent with what `SDDC_PRODUCT="sddc"` already writes into DB rows), so the row transitions cleanly from `state="registered"` to `state="ingested"` when descriptor rows land — same `connector_id`, no wire-shape break.
- De-circularises `UnknownConnectorError`'s message so it no longer points at the listing as the remediation for a listed-but-unresolvable id.

## Test plan

- [x] `ruff check` — clean (`src/meho_backplane/` + `tests/`).
- [x] `ruff format --check` — clean (411 files).
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — clean (195 source files).
- [x] Backend pytest on the affected modules — `test_api_v1_connectors_ingest.py`, `test_api_v1_operations.py`, `test_mcp_tools_connector_admin.py`, `test_operations_meta_tools.py`, `test_operations_ingest_review.py`, `test_operations_register_ingested.py`, `test_operations_dispatcher.py`, `test_connectors_base.py`, `test_connectors_resolver.py` — **214 passed**.
- [x] AC #1 — `test_register_connector_v2_round_trip_lossless_for_every_entry` walks every production v2 registration and pins the `(version, impl_id)` round-trip; explicitly includes the SDDC `product != impl_id.split("-")[0]` case.
- [x] AC #2 — `test_list_every_connector_id_round_trips_through_dispatcher` seeds a stale-rename row + a class-side-only opless connector and asserts every emitted `connector_id` with `state="ingested"` resolves through `connector_exists(parse_connector_id(...))`; the regression test the parent Initiative's Definition-of-done #2 calls out.
- [x] Targeted regression — `test_list_drops_stale_impl_id_rows_whose_connector_id_will_not_resolve` seeds the consumer's exact stale-rename row shape and asserts filtering.
- [x] AC #3 — `UnknownConnectorError` message updated; existing tests that pin `<impl_id>-<version>` substring still pass; no test pinned the removed back-reference wording.
- [ ] AC #4 — `Python (ruff + mypy + pytest)` + `Python (integration testcontainers)` green on the merge → CI gate.
- [ ] AC #5 — Manual smoke against rke2-infra → post-merge.

## Out of scope

- The Layer 2 ingest error-envelope opacity (Signal #12) — T5 #777.
- Renaming `list_ingested_connectors` to drop the misleading "ingested" — follow-up.
- Cleaning up the consumer's specific stale `kubernetes-asyncio-1.x` rows by hand — out of scope; the fix is the general listing-integrity guarantee.

Closes #773


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connector listing API now includes a `state` field to distinguish resolvable ("ingested") from non-resolvable ("registered") connectors.

* **Bug Fixes**
  * Stale connector IDs that cannot be resolved are now automatically filtered from the listing.
  * Improved error messaging for unknown connector errors.

* **Documentation**
  * Updated API specification with connector listing integrity contract and state field semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->