### PR TITLE
DIAGNOSTIC (do not merge): CI-side --durations=25 for #771 loadscope-tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
             COVERAGE_CORE=sysmon uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration \
               --cov=meho_backplane --cov-report=xml tests/
           else
-            uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration tests/
+            uv run pytest -n 6 --dist loadscope --durations=25 --ignore=tests/integration tests/
           fi
 
       - name: Upload Python coverage artifact


### PR DESCRIPTION
Temporary diagnostic for #771 — captures CI-side per-test timing to name the heavy modules in the `--dist loadscope` tail. **Do not merge; close after reading the durations from the CI log.** Earlier diagnosis used local `--durations` which mis-pointed at the model fetch (local throttles on cold fetches; CI pre-warms the HF cache). Refs #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to enhance test diagnostics for pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->