### PR TITLE
perf(test): skip per-test descriptor re-embed in unit suite (#771)

### DIFF
--- a/backend/src/meho_backplane/operations/embed.py
+++ b/backend/src/meho_backplane/operations/embed.py
@@ -37,8 +37,13 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from meho_backplane.retrieval.embedding import EmbeddingService, get_embedding_service
+from meho_backplane.retrieval.embedding import (
+    EMBEDDING_DIMENSION,
+    EmbeddingService,
+    get_embedding_service,
+)
 from meho_backplane.retrieval.indexer import compute_body_hash
+from meho_backplane.settings import get_settings
 
 __all__ = [
     "build_embedding_text",
@@ -116,5 +121,18 @@ async def encode_endpoint_text(
     bother).
     """
     if service is None:
+        # Default path (production + the per-test app-lifespan boot's
+        # run_typed_op_registrars). The #771 test stub applies ONLY
+        # here — never when a caller passes an explicit service, which
+        # is the deterministic-embedding test seam
+        # (e.g. test_operations_meta_tools seeds [0.1]*384 vectors and
+        # asserts ranking against them). Stubbing the default path skips
+        # the fastembed encode that dominates the per-test lifespan boot
+        # (~5.5s local / 35-47s CI per app-booting test); descriptor rows
+        # still INSERT with a valid-shaped zero vector, so tool-
+        # registration / RBAC / schema tests (which never read the
+        # vector) are unaffected.
+        if get_settings().test_stub_descriptor_embedding:
+            return [0.0] * EMBEDDING_DIMENSION
         service = get_embedding_service()
     return await service.encode_one(text)

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -338,6 +338,18 @@ class Settings(BaseModel):
     jwt_tenant_claim_name: str = Field(default="tenant_id", min_length=1)
     jwt_tenant_role_claim_name: str = Field(default="tenant_role", min_length=1)
     enable_rbac_test_route: bool = False
+    #: Test-only: when True, ``encode_endpoint_text`` returns a zero
+    #: vector instead of computing the real fastembed embedding for a
+    #: descriptor at registration time. Set via
+    #: ``MEHO_TEST_STUB_DESCRIPTOR_EMBEDDING`` by the test conftest so
+    #: the per-test app-lifespan boot (which re-runs
+    #: ``run_typed_op_registrars`` against a fresh per-test DB) does not
+    #: re-embed every typed-op descriptor — the dominant unit-job cost
+    #: per #771. Tests that exercise operation semantic-search seed
+    #: their own real embeddings and leave this off. NEVER set in
+    #: production: stubbed descriptor vectors make operation search
+    #: return meaningless rankings.
+    test_stub_descriptor_embedding: bool = False
     backplane_url: str = ""
     mcp_resource_uri: str = ""
     vault_addr: HttpUrl
@@ -443,6 +455,9 @@ def get_settings() -> Settings:
         ),
         enable_rbac_test_route=parse_bool_env(
             os.environ.get("MEHO_ENABLE_RBAC_TEST_ROUTE"),
+        ),
+        test_stub_descriptor_embedding=parse_bool_env(
+            os.environ.get("MEHO_TEST_STUB_DESCRIPTOR_EMBEDDING"),
         ),
         backplane_url=os.environ.get("BACKPLANE_URL", ""),
         mcp_resource_uri=os.environ.get("MCP_RESOURCE_URI", ""),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -280,6 +280,59 @@ def _default_retrieval_model_cache_dir(
 
 
 @pytest.fixture(autouse=True)
+def _stub_descriptor_embedding(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> Iterator[None]:
+    """Stub default-path descriptor embedding in the per-test lifespan boot (#771).
+
+    Every test that constructs ``TestClient(meho_backplane.main.app)``
+    (the whole ``test_mcp_*`` family, plus middleware / auth_config
+    tests that exercise the lifespan) runs ``run_typed_op_registrars``
+    against the fresh per-test DB, which re-embeds every typed-op
+    descriptor through the real fastembed model. That encode is the
+    dominant unit-job cost — ~5.5 s locally and 35-47 s on CI per
+    app-booting test (#771; confirmed via CI-side ``--durations`` +
+    cold-boot profiling). Setting ``MEHO_TEST_STUB_DESCRIPTOR_EMBEDDING``
+    makes :func:`encode_endpoint_text` return a zero vector on the
+    default (no explicit service) path, so registration is near-instant.
+    Descriptor rows still INSERT with a valid-shaped embedding column;
+    tool-registration / RBAC / schema tests never read the vector.
+
+    Scope is the *default path only* — callers that pass an explicit
+    ``embedding_service`` (the deterministic-embedding test seam, e.g.
+    :mod:`tests.test_operations_meta_tools`) are unaffected, so they keep
+    asserting ranking against their own seeded vectors. A test that
+    relies on *lifespan-registered* descriptor embeddings for ranking
+    requests :func:`real_descriptor_embeddings` to opt out.
+    """
+    if "real_descriptor_embeddings" in request.fixturenames:
+        # The opt-out fixture owns the env var for this test.
+        yield
+        return
+    monkeypatch.setenv("MEHO_TEST_STUB_DESCRIPTOR_EMBEDDING", "1")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def real_descriptor_embeddings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Opt out of the #771 default-path descriptor-embedding stub.
+
+    For the rare test that asserts operation semantic-search ranking
+    over *lifespan-registered* descriptors (rather than its own
+    explicit-service-seeded corpus). Clears
+    ``MEHO_TEST_STUB_DESCRIPTOR_EMBEDDING`` so registration computes the
+    real fastembed embedding for this test.
+    """
+    monkeypatch.delenv("MEHO_TEST_STUB_DESCRIPTOR_EMBEDDING", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
 def _default_backplane_url(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Pin a non-empty ``BACKPLANE_URL`` so the lifespan boots in tests.
 


### PR DESCRIPTION
## Summary

Skip the per-test descriptor **re-embedding** that dominates the unit-job
wall. A CI-instrumented run (diagnostic PR #793) attributed the cost
**definitively**, ending a long guess-loop.

## Root cause (measured, not hypothesised)

Every app-booting test (`client_with_operator` → `with TestClient(app)`)
runs the full FastAPI lifespan, including
[`run_typed_op_registrars`](backend/src/meho_backplane/main.py#L248).
Because each test gets a **fresh empty SQLite DB**, the registrar's
change-detection short-circuit never fires and it **re-embeds every
typed-op descriptor from scratch** through the real fastembed model.

Per-step timing from the diagnostic run (PR path, `--cov` off):

```
LIFESPAN STEP TIMING  (1297 calls)  — sorted by total seconds
step                                count      sum_s    max_s   mean_s
run_typed_op_registrars               185     4253.7    43.07    22.99   ← the wall
_preload_embedding_model              186        8.7     0.13     0.05
get_engine / get_broadcast_client / ...   ~185      ~0.1     0.03     0.00
```

`_preload_embedding_model` (a single encode) is 0.05s — the model is
**warm**. So the cost is not model load, not a container, not coverage
(the PR path is 22m35s with `--cov` already off since #726); it is the
**N sequential descriptor encodes per test**. Invisible locally because
one encode is ~0.0002s on a dev Mac vs ~0.05s on a CI core.

## Fix (test-only)

A `MEHO_TEST_STUB_DESCRIPTOR_EMBEDDING` settings flag makes
[`encode_endpoint_text`](backend/src/meho_backplane/operations/embed.py)
return a valid-shaped **zero vector** on its default (no-explicit-service)
path — exactly the path `run_typed_op_registrars` uses in the lifespan.
An autouse conftest fixture sets it for the whole suite; descriptor rows
still INSERT with a well-formed embedding column, so the ~99% of tests
that never read the vector (RBAC / schema / tool-listing / audit) are
unaffected.

Two seams are preserved:
- Callers passing an **explicit** service (e.g. `test_operations_meta_tools`
  seeding `[0.1]*384`) are untouched — the guard only fires when
  `service is None`.
- A `real_descriptor_embeddings` opt-out fixture is provided as the
  documented escape hatch for any test that asserts ranking over
  **lifespan-registered** descriptors. No current test needs it (ranking
  tests use the explicit-service seam; BM25 keeps lexical search
  non-empty), but shipping a suite-wide default without a signposted
  opt-out would be a trap.

The flag defaults `False` and is never set in production (the field
docstring says so) — stubbed vectors would make operation search
meaningless, so this is strictly a test-suite knob.

## Impact

`run_typed_op_registrars` drops from ~23s/test to ~0. Expected unit-job
wall: **~22min → ~11min**. The remaining per-test `alembic upgrade head`
cost (`_default_database_url`, ~1.02s × 2914) is a separate, more
involved follow-up.

## Test plan

- [x] `ruff check` + `ruff format --check` + `mypy src/` — clean
- [x] full unit suite green locally with the stub on — **2883 passed, 47
  skipped** (full CI scope, `--ignore=tests/integration`), no opt-outs needed
- [ ] **CI is the magnitude gate** — unit-job wall drops materially from ~22min

Closes #771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Descriptor embedding operations now default to using deterministic stubs during test execution, significantly improving test suite performance and speed.
  * New `MEHO_TEST_STUB_DESCRIPTOR_EMBEDDING` environment variable provides flexible configuration control over embedding stubbing behavior.
  * Added `real_descriptor_embeddings` fixture to disable stubbing for tests requiring actual embedding service functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->