### PR TITLE
docs(deploy): G0.9.1-T10 consolidated auth-onramp recipe + 4-wall matrix (#790)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,33 @@ connector-related release-notes line.
   rule and pair the positive example with a digit-leading negative
   example, so the constraint is visible before the call goes out
   ([#780](https://github.com/evoila/meho/issues/780), Signal #15).
+- Publish a consolidated **deployer auth-onramp recipe** (5-step
+  realm walk + 4-wall symptom→cause→fix matrix) covering both the
+  `meho login` CLI device-code path and the MCP-client onramp.
+  Lives in [`deploy/values-examples/README.md` § Auth onramp
+  recipe (CLI + MCP)](deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp);
+  cross-linked from `docs/cross-repo/mcp-client-setup.md` (the
+  pre-registered-public-client requirement is now surfaced up
+  front, not buried at Step 2) and `docs/acceptance/install.md`.
+  Closes the ~2.5-hour first-login wall the 2026-05-21 RDC
+  dogfood walked (Addendum II Ask #3), including the
+  `basic`/`sub` Keycloak 25+ gotcha (admin-API-created clients
+  don't auto-inherit realm default-default scopes, so `sub` is
+  missing and tokens are rejected with opaque `invalid_token`)
+  and the `.mcp.json` `client_id` limitation for Claude Code +
+  Cursor (RFC 7591 DCR is closed by Keycloak's Trusted Hosts
+  policy on any prod realm; the deployer-side fix doesn't help
+  until those clients expose `client_id` — shim through
+  `mcp-remote` is the workaround). Docs-only; no backplane code
+  change (the RFC 9728 surface is correct). G0.9.1-T10 under
+  [#772](https://github.com/evoila/meho/issues/772) /
+  [#790](https://github.com/evoila/meho/issues/790).
+  Auto-provisioning the recipe at install time is tracked under
+  [#791](https://github.com/evoila/meho/issues/791) (T11);
+  token-validator error specificity is
+  [#797](https://github.com/evoila/meho/issues/797) (T12); the
+  `meho login` device-flow deadline fix is
+  [#798](https://github.com/evoila/meho/issues/798) (T13).
 
 ## [0.3.1] - 2026-05-21
 

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -36,7 +36,7 @@ request.
     | --- | --- |
     | `image.tag` | An immutable tag from the G2.4 image pipeline. Production: `sha-<40-char-git-sha>` from a green CI run. Pre-prod / lab: `v0.1.0` once the release tag exists. **`:latest` and `:main` are forbidden by Goal #11 deploy discipline.** |
     | `config.keycloakIssuerUrl` / `keycloak.issuer` realm | Your Keycloak realm name. Both fields must agree — the ConfigMap-sourced env mirrors the values block (`config.keycloakIssuerUrl` is what the backplane process reads at startup). |
-    | `config.keycloakCliClientId` | The client_id of the **public** Keycloak client `meho login` uses for device-code flow. Pre-create the client in the realm above (see [§ `meho-cli` public Keycloak client](#meho-cli-public-keycloak-client-for-meho-login)) — `meho-cli` is the suggested default. Leaving this empty keeps v0.3.1 behaviour: the backplane endpoint serves an empty value and `meho login` surfaces an actionable public-client error. |
+    | `config.keycloakCliClientId` | The client_id of the **public** Keycloak client `meho login` uses for device-code flow. Pre-create the client in the realm above per the [auth onramp recipe](#auth-onramp-recipe-cli--mcp) (`meho-cli` is the suggested default). Leaving this empty keeps v0.3.1 behaviour: the backplane endpoint serves an empty value and `meho login` surfaces an actionable public-client error. |
     | `networkPolicy.postgresCIDR` | The IPv4 CIDR of your Postgres Service. Recover via `kubectl get endpoints <pg-svc> -n <ns> -o jsonpath='{.subsets[].addresses[].ip}'` and widen to the controlling subnet. |
     | `networkPolicy.vaultCIDR` | Same, for Vault. |
     | `networkPolicy.keycloakCIDR` | Same, for Keycloak. |
@@ -255,72 +255,292 @@ If `/ready` still reports `ssl_error` after the mount lands, check the
 common drift cause: a typo'd ConfigMap name (the mount succeeds but
 the file is empty / wrong).
 
-## `meho-cli` public Keycloak client (for `meho login`)
+## Auth onramp recipe (CLI + MCP)
 
-`meho login` runs the OAuth 2.0 Device Authorization Grant (RFC 8628)
-against the realm configured in `config.keycloakIssuerUrl`. The device
-grant requires a **public** client — Keycloak rejects device-code
-initiation against a confidential client (one with a client secret)
-with `401 unauthorized_client` because the CLI cannot carry a secret
-safely. Up through v0.3.1, the CLI silently re-used the **confidential**
-`keycloakAudience` value (`meho-backplane`) as the OAuth `client_id`
-and `meho login` therefore failed on its documented happy path
-(consumer report 2026-05-21, Signal #16).
+> First-login auth-onramp for both `meho login` (CLI device-code) and
+> the MCP-client surface (`/mcp` over RFC 9728 + OAuth 2.1 + PKCE).
+> The 2026-05-21 RDC dogfood walked the realm from scratch and paid
+> ~2.5 hours hitting four sequential walls — none of them documented
+> in one place at the time. This section is the consolidated 5-step
+> recipe + 4-wall symptom→cause→fix matrix that closes that gap.
+> Companion to [`docs/cross-repo/mcp-client-setup.md`](../../docs/cross-repo/mcp-client-setup.md)
+> (MCP-client-side configuration) and
+> [`docs/acceptance/install.md`](../../docs/acceptance/install.md)
+> (cold-deploy acceptance contract).
+>
+> **Scope.** Both `meho login` and most MCP clients (Claude Desktop /
+> Claude.ai, MCP Inspector, Claude Code's HTTP MCP, Cursor) need
+> **public** OAuth clients pre-provisioned in the Keycloak realm
+> before they can authenticate. MEHO is RFC-correct (the chassis
+> emits the RFC 9728 metadata document, and the `/mcp` 401 carries
+> `WWW-Authenticate: Bearer resource_metadata=…`) — but the implicit
+> "follow the metadata trail and run dynamic client registration"
+> path is closed by Keycloak's default Trusted Hosts policy on any
+> realistic prod realm, and a public client can't appear by magic.
+> The deployer creates two public clients (one for the CLI, one for
+> MCP) with the right mappers + scopes; the consolidated automation
+> verb that does this in one idempotent step ships under
+> [#791](https://github.com/evoila/meho/issues/791) (G0.9.1-T11).
+> This recipe is the manual path the verb encodes.
 
-v0.3.2 fixes the CLI shape, but **the deployer is still responsible
-for pre-creating the public client in the Keycloak realm** before
-`helm install`. Auto-provisioning the client from a Helm post-install
-hook is tracked as [#791 (T11)](https://github.com/evoila/meho/issues/791);
-this section is the manual recipe until that lands.
+### 5-step realm recipe
 
-### Realm-side recipe
+The recipe assumes the confidential resource-server client
+`meho-backplane` already exists (it's how the backplane validates
+inbound tokens; created at install time alongside the realm). Steps
+1–5 add the **public** clients + the user that approve and consume
+those tokens.
+
+#### Step 1 — Install the deployment's TLS CA on the operator workstation
+
+`meho login` (Go) and most MCP clients verify TLS against the
+operator's **OS trust store**, not the `SSL_CERT_FILE` env var.
+On Linux: `update-ca-certificates` after dropping the CA in
+`/usr/local/share/ca-certificates/`. On macOS: import to the system
+keychain via `Keychain Access` or `security add-trusted-cert -d -r
+trustRoot -k /Library/Keychains/System.keychain <ca>.pem`; Go on
+macOS reads the system keychain via the Security framework and
+**ignores `SSL_CERT_FILE`**, so the env-var trick that works for
+Python on the backplane side doesn't carry over to the workstation
+CLI. On Windows: import to `Trusted Root Certification Authorities`
+via `certutil -addstore -f Root <ca>.pem`. Verify with
+`curl -sf https://<backplane-host>/healthz` from a fresh shell.
+
+If this step is skipped, `meho login` fails at the discovery probe
+with an `x509: certificate signed by unknown authority` error and
+the breadcrumb points at `--client-id`/`--issuer` overrides — which
+doesn't fix TLS. The override surfaces a separate failure mode but
+isn't the right recovery for an untrusted CA.
+
+#### Step 2 — Create the public `meho-cli` device-code client
 
 In the Keycloak realm that hosts `meho-backplane`, create a new
 **public** client with these settings:
 
 | Setting | Value | Why |
 | --- | --- | --- |
-| Client ID | `meho-cli` (suggested) | Matches the default in `values-rdc-example.yaml`. Any short identifier works — set `config.keycloakCliClientId` to whatever you choose. |
-| Client authentication | **Off** (public client) | The device grant cannot be completed by a confidential client; the CLI has nowhere to store a secret. |
+| Client ID | `meho-cli` (suggested) | Matches the default in `values-rdc-example.yaml`. Any short identifier works — set `config.keycloakCliClientId` (`KEYCLOAK_CLI_CLIENT_ID`) to whatever you choose. |
+| Client authentication | **Off** (public client) | The device grant cannot be completed by a confidential client; the CLI has nowhere to store a secret. Confidential client + device-grant → `401 unauthorized_client` from Keycloak's device endpoint (Wall #1). |
 | Authentication flow → Standard flow | Off | The CLI doesn't run the authorization-code grant. |
 | Authentication flow → Direct access grants | Off | Resource-owner password is explicitly out of scope. |
-| Authentication flow → **OAuth 2.0 Device Authorization Grant** | **On** | Required for `meho login`. |
+| Authentication flow → Implicit flow | Off | Deprecated by OAuth 2.1. |
+| Authentication flow → Service accounts roles | Off | Public clients can't hold credentials. |
+| Authentication flow → **OAuth 2.0 Device Authorization Grant** | **On** | Required for `meho login` ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)). |
 | Valid redirect URIs | (none) | Device flow doesn't redirect. |
-| Mapper → audience mapper | Add a `meho-backplane` audience mapper that injects `meho-backplane` (your `keycloakAudience` value) into the access token's `aud` claim | Without this, tokens issued for `meho-cli` carry `aud: meho-cli` and the backplane rejects them with `audience_not_configured`. |
+
+#### Step 3 — Clone all 5 protocol mappers from `meho-backplane` onto `meho-cli`
+
+Tokens minted by `meho-cli` must carry the same claim shape the
+backplane validates — otherwise the token decodes cleanly but is
+rejected with `invalid_token` (Wall #2). The five mappers (verbatim
+names from the dogfood reference, copy hardcoded values from the
+`meho-backplane` client in the same realm):
+
+| Mapper name | Type | Output claim | Notes |
+| --- | --- | --- | --- |
+| `audience-meho-backplane` | `oidc-audience-mapper` | `aud` adds `meho-backplane` | Without this, tokens carry `aud: meho-cli` and the backplane rejects them with `audience_not_configured` / `invalid_audience`. |
+| `meho-mcp-audience` | `oidc-audience-mapper` | `aud` adds `<backplane-url>/mcp` | Required so a token minted via the CLI can also drive `/mcp` calls. Use **Included Custom Audience** (no client-mapper UI option exists for an arbitrary URI). Paste the URI **without** a trailing slash — MEHO normalises `MCP_RESOURCE_URI` server-side and the audience claim must match the no-trailing-slash form. |
+| `tenant-id` | `oidc-hardcoded-claim` | `tenant_id` | Hardcoded to the tenant UUID the operator belongs to. Without this the backplane rejects with `missing_tenant_claim` (Wall #2). |
+| `tenant-role` | `oidc-hardcoded-claim` | `tenant_role` | Hardcoded to one of `read_only` / `operator` / `tenant_admin`. Without this the backplane rejects with `missing_tenant_role_claim`. |
+| `groups-claim` | `oidc-group-membership-mapper` | `groups` | Drives group-based RBAC (`meho-admins`, etc.). Without this group-gated tools report empty results rather than failing — a softer failure than the above, but still misleading. |
+
+Hardcoded-claim mappers are intentional: in the dogfood lab the
+realm doesn't model tenants/roles as group attributes, so hardcoded
+values are the simplest path. A realm that already encodes
+tenant/role on the user (group attribute, custom user-attribute,
+identity-provider mapping) can swap these for `oidc-usermodel-*`
+mappers — keep the **claim names** identical (`tenant_id`,
+`tenant_role`) because that's what the backplane validates against.
+
+Validator-side errors at the decode stage are made specific by
+[#797](https://github.com/evoila/meho/issues/797) (G0.9.1-T12):
+once that lands, `invalid_audience` / `missing_sub` / `token_expired`
+/ `invalid_signature` / `invalid_issuer` are distinguished in the
+401 `detail` body instead of all collapsing to `invalid_token`.
+
+#### Step 4 — Explicitly assign the 4 default client scopes
+
+| Scope | Why | What breaks if it's missing |
+| --- | --- | --- |
+| `basic` | Carries the **Subject (sub) protocol mapper**. Keycloak 25 moved the `sub` claim out of the hardcoded token-generation path and into a protocol mapper inside this scope ([Keycloak 25 release notes](https://www.keycloak.org/2024/06/keycloak-2500-released) — the change persists in Keycloak 26+). RFC 9068 §2.2.1 makes `sub` REQUIRED on JWT access tokens, so a token without it is correctly rejected — the diagnostic is the opaque part. | Wall #3: every backplane call returns 401 `invalid_token` with no hint that `sub` is missing. This is the deepest wall — every other claim is present, the token *looks* well-formed, and the breakage moves with the realm regardless of how the client was created. |
+| `roles` | Carries realm-roles + client-roles into the token. | Group-gated tools may report empty / unauthorised results. |
+| `web-origins` | Allowed CORS origins for browser-driven flows. | Browser-driven MCP clients (Claude.ai Custom Connector) fail CORS pre-flight. |
+| `acr` | Authentication Context Class Reference — drives step-up auth. | Step-up flows misbehave; not load-bearing for first login but cheap to ship. |
+
+> **The `basic`/`sub` gotcha (load-bearing).** Clients **created via
+> the Keycloak admin REST API do not auto-inherit the realm's
+> default-default client scopes** the way the admin-console UI's
+> "Create" button does. The console populates `defaultClientScopes`
+> on the new client to the realm's "Default" set; `kcadm.sh` /
+> direct admin-API `POST /clients` does not, unless the request body
+> explicitly includes a `defaultClientScopes` array. Re-using a
+> realm-default scope **name** in `optionalClientScopes` doesn't
+> back-fill it as default either. The recovery is to set
+> `defaultClientScopes: ["basic","roles","web-origins","acr"]`
+> explicitly in the admin-API request body, or to re-add each scope
+> via the admin console afterwards. The consumer's reference script
+> at [`scripts/keycloak-bootstrap-meho-cli.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/670)
+> sets all four explicitly to be safe.
+
+#### Step 5 — Provision a user in `meho-admins` with a password
+
+The realm ships with zero human users — prior lab work rode
+`client_credentials` and never needed one. Device-code, by RFC 8628
+§3.4, requires a real user to approve the verification URL.
+
+Create at least one user (any username; the dogfood lab uses the
+operator's email) with:
+
+- A password (any policy-compliant value; the user is prompted to
+  change it on first login if the realm's password policy says so).
+- Group membership: `meho-admins` (so the `groups-claim` mapper at
+  Step 3 emits `meho-admins` and the backplane's group-gated tools
+  are reachable).
+
+The user's `email_verified` flag does not need to be true for
+device-code to complete; if your realm enforces verified email
+elsewhere, set it true on this user.
+
+### MCP onramp — public `meho-mcp-client` (Claude.ai / Claude Desktop / MCP Inspector)
+
+Repeat Steps 2–4 for a second public client used by MCP clients
+that **can** carry `client_id` in their config (Claude.ai Custom
+Connector, MCP Inspector). Suggested client ID `meho-mcp-client`;
+client-shape contrast with `meho-cli`:
+
+| Setting | `meho-mcp-client` | Why differs from `meho-cli` |
+| --- | --- | --- |
+| Standard flow (authorization-code + PKCE) | **On** | MCP 2025-06-18 mandates OAuth 2.1 authorization-code + PKCE for the `/mcp` path; the device grant is a CLI-only convenience. |
+| Device grant | Off | Not needed; MCP clients run the browser-redirect flow. |
+| Valid redirect URIs | `https://claude.ai/api/mcp/auth_callback`, `http://localhost:*` | Covers the Claude.ai Custom Connector and any localhost MCP Inspector. |
+| Web origins | `+` (or a tight allow-list) | CORS for the browser flow. |
+| PKCE challenge method | `S256` | Spec-required for public-client PKCE. |
+
+The 5 protocol mappers + 4 default client scopes from Steps 3–4
+apply identically. The recipe at
+[`docs/cross-repo/mcp-client-setup.md`](../../docs/cross-repo/mcp-client-setup.md)
+documents the per-client configuration step for each MCP client.
+
+> **`.mcp.json` `client_id` limitation (Claude Code + Cursor).**
+> Claude Code's HTTP-MCP support and Cursor's MCP wire-up
+> as of 2026-05 follow the RFC 9728 metadata trail to the
+> Keycloak authorization server but **do not expose a
+> `client_id` field in their `.mcp.json` shape**. They
+> attempt dynamic client registration (RFC 7591) against the
+> Keycloak `clients-registrations/openid-connect` endpoint
+> and hit Keycloak's Trusted Hosts policy — which ships with
+> an empty whitelist, so anonymous DCR is **de-facto
+> disabled** ([Keycloak docs](https://www.keycloak.org/securing-apps/client-registration)).
+> The deployer-side fix (registering a public client by hand)
+> doesn't help these clients until they expose `client_id` in
+> `.mcp.json`. Two workarounds today: (a) use Claude.ai
+> Custom Connector or MCP Inspector for first-class wire-up
+> against `meho-mcp-client`; (b) shim Claude Code / Cursor
+> through `mcp-remote` (or an equivalent stdio→HTTP proxy)
+> and bake the Bearer token into the wrapper. The right
+> long-term fix is upstream MCP-client `client_id` support,
+> not opening DCR on a prod realm.
 
 ### Wire it into Helm
 
-Set the chart value to the client_id you just created:
+Set the chart value to the CLI client_id you created at Step 2:
 
 ```yaml
 config:
   keycloakCliClientId: meho-cli   # or whatever you chose
 ```
 
-The backplane's `/api/v1/auth-config` endpoint will surface this value
+The backplane's `/api/v1/auth-config` endpoint surfaces this value
 as the `cli_client_id` JSON field, which `meho login`'s discovery
 parser maps to the OAuth `client_id`. The CLI also accepts
 `--client-id <id>` as a per-invocation override, useful when a
 deployer publishes multiple public clients (e.g. `meho-cli-prod`,
 `meho-cli-staging`) and the chart value pins one default.
 
+The MCP public client (`meho-mcp-client`) is not chart-wired today
+— Claude.ai's Custom Connector and MCP Inspector both ask the
+operator to paste a client_id at config time. Auto-discovery via
+RFC 9728 advertises the authorization server but not the
+`client_id` (the metadata document defines that as an out-of-band
+parameter, intentionally).
+
 ### Verify
 
-After `helm install` (or `helm upgrade`):
+After `helm install` / `helm upgrade` and the realm steps above:
 
 ```bash
+# 1. Auth-config endpoint carries cli_client_id.
 curl -sf https://meho.evba.lab/api/v1/auth-config | jq .
-# { "keycloak_issuer": "...", "audience": "meho-backplane", "cli_client_id": "meho-cli" }
+# {
+#   "keycloak_issuer": "https://keycloak.evba.lab/realms/evba",
+#   "audience": "meho-backplane",
+#   "cli_client_id": "meho-cli"
+# }
 
+# 2. CLI device-code flow completes.
 meho login https://meho.evba.lab
 # Logged in to https://meho.evba.lab; token stored in keyring.
+
+# 3. Authenticated REST call succeeds.
+curl -sf -H "Authorization: Bearer $(meho status --print-token)" \
+  https://meho.evba.lab/api/v1/health
+# {"status": "ok"}
+
+# 4. MCP RFC 9728 metadata document is reachable.
+curl -sf https://meho.evba.lab/.well-known/oauth-protected-resource | jq .
+# {
+#   "resource": "https://meho.evba.lab/mcp",
+#   "authorization_servers": ["https://keycloak.evba.lab/realms/evba"],
+#   ...
+# }
 ```
 
-If `cli_client_id` comes back as the empty string, the chart value
-wasn't set; if `meho login` reports `unauthorized_client` after
-discovery, the client is configured as confidential rather than
-public (toggle "Client authentication" off in the Keycloak admin UI
-and retry).
+### Four-wall symptom → cause → fix matrix
+
+The deployer's first-login walk hits these four walls in sequence;
+each surfaces with a different symptom but the cause-and-fix chain
+is bounded. Walls are numbered for the dogfood-report cross-reference.
+
+| Wall | Symptom | Cause | Fix |
+| --- | --- | --- | --- |
+| **W1** | Device-code initiation 401s with `{"error":"unauthorized_client","error_description":"Invalid client or Invalid client credentials"}`. Or DCR 403s with `{"error":"insufficient_scope","error_description":"Policy 'Trusted Hosts' rejected request to client-registration service. Details: Host not trusted."}`. | The CLI / MCP client tried to drive the device or authorization-code grant against a **confidential** client (typically `meho-backplane`), or anonymous DCR against a realm whose Trusted Hosts policy ships with an empty whitelist. Confidential clients require a `client_secret` the CLI can't carry; DCR on a prod realm is closed by design ([Keycloak docs](https://www.keycloak.org/securing-apps/client-registration)). | Pre-create a **public** client per Step 2 (and Step 2-MCP for the MCP path). Set `config.keycloakCliClientId` to the CLI client's ID so `/api/v1/auth-config` surfaces it. Operators on older backplanes can pass `--client-id <id>` per-invocation. Don't open DCR — the right fix is a deployer-side public client. |
+| **W2** | Token issuance succeeds; every backend call 401s with `{"detail":"invalid_token"}` (specifics post-[#797](https://github.com/evoila/meho/issues/797): `invalid_audience` / `missing_tenant_claim` / `missing_tenant_role_claim`). | The public client mints tokens with a different claim shape than `meho-backplane` validates against — missing the `audience-meho-backplane` mapper (wrong `aud`), the `meho-mcp-audience` mapper (no MCP audience), the `tenant-id` mapper, or the `tenant-role` mapper. | Clone all 5 mappers from the `meho-backplane` client onto the public client per Step 3. After the fix, decode the issued token (`jwt.io` or `kcadm.sh evaluate-protocol-mappers`) and confirm `aud` is an array containing both `meho-backplane` and `<backplane-url>/mcp`, plus `tenant_id`, `tenant_role`, `groups` are present. |
+| **W3** | Token issuance succeeds; every backend call 401s with `{"detail":"invalid_token"}` even after Wall #2 is closed; decoded token has `aud`, `tenant_id`, `tenant_role`, `groups` but **no `sub` claim**. | The `basic` client scope wasn't assigned. Keycloak 25 moved `sub` into the Subject (sub) protocol mapper inside the `basic` scope; clients created via the admin REST API don't auto-inherit realm default-default scopes the way the admin-console UI populates them. RFC 9068 §2.2.1 makes `sub` REQUIRED on JWT access tokens, so rejection is spec-correct — the diagnostic is the opaque part. | Add `basic`, `roles`, `web-origins`, `acr` to the public client's **default** client scopes per Step 4. Re-issue (logout and re-login; existing tokens are stale) and confirm `sub` is now present. After [#797](https://github.com/evoila/meho/issues/797) lands the symptom is `{"detail":"missing_sub"}` instead of the opaque form. |
+| **W4** | `meho login` fails with `meho: token exchange failed: context deadline exceeded`, often before the human has a chance to approve the verification URL. | Not the device-code TTL (which is already 10 minutes per `cli/internal/auth/devicecode.go:355`'s `PollTimeout = 10 * time.Minute` — longer than Keycloak's default 600 s `expires_in`). The real cause is an **ambient parent deadline** on `cmd.Context()` (CI step timeout, `claude` bash-tool timeout, IDE-task wrapper) that truncates the approval wait far below the device-code lifetime. | (Until [#798](https://github.com/evoila/meho/issues/798) lands) run `meho login` in a real interactive terminal without a short wrapper deadline; or raise the wrapper timeout to ≥ `expires_in` + headroom. After #798 lands the message distinguishes "parent deadline fired" from "device code expired" and the device-flow approval wait detaches from a too-short parent context. |
+
+### Out of scope for this recipe
+
+- **The broader Deploying-MEHO guide.** This recipe is one entry in
+  the consolidated deployment guide tracked under
+  [#559](https://github.com/evoila/meho/issues/559) (deployment-
+  friction umbrella). When #559 lands, this recipe moves there
+  verbatim; until then `deploy/values-examples/README.md` is the
+  authoritative deployer doc for the chart values + the auth-onramp
+  recipe.
+- **Automation of the recipe.** [#791](https://github.com/evoila/meho/issues/791)
+  (G0.9.1-T11) ships `meho admin keycloak bootstrap-cli-client` — an
+  idempotent verb that creates the two public clients + 5 mappers +
+  4 default scopes from one invocation. The recipe above is the
+  manual path until that automation lands.
+- **Confidential `meho-backplane` client.** Out of scope — it's
+  created at realm-install time alongside the Keycloak realm itself
+  and isn't touched by this recipe. Rotating its client secret is
+  also out of scope.
+- **RFC 7591 Dynamic Client Registration support in MEHO.** A real
+  feature with its own design tradeoffs (which clients are allowed
+  to self-register; how operators audit unknown registrations);
+  tracked separately, not a v0.3.2 onramp fix. `docs/cross-repo/mcp-client-setup.md`
+  notes it as future work.
+- **The CLI device-code client provisioning + auth-config endpoint
+  completion.** [#789](https://github.com/evoila/meho/issues/789)
+  (G0.9.1-T9) — already landed in v0.3.2.
+- **Token-validator error specificity at the decode stage.**
+  [#797](https://github.com/evoila/meho/issues/797) (G0.9.1-T12)
+  makes Wall #2 / Wall #3 symptoms specific (`invalid_audience` /
+  `missing_sub` / …) instead of opaque `invalid_token`.
+- **The `meho login` context-deadline fix.**
+  [#798](https://github.com/evoila/meho/issues/798) (G0.9.1-T13)
+  closes Wall #4 in code.
 
 ## End-to-end install flow
 

--- a/docs/acceptance/install.md
+++ b/docs/acceptance/install.md
@@ -103,17 +103,22 @@ The budget does **not** cover:
   [acceptance Task #56](https://github.com/evoila-bosnia/meho-internal/issues/56),
   the federation-chain smoke, not this one). The cold-deploy
   acceptance does **not** drive `meho login` end-to-end, but the
-  realm-side prerequisite the CLI needs — a public `meho-cli`
-  Keycloak client with the device-grant flow enabled and an audience
-  mapper — is a consumer-side provisioning step that must precede
-  `meho login`. The recipe lives in
-  [`deploy/values-examples/README.md`](../../deploy/values-examples/README.md)
-  § `meho-cli` public Keycloak client; the chart value to wire it
-  through is `config.keycloakCliClientId` (env
-  `KEYCLOAK_CLI_CLIENT_ID`). Auto-provisioning the client at
-  install time is tracked as
-  [#791](https://github.com/evoila/meho/issues/791) (G0.9.1-T11) and
-  is not yet shipped.
+  realm-side prerequisites the CLI and MCP onramp share — a
+  public `meho-cli` Keycloak client (device-grant enabled) and a
+  public `meho-mcp-client` (auth-code + PKCE), each with the same
+  5 protocol mappers and 4 default client scopes — are
+  consumer-side provisioning steps that must precede `meho login`
+  and the MCP-client wire-up. The consolidated recipe lives in
+  [`deploy/values-examples/README.md` § Auth onramp recipe (CLI + MCP)](../../deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp),
+  with a 4-wall symptom→cause→fix matrix that bounds the failure
+  modes (notably the `basic`/`sub` gotcha — Keycloak 25+ moved
+  `sub` into the `basic` scope, and admin-API-created clients
+  don't auto-inherit realm default-default scopes). The CLI-side
+  chart value to wire the resulting client_id through is
+  `config.keycloakCliClientId` (env `KEYCLOAK_CLI_CLIENT_ID`).
+  Auto-provisioning the realm-side state at install time is
+  tracked as [#791](https://github.com/evoila/meho/issues/791)
+  (G0.9.1-T11) and is not yet shipped.
 
 ### Why 5 minutes is the right bar
 

--- a/docs/cross-repo/mcp-client-setup.md
+++ b/docs/cross-repo/mcp-client-setup.md
@@ -11,6 +11,8 @@ Copyright (c) 2026 evoila Group
 
 MEHO speaks MCP 2025-06-18 over Streamable HTTP at the `/mcp` route. The wire protocol is fixed by the spec; what isn't fixed is the Keycloak realm configuration that issues tokens carrying the right `aud` claim, and the per-client configuration step that points a given MCP client at your backplane. This doc walks both — the realm-side change is one-time, the client-side change is per-installation.
 
+> **Pre-flight (load-bearing).** Before any MCP client can authenticate against MEHO, the deployer MUST pre-create a **public** OAuth client in the Keycloak realm — MEHO doesn't implement RFC 7591 Dynamic Client Registration, and Keycloak's default Trusted Hosts policy returns 403 for anonymous DCR on any prod realm. The full deployer recipe (5-step realm walk + 4-wall symptom→cause→fix matrix covering both the CLI and the MCP onramp) lives in [`deploy/values-examples/README.md` § Auth onramp recipe (CLI + MCP)](../../deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp). The steps below are the **MCP-client-side wire-up** that runs *after* the public client + mappers + scopes exist in the realm; Step 2 here is the minimum-shape recap, with the full recipe as the authoritative source. If `tools/list` returns an empty list or every call 401s with `invalid_token`, the recipe's 4-wall matrix is the right place to start.
+
 If you're operating MEHO via the dogfood consumer ([`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)), the realm-side change ships in [Goal #11's cross-repo deps](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/261); follow the client-side steps below.
 
 ## Step 1 — Register the MCP resource URI as an audience in Keycloak
@@ -43,7 +45,9 @@ A different operator (different MEHO hostname) substitutes the URI accordingly. 
 
 ## Step 2 — Register an MCP client in Keycloak
 
-MEHO v0.2 doesn't implement RFC 7591 Dynamic Client Registration; operators register the MCP client statically. The recommended shape is one client per MCP-client-implementation per operator, but a single shared client also works.
+MEHO doesn't implement RFC 7591 Dynamic Client Registration; operators register the MCP client statically. The recommended shape is one client per MCP-client-implementation per operator, but a single shared client also works.
+
+> **Use the consolidated recipe.** The full client shape (5 protocol mappers, 4 default client scopes, the `basic`/`sub` gotcha) is documented in [`deploy/values-examples/README.md` § Auth onramp recipe (CLI + MCP)](../../deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp) — that recipe is the source of truth and stays in sync with the CLI's needs. The `kcadm.sh` snippet below is the minimum shape and **does not by itself produce a working MCP onramp** — without the 5 mappers and the 4 default scopes, tokens minted by this client are rejected with `invalid_token` (Wall #2 / Wall #3 in the matrix). Read the consolidated recipe and then return here for the per-MCP-client setup at Step 3.
 
 ```bash
 # Public client (PKCE-only, no client secret) — the MCP spec mandates
@@ -133,6 +137,20 @@ Cline and Continue both consume an `mcp.json` in the workspace. The shape mirror
 
 OAuth handling is client-specific; refer to each client's docs for the token-acquisition path. Both expect the same Bearer-token flow MEHO advertises via the protected-resource metadata document.
 
+### Claude Code (HTTP MCP) and Cursor — `.mcp.json` `client_id` limitation
+
+Claude Code's native HTTP-MCP support and Cursor's MCP wire-up, as of 2026-05, follow the RFC 9728 metadata trail correctly: they fetch `/.well-known/oauth-protected-resource`, read the `authorization_servers` field, then attempt OAuth 2.1 + PKCE against the Keycloak realm. The problem is the next step: **neither `.mcp.json` shape exposes a `client_id` field**, so both clients fall back to dynamic client registration (RFC 7591). Keycloak's default Trusted Hosts policy ships with an empty whitelist — anonymous DCR is de-facto disabled — so the registration POST returns `HTTP 403 {"error":"insufficient_scope","error_description":"Policy 'Trusted Hosts' rejected request to client-registration service. Details: Host not trusted."}` and the wire-up never completes.
+
+Pre-registering `meho-mcp-client` on the realm side (Step 2 above + the [auth onramp recipe](../../deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp)) is necessary but **not sufficient** for these clients: they have no place to put the resulting `client_id`.
+
+Two workarounds today:
+
+1. **Use a wire-format-compatible MCP client.** Claude.ai Custom Connector, MCP Inspector, Cline, and Continue all expose a place for the operator to provide the OAuth client_id (Custom Connector picks it up from the realm's discovery once the operator approves the consent screen; the rest take it from `mcp.json` / per-client config). For everyday operator workflows, this is the first-class path.
+
+2. **Shim Claude Code / Cursor through `mcp-remote` (or an equivalent stdio→HTTP proxy).** The proxy holds a Bearer token (acquired out-of-band via `meho login --print-token` or any other path), translates the stdio MCP transport these clients spawn against an `npx mcp-remote ...` command-line into Streamable-HTTP calls to MEHO, and injects the `Authorization` header. The trade-off is operational: the proxy needs the token rotated when it expires; the Claude Code / Cursor process never sees the OAuth flow at all. This is the only path until the upstream MCP clients expose `client_id` in `.mcp.json`.
+
+Opening RFC 7591 DCR on the realm side is **not** the right fix: a public DCR endpoint on a prod realm is a long-term posture decision (which clients are allowed to self-register; how the operator audits unknown clients) and shouldn't be flipped on to work around a per-client config gap. The right long-term fix is upstream MCP-client `client_id` support; the right short-term fix is one of the two workarounds above.
+
 ## Step 4 — Verify connectivity
 
 After the client is wired:
@@ -154,10 +172,19 @@ The response carries `WWW-Authenticate: Bearer resource_metadata="https://meho.e
 
 ### Token rejected at the MCP server (401, `invalid_token`)
 
-The token's `aud` doesn't match `MCP_RESOURCE_URI`:
+The token's `aud` doesn't match `MCP_RESOURCE_URI`, or the token is missing a claim the backplane validates against:
 
 - Confirm Step 1 wired the audience mapper on the *correct* client (the same client that's issuing the operator's token).
 - Confirm the OAuth `resource` parameter the client sends matches `MCP_RESOURCE_URI`. Claude.ai's Custom Connector flow derives `resource` automatically from the URL the operator pasted — but a forwarder / reverse proxy that rewrites the path can leave the audience claim pointing at the wrong URI. Capture the issued token via the realm's token-introspection endpoint and read `aud` to confirm.
+- Decode the issued token (`jwt.io` or `kcadm.sh evaluate-protocol-mappers`) and confirm the **full claim shape** — `aud` is an array containing both `meho-backplane` and `<backplane-url>/mcp`; `tenant_id`, `tenant_role`, `groups`, and **`sub`** are all present. Missing `sub` is the silent killer (Wall #3 in the consolidated matrix): Keycloak 25 moved `sub` into the `basic` client scope, and clients created via the admin REST API don't auto-inherit realm default-default scopes. The full diagnostic chain lives in [`deploy/values-examples/README.md` § Four-wall symptom → cause → fix matrix](../../deploy/values-examples/README.md#four-wall-symptom--cause--fix-matrix).
+
+### MCP client → Keycloak DCR returns 403 `"Host not trusted"`
+
+The client attempted dynamic client registration (RFC 7591) and Keycloak rejected with `HTTP 403 {"error":"insufficient_scope","error_description":"Policy 'Trusted Hosts' rejected request to client-registration service. Details: Host not trusted."}`:
+
+- This is the **correct** response from Keycloak — its default Trusted Hosts policy ships with an empty whitelist, so anonymous DCR is de-facto disabled. MEHO doesn't implement RFC 7591 either; the metadata's "follow the trail" UX assumes the client already holds a `client_id`, which on a fresh realm it doesn't.
+- The fix is on the deployer side, not the realm-policy side: pre-register a public client per [`deploy/values-examples/README.md` § Auth onramp recipe (CLI + MCP)](../../deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp) Step 2. Opening DCR on a prod realm is a long-term posture decision, not the right onramp workaround.
+- If the MCP client can't carry `client_id` in its config (Claude Code's HTTP MCP, Cursor — see § Claude Code (HTTP MCP) and Cursor above), the deployer-side fix doesn't help until the upstream client exposes the field; the workaround is to shim through an stdio→HTTP proxy.
 
 ### `tools/list` returns an empty list
 
@@ -181,10 +208,14 @@ MEHO is spec-conformant; any MCP-2025-06-18 Streamable-HTTP client with OAuth 2.
 ## References
 
 - MEHO MCP architecture: [`docs/architecture/mcp.md`](../architecture/mcp.md).
+- Consolidated deployer auth-onramp recipe (CLI + MCP) + 4-wall matrix: [`deploy/values-examples/README.md` § Auth onramp recipe (CLI + MCP)](../../deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp).
 - MCP 2025-06-18 spec: <https://modelcontextprotocol.io/specification/2025-06-18>.
 - MCP authorization: <https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization>.
 - RFC 9728 (Protected Resource Metadata): <https://datatracker.ietf.org/doc/html/rfc9728>.
 - RFC 8707 (Resource Indicators): <https://www.rfc-editor.org/rfc/rfc8707.html>.
+- RFC 7591 (Dynamic Client Registration): <https://datatracker.ietf.org/doc/html/rfc7591>.
+- RFC 8628 (Device Authorization Grant): <https://www.rfc-editor.org/rfc/rfc8628>.
 - Claude.ai Custom Connectors: <https://modelcontextprotocol.io/docs/develop/connect-remote-servers>.
 - MCP Inspector: <https://github.com/modelcontextprotocol/inspector>.
 - Keycloak audience mappers: <https://www.keycloak.org/docs/latest/server_admin/#_audience>.
+- Keycloak client-registration policies (Trusted Hosts): <https://www.keycloak.org/securing-apps/client-registration>.


### PR DESCRIPTION
## Summary

- Publish a consolidated **deployer auth-onramp recipe** (5-step
  realm walk + 4-wall symptom→cause→fix matrix) that closes the
  ~2.5-hour first-login wall the 2026-05-21 RDC dogfood walked on
  a fresh `evba` realm. Covers both `meho login` (CLI device-code)
  and the MCP-client onramp in one pass — they share the same
  realm-side prerequisites (public client + 5 protocol mappers + 4
  default client scopes + a real user).
- Land the recipe in
  [`deploy/values-examples/README.md` § Auth onramp recipe (CLI + MCP)](deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp).
  Cross-link from `docs/cross-repo/mcp-client-setup.md` (now
  surfaces the pre-registered-public-client requirement up front
  in "Why this doc exists", not buried at Step 2) and
  `docs/acceptance/install.md` (cold-deploy acceptance contract
  now points at the recipe for the operator-side `meho login`
  prerequisite chain).
- Document the **`.mcp.json` `client_id` limitation** for Claude
  Code's HTTP MCP and Cursor: both follow the RFC 9728 metadata
  trail correctly but have no place to put `client_id`, so they
  fall back to RFC 7591 DCR which Keycloak's default Trusted Hosts
  policy returns 403 for. Deployer-side fix doesn't help these
  clients until upstream exposes `client_id`; workaround is to
  shim through `mcp-remote` (stdio→HTTP proxy) with an out-of-band
  token.
- Call out the **`basic`/`sub` gotcha** prominently in Step 4 of
  the recipe and in Wall #3 of the matrix: Keycloak 25+ moved the
  `sub` claim into the Subject (sub) protocol mapper inside the
  `basic` client scope, and clients created via the admin REST API
  **don't auto-inherit** the realm's default-default scopes the
  way the admin-console UI populates them. Missing `basic` ⇒
  missing `sub` ⇒ tokens rejected with opaque `invalid_token`
  even though every other claim is present. This is the deepest
  wall the consumer hit.

**Docs-only.** No backplane code change — the RFC 9728 protected-
resource metadata surface and the 401 `WWW-Authenticate: Bearer
resource_metadata=…` challenge are correct. The gap is pure
deployment experience.

**Load-bearing prerequisite for #791 (G0.9.1-T11).** That task
ships `meho admin keycloak bootstrap-cli-client`, an idempotent
verb that automates this exact recipe; #791 Depends-on #790
because the 5-step recipe is the manual procedure the verb has to
encode and stay in sync with.

## Test plan

- [x] `ruff check backend/src/ backend/tests/` — clean (no code changes)
- [x] `ruff format --check backend/src/ backend/tests/` — 411 files already formatted
- [x] `mypy backend/src/ --ignore-missing-imports` — no issues in 195 source files
- [x] `pytest backend/tests/test_auth_config.py -x -q` — 4 passed (baseline sanity)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0 (docs-only diff; no findings)
- [x] Markdown heading structure verified; cross-link anchors confirmed against GitHub slugger (`#auth-onramp-recipe-cli--mcp`, `#four-wall-symptom--cause--fix-matrix`)

### Acceptance criteria verification

- [x] **The 5-step realm recipe is published in the deployer docs with the `basic`/`sub` Keycloak-26 gotcha called out explicitly** — Steps 1–5 in `deploy/values-examples/README.md` § Auth onramp recipe; `basic`/`sub` gotcha is its own callout blockquote in Step 4.
- [x] **A symptom→cause→fix matrix covers all four walls** — Walls W1 (`unauthorized_client` / 403 Trusted Hosts), W2 (`invalid_token` / missing mappers), W3 (`invalid_token` / missing `sub` — `basic` scope), W4 (`context deadline exceeded` — ambient parent deadline) with explicit cross-references to T11 (#791), T12 (#797), T13 (#798).
- [x] **`mcp-client-setup.md` surfaces the pre-registered-public-client requirement up front and states the `.mcp.json` `client_id` limitation for Claude Code + Cursor with the workaround** — new pre-flight blockquote in "Why this doc exists"; new "Claude Code (HTTP MCP) and Cursor — `.mcp.json` `client_id` limitation" subsection in Step 3 with the `mcp-remote` shim workaround.
- [x] **The deploy onramp links to this recipe from both the CLI-login and MCP-integration steps; #559 cross-referenced** — `install.md` operator-side device-code-login note cross-links the recipe; `mcp-client-setup.md` pre-flight + References cross-link; #559 (consolidated Deploying-MEHO guide umbrella) cross-referenced in the recipe's "Out of scope" section.
- [x] **No backplane code change required** — `git diff --stat` shows 4 files, all under `docs/`, `deploy/values-examples/`, and `CHANGELOG.md`. No `.py` / `.go` / `.tpl` / `.yaml` touched.

## Out of scope

- **Auto-provisioning the recipe at install time** — [#791 (T11)](https://github.com/evoila/meho/issues/791) ships `meho admin keycloak bootstrap-cli-client`. Depends-on this PR.
- **Specific token-validator errors at the decode stage** — [#797 (T12)](https://github.com/evoila/meho/issues/797). Once landed, Wall #2 and Wall #3 symptoms become `invalid_audience` / `missing_sub` etc. instead of opaque `invalid_token`; matrix already cross-references it.
- **`meho login` device-flow `context deadline exceeded`** — [#798 (T13)](https://github.com/evoila/meho/issues/798). Wall #4 cross-references it; the matrix's interim guidance is "run in a real interactive terminal" until #798 lands.
- **CLI device-code client + `cli_client_id` field on `/api/v1/auth-config`** — [#789 (T9)](https://github.com/evoila/meho/issues/789), in flight as PR #795. The recipe references the `cli_client_id` field shape that PR introduces; merge ordering is the orchestrator's concern.
- **RFC 7591 Dynamic Client Registration support in MEHO** — a real feature, not a v0.3.2 onramp fix.
- **Broader Deploying-MEHO guide** — tracked under [#559](https://github.com/evoila/meho/issues/559); this recipe is one entry that moves there verbatim once #559 lands.

Sibling tasks running in parallel touch unrelated surfaces: **T12 (#797)** decode-stage error specificity, **T13 (#798)** CLI device-flow context-deadline fix. No expected conflicts.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #790


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a consolidated deployer auth-onramp recipe covering CLI and MCP setup, verification, TLS trust, and wiring steps
  * Introduced a required configuration parameter for the Keycloak CLI public client ID
  * Clarified cold-deploy prerequisites and a pre-flight requirement to pre-create a public MCP client
  * Expanded troubleshooting (symptom→cause→fix), token/aud claim diagnostics, and a DCR "Host not trusted" note
  * Documented a Claude/Cursor client_id limitation and recommended workarounds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->