### PR TITLE
fix(test): session-scope fastembed model cache dir (kill per-test re-fetch)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -200,12 +200,35 @@ def _default_database_url(
     get_settings.cache_clear()
 
 
+@pytest.fixture(scope="session")
+def _shared_model_cache_dir(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """A single fastembed cache dir reused by every test in the worker.
+
+    The ONNX model is identical across all tests, so a read-only cache
+    needs no per-test isolation. The previous per-test ``tmp_path`` dir
+    forced fastembed to re-materialise the model into a fresh empty
+    directory on *every* app-booting test — cheap solo (~3s) but
+    catastrophic under ``pytest-xdist``: N workers each re-fetch
+    per-test and saturate the HF Hub unauthenticated rate limit through
+    the cluster's shared NAT egress, inflating per-test setup to ~22s
+    (the #761 / #771 unit-job-wall finding). Session scope means the
+    model materialises once per worker (N fetches total, not per-test),
+    and ``tmp_path_factory`` keeps each worker's dir distinct so there
+    is no cross-worker write race on first fetch (the partial/
+    symlink-broken-cache failure mode of evoila/meho#574).
+    """
+    return str(tmp_path_factory.mktemp("fastembed-cache-shared"))
+
+
 @pytest.fixture(autouse=True)
 def _default_retrieval_model_cache_dir(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Any,
+    _shared_model_cache_dir: str,
 ) -> Iterator[None]:
-    """Redirect fastembed's ONNX model cache to a writable per-test dir.
+    """Redirect fastembed's ONNX model cache to a writable shared dir.
+
+    The dir is session-scoped (see :func:`_shared_model_cache_dir`) so
+    the model materialises once per worker rather than once per test.
 
     The production default at :attr:`Settings.retrieval_model_cache_dir`
     is ``/opt/meho/model-cache`` — the image layer the default model is
@@ -235,7 +258,7 @@ def _default_retrieval_model_cache_dir(
     auth_config tests that exercise the lifespan transitively. Setting
     the env var here, before any test imports
     :func:`get_settings`, ensures every settings construction in the
-    test process resolves to a writable :class:`tmp_path`-scoped dir.
+    test process resolves to the writable session-shared dir.
 
     Why a sibling fixture instead of merging into
     :func:`_default_database_url`: the responsibilities are genuinely
@@ -250,7 +273,7 @@ def _default_retrieval_model_cache_dir(
     an earlier test would survive into the next test and silently
     return the previous cache_dir value.
     """
-    monkeypatch.setenv("RETRIEVAL_MODEL_CACHE_DIR", str(tmp_path / "fastembed-cache"))
+    monkeypatch.setenv("RETRIEVAL_MODEL_CACHE_DIR", _shared_model_cache_dir)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()


### PR DESCRIPTION
## Summary

Session-scope the fastembed model cache dir in `tests/conftest.py` so the ONNX model materializes **once per xdist worker** instead of **once per test**. This is the real fix for the #761/#765 "unit job doesn't parallelize" finding.

## The ticket's hypothesis was wrong — profiling corrected it

#771 (which I filed) guessed the cost was the MCP lifespan's embedding-model **preload**. Direct profiling disproved it; every warm measurement is sub-second:

| Measured (warm) | Time |
|---|---|
| Embedding model load + encode | 0.09s |
| Full app lifespan startup+shutdown | 0.10s |
| Model fetch into a **fresh empty** cache dir | 3.62s solo |

The real cost: [`tests/conftest.py`](backend/tests/conftest.py)'s autouse `_default_retrieval_model_cache_dir` pinned `RETRIEVAL_MODEL_CACHE_DIR` to a per-test `tmp_path` dir. Every app-booting test got a fresh empty cache → fastembed re-materialized the model per test. Cheap locally (~0.3s, warm HF hub cache), **catastrophic on CI**: the unit job runs `-n 6`, so six workers re-fetch per-test through the cluster's shared NAT egress and hit the HF Hub **unauthenticated rate limit** → the ~22s/test the `--durations=25` diagnostic showed (slowest 25 setups were all 22-25s `test_mcp_*` modules).

## Fix

A session-scoped `_shared_model_cache_dir` (via `tmp_path_factory`) reused by the autouse fixture. Model materializes once per worker, not per test. Per-worker (not global) dirs avoid a cross-worker write race on first fetch (the partial/symlink-broken-cache failure mode of #574). The autouse fixture stays function-scoped (still sets env + clears settings cache per test); only the directory target changed. **Test-only change** — no production code, no `client_with_operator` scope change, no preload-skip flag. The ticket's three proposed approaches all targeted the wrong cost.

## Test plan

- [x] `ruff check` + `ruff format --check` + `mypy src/` — clean
- [x] `test_mcp_tools_memory + topology + connector_admin` (-n 4) — 49 passed
- [x] `test_mcp_startup_guard + registry + tool_query_audit` (serial) — 45 passed
- [x] Tests referencing the cache dir directly (`test_retrieval_embedding`, `test_g07_vsphere_canary`) pass explicit `cache_dir=` or override the env locally → unaffected
- [ ] **CI is the magnitude gate** — expect the `Python (ruff + mypy + pytest)` wall to drop materially from ~22min (this is where the per-test re-fetch throttle actually lived)

## Note on local verification limits

A broad `-n 4` local slice could not be completed: the dev machine itself throttles on the concurrent cold model fetches this change eliminates. One `-n 4` run showed a single `F` at 93% in `test_observability`/`test_middleware` — the **pre-existing #738 structlog xdist flake** in the 9 files still carrying the old `_configure_capture` pattern (documented out-of-scope in #744), **not a regression here**. CI's warm-cache step + clean environment is the real verification.

Closes #771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite performance during parallel execution by implementing a shared ONNX model cache that persists across tests, reducing model materialization overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->