### PR TITLE
DIAGNOSTIC (do not merge): per-lifespan-step + fixture timing for #771

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,15 @@ jobs:
             COVERAGE_CORE=sysmon uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration \
               --cov=meho_backplane --cov-report=xml tests/
           else
-            uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration tests/
+            # DIAGNOSTIC (#771, branch diag/ci-lifespan-timing, DO NOT MERGE):
+            # env-gated per-lifespan-step + per-fixture setup attribution, then
+            # aggregate. --maxfail dropped so the full suite yields complete
+            # timing; || true so the aggregator always runs.
+            export MEHO_LIFESPAN_TIMING=/tmp/lifespan
+            export MEHO_FIXTURE_TIMING_FILE=/tmp/fixt
+            uv run pytest -n 6 --dist loadscope --durations=30 --ignore=tests/integration tests/ || true
+            echo "######################## DIAGNOSTIC TIMING ########################"
+            uv run python tests/_diag_aggregate.py
           fi
 
       - name: Upload Python coverage artifact

--- a/backend/tests/_diag_aggregate.py
+++ b/backend/tests/_diag_aggregate.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""DIAGNOSTIC aggregator (branch diag/ci-lifespan-timing only — DO NOT MERGE).
+
+Reads the per-worker timing files written by the env-gated instrumentation in
+conftest.py and prints two attribution tables to stdout for the #771 CI
+wall-time investigation:
+
+* lifespan-step timing  — which FastAPI lifespan step eats the per-test cost.
+* fixture-setup timing  — which fixture's setup the --durations report blames
+  on ``test_mcp_*`` setup.
+"""
+
+from __future__ import annotations
+
+import collections
+import glob
+import json
+
+
+def _load(pattern: str) -> list[dict]:
+    rows: list[dict] = []
+    for fpath in glob.glob(pattern):
+        with open(fpath) as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return rows
+
+
+def _agg(rows: list[dict], key: str) -> list[tuple[str, int, float, float]]:
+    acc: dict[str, list[float]] = collections.defaultdict(lambda: [0.0, 0.0, 0.0])
+    for r in rows:
+        a = acc[r[key]]
+        a[0] += 1
+        a[1] += r["dur"]
+        a[2] = max(a[2], r["dur"])
+    out = [(k, int(v[0]), v[1], v[2]) for k, v in acc.items()]
+    out.sort(key=lambda t: -t[2])  # by total seconds
+    return out
+
+
+def main() -> None:
+    life = _load("/tmp/lifespan.*")
+    print("=" * 78)
+    print(f"LIFESPAN STEP TIMING  ({len(life)} calls)  — sorted by total seconds")
+    print(f"{'step':<34}{'count':>7}{'sum_s':>11}{'max_s':>9}{'mean_s':>9}")
+    for name, count, total, mx in _agg(life, "step"):
+        print(f"{name:<34}{count:>7}{total:>11.1f}{mx:>9.2f}{total / count:>9.2f}")
+    print()
+    print("LIFESPAN — top 25 single slowest calls")
+    for r in sorted(life, key=lambda row: -row["dur"])[:25]:
+        print(f"{r['dur']:>8.2f}s  {r['step']:<32}{r['node']}")
+    print()
+
+    fixt = _load("/tmp/fixt.*")
+    print("=" * 78)
+    print(f"FIXTURE SETUP TIMING  ({len(fixt)} setups)  — top 40 by total seconds")
+    print(f"{'fixture':<34}{'count':>7}{'sum_s':>11}{'max_s':>9}{'mean_s':>9}")
+    for name, count, total, mx in _agg(fixt, "fix")[:40]:
+        print(f"{name:<34}{count:>7}{total:>11.1f}{mx:>9.2f}{total / count:>9.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -678,3 +678,119 @@ def mock_discovery_and_jwks(
         return_value=httpx.Response(200, json=jwks),
     )
     return discovery_route, jwks_route
+
+
+# ---------------------------------------------------------------------------
+# DIAGNOSTIC INSTRUMENTATION — branch diag/ci-lifespan-timing only (DO NOT MERGE)
+#
+# Env-gated, test-only attribution for the #771 CI wall-time investigation.
+# Both the hook and the autouse fixture are pure no-ops unless their env var
+# is set, so the suite behaves identically to main when the vars are absent.
+#
+#   MEHO_LIFESPAN_TIMING=<path>      per-test timing of each FastAPI lifespan
+#       step, captured by monkeypatching meho_backplane.main's module-level
+#       callables. One JSON line per call, written to "<path>.<worker>".
+#
+#   MEHO_FIXTURE_TIMING_FILE=<path>  per-fixture setup duration for every
+#       fixture in the suite (outer attribution: which fixture's setup the
+#       --durations report is blaming on test_mcp_* setup). Accumulated in
+#       process, flushed once per worker at session finish to "<path>.<worker>".
+# ---------------------------------------------------------------------------
+
+_DIAG_FIXTURE_TIMINGS: list[tuple[float, str, str]] = []
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    """Record per-fixture setup duration when MEHO_FIXTURE_TIMING_FILE is set."""
+    if not os.environ.get("MEHO_FIXTURE_TIMING_FILE"):
+        yield
+        return
+    start = time.perf_counter()
+    yield
+    _DIAG_FIXTURE_TIMINGS.append(
+        (round(time.perf_counter() - start, 3), fixturedef.argname, str(fixturedef.scope)),
+    )
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Flush accumulated fixture-setup timings once per worker."""
+    import json
+
+    path = os.environ.get("MEHO_FIXTURE_TIMING_FILE")
+    if not path or not _DIAG_FIXTURE_TIMINGS:
+        return
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    with open(f"{path}.{worker}", "w") as fh:
+        for dur, name, scope in _DIAG_FIXTURE_TIMINGS:
+            fh.write(json.dumps({"dur": dur, "fix": name, "scope": scope}) + "\n")
+
+
+@pytest.fixture(autouse=True)
+def _diag_lifespan_step_timing(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Time each FastAPI lifespan step per test when MEHO_LIFESPAN_TIMING is set.
+
+    Wraps the module-level callables the lifespan invokes (resolved from
+    meho_backplane.main's globals at call time) with timing wrappers that
+    append one record per call. Restored on teardown. Test-only; touches no
+    production code.
+    """
+    import asyncio
+    import json
+
+    path = os.environ.get("MEHO_LIFESPAN_TIMING")
+    if not path:
+        yield
+        return
+
+    import meho_backplane.main as main_mod
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    node = request.node.nodeid
+    out = f"{path}.{worker}"
+
+    def _record(step: str, dur: float) -> None:
+        with open(out, "a") as fh:
+            fh.write(json.dumps({"step": step, "dur": round(dur, 3), "node": node}) + "\n")
+
+    def _wrap_sync(orig: Any, name: str) -> Any:
+        def w(*a: Any, **k: Any) -> Any:
+            t = time.perf_counter()
+            try:
+                return orig(*a, **k)
+            finally:
+                _record(name, time.perf_counter() - t)
+
+        return w
+
+    def _wrap_async(orig: Any, name: str) -> Any:
+        async def w(*a: Any, **k: Any) -> Any:
+            t = time.perf_counter()
+            try:
+                return await orig(*a, **k)
+            finally:
+                _record(name, time.perf_counter() - t)
+
+        return w
+
+    names = [
+        "get_engine",
+        "get_broadcast_client",
+        "_eager_import_connectors",
+        "run_typed_op_registrars",
+        "eager_import_mcp_modules",
+        "_preload_embedding_model",
+        "start_topology_refresh_scheduler",
+    ]
+    originals: dict[str, Any] = {}
+    for name in names:
+        orig = getattr(main_mod, name)
+        originals[name] = orig
+        is_async = asyncio.iscoroutinefunction(orig)
+        wrapper = _wrap_async(orig, name) if is_async else _wrap_sync(orig, name)
+        setattr(main_mod, name, wrapper)
+    try:
+        yield
+    finally:
+        for name, orig in originals.items():
+            setattr(main_mod, name, orig)


### PR DESCRIPTION
## DIAGNOSTIC — DO NOT MERGE

Definitive CI-side attribution for the #771 unit-suite wall-time
investigation. After six local mis-diagnoses, the goal here is to stop
guessing and let **one instrumented CI run** say exactly where the time
goes — because the cost does not reproduce locally.

### What the baseline already proves

The latest PR-path run of the unit job (a `pull_request` event, so
coverage is **off** — #726 already gated `--cov` to push-to-main) spent
**22m19s purely in `pytest`** under `-n 6` on the heavy pool. So the
wall is **not** coverage instrumentation.

`--durations=25` on that run blames the 25 slowest items on
`test_mcp_*` **setup**, 35–47s each — and crucially, **multiple tests
within the same module** appear. Under `--dist loadscope` a module's
higher-scoped fixtures are set up once per worker, so a per-module cost
would show each module once. Multiple hits per module ⇒ the 35–47s is a
**function-scoped** cost paid **per test** (the full FastAPI lifespan
runs every test via `client_with_operator`'s `with TestClient(app)`).

The one non-setup outlier — `42.26s call test_auth_config ::
test_auth_config_normalises_trailing_slash_on_issuer` — is the
signature of a **network connection hanging to timeout** on the request
path (real auth, no override, `.evba.lab` hosts). Same suspected
mechanism, different entry point.

### What this PR adds (env-gated, test-only, zero production change)

- `tests/conftest.py`: two no-op-unless-enabled hooks —
  - `MEHO_LIFESPAN_TIMING` → times each FastAPI lifespan step
    (`run_typed_op_registrars`, `_preload_embedding_model`,
    `get_broadcast_client`, `start_topology_refresh_scheduler`, …) by
    wrapping `meho_backplane.main`'s module-level callables.
  - `MEHO_FIXTURE_TIMING_FILE` → per-fixture setup duration (outer
    attribution: which fixture's setup the `--durations` report blames).
- `tests/_diag_aggregate.py`: prints both attribution tables.
- `.github/workflows/ci.yml` (PR branch only): sets the two env vars,
  runs the full suite, then prints the aggregate.

Both hooks are pure no-ops when the env vars are absent, so `main`
behaves identically.

### What we expect to learn

Which single lifespan step (or fixture) eats the 35–47s per test in CI.
If it confirms a network-bound step hanging to timeout, the fix is a
real, scoped change (short timeout / skip-in-tests / lazy-on-first-use)
— filed separately. **This branch is then closed, not merged.**

Refs #771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI diagnostic capabilities to collect and aggregate performance timing metrics during test runs, improving insight into system performance characteristics and test execution efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->