### PR TITLE
fix(mcp): structured ingest error envelopes on the MCP path (#777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,20 @@ connector-related release-notes line.
 
 ### Fixed
 
+- `search_memory` now returns real `created_at` / `updated_at` for
+  each hit instead of the `1970-01-01T00:00:00Z` epoch placeholder
+  that v0.3.1 surfaced. The retrieval substrate's `RetrievalHit`
+  carries the persisted `documents` row timestamps through to memory
+  search projections, so the read path matches what `add_to_memory`
+  and direct recall return for the same row (#776).
+- Structured ingest error envelopes on the MCP path —
+  `meho.connector.ingest` now maps `VersionMismatchError` and
+  `UncoveredVersionLabel` to JSON-RPC `-32602 Invalid Params` with a
+  structured `error.data` payload (`requested_version`,
+  `spec_info_versions`, registered-class ranges) instead of the prior
+  `-32603 "internal error: VersionMismatchError"`. Detail builders are
+  shared with the REST 422 envelope so the wire shapes can't drift.
+  (#777)
 - Reconcile `GET /api/v1/connectors` with the dispatcher resolve path
   so no listed `connector_id` is unresolvable. Drops stale-rename DB
   rows (e.g. pre-`k8s` `kubernetes-asyncio-1.x` survivors from G3.2
@@ -105,12 +119,6 @@ connector-related release-notes line.
   the remediation for a listed-but-unresolvable id. Closes Signal #6
   from the 2026-05-21 RDC v0.3.1 dogfood
   ([#773](https://github.com/evoila/meho/issues/773)).
-- `search_memory` now returns real `created_at` / `updated_at` for
-  each hit instead of the `1970-01-01T00:00:00Z` epoch placeholder
-  that v0.3.1 surfaced. The retrieval substrate's `RetrievalHit`
-  carries the persisted `documents` row timestamps through to memory
-  search projections, so the read path matches what `add_to_memory`
-  and direct recall return for the same row (#776).
 
 ## [0.3.1] - 2026-05-21
 

--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -141,6 +141,7 @@ from meho_backplane.operations.ingest import (
     UncoveredVersionLabel,
     UnsupportedSpecError,
     VersionMismatchError,
+    build_version_mismatch_detail,
     default_llm_client_factory,
     list_ingested_connectors,
 )
@@ -238,23 +239,6 @@ async def ingest_endpoint(
     return IngestResponse(ingestion=ingestion_model, grouping=grouping_model)
 
 
-def _version_mismatch_detail(exc: VersionMismatchError) -> dict[str, object]:
-    """Structured 422 body for :class:`VersionMismatchError`.
-
-    Named so the route handler stays readable; the body contract is
-    load-bearing for the CLI's operator-facing error message (which
-    parses the structured detail rather than the rendered string).
-    """
-    return {
-        "kind": exc.kind,
-        "requested_version": exc.requested_version,
-        "spec_info_versions": [
-            {"spec_uri": uri, "info_version": version} for uri, version in exc.spec_info_versions
-        ],
-        "message": str(exc),
-    }
-
-
 async def _run_ingest_with_http_mapping(
     *,
     service: IngestionPipelineService,
@@ -295,10 +279,14 @@ async def _run_ingest_with_http_mapping(
         # G0.9-T8 (#740). 422 (not 400) because the request was
         # syntactically valid but semantically refuses the spec-vs-label
         # cross-check. The structured detail names both versions so the
-        # operator's error message tells them exactly what to fix.
+        # operator's error message tells them exactly what to fix. The
+        # detail builder is shared with the MCP path
+        # (:mod:`meho_backplane.operations.ingest.error_envelopes`,
+        # G0.9.1-T5 #777) so the REST 422 body and the MCP -32602
+        # ``data`` member can't drift.
         raise HTTPException(
             status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=_version_mismatch_detail(exc),
+            detail=build_version_mismatch_detail(exc),
         ) from exc
     except UncoveredVersionLabel as exc:
         # G0.9-T9 (#741). The request body parsed fine (Pydantic

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -160,10 +160,29 @@ class McpInvalidParamsError(Exception):
     this distinctly from a generic :class:`Exception` so the wire
     response carries code ``-32602`` rather than ``-32603``.
 
+    The optional ``data`` attribute lands on the JSON-RPC ``error.data``
+    member (spec §5.1: "A Primitive or Structured value that contains
+    additional information about the error"). Tool handlers that have
+    structured diagnostic detail — e.g. the connector-ingest MCP path
+    surfacing expected-vs-received versions for
+    :class:`~meho_backplane.operations.ingest.VersionMismatchError`
+    via :func:`~meho_backplane.operations.ingest.build_version_mismatch_detail`
+    (G0.9.1-T5 #777) — pass it as ``data=`` so the operator-facing
+    agent gets a self-correcting envelope rather than just a string.
+
     Re-exported from :mod:`meho_backplane.mcp` so T3 (#248) tool
     handlers — and any future MCP method handler — can raise it
     without reaching into a dunder-private symbol.
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.data = data
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +299,7 @@ def _error_response(
     message: str,
     *,
     status_code: int = 200,
+    data: dict[str, Any] | None = None,
 ) -> JSONResponse:
     """Build a JSON-RPC error envelope wrapped in the chosen HTTP status.
 
@@ -298,10 +318,16 @@ def _error_response(
     spec at §"Sending Messages to the Server" allows it ("The HTTP
     response body MAY comprise a JSON-RPC error response that has no
     id") and it gives the client a structured failure to render.
+
+    Optional ``data`` lands on the JSON-RPC ``error.data`` member per
+    spec §5.1 ("A Primitive or Structured value that contains
+    additional information about the error"). Used by handlers that
+    have structured diagnostic detail to surface (G0.9.1-T5 #777, the
+    connector-ingest typed envelopes).
     """
     body = JsonRpcResponse(
         id=request_id,
-        error=JsonRpcError(code=code, message=message),
+        error=JsonRpcError(code=code, message=message, data=data),
     )
     return JSONResponse(content=_serialize_response(body), status_code=status_code)
 
@@ -491,7 +517,7 @@ async def _dispatch_to_handler(
                 error=str(exc),
             )
             return Response(status_code=202)
-        return _error_response(jrpc.id, INVALID_PARAMS, str(exc))
+        return _error_response(jrpc.id, INVALID_PARAMS, str(exc), data=exc.data)
     except Exception as exc:
         _log.exception("mcp_handler_error", method=jrpc.method)
         if is_notification:

--- a/backend/src/meho_backplane/mcp/tools/connector_admin.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_admin.py
@@ -94,12 +94,17 @@ import structlog
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.operations.ingest import (
     ConnectorStatusFilter,
     IngestionPipelineService,
     IngestRequest,
     ReviewService,
     SpecSource,
+    UncoveredVersionLabel,
+    VersionMismatchError,
+    build_uncovered_version_label_detail,
+    build_version_mismatch_detail,
     default_llm_client_factory,
     list_ingested_connectors,
 )
@@ -198,15 +203,40 @@ async def _ingest_handler(
         operator,
         llm_client_factory=default_llm_client_factory,
     )
-    result = await service.ingest(
-        product=request.product,
-        version=request.version,
-        impl_id=request.impl_id,
-        specs=request.specs,
-        base_url=request.base_url,
-        tenant_id=tenant_id,
-        dry_run=request.dry_run,
-    )
+    # G0.9.1-T5 (#777): VersionMismatchError + UncoveredVersionLabel are
+    # caller-input validation errors (the operator's ``version`` label
+    # is incompatible with the supplied spec / not covered by any
+    # registered class) — JSON-RPC ``-32602`` Invalid Params, with the
+    # structured detail on ``error.data`` per spec §5.1. Mirrors the
+    # REST 422 envelope built by
+    # :mod:`meho_backplane.api.v1.connectors_ingest`; the shared
+    # builders in :mod:`meho_backplane.operations.ingest.error_envelopes`
+    # are the single source of truth so the wire shape can't drift.
+    # Without this, the dispatcher's generic ``except Exception`` arm in
+    # :func:`meho_backplane.mcp.server._dispatch_to_handler` would
+    # surface ``-32603 "internal error: VersionMismatchError"`` and
+    # discard the (already-detailed) exception message — opaque to the
+    # agent operator and misclassified as a server fault.
+    try:
+        result = await service.ingest(
+            product=request.product,
+            version=request.version,
+            impl_id=request.impl_id,
+            specs=request.specs,
+            base_url=request.base_url,
+            tenant_id=tenant_id,
+            dry_run=request.dry_run,
+        )
+    except VersionMismatchError as exc:
+        raise McpInvalidParamsError(
+            str(exc),
+            data=build_version_mismatch_detail(exc),
+        ) from exc
+    except UncoveredVersionLabel as exc:
+        raise McpInvalidParamsError(
+            str(exc),
+            data=build_uncovered_version_label_detail(exc),
+        ) from exc
     ingestion_model, grouping_model = result.to_api_models()
     # Build the canonical IngestResponse manually rather than
     # constructing a new instance and round-tripping the inner

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -33,6 +33,10 @@ from meho_backplane.operations.ingest.connector_registration import (
     check_version_covered_by_registered_class,
     ensure_connector_class_registered,
 )
+from meho_backplane.operations.ingest.error_envelopes import (
+    build_uncovered_version_label_detail,
+    build_version_mismatch_detail,
+)
 from meho_backplane.operations.ingest.exceptions import (
     ConnectorNotFoundError,
     InvalidSchemaError,
@@ -118,6 +122,8 @@ __all__ = [
     "UncoveredVersionLabel",
     "UnsupportedSpecError",
     "VersionMismatchError",
+    "build_uncovered_version_label_detail",
+    "build_version_mismatch_detail",
     "check_version_covered_by_registered_class",
     "default_llm_client_factory",
     "detect_spec_format",

--- a/backend/src/meho_backplane/operations/ingest/error_envelopes.py
+++ b/backend/src/meho_backplane/operations/ingest/error_envelopes.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared structured-detail builders for ingest validation errors.
+
+The REST route at :mod:`meho_backplane.api.v1.connectors_ingest` and
+the MCP admin tool at :mod:`meho_backplane.mcp.tools.connector_admin`
+both need to surface :class:`VersionMismatchError` and
+:class:`UncoveredVersionLabel` as caller-input validation errors
+carrying structured diagnostic detail (expected-vs-received versions,
+the list of advertised ``supported_version_range`` strings) so the
+operator — or the agent acting on the operator's behalf — can self-
+correct without re-prompting.
+
+Both routes used to build their own envelopes; the REST path even
+shipped a structured 422 detail dict (G0.9-T8, #740) while the MCP
+path let the exception propagate to the dispatcher's generic
+:data:`~meho_backplane.mcp.schemas.INTERNAL_ERROR` handler, which
+stripped the (already-detailed) exception message and emitted
+``"internal error: VersionMismatchError"`` — opaque to the agent and
+misclassified as ``-32603``. G0.9.1-T5 (#777) lifts both detail
+builders into this module so the envelopes can't drift again.
+
+The shape returned here is a JSON-safe ``dict`` (no UUIDs / datetimes
+/ Pydantic models) — REST embeds it in the ``HTTPException.detail``
+field; MCP embeds it in the JSON-RPC ``error.data`` member (spec
+§5.1: "A Primitive or Structured value that contains additional
+information about the error").
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.operations.ingest.exceptions import (
+    UncoveredVersionLabel,
+    VersionMismatchError,
+)
+
+__all__ = [
+    "build_uncovered_version_label_detail",
+    "build_version_mismatch_detail",
+]
+
+
+def build_version_mismatch_detail(exc: VersionMismatchError) -> dict[str, Any]:
+    """Structured detail for :class:`VersionMismatchError`.
+
+    Body shape (load-bearing — the CLI and the MCP-driving agent both
+    parse it):
+
+    * ``kind`` — ``"spec_label_mismatch"`` or ``"multi_spec_inconsistent"``;
+      :class:`VersionMismatchError` already carries this on the
+      attribute and the route layer surfaces it so callers can branch
+      without re-parsing the message.
+    * ``requested_version`` — the operator-supplied
+      :class:`~meho_backplane.operations.ingest.IngestRequest.version`
+      label.
+    * ``spec_info_versions`` — list of ``{spec_uri, info_version}``
+      objects, one per spec participating in the failure. For the
+      ``spec_label_mismatch`` kind only the mismatching specs are
+      listed; for ``multi_spec_inconsistent`` every spec in the
+      bundle is listed so the operator sees the conflict at a glance.
+    * ``message`` — the rendered exception string. Carried so a
+      client that ignores the structured fields still gets the
+      human-readable detail.
+    """
+    return {
+        "kind": exc.kind,
+        "requested_version": exc.requested_version,
+        "spec_info_versions": [
+            {"spec_uri": uri, "info_version": version} for uri, version in exc.spec_info_versions
+        ],
+        "message": str(exc),
+    }
+
+
+def build_uncovered_version_label_detail(
+    exc: UncoveredVersionLabel,
+) -> dict[str, Any]:
+    """Structured detail for :class:`UncoveredVersionLabel`.
+
+    Body shape:
+
+    * ``product`` / ``version`` / ``impl_id`` — the connector triple
+      the operator submitted, surfaced so the agent doesn't need to
+      re-thread them from its own prompt.
+    * ``registered_classes`` — list of ``{class_name, version,
+      impl_id, supported_version_range}`` objects, one per existing
+      registered v2 connector class for the ``(product, impl_id)``
+      pair. The agent picks a label inside one of these ranges and
+      retries.
+    * ``message`` — the rendered exception string, for clients that
+      ignore the structured fields.
+    """
+    return {
+        "product": exc.product,
+        "version": exc.version,
+        "impl_id": exc.impl_id,
+        "registered_classes": [
+            {
+                "class_name": class_name,
+                "version": cand_version,
+                "impl_id": cand_impl_id,
+                "supported_version_range": supported_range,
+            }
+            for cand_version, cand_impl_id, class_name, supported_range in exc.candidates
+        ],
+        "message": str(exc),
+    }

--- a/backend/tests/test_mcp_tools_connector_admin.py
+++ b/backend/tests/test_mcp_tools_connector_admin.py
@@ -51,6 +51,8 @@ from meho_backplane.operations.ingest import (
     GroupingResult,
     IngestionPipelineResult,
     IngestionResult,
+    UncoveredVersionLabel,
+    VersionMismatchError,
 )
 from tests.mcp_test_fixtures import (
     OPERATOR_TENANT_ID,
@@ -811,3 +813,182 @@ def test_operator_role_cannot_call_tenant_admin_mutator(
     assert not stubbed_services["review"], (
         "operator role bypassed RBAC and reached the service layer"
     )
+
+
+# ---------------------------------------------------------------------------
+# G0.9.1-T5 (#777) — structured error envelopes on the MCP ingest path
+# ---------------------------------------------------------------------------
+
+
+class _RaisingIngestionPipelineService:
+    """A pipeline-service double whose ``ingest`` raises a pinned exception.
+
+    Used to exercise the typed-exception branches in
+    :func:`meho_backplane.mcp.tools.connector_admin._ingest_handler` without
+    spinning up the real DB-touching pipeline. Mirrors the
+    :class:`_FakeIngestionPipelineService` constructor signature so the
+    same monkeypatch seam in the production module works.
+    """
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def __call__(self, operator: Operator, **_kwargs: Any) -> _RaisingIngestionPipelineService:
+        # Reused as a factory: ``IngestionPipelineService(operator, ...)``
+        # in :mod:`connector_admin` calls this instance which returns
+        # itself, so a single fixture instance can serve one request.
+        return self
+
+    async def ingest(self, **_kwargs: Any) -> IngestionPipelineResult:
+        raise self._exc
+
+
+@pytest.fixture
+def patched_pipeline_raising_version_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> VersionMismatchError:
+    """Install a pipeline service that raises a canned :class:`VersionMismatchError`.
+
+    Returns the exception instance so the test can compare its
+    structured attributes against the wire envelope verbatim.
+    """
+    exc = VersionMismatchError(
+        kind="spec_label_mismatch",
+        requested_version="8.0",
+        spec_info_versions=[("docs:vcenter-9.0/vcenter.yaml", "9.0.3")],
+    )
+    import meho_backplane.mcp.tools.connector_admin as ca_mod
+
+    monkeypatch.setattr(ca_mod, "IngestionPipelineService", _RaisingIngestionPipelineService(exc))
+    return exc
+
+
+@pytest.fixture
+def patched_pipeline_raising_uncovered_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> UncoveredVersionLabel:
+    """Install a pipeline service that raises a canned :class:`UncoveredVersionLabel`."""
+    exc = UncoveredVersionLabel(
+        product="t9-vmware",
+        version="7.0",
+        impl_id="t9-vmware-rest",
+        candidates=[("9.0", "t9-vmware-rest", "_RangedTestConnector", ">=8.5,<10.0")],
+    )
+    import meho_backplane.mcp.tools.connector_admin as ca_mod
+
+    monkeypatch.setattr(ca_mod, "IngestionPipelineService", _RaisingIngestionPipelineService(exc))
+    return exc
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_call_meho_connector_ingest_version_mismatch_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    patched_pipeline_raising_version_mismatch: VersionMismatchError,
+) -> None:
+    """Spec/label version mismatch surfaces as JSON-RPC ``-32602`` with structured ``data``.
+
+    AC #1 / AC #3 / AC #4. Pre-fix the dispatcher's catch-all wrapped
+    the exception as ``-32603 "internal error: VersionMismatchError"``,
+    discarding the (already-detailed) message. The fix raises
+    :class:`McpInvalidParamsError` with the shared
+    :func:`build_version_mismatch_detail` envelope on ``error.data``
+    so the operator-facing agent can self-correct without re-prompting.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.connector.ingest",
+                "arguments": {
+                    "product": "vmware",
+                    "version": "8.0",
+                    "impl_id": "vmware-rest",
+                    "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" in body, body
+    # Caller-input validation, not a server fault — ``-32602``, NOT ``-32603``.
+    assert body["error"]["code"] == -32602, body["error"]
+    # The rendered message names both versions so a bare-string client
+    # still gets a self-correcting hint.
+    assert "9.0.3" in body["error"]["message"]
+    assert "8.0" in body["error"]["message"]
+    # The structured ``data`` member carries the same shape the REST
+    # 422 detail uses (G0.9-T8 #740) — both routes share
+    # :func:`build_version_mismatch_detail`.
+    data = body["error"]["data"]
+    assert data["kind"] == "spec_label_mismatch"
+    assert data["requested_version"] == "8.0"
+    assert data["spec_info_versions"] == [
+        {"spec_uri": "docs:vcenter-9.0/vcenter.yaml", "info_version": "9.0.3"},
+    ]
+    assert "9.0.3" in data["message"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_call_meho_connector_ingest_uncovered_version_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    patched_pipeline_raising_uncovered_version: UncoveredVersionLabel,
+) -> None:
+    """Uncovered ``version`` label surfaces as ``-32602`` with the registered ranges.
+
+    AC #2 / AC #3 / AC #4. The structured ``data`` enumerates every
+    registered class for the ``(product, impl_id)`` pair so the agent
+    picks a label inside one of the advertised ranges and retries
+    without re-prompting the operator.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.connector.ingest",
+                "arguments": {
+                    "product": "t9-vmware",
+                    "version": "7.0",
+                    "impl_id": "t9-vmware-rest",
+                    "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == -32602, body["error"]
+    # Rendered message mentions the label + at least one supported
+    # range so the agent has the diagnostic in plain prose too.
+    assert "version='7.0'" in body["error"]["message"]
+    assert ">=8.5,<10.0" in body["error"]["message"]
+    data = body["error"]["data"]
+    assert data["product"] == "t9-vmware"
+    assert data["version"] == "7.0"
+    assert data["impl_id"] == "t9-vmware-rest"
+    assert data["registered_classes"] == [
+        {
+            "class_name": "_RangedTestConnector",
+            "version": "9.0",
+            "impl_id": "t9-vmware-rest",
+            "supported_version_range": ">=8.5,<10.0",
+        },
+    ]
+    assert "_RangedTestConnector" in data["message"]

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -182,6 +182,17 @@ arguments` key-presence checks so omitted fields never reach
 indistinguishable from an omission with `arguments.get(...)`). Only
 fields the operator explicitly named are forwarded.
 
+The `ingest` handler additionally maps `VersionMismatchError` and
+`UncoveredVersionLabel` to JSON-RPC `-32602 Invalid Params` with
+the structured detail on `error.data` (G0.9.1-T5 #777). Both
+exceptions describe caller-input mistakes — the operator's `version`
+label disagrees with the supplied spec, or falls outside every
+registered class's advertised range — so `-32602` is the right code
+(not `-32603 Internal Error`, which the pre-fix generic catch-all
+emitted). The structured `data` payload is built by the shared
+helpers in `operations/ingest/error_envelopes.py` so the REST 422
+detail and the MCP `error.data` member share one source of truth.
+
 ## Key types
 
 ### `EndpointDescriptorProto` (`ingest/schemas.py`)
@@ -329,6 +340,33 @@ cross-checked for internal consistency: two specs disagreeing on
 the major version surface as `VersionMismatchError` with
 `kind="multi_spec_inconsistent"`. Specs missing `info.version`
 entirely skip the check (older spec dialects keep ingesting).
+
+### Shared error-envelope builders (`ingest/error_envelopes.py`)
+
+The REST route at `POST /api/v1/connectors/ingest` and the MCP
+`meho.connector.ingest` tool both need to surface
+`VersionMismatchError` and `UncoveredVersionLabel` as caller-input
+validation errors carrying structured diagnostic detail (expected-
+vs-received versions, the list of advertised
+`supported_version_range` strings) so the operator — or the agent
+acting on the operator's behalf — can self-correct without re-
+prompting.
+
+* `build_version_mismatch_detail(exc)` — REST embeds the returned
+  dict in the `HTTPException(status_code=422).detail` field; MCP
+  embeds it in the JSON-RPC `error.data` member (spec §5.1).
+* `build_uncovered_version_label_detail(exc)` — MCP-only for now;
+  REST emits `str(exc)` for backward compatibility but can switch
+  to the structured builder later without changing the wire shape
+  in a non-additive way.
+
+Pre-G0.9.1-T5 (#777) the MCP path had no typed handling for either
+exception — both fell through to the dispatcher's generic
+`except Exception` arm in `meho_backplane.mcp.server`, which
+surfaced `-32603 "internal error: VersionMismatchError"` and
+discarded the (already-detailed) exception message. The shared
+builders sit in `operations/ingest/error_envelopes.py` so the REST
+422 body and the MCP `-32602` `data` member can't drift again.
 
 ### `list_ingested_connectors()` (`ingest/list_connectors.py`)
 
@@ -630,7 +668,13 @@ operations go live.
 * Issue #407 — T7 task (admin MCP tools).
 * Issue #408 — T8 task (vSphere canary).
 * Issue #409 — T9 task (this doc + the architecture / operator-runbook pair).
+* Issue #740 — G0.9-T8 spec-vs-label cross-check + REST 422 envelope.
+* Issue #741 — G0.9-T9 `UncoveredVersionLabel` pre-flight.
+* Issue #777 — G0.9.1-T5 shared error-envelope builders + MCP `-32602`
+  mapping for `VersionMismatchError` / `UncoveredVersionLabel`.
 * Initiative #389 — G0.7 spec-ingestion pipeline.
+* Initiative #772 — G0.9.1 v0.3.2 dogfood hardening (the rollup that
+  parents #777).
 * Goal #221 — G0 foundational substrate.
 * [docs/architecture/spec-ingestion.md](../architecture/spec-ingestion.md) —
   canonical architecture doc; companion to this codebase map.


### PR DESCRIPTION
## Summary

- The MCP `meho.connector.ingest` handler used to surface `VersionMismatchError` and `UncoveredVersionLabel` as `-32603 "internal error: <ClassName>"`, discarding the already-detailed exception message and misclassifying caller-input validation as a server fault. Both errors now map to `-32602 Invalid Params` with structured detail on `error.data` (JSON-RPC spec §5.1) so the operator-driving agent can self-correct without re-prompting.
- Lifts the REST `_version_mismatch_detail` into a shared `operations/ingest/error_envelopes.py` and adds a sibling `build_uncovered_version_label_detail` so the REST 422 envelope and the MCP `-32602` `data` member can't drift again.
- Extends `McpInvalidParamsError` with an optional `data` payload threaded through `_error_response`; minimal change, no impact on existing handlers that raise it without data (REST `forbidden`, RBAC denials, schema-invalid arguments — all unchanged).
- REST behavior is unchanged: the 422 envelope for `VersionMismatchError` reuses the shared builder; `UncoveredVersionLabel` still emits `str(exc)` as `detail` for backward compatibility with existing REST clients.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (412 files already formatted)
- [x] `mypy src/ --ignore-missing-imports` — Success: no issues found in 196 source files
- [x] `pytest tests/test_mcp_tools_connector_admin.py tests/test_api_v1_connectors_ingest.py -x -q` — 51 passed, including 2 new tests (`test_call_meho_connector_ingest_version_mismatch_returns_invalid_params`, `test_call_meho_connector_ingest_uncovered_version_returns_invalid_params`)
- [x] `pytest tests/test_mcp_server.py tests/test_mcp_registry.py -x -q` — 50 passed (no regression in the `McpInvalidParamsError` / `_error_response` surface)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing file-size warnings; nothing agent-introduced)
- [x] **AC #1** — MCP `meho.connector.ingest` with spec/label version mismatch returns structured error carrying `requested_version` + `spec_info_versions` (verified by new test asserting `data.kind == "spec_label_mismatch"`, `data.requested_version == "8.0"`, `data.spec_info_versions == [{"spec_uri": ..., "info_version": "9.0.3"}]`)
- [x] **AC #2** — MCP ingest with uncovered version label returns structured error listing registered classes (verified by new test asserting `data.registered_classes == [{"class_name": "_RangedTestConnector", "supported_version_range": ">=8.5,<10.0", ...}]`)
- [x] **AC #3** — Non-`-32603` JSON-RPC code: both map to `-32602 Invalid Params` (caller-input validation per the project's existing convention)
- [x] **AC #4** — Tests assert MCP error envelope detail for both classes; REST behavior unchanged (the 35 existing REST ingest tests still pass)
- [x] **AC #5** — Python (ruff + mypy + pytest) green

## Out of scope

- Broadly auditing every MCP tool's exception mapping — scoped per the issue body to the two ingest validation classes; other tools can adopt the same shared-helper pattern in follow-ups.
- The REST `UncoveredVersionLabel` envelope stays as `str(exc)` — the structured builder exists so REST can adopt it later without changing the wire shape in a non-additive way.
- Pre-existing file-size warnings (`mcp/server.py` at 614 lines, `mcp/tools/connector_admin.py` at 695 lines) — recorded as adjacent findings; the diff is constrained to its scope and doesn't grow either file disproportionately.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #777


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * search_memory now returns real created_at/updated_at timestamps instead of a zero epoch placeholder.
  * Spec ingestion errors for version-mismatch and uncovered-version are now reported as Invalid Params with structured diagnostic details (shown in error.data) rather than generic internal-error responses.

* **Documentation**
  * Spec-ingestion docs updated to describe the new structured error payloads and mapping behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->