### PR TITLE
fix(auth): G0.9.1-T9 complete /api/v1/auth-config with cli_client_id (#789)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,24 @@ connector-related release-notes line.
   the remediation for a listed-but-unresolvable id. Closes Signal #6
   from the 2026-05-21 RDC v0.3.1 dogfood
   ([#773](https://github.com/evoila/meho/issues/773)).
+- Complete `/api/v1/auth-config` with a public `cli_client_id` field
+  (chart-wired via `config.keycloakCliClientId` / env
+  `KEYCLOAK_CLI_CLIENT_ID`) and fix the `meho login` CLI's discovery
+  mapping — the CLI now drives the device-code `client_id` from
+  `cli_client_id` instead of mis-mapping `audience` (the confidential
+  resource-server identifier, which Keycloak rejects for device-code
+  with `401 unauthorized_client`). Stale `meho login --help`
+  ("Until that endpoint ships") and the TLS-discovery-failure
+  breadcrumb are corrected; the latter now points operators at
+  `--client-id`/`--issuer` overrides **and** root-CA installation for
+  internal-CA deployments. Deployer recipe for the pre-created public
+  `meho-cli` Keycloak client added to
+  [`deploy/values-examples/README.md`](deploy/values-examples/README.md).
+  v0.3.1 first-login regression on the documented happy path; consumer
+  report 2026-05-21 Signal #16 ([#789](https://github.com/evoila/meho/issues/789),
+  G0.9.1-T9 under [#772](https://github.com/evoila/meho/issues/772)).
+  Auto-provisioning the public client at install time is tracked under
+  [#791](https://github.com/evoila/meho/issues/791) (T11).
 
 ### Documentation
 

--- a/backend/src/meho_backplane/api/v1/auth_config.py
+++ b/backend/src/meho_backplane/api/v1/auth_config.py
@@ -4,17 +4,19 @@
 """``GET /api/v1/auth-config`` — public OAuth discovery for the CLI.
 
 The CLI's device-code flow (``cli/internal/cmd/login.go``) needs the
-Keycloak realm issuer URL and the audience claim before it can run
-``cfg.DeviceAuth(flowCtx)``. Operators should only have to know one
-URL — the backplane's — so the CLI fetches both values from this
-endpoint at the start of ``meho login``.
+Keycloak realm issuer URL, the backplane audience, and the public
+device-code ``client_id`` before it can run ``cfg.DeviceAuth(flowCtx)``.
+Operators should only have to know one URL — the backplane's — so the
+CLI fetches all three values from this endpoint at the start of
+``meho login``.
 
 Unauthenticated by design:
 
 * This is the OAuth metadata the CLI needs **before** it can auth.
 * The values are public OAuth metadata — the issuer URL appears in
-  every JWT's ``iss`` claim and the audience appears in every JWT's
-  ``aud`` claim. They are not secrets.
+  every JWT's ``iss`` claim, the audience appears in every JWT's
+  ``aud`` claim, and the CLI ``client_id`` is a public OAuth identifier
+  (no client secret involved). They are not secrets.
 * Adding authentication here would create a chicken-and-egg loop with
   ``meho login``.
 
@@ -26,14 +28,31 @@ both read from the same env-var contract documented in
 
 Response shape locked by the CLI's discovery parser in
 ``cli/internal/cmd/login.go`` (search for ``keycloak_issuer`` /
-``audience`` in that file's ``fetchBackplaneAuthConfig``). Field
-renames here are wire-compat breaks for the CLI.
+``audience`` / ``cli_client_id`` in that file's
+``fetchBackplaneAuthConfig``). Field renames here are wire-compat
+breaks for the CLI.
 
-Closes the gap documented in closed Task #44's coordination note
-("add the endpoint to G2.2-T3's ``/api/v1/health`` Task body
-retroactively as a follow-up issue") that was never filed; the CLI
-shipped with the ``--issuer`` / ``--client-id`` fallback flags while
-this surface waited.
+The three fields:
+
+* ``keycloak_issuer`` — the realm issuer URL.
+* ``audience`` — the JWT ``aud`` value the backplane validates inbound
+  tokens against. This is the **confidential** resource-server
+  identifier (e.g. ``meho-backplane``); device-code clients cannot use
+  it as ``client_id`` because it carries a client secret.
+* ``cli_client_id`` — the **public** device-code ``client_id`` the CLI
+  uses to drive the RFC 8628 device authorization grant. Sourced from
+  :attr:`~meho_backplane.settings.Settings.keycloak_cli_client_id`
+  (chart-wired via ``config.keycloakCliClientId``). When unset (empty
+  string), the CLI surfaces an actionable error naming the public-client
+  requirement rather than silently using ``audience``.
+
+The ``cli_client_id`` field was added by G0.9.1-T9 after the 2026-05-21
+RDC dogfood (Signal #16) showed that the v0.3.1 endpoint (issuer +
+audience only) silently broke ``meho login`` on its documented happy
+path — the CLI was mapping ``audience`` to ``client_id``, but Keycloak
+rejects device-code initiation against a confidential resource-server
+client with ``401 unauthorized_client``. Closes the gap documented in
+closed Task #44's coordination note that was never filed.
 """
 
 from __future__ import annotations
@@ -49,14 +68,20 @@ __all__ = ["router"]
 class AuthConfigResponse(BaseModel):
     """OAuth discovery surface returned to ``meho login``.
 
-    Field names match the CLI's expected JSON keys (``keycloak_issuer``
-    and ``audience``); renaming either field is a wire-compat break.
+    Field names match the CLI's expected JSON keys (``keycloak_issuer``,
+    ``audience``, ``cli_client_id``); renaming any field is a wire-compat
+    break for the CLI's discovery parser. ``cli_client_id`` defaults to
+    the empty string on the response when the backplane has not been
+    wired (``KEYCLOAK_CLI_CLIENT_ID`` unset); the CLI distinguishes
+    empty-string from absent-key and emits the same actionable
+    public-client error in both cases.
     """
 
     model_config = ConfigDict(frozen=True)
 
     keycloak_issuer: str
     audience: str
+    cli_client_id: str
 
 
 router = APIRouter(prefix="/api/v1", tags=["auth"])
@@ -64,7 +89,7 @@ router = APIRouter(prefix="/api/v1", tags=["auth"])
 
 @router.get("/auth-config", response_model=AuthConfigResponse)
 async def auth_config() -> AuthConfigResponse:
-    """Return Keycloak issuer + audience for the CLI's device-code flow.
+    """Return Keycloak issuer, audience, and CLI client_id for device-code flow.
 
     Reads :func:`~meho_backplane.settings.get_settings` so the response
     cannot drift from the values :mod:`~meho_backplane.auth.jwt` uses
@@ -78,4 +103,5 @@ async def auth_config() -> AuthConfigResponse:
     return AuthConfigResponse(
         keycloak_issuer=str(settings.keycloak_issuer_url).rstrip("/"),
         audience=settings.keycloak_audience,
+        cli_client_id=settings.keycloak_cli_client_id,
     )

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -105,6 +105,21 @@ class Settings(BaseModel):
         backplane is registered as a Keycloak client (e.g.
         ``meho-backplane``); only tokens whose ``aud`` matches that
         client id are honoured. Required.
+    keycloak_cli_client_id:
+        The OAuth ``client_id`` of the **public** device-code client
+        that ``meho login`` uses to initiate the RFC 8628 device flow
+        (suggested name ``meho-cli``). Surfaced through
+        ``GET /api/v1/auth-config`` so the CLI can discover it without
+        the operator hand-passing ``--client-id``. Must be a public
+        client (no client secret) with the device-grant flow enabled
+        and an audience mapper that injects ``keycloak_audience`` into
+        the issued access token's ``aud`` claim — see
+        ``deploy/values-examples/README.md`` for the realm-side recipe.
+        Default ``""`` (unset) keeps backwards compatibility with the
+        v0.3.1 endpoint shape: the field still appears on the response
+        but the CLI surfaces an actionable error rather than silently
+        misusing ``audience`` (which is the confidential resource-
+        server identifier, not a public client).
     keycloak_jwks_cache_ttl_seconds:
         Maximum age of a cached JWKS document before it must be
         refetched. The cache also refreshes on a kid-miss (key
@@ -333,6 +348,7 @@ class Settings(BaseModel):
 
     keycloak_issuer_url: HttpUrl
     keycloak_audience: str = Field(min_length=1)
+    keycloak_cli_client_id: str = ""
     keycloak_jwks_cache_ttl_seconds: int = Field(default=300, gt=0)
     keycloak_jwt_leeway_seconds: int = Field(default=30, ge=0)
     jwt_tenant_claim_name: str = Field(default="tenant_id", min_length=1)
@@ -442,6 +458,7 @@ def get_settings() -> Settings:
     return Settings(
         keycloak_issuer_url=os.environ["KEYCLOAK_ISSUER_URL"],  # type: ignore[arg-type]
         keycloak_audience=os.environ["KEYCLOAK_AUDIENCE"],
+        keycloak_cli_client_id=os.environ.get("KEYCLOAK_CLI_CLIENT_ID", ""),
         keycloak_jwks_cache_ttl_seconds=int(
             os.environ.get("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300"),
         ),

--- a/backend/tests/test_auth_config.py
+++ b/backend/tests/test_auth_config.py
@@ -11,9 +11,9 @@ would deadlock ``meho login``.
 
 The wire shape is locked to the CLI's parser in
 ``cli/internal/cmd/login.go``'s ``fetchBackplaneAuthConfig``: it
-expects exactly ``keycloak_issuer`` and ``audience`` JSON keys. Field
-renames here are wire-compat breaks. The shape assertion below would
-catch that.
+expects exactly ``keycloak_issuer``, ``audience``, and
+``cli_client_id`` JSON keys. Field renames here are wire-compat
+breaks. The shape assertion below would catch that.
 """
 
 from __future__ import annotations
@@ -43,20 +43,22 @@ def _auth_config_settings(
     """
     monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.evba.lab/realms/evba")
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("KEYCLOAK_CLI_CLIENT_ID", "meho-cli")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.evba.lab")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
 
 
-def test_auth_config_returns_keycloak_issuer_and_audience(
+def test_auth_config_returns_keycloak_issuer_audience_and_cli_client_id(
     _auth_config_settings: None,
 ) -> None:
     """Happy path: response carries the values the CLI parses.
 
     Wire shape locked to the CLI's expectation in
     ``cli/internal/cmd/login.go``'s ``fetchBackplaneAuthConfig`` —
-    the parser reads ``keycloak_issuer`` and ``audience`` JSON keys.
+    the parser reads ``keycloak_issuer``, ``audience``, and
+    ``cli_client_id`` JSON keys.
     """
     with TestClient(app) as client:
         response = client.get("/api/v1/auth-config")
@@ -66,7 +68,46 @@ def test_auth_config_returns_keycloak_issuer_and_audience(
     assert payload == {
         "keycloak_issuer": "https://keycloak.evba.lab/realms/evba",
         "audience": "meho-backplane",
+        "cli_client_id": "meho-cli",
     }
+
+
+def test_auth_config_cli_client_id_defaults_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``KEYCLOAK_CLI_CLIENT_ID`` unset → ``cli_client_id`` is ``""``.
+
+    The G0.9.1-T9 contract keeps backwards compatibility with the
+    v0.3.1 endpoint by making ``KEYCLOAK_CLI_CLIENT_ID`` optional: the
+    field still appears on every response (so the CLI's parser shape
+    stays stable), but the CLI distinguishes empty-string from "field
+    was set" and emits an actionable public-client error rather than
+    silently falling back to ``audience``.
+
+    Pinning this behaviour in a test stops a future contributor from
+    "fixing" the empty default by raising at startup — that would break
+    every existing deployment on upgrade and shifts the actionable
+    error from the CLI (where the operator sees it) to a backplane
+    CrashLoopBackOff (where they don't).
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.evba.lab/realms/evba")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.delenv("KEYCLOAK_CLI_CLIENT_ID", raising=False)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.evba.lab")
+    get_settings.cache_clear()
+
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/auth-config")
+    finally:
+        get_settings.cache_clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["cli_client_id"] == ""
+    # Sanity: the other fields still populate.
+    assert payload["keycloak_issuer"] == "https://keycloak.evba.lab/realms/evba"
+    assert payload["audience"] == "meho-backplane"
 
 
 def test_auth_config_normalises_trailing_slash_on_issuer(
@@ -86,6 +127,7 @@ def test_auth_config_normalises_trailing_slash_on_issuer(
         "https://keycloak.evba.lab/realms/evba/",
     )
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("KEYCLOAK_CLI_CLIENT_ID", "meho-cli")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.evba.lab")
     get_settings.cache_clear()
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -85,7 +85,7 @@
           "auth"
         ],
         "summary": "Auth Config",
-        "description": "Return Keycloak issuer + audience for the CLI's device-code flow.\n\nReads :func:`~meho_backplane.settings.get_settings` so the response\ncannot drift from the values :mod:`~meho_backplane.auth.jwt` uses\nwhen it validates inbound JWTs. The issuer URL is trailing-slash-\nnormalised here \u2014 Keycloak's discovery document advertises the\ncanonical form without a trailing slash and the CLI's own URL\nconstruction (``<issuer>/.well-known/openid-configuration``) is\ncleaner against the normalised form.",
+        "description": "Return Keycloak issuer, audience, and CLI client_id for device-code flow.\n\nReads :func:`~meho_backplane.settings.get_settings` so the response\ncannot drift from the values :mod:`~meho_backplane.auth.jwt` uses\nwhen it validates inbound JWTs. The issuer URL is trailing-slash-\nnormalised here \u2014 Keycloak's discovery document advertises the\ncanonical form without a trailing slash and the CLI's own URL\nconstruction (``<issuer>/.well-known/openid-configuration``) is\ncleaner against the normalised form.",
         "operationId": "auth_config_api_v1_auth_config_get",
         "responses": {
           "200": {
@@ -1496,15 +1496,20 @@
           "audience": {
             "type": "string",
             "title": "Audience"
+          },
+          "cli_client_id": {
+            "type": "string",
+            "title": "Cli Client Id"
           }
         },
         "type": "object",
         "required": [
           "keycloak_issuer",
-          "audience"
+          "audience",
+          "cli_client_id"
         ],
         "title": "AuthConfigResponse",
-        "description": "OAuth discovery surface returned to ``meho login``.\n\nField names match the CLI's expected JSON keys (``keycloak_issuer``\nand ``audience``); renaming either field is a wire-compat break."
+        "description": "OAuth discovery surface returned to ``meho login``.\n\nField names match the CLI's expected JSON keys (``keycloak_issuer``,\n``audience``, ``cli_client_id``); renaming any field is a wire-compat\nbreak for the CLI's discovery parser. ``cli_client_id`` defaults to\nthe empty string on the response when the backplane has not been\nwired (``KEYCLOAK_CLI_CLIENT_ID`` unset); the CLI distinguishes\nempty-string from absent-key and emits the same actionable\npublic-client error in both cases."
       },
       "AuthModel": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -93,10 +93,16 @@ const (
 
 // AuthConfigResponse OAuth discovery surface returned to “meho login“.
 //
-// Field names match the CLI's expected JSON keys (“keycloak_issuer“
-// and “audience“); renaming either field is a wire-compat break.
+// Field names match the CLI's expected JSON keys (“keycloak_issuer“,
+// “audience“, “cli_client_id“); renaming any field is a wire-compat
+// break for the CLI's discovery parser. “cli_client_id“ defaults to
+// the empty string on the response when the backplane has not been
+// wired (“KEYCLOAK_CLI_CLIENT_ID“ unset); the CLI distinguishes
+// empty-string from absent-key and emits the same actionable
+// public-client error in both cases.
 type AuthConfigResponse struct {
 	Audience       string `json:"audience"`
+	CliClientId    string `json:"cli_client_id"`
 	KeycloakIssuer string `json:"keycloak_issuer"`
 }
 

--- a/cli/internal/cmd/login.go
+++ b/cli/internal/cmd/login.go
@@ -48,8 +48,10 @@ func newLoginCmd() *cobra.Command {
 			"$XDG_CONFIG_HOME/meho/credentials.json on headless hosts.\n\n" +
 			"Discovery: by default the CLI fetches the backplane's auth-config " +
 			"endpoint at <backplane-url>/api/v1/auth-config to learn the realm " +
-			"issuer and OAuth client ID. Until that endpoint ships, pass " +
-			"--issuer and --client-id explicitly.",
+			"issuer and the public device-code client_id. Pass --issuer and/or " +
+			"--client-id to skip discovery or override either half (e.g. when " +
+			"the backplane URL isn't reachable on the operator's network but " +
+			"the IdP is).",
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,10 +65,11 @@ func newLoginCmd() *cobra.Command {
 
 			// Resolve auth config. Override flags win; otherwise hit
 			// the backplane's discovery endpoint. The override path
-			// is the documented fallback while G2.2 is still wiring
-			// up /api/v1/auth-config — operators can ship a working
-			// login today even though the backplane endpoint doesn't
-			// exist yet.
+			// stays useful when the backplane URL isn't reachable on
+			// the operator's network (locked-down VPN, intermediate
+			// firewall) but the IdP is — meho login can still
+			// complete by skipping discovery via both --issuer and
+			// --client-id.
 			cfg, err := resolveAuthConfig(ctx, http.DefaultClient, backplaneURL, issuerOverride, clientIDOverride)
 			if err != nil {
 				return err
@@ -163,17 +166,26 @@ func resolveAuthConfig(ctx context.Context, httpClient *http.Client, backplaneUR
 
 	cfg, err := fetchBackplaneAuthConfig(ctx, httpClient, backplaneURL)
 	if err != nil {
+		// The remediation differs depending on the failure shape, but
+		// the CLI can't tell a TLS verify error from a 404 reliably
+		// without sniffing the wrapped error chain — and a misleading
+		// hint is worse than a complete one. Both error paths name
+		// the flag-override fallback AND the TLS-trust remediation so
+		// the operator can pick whichever matches what they see. (The
+		// TLS hint addresses internal-CA deployments where the
+		// operator's system trust store doesn't yet know the
+		// deployment's CA; Goal #11 RDC dogfood Signal #16, 2026-05-21.)
 		if issuerOverride != "" || clientIDOverride != "" {
 			// Caller pinned at least one half; surface the discovery
 			// failure with a hint that pinning both flags is the
 			// supported fallback.
 			return authConfig{}, fmt.Errorf(
-				"backplane auth-config discovery failed (%w); pass both --issuer and --client-id to skip discovery",
+				"backplane auth-config discovery failed (%w); pass both --issuer and --client-id to skip discovery, or install your deployment's root CA in your system trust store",
 				err,
 			)
 		}
 		return authConfig{}, fmt.Errorf(
-			"backplane auth-config discovery failed (%w); rerun with --issuer and --client-id",
+			"backplane auth-config discovery failed (%w); rerun with --issuer and --client-id, or install your deployment's root CA in your system trust store",
 			err,
 		)
 	}
@@ -188,18 +200,31 @@ func resolveAuthConfig(ctx context.Context, httpClient *http.Client, backplaneUR
 }
 
 // fetchBackplaneAuthConfig queries the backplane for its OIDC
-// configuration. The endpoint is documented in Initiative #42 / Task
-// #44 as /api/v1/auth-config — once G2.2 ships it, this function
-// becomes the happy path. Until then it'll return a discovery error
-// and operators use the --issuer / --client-id overrides.
+// configuration. The endpoint shipped with v0.3.1 carried two fields
+// (issuer + audience); v0.3.2 (G0.9.1-T9, after RDC dogfood Signal #16)
+// added the public device-code client_id as a third field.
 //
-// Response shape (per the Task body coordination note):
+// Response shape:
 //
-//	{ "keycloak_issuer": "...", "audience": "..." }
+//	{
+//	  "keycloak_issuer": "...",      // realm URL — driven into Issuer
+//	  "audience":        "...",      // backplane resource-server id
+//	  "cli_client_id":   "..."       // public device-code client — driven into ClientID
+//	}
 //
-// We map keycloak_issuer → Issuer and audience → ClientID; the
-// audience claim in Keycloak's JWT is the OAuth client_id by
-// default, so the same value drives both.
+// We map keycloak_issuer → Issuer and cli_client_id → ClientID. The
+// audience field is intentionally NOT used here as ClientID: it is
+// the confidential resource-server identifier the backplane validates
+// inbound JWTs against, and Keycloak rejects device-code initiation
+// against a confidential client with `401 unauthorized_client` (the
+// device grant requires a public client because the CLI can't carry
+// a client secret). v0.3.1 mis-mapped audience → ClientID and broke
+// `meho login`'s documented happy path; the v0.3.2 endpoint adds the
+// dedicated cli_client_id field for this exact reason. Older
+// backplanes that don't carry the field — or operators that haven't
+// wired KEYCLOAK_CLI_CLIENT_ID — surface as an empty string here,
+// which we promote to an actionable error naming the public-client
+// requirement rather than silently retrying with audience.
 func fetchBackplaneAuthConfig(ctx context.Context, httpClient *http.Client, backplaneURL string) (authConfig, error) {
 	endpoint := backplaneURL + "/api/v1/auth-config"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
@@ -229,6 +254,7 @@ func fetchBackplaneAuthConfig(ctx context.Context, httpClient *http.Client, back
 	var payload struct {
 		KeycloakIssuer string `json:"keycloak_issuer"`
 		Audience       string `json:"audience"`
+		CLIClientID    string `json:"cli_client_id"`
 	}
 	if err := decodeJSON(body, &payload); err != nil {
 		return authConfig{}, fmt.Errorf("parse auth-config: %w", err)
@@ -236,7 +262,21 @@ func fetchBackplaneAuthConfig(ctx context.Context, httpClient *http.Client, back
 	if payload.KeycloakIssuer == "" || payload.Audience == "" {
 		return authConfig{}, errors.New("auth-config response missing keycloak_issuer or audience")
 	}
-	return authConfig{Issuer: payload.KeycloakIssuer, ClientID: payload.Audience}, nil
+	if payload.CLIClientID == "" {
+		// Treat absent-key and empty-string identically — both mean
+		// "this backplane has not been wired with a public CLI
+		// client_id". Naming the public-client requirement (and the
+		// override escape hatch) up front is the highest-signal hint
+		// we can give an operator who has only ever seen Keycloak's
+		// `401 unauthorized_client` from the device-grant endpoint.
+		return authConfig{}, fmt.Errorf(
+			"auth-config response carries no cli_client_id: the backplane has not been wired with a public OAuth client for device-code login. " +
+				"Ask your deployer to register a public Keycloak client (suggested name `meho-cli`, device-grant enabled, audience mapper -> backplane) " +
+				"and set the chart value `config.keycloakCliClientId` (env `KEYCLOAK_CLI_CLIENT_ID`) to its client_id. " +
+				"Override per-invocation with `--client-id <public-client-id>`",
+		)
+	}
+	return authConfig{Issuer: payload.KeycloakIssuer, ClientID: payload.CLIClientID}, nil
 }
 
 // decodeJSON is a tiny wrapper that lets us swap json.Unmarshal for a

--- a/cli/internal/cmd/login_test.go
+++ b/cli/internal/cmd/login_test.go
@@ -40,9 +40,13 @@ func TestResolveAuthConfigUsesOverrides(t *testing.T) {
 }
 
 // TestResolveAuthConfigDiscoveryHappyPath drives the
-// /api/v1/auth-config endpoint that the backplane will expose once
-// G2.2 ships the corresponding endpoint. We fake the shape locally
-// per the Task body's coordination note.
+// /api/v1/auth-config endpoint shape codified by G0.9.1-T9 / Signal #16
+// after the 2026-05-21 RDC dogfood: cli_client_id is the public
+// device-code client, audience is the confidential resource-server
+// identifier. The CLI must map cli_client_id (NOT audience) to
+// ClientID; mapping audience would deadlock device-code initiation
+// with `401 unauthorized_client` (the v0.3.1 regression this Task
+// fixes).
 func TestResolveAuthConfigDiscoveryHappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/auth-config" {
@@ -52,7 +56,8 @@ func TestResolveAuthConfigDiscoveryHappyPath(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"keycloak_issuer": "https://kc/realms/meho",
-			"audience":        "meho-cli",
+			"audience":        "meho-backplane",
+			"cli_client_id":   "meho-cli",
 		})
 	}))
 	defer srv.Close()
@@ -65,7 +70,88 @@ func TestResolveAuthConfigDiscoveryHappyPath(t *testing.T) {
 		t.Errorf("issuer: %q", cfg.Issuer)
 	}
 	if cfg.ClientID != "meho-cli" {
-		t.Errorf("client id: %q", cfg.ClientID)
+		t.Errorf("client id should be cli_client_id, got: %q", cfg.ClientID)
+	}
+}
+
+// TestResolveAuthConfigDiscoveryRejectsAbsentCliClientID surfaces the
+// actionable public-client error when the backplane returns the v0.3.1
+// shape (issuer + audience only, no cli_client_id) or has been deployed
+// without `KEYCLOAK_CLI_CLIENT_ID` wired. Silently falling back to
+// audience as ClientID is what shipped on v0.3.1 and is the exact
+// regression Signal #16 reported — pinning the "no silent fallback"
+// behaviour here stops that regression returning.
+func TestResolveAuthConfigDiscoveryRejectsAbsentCliClientID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// v0.3.1-era shape: no cli_client_id field at all.
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"keycloak_issuer": "https://kc/realms/meho",
+			"audience":        "meho-backplane",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := resolveAuthConfig(context.Background(), srv.Client(), srv.URL, "", "")
+	if err == nil {
+		t.Fatalf("expected actionable error when cli_client_id is absent")
+	}
+	for _, want := range []string{"cli_client_id", "public", "--client-id"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q so the operator can recover; got: %v", want, err)
+		}
+	}
+}
+
+// TestResolveAuthConfigDiscoveryRejectsEmptyCliClientID covers the
+// matched case where the backplane has been upgraded to v0.3.2 but
+// the deployer never wired `KEYCLOAK_CLI_CLIENT_ID` — the field
+// appears on the response as `""`. Treating it identically to absent
+// keeps the operator-facing message stable regardless of whether the
+// backplane omits the key or sends an empty value.
+func TestResolveAuthConfigDiscoveryRejectsEmptyCliClientID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"keycloak_issuer": "https://kc/realms/meho",
+			"audience":        "meho-backplane",
+			"cli_client_id":   "",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := resolveAuthConfig(context.Background(), srv.Client(), srv.URL, "", "")
+	if err == nil {
+		t.Fatalf("expected actionable error when cli_client_id is empty")
+	}
+	if !strings.Contains(err.Error(), "cli_client_id") {
+		t.Errorf("error should mention cli_client_id; got: %v", err)
+	}
+}
+
+// TestResolveAuthConfigOverrideBypassesAbsentCliClientID confirms the
+// escape hatch: an operator who already knows the public client_id
+// can pass `--client-id` and bypass the auth-config endpoint entirely.
+// This is the recovery path operators on older backplanes (or those
+// who haven't wired KEYCLOAK_CLI_CLIENT_ID yet) take.
+func TestResolveAuthConfigOverrideBypassesAbsentCliClientID(t *testing.T) {
+	// httptest server is created but never hit — both override flags
+	// supplied means discovery is skipped entirely. Pointing the
+	// helper at a non-listening port (1) would also work, but a real
+	// server makes the failure mode obvious if discovery accidentally
+	// fires.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("discovery should not be called when both overrides are set")
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg, err := resolveAuthConfig(context.Background(), srv.Client(), srv.URL, "https://kc/realms/meho", "meho-cli")
+	if err != nil {
+		t.Fatalf("resolveAuthConfig: %v", err)
+	}
+	if cfg.ClientID != "meho-cli" {
+		t.Errorf("client id should be the override: %q", cfg.ClientID)
 	}
 }
 
@@ -76,6 +162,7 @@ func TestResolveAuthConfigPartialOverride(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"keycloak_issuer": "https://discovered-issuer",
 			"audience":        "discovered-audience",
+			"cli_client_id":   "discovered-cli-client",
 		})
 	}))
 	defer srv.Close()
@@ -96,7 +183,11 @@ func TestResolveAuthConfigPartialOverride(t *testing.T) {
 // helpful hint when the backplane endpoint isn't reachable and no
 // overrides were supplied. The hint is operator-facing prose so
 // touching it is a UX change — pinning it here makes that an
-// intentional decision rather than an oversight.
+// intentional decision rather than an oversight. The root-CA-trust
+// breadcrumb covers internal-CA deployments where the operator's
+// system trust store doesn't know the deployment's CA (RDC Signal #16,
+// 2026-05-21); the flag-override breadcrumb covers everything else
+// (404, refused, etc.).
 func TestResolveAuthConfigDiscoveryFailureMentionsFlags(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "auth-config not implemented", http.StatusNotFound)
@@ -107,8 +198,10 @@ func TestResolveAuthConfigDiscoveryFailureMentionsFlags(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error")
 	}
-	if !strings.Contains(err.Error(), "--issuer") || !strings.Contains(err.Error(), "--client-id") {
-		t.Errorf("error should mention --issuer and --client-id, got: %v", err)
+	for _, want := range []string{"--issuer", "--client-id", "root CA"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q so the operator has a remediation; got: %v", want, err)
+		}
 	}
 }
 
@@ -122,6 +215,28 @@ func TestLoginCommandHelpListsFlags(t *testing.T) {
 	for _, want := range []string{"--issuer", "--client-id", "--scope"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("usage missing flag %s:\n%s", want, out)
+		}
+	}
+}
+
+// TestLoginCommandHelpDoesNotClaimEndpointUnshipped pins the breadcrumb
+// fix from G0.9.1-T9 / Signal #16. The v0.3.1 help text claimed
+// `/api/v1/auth-config` was still on the way ("Until that endpoint
+// ships"); the endpoint shipped in v0.3.1 (incompletely), and Signal
+// #16 flagged the stale text as misleading. This test fails-loud if
+// anyone reintroduces a "not shipped yet" / "until that endpoint
+// ships" phrasing.
+func TestLoginCommandHelpDoesNotClaimEndpointUnshipped(t *testing.T) {
+	cmd := newLoginCmd()
+	out := cmd.Long
+	for _, forbidden := range []string{
+		"Until that endpoint ships",
+		"endpoint doesn't exist yet",
+		"endpoint isn't shipped",
+		"endpoint hasn't shipped",
+	} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("login help should not claim auth-config endpoint is unshipped; contained %q", forbidden)
 		}
 	}
 }

--- a/deploy/charts/meho/templates/configmap.yaml
+++ b/deploy/charts/meho/templates/configmap.yaml
@@ -39,6 +39,14 @@ data:
   # in the Deployment template.
   KEYCLOAK_ISSUER_URL: {{ .Values.config.keycloakIssuerUrl | quote }}
   KEYCLOAK_AUDIENCE: {{ .Values.config.keycloakAudience | quote }}
+  # G0.9.1-T9 (#789, RDC Signal #16). Public OAuth client_id surfaced
+  # to `meho login` via `GET /api/v1/auth-config` as `cli_client_id`.
+  # Unconditionally emitted so the env-var contract stays stable
+  # across deploys; when the operator hasn't wired the value the
+  # backplane sends an empty string and the CLI surfaces an
+  # actionable public-client error rather than silently misusing
+  # `KEYCLOAK_AUDIENCE` (the confidential resource-server id).
+  KEYCLOAK_CLI_CLIENT_ID: {{ .Values.config.keycloakCliClientId | quote }}
   KEYCLOAK_JWKS_CACHE_TTL_SECONDS: {{ .Values.config.keycloakJwksCacheTtlSeconds | quote }}
   KEYCLOAK_JWT_LEEWAY_SECONDS: {{ .Values.config.keycloakJwtLeewaySeconds | quote }}
   VAULT_ADDR: {{ .Values.config.vaultAddr | quote }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -201,6 +201,10 @@
       "properties": {
         "keycloakIssuerUrl": { "type": "string", "minLength": 1 },
         "keycloakAudience": { "type": "string", "minLength": 1 },
+        "keycloakCliClientId": {
+          "type": "string",
+          "description": "Public OAuth client_id surfaced to `meho login` via `GET /api/v1/auth-config` as `cli_client_id`. The CLI maps this field (NOT `keycloakAudience`) to the device-code `client_id`. Must be a Keycloak public client (no client secret) with the device-grant flow enabled and an audience mapper that injects `keycloakAudience` into the issued access token. Default `\"\"` keeps backwards compatibility with v0.3.1 — the backplane endpoint still returns the field but the CLI surfaces an actionable public-client error rather than silently misusing `keycloakAudience` (which is the confidential resource-server id and is rejected by Keycloak's device-grant endpoint with `401 unauthorized_client`). G0.9.1-T9, RDC dogfood Signal #16, 2026-05-21. See `deploy/values-examples/README.md` for the realm-side recipe."
+        },
         "keycloakJwksCacheTtlSeconds": { "type": "string", "pattern": "^[0-9]+$" },
         "keycloakJwtLeewaySeconds": { "type": "string", "pattern": "^[0-9]+$" },
         "vaultAddr": { "type": "string", "format": "uri", "minLength": 1 },

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -166,6 +166,23 @@ resources:
 config:
   keycloakIssuerUrl: ""
   keycloakAudience: ""
+  # -- Public OAuth client_id the CLI uses to drive the RFC 8628
+  # device-code grant (`meho login`). Surfaced via
+  # `GET /api/v1/auth-config` as the `cli_client_id` field; the CLI
+  # maps it to `client_id` when initiating the device flow. Default
+  # `""` (unset) keeps backwards compatibility with v0.3.1 — the
+  # endpoint still returns the field but `meho login` surfaces an
+  # actionable public-client error rather than silently falling back
+  # to `keycloakAudience` (which is the confidential resource-server
+  # identifier and cannot run device-code; Keycloak rejects it with
+  # `401 unauthorized_client`). Operators MUST set this to the
+  # client_id of a public Keycloak client (suggested name `meho-cli`)
+  # with the device-grant flow enabled and an audience mapper that
+  # injects `keycloakAudience` into the issued access token's `aud`
+  # claim — see `deploy/values-examples/README.md` § meho-cli public
+  # client for the realm-side recipe. G0.9.1-T9 (RDC dogfood Signal
+  # #16, 2026-05-21).
+  keycloakCliClientId: ""
   keycloakJwksCacheTtlSeconds: "300"
   keycloakJwtLeewaySeconds: "30"
   vaultAddr: ""

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -36,6 +36,7 @@ request.
     | --- | --- |
     | `image.tag` | An immutable tag from the G2.4 image pipeline. Production: `sha-<40-char-git-sha>` from a green CI run. Pre-prod / lab: `v0.1.0` once the release tag exists. **`:latest` and `:main` are forbidden by Goal #11 deploy discipline.** |
     | `config.keycloakIssuerUrl` / `keycloak.issuer` realm | Your Keycloak realm name. Both fields must agree — the ConfigMap-sourced env mirrors the values block (`config.keycloakIssuerUrl` is what the backplane process reads at startup). |
+    | `config.keycloakCliClientId` | The client_id of the **public** Keycloak client `meho login` uses for device-code flow. Pre-create the client in the realm above (see [§ `meho-cli` public Keycloak client](#meho-cli-public-keycloak-client-for-meho-login)) — `meho-cli` is the suggested default. Leaving this empty keeps v0.3.1 behaviour: the backplane endpoint serves an empty value and `meho login` surfaces an actionable public-client error. |
     | `networkPolicy.postgresCIDR` | The IPv4 CIDR of your Postgres Service. Recover via `kubectl get endpoints <pg-svc> -n <ns> -o jsonpath='{.subsets[].addresses[].ip}'` and widen to the controlling subnet. |
     | `networkPolicy.vaultCIDR` | Same, for Vault. |
     | `networkPolicy.keycloakCIDR` | Same, for Keycloak. |
@@ -253,6 +254,73 @@ If `/ready` still reports `ssl_error` after the mount lands, check the
 **migration Job's** Pod logs — that Job uses the same bundle. A
 common drift cause: a typo'd ConfigMap name (the mount succeeds but
 the file is empty / wrong).
+
+## `meho-cli` public Keycloak client (for `meho login`)
+
+`meho login` runs the OAuth 2.0 Device Authorization Grant (RFC 8628)
+against the realm configured in `config.keycloakIssuerUrl`. The device
+grant requires a **public** client — Keycloak rejects device-code
+initiation against a confidential client (one with a client secret)
+with `401 unauthorized_client` because the CLI cannot carry a secret
+safely. Up through v0.3.1, the CLI silently re-used the **confidential**
+`keycloakAudience` value (`meho-backplane`) as the OAuth `client_id`
+and `meho login` therefore failed on its documented happy path
+(consumer report 2026-05-21, Signal #16).
+
+v0.3.2 fixes the CLI shape, but **the deployer is still responsible
+for pre-creating the public client in the Keycloak realm** before
+`helm install`. Auto-provisioning the client from a Helm post-install
+hook is tracked as [#791 (T11)](https://github.com/evoila/meho/issues/791);
+this section is the manual recipe until that lands.
+
+### Realm-side recipe
+
+In the Keycloak realm that hosts `meho-backplane`, create a new
+**public** client with these settings:
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| Client ID | `meho-cli` (suggested) | Matches the default in `values-rdc-example.yaml`. Any short identifier works — set `config.keycloakCliClientId` to whatever you choose. |
+| Client authentication | **Off** (public client) | The device grant cannot be completed by a confidential client; the CLI has nowhere to store a secret. |
+| Authentication flow → Standard flow | Off | The CLI doesn't run the authorization-code grant. |
+| Authentication flow → Direct access grants | Off | Resource-owner password is explicitly out of scope. |
+| Authentication flow → **OAuth 2.0 Device Authorization Grant** | **On** | Required for `meho login`. |
+| Valid redirect URIs | (none) | Device flow doesn't redirect. |
+| Mapper → audience mapper | Add a `meho-backplane` audience mapper that injects `meho-backplane` (your `keycloakAudience` value) into the access token's `aud` claim | Without this, tokens issued for `meho-cli` carry `aud: meho-cli` and the backplane rejects them with `audience_not_configured`. |
+
+### Wire it into Helm
+
+Set the chart value to the client_id you just created:
+
+```yaml
+config:
+  keycloakCliClientId: meho-cli   # or whatever you chose
+```
+
+The backplane's `/api/v1/auth-config` endpoint will surface this value
+as the `cli_client_id` JSON field, which `meho login`'s discovery
+parser maps to the OAuth `client_id`. The CLI also accepts
+`--client-id <id>` as a per-invocation override, useful when a
+deployer publishes multiple public clients (e.g. `meho-cli-prod`,
+`meho-cli-staging`) and the chart value pins one default.
+
+### Verify
+
+After `helm install` (or `helm upgrade`):
+
+```bash
+curl -sf https://meho.evba.lab/api/v1/auth-config | jq .
+# { "keycloak_issuer": "...", "audience": "meho-backplane", "cli_client_id": "meho-cli" }
+
+meho login https://meho.evba.lab
+# Logged in to https://meho.evba.lab; token stored in keyring.
+```
+
+If `cli_client_id` comes back as the empty string, the chart value
+wasn't set; if `meho login` reports `unauthorized_client` after
+discovery, the client is configured as confidential rather than
+public (toggle "Client authentication" off in the Keycloak admin UI
+and retry).
 
 ## End-to-end install flow
 

--- a/deploy/values-examples/values-kind.yaml
+++ b/deploy/values-examples/values-kind.yaml
@@ -121,6 +121,14 @@ postgres:
 config:
   keycloakIssuerUrl: http://mock-keycloak.meho.svc:8080/realms/meho
   keycloakAudience: meho-backplane
+  # Mock public CLI client_id for the kind overlay. The mock IdP
+  # above doesn't actually run device-code — this value just exercises
+  # the env-var plumbing and lets `GET /api/v1/auth-config` return a
+  # non-empty `cli_client_id` so the response shape matches what a
+  # real deploy would serve. For a functional `meho login` end-to-end,
+  # use `values-rdc-example.yaml` against a real Keycloak realm with
+  # a pre-created public `meho-cli` client.
+  keycloakCliClientId: meho-cli
   vaultAddr: http://mock-vault.meho.svc:8200
 
 # The bundled broadcast subchart (Valkey 9.x per ADR 0005) is left

--- a/deploy/values-examples/values-rdc-example.yaml
+++ b/deploy/values-examples/values-rdc-example.yaml
@@ -115,6 +115,16 @@ resources:
 config:
   keycloakIssuerUrl: "https://keycloak.evba.lab/realms/<REPLACE: realm-name>"
   keycloakAudience: meho-backplane
+  # G0.9.1-T9 (#789, RDC Signal #16). Public OAuth client_id `meho
+  # login` uses for device-code initiation. Must reference a
+  # PRE-CREATED public Keycloak client in the realm above (the
+  # deployer creates it before `helm install` — auto-provisioning is
+  # tracked as T11 / #791). See `deploy/values-examples/README.md`
+  # for the realm-side recipe (device-grant flow enabled, audience
+  # mapper -> keycloakAudience, no client secret). Leave empty to
+  # keep v0.3.1 behaviour: the backplane still serves the endpoint
+  # but `meho login` surfaces an actionable public-client error.
+  keycloakCliClientId: meho-cli
   keycloakJwksCacheTtlSeconds: "300"
   keycloakJwtLeewaySeconds: "30"
   vaultAddr: https://vault.evba.lab

--- a/docs/acceptance/install.md
+++ b/docs/acceptance/install.md
@@ -101,7 +101,19 @@ The budget does **not** cover:
   Section 4)
 - Operator-side device-code login (`meho login` is exercised by
   [acceptance Task #56](https://github.com/evoila-bosnia/meho-internal/issues/56),
-  the federation-chain smoke, not this one)
+  the federation-chain smoke, not this one). The cold-deploy
+  acceptance does **not** drive `meho login` end-to-end, but the
+  realm-side prerequisite the CLI needs — a public `meho-cli`
+  Keycloak client with the device-grant flow enabled and an audience
+  mapper — is a consumer-side provisioning step that must precede
+  `meho login`. The recipe lives in
+  [`deploy/values-examples/README.md`](../../deploy/values-examples/README.md)
+  § `meho-cli` public Keycloak client; the chart value to wire it
+  through is `config.keycloakCliClientId` (env
+  `KEYCLOAK_CLI_CLIENT_ID`). Auto-provisioning the client at
+  install time is tracked as
+  [#791](https://github.com/evoila/meho/issues/791) (G0.9.1-T11) and
+  is not yet shipped.
 
 ### Why 5 minutes is the right bar
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -265,14 +265,33 @@ Authorization Grant (RFC 8628). End-to-end shape:
 
 1. **Auth-config discovery.** The CLI calls
    `GET <backplane-url>/api/v1/auth-config` to learn the Keycloak
-   realm issuer and the OAuth `client_id` to use. The response shape
-   is `{"keycloak_issuer": "...", "audience": "..."}`.
-   * **Operator override.** When that endpoint isn't reachable
-     (G2.2 hasn't wired it yet, the operator is behind a VPN that
-     blocks the backplane but routes the IdP, etc.), pass
-     `--issuer` and `--client-id` to skip discovery entirely. A
-     partial override (just one flag) still hits the backplane for
-     the other half.
+   realm issuer and the public device-code `client_id` to use. The
+   response shape is
+   `{"keycloak_issuer": "...", "audience": "...", "cli_client_id": "..."}`.
+   * **Field mapping.** `keycloak_issuer` drives the OIDC issuer
+     URL; `cli_client_id` drives the OAuth `client_id` for the
+     device-code grant. `audience` is the **confidential**
+     resource-server identifier the backplane validates inbound
+     JWTs against — it is NOT used as `client_id` (Keycloak rejects
+     device-code initiation against a confidential client with
+     `401 unauthorized_client`). v0.3.1 shipped without
+     `cli_client_id` and the CLI mis-mapped `audience` → `client_id`,
+     which deadlocked `meho login` on its documented happy path
+     (G0.9.1-T9, RDC Signal #16, 2026-05-21); v0.3.2 added the
+     dedicated field and fixed the mapping.
+   * **Absent / empty `cli_client_id`.** When the field is missing
+     (older backplane) or empty (newer backplane without
+     `KEYCLOAK_CLI_CLIENT_ID` wired), the CLI surfaces an
+     actionable error naming the public-client requirement and the
+     `--client-id` override rather than silently retrying with
+     `audience`.
+   * **Operator override.** Pass `--issuer` and `--client-id` to
+     skip discovery entirely — useful when the backplane URL isn't
+     reachable on the operator's network but the IdP is. A partial
+     override (just one flag) still hits the backplane for the
+     other half. TLS-discovery failures additionally point at the
+     "install your deployment's root CA in your system trust store"
+     remediation for internal-CA deployments.
 2. **OIDC discovery.** The CLI fetches
    `<issuer>/.well-known/openid-configuration` to learn the
    `device_authorization_endpoint` and `token_endpoint`. If the
@@ -1482,11 +1501,13 @@ have to trust to run `meho login` against their secrets.
   thrash. Filed as a follow-up adjacent to T3.
 * Persistent `--config` and `-v/--verbose` flags are registered on
   the root command but not yet consumed; reserved for v0.2.
-* The auth-config endpoint at `/api/v1/auth-config` doesn't exist on
-  the backplane yet (a G2.2 coordination Task). Operators using
-  this Task's binary against today's backplane must pass `--issuer`
-  and `--client-id` explicitly to `meho login`; the prose error
-  message guides them to those flags.
+* The auth-config endpoint at `/api/v1/auth-config` shipped in v0.3.1
+  (issuer + audience) and was completed in v0.3.2 (G0.9.1-T9) with
+  the `cli_client_id` field that drives the CLI's device-code
+  `client_id`. Operators on a backplane older than v0.3.2 (or one
+  where `KEYCLOAK_CLI_CLIENT_ID` was never wired) get an actionable
+  public-client error from `meho login` and the `--issuer`/
+  `--client-id` overrides as the documented escape hatch.
 * The `/api/v1/commands` discovery endpoint doesn't exist on the
   backplane yet (G2.2 coordination, identical to `/api/v1/auth-config`).
   The CLI's discovery fetch degrades to "no extra commands"


### PR DESCRIPTION
## Summary

- Complete `/api/v1/auth-config` with a new `cli_client_id` field
  (chart-wired via `config.keycloakCliClientId` / env
  `KEYCLOAK_CLI_CLIENT_ID`) and fix the `meho login` CLI's discovery
  mapping so device-code initiation no longer 401s on its documented
  happy path. v0.3.1 mis-mapped `audience` (the confidential
  resource-server identifier) to the OAuth `client_id`; Keycloak
  rejects the device grant against a confidential client with
  `401 unauthorized_client`. The CLI now reads `cli_client_id`; when
  the field is empty or absent (older backplane, unwired deploy) it
  surfaces an actionable public-client error rather than silently
  falling back to `audience`.
- Correct stale `meho login --help` ("Until that endpoint ships") and
  the TLS-discovery-failure breadcrumb (now points at `--client-id`/
  `--issuer` overrides **and** root-CA installation for internal-CA
  deployments). Misleading `audience → client_id` comment removed.
- Deployer recipe for the pre-created public `meho-cli` Keycloak
  client added to `deploy/values-examples/README.md` § `meho-cli`
  public Keycloak client; cross-references added to
  `docs/acceptance/install.md` and the README substitution table;
  chart `values.yaml` / `values.schema.json` / ConfigMap template
  carry the new key; `values-rdc-example.yaml` and
  `values-kind.yaml` ship a working default.
- Auto-provisioning the public client at install time is deliberately
  out of scope here; tracked under T11 (#791) which Depends-on this.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — 411 files already formatted
- [x] `mypy src/ --ignore-missing-imports` — 195 source files, no issues
- [x] `pytest tests/test_auth_config.py tests/test_settings.py` — 13 passed
- [x] Broader `pytest tests/ -q --ignore=tests/integration --ignore=tests/contracts -k "not testcontainers"` — see CI for the full surface
- [x] `go vet ./...` (cli/) — clean
- [x] `gofmt -l .` (cli/) — clean
- [x] `go test ./...` (cli/) — all packages pass, including the new tests for `cli_client_id` mapping, absent-field error, root-CA breadcrumb, and help-text guard
- [x] `helm template ... -f values-rdc-example.yaml` — ConfigMap renders `KEYCLOAK_CLI_CLIENT_ID: "meho-cli"`; unset deploy renders `""`
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing settings.py size warnings only)
- [x] `make snapshot-openapi` + `make generate` (cli/) — OpenAPI snapshot and Go client regenerated; the new `cli_client_id` field is in the `AuthConfigResponse` struct

### Acceptance criteria verification

- [x] `GET /api/v1/auth-config` returns `cli_client_id` from chart-wired `Settings.keycloak_cli_client_id`; existing `keycloak_issuer`/`audience` fields unchanged — `test_auth_config_returns_keycloak_issuer_audience_and_cli_client_id` + `test_auth_config_cli_client_id_defaults_empty_when_unset`
- [x] CLI device-code flow uses `cli_client_id` (override via `--client-id` still works); absent field → actionable error naming the public-client requirement, no silent `audience` fallback; misleading comment corrected — `TestResolveAuthConfigDiscoveryHappyPath` + `TestResolveAuthConfigDiscoveryRejectsAbsentCliClientID` + `TestResolveAuthConfigDiscoveryRejectsEmptyCliClientID` + `TestResolveAuthConfigOverrideBypassesAbsentCliClientID`
- [x] `meho login --help` no longer says the endpoint is unshipped; the TLS-discovery-failure error includes the root-CA-trust breadcrumb — `TestLoginCommandHelpDoesNotClaimEndpointUnshipped` + `TestResolveAuthConfigDiscoveryFailureMentionsFlags`
- [x] Deployer docs (`install.md` + `deploy/values-examples/README.md`) document creating the public `meho-cli` device-code client and wiring `keycloak_cli_client_id`
- [x] `Go (gofmt + vet + test)` and `Python (ruff + mypy + pytest)` green; CLI tests cover the `cli_client_id` mapping + the absent-field error

## Out of scope

- Auto-provisioning the Keycloak client at install time — split to **T11 (#791)** as documented in the issue body. This PR is a load-bearing prerequisite for #791, which depends on the `cli_client_id` field shape this PR encodes.
- MCP first-login onramp — **T10 (#790)**, sibling task.
- Sibling tasks running in parallel touch unrelated files: **T7 (#779)** MCP schema symmetry, **T8 (#780)** schema clarity docs.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #789


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auth config endpoint now returns a CLI client_id to support device-code login.

* **Bug Fixes**
  * `meho login` uses the returned CLI client_id (not audience) for device-code flows.
  * Improved discovery error messages to include TLS/root-CA remediation and override guidance.

* **Documentation**
  * Added operator guides and chart values documenting the required public Keycloak client and wiring.

* **Tests**
  * Added/updated tests covering CLI auth-config handling and regression scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->