### PR TITLE
test: opt-in real-embedding guard + harvest CI-perf timing instrumentation

### DIFF
--- a/backend/tests/_perf_timing_report.py
+++ b/backend/tests/_perf_timing_report.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""CI-perf timing report — companion to the dormant instrumentation in conftest.
+
+Reads the per-worker JSONL files written by the env-gated hooks in
+``tests/conftest.py`` (enabled via ``MEHO_LIFESPAN_TIMING`` and
+``MEHO_FIXTURE_TIMING_FILE``) and prints two attribution tables:
+
+* lifespan-step timing  — which FastAPI lifespan step dominates per-test setup.
+* fixture-setup timing  — which fixture's setup the ``--durations`` report is
+  really blaming.
+
+Usage::
+
+    MEHO_LIFESPAN_TIMING=/tmp/lifespan MEHO_FIXTURE_TIMING_FILE=/tmp/fixt \\
+        uv run pytest -n 6 --dist loadscope --ignore=tests/integration tests/
+    uv run python tests/_perf_timing_report.py
+
+This is reusable diagnostic tooling, not a test (the leading underscore keeps
+pytest from collecting it). It cracked the #771 unit-job wall investigation
+where ``--durations`` alone could not see inside the lifespan-booting fixture.
+"""
+
+from __future__ import annotations
+
+import collections
+import glob
+import json
+
+
+def _load(pattern: str) -> list[dict]:
+    rows: list[dict] = []
+    for fpath in glob.glob(pattern):
+        with open(fpath) as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return rows
+
+
+def _agg(rows: list[dict], key: str) -> list[tuple[str, int, float, float]]:
+    acc: dict[str, list[float]] = collections.defaultdict(lambda: [0.0, 0.0, 0.0])
+    for r in rows:
+        a = acc[r[key]]
+        a[0] += 1
+        a[1] += r["dur"]
+        a[2] = max(a[2], r["dur"])
+    out = [(k, int(v[0]), v[1], v[2]) for k, v in acc.items()]
+    out.sort(key=lambda t: -t[2])  # by total seconds
+    return out
+
+
+def main() -> None:
+    life = _load("/tmp/lifespan.*")
+    print("=" * 78)
+    print(f"LIFESPAN STEP TIMING  ({len(life)} calls)  — sorted by total seconds")
+    print(f"{'step':<34}{'count':>7}{'sum_s':>11}{'max_s':>9}{'mean_s':>9}")
+    for name, count, total, mx in _agg(life, "step"):
+        print(f"{name:<34}{count:>7}{total:>11.1f}{mx:>9.2f}{total / count:>9.2f}")
+    print()
+    print("LIFESPAN — top 25 single slowest calls")
+    for r in sorted(life, key=lambda row: -row["dur"])[:25]:
+        print(f"{r['dur']:>8.2f}s  {r['step']:<32}{r['node']}")
+    print()
+
+    fixt = _load("/tmp/fixt.*")
+    print("=" * 78)
+    print(f"FIXTURE SETUP TIMING  ({len(fixt)} setups)  — top 40 by total seconds")
+    print(f"{'fixture':<34}{'count':>7}{'sum_s':>11}{'max_s':>9}{'mean_s':>9}")
+    for name, count, total, mx in _agg(fixt, "fix")[:40]:
+        print(f"{name:<34}{count:>7}{total:>11.1f}{mx:>9.2f}{total / count:>9.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -731,3 +731,127 @@ def mock_discovery_and_jwks(
         return_value=httpx.Response(200, json=jwks),
     )
     return discovery_route, jwks_route
+
+
+# ---------------------------------------------------------------------------
+# CI-PERF TIMING INSTRUMENTATION (permanent, dormant unless enabled)
+#
+# Reusable per-step / per-fixture setup-cost attribution for the suite. Both
+# the hook and the autouse fixture are pure no-ops unless their env var is
+# set, so a normal run is unaffected. Harvested from the #771 investigation
+# (PR #793), where it attributed the unit-job wall to per-test descriptor
+# re-embedding — `--durations` alone could only blame the *fixture*, not the
+# step inside the lifespan.
+#
+# To use (one-off diagnostic run, locally or on a throwaway branch):
+#
+#   MEHO_LIFESPAN_TIMING=/tmp/lifespan \
+#   MEHO_FIXTURE_TIMING_FILE=/tmp/fixt \
+#     uv run pytest -n 6 --dist loadscope --ignore=tests/integration tests/
+#   uv run python tests/_perf_timing_report.py   # prints both tables
+#
+#   MEHO_LIFESPAN_TIMING=<path>      per-test timing of each FastAPI lifespan
+#       step, by wrapping meho_backplane.main's module-level callables. One
+#       JSON line per call, written to "<path>.<worker>".
+#   MEHO_FIXTURE_TIMING_FILE=<path>  per-fixture setup duration for every
+#       fixture (outer attribution: which fixture's setup dominates).
+#       Accumulated in process, flushed once per worker at session finish.
+# ---------------------------------------------------------------------------
+
+_PERF_FIXTURE_TIMINGS: list[tuple[float, str, str]] = []
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    """Record per-fixture setup duration when MEHO_FIXTURE_TIMING_FILE is set."""
+    if not os.environ.get("MEHO_FIXTURE_TIMING_FILE"):
+        yield
+        return
+    start = time.perf_counter()
+    yield
+    _PERF_FIXTURE_TIMINGS.append(
+        (round(time.perf_counter() - start, 3), fixturedef.argname, str(fixturedef.scope)),
+    )
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Flush accumulated fixture-setup timings once per worker."""
+    import json
+
+    path = os.environ.get("MEHO_FIXTURE_TIMING_FILE")
+    if not path or not _PERF_FIXTURE_TIMINGS:
+        return
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    with open(f"{path}.{worker}", "w") as fh:
+        for dur, name, scope in _PERF_FIXTURE_TIMINGS:
+            fh.write(json.dumps({"dur": dur, "fix": name, "scope": scope}) + "\n")
+
+
+@pytest.fixture(autouse=True)
+def _perf_lifespan_step_timing(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Time each FastAPI lifespan step per test when MEHO_LIFESPAN_TIMING is set.
+
+    Wraps the module-level callables the lifespan invokes (resolved from
+    meho_backplane.main's globals at call time) with timing wrappers that
+    append one record per call. Restored on teardown. Test-only; touches no
+    production code.
+    """
+    import asyncio
+    import json
+
+    path = os.environ.get("MEHO_LIFESPAN_TIMING")
+    if not path:
+        yield
+        return
+
+    import meho_backplane.main as main_mod
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    node = request.node.nodeid
+    out = f"{path}.{worker}"
+
+    def _record(step: str, dur: float) -> None:
+        with open(out, "a") as fh:
+            fh.write(json.dumps({"step": step, "dur": round(dur, 3), "node": node}) + "\n")
+
+    def _wrap_sync(orig: Any, name: str) -> Any:
+        def w(*a: Any, **k: Any) -> Any:
+            t = time.perf_counter()
+            try:
+                return orig(*a, **k)
+            finally:
+                _record(name, time.perf_counter() - t)
+
+        return w
+
+    def _wrap_async(orig: Any, name: str) -> Any:
+        async def w(*a: Any, **k: Any) -> Any:
+            t = time.perf_counter()
+            try:
+                return await orig(*a, **k)
+            finally:
+                _record(name, time.perf_counter() - t)
+
+        return w
+
+    names = [
+        "get_engine",
+        "get_broadcast_client",
+        "_eager_import_connectors",
+        "run_typed_op_registrars",
+        "eager_import_mcp_modules",
+        "_preload_embedding_model",
+        "start_topology_refresh_scheduler",
+    ]
+    originals: dict[str, Any] = {}
+    for name in names:
+        orig = getattr(main_mod, name)
+        originals[name] = orig
+        is_async = asyncio.iscoroutinefunction(orig)
+        wrapper = _wrap_async(orig, name) if is_async else _wrap_sync(orig, name)
+        setattr(main_mod, name, wrapper)
+    try:
+        yield
+    finally:
+        for name, orig in originals.items():
+            setattr(main_mod, name, orig)

--- a/backend/tests/test_operations_meta_tools.py
+++ b/backend/tests/test_operations_meta_tools.py
@@ -39,6 +39,7 @@ from unittest.mock import AsyncMock
 from uuid import UUID
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
@@ -56,6 +57,7 @@ from meho_backplane.operations.meta_tools import (
     list_operation_groups,
     search_operations,
 )
+from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
 from meho_backplane.settings import get_settings
 
 # ---------------------------------------------------------------------------
@@ -1074,3 +1076,67 @@ async def test_describe_descriptor_cross_tenant_is_invisible() -> None:
     op_b = _make_operator(tenant_id=_TENANT_B)
     result = await describe_descriptor(op_b, descriptor_id)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_real_descriptor_embedding_path(
+    real_descriptor_embeddings: None,
+    session: AsyncSession,
+) -> None:
+    """Guard the real (non-stubbed) descriptor-embedding path end-to-end.
+
+    The suite-wide #771 stub (``_stub_descriptor_embedding`` in
+    ``tests/conftest.py``) makes ``encode_endpoint_text`` return a zero
+    vector on its default path, so almost every test registers descriptors
+    with a placeholder embedding. Opting into ``real_descriptor_embeddings``
+    turns the stub off for this test, so the registrar computes a genuine
+    fastembed vector — covering the path the global stub otherwise blinds
+    the suite to (a regression breaking real descriptor embedding, or search
+    ranking over it, would pass every other test).
+    """
+    # No ``embedding_service`` -> default path -> real fastembed, because
+    # ``real_descriptor_embeddings`` cleared the stub env var.
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.read",
+        handler=_module_handler,
+        summary="Read a KV v2 secret from a path.",
+        description="Reads a secret stored in the KV v2 mount.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.health",
+        handler=_module_handler,
+        summary="Check the cluster health.",
+        description="Reports the seal status and leader info.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+    )
+
+    # The stored descriptor carries a real, non-zero embedding -- not the
+    # suite-wide stub's zero vector.
+    descriptor = (
+        await session.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.op_id == "vault.kv.read"),
+        )
+    ).scalar_one()
+    assert descriptor.embedding is not None
+    assert len(descriptor.embedding) == EMBEDDING_DIMENSION
+    assert any(component != 0.0 for component in descriptor.embedding)
+
+    # Hybrid BM25 + cosine search over the real vectors ranks the obvious
+    # match first.
+    operator = _make_operator()
+    result = await search_operations(
+        operator,
+        {"connector_id": "vault-1.x", "query": "read secret"},
+    )
+    hits = result["hits"]
+    assert hits, "expected at least one hit"
+    assert hits[0]["op_id"] == "vault.kv.read"


### PR DESCRIPTION
## Summary

Two test-only follow-ups to #771 / #799 — close the blind spot the
suite-wide embedding stub created, and make the diagnostic that cracked
#771 permanently reusable.

### 1. Guard the real descriptor-embedding path

#799 stubs descriptor embeddings suite-wide (zero vectors) to kill the
per-test re-embed cost. That leaves a blind spot: the real fastembed path
and search ranking over real vectors are no longer exercised by the unit
suite. `test_real_descriptor_embedding_path` opts into the
`real_descriptor_embeddings` fixture (added by #799), registers ops via the
default path (real fastembed), and asserts the stored descriptor carries a
**non-zero 384-dim vector** and that `search_operations` ranks the obvious
match first. This also makes the opt-out fixture **live code** instead of a
dead escape hatch.

### 2. Harvest the timing instrumentation as permanent tooling

The lifespan-step + fixture-setup timing that cracked #771 (diagnostic
#793) is harvested into `conftest.py` as permanent, env-gated, **dormant**
tooling, plus `tests/_perf_timing_report.py`. Pure no-op unless
`MEHO_LIFESPAN_TIMING` / `MEHO_FIXTURE_TIMING_FILE` are set. `--durations`
alone could only blame the lifespan-booting *fixture*; this attributes the
cost to the *step inside it*. Reusable for the next regression (e.g. the
#801 per-test Alembic follow-up).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `test_real_descriptor_embedding_path` passes (real fastembed: non-zero
  vector + ranking) — 1 passed, 7.5s
- [x] full `test_operations_meta_tools.py` green — 22 passed
- [x] instrumentation dormant when env unset (no timing files written)
- [ ] CI green

Refs #771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance timing instrumentation to track test operation and fixture setup durations
  * Added new test validating real descriptor embedding search functionality with hybrid lexical and cosine similarity matching

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->