### PR TITLE
fix(cli): detach `meho login` device-flow wait from ambient parent context (#798)

### DIFF
--- a/cli/internal/auth/devicecode.go
+++ b/cli/internal/auth/devicecode.go
@@ -11,7 +11,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -208,6 +211,18 @@ type DeviceFlowOptions struct {
 	// without one. The cobra command in cmd/login.go supplies a
 	// stdout-writing implementation; tests pass an in-memory one.
 	Prompter DeviceFlowPrompter
+	// ParentContext is the caller's ambient context (`cmd.Context()`
+	// in the cobra layer). It is **not** used to govern the polling
+	// wait — that role belongs to `ctx`, which the caller should
+	// build via NewDeviceFlowContext so a short ambient deadline
+	// cannot truncate the operator's approval window. ParentContext
+	// is consulted *only* in the error path: if the polling wait
+	// ends with `context.DeadlineExceeded` and ParentContext has
+	// also timed out, the returned error names the ambient deadline
+	// explicitly instead of the generic IdP-shaped message.
+	// Optional — leave nil if the caller has no separate parent
+	// (tests, embedded uses).
+	ParentContext context.Context
 }
 
 // RunDeviceFlow performs RFC 8628 against the supplied discovery
@@ -272,7 +287,7 @@ func RunDeviceFlow(ctx context.Context, doc *DiscoveryDocument, clientID string,
 	// interval and slow_down semantics in RFC 8628 §3.5.
 	tok, err := cfg.DeviceAccessToken(flowCtx, deviceResp)
 	if err != nil {
-		return nil, classifyDeviceTokenError(err)
+		return nil, classifyDeviceTokenError(opts.ParentContext, err)
 	}
 
 	return &LoginResult{Token: tok, Issuer: doc.Issuer}, nil
@@ -284,7 +299,18 @@ func RunDeviceFlow(ctx context.Context, doc *DiscoveryDocument, clientID string,
 // as Go-native sentinels so the cobra command can render them with
 // operator-friendly hints rather than dumping the raw upstream
 // payload.
-func classifyDeviceTokenError(err error) error {
+//
+// parentCtx is the cobra `cmd.Context()` (i.e. the ambient process /
+// CI / wrapper context). The polling wait runs on a context that's
+// deliberately detached from parentCtx (see NewDeviceFlowContext) so
+// a short ambient deadline can no longer truncate the operator's
+// approval window. But if a non-IdP timeout fires (our own
+// PollTimeout cap, or — for diagnostic value — an ambient deadline
+// that was previously the failure mode), we want the operator to see
+// which deadline was at fault rather than the generic
+// `context deadline exceeded`. A nil parentCtx is treated the same
+// as a non-cancelled parent.
+func classifyDeviceTokenError(parentCtx context.Context, err error) error {
 	var retr *oauth2.RetrieveError
 	if errors.As(err, &retr) {
 		switch retr.ErrorCode {
@@ -294,7 +320,92 @@ func classifyDeviceTokenError(err error) error {
 			return fmt.Errorf("meho: authorisation denied by the operator at the verification URI")
 		}
 	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		// Our own PollTimeout cap fired (10m). The ambient parent
+		// context having ALSO timed out is the historical
+		// misattribution case — name it so the operator stops
+		// chasing the IdP for a CI/wrapper timeout.
+		if parentCtx != nil && errors.Is(parentCtx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("meho: login timed out waiting for approval; the parent process imposed a deadline shorter than the %s device-flow cap — rerun in a terminal without a wrapping timeout, or approve faster", PollTimeout)
+		}
+		return fmt.Errorf("meho: login timed out waiting for approval after %s; rerun and approve sooner, or pass a longer device-code lifetime via your IdP", PollTimeout)
+	}
+	if errors.Is(err, context.Canceled) {
+		return fmt.Errorf("meho: login cancelled before approval (received SIGINT/SIGTERM or explicit cancel)")
+	}
 	return fmt.Errorf("meho: token exchange failed: %w", err)
+}
+
+// NewDeviceFlowContext returns the context that should govern the
+// device-code approval wait, decoupled from the caller's ambient
+// context (cobra's `cmd.Context()`, a CI job step, the wrapping
+// shell's process group, the IDE's bash-tool timeout, …).
+//
+// Why detach. RFC 8628's device-code lifetime (`expires_in`) is
+// typically minutes — Keycloak defaults to 600s. The whole point of
+// the device-code flow is that the operator may be on a different
+// machine, may walk to a kiosk, may need to fetch a hardware token.
+// If the polling wait inherits the parent's deadline, a 30-second
+// CI-step timeout (or any wrapper that imposed a similar bound)
+// silently truncates the approval window and the operator sees
+// `context deadline exceeded` — misattributed to the device code,
+// which was still valid. The original consumer report (Initiative
+// G0.9.1, Addendum II Wall #4) hit this twice; the fix is structural,
+// not a value bump.
+//
+// What we keep:
+//
+//   - Context values from `parent` (e.g. `oauth2.HTTPClient`) ride
+//     through via `context.WithoutCancel` — values propagate, the
+//     parent's Done channel does not.
+//   - SIGINT / SIGTERM still abort promptly via `signal.NotifyContext`
+//     — a Ctrl-C at the terminal must not be ignored just because the
+//     caller's process context was already detached.
+//   - An absolute upper bound of `PollTimeout` (10 minutes) prevents
+//     a wedged IdP from holding the CLI forever.
+//
+// What we drop:
+//
+//   - The parent's deadline. Whether the caller is `bash` with a
+//     `timeout 30s` prefix, a CI step with a default 60s budget, or
+//     a test harness with `context.WithTimeout`, the device-flow
+//     wait now ignores it. The parent's deadline still applies to
+//     network calls that ran before this point (discovery,
+//     auth-config); only the interactive wait is exempt.
+//   - The parent's `cancel` call. A caller that explicitly cancels
+//     `parent` does not abort the device-flow wait. This is
+//     deliberate — the device flow is uncancellable from outside the
+//     terminal (the user has already been shown the verification
+//     URL). For genuine cancellation, send SIGINT.
+//
+// The returned cancel func must always be called (use defer) — it
+// releases both the signal handler and the PollTimeout timer.
+func NewDeviceFlowContext(parent context.Context) (context.Context, context.CancelFunc) {
+	// Step 1: shed the parent's Done channel but inherit its values.
+	// Available since Go 1.21; semantics documented at
+	// https://pkg.go.dev/context#WithoutCancel.
+	detached := context.WithoutCancel(parent)
+
+	// Step 2: re-attach a clean cancellation source rooted in OS
+	// signals only. signal.NotifyContext registers the signals on
+	// the returned context and stops the relay when the cancel func
+	// runs, so we don't leak a signal handler across logins.
+	signalCtx, stopSignals := signal.NotifyContext(detached, os.Interrupt, syscall.SIGTERM)
+
+	// Step 3: cap the whole interactive wait at PollTimeout. Keeps
+	// the worst case bounded if the IdP wedges and the operator
+	// walks away. The oauth2 package additionally caps polling at
+	// `deviceResp.Expiry` internally, so this is the *outer* bound.
+	flowCtx, cancelTimeout := context.WithTimeout(signalCtx, PollTimeout)
+
+	// Compose both cleanup hooks into one cancel func. Callers only
+	// have to defer the returned func and both inner resources
+	// release. Order is timeout first (releases the timer), then
+	// signal relay (releases the signal.Notify registration).
+	return flowCtx, func() {
+		cancelTimeout()
+		stopSignals()
+	}
 }
 
 // ConvertOAuthToken collapses an oauth2.Token into the StoredToken

--- a/cli/internal/auth/devicecode_test.go
+++ b/cli/internal/auth/devicecode_test.go
@@ -429,3 +429,224 @@ func TestDiscoveryErrorUnwraps(t *testing.T) {
 		t.Errorf("DiscoveryError should unwrap to context.DeadlineExceeded")
 	}
 }
+
+// TestNewDeviceFlowContextDropsParentDeadline is the regression pin
+// for Initiative G0.9.1, Wall #4. A parent context with a deadline
+// shorter than the device-flow approval window must not propagate
+// that deadline to the polling wait. Inheriting context *values*
+// stays — `oauth2.HTTPClient` injection at higher layers depends on
+// it.
+func TestNewDeviceFlowContextDropsParentDeadline(t *testing.T) {
+	type ctxKey struct{}
+
+	// Parent: short deadline + a stuffed value.
+	parent, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	parent = context.WithValue(parent, ctxKey{}, "carried-through")
+
+	flowCtx, cancelFlow := NewDeviceFlowContext(parent)
+	defer cancelFlow()
+
+	// The parent's deadline must not appear on the flow context (we
+	// installed PollTimeout = 10m, not 10ms). Use Deadline() rather
+	// than waiting and observing Done() so the test stays fast.
+	dl, ok := flowCtx.Deadline()
+	if !ok {
+		t.Fatalf("flow context should have a deadline (PollTimeout cap), got none")
+	}
+	if remaining := time.Until(dl); remaining < PollTimeout-time.Minute {
+		t.Errorf("flow context deadline too close (%v); parent's short deadline leaked", remaining)
+	}
+
+	// Wait past the parent's deadline; the flow context must remain
+	// open. The parent will be Done; the flow context must not be.
+	time.Sleep(40 * time.Millisecond)
+	if parent.Err() == nil {
+		t.Fatalf("parent context should already be expired by now")
+	}
+	if err := flowCtx.Err(); err != nil {
+		t.Errorf("flow context should still be alive after parent expires; got err=%v", err)
+	}
+
+	// Values must still ride through.
+	if got := flowCtx.Value(ctxKey{}); got != "carried-through" {
+		t.Errorf("value not inherited: got %v", got)
+	}
+}
+
+// TestNewDeviceFlowContextCancelStopsSignalRelay ensures the cancel
+// func returned by NewDeviceFlowContext releases both inner
+// resources — the PollTimeout timer and the signal.Notify
+// registration — so spawning a hundred logins doesn't leak a
+// hundred SIGINT handlers. We can't directly observe signal-relay
+// teardown without reaching into runtime internals, so we settle
+// for confirming the context becomes Done after cancel and that
+// the cancel func is safe to call twice.
+func TestNewDeviceFlowContextCancelStopsSignalRelay(t *testing.T) {
+	flowCtx, cancel := NewDeviceFlowContext(context.Background())
+	cancel()
+	cancel() // idempotent — double-defer in callers must not panic.
+
+	select {
+	case <-flowCtx.Done():
+		// Expected.
+	case <-time.After(time.Second):
+		t.Fatalf("flow context should be Done after cancel")
+	}
+}
+
+// TestRunDeviceFlowSurvivesShortParentDeadline is the integration-
+// shaped pin: drive RunDeviceFlow with a parent context whose
+// deadline elapses while the stub IdP is still returning
+// `authorization_pending`. Before the fix, this scenario produced
+// `context deadline exceeded`. After the fix, the polling wait
+// continues past the parent's deadline and the flow completes with
+// the IdP-issued token.
+func TestRunDeviceFlowSurvivesShortParentDeadline(t *testing.T) {
+	const parentBudget = 50 * time.Millisecond
+
+	var tokenCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/device":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":      "dc",
+				"user_code":        "UC",
+				"verification_uri": "https://kc/device",
+				"expires_in":       600,
+				"interval":         1,
+			})
+		case "/token":
+			n := tokenCalls.Add(1)
+			// Stay pending until the parent budget has elapsed, then
+			// approve. This pins the exact scenario reported in
+			// G0.9.1 Wall #4: the IdP would have approved, but the
+			// CLI had already given up because the ambient deadline
+			// fired first.
+			if n < 3 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error": "authorization_pending",
+				})
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "at",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	doc := &DiscoveryDocument{
+		Issuer:                      "iss",
+		DeviceAuthorizationEndpoint: srv.URL + "/auth/device",
+		TokenEndpoint:               srv.URL + "/token",
+	}
+
+	parent, cancelParent := context.WithTimeout(context.Background(), parentBudget)
+	defer cancelParent()
+
+	flowCtx, cancelFlow := NewDeviceFlowContext(parent)
+	defer cancelFlow()
+
+	// Sanity check: by the time the polling loop logs the second
+	// pending response (~2s into a 1s-interval poll), the parent
+	// deadline is long gone. The detached flow context must still
+	// be open.
+	result, err := RunDeviceFlow(flowCtx, doc, "meho-cli", DeviceFlowOptions{
+		HTTPClient:    srv.Client(),
+		Prompter:      func(context.Context, *oauth2.DeviceAuthResponse) error { return nil },
+		ParentContext: parent,
+	})
+	if err != nil {
+		t.Fatalf("RunDeviceFlow failed even though IdP approved after parent deadline: %v", err)
+	}
+	if result.Token.AccessToken != "at" {
+		t.Errorf("token: got %q, want at", result.Token.AccessToken)
+	}
+	if parent.Err() == nil {
+		t.Fatalf("test invariant violated: parent should have expired by now (budget %v)", parentBudget)
+	}
+}
+
+// TestClassifyDeviceTokenErrorNamesAmbientDeadline verifies the
+// error-message disambiguation for the case where the polling
+// timeout fires *and* the parent context is also past deadline.
+// Operators wrapped under a CI step or bash-tool timeout need to be
+// told the wrapper is the problem, not the IdP — see G0.9.1 Wall
+// #4 acceptance criteria.
+func TestClassifyDeviceTokenErrorNamesAmbientDeadline(t *testing.T) {
+	expiredParent, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	// Parent must be observably expired before we classify.
+	if expiredParent.Err() == nil {
+		t.Fatalf("test setup: parent should be expired")
+	}
+
+	err := classifyDeviceTokenError(expiredParent, context.DeadlineExceeded)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"parent process", "deadline", "wrapping timeout"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message should mention %q, got %q", want, msg)
+		}
+	}
+}
+
+// TestClassifyDeviceTokenErrorDistinguishesCancel pins the cancel
+// branch separately from the deadline branch so SIGINT / explicit
+// cancel still produces a clean message rather than the raw
+// `context canceled`. Acceptance criterion: "Genuine cancellation
+// (SIGINT / explicit cancel) still aborts promptly".
+func TestClassifyDeviceTokenErrorDistinguishesCancel(t *testing.T) {
+	err := classifyDeviceTokenError(context.Background(), context.Canceled)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("cancel message missing 'cancelled', got %q", err.Error())
+	}
+}
+
+// TestClassifyDeviceTokenErrorOwnPollTimeout covers the case where
+// our PollTimeout cap fires (10m elapsed) but the parent context
+// is still healthy. The message should not blame the parent.
+func TestClassifyDeviceTokenErrorOwnPollTimeout(t *testing.T) {
+	err := classifyDeviceTokenError(context.Background(), context.DeadlineExceeded)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "parent process") {
+		t.Errorf("should not blame parent when parent is healthy: %q", msg)
+	}
+	if !strings.Contains(msg, "approval") {
+		t.Errorf("message should mention the approval wait: %q", msg)
+	}
+}
+
+// TestClassifyDeviceTokenErrorIdPCodesUnchanged confirms the
+// existing classifications for `expired_token` / `access_denied`
+// still produce the same operator-facing strings — those branches
+// pre-date this fix and tests / docs already pin them.
+func TestClassifyDeviceTokenErrorIdPCodesUnchanged(t *testing.T) {
+	expired := &oauth2.RetrieveError{ErrorCode: "expired_token"}
+	denied := &oauth2.RetrieveError{ErrorCode: "access_denied"}
+
+	if got := classifyDeviceTokenError(context.Background(), expired).Error(); !strings.Contains(got, "device code expired") {
+		t.Errorf("expired_token message regressed: %q", got)
+	}
+	if got := classifyDeviceTokenError(context.Background(), denied).Error(); !strings.Contains(got, "denied") {
+		t.Errorf("access_denied message regressed: %q", got)
+	}
+}

--- a/cli/internal/cmd/login.go
+++ b/cli/internal/cmd/login.go
@@ -60,8 +60,17 @@ func newLoginCmd() *cobra.Command {
 				return fmt.Errorf("invalid backplane URL %q: %w", backplaneURL, err)
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), auth.PollTimeout)
-			defer cancel()
+			// Discovery and auth-config fetches honour the ambient
+			// `cmd.Context()` deadline: those are short, bounded HTTP
+			// calls that should fail fast if the network is wedged.
+			// Only the interactive device-flow wait below detaches
+			// from that ambient context (see NewDeviceFlowContext) —
+			// without that split, a wrapping CI step or bash-tool
+			// deadline would silently truncate the operator's
+			// approval window and `context deadline exceeded` would
+			// be misattributed to the device code itself
+			// (Initiative G0.9.1, Wall #4).
+			parentCtx := cmd.Context()
 
 			// Resolve auth config. Override flags win; otherwise hit
 			// the backplane's discovery endpoint. The override path
@@ -70,12 +79,12 @@ func newLoginCmd() *cobra.Command {
 			// firewall) but the IdP is — meho login can still
 			// complete by skipping discovery via both --issuer and
 			// --client-id.
-			cfg, err := resolveAuthConfig(ctx, http.DefaultClient, backplaneURL, issuerOverride, clientIDOverride)
+			cfg, err := resolveAuthConfig(parentCtx, http.DefaultClient, backplaneURL, issuerOverride, clientIDOverride)
 			if err != nil {
 				return err
 			}
 
-			doc, err := auth.FetchDiscoveryFromRealm(ctx, http.DefaultClient, cfg.Issuer)
+			doc, err := auth.FetchDiscoveryFromRealm(parentCtx, http.DefaultClient, cfg.Issuer)
 			if err != nil {
 				return err
 			}
@@ -92,10 +101,20 @@ func newLoginCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			prompter := stdoutPrompter(out)
 
-			result, err := auth.RunDeviceFlow(ctx, doc, cfg.ClientID, auth.DeviceFlowOptions{
-				HTTPClient: http.DefaultClient,
-				Scopes:     scopes,
-				Prompter:   prompter,
+			// Build the detached device-flow context. Inherits values
+			// from parentCtx (so future oauth2.HTTPClient injections
+			// at this layer would still ride through), drops the
+			// parent's deadline (so a short wrapper deadline can't
+			// truncate the approval wait), and re-attaches
+			// SIGINT/SIGTERM cancellation + a PollTimeout cap.
+			flowCtx, cancelFlow := auth.NewDeviceFlowContext(parentCtx)
+			defer cancelFlow()
+
+			result, err := auth.RunDeviceFlow(flowCtx, doc, cfg.ClientID, auth.DeviceFlowOptions{
+				HTTPClient:    http.DefaultClient,
+				Scopes:        scopes,
+				Prompter:      prompter,
+				ParentContext: parentCtx,
 			})
 			if err != nil {
 				return err

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -311,9 +311,38 @@ Authorization Grant (RFC 8628). End-to-end shape:
    at the IdP-supplied `interval`, honouring RFC 8628's
    `authorization_pending` and `slow_down` semantics. The polling
    loop returns when the IdP issues a token, the device code
-   expires (`expired_token`), the operator denies the grant
-   (`access_denied`), or the context is cancelled. The outer
-   timeout is 10 minutes (`auth.PollTimeout`).
+   expires (`expires_in`, enforced inside the oauth2 package), the
+   operator denies the grant (`access_denied`), or the polling
+   context is cancelled. The outer timeout is 10 minutes
+   (`auth.PollTimeout`).
+
+   **Detached from ambient deadlines.** The interactive approval
+   wait runs on a context built by `auth.NewDeviceFlowContext`,
+   which deliberately drops the ambient `cmd.Context()` deadline
+   while keeping context values (`oauth2.HTTPClient` etc.) and
+   re-attaching `SIGINT` / `SIGTERM` cancellation. Rationale:
+   non-interactive wrappers (CI steps, the Claude Code bash tool,
+   `timeout 30s …` prefixes) often impose deadlines shorter than
+   the device code's `expires_in`. Without the detachment, a
+   wrapper-imposed deadline would propagate into the polling loop
+   and surface as `context deadline exceeded` even though the
+   device code was still valid (Initiative G0.9.1, Wall #4). Only
+   the interactive wait detaches — the discovery and auth-config
+   HTTP calls (steps 1–2) still honour `cmd.Context()`, so genuine
+   network wedges fail fast.
+
+   When the wait does time out, `classifyDeviceTokenError`
+   distinguishes the culprit:
+
+   * IdP-reported `expired_token` / `access_denied` → device-code-
+     specific messages.
+   * `PollTimeout` (10m) elapsed and the ambient parent context is
+     ALSO past deadline → message names the wrapping timeout as
+     the cause and points the operator at running outside the
+     wrapper.
+   * `PollTimeout` elapsed with a healthy parent → message says
+     the operator didn't approve in 10 minutes.
+   * `context.Canceled` → SIGINT / SIGTERM message.
 6. **Persistence.** The access token plus issuer, client_id,
    refresh token (captured for v0.2), and id_token are persisted to
    a backend chosen at runtime — see below.


### PR DESCRIPTION
## Summary
- Detach `meho login`'s device-code polling context from `cmd.Context()` so wrapped / non-interactive invocations (CI steps, the Claude Code bash tool, `timeout 30s …` prefixes) can no longer truncate the operator's approval window. Initiative G0.9.1 Wall #4 — premise corrected: `PollTimeout` was already 10m and oauth2 already honoured RFC 8628's `expires_in`, so bumping `PollTimeout` would have been a no-op. The real fix is structural at `login.go:61`.
- New `auth.NewDeviceFlowContext(parent)` builds the polling context via `context.WithoutCancel` (inherits values, drops Done) → `signal.NotifyContext` for SIGINT/SIGTERM → `WithTimeout(PollTimeout)` cap. Discovery / auth-config HTTP calls still honour `cmd.Context()` so genuine network wedges fail fast.
- `classifyDeviceTokenError` now takes the parent context and distinguishes the timeout sources in the operator-facing message: ambient parent deadline vs `PollTimeout` cap vs cancellation signal. IdP-specific classifications (`expired_token`, `access_denied`) keep their existing strings.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l internal/ cmd/` — clean
- [x] `go test ./...` — all packages pass (full CLI suite)
- [x] `TestRunDeviceFlowSurvivesShortParentDeadline` — stub IdP returns `authorization_pending` until ~2s, parent context expires at 50ms; flow completes with the IdP-issued token. This is the regression pin for Wall #4 acceptance criterion 1.
- [x] `TestNewDeviceFlowContextDropsParentDeadline` — verifies the flow context's deadline is `PollTimeout` (not the parent's 10ms), values still ride through, and the flow ctx stays alive after parent expires.
- [x] `TestNewDeviceFlowContextCancelStopsSignalRelay` — confirms the returned cancel func is idempotent and tears down the signal relay + timer.
- [x] `TestClassifyDeviceTokenErrorNamesAmbientDeadline` — when both PollTimeout fired and parent is past deadline, the message names the wrapping timeout.
- [x] `TestClassifyDeviceTokenErrorDistinguishesCancel` — `context.Canceled` produces a "cancelled" message, not the raw context-error.
- [x] `TestClassifyDeviceTokenErrorOwnPollTimeout` — PollTimeout with healthy parent says "approval" without blaming the parent.
- [x] `TestClassifyDeviceTokenErrorIdPCodesUnchanged` — pins `expired_token` / `access_denied` operator-facing strings.

## Out of scope
- `PollTimeout` value untouched (still 10m). The corrected premise note in #798 explicitly records that the 600s extension proposed in Addendum II was incorrect.
- Refresh-token / non-device-code grants — CLI ships device-code only.
- `audience → client_id` mapping and the auth-config completion — covered by sibling T9 (#789).
- Server-side token-validator error specificity — sibling T12 (#797).
- Deployer onramp docs — sibling T10 (#790).

Closes #798


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout and cancellation messages during device-code authentication, clearly distinguishing parent-context expiry, the flow’s own polling timeout, and user interrupts (Ctrl+C).
  * Better handling of interrupts (SIGINT/SIGTERM) for graceful cleanup during interactive waits.

* **Refactor**
  * Separated discovery/network steps from the interactive approval polling to improve error attribution and reliability of the login flow.

* **Tests**
  * Added unit and integration-style tests covering context behavior, cancellation, timeout distinctions, and error-message selection.

* **Documentation**
  * Updated device-code polling docs to explain context separation and timeout/cancel cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->