### PR TITLE
feat(memory): G5.2-T5 meho promote Cobra verb + exit-code mapping + E2E smoke (#627)

### DIFF
--- a/cli/internal/cmd/memory/promote.go
+++ b/cli/internal/cmd/memory/promote.go
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// exitIdempotentPromote is the informational exit code surfaced when a
+// `meho promote` re-run returns the existing target row instead of
+// minting a fresh one. The route returns 200 in both cases (per the
+// G5.2-T4 #626 idempotency contract); the CLI distinguishes them by
+// comparing the entry's “created_at“ against a pre-POST timestamp.
+//
+// 6 was the next free slot in the cli/internal/output exit-code ladder
+// (2 auth_expired, 3 unreachable, 4 unexpected_response, 5
+// insufficient_role). The code is **informational** -- under “--json“
+// the verb collapses to exit 0 so scripts piping through “jq“ don't
+// trip on a successful no-op. Issue #627 acceptance criterion: "exit 6
+// in human mode, exit 0 under --json".
+const exitIdempotentPromote = 6
+
+// errCodeIdempotentPromote is the stable machine-readable identifier
+// for the idempotent-re-run path. Mirrors the “output.ErrCode*“
+// naming convention; appears in the human-mode summary line so
+// forensic log scrapers can grep one string across promote runs that
+// hit the no-op branch.
+const errCodeIdempotentPromote = "already_promoted_at_target_idempotent"
+
+// NewPromoteCmd returns the top-level `meho promote` command (issue
+// #627).
+//
+// CLI shape:
+//
+//	meho promote <scope>/<slug> --to <target-scope> [--move] [--json] [--backplane <url>]
+//
+// Calls POST /api/v1/memory/{scope}/{slug}/promote (G5.2-T4 #626).
+// Role: any operator who can read the source row AND satisfies the
+// per-ladder-step authority gate (own user-scoped row → user-tenant /
+// user-target needs operator; user-tenant → tenant needs tenant_admin;
+// see T3 “assert_can_promote“ for the matrix). The service-layer
+// :class:`PermissionDeniedError` surfaces as 403 with the canonical
+// “insufficient_promotion_authority“ detail.
+//
+// Idempotency: a re-run against an already-promoted slug returns 200
+// with the existing target row (no duplicate insert, no 409). The CLI
+// detects this case by comparing the entry's “created_at“ against a
+// pre-POST timestamp and surfaces exit code 6 (informational) in
+// human-readable mode; “--json“ collapses to exit 0 so scripts
+// don't treat the no-op as failure.
+//
+// Exit codes:
+//   - 0  success — fresh promotion
+//   - 2  auth_expired
+//   - 3  unreachable
+//   - 4  unexpected_response (incl. 400 cross-ladder, 404 source not visible)
+//   - 5  insufficient_promotion_authority (HTTP 403)
+//   - 6  already_promoted_at_target_idempotent (HTTP 200 no-op,
+//     human-readable mode only; “--json“ collapses to exit 0)
+func NewPromoteCmd() *cobra.Command {
+	var (
+		toFlag            string
+		moveFlag          bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "promote <scope>/<slug>",
+		Short: "Promote one memory to a strictly broader scope (POST /api/v1/memory/{scope}/{slug}/promote)",
+		Long: "promote calls POST /api/v1/memory/{scope}/{slug}/promote " +
+			"to broaden a memory's visibility. The ladder is enforced " +
+			"server-side: user → user-tenant / user-target → tenant / " +
+			"target. Cross-ladder steps (e.g. user-tenant → target) are " +
+			"rejected as 400 cross_ladder and surfaced as " +
+			"unexpected_response (exit 4).\n\n" +
+			"--to NAME selects the target scope (required). --move " +
+			"deletes the source row in the same transaction as the " +
+			"target insert (broadens-and-leaves vs. broadens-and-" +
+			"rewires); default behaviour leaves the source intact.\n\n" +
+			"Idempotency: a re-run against an already-promoted slug " +
+			"returns 200 with the existing target row (no duplicate " +
+			"insert, no 409). Human-readable output surfaces this as " +
+			"exit 6 (informational); --json collapses to exit 0 so " +
+			"scripts piping through `jq` don't treat the no-op as " +
+			"failure.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPromote(cmd, promoteOptions{
+				ScopeSlugArg:      args[0],
+				ToArg:             toFlag,
+				Move:              moveFlag,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+				Now:               time.Now,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&toFlag, "to", "",
+		"target scope: user-tenant|user-target|tenant|target (required)")
+	cmd.Flags().BoolVar(&moveFlag, "move", false,
+		"delete the source row in the same transaction (broadens-and-leaves vs. broadens-and-rewires)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw Entry JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by `meho login`)")
+	// --to is required at the CLI layer; failing to flag it raises a
+	// cobra error before any RBAC / network round-trip.
+	if err := cmd.MarkFlagRequired("to"); err != nil {
+		// cobra.MarkFlagRequired returns an error only when the flag
+		// doesn't exist on the command. Defensive panic: the flag is
+		// declared two lines above, so this is a programmer-error path
+		// that would surface in CI well before any operator ran it.
+		panic(fmt.Sprintf("cli/promote: MarkFlagRequired(\"to\"): %v", err))
+	}
+	return cmd
+}
+
+type promoteOptions struct {
+	ScopeSlugArg      string
+	ToArg             string
+	Move              bool
+	JSONOut           bool
+	BackplaneOverride string
+	// Now is injectable so unit tests can pin the reference time used
+	// to distinguish "fresh promotion" from "idempotent re-run".
+	// Production callers pass ``time.Now``.
+	Now func() time.Time
+}
+
+// promoteRequest mirrors the backend “PromoteBody“ pydantic model
+// (`backend/src/meho_backplane/api/v1/memory.py`). “move“ is sent
+// regardless of value (the route's pydantic v2 “BaseModel“ accepts
+// the default “false“ explicitly — same shape “forget“ /
+// “remember“ use).
+type promoteRequest struct {
+	To         Scope  `json:"to"`
+	Move       bool   `json:"move"`
+	TargetName string `json:"target_name,omitempty"`
+}
+
+func runPromote(cmd *cobra.Command, opts promoteOptions) error {
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	sourceScope, sourceSlug, err := parseScopeSlugArg(opts.ScopeSlugArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	targetScope, err := parseScope(opts.ToArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			classifyBackplaneError(err), opts.JSONOut)
+	}
+	req := promoteRequest{
+		To:   targetScope,
+		Move: opts.Move,
+	}
+	// Capture the pre-POST wall clock so a successful response can be
+	// classified as fresh (entry.CreatedAt >= preCallAt) vs.
+	// idempotent re-run (entry.CreatedAt < preCallAt). The granularity
+	// is comfortable: backend writes ``created_at`` from a clock
+	// inside the same transaction that returns the row, so the gap
+	// between "client about to send POST" and "row inserted" is
+	// bounded by the round-trip — single-digit milliseconds in
+	// practice. A re-run finds an existing row whose ``created_at`` is
+	// from a previous wall-clock, which is on the seconds-or-more
+	// timescale.
+	preCallAt := opts.Now().UTC()
+	entry, err := postPromote(cmd.Context(), backplaneURL, sourceScope, sourceSlug, req)
+	if err != nil {
+		return renderPromoteRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	idempotent := isIdempotentRerun(entry, preCallAt)
+	if opts.JSONOut {
+		// JSON consumers should never see a non-zero exit on an
+		// idempotent re-run — the response shape is identical and
+		// scripts that pipe into jq would otherwise need to special-
+		// case exit 6. The acceptance criterion (#627) pins this
+		// shape: ``--json`` collapses to exit 0 even on the no-op
+		// branch.
+		return output.PrintJSON(cmd.OutOrStdout(), entry)
+	}
+	printPromoteSummary(cmd.OutOrStdout(), entry, idempotent, opts.Move)
+	if idempotent {
+		// Return a typed silent error so cli/cmd/meho/main.go's
+		// ExitCoder type assertion picks up the informational exit
+		// code without re-emitting the human line (already printed
+		// above).
+		return &idempotentPromoteError{}
+	}
+	return nil
+}
+
+// idempotentPromoteError carries the informational exit code 6 to
+// main.go via the “output.ExitCoder“ type assertion. The “Error“
+// method returns an empty string so cobra's default error printer
+// stays silent — the printed line lives in
+// :func:`printPromoteSummary`.
+//
+// Implements “error“ + “ExitCode() int“. Same silent-error shape
+// :mod:`cli/internal/output`'s “RenderError“ uses for the JSON
+// path; reused here for the human-mode exit-6 surface.
+type idempotentPromoteError struct{}
+
+func (idempotentPromoteError) Error() string  { return "" }
+func (*idempotentPromoteError) ExitCode() int { return exitIdempotentPromote }
+
+// isIdempotentRerun returns true when the entry returned by the
+// promote route looks like an idempotent re-run rather than a fresh
+// insert. The signal is a “created_at“ timestamp strictly before
+// the wall clock the CLI captured immediately before sending the
+// POST.
+//
+// Robustness notes:
+//
+//   - Empty / unparseable “created_at“ → treated as fresh (false).
+//     Misclassifying a re-run as fresh degrades the UX (operator sees
+//     exit 0 + "promoted" wording) but never returns the wrong row;
+//     the alternative — treating a parse failure as idempotent —
+//     would block a successful first promotion behind a false-positive
+//     warning.
+//   - Sub-second skew between client and server clocks is tolerable
+//     because a re-run carries the “created_at“ from a previous
+//     promotion, which is seconds-or-more in the past.
+func isIdempotentRerun(entry *Entry, preCallAt time.Time) bool {
+	if entry == nil || entry.CreatedAt == "" {
+		return false
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, entry.CreatedAt)
+	if err != nil {
+		// Fall back to RFC3339 for backends that strip sub-second
+		// precision in serialisation.
+		createdAt, err = time.Parse(time.RFC3339, entry.CreatedAt)
+		if err != nil {
+			return false
+		}
+	}
+	return createdAt.UTC().Before(preCallAt)
+}
+
+func postPromote(
+	ctx context.Context,
+	backplaneURL string,
+	sourceScope Scope,
+	sourceSlug string,
+	req promoteRequest,
+) (*Entry, error) {
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal promote request: %w", err)
+	}
+	path := fmt.Sprintf("/api/v1/memory/%s/%s/promote",
+		pathEscape(string(sourceScope)), pathEscape(sourceSlug))
+	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", path, raw)
+	if err != nil {
+		return nil, err
+	}
+	var out Entry
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, fmt.Errorf("decode promote response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderPromoteRequestError translates an error from postPromote into
+// the right “output.StructuredError“ category. Specialises the
+// shared :func:`renderRequestError` to surface the promote route's
+// 403 canonical detail (“insufficient_promotion_authority“) under
+// the explicit “insufficient_promotion_authority“ exit code 5 from
+// the issue #627 mapping, and to keep the 400 cross-ladder /
+// 404 source-not-visible branches uniformly under
+// “unexpected_response“ (exit 4).
+func renderPromoteRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	// Sentinel-error paths (errMissingAccessToken / token-not-found /
+	// no-refresh-token / transport) flow through the shared helper
+	// unchanged — only the http-status branch needs verb-specific
+	// shaping.
+	var he *httpError
+	if !errors.As(err, &he) {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	switch he.StatusCode {
+	case http.StatusUnauthorized:
+		// Mirrors the shared helper; pinned here so the per-verb error
+		// table is one read.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		// Issue #627 AC: 403 → exit 5 with detail surfacing the
+		// route's canonical ``insufficient_promotion_authority``
+		// string verbatim. The route's HTTPException carries the
+		// short literal as the ``detail`` field (see
+		// :func:`api.v1.memory.promote`); decodeDetailString unwraps
+		// it.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	default:
+		// 400 cross-ladder, 404 source-not-visible, 409 target slug
+		// conflict, 422 validation, 501 not-implemented per-target
+		// ACL gap — all surface as unexpected_response (exit 4) with
+		// the route's detail string passed through. The CLI is the
+		// thin transport; the operator-facing remedy lives in the
+		// detail prose.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, decodeDetailString(he.Body))),
+			jsonOut,
+		)
+	}
+}
+
+// printPromoteSummary renders the promoted entry as a compact
+// confirmation line plus the natural-key coordinates the operator
+// will use for a subsequent “meho recall“ against the target scope.
+// On an idempotent re-run the wording flips to "already promoted" so
+// the operator sees the no-op explicitly; the human-mode exit-6 code
+// is what scripts read.
+func printPromoteSummary(w io.Writer, e *Entry, idempotent bool, move bool) {
+	if e == nil {
+		return
+	}
+	verb := "promoted"
+	if idempotent {
+		verb = fmt.Sprintf("already promoted (%s)", errCodeIdempotentPromote)
+	}
+	suffix := ""
+	if move && !idempotent {
+		// "--move" on a re-run is a no-op (the source was already
+		// deleted on the original call); only surface the suffix on
+		// the fresh-insert path so the operator's mental model
+		// matches the wire shape.
+		suffix = " (source row removed)"
+	}
+	fmt.Fprintf(w, "%s %s/%s%s\n", verb, e.Scope, e.Slug, suffix)
+	fmt.Fprintf(w, "%-14s %s\n", "id:", e.ID)
+	fmt.Fprintf(w, "%-14s %s\n", "scope:", e.Scope)
+	fmt.Fprintf(w, "%-14s %s\n", "slug:", e.Slug)
+	fmt.Fprintf(w, "%-14s %s\n", "expires_at:", pluralisePtr(e.ExpiresAt))
+	fmt.Fprintf(w, "%-14s %s\n", "user_sub:", pluralisePtr(e.UserSub))
+	fmt.Fprintf(w, "%-14s %s\n", "target_name:", pluralisePtr(e.TargetName))
+	fmt.Fprintf(w, "%-14s %s\n", "created_at:", e.CreatedAt)
+	if promotedFrom := metadataStringField(e.Metadata, "promoted_from"); promotedFrom != "" {
+		fmt.Fprintf(w, "%-14s %s\n", "promoted_from:", promotedFrom)
+	}
+}
+
+// metadataStringField extracts a string field from the typed
+// “map[string]any“ metadata blob, returning "" when the field is
+// absent or non-string. The promoted_from key is the load-bearing
+// provenance marker the backend writes (`memory/service.py
+// _build_promotion_metadata`); surfacing it in the summary lets the
+// operator verify the ladder step in one read.
+func metadataStringField(md map[string]any, key string) string {
+	if md == nil {
+		return ""
+	}
+	v, ok := md[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}

--- a/cli/internal/cmd/memory/promote_e2e_test.go
+++ b/cli/internal/cmd/memory/promote_e2e_test.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package memory
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// E2E smoke for `meho promote` against a **live backplane**.
+//
+// Issue #627 acceptance criterion: "E2E smoke test promotes a real
+// memory end-to-end against a running backplane (CI integration
+// job)." This file runs only when the operator has provisioned a
+// live backplane via the same `MEHO_E2E_BACKPLANE` /
+// `MEHO_E2E_ACCESS_TOKEN` envs the CI integration job sets. With
+// either env unset, every test in this file is t.Skip'd so the
+// default `go test ./...` sandbox run stays hermetic.
+//
+// What the smoke covers (matches the bullet list in the issue body):
+//
+//   - Happy path: `meho promote user/<slug> --to user-tenant` →
+//     exit 0; target row visible via `meho recall`.
+//   - --move happy path → exit 0; source row gone (recall → 404).
+//   - Idempotent re-run → exit 6 in human mode, exit 0 with --json.
+//   - 403 promotion-without-authority → exit 5. (Not exercised in
+//     this file — the integration harness would need a separate
+//     non-admin operator token; left to the CI job's per-token
+//     matrix.)
+//
+// Each test uses a unique slug (timestamp-suffixed) so reruns don't
+// collide with leftover rows from a prior failed run.
+
+const (
+	e2eBackplaneEnv   = "MEHO_E2E_BACKPLANE"
+	e2eAccessTokenEnv = "MEHO_E2E_ACCESS_TOKEN" //nolint:gosec // env name only
+)
+
+// requireLiveBackplane returns the backplane URL or t.Skip's the
+// test when the env is unset. Mirrors the env-gate shape every
+// integration-test convention adopts.
+//
+// The same `seedXDGAndToken` helper used by the in-process httptest
+// tests is reused, but pointed at the live URL with the operator's
+// real access token in the file store — this is exactly the shape
+// `meho login` writes, so the auth + transport stack hits the
+// production refresh path.
+func requireLiveBackplane(t *testing.T) string {
+	t.Helper()
+	url := strings.TrimSpace(os.Getenv(e2eBackplaneEnv))
+	token := strings.TrimSpace(os.Getenv(e2eAccessTokenEnv))
+	if url == "" || token == "" {
+		t.Skipf("skipping live-backplane smoke: set %s + %s to enable",
+			e2eBackplaneEnv, e2eAccessTokenEnv)
+	}
+	// Layer the live URL + token over the per-test XDG_CONFIG_HOME
+	// the helper builds. `seedXDGAndToken` writes a placeholder
+	// token; override with the operator's real one so the live
+	// backplane accepts the bearer.
+	seedLiveTokenStore(t, url, token)
+	return url
+}
+
+// seedLiveTokenStore reuses the file-store path the helper writes
+// and replaces the placeholder access token with the env-provided
+// value. Kept verbose so the wire shape stays obvious when
+// debugging a failed CI job.
+//
+// `seedXDGAndToken` writes a placeholder StoredToken; we overwrite
+// it with the operator's real bearer here so `doAuthedRequest`
+// sends production credentials to the live backplane.
+func seedLiveTokenStore(t *testing.T, backplaneURL, accessToken string) {
+	t.Helper()
+	seedXDGAndToken(t, backplaneURL)
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("seedLiveTokenStore: NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  accessToken,
+		TokenType:    "Bearer",
+		// 1h expiry mirrors the placeholder; the CI integration
+		// job is expected to either re-mint a fresh token per
+		// matrix entry or rely on the backplane's refresh path
+		// (`api.AuthedClient.Refresh`) if MEHO_E2E_REFRESH_TOKEN
+		// is also set.
+		Expiry: time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seedLiveTokenStore: store.Save: %v", err)
+	}
+}
+
+// uniqueSlug returns a slug guaranteed unique across re-runs of the
+// same CI job by suffixing the test name with a timestamp + a
+// monotonically-incrementing nonce. Slugs containing dots /
+// hyphens / underscores are legal per the substrate's
+// SLUG_PATTERN, so the timestamp shape `e2e-promote-<unix-ns>`
+// always validates.
+func uniqueSlug(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// TestE2EPromoteUserToUserTenantHappyPath — fresh promotion against a
+// live backplane: remember a `user`-scoped row, promote to
+// `user-tenant`, verify the target row is visible.
+func TestE2EPromoteUserToUserTenantHappyPath(t *testing.T) {
+	backplaneURL := requireLiveBackplane(t)
+	slug := uniqueSlug("e2e-promote-happy")
+
+	// 1. Seed a user-scoped source row.
+	cmdRem, _, stderrRem := newRunCmd(t)
+	cmdRem.SetIn(bytes.NewBufferString(""))
+	if err := runRemember(cmdRem, rememberOptions{
+		BodyArg:           "e2e-promote-happy",
+		ScopeArg:          "user",
+		SlugArg:           slug,
+		Persist:           true, // skip default 7-day TTL so test cleanup is deterministic
+		BackplaneOverride: backplaneURL,
+	}); err != nil {
+		t.Fatalf("E2E remember (seed): %v; stderr=%s", err, stderrRem.String())
+	}
+	defer cleanupMemory(t, backplaneURL, "user-tenant", slug)
+	defer cleanupMemory(t, backplaneURL, "user", slug)
+
+	// 2. Promote to user-tenant.
+	cmdProm, stdoutProm, stderrProm := newRunCmd(t)
+	cmdProm.SetIn(bytes.NewBufferString(""))
+	if err := runPromote(cmdProm, promoteOptions{
+		ScopeSlugArg:      "user/" + slug,
+		ToArg:             "user-tenant",
+		BackplaneOverride: backplaneURL,
+	}); err != nil {
+		t.Fatalf("E2E promote: %v; stderr=%s", err, stderrProm.String())
+	}
+	out := stdoutProm.String()
+	if !strings.Contains(out, "promoted user-tenant/"+slug) {
+		t.Errorf("expected fresh-promotion line; got %q", out)
+	}
+
+	// 3. Verify the target row is visible (recall succeeds).
+	cmdRec, stdoutRec, _ := newRunCmd(t)
+	cmdRec.SetIn(bytes.NewBufferString(""))
+	if err := runRecall(cmdRec, recallOptions{
+		ScopeSlugArg: "user-tenant/" + slug, BackplaneOverride: backplaneURL,
+	}); err != nil {
+		t.Fatalf("E2E recall target: %v", err)
+	}
+	if !strings.Contains(stdoutRec.String(), "e2e-promote-happy") {
+		t.Errorf("expected target row body; got %q", stdoutRec.String())
+	}
+}
+
+// TestE2EPromoteWithMoveDeletesSource — `--move` removes the source
+// row server-side; a follow-up recall against the source returns
+// 404 (memory_not_found / unexpected_response exit 4).
+func TestE2EPromoteWithMoveDeletesSource(t *testing.T) {
+	backplaneURL := requireLiveBackplane(t)
+	slug := uniqueSlug("e2e-promote-move")
+
+	cmdRem, _, _ := newRunCmd(t)
+	cmdRem.SetIn(bytes.NewBufferString(""))
+	if err := runRemember(cmdRem, rememberOptions{
+		BodyArg: "move-me", ScopeArg: "user", SlugArg: slug,
+		Persist: true, BackplaneOverride: backplaneURL,
+	}); err != nil {
+		t.Fatalf("E2E remember: %v", err)
+	}
+	defer cleanupMemory(t, backplaneURL, "user-tenant", slug)
+
+	// Promote with --move; expect source gone afterwards.
+	cmdProm, _, stderrProm := newRunCmd(t)
+	cmdProm.SetIn(bytes.NewBufferString(""))
+	if err := runPromote(cmdProm, promoteOptions{
+		ScopeSlugArg: "user/" + slug, ToArg: "user-tenant", Move: true,
+		BackplaneOverride: backplaneURL,
+	}); err != nil {
+		t.Fatalf("E2E promote --move: %v; stderr=%s", err, stderrProm.String())
+	}
+
+	// Source recall must 404.
+	cmdRec, _, stderrRec := newRunCmd(t)
+	cmdRec.SetIn(bytes.NewBufferString(""))
+	err := runRecall(cmdRec, recallOptions{
+		ScopeSlugArg: "user/" + slug, BackplaneOverride: backplaneURL,
+	})
+	if err == nil {
+		t.Fatalf("E2E: source row should be 404 after --move; recall returned nil")
+	}
+	if !strings.Contains(stderrRec.String(), "memory_not_found") {
+		t.Errorf("expected memory_not_found on source after --move; got %q", stderrRec.String())
+	}
+}
+
+// TestE2EPromoteIdempotentRerun — re-running the same promote returns
+// exit 6 in human-readable mode (the route returns 200 + the
+// existing row; the CLI surfaces "already promoted" + exit 6).
+func TestE2EPromoteIdempotentRerun(t *testing.T) {
+	backplaneURL := requireLiveBackplane(t)
+	slug := uniqueSlug("e2e-promote-rerun")
+
+	cmdRem, _, _ := newRunCmd(t)
+	cmdRem.SetIn(bytes.NewBufferString(""))
+	if err := runRemember(cmdRem, rememberOptions{
+		BodyArg: "rerun-test", ScopeArg: "user", SlugArg: slug,
+		Persist: true, BackplaneOverride: backplaneURL,
+	}); err != nil {
+		t.Fatalf("E2E remember: %v", err)
+	}
+	defer cleanupMemory(t, backplaneURL, "user", slug)
+	defer cleanupMemory(t, backplaneURL, "user-tenant", slug)
+
+	// First promote — fresh, exit 0.
+	cmdFirst, _, _ := newRunCmd(t)
+	cmdFirst.SetIn(bytes.NewBufferString(""))
+	if err := runPromote(cmdFirst, promoteOptions{
+		ScopeSlugArg: "user/" + slug, ToArg: "user-tenant",
+		BackplaneOverride: backplaneURL,
+	}); err != nil {
+		t.Fatalf("E2E first promote: %v", err)
+	}
+
+	// Sleep so the second call's pre-POST timestamp is strictly
+	// after the first promote's created_at. The wall-clock gap
+	// between fresh and rerun is what isIdempotentRerun keys on;
+	// a sub-second turnaround on a fast backplane could otherwise
+	// false-negative.
+	time.Sleep(1500 * time.Millisecond)
+
+	// Second promote — idempotent re-run.
+	cmdSec, stdoutSec, _ := newRunCmd(t)
+	cmdSec.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmdSec, promoteOptions{
+		ScopeSlugArg: "user/" + slug, ToArg: "user-tenant",
+		BackplaneOverride: backplaneURL,
+	})
+	if err == nil {
+		t.Fatalf("E2E idempotent: expected exit-6 error; got nil")
+	}
+	var coder interface{ ExitCode() int }
+	if !errors.As(err, &coder) || coder.ExitCode() != 6 {
+		t.Errorf("E2E idempotent: expected exit 6; got %v", err)
+	}
+	if !strings.Contains(stdoutSec.String(), "already promoted") {
+		t.Errorf("E2E idempotent: expected idempotent wording; got %q", stdoutSec.String())
+	}
+
+	// Third promote with --json — collapses to exit 0.
+	cmdJSON, stdoutJSON, _ := newRunCmd(t)
+	cmdJSON.SetIn(bytes.NewBufferString(""))
+	if err := runPromote(cmdJSON, promoteOptions{
+		ScopeSlugArg: "user/" + slug, ToArg: "user-tenant",
+		JSONOut:           true,
+		BackplaneOverride: backplaneURL,
+	}); err != nil {
+		t.Fatalf("E2E idempotent --json: %v", err)
+	}
+	var decoded Entry
+	if err := json.Unmarshal(stdoutJSON.Bytes(), &decoded); err != nil {
+		t.Fatalf("E2E idempotent --json: stdout not JSON: %v\n%s", err, stdoutJSON.String())
+	}
+	if decoded.Slug != slug {
+		t.Errorf("E2E idempotent --json: expected slug %q; got %+v", slug, decoded)
+	}
+}
+
+// cleanupMemory deletes one memory row to keep the live backplane
+// tidy. Failures during cleanup are logged but not fatal — a
+// leftover row from a flaky test shouldn't mask the real failure.
+func cleanupMemory(t *testing.T, backplaneURL, scopeStr, slug string) {
+	t.Helper()
+	scope := Scope(scopeStr)
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runForget(cmd, forgetOptions{
+		ScopeSlugArg: string(scope) + "/" + slug,
+		Confirm:      true, BackplaneOverride: backplaneURL,
+	}); err != nil {
+		// idempotent forget — log but don't fail. Cleanup failures
+		// don't change the test verdict.
+		t.Logf("cleanup forget %s/%s: %v", scope, slug, err)
+	}
+}

--- a/cli/internal/cmd/memory/promote_test.go
+++ b/cli/internal/cmd/memory/promote_test.go
@@ -1,0 +1,594 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package memory
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRunPromoteHappyPath exercises the fresh-promotion branch end-to-
+// end through the auth + transport stack. The httptest server returns
+// a target row whose “created_at“ is *after* the pre-POST timestamp
+// so isIdempotentRerun classifies the response as fresh (exit 0).
+func TestRunPromoteHappyPath(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/wine-preference/promote",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST; got %s", r.Method)
+			}
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &bodyJSON); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// CreatedAt slightly in the future ensures
+			// isIdempotentRerun returns false even if the test
+			// runner's clock skews backward by milliseconds.
+			created := time.Now().UTC().Add(50 * time.Millisecond).Format(time.RFC3339Nano)
+			_ = json.NewEncoder(w).Encode(Entry{
+				ID:        "00000000-0000-0000-0000-000000000001",
+				TenantID:  "00000000-0000-0000-0000-000000000002",
+				Scope:     ScopeUserTenant,
+				Slug:      "wine-preference",
+				Body:      "Prefers dry red.",
+				Metadata:  map[string]any{"promoted_from": "user/wine-preference"},
+				CreatedAt: created,
+				UpdatedAt: created,
+			})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/wine-preference",
+		ToArg:             "user-tenant",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runPromote: %v; stderr=%s", err, stderr.String())
+	}
+	if got := bodyJSON["to"]; got != "user-tenant" {
+		t.Errorf("expected to=user-tenant in body; got %+v", bodyJSON)
+	}
+	if got := bodyJSON["move"]; got != false {
+		t.Errorf("expected move=false default; got %+v", bodyJSON)
+	}
+	out := stdout.String()
+	for _, want := range []string{"promoted user-tenant/wine-preference", "promoted_from:", "user/wine-preference"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in stdout; got %q", want, out)
+		}
+	}
+	// Idempotent suffix must not appear on a fresh promotion.
+	if strings.Contains(out, "already promoted") {
+		t.Errorf("fresh promotion should not render idempotent wording; got %q", out)
+	}
+}
+
+// TestRunPromoteMoveHappyPath asserts “--move“ lands on the wire and
+// the human summary mentions source removal.
+func TestRunPromoteMoveHappyPath(t *testing.T) {
+	var bodyJSON map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/note/promote",
+		func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &bodyJSON); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+			created := time.Now().UTC().Add(50 * time.Millisecond).Format(time.RFC3339Nano)
+			_ = json.NewEncoder(w).Encode(Entry{
+				Scope: ScopeUserTenant, Slug: "note", Body: "z",
+				Metadata:  map[string]any{"promoted_from": "user/note"},
+				CreatedAt: created, UpdatedAt: created,
+			})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/note",
+		ToArg:             "user-tenant",
+		Move:              true,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runPromote --move: %v; stderr=%s", err, stderr.String())
+	}
+	if got := bodyJSON["move"]; got != true {
+		t.Errorf("expected move=true in body; got %+v", bodyJSON)
+	}
+	if !strings.Contains(stdout.String(), "source row removed") {
+		t.Errorf("expected source-removed suffix; got %q", stdout.String())
+	}
+}
+
+// TestRunPromoteIdempotentRerunHumanExit6 — the server returns 200
+// with an entry whose “created_at“ is well before the CLI's pre-POST
+// timestamp. The CLI surfaces the no-op as exit 6 in human-readable
+// mode.
+func TestRunPromoteIdempotentRerunHumanExit6(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/wine/promote",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			// Created an hour ago — well before any pre-POST clock.
+			ancient := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
+			_ = json.NewEncoder(w).Encode(Entry{
+				ID:        "11111111-1111-1111-1111-111111111111",
+				Scope:     ScopeUserTenant,
+				Slug:      "wine",
+				Body:      "prefers dry red",
+				Metadata:  map[string]any{"promoted_from": "user/wine"},
+				CreatedAt: ancient,
+				UpdatedAt: ancient,
+			})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/wine",
+		ToArg:             "user-tenant",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected idempotent-promote error (exit 6); got nil; stderr=%s", stderr.String())
+	}
+	var coder interface{ ExitCode() int }
+	if !errors.As(err, &coder) {
+		t.Fatalf("expected ExitCoder; got %T (%v)", err, err)
+	}
+	if coder.ExitCode() != 6 {
+		t.Errorf("expected exit 6 (idempotent); got %d", coder.ExitCode())
+	}
+	if !strings.Contains(stdout.String(), "already promoted") {
+		t.Errorf("expected idempotent wording; got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), errCodeIdempotentPromote) {
+		t.Errorf("expected canonical code string; got %q", stdout.String())
+	}
+}
+
+// TestRunPromoteIdempotentRerunJSONExit0 — under “--json“ the
+// idempotent re-run collapses to exit 0 so scripts piping into “jq“
+// don't trip on a successful no-op. The entry envelope is emitted
+// verbatim.
+func TestRunPromoteIdempotentRerunJSONExit0(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/wine/promote",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			ancient := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
+			_ = json.NewEncoder(w).Encode(Entry{
+				ID:        "22222222-2222-2222-2222-222222222222",
+				Scope:     ScopeUserTenant,
+				Slug:      "wine",
+				Body:      "prefers dry red",
+				Metadata:  map[string]any{"promoted_from": "user/wine"},
+				CreatedAt: ancient,
+				UpdatedAt: ancient,
+			})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/wine",
+		ToArg:             "user-tenant",
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("--json idempotent should be exit 0; got %v; stderr=%s", err, stderr.String())
+	}
+	var decoded Entry
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.ID != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("expected target row id round-trip; got %+v", decoded)
+	}
+	// The promoted_from marker must survive the JSON round-trip so a
+	// jq consumer can grep on it (#627 AC).
+	got, _ := decoded.Metadata["promoted_from"].(string)
+	if got != "user/wine" {
+		t.Errorf("expected promoted_from in JSON envelope; got %+v", decoded.Metadata)
+	}
+}
+
+// TestRunPromote403SurfacesInsufficientPromotionAuthority — the route
+// returns 403 with the canonical
+// “insufficient_promotion_authority“ detail; the CLI surfaces it as
+// exit 5 with the detail verbatim per #627 AC.
+func TestRunPromote403SurfacesInsufficientPromotionAuthority(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user-tenant/team-note/promote",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"detail":"insufficient_promotion_authority"}`)
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user-tenant/team-note",
+		ToArg:             "tenant",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error from 403")
+	}
+	var coder interface{ ExitCode() int }
+	if !errors.As(err, &coder) || coder.ExitCode() != 5 {
+		t.Errorf("expected exit 5 (insufficient_role); got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "insufficient_role") {
+		t.Errorf("expected insufficient_role code; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "insufficient_promotion_authority") {
+		t.Errorf("expected promote detail round-trip; got %q", stderr.String())
+	}
+}
+
+// TestRunPromote400CrossLadderSurfacesUnexpected — cross-ladder steps
+// (e.g. “user-tenant -> target“) return 400 from the route; the CLI
+// classes them as unexpected_response (exit 4) per #627 AC.
+func TestRunPromote400CrossLadderSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user-tenant/team-note/promote",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"detail":"cross_ladder: user-tenant cannot promote to target"}`)
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user-tenant/team-note",
+		ToArg:             "target",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error from 400")
+	}
+	var coder interface{ ExitCode() int }
+	if !errors.As(err, &coder) || coder.ExitCode() != 4 {
+		t.Errorf("expected exit 4 (unexpected_response); got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "unexpected_response") {
+		t.Errorf("expected unexpected_response code; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cross_ladder") {
+		t.Errorf("expected cross_ladder detail round-trip; got %q", stderr.String())
+	}
+}
+
+// TestRunPromote404SourceNotVisibleSurfacesUnexpected — the route
+// collapses "source not found" + "source not visible" into 404 for
+// tenant-boundary info-leak avoidance; the CLI passes that through as
+// unexpected_response (exit 4) per #627 AC.
+func TestRunPromote404SourceNotVisibleSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/ghost/promote",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"detail":"memory_not_found"}`)
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/ghost",
+		ToArg:             "user-tenant",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error from 404")
+	}
+	var coder interface{ ExitCode() int }
+	if !errors.As(err, &coder) || coder.ExitCode() != 4 {
+		t.Errorf("expected exit 4 (unexpected_response); got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "memory_not_found") {
+		t.Errorf("expected memory_not_found detail round-trip; got %q", stderr.String())
+	}
+}
+
+// TestRunPromoteUnreachableNetworkErrorSurfacesExit3 — a server-side
+// abort surfaces as unreachable (exit 3).
+func TestRunPromoteUnreachableNetworkErrorSurfacesExit3(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Close the connection without writing anything so the
+		// client sees a transport error.
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatalf("http.ResponseWriter does not support Hijacker")
+		}
+		conn, _, err := hijacker.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/foo",
+		ToArg:             "user-tenant",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected transport error")
+	}
+	var coder interface{ ExitCode() int }
+	if !errors.As(err, &coder) || coder.ExitCode() != 3 {
+		t.Errorf("expected exit 3 (unreachable); got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "unreachable") {
+		t.Errorf("expected unreachable code; got %q", stderr.String())
+	}
+}
+
+// TestRunPromote401AuthExpiredSurfacesExit2 — exhausting the refresh
+// budget renders auth_expired (exit 2) with a `meho login` hint.
+func TestRunPromote401AuthExpiredSurfacesExit2(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/x/promote",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"detail":"token expired"}`)
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL) // no refresh_token present
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/x",
+		ToArg:             "user-tenant",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error from 401")
+	}
+	var coder interface{ ExitCode() int }
+	if !errors.As(err, &coder) || coder.ExitCode() != 2 {
+		t.Errorf("expected exit 2 (auth_expired); got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "auth_expired") {
+		t.Errorf("expected auth_expired code; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected meho login hint; got %q", stderr.String())
+	}
+}
+
+// TestRunPromoteJSONHappyPathEmitsEntry — “--json“ on the fresh-
+// promotion branch emits the raw Entry envelope; exit 0.
+func TestRunPromoteJSONHappyPathEmitsEntry(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/wine/promote",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			created := time.Now().UTC().Add(50 * time.Millisecond).Format(time.RFC3339Nano)
+			_ = json.NewEncoder(w).Encode(Entry{
+				ID:        "33333333-3333-3333-3333-333333333333",
+				Scope:     ScopeUserTenant,
+				Slug:      "wine",
+				Body:      "prefers dry red",
+				Metadata:  map[string]any{"promoted_from": "user/wine"},
+				CreatedAt: created,
+				UpdatedAt: created,
+			})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/wine",
+		ToArg:             "user-tenant",
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runPromote --json: %v; stderr=%s", err, stderr.String())
+	}
+	var decoded Entry
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.ID != "33333333-3333-3333-3333-333333333333" {
+		t.Errorf("expected target row id round-trip; got %+v", decoded)
+	}
+	got, _ := decoded.Metadata["promoted_from"].(string)
+	if got != "user/wine" {
+		t.Errorf("expected promoted_from in JSON envelope; got %+v", decoded.Metadata)
+	}
+}
+
+// TestRunPromoteRejectsMissingToFlag — empty --to argument fails fast
+// client-side (no round-trip).
+func TestRunPromoteRejectsMissingToFlag(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("network call not expected; got %s %s", r.Method, r.URL)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/foo",
+		ToArg:             "", // empty -- parseScope rejects
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error for empty --to")
+	}
+	if !strings.Contains(stderr.String(), "invalid --scope") {
+		t.Errorf("expected scope-validation message; got %q", stderr.String())
+	}
+}
+
+// TestRunPromoteRejectsMalformedScopeSlug — the positional arg must be
+// “<scope>/<slug>“; bare slug fails fast.
+func TestRunPromoteRejectsMalformedScopeSlug(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "bare-slug-no-scope",
+		ToArg:             "user-tenant",
+		BackplaneOverride: "https://meho.test",
+	})
+	if err == nil {
+		t.Fatalf("expected error for malformed arg")
+	}
+	if !strings.Contains(stderr.String(), "expected <scope>/<slug>") {
+		t.Errorf("expected arg-shape hint; got %q", stderr.String())
+	}
+}
+
+// TestPromoteRegisteredOnRoot — the `meho promote` verb appears under
+// the root's subcommand list via NewPromoteCmd. Pinning this here so a
+// future root-cmd refactor that accidentally drops the registration
+// fails loudly (mirrors the registration-pinning tests on the kb /
+// targets / audit verb trees).
+func TestPromoteRegisteredOnRoot(t *testing.T) {
+	cmd := NewPromoteCmd()
+	if cmd.Use != "promote <scope>/<slug>" {
+		t.Errorf("unexpected Use: %q", cmd.Use)
+	}
+	if !cmd.SilenceUsage {
+		t.Error("expected SilenceUsage on promote")
+	}
+	if !cmd.SilenceErrors {
+		t.Error("expected SilenceErrors on promote")
+	}
+	// Required flags surface client-side, not via a 422 round-trip.
+	if got := cmd.Flag("to"); got == nil {
+		t.Fatal("expected --to flag declared")
+	}
+	for _, flag := range []string{"to", "move", "json", "backplane"} {
+		if got := cmd.Flag(flag); got == nil {
+			t.Errorf("expected --%s flag declared", flag)
+		}
+	}
+}
+
+// TestIsIdempotentRerunVariousTimestamps exercises the timestamp
+// classifier directly so any edge case in the parse fallback is
+// covered without standing up a httptest server.
+func TestIsIdempotentRerunVariousTimestamps(t *testing.T) {
+	preCall := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		entry *Entry
+		want  bool
+	}{
+		{
+			name:  "nil entry returns false",
+			entry: nil,
+			want:  false,
+		},
+		{
+			name:  "empty created_at returns false",
+			entry: &Entry{CreatedAt: ""},
+			want:  false,
+		},
+		{
+			name:  "unparseable created_at returns false",
+			entry: &Entry{CreatedAt: "not-a-timestamp"},
+			want:  false,
+		},
+		{
+			name:  "created_at strictly before pre-call wall clock is idempotent",
+			entry: &Entry{CreatedAt: "2026-05-21T11:00:00Z"},
+			want:  true,
+		},
+		{
+			name:  "created_at after pre-call wall clock is fresh",
+			entry: &Entry{CreatedAt: "2026-05-21T13:00:00Z"},
+			want:  false,
+		},
+		{
+			name:  "created_at equal to pre-call wall clock is fresh",
+			entry: &Entry{CreatedAt: "2026-05-21T12:00:00Z"},
+			want:  false,
+		},
+		{
+			name:  "RFC3339 without sub-second precision parses cleanly",
+			entry: &Entry{CreatedAt: "2026-05-21T11:00:00Z"},
+			want:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isIdempotentRerun(tc.entry, preCall)
+			if got != tc.want {
+				t.Errorf("isIdempotentRerun: got %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMetadataStringFieldEdgeCases covers nil / missing-key / non-
+// string paths so the printed-summary loop never panics on an
+// unexpected metadata shape.
+func TestMetadataStringFieldEdgeCases(t *testing.T) {
+	if got := metadataStringField(nil, "promoted_from"); got != "" {
+		t.Errorf("nil metadata: got %q", got)
+	}
+	if got := metadataStringField(map[string]any{}, "promoted_from"); got != "" {
+		t.Errorf("empty metadata: got %q", got)
+	}
+	if got := metadataStringField(map[string]any{"promoted_from": 42}, "promoted_from"); got != "" {
+		t.Errorf("non-string field: got %q", got)
+	}
+	if got := metadataStringField(map[string]any{"promoted_from": "user/x"}, "promoted_from"); got != "user/x" {
+		t.Errorf("string field: got %q", got)
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -151,10 +151,17 @@ func newRootCmd() *cobra.Command {
 	// /api/v1/retrieve route for the `recall --query` retrieval form.
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in verbs.
+	//
+	// G5.2-T5 (#627) -- top-level `meho promote` verb for Initiative
+	// #374. Wraps POST /api/v1/memory/{scope}/{slug}/promote shipped
+	// by G5.2-T4 (#626). Registered alongside the G5.1 verbs because
+	// the consumer-needs.md §G5 ergonomic shape applies (`meho promote
+	// user/foo --to user-tenant`, not `meho memory promote ...`).
 	root.AddCommand(memory.NewRememberCmd())
 	root.AddCommand(memory.NewRecallCmd())
 	root.AddCommand(memory.NewForgetCmd())
 	root.AddCommand(memory.NewListCmd())
+	root.AddCommand(memory.NewPromoteCmd())
 
 	// G3.1-T7 (#511) -- vmware-rest-9.0 operator alias verbs for
 	// Initiative #227. The verb tree pre-bakes connector_id=


### PR DESCRIPTION
## Summary
- Ships the operator-facing `meho promote <scope>/<slug> --to <target-scope> [--move] [--json] [--backplane <url>]` Cobra verb that wraps the G5.2-T4 (#626) `POST /api/v1/memory/{scope}/{slug}/promote` route.
- Wires the full exit-code mapping from the issue body — 0 fresh, 2 auth_expired, 3 unreachable, 4 unexpected_response (covers 400 cross-ladder + 404 source-not-visible), 5 insufficient_promotion_authority (403), 6 already_promoted_at_target_idempotent (200 no-op).
- Idempotency detection compares the response entry's `created_at` against a pre-POST wall-clock timestamp; human-mode surfaces exit 6, `--json` collapses to exit 0 so scripts piping through `jq` don't treat the no-op as failure.

## Why exit 6 lives on the verb (not in the shared `output` ladder)

The informational nature of the idempotent code — collapses to 0 under `--json`, surfaces as 6 in human mode — is promote-specific. The shared exit constants (`auth_expired`, `unreachable`, `insufficient_role`, `unexpected_response`) all flow through `output.StructuredError` + `RenderError`. The idempotent path keeps its own silent `ExitCoder` (`idempotentPromoteError`) so cobra's printer stays mute while `main.go`'s `errors.As` picks up the exit code.

## Idempotency detection strategy

The route returns 200 + the same `MemoryEntry` shape in both branches (fresh insert vs. existing-row re-run). The only stable signal in the response is the entry's `created_at` timestamp. The CLI captures `time.Now().UTC()` immediately before the POST and compares to `entry.CreatedAt` on the response. A re-run finds a row created before the pre-POST clock; a fresh insert finds a row created inside the same transaction. Parse failures on `created_at` degrade gracefully (treated as fresh) so an unexpected backend timestamp shape never blocks a successful first promotion.

## Test plan
- [x] `go test ./...` — clean across the cli module (memory + every sibling verb tree).
- [x] `go vet ./...` — clean.
- [x] `gofmt -l ./...` — clean.
- [x] `python3 .claude/hooks/code-quality.py --diff` — clean.
- [x] Runner tests (httptest server, full auth + transport stack):
  - happy path (POST body wire shape, fresh exit 0)
  - `--move` (boolean lands on the wire; source-removed suffix in summary)
  - idempotent re-run human-mode exit 6 + canonical code string in stdout
  - idempotent re-run `--json` exit 0 + entry envelope round-trip
  - 403 → exit 5 with `insufficient_promotion_authority` detail
  - 400 cross-ladder → exit 4 + detail round-trip
  - 404 source-not-visible → exit 4 + `memory_not_found` detail
  - transport unreachable → exit 3
  - 401 → exit 2 + `meho login` hint
  - `--json` fresh path round-trips the Entry envelope (exit 0)
  - missing `--to` flag fails fast (no round-trip)
  - malformed `<scope>/<slug>` positional fails fast
- [x] Helper-level tests: `isIdempotentRerun` edge cases (nil, empty, unparseable, past, future, equal `created_at`) + `metadataStringField` shape robustness
- [x] `meho promote` registered under root: `TestPromoteRegisteredOnRoot` pins `Use` / flag set / SilenceUsage / SilenceErrors.
- [x] E2E smoke (gated on `MEHO_E2E_BACKPLANE` + `MEHO_E2E_ACCESS_TOKEN`): three opt-in tests covering happy path → recall, `--move` → recall 404, double-promote → exit 6 human / exit 0 `--json`. Skips cleanly when env unset.

## Out of scope
- Backend changes (promote route + admin meta-tool shipped in G5.2-T4 #626; `meho.memory.promote` MCP tool likewise).
- Per-target ACL behavior (gated on G0.3 #224; the CLI surfaces a 501 from the route as `unexpected_response` exit 4).
- The non-admin operator matrix for the 403 path — left to the CI integration job's per-token matrix.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #627


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `meho promote` command to elevate memory entries between scopes. Supports required `--to` flag for target scope, `--move` to delete the source entry, `--json` for JSON output, and built-in idempotent re-running for safe repeated execution.
* Enhanced error handling with specific exit codes for authentication expiration and insufficient promotion authority.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->