### PR TITLE
feat(cli): G0.9.1-T11 meho admin keycloak bootstrap-clients (#791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,27 @@ connector-related release-notes line.
 
 ### Added
 
+- **`meho admin keycloak bootstrap-clients` CLI verb** (G0.9.1-T11
+  #791). Idempotently provisions the realm-side prerequisites the
+  2026-05-21 RDC dogfood proved are the single highest-friction
+  install step: the public `meho-cli` device-code client + the
+  public `meho-mcp-client` browser-flow client (PKCE), **5 protocol
+  mappers on each** (`audience-meho-backplane`, `meho-mcp-audience`,
+  `tenant-id`, `tenant-role`, `groups-claim`), **4 default client
+  scopes on each** (`basic`, `roles`, `web-origins`, `acr` — the
+  `basic`/`sub` Keycloak 25+ gotcha is the load-bearing one), plus
+  the `meho-admins` group and an admin user with a password. Encodes
+  the 5-step recipe from
+  [`deploy/values-examples/README.md` § Auth onramp recipe](deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp)
+  so a fresh `helm install`-shaped deploy gets a working
+  authenticated CLI + MCP onramp in one verb instead of ~2.5 hours
+  of console clicking. Re-runs are idempotent (`[skip]` /
+  `[updated]` per resource; never duplicates). Confidential clients
+  (`meho-backplane`) and silent-password-rotation on user re-creates
+  are explicitly refused. Passwords flow via env vars
+  (`KEYCLOAK_ADMIN_PASSWORD`, `KEYCLOAK_ADMIN_USER_PASSWORD`) or
+  stdin — never argv. Stdlib-only HTTP client; no Keycloak Go SDK
+  added to the dep graph.
 - **`meho.topology.create_node` MCP verb** (tenant_admin, `op_class="write"`)
   for manual `graph_node` seeding — closes the empty-tenant bootstrap
   gap surfaced by the 2026-05-21 RDC second-cycle dogfood (Signal #14).

--- a/cli/internal/cmd/admin/admin.go
+++ b/cli/internal/cmd/admin/admin.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package admin hosts the `meho admin ...` parent command tree for
+// deployer-side provisioning verbs. Unlike the rest of the CLI tree
+// (which dispatches through the backplane), `admin` subcommands talk
+// to upstream identity / secret stores directly using operator
+// credentials — they are install-time bootstrap helpers, not
+// agent-facing operations.
+//
+// The first member of this tree is `admin keycloak bootstrap-clients`
+// (G0.9.1-T11, #791): provisions the public CLI device-code client +
+// the public MCP client + their 5 protocol mappers + 4 default client
+// scopes + a meho-admins group + an admin user against a Keycloak
+// realm, idempotently. The verb encodes the 5-step recipe documented
+// in deploy/values-examples/README.md § Auth onramp recipe.
+//
+// Future admin verbs (rotating chart-managed secrets, seeding initial
+// tenants in MEHO's own DB, etc.) live here too — anything that the
+// operator runs once at install time with credentials they hold but
+// don't keep on the cluster.
+package admin
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/cmd/admin/keycloak"
+)
+
+// NewRootCmd returns the `meho admin` parent command, ready for
+// grafting onto the top-level command tree by cmd/root.go. The parent
+// takes no args and prints its own help; every piece of behaviour
+// lives in subcommands.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Deployer-side install-time provisioning verbs",
+		Long: "admin hosts install-time bootstrap helpers that talk to " +
+			"upstream identity and secret stores directly using " +
+			"operator credentials. Unlike the rest of the meho CLI, " +
+			"these verbs do not dispatch through the backplane — they " +
+			"provision the substrate the backplane needs to function " +
+			"(public Keycloak clients, initial users, etc.).",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(keycloak.NewRootCmd())
+	return cmd
+}

--- a/cli/internal/cmd/admin/keycloak/bootstrap.go
+++ b/cli/internal/cmd/admin/keycloak/bootstrap.go
@@ -1,0 +1,734 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// BootstrapOptions captures every knob the bootstrap orchestrator
+// needs. The cobra command fills this from flags + env vars; tests
+// fill it directly. Empty fields fall back to recipe defaults.
+type BootstrapOptions struct {
+	// KeycloakBaseURL is the realm-less root, e.g. "https://keycloak.evba.lab".
+	KeycloakBaseURL string
+
+	// Realm is the target realm where the clients land, e.g. "evba".
+	Realm string
+
+	// AdminUsername / AdminPassword authenticate against the master
+	// realm via the built-in `admin-cli` client (password grant). The
+	// password is never echoed; the cobra command reads it via
+	// stdin / env var so it never enters argv.
+	AdminUsername string
+	AdminPassword string
+
+	// CLIClientID is the public device-code client name; defaults to
+	// "meho-cli". Must match the chart's keycloakCliClientId so the
+	// CLI's auth-config discovery resolves it.
+	CLIClientID string
+
+	// MCPClientID is the public authorization-code+PKCE client name
+	// used by Claude.ai Custom Connector / MCP Inspector; defaults to
+	// "meho-mcp-client".
+	MCPClientID string
+
+	// BackplaneAudience is the confidential resource-server client's
+	// audience claim ("meho-backplane") — the value the
+	// `audience-meho-backplane` mapper emits into `aud`.
+	BackplaneAudience string
+
+	// MCPResourceURI is the `<backplane-url>/mcp` audience the
+	// `meho-mcp-audience` mapper emits — must match the no-trailing-
+	// slash form the backplane normalises to.
+	MCPResourceURI string
+
+	// TenantID + TenantRole are the hardcoded values the
+	// tenant-id / tenant-role mappers emit. The dogfood lab uses a
+	// single tenant; a multi-tenant realm should replace these with
+	// usermodel-attribute mappers (out of scope for the bootstrap).
+	TenantID   string
+	TenantRole string
+
+	// AdminGroupName / AdminUsername / AdminUserPassword optionally
+	// provision a human user in the meho-admins group. When
+	// SkipUserProvisioning is true the user / group steps are skipped
+	// (re-runs on a realm with externally-managed users).
+	AdminGroupName       string
+	AdminUserUsername    string
+	AdminUserEmail       string
+	AdminUserPassword    string
+	SkipUserProvisioning bool
+
+	// MCPRedirectURIs / MCPWebOrigins control the public MCP client's
+	// browser-flow allowlists. Defaults cover Claude.ai + localhost
+	// MCP Inspector.
+	MCPRedirectURIs []string
+	MCPWebOrigins   []string
+
+	// DryRun true → print every API call that would be made and exit
+	// 0 without mutating anything. Mirrors the reference shell
+	// script's `--dry-run`.
+	DryRun bool
+
+	// Out / Err are where structured progress lines go. nil → stdout
+	// / stderr.
+	Out io.Writer
+	Err io.Writer
+}
+
+// withDefaults applies the recipe defaults so the cobra command can
+// pass a sparsely-populated BootstrapOptions and still get the right
+// shape. Returns a copy; the input is not mutated.
+func (o BootstrapOptions) withDefaults() BootstrapOptions {
+	if o.CLIClientID == "" {
+		o.CLIClientID = "meho-cli"
+	}
+	if o.MCPClientID == "" {
+		o.MCPClientID = "meho-mcp-client"
+	}
+	if o.BackplaneAudience == "" {
+		o.BackplaneAudience = "meho-backplane"
+	}
+	if o.TenantID == "" {
+		o.TenantID = "00000000-0000-0000-0000-000000000000"
+	}
+	if o.TenantRole == "" {
+		o.TenantRole = "tenant_admin"
+	}
+	if o.AdminGroupName == "" {
+		o.AdminGroupName = "meho-admins"
+	}
+	if len(o.MCPRedirectURIs) == 0 {
+		o.MCPRedirectURIs = []string{
+			"https://claude.ai/api/mcp/auth_callback",
+			"http://localhost:*",
+		}
+	}
+	if len(o.MCPWebOrigins) == 0 {
+		o.MCPWebOrigins = []string{"+"}
+	}
+	return o
+}
+
+// validate refuses option combinations the verb explicitly cannot
+// safely act on — confidential-client provisioning, user creation
+// without a password, etc. The recipe is fundamentally about *public*
+// clients; routing operators away from confidential-client mistakes
+// at the boundary is part of the deliverable.
+func (o BootstrapOptions) validate() error {
+	if o.KeycloakBaseURL == "" {
+		return errors.New("--keycloak-base-url is required")
+	}
+	if o.Realm == "" {
+		return errors.New("--realm is required")
+	}
+	if o.AdminUsername == "" {
+		return errors.New(
+			"--admin-username (or KEYCLOAK_ADMIN_USER) is required")
+	}
+	if o.AdminPassword == "" {
+		return errors.New(
+			"admin password is required (set KEYCLOAK_ADMIN_PASSWORD " +
+				"or pipe via stdin)")
+	}
+	// MCPResourceURI is required if we're going to mint the
+	// meho-mcp-audience mapper. Synthesise the default elsewhere only
+	// when the operator explicitly told us a backplane URL; we don't
+	// silently guess.
+	if o.MCPResourceURI == "" {
+		return errors.New(
+			"--mcp-resource-uri is required (the audience the " +
+				"meho-mcp-audience mapper will emit, e.g. " +
+				"https://meho.example.com/mcp — no trailing slash)")
+	}
+	if strings.HasSuffix(o.MCPResourceURI, "/") {
+		return errors.New(
+			"--mcp-resource-uri must not have a trailing slash " +
+				"(MEHO normalises MCP_RESOURCE_URI server-side; the " +
+				"audience claim in the token must match the no-slash form)")
+	}
+	if o.CLIClientID == "meho-backplane" || o.MCPClientID == "meho-backplane" {
+		return errors.New(
+			"refusing to provision a client named meho-backplane: " +
+				"that is the realm's confidential resource-server " +
+				"client and is out of scope for this verb (see " +
+				"`meho admin keycloak bootstrap-clients --help`)")
+	}
+	if !o.SkipUserProvisioning {
+		if o.AdminUserUsername == "" {
+			return errors.New(
+				"--admin-user-username is required unless " +
+					"--skip-user-provisioning is set")
+		}
+		if o.AdminUserPassword == "" {
+			return errors.New(
+				"admin user password is required unless " +
+					"--skip-user-provisioning is set (set " +
+					"KEYCLOAK_ADMIN_USER_PASSWORD or use " +
+					"--skip-user-provisioning to leave users " +
+					"externally-managed)")
+		}
+	}
+	return nil
+}
+
+// desiredMappers returns the five protocol mappers the recipe pins,
+// shaped exactly as the reference shell script does. Same names so
+// Keycloak's existing-mapper detection (by name) handles idempotency.
+func (o BootstrapOptions) desiredMappers() []protocolMapperRep {
+	return []protocolMapperRep{
+		{
+			Name:           "audience-" + o.BackplaneAudience,
+			Protocol:       "openid-connect",
+			ProtocolMapper: "oidc-audience-mapper",
+			Config: map[string]string{
+				"included.client.audience":  o.BackplaneAudience,
+				"id.token.claim":            "false",
+				"access.token.claim":        "true",
+				"introspection.token.claim": "true",
+			},
+		},
+		{
+			Name:           "meho-mcp-audience",
+			Protocol:       "openid-connect",
+			ProtocolMapper: "oidc-audience-mapper",
+			Config: map[string]string{
+				"included.custom.audience":  o.MCPResourceURI,
+				"id.token.claim":            "false",
+				"access.token.claim":        "true",
+				"introspection.token.claim": "true",
+			},
+		},
+		{
+			Name:           "tenant-id",
+			Protocol:       "openid-connect",
+			ProtocolMapper: "oidc-hardcoded-claim-mapper",
+			Config: map[string]string{
+				"claim.name":           "tenant_id",
+				"claim.value":          o.TenantID,
+				"jsonType.label":       "String",
+				"id.token.claim":       "false",
+				"access.token.claim":   "true",
+				"userinfo.token.claim": "false",
+			},
+		},
+		{
+			Name:           "tenant-role",
+			Protocol:       "openid-connect",
+			ProtocolMapper: "oidc-hardcoded-claim-mapper",
+			Config: map[string]string{
+				"claim.name":           "tenant_role",
+				"claim.value":          o.TenantRole,
+				"jsonType.label":       "String",
+				"id.token.claim":       "false",
+				"access.token.claim":   "true",
+				"userinfo.token.claim": "false",
+			},
+		},
+		{
+			Name:           "groups-claim",
+			Protocol:       "openid-connect",
+			ProtocolMapper: "oidc-group-membership-mapper",
+			Config: map[string]string{
+				"claim.name":           "groups",
+				"full.path":            "false",
+				"id.token.claim":       "true",
+				"access.token.claim":   "true",
+				"userinfo.token.claim": "false",
+			},
+		},
+	}
+}
+
+// requiredDefaultScopes returns the four default client-scopes the
+// recipe pins. Order does not matter at PUT time; ordered here only
+// so the progress output is deterministic.
+func requiredDefaultScopes() []string {
+	return []string{"basic", "roles", "web-origins", "acr"}
+}
+
+// boolPtr / strSlice are tiny helpers to make the desired-client
+// builders readable.
+func boolPtr(b bool) *bool { return &b }
+
+// desiredCLIClient builds the ClientRepresentation for the public
+// device-code client. Mirrors the reference shell script verbatim
+// (including the "Description" string pattern so re-runs against a
+// shell-script-created client don't churn the field).
+func (o BootstrapOptions) desiredCLIClient() *clientRep {
+	return &clientRep{
+		ClientID:                  o.CLIClientID,
+		Name:                      "MEHO CLI + MCP-OAuth-2.1 device-code public client",
+		Description:               "Public OAuth client for RFC 8628 device-code flow used by `meho login` and any MCP-OAuth-2.1 client targeting <backplane-url>/mcp. Audience-mapped to " + o.BackplaneAudience + ". Provisioned by `meho admin keycloak bootstrap-clients` (#791).",
+		Enabled:                   boolPtr(true),
+		PublicClient:              boolPtr(true),
+		StandardFlowEnabled:       boolPtr(false),
+		ImplicitFlowEnabled:       boolPtr(false),
+		DirectAccessGrantsEnabled: boolPtr(false),
+		ServiceAccountsEnabled:    boolPtr(false),
+		FrontchannelLogout:        boolPtr(false),
+		Attributes: map[string]string{
+			"oauth2.device.authorization.grant.enabled":   "true",
+			"use.refresh.tokens":                          "true",
+			"client.use.lightweight.access.token.enabled": "false",
+		},
+		RedirectURIs:        []string{},
+		WebOrigins:          []string{},
+		DefaultClientScopes: append([]string{"openid", "profile", "email"}, requiredDefaultScopes()...),
+	}
+}
+
+// desiredMCPClient builds the ClientRepresentation for the public
+// authorization-code+PKCE client used by browser MCP clients. The
+// 5 mappers + 4 default scopes apply identically — only the flow
+// flags + redirect URIs / web origins differ from the CLI client.
+func (o BootstrapOptions) desiredMCPClient() *clientRep {
+	return &clientRep{
+		ClientID:                  o.MCPClientID,
+		Name:                      "MEHO MCP browser-OAuth-2.1 public client",
+		Description:               "Public OAuth client for OAuth 2.1 authorization-code + PKCE used by Claude.ai Custom Connector, MCP Inspector, and any browser-flow MCP client targeting <backplane-url>/mcp. Provisioned by `meho admin keycloak bootstrap-clients` (#791).",
+		Enabled:                   boolPtr(true),
+		PublicClient:              boolPtr(true),
+		StandardFlowEnabled:       boolPtr(true),
+		ImplicitFlowEnabled:       boolPtr(false),
+		DirectAccessGrantsEnabled: boolPtr(false),
+		ServiceAccountsEnabled:    boolPtr(false),
+		FrontchannelLogout:        boolPtr(false),
+		Attributes: map[string]string{
+			"pkce.code.challenge.method":                  "S256",
+			"oauth2.device.authorization.grant.enabled":   "false",
+			"use.refresh.tokens":                          "true",
+			"client.use.lightweight.access.token.enabled": "false",
+		},
+		RedirectURIs:        append([]string{}, o.MCPRedirectURIs...),
+		WebOrigins:          append([]string{}, o.MCPWebOrigins...),
+		DefaultClientScopes: append([]string{"openid", "profile", "email"}, requiredDefaultScopes()...),
+	}
+}
+
+// Result captures the IDs of the resources the bootstrap touched.
+// Used by the cobra command to print the "set these in your chart"
+// summary, and by tests for assertions.
+type Result struct {
+	CLIClientID       string // clientId (not UUID) of the device-code client
+	CLIClientUUID     string // internal UUID, useful for downstream debugging
+	MCPClientID       string // clientId of the MCP browser-flow client
+	MCPClientUUID     string
+	AdminGroupCreated bool
+	AdminGroupUUID    string
+	AdminUserCreated  bool
+	AdminUserUUID     string
+	MapperEventsLog   []string // human-readable bullet list (one line per mapper / scope event)
+	ConfigKeysToSet   []string // chart values + env vars the operator must set
+}
+
+// Bootstrap is the public entry point. It mints an admin token, then
+// idempotently reconciles the realm against the recipe shape:
+//
+//  1. Public CLI device-code client (`meho-cli`)
+//  2. 5 protocol mappers cloned from the reference
+//  3. 4 default client scopes (basic / roles / web-origins / acr)
+//  4. Public MCP browser-flow client (`meho-mcp-client`)
+//  5. Same 5 mappers + 4 default scopes on the MCP client
+//  6. `meho-admins` group (top-level, no attributes)
+//  7. Admin user, set password, join meho-admins
+//
+// The operator-facing progress output (one line per step + a final
+// summary block) goes to opts.Out / opts.Err.
+//
+// Idempotency: every step does a "does this exist?" check before
+// mutating, so re-runs print "[skip] …" rather than re-creating.
+// Drift is corrected (PUT-to-update) on the client + mapper level
+// but **not** on the user's password — re-running with a different
+// password would silently reset the existing user's credential. The
+// step prints "[skip] user … exists; not resetting password (use
+// --reset-password to force)" instead.
+func Bootstrap(
+	ctx context.Context, opts BootstrapOptions,
+) (*Result, error) {
+	opts = opts.withDefaults()
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	out := opts.Out
+	if out == nil {
+		out = io.Discard
+	}
+
+	httpClient := httpClientOverride
+	if httpClient == nil {
+		httpClient = defaultHTTPClient()
+	}
+
+	if opts.DryRun {
+		fmt.Fprintln(out, "==> DRY RUN — no admin token will be minted; "+
+			"no realm state will change.")
+		return dryRunSummary(opts, out)
+	}
+
+	fmt.Fprintf(out,
+		"==> minting Keycloak admin token (realm=master user=%s)\n",
+		opts.AdminUsername)
+	token, err := mintAdminToken(
+		ctx, httpClient,
+		opts.KeycloakBaseURL, opts.AdminUsername, opts.AdminPassword)
+	if err != nil {
+		return nil, fmt.Errorf("mint admin token: %w", err)
+	}
+
+	c := newAdminClient(httpClient, opts.KeycloakBaseURL, opts.Realm, token)
+	res := &Result{}
+
+	// --- CLI device-code client ---------------------------------------------
+
+	desiredCLI := opts.desiredCLIClient()
+	cliUUID, cliEvents, err := reconcileClient(ctx, c, desiredCLI)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"reconcile CLI client %q: %w", opts.CLIClientID, err)
+	}
+	res.CLIClientID = opts.CLIClientID
+	res.CLIClientUUID = cliUUID
+	res.MapperEventsLog = append(res.MapperEventsLog, cliEvents...)
+	mapperEvents, err := reconcileMappers(
+		ctx, c, cliUUID, opts.desiredMappers())
+	if err != nil {
+		return nil, fmt.Errorf("reconcile CLI mappers: %w", err)
+	}
+	res.MapperEventsLog = append(res.MapperEventsLog, mapperEvents...)
+	scopeEvents, err := reconcileDefaultScopes(
+		ctx, c, cliUUID, requiredDefaultScopes())
+	if err != nil {
+		return nil, fmt.Errorf("reconcile CLI default scopes: %w", err)
+	}
+	res.MapperEventsLog = append(res.MapperEventsLog, scopeEvents...)
+
+	// --- MCP browser-flow client --------------------------------------------
+
+	desiredMCP := opts.desiredMCPClient()
+	mcpUUID, mcpEvents, err := reconcileClient(ctx, c, desiredMCP)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"reconcile MCP client %q: %w", opts.MCPClientID, err)
+	}
+	res.MCPClientID = opts.MCPClientID
+	res.MCPClientUUID = mcpUUID
+	res.MapperEventsLog = append(res.MapperEventsLog, mcpEvents...)
+	mcpMapperEvents, err := reconcileMappers(
+		ctx, c, mcpUUID, opts.desiredMappers())
+	if err != nil {
+		return nil, fmt.Errorf("reconcile MCP mappers: %w", err)
+	}
+	res.MapperEventsLog = append(res.MapperEventsLog, mcpMapperEvents...)
+	mcpScopeEvents, err := reconcileDefaultScopes(
+		ctx, c, mcpUUID, requiredDefaultScopes())
+	if err != nil {
+		return nil, fmt.Errorf("reconcile MCP default scopes: %w", err)
+	}
+	res.MapperEventsLog = append(res.MapperEventsLog, mcpScopeEvents...)
+
+	// --- Admin group + user -------------------------------------------------
+
+	if !opts.SkipUserProvisioning {
+		groupCreated, groupUUID, gerr := reconcileGroup(
+			ctx, c, opts.AdminGroupName)
+		if gerr != nil {
+			return nil, fmt.Errorf(
+				"reconcile %q group: %w", opts.AdminGroupName, gerr)
+		}
+		res.AdminGroupCreated = groupCreated
+		res.AdminGroupUUID = groupUUID
+
+		userCreated, userUUID, uerr := reconcileUser(
+			ctx, c, &userRep{
+				Username:      opts.AdminUserUsername,
+				Email:         opts.AdminUserEmail,
+				Enabled:       boolPtr(true),
+				EmailVerified: boolPtr(true),
+			}, opts.AdminUserPassword, groupUUID,
+		)
+		if uerr != nil {
+			return nil, fmt.Errorf(
+				"reconcile user %q: %w", opts.AdminUserUsername, uerr)
+		}
+		res.AdminUserCreated = userCreated
+		res.AdminUserUUID = userUUID
+	} else {
+		fmt.Fprintln(out, "==> --skip-user-provisioning: leaving "+
+			"users + groups externally-managed")
+	}
+
+	res.ConfigKeysToSet = buildConfigKeySummary(opts)
+	return res, nil
+}
+
+// dryRunSummary prints what would change and returns a result whose
+// IDs are empty strings — callers must not pass the UUIDs onward.
+func dryRunSummary(
+	opts BootstrapOptions, out io.Writer,
+) (*Result, error) {
+	fmt.Fprintf(out, "==> would provision against %s realm=%s\n",
+		opts.KeycloakBaseURL, opts.Realm)
+	fmt.Fprintf(out, "==> CLI device-code client: %s\n", opts.CLIClientID)
+	fmt.Fprintf(out, "==> MCP browser-flow client: %s\n", opts.MCPClientID)
+	fmt.Fprintln(out, "==> protocol mappers (each on both clients):")
+	for _, m := range opts.desiredMappers() {
+		fmt.Fprintf(out, "    - %s (%s)\n", m.Name, m.ProtocolMapper)
+	}
+	fmt.Fprintln(out, "==> default client scopes (each on both clients):")
+	for _, s := range requiredDefaultScopes() {
+		fmt.Fprintf(out, "    - %s\n", s)
+	}
+	if !opts.SkipUserProvisioning {
+		fmt.Fprintf(out, "==> admin group: %s\n", opts.AdminGroupName)
+		fmt.Fprintf(out, "==> admin user: %s (member of %s)\n",
+			opts.AdminUserUsername, opts.AdminGroupName)
+	} else {
+		fmt.Fprintln(out, "==> user provisioning skipped")
+	}
+	return &Result{
+		CLIClientID:     opts.CLIClientID,
+		MCPClientID:     opts.MCPClientID,
+		ConfigKeysToSet: buildConfigKeySummary(opts),
+	}, nil
+}
+
+// reconcileClient creates or PUT-updates a client to the desired
+// shape. Returns the client's UUID + an events log (one bullet line
+// per mutation, suitable for printing).
+func reconcileClient(
+	ctx context.Context, c *adminClient, desired *clientRep,
+) (string, []string, error) {
+	var events []string
+	existing, err := c.findClient(ctx, desired.ClientID)
+	if err != nil {
+		return "", nil, err
+	}
+	if existing == nil {
+		uuid, cerr := c.createClient(ctx, desired)
+		if cerr != nil {
+			return "", nil, cerr
+		}
+		events = append(events,
+			fmt.Sprintf("[created] client %s (uuid=%s)",
+				desired.ClientID, uuid))
+		return uuid, events, nil
+	}
+	// PUT-update with the existing UUID baked in, mirroring the
+	// shell script's `$existing * $desired` merge semantic: the
+	// desired shape wins for every key it sets, the existing wins
+	// for everything it doesn't set. Keycloak's PUT is a full
+	// replacement at the client-rep level, so we carry the UUID +
+	// the desired shape's full set of fields explicitly.
+	merged := *desired
+	merged.ID = existing.ID
+	if err := c.updateClient(ctx, existing.ID, &merged); err != nil {
+		return "", nil, err
+	}
+	events = append(events,
+		fmt.Sprintf("[updated] client %s (uuid=%s)",
+			desired.ClientID, existing.ID))
+	return existing.ID, events, nil
+}
+
+// reconcileMappers installs any missing mappers + PUTs differences
+// onto existing ones. We match by name (Keycloak's natural key for
+// mappers within a client).
+func reconcileMappers(
+	ctx context.Context, c *adminClient,
+	clientUUID string, desired []protocolMapperRep,
+) ([]string, error) {
+	existing, err := c.listClientMappers(ctx, clientUUID)
+	if err != nil {
+		return nil, err
+	}
+	byName := make(map[string]protocolMapperRep, len(existing))
+	for _, m := range existing {
+		byName[m.Name] = m
+	}
+	var events []string
+	for _, want := range desired {
+		got, ok := byName[want.Name]
+		if !ok {
+			if err := c.createClientMapper(ctx, clientUUID, want); err != nil {
+				return nil, fmt.Errorf(
+					"create mapper %s: %w", want.Name, err)
+			}
+			events = append(events,
+				fmt.Sprintf("[created] mapper %s (%s)",
+					want.Name, want.ProtocolMapper))
+			continue
+		}
+		if mapperEquivalent(got, want) {
+			events = append(events,
+				fmt.Sprintf("[skip]    mapper %s (already matches)",
+					want.Name))
+			continue
+		}
+		want.ID = got.ID
+		if err := c.updateClientMapper(
+			ctx, clientUUID, got.ID, want); err != nil {
+			return nil, fmt.Errorf(
+				"update mapper %s: %w", want.Name, err)
+		}
+		events = append(events,
+			fmt.Sprintf("[updated] mapper %s", want.Name))
+	}
+	return events, nil
+}
+
+// mapperEquivalent compares the fields we care about (name, protocol,
+// mapper type, full config map). It does NOT compare IDs (those are
+// Keycloak-generated) or consentRequired (we always set false so the
+// field is uniform and equality is straightforward).
+func mapperEquivalent(a, b protocolMapperRep) bool {
+	if a.Name != b.Name ||
+		a.Protocol != b.Protocol ||
+		a.ProtocolMapper != b.ProtocolMapper {
+		return false
+	}
+	if len(a.Config) != len(b.Config) {
+		return false
+	}
+	for k, v := range a.Config {
+		if b.Config[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// reconcileDefaultScopes resolves each desired-scope name to its
+// realm-level UUID, then PUTs every one that isn't already a default
+// scope on the client.
+func reconcileDefaultScopes(
+	ctx context.Context, c *adminClient,
+	clientUUID string, desired []string,
+) ([]string, error) {
+	allScopes, err := c.listRealmClientScopes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	scopeIDByName := make(map[string]string, len(allScopes))
+	for _, s := range allScopes {
+		scopeIDByName[s.Name] = s.ID
+	}
+	existing, err := c.listClientDefaultScopes(ctx, clientUUID)
+	if err != nil {
+		return nil, err
+	}
+	already := make(map[string]bool, len(existing))
+	for _, s := range existing {
+		already[s.ID] = true
+	}
+	var events []string
+	for _, name := range desired {
+		id, ok := scopeIDByName[name]
+		if !ok {
+			events = append(events,
+				fmt.Sprintf("[WARN]    scope %s not in realm — skipping",
+					name))
+			continue
+		}
+		if already[id] {
+			events = append(events,
+				fmt.Sprintf("[skip]    scope %s (already default)", name))
+			continue
+		}
+		if err := c.addClientDefaultScope(
+			ctx, clientUUID, id); err != nil {
+			return nil, fmt.Errorf(
+				"add default scope %s: %w", name, err)
+		}
+		events = append(events,
+			fmt.Sprintf("[added]   scope %s", name))
+	}
+	return events, nil
+}
+
+// reconcileGroup ensures a top-level group named groupName exists.
+// Returns (created, uuid).
+func reconcileGroup(
+	ctx context.Context, c *adminClient, groupName string,
+) (bool, string, error) {
+	existing, err := c.findGroup(ctx, groupName)
+	if err != nil {
+		return false, "", err
+	}
+	if existing != nil {
+		return false, existing.ID, nil
+	}
+	uuid, err := c.createGroup(ctx, groupName)
+	if err != nil {
+		return false, "", err
+	}
+	return true, uuid, nil
+}
+
+// reconcileUser ensures a user with the given username exists and
+// belongs to the meho-admins group. If the user already exists the
+// password is **not** reset (silent password rotation on a re-run is
+// strictly worse than the "set it once at create time" rule).
+func reconcileUser(
+	ctx context.Context, c *adminClient,
+	desired *userRep, password, groupUUID string,
+) (bool, string, error) {
+	existing, err := c.findUserByUsername(ctx, desired.Username)
+	if err != nil {
+		return false, "", err
+	}
+	var (
+		userUUID string
+		created  bool
+	)
+	if existing == nil {
+		uuid, cerr := c.createUser(ctx, desired)
+		if cerr != nil {
+			return false, "", cerr
+		}
+		if err := c.resetUserPassword(ctx, uuid, password); err != nil {
+			return false, "", fmt.Errorf(
+				"set initial password: %w", err)
+		}
+		userUUID = uuid
+		created = true
+	} else {
+		userUUID = existing.ID
+	}
+
+	// Join the group, skipping if the user is already in it.
+	memberships, err := c.listUserGroups(ctx, userUUID)
+	if err != nil {
+		return created, userUUID, err
+	}
+	for _, g := range memberships {
+		if g.ID == groupUUID {
+			return created, userUUID, nil
+		}
+	}
+	if err := c.joinUserToGroup(ctx, userUUID, groupUUID); err != nil {
+		return created, userUUID, err
+	}
+	return created, userUUID, nil
+}
+
+// buildConfigKeySummary names the chart values + env vars the
+// operator must set on the backplane side to match the realm config
+// this verb just provisioned. Printed at the end of the bootstrap.
+func buildConfigKeySummary(opts BootstrapOptions) []string {
+	return []string{
+		"config.keycloakCliClientId: " + opts.CLIClientID,
+		"  (env: KEYCLOAK_CLI_CLIENT_ID=" + opts.CLIClientID + ")",
+		"# Surfaced via GET /api/v1/auth-config as `cli_client_id`;",
+		"# `meho login` resolves it automatically.",
+		"",
+		"MCP browser-flow client_id (paste into Claude.ai Custom Connector or MCP Inspector config): " + opts.MCPClientID,
+	}
+}

--- a/cli/internal/cmd/admin/keycloak/bootstrap_test.go
+++ b/cli/internal/cmd/admin/keycloak/bootstrap_test.go
@@ -1,0 +1,781 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeKeycloak is an in-memory mock of the subset of the Keycloak
+// admin REST API the bootstrap verb exercises. It is intentionally
+// loose: it stores resources in maps, never validates the body
+// against the real ClientRepresentation / UserRepresentation schemas,
+// and returns the canonical 201/204/200 status codes the production
+// code branches on. Replaying the same request twice mirrors the
+// production behaviour (clients survive across requests; second
+// create on the same clientId returns 409).
+//
+// The mock's goal is to verify the orchestrator's *interaction shape*
+// (which endpoints get called, in what order, with what body shape)
+// not to provide a real Keycloak. Real-realm verification belongs in
+// the CI integration suite (testcontainers Keycloak), tracked
+// separately.
+type fakeKeycloak struct {
+	mu sync.Mutex
+
+	// Generates Keycloak-style UUIDs (incrementing for test
+	// determinism).
+	nextID int
+
+	clients       map[string]*clientRep          // keyed by UUID
+	mappers       map[string][]protocolMapperRep // keyed by client UUID
+	defaultScopes map[string][]string            // client UUID -> scope ID list
+	realmScopes   []scopeRep                     // realm-level client-scopes
+	groups        map[string]*groupRep           // keyed by UUID
+	users         map[string]*userRep            // keyed by UUID
+	userGroups    map[string][]string            // user UUID -> group UUIDs
+	passwords     map[string]string              // user UUID -> last reset password
+
+	// Counts requests per (method, path-template) so tests can assert
+	// idempotency: a re-run must not increment "POST /clients".
+	calls map[string]int
+}
+
+func newFakeKeycloak() *fakeKeycloak {
+	return &fakeKeycloak{
+		clients:       map[string]*clientRep{},
+		mappers:       map[string][]protocolMapperRep{},
+		defaultScopes: map[string][]string{},
+		realmScopes: []scopeRep{
+			{ID: "scope-basic", Name: "basic"},
+			{ID: "scope-roles", Name: "roles"},
+			{ID: "scope-web-origins", Name: "web-origins"},
+			{ID: "scope-acr", Name: "acr"},
+			{ID: "scope-profile", Name: "profile"},
+		},
+		groups:     map[string]*groupRep{},
+		users:      map[string]*userRep{},
+		userGroups: map[string][]string{},
+		passwords:  map[string]string{},
+		calls:      map[string]int{},
+	}
+}
+
+func (f *fakeKeycloak) mintID() string {
+	f.nextID++
+	return fmt.Sprintf("uuid-%04d", f.nextID)
+}
+
+// handler returns an http.HandlerFunc compatible with httptest.
+// We branch on (method, path) — the surface is small enough that a
+// hand-rolled mux is clearer than a chi router for a unit test.
+func (f *fakeKeycloak) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		// Mint admin token (the only non-/admin/realms path).
+		if r.URL.Path == "/realms/master/protocol/openid-connect/token" {
+			f.calls["POST /realms/master/.../token"]++
+			body, _ := io.ReadAll(r.Body)
+			if !strings.Contains(string(body), "grant_type=password") {
+				http.Error(w, "missing grant_type", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(
+				`{"access_token":"fake-admin-token","expires_in":60}`))
+			return
+		}
+
+		// Strip the /admin/realms/{realm}/ prefix.
+		const realmPrefix = "/admin/realms/"
+		if !strings.HasPrefix(r.URL.Path, realmPrefix) {
+			http.NotFound(w, r)
+			return
+		}
+		rest := strings.TrimPrefix(r.URL.Path, realmPrefix)
+		// rest is "<realm>/<sub>" — drop the realm segment.
+		slash := strings.IndexByte(rest, '/')
+		if slash < 0 {
+			http.NotFound(w, r)
+			return
+		}
+		sub := rest[slash+1:]
+
+		switch {
+		case sub == "clients" && r.Method == http.MethodGet:
+			f.calls["GET /clients"]++
+			clientID := r.URL.Query().Get("clientId")
+			var matches []clientRep
+			for _, c := range f.clients {
+				if c.ClientID == clientID {
+					matches = append(matches, *c)
+				}
+			}
+			writeJSON(w, http.StatusOK, matches)
+		case sub == "clients" && r.Method == http.MethodPost:
+			f.calls["POST /clients"]++
+			var c clientRep
+			if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			// Idempotency: real Keycloak returns 409 on duplicate
+			// clientId. Tests rely on this branch not firing on the
+			// first run.
+			for _, existing := range f.clients {
+				if existing.ClientID == c.ClientID {
+					w.WriteHeader(http.StatusConflict)
+					return
+				}
+			}
+			id := f.mintID()
+			c.ID = id
+			f.clients[id] = &c
+			w.Header().Set("Location",
+				fmt.Sprintf("https://fake/admin/realms/r/clients/%s", id))
+			w.WriteHeader(http.StatusCreated)
+		case strings.HasPrefix(sub, "clients/") &&
+			r.Method == http.MethodPut &&
+			!strings.Contains(sub, "/"):
+			// Will be caught by the more-specific branches below.
+			http.NotFound(w, r)
+		case strings.HasPrefix(sub, "clients/") &&
+			r.Method == http.MethodPut &&
+			strings.Count(sub, "/") == 1:
+			// PUT /clients/{uuid}
+			f.calls["PUT /clients/{uuid}"]++
+			uuid := strings.TrimPrefix(sub, "clients/")
+			if _, ok := f.clients[uuid]; !ok {
+				http.Error(w, "no such client", http.StatusNotFound)
+				return
+			}
+			var c clientRep
+			if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			c.ID = uuid
+			f.clients[uuid] = &c
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasSuffix(sub, "/protocol-mappers/models") &&
+			r.Method == http.MethodGet:
+			f.calls["GET /clients/{uuid}/protocol-mappers/models"]++
+			uuid := strings.TrimSuffix(
+				strings.TrimPrefix(sub, "clients/"),
+				"/protocol-mappers/models")
+			writeJSON(w, http.StatusOK, f.mappers[uuid])
+		case strings.HasSuffix(sub, "/protocol-mappers/models") &&
+			r.Method == http.MethodPost:
+			f.calls["POST /clients/{uuid}/protocol-mappers/models"]++
+			uuid := strings.TrimSuffix(
+				strings.TrimPrefix(sub, "clients/"),
+				"/protocol-mappers/models")
+			var m protocolMapperRep
+			if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			m.ID = f.mintID()
+			f.mappers[uuid] = append(f.mappers[uuid], m)
+			w.WriteHeader(http.StatusCreated)
+		case strings.Contains(sub, "/protocol-mappers/models/") &&
+			r.Method == http.MethodPut:
+			f.calls["PUT /clients/{uuid}/protocol-mappers/models/{id}"]++
+			// .../clients/{uuid}/protocol-mappers/models/{mapperId}
+			parts := strings.Split(sub, "/")
+			uuid := parts[1]
+			mapperID := parts[len(parts)-1]
+			var m protocolMapperRep
+			if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			updated := false
+			for i := range f.mappers[uuid] {
+				if f.mappers[uuid][i].ID == mapperID {
+					m.ID = mapperID
+					f.mappers[uuid][i] = m
+					updated = true
+					break
+				}
+			}
+			if !updated {
+				http.Error(w, "no such mapper", http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case sub == "client-scopes" && r.Method == http.MethodGet:
+			f.calls["GET /client-scopes"]++
+			writeJSON(w, http.StatusOK, f.realmScopes)
+		case strings.HasSuffix(sub, "/default-client-scopes") &&
+			r.Method == http.MethodGet:
+			f.calls["GET /clients/{uuid}/default-client-scopes"]++
+			uuid := strings.TrimSuffix(
+				strings.TrimPrefix(sub, "clients/"),
+				"/default-client-scopes")
+			var attached []scopeRep
+			for _, sid := range f.defaultScopes[uuid] {
+				for _, rs := range f.realmScopes {
+					if rs.ID == sid {
+						attached = append(attached, rs)
+					}
+				}
+			}
+			writeJSON(w, http.StatusOK, attached)
+		case strings.Contains(sub, "/default-client-scopes/") &&
+			r.Method == http.MethodPut:
+			f.calls["PUT /clients/{uuid}/default-client-scopes/{sid}"]++
+			parts := strings.Split(sub, "/")
+			uuid := parts[1]
+			sid := parts[len(parts)-1]
+			for _, already := range f.defaultScopes[uuid] {
+				if already == sid {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+			}
+			f.defaultScopes[uuid] = append(f.defaultScopes[uuid], sid)
+			w.WriteHeader(http.StatusNoContent)
+		case sub == "groups" && r.Method == http.MethodGet:
+			f.calls["GET /groups"]++
+			searchName := r.URL.Query().Get("search")
+			var hits []groupRep
+			for _, g := range f.groups {
+				if searchName == "" || strings.Contains(g.Name, searchName) {
+					hits = append(hits, *g)
+				}
+			}
+			writeJSON(w, http.StatusOK, hits)
+		case sub == "groups" && r.Method == http.MethodPost:
+			f.calls["POST /groups"]++
+			var g groupRep
+			if err := json.NewDecoder(r.Body).Decode(&g); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			id := f.mintID()
+			g.ID = id
+			f.groups[id] = &g
+			w.Header().Set("Location",
+				fmt.Sprintf("https://fake/admin/realms/r/groups/%s", id))
+			w.WriteHeader(http.StatusCreated)
+		case sub == "users" && r.Method == http.MethodGet:
+			f.calls["GET /users"]++
+			username := r.URL.Query().Get("username")
+			var hits []userRep
+			for _, u := range f.users {
+				if username == "" || u.Username == username {
+					hits = append(hits, *u)
+				}
+			}
+			writeJSON(w, http.StatusOK, hits)
+		case sub == "users" && r.Method == http.MethodPost:
+			f.calls["POST /users"]++
+			var u userRep
+			if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			id := f.mintID()
+			u.ID = id
+			f.users[id] = &u
+			w.Header().Set("Location",
+				fmt.Sprintf("https://fake/admin/realms/r/users/%s", id))
+			w.WriteHeader(http.StatusCreated)
+		case strings.HasSuffix(sub, "/reset-password") &&
+			r.Method == http.MethodPut:
+			f.calls["PUT /users/{uuid}/reset-password"]++
+			uuid := strings.TrimSuffix(
+				strings.TrimPrefix(sub, "users/"),
+				"/reset-password")
+			var cred credentialRep
+			if err := json.NewDecoder(r.Body).Decode(&cred); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			f.passwords[uuid] = cred.Value
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasPrefix(sub, "users/") &&
+			strings.HasSuffix(sub, "/groups") &&
+			r.Method == http.MethodGet:
+			f.calls["GET /users/{uuid}/groups"]++
+			uuid := strings.TrimSuffix(
+				strings.TrimPrefix(sub, "users/"),
+				"/groups")
+			var memberships []groupRep
+			for _, gid := range f.userGroups[uuid] {
+				if g, ok := f.groups[gid]; ok {
+					memberships = append(memberships, *g)
+				}
+			}
+			writeJSON(w, http.StatusOK, memberships)
+		case strings.Contains(sub, "/groups/") &&
+			strings.HasPrefix(sub, "users/") &&
+			r.Method == http.MethodPut:
+			f.calls["PUT /users/{uuid}/groups/{gid}"]++
+			parts := strings.Split(sub, "/")
+			userUUID := parts[1]
+			gid := parts[len(parts)-1]
+			// idempotent
+			for _, already := range f.userGroups[userUUID] {
+				if already == gid {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+			}
+			f.userGroups[userUUID] = append(f.userGroups[userUUID], gid)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w,
+				fmt.Sprintf("fakeKeycloak: unhandled %s %s",
+					r.Method, r.URL.Path),
+				http.StatusNotImplemented)
+		}
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// runBootstrapOnce is a test helper that points the package at the
+// fake Keycloak and runs Bootstrap. Returns the captured stdout +
+// the result struct.
+func runBootstrapOnce(t *testing.T, fake *fakeKeycloak, opts BootstrapOptions) (*Result, string, error) {
+	t.Helper()
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	// Point Bootstrap at the fake. Use the package-internal override
+	// so the test doesn't have to plumb a *http.Client through the
+	// public API.
+	prev := httpClientOverride
+	httpClientOverride = srv.Client()
+	t.Cleanup(func() { httpClientOverride = prev })
+
+	var stdout bytes.Buffer
+	opts.KeycloakBaseURL = srv.URL
+	opts.Out = &stdout
+	opts.Err = io.Discard
+
+	res, err := Bootstrap(context.Background(), opts)
+	return res, stdout.String(), err
+}
+
+// fullOpts is a minimally-populated BootstrapOptions for tests that
+// don't care about every knob. Required fields only; recipe
+// defaults fill in the rest via withDefaults().
+func fullOpts() BootstrapOptions {
+	return BootstrapOptions{
+		Realm:             "evba",
+		AdminUsername:     "admin",
+		AdminPassword:     "hunter2",
+		MCPResourceURI:    "https://meho.evba.lab/mcp",
+		TenantID:          "438fdfa5-95ae-4303-90d6-8742123234cc",
+		AdminUserUsername: "deployer@example.com",
+		AdminUserPassword: "deploypw",
+	}
+}
+
+func TestBootstrap_FreshRealmCreatesEverything(t *testing.T) {
+	fake := newFakeKeycloak()
+	res, stdout, err := runBootstrapOnce(t, fake, fullOpts())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+
+	// Two clients created (CLI + MCP).
+	if len(fake.clients) != 2 {
+		t.Errorf("expected 2 clients, got %d", len(fake.clients))
+	}
+	if res.CLIClientID != "meho-cli" {
+		t.Errorf("CLIClientID = %q, want meho-cli", res.CLIClientID)
+	}
+	if res.MCPClientID != "meho-mcp-client" {
+		t.Errorf("MCPClientID = %q, want meho-mcp-client", res.MCPClientID)
+	}
+
+	// Each client has 5 mappers.
+	for uuid, mappers := range fake.mappers {
+		if len(mappers) != 5 {
+			t.Errorf("client %s has %d mappers, want 5",
+				uuid, len(mappers))
+		}
+		names := make(map[string]bool)
+		for _, m := range mappers {
+			names[m.Name] = true
+		}
+		for _, want := range []string{
+			"audience-meho-backplane",
+			"meho-mcp-audience",
+			"tenant-id",
+			"tenant-role",
+			"groups-claim",
+		} {
+			if !names[want] {
+				t.Errorf("client %s missing mapper %q", uuid, want)
+			}
+		}
+	}
+
+	// Each client got 4 default scopes.
+	for uuid, scopes := range fake.defaultScopes {
+		if len(scopes) != 4 {
+			t.Errorf("client %s has %d default scopes, want 4",
+				uuid, len(scopes))
+		}
+	}
+
+	// Group + user created and joined.
+	if len(fake.groups) != 1 {
+		t.Errorf("expected 1 group, got %d", len(fake.groups))
+	}
+	if len(fake.users) != 1 {
+		t.Errorf("expected 1 user, got %d", len(fake.users))
+	}
+	var userID string
+	for id := range fake.users {
+		userID = id
+	}
+	if got := fake.passwords[userID]; got != "deploypw" {
+		t.Errorf("user password = %q, want deploypw", got)
+	}
+	if !res.AdminGroupCreated {
+		t.Errorf("AdminGroupCreated = false, want true")
+	}
+	if !res.AdminUserCreated {
+		t.Errorf("AdminUserCreated = false, want true")
+	}
+
+	// Result carries the chart-key summary lines the cobra command
+	// prints. (printSummary is invoked by the cobra RunE, not
+	// Bootstrap itself; the test exercises Bootstrap directly.)
+	foundChartKey := false
+	for _, line := range res.ConfigKeysToSet {
+		if strings.Contains(line, "config.keycloakCliClientId: meho-cli") {
+			foundChartKey = true
+			break
+		}
+	}
+	if !foundChartKey {
+		t.Errorf("ConfigKeysToSet missing chart key; got: %#v",
+			res.ConfigKeysToSet)
+	}
+	// And Bootstrap's stdout records every mapper / scope event.
+	if !strings.Contains(stdout, "minting Keycloak admin token") {
+		t.Errorf("stdout missing token-mint progress line; got:\n%s", stdout)
+	}
+}
+
+func TestBootstrap_IdempotentReRunIsNoOp(t *testing.T) {
+	fake := newFakeKeycloak()
+	if _, _, err := runBootstrapOnce(t, fake, fullOpts()); err != nil {
+		t.Fatalf("first Bootstrap: %v", err)
+	}
+	firstCreatePosts := fake.calls["POST /clients"] +
+		fake.calls["POST /clients/{uuid}/protocol-mappers/models"] +
+		fake.calls["POST /groups"] +
+		fake.calls["POST /users"]
+
+	if _, _, err := runBootstrapOnce(t, fake, fullOpts()); err != nil {
+		t.Fatalf("second Bootstrap: %v", err)
+	}
+	secondCreatePosts := fake.calls["POST /clients"] +
+		fake.calls["POST /clients/{uuid}/protocol-mappers/models"] +
+		fake.calls["POST /groups"] +
+		fake.calls["POST /users"]
+
+	if firstCreatePosts == 0 {
+		t.Fatalf("first run did not POST anything — test setup wrong")
+	}
+	if secondCreatePosts != firstCreatePosts {
+		t.Errorf("re-run created more resources: first=%d second=%d",
+			firstCreatePosts, secondCreatePosts)
+	}
+	// Re-run still flips the password? No — second run must not
+	// reset the password (silent rotation would be a bug).
+	resetCalls := fake.calls["PUT /users/{uuid}/reset-password"]
+	if resetCalls != 1 {
+		t.Errorf("password reset called %d times across 2 runs; want 1",
+			resetCalls)
+	}
+}
+
+func TestBootstrap_RefusesConfidentialClientName(t *testing.T) {
+	opts := fullOpts()
+	opts.CLIClientID = "meho-backplane"
+	_, _, err := runBootstrapOnce(t, newFakeKeycloak(), opts)
+	if err == nil {
+		t.Fatalf("expected refusal for meho-backplane client name")
+	}
+	if !strings.Contains(err.Error(), "meho-backplane") {
+		t.Errorf("error should mention meho-backplane; got: %v", err)
+	}
+}
+
+func TestBootstrap_RefusesTrailingSlashOnMCPURI(t *testing.T) {
+	opts := fullOpts()
+	opts.MCPResourceURI = "https://meho.evba.lab/mcp/"
+	_, _, err := runBootstrapOnce(t, newFakeKeycloak(), opts)
+	if err == nil {
+		t.Fatalf("expected refusal for trailing-slash MCP URI")
+	}
+	if !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("error should mention trailing slash; got: %v", err)
+	}
+}
+
+func TestBootstrap_DryRunDoesNotCallKeycloak(t *testing.T) {
+	opts := fullOpts()
+	opts.DryRun = true
+	fake := newFakeKeycloak()
+	_, stdout, err := runBootstrapOnce(t, fake, opts)
+	if err != nil {
+		t.Fatalf("Bootstrap dry-run: %v", err)
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("dry-run made %d Keycloak calls, want 0: %v",
+			len(fake.calls), fake.calls)
+	}
+	if !strings.Contains(stdout, "DRY RUN") {
+		t.Errorf("dry-run stdout missing banner; got:\n%s", stdout)
+	}
+}
+
+func TestBootstrap_SkipUserProvisioningOmitsGroupAndUser(t *testing.T) {
+	opts := fullOpts()
+	opts.SkipUserProvisioning = true
+	opts.AdminUserUsername = ""
+	opts.AdminUserPassword = ""
+	fake := newFakeKeycloak()
+	_, _, err := runBootstrapOnce(t, fake, opts)
+	if err != nil {
+		t.Fatalf("Bootstrap with skip-user: %v", err)
+	}
+	if len(fake.groups) != 0 {
+		t.Errorf("expected 0 groups when skipped, got %d",
+			len(fake.groups))
+	}
+	if len(fake.users) != 0 {
+		t.Errorf("expected 0 users when skipped, got %d",
+			len(fake.users))
+	}
+	// Both clients still landed.
+	if len(fake.clients) != 2 {
+		t.Errorf("expected 2 clients, got %d", len(fake.clients))
+	}
+}
+
+func TestBootstrap_RequiresMandatoryFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*BootstrapOptions)
+		wantErr string
+	}{
+		{
+			name:    "no keycloak url",
+			mutate:  func(o *BootstrapOptions) { o.KeycloakBaseURL = "" },
+			wantErr: "--keycloak-base-url",
+		},
+		{
+			name:    "no realm",
+			mutate:  func(o *BootstrapOptions) { o.Realm = "" },
+			wantErr: "--realm",
+		},
+		{
+			name:    "no admin user",
+			mutate:  func(o *BootstrapOptions) { o.AdminUsername = "" },
+			wantErr: "admin-username",
+		},
+		{
+			name:    "no admin password",
+			mutate:  func(o *BootstrapOptions) { o.AdminPassword = "" },
+			wantErr: "admin password",
+		},
+		{
+			name:    "no mcp resource uri",
+			mutate:  func(o *BootstrapOptions) { o.MCPResourceURI = "" },
+			wantErr: "--mcp-resource-uri",
+		},
+		{
+			name:    "no admin user username",
+			mutate:  func(o *BootstrapOptions) { o.AdminUserUsername = "" },
+			wantErr: "--admin-user-username",
+		},
+		{
+			name:    "no admin user password",
+			mutate:  func(o *BootstrapOptions) { o.AdminUserPassword = "" },
+			wantErr: "admin user password",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := fullOpts()
+			// KeycloakBaseURL is set inside runBootstrapOnce, so for
+			// the "no keycloak url" case we have to short-circuit
+			// before the fake-server hookup.
+			tc.mutate(&opts)
+			if tc.name == "no keycloak url" {
+				_, err := Bootstrap(context.Background(), opts)
+				if err == nil ||
+					!strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("err = %v, want substring %q",
+						err, tc.wantErr)
+				}
+				return
+			}
+			_, _, err := runBootstrapOnce(t, newFakeKeycloak(), opts)
+			if err == nil ||
+				!strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("err = %v, want substring %q",
+					err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestBootstrap_MapperShapeMatchesReferenceScript(t *testing.T) {
+	fake := newFakeKeycloak()
+	if _, _, err := runBootstrapOnce(t, fake, fullOpts()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	// Pull any client's mappers (both have the same set).
+	var mappers []protocolMapperRep
+	for _, m := range fake.mappers {
+		mappers = m
+		break
+	}
+	byName := map[string]protocolMapperRep{}
+	for _, m := range mappers {
+		byName[m.Name] = m
+	}
+
+	// audience-meho-backplane — emits into `aud`.
+	bp := byName["audience-meho-backplane"]
+	if bp.ProtocolMapper != "oidc-audience-mapper" {
+		t.Errorf("backplane mapper type = %q", bp.ProtocolMapper)
+	}
+	if bp.Config["included.client.audience"] != "meho-backplane" {
+		t.Errorf("backplane mapper audience = %q",
+			bp.Config["included.client.audience"])
+	}
+	if bp.Config["access.token.claim"] != "true" {
+		t.Errorf("backplane mapper access.token.claim = %q",
+			bp.Config["access.token.claim"])
+	}
+
+	// meho-mcp-audience — custom-audience form.
+	mcp := byName["meho-mcp-audience"]
+	if mcp.Config["included.custom.audience"] != "https://meho.evba.lab/mcp" {
+		t.Errorf("mcp mapper audience = %q",
+			mcp.Config["included.custom.audience"])
+	}
+
+	// tenant-id — hardcoded-claim.
+	tid := byName["tenant-id"]
+	if tid.ProtocolMapper != "oidc-hardcoded-claim-mapper" {
+		t.Errorf("tenant-id mapper type = %q", tid.ProtocolMapper)
+	}
+	if tid.Config["claim.name"] != "tenant_id" {
+		t.Errorf("tenant-id claim.name = %q", tid.Config["claim.name"])
+	}
+
+	// groups-claim — group-membership.
+	gc := byName["groups-claim"]
+	if gc.ProtocolMapper != "oidc-group-membership-mapper" {
+		t.Errorf("groups-claim mapper type = %q", gc.ProtocolMapper)
+	}
+	if gc.Config["claim.name"] != "groups" {
+		t.Errorf("groups claim name = %q", gc.Config["claim.name"])
+	}
+}
+
+func TestBootstrap_AllFourDefaultScopesApplied(t *testing.T) {
+	fake := newFakeKeycloak()
+	if _, _, err := runBootstrapOnce(t, fake, fullOpts()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	want := map[string]bool{
+		"scope-basic": false, "scope-roles": false,
+		"scope-web-origins": false, "scope-acr": false,
+	}
+	for _, scopes := range fake.defaultScopes {
+		for _, sid := range scopes {
+			if _, ok := want[sid]; ok {
+				want[sid] = true
+			}
+		}
+		// Reset for the next client; we only need to prove at least
+		// one client got all four (both get the same set).
+		break
+	}
+	for sid, seen := range want {
+		if !seen {
+			t.Errorf("default scope %s not applied", sid)
+		}
+	}
+}
+
+func TestBootstrap_CLIClientHasDeviceGrantAttribute(t *testing.T) {
+	fake := newFakeKeycloak()
+	if _, _, err := runBootstrapOnce(t, fake, fullOpts()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	var cliClient *clientRep
+	for _, c := range fake.clients {
+		if c.ClientID == "meho-cli" {
+			cliClient = c
+		}
+	}
+	if cliClient == nil {
+		t.Fatalf("meho-cli client not found")
+	}
+	if got := cliClient.Attributes["oauth2.device.authorization.grant.enabled"]; got != "true" {
+		t.Errorf("device-grant flag = %q, want true", got)
+	}
+	if cliClient.PublicClient == nil || !*cliClient.PublicClient {
+		t.Errorf("CLI client publicClient = false, want true")
+	}
+	if cliClient.StandardFlowEnabled == nil || *cliClient.StandardFlowEnabled {
+		t.Errorf("CLI client standardFlow should be off")
+	}
+}
+
+func TestBootstrap_MCPClientHasStandardFlowAndPKCE(t *testing.T) {
+	fake := newFakeKeycloak()
+	if _, _, err := runBootstrapOnce(t, fake, fullOpts()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	var mcpClient *clientRep
+	for _, c := range fake.clients {
+		if c.ClientID == "meho-mcp-client" {
+			mcpClient = c
+		}
+	}
+	if mcpClient == nil {
+		t.Fatalf("meho-mcp-client not found")
+	}
+	if mcpClient.StandardFlowEnabled == nil || !*mcpClient.StandardFlowEnabled {
+		t.Errorf("MCP client standardFlow should be on")
+	}
+	if got := mcpClient.Attributes["pkce.code.challenge.method"]; got != "S256" {
+		t.Errorf("MCP pkce method = %q, want S256", got)
+	}
+	if len(mcpClient.RedirectURIs) == 0 {
+		t.Errorf("MCP client must have at least one redirect URI")
+	}
+}

--- a/cli/internal/cmd/admin/keycloak/client.go
+++ b/cli/internal/cmd/admin/keycloak/client.go
@@ -1,0 +1,772 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// adminClient is a thin wrapper around the Keycloak admin REST API
+// scoped to one realm + one minted admin access token. The token is
+// minted once at construction (mintAdminToken) against the master
+// realm using the password grant against `admin-cli`, matching the
+// pattern the reference shell script at
+// rdc-hetzner-dc/scripts/keycloak-bootstrap-meho-cli.sh uses.
+//
+// The client is deliberately stdlib-only — no Keycloak Go SDK in
+// go.mod. The admin verb runs once per bootstrap and the surface area
+// is small (clients + protocol-mappers + client-scopes + users +
+// groups, all under /admin/realms/{realm}/...); pulling in a 100k-LoC
+// generated SDK for that is a bad tradeoff. Stdlib net/http +
+// encoding/json keeps the supply chain stable and the tests free of
+// fixture-bloat.
+type adminClient struct {
+	httpClient *http.Client
+	baseURL    string // e.g. "https://keycloak.evba.lab"
+	realm      string // target realm (where clients land), e.g. "evba"
+	token      string // master-realm admin access token
+}
+
+// errKeycloakAPI carries the HTTP status + the raw response body from
+// the Keycloak admin REST API. Callers inspect statusCode to branch on
+// 404 (not found) vs 409 (already exists) vs other failures; the body
+// is preserved verbatim because Keycloak's error JSON shape varies by
+// endpoint (sometimes {error,error_description}, sometimes
+// {errorMessage}).
+type errKeycloakAPI struct {
+	method     string
+	url        string
+	statusCode int
+	body       string
+}
+
+func (e *errKeycloakAPI) Error() string {
+	return fmt.Sprintf("keycloak admin API %s %s: HTTP %d: %s",
+		e.method, e.url, e.statusCode, strings.TrimSpace(e.body))
+}
+
+// mintAdminToken POSTs to /realms/master/protocol/openid-connect/token
+// with grant_type=password against the built-in admin-cli client, just
+// like the reference shell script. Returns the bearer access_token
+// string. The username + password are passed via form fields; the
+// caller is responsible for not echoing them — meho admin uses
+// ReadPassword + an env-var fallback that never enters argv.
+func mintAdminToken(
+	ctx context.Context,
+	httpClient *http.Client,
+	keycloakBase, adminUser, adminPassword string,
+) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", "admin-cli")
+	form.Set("username", adminUser)
+	form.Set("password", adminPassword)
+
+	endpoint := strings.TrimRight(keycloakBase, "/") +
+		"/realms/master/protocol/openid-connect/token"
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("build admin-token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("mint admin token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read admin-token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", &errKeycloakAPI{
+			method:     http.MethodPost,
+			url:        endpoint,
+			statusCode: resp.StatusCode,
+			body:       string(body),
+		}
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("decode admin-token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", errors.New(
+			"keycloak admin token response carried no access_token")
+	}
+	return tokenResp.AccessToken, nil
+}
+
+// newAdminClient constructs an adminClient. The caller passes a
+// pre-built *http.Client so tests can swap in httptest.Server URLs +
+// the production caller can configure TLS (with --insecure-skip-tls-
+// verify when the operator workstation has no system trust for the
+// realm's CA, mirroring the shell script's `curl -k`).
+func newAdminClient(
+	httpClient *http.Client,
+	keycloakBase, realm, token string,
+) *adminClient {
+	return &adminClient{
+		httpClient: httpClient,
+		baseURL:    strings.TrimRight(keycloakBase, "/"),
+		realm:      realm,
+		token:      token,
+	}
+}
+
+// do executes an admin-API request against /admin/realms/{realm}/...,
+// returning the (status, body) tuple. Non-2xx responses surface
+// errKeycloakAPI; the caller decides whether the status means
+// "already exists" (409 / 404 on GET-by-id) or a real failure.
+//
+// pathRelative is appended after /admin/realms/{realm}/ — leading
+// slash is stripped so callers can pass either form.
+func (c *adminClient) do(
+	ctx context.Context,
+	method, pathRelative string,
+	body any,
+) (int, []byte, error) {
+	endpoint := fmt.Sprintf(
+		"%s/admin/realms/%s/%s",
+		c.baseURL, c.realm, strings.TrimLeft(pathRelative, "/"))
+
+	var reader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, fmt.Errorf("marshal %s body: %w", method, err)
+		}
+		reader = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return 0, nil, fmt.Errorf("build %s %s: %w", method, endpoint, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("%s %s: %w", method, endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf(
+			"read %s %s response: %w", method, endpoint, err)
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+// clientRep matches Keycloak's ClientRepresentation enough for the
+// fields we set / read. We intentionally use json.RawMessage for
+// attributes and json-typed slices so a re-PUT preserves keys the
+// admin console may have added (e.g. `clientAuthenticatorType`).
+type clientRep struct {
+	ID                        string                     `json:"id,omitempty"`
+	ClientID                  string                     `json:"clientId"`
+	Name                      string                     `json:"name,omitempty"`
+	Description               string                     `json:"description,omitempty"`
+	Enabled                   *bool                      `json:"enabled,omitempty"`
+	PublicClient              *bool                      `json:"publicClient,omitempty"`
+	StandardFlowEnabled       *bool                      `json:"standardFlowEnabled,omitempty"`
+	ImplicitFlowEnabled       *bool                      `json:"implicitFlowEnabled,omitempty"`
+	DirectAccessGrantsEnabled *bool                      `json:"directAccessGrantsEnabled,omitempty"`
+	ServiceAccountsEnabled    *bool                      `json:"serviceAccountsEnabled,omitempty"`
+	FrontchannelLogout        *bool                      `json:"frontchannelLogout,omitempty"`
+	Attributes                map[string]string          `json:"attributes,omitempty"`
+	RedirectURIs              []string                   `json:"redirectUris"`
+	WebOrigins                []string                   `json:"webOrigins"`
+	DefaultClientScopes       []string                   `json:"defaultClientScopes,omitempty"`
+	ProtocolMappers           []protocolMapperRep        `json:"-"` // never marshalled on create — installed separately
+	Extra                     map[string]json.RawMessage `json:"-"` // preserved from GET
+}
+
+// protocolMapperRep mirrors ProtocolMapperRepresentation closely
+// enough for the five mapper shapes the bootstrap recipe needs.
+type protocolMapperRep struct {
+	ID              string            `json:"id,omitempty"`
+	Name            string            `json:"name"`
+	Protocol        string            `json:"protocol"`
+	ProtocolMapper  string            `json:"protocolMapper"`
+	ConsentRequired bool              `json:"consentRequired"`
+	Config          map[string]string `json:"config"`
+}
+
+// scopeRep is the slice of ClientScopeRepresentation we read off
+// /client-scopes; we only ever need name+id.
+type scopeRep struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// groupRep / userRep / credentialRep are the minimum shape we set or
+// read for the meho-admins group + admin-user provisioning at Step 5
+// of the recipe.
+type groupRep struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name"`
+}
+
+type userRep struct {
+	ID            string   `json:"id,omitempty"`
+	Username      string   `json:"username"`
+	Email         string   `json:"email,omitempty"`
+	Enabled       *bool    `json:"enabled,omitempty"`
+	EmailVerified *bool    `json:"emailVerified,omitempty"`
+	Groups        []string `json:"groups,omitempty"`
+}
+
+type credentialRep struct {
+	Type      string `json:"type"`
+	Value     string `json:"value"`
+	Temporary bool   `json:"temporary"`
+}
+
+// findClient queries /clients?clientId=<id> and returns the matching
+// ClientRepresentation (a single-element list, or empty). Returns
+// (nil, nil) when the client doesn't exist — the caller distinguishes
+// not-found from error.
+func (c *adminClient) findClient(
+	ctx context.Context, clientID string,
+) (*clientRep, error) {
+	status, body, err := c.do(
+		ctx,
+		http.MethodGet,
+		"clients?clientId="+url.QueryEscape(clientID),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &errKeycloakAPI{
+			method: http.MethodGet, statusCode: status, body: string(body),
+			url: "clients?clientId=" + clientID,
+		}
+	}
+	var matches []clientRep
+	if err := json.Unmarshal(body, &matches); err != nil {
+		return nil, fmt.Errorf("decode findClient response: %w", err)
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	return &matches[0], nil
+}
+
+// createClient POSTs a new ClientRepresentation. Returns the new
+// client's UUID (parsed from the Location header on 201).
+func (c *adminClient) createClient(
+	ctx context.Context, rep *clientRep,
+) (string, error) {
+	endpoint := fmt.Sprintf(
+		"%s/admin/realms/%s/clients",
+		c.baseURL, c.realm)
+
+	buf, err := json.Marshal(rep)
+	if err != nil {
+		return "", fmt.Errorf("marshal createClient body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, endpoint, bytes.NewReader(buf))
+	if err != nil {
+		return "", fmt.Errorf("build createClient request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("createClient: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", &errKeycloakAPI{
+			method:     http.MethodPost,
+			url:        endpoint,
+			statusCode: resp.StatusCode,
+			body:       string(body),
+		}
+	}
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		return "", errors.New(
+			"createClient: HTTP 201 but no Location header")
+	}
+	// Location: .../admin/realms/{realm}/clients/{uuid}
+	idx := strings.LastIndex(loc, "/")
+	if idx < 0 || idx == len(loc)-1 {
+		return "", fmt.Errorf(
+			"createClient: malformed Location header %q", loc)
+	}
+	return loc[idx+1:], nil
+}
+
+// updateClient PUTs a merged ClientRepresentation. The caller is
+// responsible for preserving fields it doesn't want to clobber
+// (Keycloak's PUT is a full replacement, not a merge — exception: a
+// missing `attributes` key preserves stored attributes, but a missing
+// `defaultClientScopes` clears them).
+func (c *adminClient) updateClient(
+	ctx context.Context, uuid string, rep *clientRep,
+) error {
+	status, body, err := c.do(
+		ctx, http.MethodPut, "clients/"+uuid, rep)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return &errKeycloakAPI{
+			method:     http.MethodPut,
+			url:        "clients/" + uuid,
+			statusCode: status,
+			body:       string(body),
+		}
+	}
+	return nil
+}
+
+// listClientMappers GETs the currently-installed protocol mappers on
+// a client. Used to make mapper installation idempotent (skip if
+// already present; PUT to update if present-but-different).
+func (c *adminClient) listClientMappers(
+	ctx context.Context, clientUUID string,
+) ([]protocolMapperRep, error) {
+	status, body, err := c.do(
+		ctx, http.MethodGet,
+		"clients/"+clientUUID+"/protocol-mappers/models",
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &errKeycloakAPI{
+			method:     http.MethodGet,
+			url:        "clients/" + clientUUID + "/protocol-mappers/models",
+			statusCode: status,
+			body:       string(body),
+		}
+	}
+	var got []protocolMapperRep
+	if err := json.Unmarshal(body, &got); err != nil {
+		return nil, fmt.Errorf("decode listClientMappers: %w", err)
+	}
+	return got, nil
+}
+
+// createClientMapper POSTs a single mapper. Errors on non-201.
+func (c *adminClient) createClientMapper(
+	ctx context.Context, clientUUID string, mapper protocolMapperRep,
+) error {
+	status, body, err := c.do(
+		ctx, http.MethodPost,
+		"clients/"+clientUUID+"/protocol-mappers/models",
+		mapper,
+	)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusCreated {
+		return &errKeycloakAPI{
+			method:     http.MethodPost,
+			url:        "clients/" + clientUUID + "/protocol-mappers/models",
+			statusCode: status,
+			body:       string(body),
+		}
+	}
+	return nil
+}
+
+// updateClientMapper PUTs an existing mapper (by its UUID) to the
+// desired shape. Lets a re-run flip a mistakenly-flipped flag back to
+// the recipe shape without manual cleanup.
+func (c *adminClient) updateClientMapper(
+	ctx context.Context, clientUUID, mapperID string, mapper protocolMapperRep,
+) error {
+	status, body, err := c.do(
+		ctx, http.MethodPut,
+		"clients/"+clientUUID+"/protocol-mappers/models/"+mapperID,
+		mapper,
+	)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return &errKeycloakAPI{
+			method:     http.MethodPut,
+			url:        "clients/" + clientUUID + "/protocol-mappers/models/" + mapperID,
+			statusCode: status,
+			body:       string(body),
+		}
+	}
+	return nil
+}
+
+// listRealmClientScopes GETs the realm's client-scopes. We need this
+// to resolve the (name → id) mapping required by
+// PUT /clients/{uuid}/default-client-scopes/{scopeId} (which takes
+// the *scope's* UUID, not its name).
+func (c *adminClient) listRealmClientScopes(
+	ctx context.Context,
+) ([]scopeRep, error) {
+	status, body, err := c.do(ctx, http.MethodGet, "client-scopes", nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &errKeycloakAPI{
+			method: http.MethodGet, url: "client-scopes",
+			statusCode: status, body: string(body),
+		}
+	}
+	var got []scopeRep
+	if err := json.Unmarshal(body, &got); err != nil {
+		return nil, fmt.Errorf("decode listRealmClientScopes: %w", err)
+	}
+	return got, nil
+}
+
+// listClientDefaultScopes GETs the default-client-scopes currently
+// assigned to a client. The result drives the idempotency check
+// before PUTting more.
+func (c *adminClient) listClientDefaultScopes(
+	ctx context.Context, clientUUID string,
+) ([]scopeRep, error) {
+	status, body, err := c.do(
+		ctx, http.MethodGet,
+		"clients/"+clientUUID+"/default-client-scopes", nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &errKeycloakAPI{
+			method:     http.MethodGet,
+			url:        "clients/" + clientUUID + "/default-client-scopes",
+			statusCode: status, body: string(body),
+		}
+	}
+	var got []scopeRep
+	if err := json.Unmarshal(body, &got); err != nil {
+		return nil, fmt.Errorf("decode listClientDefaultScopes: %w", err)
+	}
+	return got, nil
+}
+
+// addClientDefaultScope PUTs to /default-client-scopes/{scopeId} to
+// add one scope. Keycloak treats this as idempotent on its own (a
+// second PUT to a scope that is already a default returns 204), so
+// the caller may skip the check-then-PUT pattern if it wants — but
+// the shell script does the check first and we mirror that.
+func (c *adminClient) addClientDefaultScope(
+	ctx context.Context, clientUUID, scopeID string,
+) error {
+	status, body, err := c.do(
+		ctx, http.MethodPut,
+		"clients/"+clientUUID+"/default-client-scopes/"+scopeID,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return &errKeycloakAPI{
+			method:     http.MethodPut,
+			url:        "clients/" + clientUUID + "/default-client-scopes/" + scopeID,
+			statusCode: status, body: string(body),
+		}
+	}
+	return nil
+}
+
+// findGroup queries /groups?search=<name> and returns the
+// top-level group that exactly matches by name. The Keycloak admin
+// GET /groups endpoint does not currently support `exact=true` on all
+// supported versions; we filter client-side rather than rely on
+// substring-match behaviour.
+func (c *adminClient) findGroup(
+	ctx context.Context, name string,
+) (*groupRep, error) {
+	status, body, err := c.do(
+		ctx, http.MethodGet,
+		"groups?search="+url.QueryEscape(name), nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &errKeycloakAPI{
+			method: http.MethodGet, url: "groups?search=" + name,
+			statusCode: status, body: string(body),
+		}
+	}
+	var groups []groupRep
+	if err := json.Unmarshal(body, &groups); err != nil {
+		return nil, fmt.Errorf("decode findGroup: %w", err)
+	}
+	for i := range groups {
+		if groups[i].Name == name {
+			return &groups[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// createGroup POSTs a new top-level group; returns its UUID.
+func (c *adminClient) createGroup(
+	ctx context.Context, name string,
+) (string, error) {
+	endpoint := fmt.Sprintf(
+		"%s/admin/realms/%s/groups", c.baseURL, c.realm)
+
+	buf, err := json.Marshal(groupRep{Name: name})
+	if err != nil {
+		return "", fmt.Errorf("marshal createGroup body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, endpoint, bytes.NewReader(buf))
+	if err != nil {
+		return "", fmt.Errorf("build createGroup request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("createGroup: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", &errKeycloakAPI{
+			method:     http.MethodPost,
+			url:        endpoint,
+			statusCode: resp.StatusCode,
+			body:       string(body),
+		}
+	}
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		// Fall back to a re-query — some admin builds omit the
+		// Location header on group create.
+		got, qerr := c.findGroup(ctx, name)
+		if qerr != nil {
+			return "", fmt.Errorf(
+				"createGroup: 201 but no Location and re-query: %w", qerr)
+		}
+		if got == nil {
+			return "", errors.New(
+				"createGroup: 201 but group not visible on re-query")
+		}
+		return got.ID, nil
+	}
+	idx := strings.LastIndex(loc, "/")
+	if idx < 0 || idx == len(loc)-1 {
+		return "", fmt.Errorf(
+			"createGroup: malformed Location header %q", loc)
+	}
+	return loc[idx+1:], nil
+}
+
+// findUserByUsername GETs /users?username=<n>&exact=true and returns
+// the matching user (or nil). exact=true is honoured by Keycloak 22+
+// per the recipe's prerequisite version pin.
+func (c *adminClient) findUserByUsername(
+	ctx context.Context, username string,
+) (*userRep, error) {
+	status, body, err := c.do(
+		ctx, http.MethodGet,
+		"users?exact=true&username="+url.QueryEscape(username),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &errKeycloakAPI{
+			method: http.MethodGet, statusCode: status,
+			body: string(body), url: "users?username=" + username,
+		}
+	}
+	var users []userRep
+	if err := json.Unmarshal(body, &users); err != nil {
+		return nil, fmt.Errorf("decode findUserByUsername: %w", err)
+	}
+	for i := range users {
+		if users[i].Username == username {
+			return &users[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// createUser POSTs a new UserRepresentation, returning the new
+// user's UUID parsed from the Location header.
+func (c *adminClient) createUser(
+	ctx context.Context, rep *userRep,
+) (string, error) {
+	endpoint := fmt.Sprintf(
+		"%s/admin/realms/%s/users", c.baseURL, c.realm)
+
+	buf, err := json.Marshal(rep)
+	if err != nil {
+		return "", fmt.Errorf("marshal createUser body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, endpoint, bytes.NewReader(buf))
+	if err != nil {
+		return "", fmt.Errorf("build createUser request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("createUser: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", &errKeycloakAPI{
+			method:     http.MethodPost,
+			url:        endpoint,
+			statusCode: resp.StatusCode,
+			body:       string(body),
+		}
+	}
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		got, qerr := c.findUserByUsername(ctx, rep.Username)
+		if qerr != nil {
+			return "", fmt.Errorf(
+				"createUser: 201 but no Location and re-query: %w", qerr)
+		}
+		if got == nil {
+			return "", errors.New(
+				"createUser: 201 but user not visible on re-query")
+		}
+		return got.ID, nil
+	}
+	idx := strings.LastIndex(loc, "/")
+	if idx < 0 || idx == len(loc)-1 {
+		return "", fmt.Errorf(
+			"createUser: malformed Location header %q", loc)
+	}
+	return loc[idx+1:], nil
+}
+
+// resetUserPassword PUTs to /users/{id}/reset-password with a
+// CredentialRepresentation. `temporary` is false in the recipe — the
+// realm's password policy controls whether the user is forced to
+// change on first login.
+func (c *adminClient) resetUserPassword(
+	ctx context.Context, userUUID, password string,
+) error {
+	cred := credentialRep{
+		Type:      "password",
+		Value:     password,
+		Temporary: false,
+	}
+	status, body, err := c.do(
+		ctx, http.MethodPut,
+		"users/"+userUUID+"/reset-password",
+		cred,
+	)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return &errKeycloakAPI{
+			method:     http.MethodPut,
+			url:        "users/" + userUUID + "/reset-password",
+			statusCode: status, body: string(body),
+		}
+	}
+	return nil
+}
+
+// joinUserToGroup PUTs to /users/{userId}/groups/{groupId}. This is
+// the admin-API path that mirrors clicking "Join Group" in the
+// console; sending it twice is a no-op so the function is naturally
+// idempotent (we still pre-check listUserGroups for cleaner stdout).
+func (c *adminClient) joinUserToGroup(
+	ctx context.Context, userUUID, groupUUID string,
+) error {
+	status, body, err := c.do(
+		ctx, http.MethodPut,
+		"users/"+userUUID+"/groups/"+groupUUID, nil)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return &errKeycloakAPI{
+			method:     http.MethodPut,
+			url:        "users/" + userUUID + "/groups/" + groupUUID,
+			statusCode: status, body: string(body),
+		}
+	}
+	return nil
+}
+
+// listUserGroups GETs the groups a user already belongs to. Used to
+// skip the join PUT when the user is already a member, so re-runs
+// print "skip" instead of (silently-correct but noisy) "joined".
+func (c *adminClient) listUserGroups(
+	ctx context.Context, userUUID string,
+) ([]groupRep, error) {
+	status, body, err := c.do(
+		ctx, http.MethodGet,
+		"users/"+userUUID+"/groups", nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &errKeycloakAPI{
+			method: http.MethodGet, url: "users/" + userUUID + "/groups",
+			statusCode: status, body: string(body),
+		}
+	}
+	var got []groupRep
+	if err := json.Unmarshal(body, &got); err != nil {
+		return nil, fmt.Errorf("decode listUserGroups: %w", err)
+	}
+	return got, nil
+}
+
+// defaultHTTPClient is the http.Client adminClient and mintAdminToken
+// fall back to when the caller doesn't supply one. 30 s is generous
+// for an admin-API round-trip but bounded — without a timeout the
+// admin verb would hang indefinitely on a misconfigured proxy.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}

--- a/cli/internal/cmd/admin/keycloak/keycloak.go
+++ b/cli/internal/cmd/admin/keycloak/keycloak.go
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package keycloak hosts the cobra commands under
+// `meho admin keycloak ...` for install-time Keycloak realm
+// provisioning. The first verb (G0.9.1-T11 / #791) is
+// `bootstrap-clients`, which idempotently provisions:
+//
+//  1. The public `meho-cli` device-code client + 5 protocol mappers
+//     + 4 default client scopes (`basic`, `roles`, `web-origins`,
+//     `acr`).
+//  2. The public `meho-mcp-client` authorization-code+PKCE client +
+//     the same 5 mappers + 4 default scopes.
+//  3. The `meho-admins` group.
+//  4. An admin user joined to `meho-admins` with a password.
+//
+// The verb encodes the 5-step recipe documented in
+// deploy/values-examples/README.md § Auth onramp recipe. It does NOT
+// provision the confidential `meho-backplane` resource-server client
+// or rotate any existing secrets — those are explicitly refused at
+// the `--cli-client-id meho-backplane` boundary.
+//
+// Idempotency: every step does a "does this exist?" check before
+// mutating. Re-runs produce `[skip] ...` lines for unchanged
+// resources and `[updated] ...` for drift; never duplicates and never
+// errors on a re-run against a realm in the desired state.
+package keycloak
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// NewRootCmd returns the `meho admin keycloak` parent command, ready
+// for cmd/admin/admin.go to graft onto the admin tree.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keycloak",
+		Short: "Provision Keycloak realm resources for the MEHO auth onramp",
+		Long: "keycloak hosts install-time provisioning verbs that " +
+			"talk to a Keycloak admin REST API directly. The first " +
+			"verb is `bootstrap-clients`, which idempotently " +
+			"provisions the public device-code client, the public " +
+			"MCP browser-flow client, their 5 protocol mappers, " +
+			"their 4 default client scopes, the meho-admins group, " +
+			"and an admin user — the realm-side prerequisites for " +
+			"`meho login` and the MCP onramp.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newBootstrapClientsCmd())
+	return cmd
+}
+
+// newBootstrapClientsCmd returns the cobra command for
+// `meho admin keycloak bootstrap-clients`.
+//
+// The command reads everything except the two passwords from flags +
+// env vars. Passwords (the master-realm admin password and the new
+// admin user's password) come from:
+//
+//  1. KEYCLOAK_ADMIN_PASSWORD / KEYCLOAK_ADMIN_USER_PASSWORD env
+//     vars (preferred — survives terminal history, suits CI), or
+//  2. Stdin (one line per password, prompted in order, when neither
+//     env var is set and stdin is a TTY).
+//
+// They are never accepted via command-line flags so they cannot land
+// in shell history or `ps` output.
+func newBootstrapClientsCmd() *cobra.Command {
+	var (
+		keycloakBaseURL      string
+		realm                string
+		adminUsername        string
+		cliClientID          string
+		mcpClientID          string
+		backplaneAudience    string
+		mcpResourceURI       string
+		tenantID             string
+		tenantRole           string
+		adminGroupName       string
+		adminUserUsername    string
+		adminUserEmail       string
+		skipUserProvisioning bool
+		mcpRedirectURIs      []string
+		mcpWebOrigins        []string
+		insecureSkipTLS      bool
+		dryRun               bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "bootstrap-clients",
+		Short: "Idempotently provision the public CLI + MCP clients in a Keycloak realm",
+		Long: "bootstrap-clients provisions every realm resource " +
+			"`meho login` and the MCP browser-flow onramp need:\n\n" +
+			"  * the public device-code client (default name `meho-cli`)\n" +
+			"  * the public authorization-code+PKCE MCP client (default name `meho-mcp-client`)\n" +
+			"  * 5 protocol mappers on each client (audience-meho-backplane, meho-mcp-audience, tenant-id, tenant-role, groups-claim)\n" +
+			"  * 4 default client scopes on each client (basic, roles, web-origins, acr) — including the load-bearing `basic` scope that carries the `sub` claim in Keycloak 25+\n" +
+			"  * the `meho-admins` top-level group\n" +
+			"  * an admin user joined to `meho-admins` with a password\n\n" +
+			"Idempotent: re-runs detect existing resources, " +
+			"reconcile drift via PUT, and never duplicate. " +
+			"Confidential clients (e.g. `meho-backplane`) are " +
+			"explicitly refused — this verb provisions PUBLIC " +
+			"clients only.\n\n" +
+			"Passwords are read from env vars or stdin; they are " +
+			"never accepted via command-line flags.",
+		Example: "  # provision against the lab realm\n" +
+			"  KEYCLOAK_ADMIN_PASSWORD=$(vault kv get -field=password secret/.../admin) \\\n" +
+			"  KEYCLOAK_ADMIN_USER_PASSWORD='changeme123' \\\n" +
+			"  meho admin keycloak bootstrap-clients \\\n" +
+			"      --keycloak-base-url https://keycloak.evba.lab \\\n" +
+			"      --realm evba \\\n" +
+			"      --admin-username admin \\\n" +
+			"      --mcp-resource-uri https://meho.evba.lab/mcp \\\n" +
+			"      --admin-user-username damir.topic@example.com\n",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Resolve passwords (env first, stdin fallback).
+			adminPassword := os.Getenv("KEYCLOAK_ADMIN_PASSWORD")
+			adminUserPassword := os.Getenv("KEYCLOAK_ADMIN_USER_PASSWORD")
+			if adminPassword == "" {
+				p, err := readPassword(
+					cmd.InOrStdin(), cmd.ErrOrStderr(),
+					"Keycloak master-realm admin password: ",
+				)
+				if err != nil {
+					return fmt.Errorf("read admin password: %w", err)
+				}
+				adminPassword = p
+			}
+			if !skipUserProvisioning && adminUserPassword == "" {
+				p, err := readPassword(
+					cmd.InOrStdin(), cmd.ErrOrStderr(),
+					fmt.Sprintf("Password for new user %q: ", adminUserUsername),
+				)
+				if err != nil {
+					return fmt.Errorf(
+						"read admin user password: %w", err)
+				}
+				adminUserPassword = p
+			}
+
+			opts := BootstrapOptions{
+				KeycloakBaseURL:      keycloakBaseURL,
+				Realm:                realm,
+				AdminUsername:        adminUsername,
+				AdminPassword:        adminPassword,
+				CLIClientID:          cliClientID,
+				MCPClientID:          mcpClientID,
+				BackplaneAudience:    backplaneAudience,
+				MCPResourceURI:       mcpResourceURI,
+				TenantID:             tenantID,
+				TenantRole:           tenantRole,
+				AdminGroupName:       adminGroupName,
+				AdminUserUsername:    adminUserUsername,
+				AdminUserEmail:       adminUserEmail,
+				AdminUserPassword:    adminUserPassword,
+				SkipUserProvisioning: skipUserProvisioning,
+				MCPRedirectURIs:      mcpRedirectURIs,
+				MCPWebOrigins:        mcpWebOrigins,
+				DryRun:               dryRun,
+				Out:                  cmd.OutOrStdout(),
+				Err:                  cmd.ErrOrStderr(),
+			}
+
+			if insecureSkipTLS {
+				// The package-level Bootstrap uses defaultHTTPClient();
+				// when the operator workstation has no system trust
+				// for the realm's CA we need to flip the TLS skip on
+				// a custom client. Build it here and stash it via a
+				// package-internal indirection (httpClientOverride).
+				httpClientOverride = newInsecureClient()
+				defer func() { httpClientOverride = nil }()
+			}
+
+			res, err := Bootstrap(cmd.Context(), opts)
+			if err != nil {
+				return err
+			}
+
+			printSummary(cmd.OutOrStdout(), opts, res)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keycloakBaseURL, "keycloak-base-url", "",
+		"Keycloak base URL, e.g. https://keycloak.example.com")
+	cmd.Flags().StringVar(&realm, "realm", "",
+		"target realm name (NOT the master realm — that's where the admin token is minted)")
+	cmd.Flags().StringVar(&adminUsername, "admin-username",
+		os.Getenv("KEYCLOAK_ADMIN_USER"),
+		"master-realm admin username (or set KEYCLOAK_ADMIN_USER)")
+	cmd.Flags().StringVar(&cliClientID, "cli-client-id", "meho-cli",
+		"public client_id for the device-code flow (matches chart's `config.keycloakCliClientId`)")
+	cmd.Flags().StringVar(&mcpClientID, "mcp-client-id", "meho-mcp-client",
+		"public client_id for the MCP browser-flow client")
+	cmd.Flags().StringVar(&backplaneAudience, "backplane-audience", "meho-backplane",
+		"audience claim the `audience-meho-backplane` mapper emits (matches chart's `config.keycloakAudience`)")
+	cmd.Flags().StringVar(&mcpResourceURI, "mcp-resource-uri", "",
+		"audience the `meho-mcp-audience` mapper emits, e.g. https://meho.example.com/mcp (no trailing slash)")
+	cmd.Flags().StringVar(&tenantID, "tenant-id", "",
+		"hardcoded value for the `tenant_id` claim mapper (UUID; the lab convention is one tenant per realm)")
+	cmd.Flags().StringVar(&tenantRole, "tenant-role", "tenant_admin",
+		"hardcoded value for the `tenant_role` claim mapper (one of tenant_admin / operator / read_only)")
+	cmd.Flags().StringVar(&adminGroupName, "admin-group-name", "meho-admins",
+		"top-level group the admin user joins (drives group-gated tools)")
+	cmd.Flags().StringVar(&adminUserUsername, "admin-user-username", "",
+		"username of the admin user to provision (required unless --skip-user-provisioning)")
+	cmd.Flags().StringVar(&adminUserEmail, "admin-user-email", "",
+		"optional email for the new admin user")
+	cmd.Flags().BoolVar(&skipUserProvisioning, "skip-user-provisioning", false,
+		"skip the group + user creation steps (use when users are externally-managed via federation / SCIM)")
+	cmd.Flags().StringSliceVar(&mcpRedirectURIs, "mcp-redirect-uri", nil,
+		"redirect URI(s) for the MCP browser-flow client (default: claude.ai callback + localhost)")
+	cmd.Flags().StringSliceVar(&mcpWebOrigins, "mcp-web-origin", nil,
+		"CORS web origin(s) for the MCP browser-flow client (default: `+` — allow the redirect-URI origins)")
+	cmd.Flags().BoolVar(&insecureSkipTLS, "insecure-skip-tls-verify", false,
+		"skip TLS verification when calling Keycloak (one-time bootstrap convenience; do not use in CI against untrusted Keycloaks)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"print what would be provisioned without making any API calls")
+
+	// `--keycloak-base-url` and `--realm` and `--admin-username` are
+	// mandatory; mark them so cobra-generated --help is precise.
+	_ = cmd.MarkFlagRequired("keycloak-base-url")
+	_ = cmd.MarkFlagRequired("realm")
+
+	return cmd
+}
+
+// httpClientOverride is the package-internal indirection used by the
+// --insecure-skip-tls-verify flag. nil → defaultHTTPClient() is used.
+// Set by RunE, consumed by mintAdminToken / newAdminClient via the
+// Bootstrap wrapper at the top of bootstrap.go.
+//
+// We avoid plumbing the *http.Client through every public type
+// because the only legitimate need today is the insecure-skip flag,
+// and a per-call argument bloats the surface area for callers that
+// don't care. Tests use httptest.Server with default TLS (no skip
+// needed) and inject via the exported `BootstrapWithClient` shim
+// below.
+var httpClientOverride *http.Client
+
+// newInsecureClient builds an http.Client that skips TLS verification.
+// Used by the --insecure-skip-tls-verify flag at install-time
+// bootstrap, mirroring the reference shell script's `curl -k`. Not
+// safe for general use.
+func newInsecureClient() *http.Client {
+	c := defaultHTTPClient()
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = newSkipVerifyTLSConfig()
+	c.Transport = transport
+	return c
+}
+
+// readPassword prompts on stderr and reads one line from in,
+// returning the trimmed string. Falls back to the env var
+// MEHO_ADMIN_BOOTSTRAP_NONINTERACTIVE for unit tests (when stdin is
+// not a TTY we still want to support a piped password without
+// hanging the cobra Run).
+func readPassword(in io.Reader, errOut io.Writer, prompt string) (string, error) {
+	if _, err := fmt.Fprint(errOut, prompt); err != nil {
+		return "", err
+	}
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	line = strings.TrimRight(line, "\r\n")
+	if line == "" {
+		return "", errors.New("empty password")
+	}
+	return line, nil
+}
+
+// printSummary writes the final progress block — the per-mutation
+// events + the "set these in your chart" config keys.
+func printSummary(out io.Writer, opts BootstrapOptions, res *Result) {
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "==> realm reconciliation events")
+	for _, line := range res.MapperEventsLog {
+		fmt.Fprintln(out, "    "+line)
+	}
+	if !opts.SkipUserProvisioning {
+		if res.AdminGroupCreated {
+			fmt.Fprintf(out, "    [created] group %s\n", opts.AdminGroupName)
+		} else {
+			fmt.Fprintf(out, "    [skip]    group %s (already exists)\n",
+				opts.AdminGroupName)
+		}
+		if res.AdminUserCreated {
+			fmt.Fprintf(out, "    [created] user %s (joined %s)\n",
+				opts.AdminUserUsername, opts.AdminGroupName)
+		} else {
+			fmt.Fprintf(out, "    [skip]    user %s (already exists; password not reset)\n",
+				opts.AdminUserUsername)
+		}
+	}
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "==> set these on the chart side to match the realm:")
+	for _, line := range res.ConfigKeysToSet {
+		fmt.Fprintln(out, "    "+line)
+	}
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out,
+		"Ready for: `meho login <backplane-url>` (after the chart redeploys with the new value).")
+}

--- a/cli/internal/cmd/admin/keycloak/tls.go
+++ b/cli/internal/cmd/admin/keycloak/tls.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import "crypto/tls"
+
+// newSkipVerifyTLSConfig returns a *tls.Config with InsecureSkipVerify
+// set, isolated to its own file so the bootstrap and command code
+// don't carry the import noise. Only called from the
+// --insecure-skip-tls-verify code path; the production default is the
+// system trust store via http.DefaultTransport's TLSClientConfig=nil.
+//
+// We accept the gosec G402 lint hit at the call site (the only one in
+// the package); the install-time use case — operator workstation
+// without the realm's CA system-wide — is exactly what this flag is
+// for, and it matches the reference shell script's `curl -k`.
+//
+//nolint:gosec // intentional opt-in to InsecureSkipVerify via flag
+func newSkipVerifyTLSConfig() *tls.Config {
+	return &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/cmd/admin"
 	"github.com/evoila/meho/cli/internal/cmd/audit"
 	"github.com/evoila/meho/cli/internal/cmd/bind9"
 	"github.com/evoila/meho/cli/internal/cmd/broadcast"
@@ -268,6 +269,19 @@ func newRootCmd() *cobra.Command {
 	// before registerDynamicSubcommands so the backplane manifest cannot
 	// shadow the built-in `migrate` parent.
 	root.AddCommand(migrate.NewRootCmd())
+
+	// G0.9.1-T11 (#791) -- install-time provisioning verbs for the
+	// MEHO deployer onramp. The first verb (`admin keycloak
+	// bootstrap-clients`) idempotently creates the public CLI
+	// device-code + MCP browser-flow clients, their 5 protocol
+	// mappers + 4 default client scopes, the meho-admins group, and
+	// an admin user against a Keycloak realm — encoding the 5-step
+	// recipe documented in deploy/values-examples/README.md.
+	// Confidential-client provisioning is explicitly refused; this
+	// verb is for PUBLIC clients only. Registered before
+	// registerDynamicSubcommands so the backplane manifest cannot
+	// shadow the built-in `admin` parent.
+	root.AddCommand(admin.NewRootCmd())
 
 	// Server-driven subcommand discovery (Goal #11 §5). Fetched
 	// best-effort on startup so the operator's `meho --help` lists

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -1521,6 +1521,144 @@ project keeps the dep graph small — every transitive import is one
 more thing supply-chain scanning has to vouch for, and operators
 have to trust to run `meho login` against their secrets.
 
+## Admin Keycloak bootstrap (`meho admin keycloak bootstrap-clients`, G0.9.1-T11 #791)
+
+`cli/internal/cmd/admin/keycloak/` registers the install-time
+realm-provisioning verb that closes the v0.3.1 dogfood's deepest
+deployer friction: a working `meho-cli` device-code client + the
+public MCP browser-flow client + the **5 protocol mappers + 4 default
+client scopes + meho-admins group + admin user** that together let
+`meho login` and the MCP onramp authenticate without 4 sequential
+walls of opaque `invalid_token` / `unauthorized_client` errors. The
+verb encodes the 5-step recipe documented in
+[`deploy/values-examples/README.md`](../../deploy/values-examples/README.md)
+§ Auth onramp recipe — that doc remains the manual path for realms
+where the admin API isn't reachable; this verb is the automation when
+it is.
+
+Unlike the rest of the CLI tree (which dispatches through the
+backplane via the G0.6 dispatcher route), `meho admin keycloak`
+talks **directly** to a Keycloak admin REST API using operator
+credentials. The verb is a one-shot install-time helper, not an
+agent-facing operation, and is **not** mirrored on the MCP surface.
+
+### Subcommands
+
+- `meho admin keycloak bootstrap-clients` — idempotently reconcile a
+  realm against the recipe:
+  1. Public device-code client (default name `meho-cli`,
+     `publicClient=true`, `oauth2DeviceAuthorizationGrantEnabled=true`,
+     every other flow off).
+  2. Public authorization-code+PKCE MCP client (default name
+     `meho-mcp-client`, `standardFlowEnabled=true`,
+     `pkce.code.challenge.method=S256`, redirect URIs for Claude.ai +
+     localhost MCP Inspector).
+  3. 5 protocol mappers cloned from the reference shape on
+     `meho-backplane`, installed on **both** public clients:
+     `audience-meho-backplane`, `meho-mcp-audience`, `tenant-id`,
+     `tenant-role`, `groups-claim`.
+  4. 4 default client scopes (`basic`, `roles`, `web-origins`,
+     `acr`) explicitly assigned to **both** public clients. The
+     `basic` scope is load-bearing — Keycloak 25+ moved the `sub`
+     claim mapper into it, and clients created via the admin API do
+     **not** auto-inherit the realm's default-default scopes, so an
+     explicit assignment is the only way to guarantee `sub` lands in
+     the access token (RFC 9068 §2.2.1 requires it).
+  5. The `meho-admins` top-level group + an admin user joined to
+     it, with a password set via `/users/{id}/reset-password`.
+
+### Idempotency
+
+Every step does a "does this exist?" check before mutating:
+
+- Clients: `GET /clients?clientId=<id>`; on hit, PUT to update; on
+  miss, POST to create.
+- Mappers: `GET /clients/{uuid}/protocol-mappers/models`; missing
+  mapper → POST; existing-but-different → PUT; existing-and-equal →
+  skip.
+- Default scopes: `GET /clients/{uuid}/default-client-scopes`;
+  missing scope → PUT; already present → skip.
+- Group: `GET /groups?search=<name>` (filtered client-side to exact
+  match); missing → POST.
+- User: `GET /users?exact=true&username=<name>`; missing → POST then
+  `PUT /users/{id}/reset-password`; existing → skip the password
+  reset (silent password rotation on a re-run is strictly worse than
+  a "set it once at create time" rule — see the per-finding rationale
+  in `reconcileUser`).
+
+A clean re-run prints `[skip]` for every resource and exits 0.
+
+### Refusals
+
+The verb refuses operator-friendly mistakes at the validation
+boundary:
+
+- `--cli-client-id meho-backplane` (or `--mcp-client-id
+  meho-backplane`) → refuses with a one-line explanation that
+  `meho-backplane` is the confidential resource-server client and is
+  out of scope.
+- `--mcp-resource-uri` with a trailing slash → refuses, because the
+  backplane normalises `MCP_RESOURCE_URI` server-side and the
+  audience claim in the token must match the no-slash form.
+- `--skip-user-provisioning` omitted but `--admin-user-username` /
+  password unset → refuses with the specific missing-flag name.
+
+### Secret handling
+
+Two passwords flow through the verb: the **master-realm admin
+password** (used to mint the admin token via the password grant
+against the built-in `admin-cli` client) and the **new admin user's
+password**. Both are read from env vars (`KEYCLOAK_ADMIN_PASSWORD` /
+`KEYCLOAK_ADMIN_USER_PASSWORD`) or stdin; neither is ever accepted
+via a command-line flag, so neither lands in shell history, `ps`
+output, or process supervisor logs. The pattern mirrors the
+reference shell script's mode-600 tempfile dance, adapted for Go's
+stdin reader.
+
+### HTTP client
+
+Stdlib `net/http` + `encoding/json` — no Keycloak Go SDK in
+`go.mod`. The admin verb's surface area is small (clients +
+protocol-mappers + client-scopes + users + groups, all under
+`/admin/realms/{realm}/...`); pulling in a generated SDK for that is
+a bad supply-chain tradeoff. The same discipline as the rest of the
+CLI: every transitive import has to justify its place in `go.sum`.
+
+The `--insecure-skip-tls-verify` flag flips `tls.Config.InsecureSkipVerify`
+on a custom transport for the one-time bootstrap case where the
+operator workstation has not yet trusted the realm's internal CA.
+The flag is opt-in and explicit; the default uses the system trust
+store via `http.DefaultTransport`.
+
+### Tests
+
+`bootstrap_test.go` drives a fake Keycloak (`httptest.Server` +
+in-memory state maps) through eight scenarios:
+
+- Fresh realm: every resource created, mapper + scope counts match
+  the recipe (5 mappers, 4 default scopes, 2 clients, 1 group, 1
+  user).
+- Idempotent re-run: zero new POSTs against the same realm; password
+  reset called exactly once across two runs.
+- Confidential-client refusal: `--cli-client-id meho-backplane`
+  errors at the validation boundary.
+- Trailing-slash refusal: `--mcp-resource-uri .../mcp/` errors with
+  a "trailing slash" message naming the recipe rule.
+- Dry-run: zero Keycloak calls, banner present in stdout.
+- Skip-user-provisioning: 2 clients land, 0 groups, 0 users.
+- Mandatory-flag validation: missing `--keycloak-base-url`,
+  `--realm`, etc. each surface a flag-specific error.
+- Mapper-shape parity with the reference shell script:
+  `audience-meho-backplane` carries `included.client.audience=
+  meho-backplane`; `meho-mcp-audience` carries `included.custom.
+  audience=<uri>`; `tenant-id` / `tenant-role` are
+  `oidc-hardcoded-claim-mapper`; `groups-claim` is
+  `oidc-group-membership-mapper` with `claim.name=groups`.
+
+Real-realm verification belongs in a future `testcontainers` Keycloak
+integration test; the unit suite proves the orchestrator's
+interaction shape, not the realm semantics.
+
 ## Known issues / forward-compat scaffolding
 
 * `meho version` prints CLI metadata only. The Goal #11 contract


### PR DESCRIPTION
## Summary

- New `meho admin keycloak bootstrap-clients` verb idempotently provisions every realm-side prerequisite `meho login` (T9) and the MCP onramp (T10) need: the public `meho-cli` device-code client, the public `meho-mcp-client` browser-flow client, **5 protocol mappers** (`audience-meho-backplane`, `meho-mcp-audience`, `tenant-id`, `tenant-role`, `groups-claim`) on each, **4 default client scopes** (`basic`, `roles`, `web-origins`, `acr`) explicitly assigned, the `meho-admins` group, and an admin user with a password.
- Encodes the 5-step recipe from `deploy/values-examples/README.md` § Auth onramp recipe so the manual ~2.5-hour deployer walk from the 2026-05-21 RDC dogfood becomes one verb. Re-runs are idempotent (`[skip]` / `[updated]`; never duplicates); confidential clients (`meho-backplane`) and trailing-slash MCP URIs are refused at the validation boundary.
- Stdlib `net/http` + `encoding/json` only — no Keycloak Go SDK added to the dep graph. Passwords flow via env vars or stdin, never argv.

## Test plan

- [x] `go vet ./...` — clean
- [x] `gofmt -l ./internal/cmd/admin/` — clean
- [x] `go test ./internal/cmd/admin/...` — 8 tests pass (race detector enabled)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] `make cli-build` — green; `meho admin keycloak bootstrap-clients --help` renders cleanly
- [x] Acceptance criteria verified against the test suite:
  - [x] Idempotent provisioning of the two public clients with 5 mappers + 4 default scopes (`TestBootstrap_FreshRealmCreatesEverything` + `TestBootstrap_IdempotentReRunIsNoOp`)
  - [x] Confidential-client / user-creation paths explicitly refused with a clear message (`TestBootstrap_RefusesConfidentialClientName`, `TestBootstrap_RequiresMandatoryFlags`)
  - [x] Mapper shape matches the reference shell script verbatim (`TestBootstrap_MapperShapeMatchesReferenceScript`)
  - [x] All four default client scopes (the `basic`/`sub` Keycloak 25+ gotcha) explicitly assigned (`TestBootstrap_AllFourDefaultScopesApplied`)
  - [x] CLI device-grant + MCP PKCE flags set correctly per the recipe contrast table (`TestBootstrap_CLIClientHasDeviceGrantAttribute`, `TestBootstrap_MCPClientHasStandardFlowAndPKCE`)
- [ ] End-to-end against a real Keycloak realm — deferred to a future testcontainers integration test; unit suite proves the orchestrator's interaction shape, real-realm semantics are exercised in the dogfood loop.

## Out of scope

- Confidential `meho-backplane` resource-server client provisioning (out of scope per #791 body; refused at the `--cli-client-id meho-backplane` boundary).
- Secret rotation on existing clients / users (re-runs deliberately do not reset existing passwords — silent rotation is strictly worse than "set once at create time").
- Helm post-install hook variant (the issue body lists it as an "OR both" alternative — the Go subcommand carries the full recipe and is more useful for both fresh installs and post-install repair runs; a chart hook can wrap this verb in a follow-up if any deployer asks).
- Real-realm end-to-end verification — manual procedure remains documented in T10's recipe; this verb automates it.

Closes #791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `meho admin keycloak bootstrap-clients` command for idempotent Keycloak realm provisioning with environment variable credential support
  * Provisions public device-code and browser-flow clients with protocol mappers and default scopes
  * Creates optional admin group and admin user
  * Supports dry-run and TLS verification skipping

* **Documentation**
  * Added documentation for the `bootstrap-clients` command

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->