### PR TITLE
docs(mcp): G0.9.1-T8 target-reference shape convention + kb slug docs (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,35 @@ connector-related release-notes line.
   from the 2026-05-21 RDC v0.3.1 dogfood
   ([#773](https://github.com/evoila/meho/issues/773)).
 
+### Documentation
+
+- **Target-reference shape convention documented** for the MCP
+  agent surface. The agent surface today carries three internally
+  coherent but cross-tool-divergent shapes for naming a target /
+  node — `call_operation` takes `target: {name: ...}` (object),
+  `query_topology` / `query_audit` take `target: "<name>"` (bare
+  string), `meho.topology.annotate` takes paired `from_name` /
+  `to_name`. The 2026-05-21 RDC second-cycle dogfood (Signal #8)
+  flagged this as migration fatigue across tools. A new
+  "Target-reference shape convention" section in
+  [`docs/architecture/mcp.md`](docs/architecture/mcp.md) captures
+  the three shapes, the rationale for each, and the forward
+  convention any new tool should follow — so no fourth shape lands
+  by accident before the deliberate v0.4+ unification. The
+  `call_operation` / `query_topology` / `query_audit` tool
+  descriptions now cross-reference this section. **No wire-schema
+  change** — this is docs-only ([#780](https://github.com/evoila/meho/issues/780)).
+- **kb slug leading-letter constraint surfaced in schema descriptions**
+  for the `add_to_knowledge` MCP tool and the `POST /api/v1/kb`
+  request body. The slug regex requires a leading lowercase letter,
+  but the existing example (`vcenter-9.0-snapshot-revert`)
+  satisfied the rule silently — a caller running a digit-leading
+  slug (`657-recovery`) tripped a -32602 / 422 without ever seeing
+  the constraint in the schema. Both descriptions now name the
+  rule and pair the positive example with a digit-leading negative
+  example, so the constraint is visible before the call goes out
+  ([#780](https://github.com/evoila/meho/issues/780), Signal #15).
+
 ## [0.3.1] - 2026-05-21
 
 **v0.3.0 dogfood-hardening patch.** No new headline features — this

--- a/backend/src/meho_backplane/api/v1/kb.py
+++ b/backend/src/meho_backplane/api/v1/kb.py
@@ -159,7 +159,19 @@ class KbEntryCreate(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    slug: str = Field(min_length=1, max_length=_SLUG_MAX_LENGTH)
+    slug: str = Field(
+        min_length=1,
+        max_length=_SLUG_MAX_LENGTH,
+        description=(
+            "Operator-facing identifier in kebab-case. Must start with "
+            "a lowercase letter, end with a lowercase letter or digit, "
+            "and contain only lowercase letters, digits, hyphens, or "
+            "dots. The leading-letter rule (G0.9.1-T8, Signal #15) is "
+            "the most common surprise: '657-recovery' is rejected; "
+            "rewrite as 'ticket-657-recovery'."
+        ),
+        examples=["vcenter-9.0-snapshot-revert"],
+    )
     body: str = Field(min_length=1)
     metadata: dict[str, Any] | None = None
 

--- a/backend/src/meho_backplane/mcp/tools/audit.py
+++ b/backend/src/meho_backplane/mcp/tools/audit.py
@@ -85,7 +85,12 @@ _INPUT_SCHEMA: Final[dict[str, Any]] = {
             "description": (
                 "Target name or alias. Substrate matches against "
                 "`targets.name` scoped to the operator's tenant; an "
-                "unknown name returns zero rows, not an error."
+                "unknown name returns zero rows, not an error. "
+                "NOTE: this tool's `target` is a bare string (read "
+                "tools only need the name); `call_operation` wraps "
+                "the same concept in a `{name: ...}` dict. See "
+                "`docs/architecture/mcp.md` ('Target-reference shape "
+                "convention')."
             ),
             "maxLength": 256,
         },

--- a/backend/src/meho_backplane/mcp/tools/knowledge.py
+++ b/backend/src/meho_backplane/mcp/tools/knowledge.py
@@ -95,12 +95,21 @@ _MAX_SEARCH_LIMIT: Final[int] = 50
 
 #: Shared slug-shape description rendered into both the tool input schema
 #: (``add_to_knowledge``) and the resource template (``meho://kb/{slug}``).
-#: Authored once so a future contract tweak edits one string.
+#: Authored once so a future contract tweak edits one string. The
+#: leading-letter rule is called out twice (in the prose AND in a paired
+#: positive/negative example) because the v0.3.1 consumer dogfood
+#: (G0.9.1-T8, Signal #15) hit -32602 on a digit-leading slug
+#: ('657-recovery') without finding the rule in the schema description —
+#: the regex catches it, but the example-of-an-invalid-slug here is
+#: what makes the constraint discoverable before the call goes out.
 _SLUG_DESCRIPTION: Final[str] = (
     "Operator-facing identifier in kebab-case, recommended shape "
-    "'<product>-<version>-<topic>' (e.g. 'vcenter-9.0-snapshot-revert'). "
+    "'<product>-<version>-<topic>'. "
     "Must start with a lowercase letter, end with a lowercase letter or "
-    "digit, and contain only lowercase letters, digits, hyphens, or dots."
+    "digit, and contain only lowercase letters, digits, hyphens, or dots. "
+    "Valid example: 'vcenter-9.0-snapshot-revert'. "
+    "Invalid example: '657-recovery' — slugs may not start with a digit; "
+    "rewrite to 'ticket-657-recovery' or similar."
 )
 
 

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -295,7 +295,17 @@ register_mcp_tool(
                         "Partial target descriptor. The dispatcher "
                         "resolves the `name` field against the targets "
                         "registry; aliases are accepted. Pass null "
-                        "for operations that do not act on a target."
+                        "for operations that do not act on a target. "
+                        "NOTE: this tool's `target` is a dict "
+                        '({"name": "<target-name>"}) because the '
+                        "dispatcher reserves room for additional "
+                        "future fields (e.g. an alias-precedence pin); "
+                        "the topology / audit read tools (`query_topology`, "
+                        "`query_audit`) take a bare-string `target` "
+                        "since they only need the name. See "
+                        "`docs/architecture/mcp.md` ('Target-reference "
+                        "shape convention') for the canonical forward "
+                        "convention any new tool should follow."
                     ),
                     "properties": {
                         "name": {"type": "string", "minLength": 1},

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -168,7 +168,13 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
                 "Root node name for `dependents` / `dependencies`. "
                 "Resolved against `graph_node.name` scoped to the "
                 "operator's tenant. Required when `kind` is `dependents` "
-                "or `dependencies`; ignored for `path`."
+                "or `dependencies`; ignored for `path`. "
+                "NOTE: this tool's `target` is a bare string because "
+                "the read path only needs the name; `call_operation` "
+                "wraps the same concept in a `{name: ...}` dict to "
+                "leave room for future selector fields. See "
+                "`docs/architecture/mcp.md` ('Target-reference shape "
+                "convention')."
             ),
             "maxLength": 256,
         },

--- a/backend/tests/test_api_v1_kb.py
+++ b/backend/tests/test_api_v1_kb.py
@@ -259,6 +259,31 @@ def test_all_five_routes_mounted_on_main_app() -> None:
     assert "post" in paths["/api/v1/kb/ingest"]
 
 
+def test_kb_entry_create_slug_field_teaches_leading_letter_rule() -> None:
+    """G0.9.1-T8 / Signal #15: the POST body's slug field carries a
+    description that names the leading-letter rule and a positive example,
+    so OpenAPI consumers (Swagger UI, generated SDKs, CLI help) see the
+    constraint before they ship a 422.
+
+    Doc-drift guard — substring assertions kept loose so prose can evolve.
+    """
+    from meho_backplane.api.v1.kb import KbEntryCreate
+
+    schema = KbEntryCreate.model_json_schema()
+    slug_field = schema["properties"]["slug"]
+
+    description = slug_field.get("description", "")
+    assert "lowercase letter" in description.lower()
+    assert "start with" in description.lower()
+    # Negative example must be present so the constraint is discoverable.
+    assert "657" in description
+
+    # Positive example must round-trip through Pydantic v2's `examples=`
+    # surface so Swagger UI / openapi.json carries it.
+    examples = slug_field.get("examples") or []
+    assert "vcenter-9.0-snapshot-revert" in examples
+
+
 # ---------------------------------------------------------------------------
 # Unauthenticated (401) -- every route
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_tools_knowledge.py
+++ b/backend/tests/test_mcp_tools_knowledge.py
@@ -160,6 +160,47 @@ def test_tool_descriptions_satisfy_ai_engineering_anchor(
     assert "search_knowledge" in add_desc
 
 
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_add_to_knowledge_slug_description_teaches_leading_letter_rule(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """G0.9.1-T8 / Signal #15: the slug schema description names the
+    leading-letter constraint AND carries a digit-leading negative
+    example, so an agent reading the schema (not just the regex)
+    learns the rule before it ships a 422/-32602.
+
+    Doc-drift guard: a future edit that drops either half of the
+    positive / negative example pair surfaces here. Substring matching
+    keeps the assertion loose so prose can evolve.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+
+    slug_desc = tools_by_name["add_to_knowledge"]["inputSchema"]["properties"]["slug"][
+        "description"
+    ]
+
+    # The leading-letter rule must be stated in prose, not just enforced
+    # by the regex behind the scenes.
+    assert "lowercase letter" in slug_desc.lower()
+    assert "start with" in slug_desc.lower()
+
+    # A positive AND a negative example must both be present — the
+    # consumer-feedback signal (#15) was that the example-only schema
+    # left the constraint undiscoverable until the call failed.
+    assert "vcenter-9.0-snapshot-revert" in slug_desc  # positive
+    assert "657" in slug_desc  # negative (digit-leading)
+    assert "invalid" in slug_desc.lower()
+
+
 # ---------------------------------------------------------------------------
 # search_knowledge — call path
 # ---------------------------------------------------------------------------

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -143,12 +143,35 @@ Fail-closed: audit write failure → MCP call fails with JSON-RPC `INTERNAL_ERRO
 
 `params_hash` is SHA256 of canonicalized (sorted-keys JSON) arguments — content-addressable, deterministic, doesn't leak the args.
 
+## Target-reference shape convention
+
+The agent surface today has three distinct shapes for "name a target/node by name". This is deliberate but easy to mistake for inconsistency — and it surfaced as Signal #8 of the 2026-05-21 RDC second-cycle dogfood (#780). The shapes are internally coherent per tool; the divergence is *across* tools.
+
+| Shape | Tool(s) | Why |
+|---|---|---|
+| `target: {"name": "<name>"}` (object with `name` key) | [`call_operation`](../../backend/src/meho_backplane/mcp/tools/operations.py) | The dispatcher reserves room for additional future selector fields on the target descriptor (e.g. an `alias_precedence` pin or a tenant-scoped `kind` disambiguator) without a breaking schema change. The `{name}` envelope is the partial form; only `name` is honoured today. |
+| `target: "<name>"` (bare string) | [`query_topology`](../../backend/src/meho_backplane/mcp/tools/topology.py) (kind=`dependents`/`dependencies`), [`query_audit`](../../backend/src/meho_backplane/mcp/tools/audit.py) | Read tools only need the name. The bare-string shape keeps the argument cheap and the schema legible; no selector fields are anticipated. |
+| `from_name`/`to_name`: `"<name>"` (paired strings) | [`meho.topology.annotate`](../../backend/src/meho_backplane/mcp/tools/topology.py), [`meho.topology.unannotate`](../../backend/src/meho_backplane/mcp/tools/topology.py), [`query_topology`](../../backend/src/meho_backplane/mcp/tools/topology.py) (kind=`path`) | These tools name **two** nodes (a directed edge pair). The two flat fields mirror Python's `(from_, to)` keyword convention (with `from_name` because `from` is a reserved word) and let the JSON Schema layer require both atomically. A nested `{from: {name}, to: {name}}` object would be ceremony for no benefit. |
+
+[`list_targets`](../../backend/src/meho_backplane/mcp/tools/topology.py) returns rows that carry a bare `name`; that is the value the caller passes to `call_operation` (wrapped as `{name: ...}`) or to `query_topology` (as a bare string).
+
+### Forward convention for new tools
+
+When a new tool needs to reference a target/node by name, pick the shape that matches the tool's *role*:
+
+1. **Write/dispatch tools that act on one target** (anything like `call_operation`) — **use the `{name: ...}` object form.** The forward-compat headroom matters; the cost of an envelope is one extra brace pair.
+2. **Read tools that filter by one target name** (anything like `query_audit`, single-anchor closure queries) — **use the bare-string `target`.** No selector room is needed; keep the schema flat.
+3. **Tools that operate on an edge (two endpoints)** — **use the `from_name`/`to_name` pair.** Match the existing `meho.topology.annotate` schema verbatim so an agent carrying a node-pair through the topology surface can hand the same arguments to the next tool without renaming.
+
+A future v0.4+ unification (a shared `TargetRef` / `TargetSelector` model with strict-schema breakage) is on the roadmap (Initiative #772 out-of-scope; v0.3.2 is docs-first); that decision will cite this section. Until then: **do not introduce a fourth shape**. If you find yourself reaching for one, file an Initiative-level discussion rather than landing it.
+
 ## Adding an MCP tool
 
 For a new vendor connector op:
 
 1. **Implement the op** in your connector's `_op_map` (per [`connectors.md`](connectors.md)).
-2. **Register an MCP tool** in `backend/src/meho_backplane/mcp/tools/<product>.py`:
+2. **Pick the target-reference shape** per the "Target-reference shape convention" section above — bare-string `target` for read tools, `{name: ...}` object for write/dispatch tools, `from_name`/`to_name` pair for edge tools. The example below is a single-target read.
+3. **Register an MCP tool** in `backend/src/meho_backplane/mcp/tools/<product>.py`:
    ```python
    register_mcp_tool(
        ToolDefinition(
@@ -169,8 +192,8 @@ For a new vendor connector op:
        handler=_vsphere_vm_list_handler,
    )
    ```
-3. **Lifespan eager-import** picks it up on restart.
-4. **Verify** via `tools/list` then `tools/call` against a running backplane (use `@modelcontextprotocol/inspector`).
+4. **Lifespan eager-import** picks it up on restart.
+5. **Verify** via `tools/list` then `tools/call` against a running backplane (use `@modelcontextprotocol/inspector`).
 
 ## Adding an MCP resource
 


### PR DESCRIPTION
## Summary

- Document the **target-reference shape convention** for the MCP agent surface in [`docs/architecture/mcp.md`](docs/architecture/mcp.md): three internally coherent but cross-tool-divergent shapes (`call_operation`'s `{name}` object, `query_topology` / `query_audit`'s bare-string `target`, `meho.topology.annotate`'s paired `from_name`/`to_name`), the rationale for each, and the forward convention so no fourth shape lands by accident before the deliberate v0.4+ unification. The `call_operation` / `query_topology` / `query_audit` tool descriptions now carry a one-paragraph cross-reference. **No wire-schema change.**
- Surface the **kb slug leading-letter constraint** in the `add_to_knowledge` MCP tool description AND the `POST /api/v1/kb` request body Pydantic field. The existing positive example (`vcenter-9.0-snapshot-revert`) satisfied the leading-letter rule silently; a digit-leading slug (`657-recovery`) tripped -32602 / 422 with no schema-side foreshadowing. Both surfaces now pair the positive example with a digit-leading negative example and state the rule in prose. The custom error message (already correct) is unchanged.
- Add two doc-drift guard tests — one each on the MCP tool schema and the Pydantic `KbEntryCreate` field — so a future rewording that drops either half of the positive / negative example pair surfaces in test rather than silently degrading discoverability.

Why this scope (docs-first, no breaking renames): the parent initiative [#772](https://github.com/evoila/meho/issues/772) explicitly marks any breaking renormalization of the ~17 agent-surface meta-tools as a deliberate v0.4+ decision; v0.3.2 is operator-experience polish. This PR records the forward convention so the eventual unification has a cited reference.

## Test plan

- [x] `ruff check` — clean on touched files
- [x] `ruff format --check` — clean on touched files
- [x] `mypy --ignore-missing-imports` — clean on touched files
- [x] `pytest tests/test_mcp_tools_knowledge.py tests/test_api_v1_kb.py tests/test_kb_schemas.py` — 72 passed
- [x] `pytest tests/test_mcp_tool_query_audit.py tests/test_mcp_tools_topology.py tests/test_mcp_tools_topology_annotate.py tests/test_mcp_tools_operations.py` — green (sibling MCP tools whose descriptions I touched stay green)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 5 warnings (all pre-existing file-size warnings on `topology.py` / `kb.py`; nothing introduced by this PR)
- [x] **AC #1** (target-ref convention documented): new "Target-reference shape convention" section in `docs/architecture/mcp.md` + cross-references in three tool descriptions
- [x] **AC #2** (kb slug leading-letter rule discoverable): negative example `657-recovery` present in both the MCP `_SLUG_DESCRIPTION` and the `KbEntryCreate.slug` Pydantic field; verified by the two new tests
- [x] **AC #3** (doc-drift guard): `test_add_to_knowledge_slug_description_teaches_leading_letter_rule` + `test_kb_entry_create_slug_field_teaches_leading_letter_rule` assert substring presence of the positive + negative example
- [x] **AC #4** (`Python (ruff + mypy + pytest)` green): see above

## Out of scope

- **Breaking renormalization** of `call_operation` / `query_topology` / `annotate` target shapes — deliberate v0.4+ decision per Initiative #772.
- The `meho.topology.annotate` tool description — extended by sibling PR #792 (T6 #778) with bootstrap-precondition guidance; this PR avoids that surface to stay collision-free with the in-flight initiative work.
- Memory slug pattern — different subsystem, intentionally permissive.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a target-reference shape convention for MCP tools and updated guidance for adding MCP tools.
  * Enhanced slug guidance in API and tool schemas to teach the “starts with a lowercase letter” rule with positive and negative examples.
  * Clarified which tools expect bare-string vs. object-shaped target arguments.

* **Tests**
  * Added contract tests ensuring slug schema descriptions and examples surface the leading-letter rule in API docs and tool listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->