### PR TITLE
feat(connectors): G3.6-T13 shared vcf_auth.py + recorded-fixture refresh tool (#841)

### DIFF
--- a/backend/src/meho_backplane/connectors/_shared/__init__.py
+++ b/backend/src/meho_backplane/connectors/_shared/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Cross-connector shared helpers.
+
+Currently exports :mod:`meho_backplane.connectors._shared.vcf_auth` — the
+common subset of auth scaffolding the four VCF management-plane connectors
+(vROps #829, vRLI #830, Fleet #831; Automation #832 is intentionally
+excluded — its dual-plane shape doesn't fit) all share.
+
+See :mod:`.vcf_auth` for the public surface. New cross-connector shared
+modules land alongside ``vcf_auth.py`` — keep each module focused on a
+single concern (auth, retries, pagination, etc.) rather than growing this
+package into a god-module.
+"""
+
+from meho_backplane.connectors._shared import vcf_auth
+
+__all__ = ["vcf_auth"]

--- a/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
+++ b/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
@@ -277,23 +277,36 @@ class CredentialsCache:
             )
             return raw
 
-    def invalidate(self, target: VcfTargetLike) -> None:
+    async def invalidate(self, target: VcfTargetLike) -> None:
         """Drop the cached credentials for *target*.
 
-        Synchronous because callers hold no lock on read-only invalidation
-        decisions; concurrent ``get`` callers re-acquire the lock and
-        re-load. Used by the consuming connector after a credentials
-        rotation event (rare; surfaced via a future admin endpoint).
+        Coroutine acquiring ``self._lock`` so the mutation is serialised
+        against in-flight :meth:`get` callers for the same target; otherwise
+        a concurrent ``invalidate(t)`` between ``get(t)``'s load and its
+        cache write would silently re-introduce a stale entry. Used by the
+        consuming connector after a credentials rotation event (rare;
+        surfaced via a future admin endpoint).
         """
-        self._cache.pop(target.name, None)
+        async with self._lock:
+            self._cache.pop(target.name, None)
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         """Drop all cached credentials.
 
-        Called by the consuming connector's ``aclose`` so credentials don't
-        outlive the connector instance.
+        Coroutine acquiring ``self._lock`` for the same reason
+        :meth:`invalidate` does — a concurrent ``clear()`` racing an
+        in-flight ``get(t)`` could otherwise leave the just-loaded entry
+        in the cache after ``clear()`` returned. Called by the consuming
+        connector's ``aclose`` so credentials don't outlive the connector
+        instance; Harbor's ``aclose`` at
+        ``backend/src/meho_backplane/connectors/harbor/connector.py:471-481``
+        and SDDC Manager's at
+        ``backend/src/meho_backplane/connectors/sddc_manager/connector.py:317-318``
+        are the in-tree precedent (each wraps a ``dict.clear`` in
+        ``async with self._creds_lock``).
         """
-        self._cache.clear()
+        async with self._lock:
+            self._cache.clear()
 
     @property
     def cached_targets(self) -> frozenset[str]:

--- a/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
+++ b/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared auth scaffolding for the four VCF management-plane connectors.
+
+The three skeleton connectors landing under G3.6 — VCF Operations (vROps,
+#829), VCF Operations for Logs (vRLI, #830), and VCF Fleet (#831) — share a
+small set of auth helpers:
+
+* HTTP Basic ``Authorization`` header construction (vROps, Fleet send Basic
+  on every request; vRLI sends it once at session-login).
+* The ``auth_model`` boundary gate (accept ``SHARED_SERVICE_ACCOUNT`` enum
+  member, its string value, or ``None`` — the pre-G0.3
+  column-not-yet-populated sentinel — and reject everything else).
+* A Vault-credentials-loader protocol + first-use-cached per-target
+  ``{"username": str, "password": str}`` dict with the
+  "missing-key → ``RuntimeError`` naming target" contract.
+* A flexible session-login helper for products that POST credentials and
+  consume a token from the response (vRLI specifically; vROps doesn't
+  establish a session, Fleet doesn't either).
+
+This module is the common subset — what's genuinely identical across the
+three consumers. Anything per-connector (response-token shape, downstream
+path, the 401-driven re-login loop around downstream calls) stays in the
+per-connector module.
+
+VCF Automation (#832) is intentionally **NOT** a consumer of this module.
+Its dual-plane auth (provider Basic → ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT
++ tenant JSON login → ``{token: ...}`` + vhost routing via ``--fqdn``) is
+bespoke and stays in the Automation connector.
+
+Lift sources
+------------
+
+Each helper is a verbatim lift from an existing connector, with the
+connector-specific names generalised:
+
+* ``basic_auth_header`` ← Harbor's ``_basic_auth_header``.
+* ``is_acceptable_auth_model`` ← Harbor's ``_is_acceptable_auth_model``.
+* The credentials cache + missing-key error shape ← Harbor's
+  ``HarborConnector._load_credentials`` (``connector.py`` L209-238).
+* ``vcf_session_login`` ← the session-create round-trip inside
+  :meth:`meho_backplane.connectors.nsx.connector.NsxConnector._session_token`
+  (``connector.py`` L213-279), pulled out of the 401-retry loop. The retry
+  loop stays in the consumer because the downstream call paths differ
+  per connector.
+
+Harbor / NSX / SDDC Manager keep their inlined copies — migrating them is
+out of scope per #369's cross-cutting note ("opportunistic later refactor
+only"). The downstream G3.6 skeletons import from here.
+
+References
+----------
+
+* Task: https://github.com/evoila/meho/issues/841
+* Parent initiative: https://github.com/evoila/meho/issues/369
+* Parent goal: https://github.com/evoila/meho/issues/214
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol, runtime_checkable
+
+import httpx
+import structlog
+
+from meho_backplane.connectors.schemas import AuthModel
+
+__all__ = [
+    "CredentialsCache",
+    "SessionLoginError",
+    "VcfCredentialsLoader",
+    "VcfTargetLike",
+    "basic_auth_header",
+    "is_acceptable_auth_model",
+    "load_credentials_from_vault",
+    "vcf_session_login",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Basic auth header
+# ---------------------------------------------------------------------------
+
+
+def basic_auth_header(username: str, password: str) -> str:
+    """Return the ``Authorization: Basic <b64>`` header value.
+
+    Encodes ``f"{username}:{password}"`` as UTF-8 then base64. Lifted from
+    :func:`meho_backplane.connectors.harbor.connector._basic_auth_header`
+    verbatim — VCF management-plane products that use HTTP Basic (vROps,
+    Fleet, and the *login round-trip* of vRLI) all encode the same way.
+    """
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+# ---------------------------------------------------------------------------
+# Auth-model gating
+# ---------------------------------------------------------------------------
+
+
+def is_acceptable_auth_model(value: Any) -> bool:
+    """Return ``True`` iff *value* is ``SHARED_SERVICE_ACCOUNT`` (any form) or ``None``.
+
+    Accepts:
+
+    * the :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` enum member,
+    * its string value (``"shared_service_account"``),
+    * ``None`` — the "auth_model column not yet populated" sentinel for
+      pre-G0.3 targets.
+
+    Anything else returns ``False`` and the caller raises with a clear
+    message naming both the target and the requested mode. Same predicate
+    the Harbor / NSX / SDDC Manager connectors use today; lifted into this
+    module so the four VCF skeletons share one canonical implementation.
+    """
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+# ---------------------------------------------------------------------------
+# Target shape Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class VcfTargetLike(Protocol):
+    """Minimum target shape the VCF management-plane connectors read.
+
+    Structural Protocol — the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` (G0.3 #224) satisfies this unchanged.
+
+    Fields:
+
+    * ``name`` — per-target cache key (credentials + session token).
+    * ``host`` / ``port`` — forwarded to
+      :meth:`meho_backplane.connectors.adapters.http.HttpConnector._base_url`.
+    * ``secret_ref`` — Vault path the loader resolves to a
+      ``{"username": str, "password": str}`` dict.
+    * ``auth_model`` — checked at the boundary by
+      :func:`is_acceptable_auth_model`.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+
+
+# ---------------------------------------------------------------------------
+# Credentials loader Protocol + default stub
+# ---------------------------------------------------------------------------
+
+
+VcfCredentialsLoader = Callable[[VcfTargetLike], Awaitable[dict[str, str]]]
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+Injected on connector construction so:
+
+* Production deploys override the default loader once the operator-context
+  per-target Vault credential read is wired for the VCF connectors.
+* Unit tests pass a stub returning canned credentials.
+* Integration tests pass a loader yielding lab-account credentials.
+
+The return type is the looser ``dict[str, str]`` rather than a
+``SessionCredentials`` Protocol because Python ``Protocol`` instances aren't
+runtime-constructible without a matching concrete class — production code
+returns a plain dict and consumers read by key.
+"""
+
+
+async def load_credentials_from_vault(target: VcfTargetLike) -> dict[str, str]:
+    """Default credential loader — Vault read by ``target.secret_ref``.
+
+    Deliberate stub mirroring
+    :func:`meho_backplane.connectors.harbor.session.load_credentials_from_vault`
+    and :func:`meho_backplane.connectors.nsx.session.load_session_credentials_from_vault`:
+    a production caller without an explicit loader override receives a clear
+    error rather than a silent fallback or a hallucinated credential pair.
+
+    The supported workaround is to inject a custom loader on the
+    consuming connector at construction time. Tracked under the open
+    Goal #214 (Connector parity); once the operator-context Vault read
+    lands, this stub becomes the live implementation.
+    """
+    raise NotImplementedError(
+        "load_credentials_from_vault is a deliberate stub: the operator-context "
+        "per-target Vault credential read is not yet wired for the VCF "
+        f"management-plane connectors; target={target.name!r} "
+        f"secret_ref={target.secret_ref!r}. Workaround: inject a custom "
+        "credentials_loader on the connector at construction time. Tracked "
+        "under open Goal #214 (Connector parity): "
+        "https://github.com/evoila/meho/issues/214"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Credentials cache (load-once-per-target with missing-key error contract)
+# ---------------------------------------------------------------------------
+
+
+class CredentialsCache:
+    """Per-target ``{"username": str, "password": str}`` cache.
+
+    Composes into a connector via ``self._creds = CredentialsCache(loader)``
+    rather than inheritance — each VCF connector keeps a flat layout and the
+    cache is one of several collaborating helpers.
+
+    The lock serialises concurrent first-use callers for the same target;
+    subsequent calls take the fast path under the same lock. Missing keys
+    in the loader-returned dict raise :exc:`RuntimeError` naming the target
+    and the missing key, so operators can identify a misconfigured Vault
+    path (a typo in a production loader otherwise surfaces as a confusing
+    ``KeyError`` deep inside the consuming code).
+
+    The cache is keyed on ``target.name``. Production deploys with multiple
+    connector instances each get their own cache — there is no
+    process-global cache by design, so connector-instance teardown
+    (``aclose``) clears credentials immediately.
+    """
+
+    def __init__(
+        self,
+        loader: VcfCredentialsLoader,
+        *,
+        product_label: str,
+    ) -> None:
+        """Construct an empty cache.
+
+        ``product_label`` is the connector identifier (e.g. ``"vrops"``,
+        ``"vrli"``, ``"vcf-fleet"``) used in error messages and the
+        ``structlog`` ``connector=...`` field so operators reading audit
+        logs can attribute "credentials loaded" events to a specific
+        connector.
+        """
+        self._loader = loader
+        self._product_label = product_label
+        self._cache: dict[str, dict[str, str]] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, target: VcfTargetLike) -> dict[str, str]:
+        """Return the cached credentials for *target*, loading on first use.
+
+        Raises :exc:`RuntimeError` if the loader returns a dict missing
+        ``"username"`` or ``"password"``. The error message names both the
+        target and the missing key.
+        """
+        async with self._lock:
+            cached = self._cache.get(target.name)
+            if cached is not None:
+                return cached
+            raw = await self._loader(target)
+            for required in ("username", "password"):
+                if required not in raw:
+                    raise RuntimeError(
+                        f"{self._product_label} credentials loader for target "
+                        f"{target.name!r} returned a dict missing required key "
+                        f"{required!r}; need "
+                        "{'username': str, 'password': str}"
+                    )
+            self._cache[target.name] = raw
+            _log.info(
+                "vcf_credentials_loaded",
+                connector=self._product_label,
+                target=target.name,
+                host=target.host,
+            )
+            return raw
+
+    def invalidate(self, target: VcfTargetLike) -> None:
+        """Drop the cached credentials for *target*.
+
+        Synchronous because callers hold no lock on read-only invalidation
+        decisions; concurrent ``get`` callers re-acquire the lock and
+        re-load. Used by the consuming connector after a credentials
+        rotation event (rare; surfaced via a future admin endpoint).
+        """
+        self._cache.pop(target.name, None)
+
+    def clear(self) -> None:
+        """Drop all cached credentials.
+
+        Called by the consuming connector's ``aclose`` so credentials don't
+        outlive the connector instance.
+        """
+        self._cache.clear()
+
+    @property
+    def cached_targets(self) -> frozenset[str]:
+        """Frozen view of the cached target names (read-only, for tests/audit)."""
+        return frozenset(self._cache)
+
+
+# ---------------------------------------------------------------------------
+# Session-login helper (vRLI consumer)
+# ---------------------------------------------------------------------------
+
+
+class SessionLoginError(RuntimeError):
+    """Raised when a VCF session-login POST fails or returns an unusable response.
+
+    Wraps the underlying :exc:`httpx.HTTPStatusError` (when the appliance
+    returned a non-2xx) or signals a structurally invalid 2xx response
+    (missing token in headers or body). Carries the target name so
+    operator-facing audit rows can identify which target failed.
+    """
+
+
+SessionTokenExtractor = Callable[[httpx.Response], str | None]
+"""Pull the session token out of a :class:`httpx.Response`.
+
+Returns ``None`` if the token isn't present; the helper then raises
+:exc:`SessionLoginError`. Consumers pass an extractor matching their
+product's response shape — vRLI reads ``response.headers["sessionId"]``,
+a hypothetical product reading from the body uses
+``lambda r: r.json().get("sessionId")``, etc.
+"""
+
+
+SessionPayloadBuilder = Callable[[str, str], dict[str, Any]]
+"""Build the JSON body for the session-login POST from ``(username, password)``.
+
+vRLI's body shape is
+``{"username": ..., "password": ..., "provider": "Local"}`` (or
+``"ActiveDirectory"``); a different consumer using basic ``{"username":
+..., "password": ...}`` passes that. The connector owns the choice — this
+helper is just the round-trip.
+"""
+
+
+async def vcf_session_login(
+    client: httpx.AsyncClient,
+    path: str,
+    *,
+    username: str,
+    password: str,
+    target_name: str,
+    payload_builder: SessionPayloadBuilder | None = None,
+    token_extractor: SessionTokenExtractor,
+    request_headers: dict[str, str] | None = None,
+) -> str:
+    """POST credentials to *path* and return the extracted session token.
+
+    The login round-trip itself — the helper most callers want. The
+    surrounding "single-retry-on-401 around *downstream* calls" loop stays
+    in the consumer because the downstream paths and the request mechanics
+    (form-encoded vs JSON, header vs body) differ per connector.
+
+    Parameters:
+
+    * ``client`` — a pre-pooled :class:`httpx.AsyncClient` bound to the
+      target's base URL. The connector owns the client pool; this helper
+      doesn't create or close clients.
+    * ``path`` — the session-login path (e.g. ``"/api/v2/sessions"`` for
+      vRLI).
+    * ``username`` / ``password`` — the credentials.
+    * ``target_name`` — for the error message + the structlog event.
+    * ``payload_builder`` — builds the JSON body. If ``None``, the default
+      is ``{"username": username, "password": password}``. vRLI passes a
+      builder that adds the ``"provider"`` field.
+    * ``token_extractor`` — pulls the token out of the response (header or
+      body). Required — no sensible default exists because the four
+      products diverge here.
+    * ``request_headers`` — optional headers to set on the POST (e.g.
+      ``Content-Type: application/json``, ``Accept: application/json``).
+      The client's default headers are not modified.
+
+    Raises:
+
+    * :exc:`SessionLoginError` if the POST returns a non-2xx (the cause
+      chain carries the underlying :exc:`httpx.HTTPStatusError`) or if
+      the 2xx response doesn't yield a non-empty token via
+      ``token_extractor``. The error message names the target.
+
+    Returns the non-empty session token string.
+
+    Does **not** raise on transient network errors at this layer — the
+    consuming connector's tenacity retry decorator on
+    :meth:`HttpConnector._request_json` already covers connection-error
+    retries; the session-login POST going through ``client.post`` directly
+    bypasses that decorator on purpose so this helper's contract is "one
+    attempt, surface the failure cleanly".
+    """
+    if payload_builder is not None:
+        body = payload_builder(username, password)
+    else:
+        body = {"username": username, "password": password}
+    try:
+        resp = await client.post(path, json=body, headers=request_headers)
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise SessionLoginError(
+            f"vcf session-login failed for target {target_name!r}: "
+            f"POST {path} returned HTTP {exc.response.status_code}"
+        ) from exc
+    token = token_extractor(resp)
+    if not token:
+        raise SessionLoginError(
+            f"vcf session-login for target {target_name!r}: "
+            f"POST {path} returned {resp.status_code} but token_extractor "
+            f"yielded no token"
+        )
+    _log.info(
+        "vcf_session_established",
+        target=target_name,
+        path=path,
+    )
+    return token

--- a/backend/tests/fixtures/vcf/__init__.py
+++ b/backend/tests/fixtures/vcf/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded HTTP fixtures for the four VCF management-plane connectors.
+
+Each consumer's per-connector subdirectory holds JSON-serialised
+``RecordedResponse`` files (one per endpoint + scenario) replayed by the
+E2E tests in G3.6-T15 / T18 / T21 / T24 (#837/#838/#839/#840).
+
+The refresh tooling lives in :mod:`refresh` — an operator-run script that
+hits a live appliance, records responses, redacts secrets, and writes them
+into ``backend/tests/fixtures/vcf/<connector>/`` for replay.
+
+See ``docs/cross-repo/vcf-fixture-refresh.md`` for the operator recipe.
+"""

--- a/backend/tests/fixtures/vcf/refresh.py
+++ b/backend/tests/fixtures/vcf/refresh.py
@@ -1,0 +1,531 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture refresh tool for the four VCF management-plane connectors.
+
+Hits a live VCF appliance, records HTTP responses, redacts well-known
+secret fields, and writes JSON-serialised ``RecordedResponse`` files into
+``backend/tests/fixtures/vcf/<connector>/`` for the E2E tests in #837 /
+#838 / #839 / #840 to replay.
+
+Operator-run only (the four products have no public CI simulator — same
+constraint NSX and SDDC Manager hit). Not invoked from automated tests.
+
+Usage::
+
+    uv run python backend/tests/fixtures/vcf/refresh.py \\
+        --connector vcf-operations \\
+        --target vrops-a \\
+        --host vrops-a.lab.example.com \\
+        --username admin \\
+        --password "$VROPS_PASSWORD" \\
+        --output-dir backend/tests/fixtures/vcf/vcf-operations
+
+See ``docs/cross-repo/vcf-fixture-refresh.md`` for the full recipe and
+the credential / safety caveats.
+
+Safety
+------
+
+* Refuses to overwrite an existing fixture file without ``--force``. Stale
+  fixtures from a prior appliance version are silently masked otherwise
+  (one of NSX-T's bigger fixture-debt incidents in 2025-Q2).
+* Redacts ``Set-Cookie``, ``Authorization``, ``sessionId``, and
+  ``X-XSRF-TOKEN`` from response headers; redacts ``password`` /
+  ``session_token`` / ``sessionId`` keys from JSON response bodies. The
+  redaction list is configurable via ``--redact-header`` /
+  ``--redact-json-key`` flags.
+* ``--dry-run`` records nothing — prints the would-be operations for the
+  operator to eyeball.
+* Refuses to run with no ``--insecure`` flag against an appliance with a
+  self-signed cert; operators run against lab appliances with proper certs
+  or pass ``--insecure`` explicitly.
+
+The fixture format is intentionally human-readable JSON (not the pickled
+``httpx.Response`` form) so a maintainer can hand-edit a redacted field or
+inspect what's checked in. The replay side reads the same JSON and
+constructs a respx response from it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import logging
+import sys
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    SessionLoginError,
+    basic_auth_header,
+    vcf_session_login,
+)
+
+_log = logging.getLogger("vcf.fixture.refresh")
+
+
+# ---------------------------------------------------------------------------
+# Recorded response shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RecordedResponse:
+    """JSON-serialisable snapshot of an HTTP response.
+
+    Stored as ``backend/tests/fixtures/vcf/<connector>/<fixture-name>.json``;
+    the E2E replay layer reads this back and builds a
+    :class:`httpx.Response` for ``respx`` to mock with.
+
+    ``request_path`` carries the path that was hit so a maintainer can
+    diff fixtures across appliance versions without re-deriving the path
+    from the filename.
+    """
+
+    fixture_name: str
+    request_method: str
+    request_path: str
+    response_status: int
+    response_headers: dict[str, str]
+    response_body: Any  # JSON-deserialised dict / list / scalar
+    recorded_at: str  # ISO-8601 UTC
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(frozen=True)
+class FixtureCall:
+    """A single endpoint to record.
+
+    ``auth`` is one of:
+
+    * ``"basic"`` — Basic auth from the operator-provided credentials.
+    * ``"session"`` — POST credentials to ``session_login_path``, extract
+      token via ``session_token_header``, send subsequent calls with
+      ``Authorization: Bearer <token>``.
+    * ``"none"`` — unauthenticated (probe / version endpoints).
+
+    ``params`` is forwarded to ``httpx.AsyncClient.get`` as the query
+    string. ``fixture_name`` becomes the on-disk filename stem.
+    """
+
+    fixture_name: str
+    method: str
+    path: str
+    params: dict[str, str] = field(default_factory=dict)
+    auth: str = "basic"  # "basic" | "session" | "none"
+
+
+@dataclass(frozen=True)
+class ConnectorRecipe:
+    """All endpoints the refresh tool captures for one product."""
+
+    connector_id: str  # "vcf-operations" | "vcf-logs" | "vcf-fleet" | "vcf-automation"
+    calls: tuple[FixtureCall, ...]
+    session_login_path: str | None = None  # only when any call uses auth="session"
+    session_token_header: str | None = None
+    session_payload_provider: str | None = None  # vRLI provider field; None ⇒ omit
+
+
+# ---------------------------------------------------------------------------
+# Per-connector recipes
+# ---------------------------------------------------------------------------
+#
+# The recipes are intentionally minimal at first ship — enough to cover the
+# version + about + a single list call per connector so the E2E tests have
+# something to replay. The downstream skeletons (#829/#830/#831) extend the
+# recipes as they add ops.
+
+_VCF_OPERATIONS_RECIPE = ConnectorRecipe(
+    connector_id="vcf-operations",
+    calls=(
+        FixtureCall(
+            fixture_name="versions-current",
+            method="GET",
+            path="/suite-api/api/versions/current",
+            auth="none",
+        ),
+        FixtureCall(
+            fixture_name="adapters",
+            method="GET",
+            path="/suite-api/api/adapters",
+            auth="basic",
+        ),
+    ),
+)
+
+_VCF_LOGS_RECIPE = ConnectorRecipe(
+    connector_id="vcf-logs",
+    calls=(
+        FixtureCall(
+            fixture_name="version",
+            method="GET",
+            path="/api/v2/version",
+            auth="none",
+        ),
+        FixtureCall(
+            fixture_name="cluster-info",
+            method="GET",
+            path="/api/v2/cluster",
+            auth="session",
+        ),
+    ),
+    session_login_path="/api/v2/sessions",
+    session_token_header="sessionId",
+    session_payload_provider="Local",
+)
+
+_VCF_FLEET_RECIPE = ConnectorRecipe(
+    connector_id="vcf-fleet",
+    calls=(
+        FixtureCall(
+            fixture_name="about",
+            method="GET",
+            path="/lcm/lcops/api/v2/about",
+            auth="none",
+        ),
+        FixtureCall(
+            fixture_name="datacenters",
+            method="GET",
+            path="/lcm/api/v2/datacenters",
+            auth="basic",
+        ),
+    ),
+)
+
+_RECIPES: dict[str, ConnectorRecipe] = {
+    "vcf-operations": _VCF_OPERATIONS_RECIPE,
+    "vcf-logs": _VCF_LOGS_RECIPE,
+    "vcf-fleet": _VCF_FLEET_RECIPE,
+    # vcf-automation has dual-plane bespoke auth and skips this shared
+    # tooling — its E2E fixtures live alongside the Automation connector
+    # itself in #840. Listed here in the comment so future maintainers
+    # don't add it back by reflex.
+}
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_REDACT_HEADERS: frozenset[str] = frozenset(
+    {"authorization", "set-cookie", "sessionid", "x-xsrf-token", "cookie"}
+)
+
+_DEFAULT_REDACT_JSON_KEYS: frozenset[str] = frozenset(
+    {"password", "session_token", "sessionid", "token", "access_token", "refresh_token"}
+)
+
+_REDACTED_VALUE = "<redacted>"
+
+
+def _redact_headers(headers: dict[str, str], denylist: Iterable[str]) -> dict[str, str]:
+    """Return a copy of *headers* with denylisted names (case-insensitive) redacted."""
+    deny_lower = {h.lower() for h in denylist}
+    return {k: (_REDACTED_VALUE if k.lower() in deny_lower else v) for k, v in headers.items()}
+
+
+def _redact_json(value: Any, denylist: Iterable[str]) -> Any:
+    """Walk a JSON-deserialised structure and redact denylisted keys.
+
+    Case-insensitive on key names. Nested dicts and lists are walked
+    recursively. Non-dict/non-list values are returned as-is.
+    """
+    deny_lower = {k.lower() for k in denylist}
+    if isinstance(value, dict):
+        return {
+            k: (_REDACTED_VALUE if k.lower() in deny_lower else _redact_json(v, denylist))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_json(item, denylist) for item in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Recording
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RecordingOptions:
+    """Per-run knobs."""
+
+    connector: str
+    target_name: str
+    host: str
+    port: int
+    username: str
+    password: str
+    output_dir: Path
+    insecure: bool
+    force: bool
+    dry_run: bool
+    redact_headers: frozenset[str]
+    redact_json_keys: frozenset[str]
+
+
+async def _record_one(
+    client: httpx.AsyncClient,
+    call: FixtureCall,
+    *,
+    options: RecordingOptions,
+    session_token: str | None,
+) -> RecordedResponse:
+    """Execute *call* against *client* and return a redacted snapshot."""
+    headers: dict[str, str] = {}
+    if call.auth == "basic":
+        headers["Authorization"] = basic_auth_header(options.username, options.password)
+    elif call.auth == "session":
+        if session_token is None:
+            raise RuntimeError(
+                f"call {call.fixture_name!r} requires session auth but no "
+                "session_token was established; check the recipe's "
+                "session_login_path"
+            )
+        headers["Authorization"] = f"Bearer {session_token}"
+    elif call.auth == "none":
+        pass
+    else:
+        raise ValueError(f"unknown auth mode {call.auth!r} for {call.fixture_name!r}")
+
+    _log.info("recording %s %s %s", call.method, call.path, call.params or "")
+    resp = await client.request(call.method, call.path, params=call.params or None, headers=headers)
+    try:
+        body: Any = resp.json()
+    except ValueError:
+        body = resp.text
+
+    from datetime import UTC, datetime
+
+    return RecordedResponse(
+        fixture_name=call.fixture_name,
+        request_method=call.method,
+        request_path=call.path,
+        response_status=resp.status_code,
+        response_headers=_redact_headers(dict(resp.headers), options.redact_headers),
+        response_body=_redact_json(body, options.redact_json_keys),
+        recorded_at=datetime.now(UTC).isoformat(timespec="seconds"),
+    )
+
+
+def _write_fixture(snapshot: RecordedResponse, options: RecordingOptions) -> Path:
+    """Write a single fixture to disk; respect ``--dry-run`` and ``--force``."""
+    target_path = options.output_dir / f"{snapshot.fixture_name}.json"
+    if options.dry_run:
+        _log.info("[dry-run] would write %s", target_path)
+        return target_path
+    if target_path.exists() and not options.force:
+        raise FileExistsError(
+            f"fixture {target_path} already exists; pass --force to overwrite "
+            "(stale fixtures from a prior appliance version mask drift)"
+        )
+    options.output_dir.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(
+        json.dumps(snapshot.to_json_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _log.info("wrote %s", target_path)
+    return target_path
+
+
+async def _refresh(options: RecordingOptions) -> list[Path]:
+    """Run the full refresh for one connector. Returns the list of written paths."""
+    recipe = _RECIPES.get(options.connector)
+    if recipe is None:
+        raise SystemExit(f"unknown connector {options.connector!r}; supported: {sorted(_RECIPES)}")
+
+    base_url = f"https://{options.host}:{options.port}"
+    verify_arg: bool = not options.insecure
+
+    written: list[Path] = []
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        verify=verify_arg,
+        timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
+    ) as client:
+        session_token: str | None = None
+        if any(call.auth == "session" for call in recipe.calls):
+            if recipe.session_login_path is None or recipe.session_token_header is None:
+                raise SystemExit(
+                    f"recipe for {options.connector!r} lists session-auth calls "
+                    "but is missing session_login_path / session_token_header"
+                )
+
+            def _extractor(
+                resp: httpx.Response,
+                header: str = recipe.session_token_header,
+            ) -> str | None:
+                value = resp.headers.get(header)
+                return value if value is None else str(value)
+
+            payload_builder: Callable[[str, str], dict[str, Any]] | None = None
+            if recipe.session_payload_provider is not None:
+                provider = recipe.session_payload_provider
+
+                def payload_builder(u: str, p: str, _provider: str = provider) -> dict[str, Any]:
+                    return {"username": u, "password": p, "provider": _provider}
+
+            try:
+                session_token = await vcf_session_login(
+                    client,
+                    recipe.session_login_path,
+                    username=options.username,
+                    password=options.password,
+                    target_name=options.target_name,
+                    payload_builder=payload_builder,
+                    token_extractor=_extractor,
+                )
+            except SessionLoginError as exc:
+                raise SystemExit(f"session-login failed: {exc}") from exc
+
+        for call in recipe.calls:
+            snapshot = await _record_one(client, call, options=options, session_token=session_token)
+            written.append(_write_fixture(snapshot, options))
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="vcf-fixture-refresh",
+        description=(
+            "Record HTTP responses from a live VCF management-plane appliance "
+            "into backend/tests/fixtures/vcf/<connector>/ for E2E replay."
+        ),
+    )
+    parser.add_argument(
+        "--connector",
+        required=True,
+        choices=sorted(_RECIPES),
+        help="Connector identifier (matches the recipe registry).",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="Logical target name (used in log messages; not a hostname).",
+    )
+    parser.add_argument("--host", required=True, help="Appliance hostname.")
+    parser.add_argument("--port", type=int, default=443, help="Appliance port (default 443).")
+    parser.add_argument("--username", required=True, help="Service-account username.")
+    parser.add_argument(
+        "--password",
+        required=True,
+        help=(
+            "Service-account password. Prefer passing via $VCF_PASSWORD env var "
+            'and `--password "$VCF_PASSWORD"` so the value doesn\'t land in shell '
+            "history."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Destination directory (default: backend/tests/fixtures/vcf/<connector>/ "
+            "relative to the repo root). Created if missing."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing fixtures (refuses by default to mask drift).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Hit the appliance + print would-be writes; do not write anything.",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Skip TLS verification (lab appliances with self-signed certs).",
+    )
+    parser.add_argument(
+        "--redact-header",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help=(
+            "Add a header name (case-insensitive) to the redaction denylist. "
+            "Defaults: Authorization, Set-Cookie, sessionId, X-XSRF-TOKEN, Cookie."
+        ),
+    )
+    parser.add_argument(
+        "--redact-json-key",
+        action="append",
+        default=[],
+        metavar="KEY",
+        help=(
+            "Add a JSON key (case-insensitive) to the response-body redaction "
+            "denylist. Defaults: password, session_token, sessionId, token, "
+            "access_token, refresh_token."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="DEBUG-level logging.",
+    )
+    return parser
+
+
+def _resolve_output_dir(connector: str, override: Path | None) -> Path:
+    if override is not None:
+        return override
+    # Place fixtures alongside this script so the layout matches what the
+    # replay tests expect, regardless of where the operator invoked the
+    # script from.
+    return Path(__file__).resolve().parent / connector
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    options = RecordingOptions(
+        connector=args.connector,
+        target_name=args.target,
+        host=args.host,
+        port=args.port,
+        username=args.username,
+        password=args.password,
+        output_dir=_resolve_output_dir(args.connector, args.output_dir),
+        insecure=args.insecure,
+        force=args.force,
+        dry_run=args.dry_run,
+        redact_headers=_DEFAULT_REDACT_HEADERS | frozenset(args.redact_header),
+        redact_json_keys=_DEFAULT_REDACT_JSON_KEYS | frozenset(args.redact_json_key),
+    )
+
+    try:
+        written = asyncio.run(_refresh(options))
+    except SystemExit:
+        raise
+    except Exception as exc:
+        _log.error("fixture refresh failed: %s", exc)
+        return 1
+    _log.info("recorded %d fixture(s) under %s", len(written), options.output_dir)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entrypoint
+    sys.exit(main())

--- a/backend/tests/fixtures/vcf/refresh.py
+++ b/backend/tests/fixtures/vcf/refresh.py
@@ -300,6 +300,18 @@ async def _record_one(
 
     _log.info("recording %s %s %s", call.method, call.path, call.params or "")
     resp = await client.request(call.method, call.path, params=call.params or None, headers=headers)
+    if resp.status_code >= 400:
+        # Refuse to write a vendor error payload as a fixture — the recorded-
+        # fixture E2E suites in #837/#838/#839/#840 replay these as the canonical
+        # "appliance returned X" shape, and a 4xx/5xx body would poison the set.
+        # main()'s outer ``except Exception`` returns exit code 1, so the
+        # operator sees the failure immediately and can rerun once the
+        # appliance call is fixed.
+        raise RuntimeError(
+            f"{call.fixture_name}: {call.method} {call.path} returned HTTP "
+            f"{resp.status_code}; refusing to record a non-2xx response as a "
+            f"fixture (body[:200]={resp.text[:200]!r})"
+        )
     try:
         body: Any = resp.json()
     except ValueError:

--- a/backend/tests/test_connectors_vcf_shared_auth.py
+++ b/backend/tests/test_connectors_vcf_shared_auth.py
@@ -1,0 +1,633 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :mod:`meho_backplane.connectors._shared.vcf_auth` (G3.6-T13 #841).
+
+Covers the four reusable helpers per the issue's acceptance criteria:
+
+1. ``basic_auth_header`` — header value shape.
+2. ``is_acceptable_auth_model`` — accept ``SHARED_SERVICE_ACCOUNT`` (enum +
+   string) + ``None``; reject ``per_user`` / ``impersonation`` / unknown.
+3. ``CredentialsCache`` — load-once, cache-per-target, missing-key →
+   ``RuntimeError`` naming target.
+4. ``vcf_session_login`` — POST credentials, return token, raise
+   :exc:`SessionLoginError` on 401 or empty-token response.
+
+The downstream-call 401-retry-once loop is NOT tested here — that lives in
+the consuming connector module (vRLI #830 owns its retry shape). This file
+covers only the *login round-trip* this module is responsible for.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    CredentialsCache,
+    SessionLoginError,
+    VcfTargetLike,
+    basic_auth_header,
+    is_acceptable_auth_model,
+    load_credentials_from_vault,
+    vcf_session_login,
+)
+from meho_backplane.connectors.schemas import AuthModel
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies VcfTargetLike Protocol structurally
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET_A = _StubTarget(
+    name="vrops-a",
+    host="vrops-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/vcf-operations/vrops-a",
+)
+_TARGET_B = _StubTarget(
+    name="vrops-b",
+    host="vrops-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/vcf-operations/vrops-b",
+)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode ``Authorization: Basic <b64>`` into ``(username, password)``."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# basic_auth_header
+# ---------------------------------------------------------------------------
+
+
+def test_basic_auth_header_encodes_username_and_password() -> None:
+    header = basic_auth_header("admin", "stub-password")
+    assert header.startswith("Basic ")
+    username, password = _decode_basic_auth(header)
+    assert username == "admin"
+    assert password == "stub-password"
+
+
+def test_basic_auth_header_handles_non_ascii_password() -> None:
+    """Vault may legitimately return passwords with UTF-8 codepoints."""
+    header = basic_auth_header("admin", "pässwörd-€")
+    username, password = _decode_basic_auth(header)
+    assert username == "admin"
+    assert password == "pässwörd-€"
+
+
+def test_basic_auth_header_preserves_special_username_forms() -> None:
+    """Some vendor account forms include `$`, `@`, `\\` — passed verbatim.
+
+    No vendor in the four VCF products uses these forms today, but the
+    helper has no business mangling whatever Vault returns.
+    """
+    header = basic_auth_header("svc\\admin@local", "p")
+    username, _ = _decode_basic_auth(header)
+    assert username == "svc\\admin@local"
+
+
+# ---------------------------------------------------------------------------
+# is_acceptable_auth_model
+# ---------------------------------------------------------------------------
+
+
+def test_is_acceptable_auth_model_accepts_enum_member() -> None:
+    assert is_acceptable_auth_model(AuthModel.SHARED_SERVICE_ACCOUNT) is True
+
+
+def test_is_acceptable_auth_model_accepts_string_value() -> None:
+    assert is_acceptable_auth_model("shared_service_account") is True
+
+
+def test_is_acceptable_auth_model_accepts_none_for_pre_g03_targets() -> None:
+    """The auth_model column is nullable for pre-G0.3 targets — treat as default."""
+    assert is_acceptable_auth_model(None) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        AuthModel.PER_USER,
+        AuthModel.PER_USER.value,
+        AuthModel.IMPERSONATION,
+        AuthModel.IMPERSONATION.value,
+        "unknown-mode",
+        "",
+        0,
+        False,
+    ],
+)
+def test_is_acceptable_auth_model_rejects_everything_else(value: object) -> None:
+    assert is_acceptable_auth_model(value) is False
+
+
+# ---------------------------------------------------------------------------
+# load_credentials_from_vault — default stub raises pointing at #214
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_credentials_loader_raises_until_g214_lands() -> None:
+    with pytest.raises(NotImplementedError) as exc_info:
+        await load_credentials_from_vault(_TARGET_A)
+    msg = str(exc_info.value)
+    assert "Goal #214" in msg
+    assert "vrops-a" in msg
+    assert "kv/data/vcf-operations/vrops-a" in msg
+
+
+# ---------------------------------------------------------------------------
+# CredentialsCache — happy path, caching, isolation
+# ---------------------------------------------------------------------------
+
+
+async def _stub_loader(_target: VcfTargetLike) -> dict[str, str]:
+    return {"username": "admin", "password": "stub-password"}
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_loads_and_returns_keys() -> None:
+    cache = CredentialsCache(_stub_loader, product_label="vrops")
+    creds = await cache.get(_TARGET_A)
+    assert creds == {"username": "admin", "password": "stub-password"}
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_reuses_value_across_calls() -> None:
+    """Second get() against the same target does NOT re-invoke the loader."""
+    call_count = 0
+
+    async def _counting_loader(_target: VcfTargetLike) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "admin", "password": "stub-password"}
+
+    cache = CredentialsCache(_counting_loader, product_label="vrops")
+    a = await cache.get(_TARGET_A)
+    b = await cache.get(_TARGET_A)
+    assert a == b
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_isolates_per_target() -> None:
+    """Two targets get two distinct cache entries; no cross-target leakage."""
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: VcfTargetLike) -> dict[str, str]:
+        call_log.append(target.name)
+        return {"username": f"svc-{target.name}", "password": "pass"}
+
+    cache = CredentialsCache(_tracking_loader, product_label="vrli")
+    a = await cache.get(_TARGET_A)
+    b = await cache.get(_TARGET_B)
+    assert a["username"] == "svc-vrops-a"
+    assert b["username"] == "svc-vrops-b"
+    assert call_log == ["vrops-a", "vrops-b"]
+    assert cache.cached_targets == frozenset({"vrops-a", "vrops-b"})
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_invalidate_drops_only_that_target() -> None:
+    cache = CredentialsCache(_stub_loader, product_label="vcf-fleet")
+    await cache.get(_TARGET_A)
+    await cache.get(_TARGET_B)
+    cache.invalidate(_TARGET_A)
+    assert cache.cached_targets == frozenset({"vrops-b"})
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_clear_drops_all_entries() -> None:
+    cache = CredentialsCache(_stub_loader, product_label="vcf-fleet")
+    await cache.get(_TARGET_A)
+    await cache.get(_TARGET_B)
+    cache.clear()
+    assert cache.cached_targets == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# CredentialsCache — missing-key error contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_missing_username_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: VcfTargetLike) -> dict[str, str]:
+        return {"password": "stub-password"}
+
+    cache = CredentialsCache(_bad_loader, product_label="vrops")
+    with pytest.raises(RuntimeError) as exc_info:
+        await cache.get(_TARGET_A)
+    msg = str(exc_info.value)
+    assert "vrops" in msg
+    assert "vrops-a" in msg
+    assert "username" in msg
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_missing_password_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: VcfTargetLike) -> dict[str, str]:
+        return {"username": "admin"}
+
+    cache = CredentialsCache(_bad_loader, product_label="vrli")
+    with pytest.raises(RuntimeError) as exc_info:
+        await cache.get(_TARGET_A)
+    msg = str(exc_info.value)
+    assert "vrli" in msg
+    assert "vrops-a" in msg
+    assert "password" in msg
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_missing_key_does_not_poison_subsequent_attempts() -> None:
+    """A first-call missing-key failure must not persist a half-built entry.
+
+    The contract is "load-once, succeed-or-raise". If the loader is fixed
+    between calls (e.g. an operator amends a Vault path), the next get()
+    must retry.
+    """
+    attempt = 0
+
+    async def _eventually_correct_loader(
+        _target: VcfTargetLike,
+    ) -> dict[str, str]:
+        nonlocal attempt
+        attempt += 1
+        if attempt == 1:
+            return {"username": "admin"}
+        return {"username": "admin", "password": "stub-password"}
+
+    cache = CredentialsCache(_eventually_correct_loader, product_label="vrops")
+    with pytest.raises(RuntimeError):
+        await cache.get(_TARGET_A)
+    # Second attempt must succeed; the cache must not have poisoned itself.
+    creds = await cache.get(_TARGET_A)
+    assert creds == {"username": "admin", "password": "stub-password"}
+    assert attempt == 2
+
+
+# ---------------------------------------------------------------------------
+# vcf_session_login — happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def _client() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(base_url="https://vrli-a.test.invalid") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_returns_token_from_response_header(
+    _client: httpx.AsyncClient,
+) -> None:
+    """vRLI shape: token is in the ``sessionId`` response header."""
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(
+            200,
+            json={},
+            headers={"sessionId": "header-token-xyz"},
+        )
+        token = await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            token_extractor=lambda r: r.headers.get("sessionId"),
+        )
+    assert token == "header-token-xyz"
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_returns_token_from_response_body(
+    _client: httpx.AsyncClient,
+) -> None:
+    """A hypothetical product returning the token in the JSON body."""
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"sessionId": "body-token-abc"})
+        token = await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            token_extractor=lambda r: r.json().get("sessionId"),
+        )
+    assert token == "body-token-abc"
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_uses_default_payload_when_none_provided(
+    _client: httpx.AsyncClient,
+) -> None:
+    """Default payload is ``{"username": ..., "password": ...}``."""
+    captured: dict[str, object] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured["json"] = httpx.Request(
+            request.method, request.url, content=request.content
+        ).read()
+        captured["content"] = request.content
+        return httpx.Response(200, headers={"sessionId": "tok"})
+
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").mock(side_effect=_capture)
+        await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            token_extractor=lambda r: r.headers.get("sessionId"),
+        )
+
+    body = captured["content"]
+    assert isinstance(body, bytes)
+    import json
+
+    parsed = json.loads(body.decode())
+    assert parsed == {"username": "admin", "password": "p"}
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_payload_builder_takes_precedence(
+    _client: httpx.AsyncClient,
+) -> None:
+    """vRLI shape: builder injects ``"provider"`` field."""
+    captured_bodies: list[bytes] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured_bodies.append(request.content)
+        return httpx.Response(200, headers={"sessionId": "tok"})
+
+    def _vrli_builder(username: str, password: str) -> dict[str, object]:
+        return {"username": username, "password": password, "provider": "Local"}
+
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").mock(side_effect=_capture)
+        await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            payload_builder=_vrli_builder,
+            token_extractor=lambda r: r.headers.get("sessionId"),
+        )
+
+    import json
+
+    parsed = json.loads(captured_bodies[0].decode())
+    assert parsed == {
+        "username": "admin",
+        "password": "p",
+        "provider": "Local",
+    }
+
+
+# ---------------------------------------------------------------------------
+# vcf_session_login — failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_401_raises_session_login_error_naming_target(
+    _client: httpx.AsyncClient,
+) -> None:
+    """A 401 on the login round-trip surfaces :exc:`SessionLoginError`.
+
+    Note: the *retry-once on 401 around downstream calls* is a separate
+    layer the consumer (vRLI #830) owns. The login round-trip itself
+    failing 401 means the credentials are wrong — no retry value.
+    """
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(401, json={"error": "invalid_credentials"})
+        with pytest.raises(SessionLoginError) as exc_info:
+            await vcf_session_login(
+                _client,
+                "/api/v2/sessions",
+                username="admin",
+                password="wrong",
+                target_name="vrli-a",
+                token_extractor=lambda r: r.headers.get("sessionId"),
+            )
+    msg = str(exc_info.value)
+    assert "vrli-a" in msg
+    assert "401" in msg
+    # The cause chain carries the underlying httpx error so callers can
+    # introspect status / response if they need to.
+    assert isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_500_also_raises_session_login_error(
+    _client: httpx.AsyncClient,
+) -> None:
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(500)
+        with pytest.raises(SessionLoginError) as exc_info:
+            await vcf_session_login(
+                _client,
+                "/api/v2/sessions",
+                username="admin",
+                password="p",
+                target_name="vrli-a",
+                token_extractor=lambda r: r.headers.get("sessionId"),
+            )
+    assert "500" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_2xx_without_token_raises_session_login_error(
+    _client: httpx.AsyncClient,
+) -> None:
+    """A 200 with no token in the configured location is structurally invalid.
+
+    A misbehaving proxy or a wrong endpoint (Basic-auth-only path responding
+    200 with no session header) would silently 401 every subsequent call;
+    fail loudly here instead.
+    """
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={})  # no sessionId header
+        with pytest.raises(SessionLoginError) as exc_info:
+            await vcf_session_login(
+                _client,
+                "/api/v2/sessions",
+                username="admin",
+                password="p",
+                target_name="vrli-a",
+                token_extractor=lambda r: r.headers.get("sessionId"),
+            )
+    msg = str(exc_info.value)
+    assert "vrli-a" in msg
+    assert "no token" in msg
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_empty_string_token_treated_as_no_token(
+    _client: httpx.AsyncClient,
+) -> None:
+    """An empty-string token from the extractor is treated as "no token".
+
+    The contract is ``bool(token)`` — empty strings, None, 0 all fall
+    through to the error. A vendor returning ``"sessionId: "`` (empty)
+    is a misconfigured appliance, not a successful login.
+    """
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={}, headers={"sessionId": ""})
+        with pytest.raises(SessionLoginError):
+            await vcf_session_login(
+                _client,
+                "/api/v2/sessions",
+                username="admin",
+                password="p",
+                target_name="vrli-a",
+                token_extractor=lambda r: r.headers.get("sessionId"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Re-login scenario covering the acceptance criterion's "401→re-login-once→
+# retry-once→success / second-401→RuntimeError" shape
+# ---------------------------------------------------------------------------
+#
+# The downstream-call 401-retry loop lives in the *consumer* (vRLI #830),
+# not in vcf_auth.py. But the acceptance criterion's last clause covers the
+# end-to-end story. This test simulates the consumer's loop using the
+# shared helper for the login round-trip to confirm the building blocks
+# fit together.
+
+
+@pytest.mark.asyncio
+async def test_simulated_consumer_relogin_flow_success(
+    _client: httpx.AsyncClient,
+) -> None:
+    """Simulate a vRLI-style 401→re-login→retry-once flow ending in success.
+
+    The consumer's loop calls ``vcf_session_login`` to get a token, makes
+    a downstream call, gets 401, calls ``vcf_session_login`` again, retries
+    the downstream call, and succeeds.
+    """
+    login_calls = 0
+
+    def _login_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal login_calls
+        login_calls += 1
+        return httpx.Response(200, json={}, headers={"sessionId": f"token-{login_calls}"})
+
+    downstream_calls = 0
+
+    def _downstream_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal downstream_calls
+        downstream_calls += 1
+        # First call 401s; second succeeds.
+        if downstream_calls == 1:
+            return httpx.Response(401)
+        return httpx.Response(200, json={"ok": True})
+
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").mock(side_effect=_login_handler)
+        mock.get("/api/v2/data").mock(side_effect=_downstream_handler)
+
+        token = await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            token_extractor=lambda r: r.headers.get("sessionId"),
+        )
+        assert token == "token-1"
+
+        # Consumer's downstream call.
+        resp1 = await _client.get("/api/v2/data", headers={"Authorization": f"Bearer {token}"})
+        assert resp1.status_code == 401
+
+        # Consumer re-logs in.
+        token = await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            token_extractor=lambda r: r.headers.get("sessionId"),
+        )
+        assert token == "token-2"
+
+        # Consumer retries the downstream call.
+        resp2 = await _client.get("/api/v2/data", headers={"Authorization": f"Bearer {token}"})
+        assert resp2.status_code == 200
+
+    assert login_calls == 2
+    assert downstream_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_simulated_consumer_relogin_second_401_surfaces_runtime_error(
+    _client: httpx.AsyncClient,
+) -> None:
+    """If the re-login itself 401s, ``SessionLoginError`` surfaces with the target name.
+
+    This is the acceptance criterion's "second-401 → RuntimeError" clause.
+    The consumer's loop would catch the first downstream 401, call
+    ``vcf_session_login`` again, and this raises.
+    """
+    login_calls = 0
+
+    def _login_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal login_calls
+        login_calls += 1
+        if login_calls == 1:
+            return httpx.Response(200, json={}, headers={"sessionId": "token-1"})
+        return httpx.Response(401, json={"error": "credentials_rotated"})
+
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").mock(side_effect=_login_handler)
+
+        # First login succeeds.
+        first_token = await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            token_extractor=lambda r: r.headers.get("sessionId"),
+        )
+        assert first_token == "token-1"
+
+        # Second login (simulating the consumer's re-login attempt) raises.
+        with pytest.raises(SessionLoginError) as exc_info:
+            await vcf_session_login(
+                _client,
+                "/api/v2/sessions",
+                username="admin",
+                password="p",
+                target_name="vrli-a",
+                token_extractor=lambda r: r.headers.get("sessionId"),
+            )
+
+    msg = str(exc_info.value)
+    assert "vrli-a" in msg
+    assert "401" in msg

--- a/backend/tests/test_connectors_vcf_shared_auth.py
+++ b/backend/tests/test_connectors_vcf_shared_auth.py
@@ -21,6 +21,7 @@ covers only the *login round-trip* this module is responsible for.
 from __future__ import annotations
 
 import base64
+import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
@@ -213,7 +214,7 @@ async def test_credentials_cache_invalidate_drops_only_that_target() -> None:
     cache = CredentialsCache(_stub_loader, product_label="vcf-fleet")
     await cache.get(_TARGET_A)
     await cache.get(_TARGET_B)
-    cache.invalidate(_TARGET_A)
+    await cache.invalidate(_TARGET_A)
     assert cache.cached_targets == frozenset({"vrops-b"})
 
 
@@ -222,7 +223,7 @@ async def test_credentials_cache_clear_drops_all_entries() -> None:
     cache = CredentialsCache(_stub_loader, product_label="vcf-fleet")
     await cache.get(_TARGET_A)
     await cache.get(_TARGET_B)
-    cache.clear()
+    await cache.clear()
     assert cache.cached_targets == frozenset()
 
 
@@ -346,9 +347,6 @@ async def test_vcf_session_login_uses_default_payload_when_none_provided(
     captured: dict[str, object] = {}
 
     def _capture(request: httpx.Request) -> httpx.Response:
-        captured["json"] = httpx.Request(
-            request.method, request.url, content=request.content
-        ).read()
         captured["content"] = request.content
         return httpx.Response(200, headers={"sessionId": "tok"})
 
@@ -365,8 +363,6 @@ async def test_vcf_session_login_uses_default_payload_when_none_provided(
 
     body = captured["content"]
     assert isinstance(body, bytes)
-    import json
-
     parsed = json.loads(body.decode())
     assert parsed == {"username": "admin", "password": "p"}
 
@@ -396,8 +392,6 @@ async def test_vcf_session_login_payload_builder_takes_precedence(
             payload_builder=_vrli_builder,
             token_extractor=lambda r: r.headers.get("sessionId"),
         )
-
-    import json
 
     parsed = json.loads(captured_bodies[0].decode())
     assert parsed == {

--- a/docs/codebase/connectors-vcf-auth-shared.md
+++ b/docs/codebase/connectors-vcf-auth-shared.md
@@ -41,8 +41,12 @@ The recorded-fixture refresh tool at
   `NotImplementedError` until Goal #214 lands the operator-context
   per-target Vault credential read.
 - **`CredentialsCache`** — small per-target cache around a
-  `VcfCredentialsLoader`. Methods: `get(target)`, `invalidate(target)`,
-  `clear()`. Property: `cached_targets`. Construct with
+  `VcfCredentialsLoader`. Methods are all coroutines:
+  `await get(target)`, `await invalidate(target)`, `await clear()` —
+  each acquires the same internal `asyncio.Lock` so a concurrent
+  rotation / connector-teardown cannot race an in-flight load (the
+  load-once-per-target contract downstream consumers depend on).
+  Property: `cached_targets`. Construct with
   `CredentialsCache(loader, product_label="vrops")` — the label is used
   in error messages so operators reading audit logs can attribute
   failures to a specific connector.

--- a/docs/codebase/connectors-vcf-auth-shared.md
+++ b/docs/codebase/connectors-vcf-auth-shared.md
@@ -1,0 +1,123 @@
+# Shared VCF management-plane auth helpers
+
+## Overview
+
+`backend/src/meho_backplane/connectors/_shared/vcf_auth.py` is the
+cross-connector module the three skeleton VCF management-plane connectors
+(VCF Operations / vROps #829, VCF Operations for Logs / vRLI #830, VCF
+Fleet #831) import for their auth scaffolding. G3.6-T13 (#841) landed it
+ahead of the three skeletons so each connector imports common helpers
+instead of duplicating four copies of the same code (Harbor / NSX / SDDC
+Manager each carry their own inlined copy — those stay; migrating them is
+opportunistic later refactor only).
+
+VCF Automation (#832) is **not** a consumer — its dual-plane auth
+(provider Basic → `X-VMWARE-VCLOUD-ACCESS-TOKEN` JWT + tenant JSON login
+→ `{token: ...}` + vhost routing via `--fqdn`) is bespoke and stays in
+the Automation connector module.
+
+The recorded-fixture refresh tool at
+`backend/tests/fixtures/vcf/refresh.py` is documented separately in
+`docs/cross-repo/vcf-fixture-refresh.md` (the operator-facing recipe).
+
+## Key types
+
+- **`basic_auth_header(username, password) -> str`** — returns the
+  `Authorization: Basic <b64>` header value. Lifted verbatim from
+  Harbor's `_basic_auth_header`.
+- **`is_acceptable_auth_model(value) -> bool`** — accepts the
+  `AuthModel.SHARED_SERVICE_ACCOUNT` enum member, its string value, or
+  `None` (pre-G0.3 column-not-yet-populated sentinel); rejects
+  everything else. Same predicate Harbor / NSX / SDDC Manager use.
+- **`VcfTargetLike`** — runtime-checkable Protocol with fields `name`,
+  `host`, `port`, `secret_ref`, `auth_model`. The concrete `Target`
+  model in `meho_backplane.targets` (G0.3 #224) satisfies it
+  structurally unchanged.
+- **`VcfCredentialsLoader`** — async callable resolving a target to
+  `{"username": ..., "password": ...}`. Injected on connector
+  construction; tests / pre-G0.3 production deploys override the
+  default Vault loader.
+- **`load_credentials_from_vault`** — default loader, stubbed
+  `NotImplementedError` until Goal #214 lands the operator-context
+  per-target Vault credential read.
+- **`CredentialsCache`** — small per-target cache around a
+  `VcfCredentialsLoader`. Methods: `get(target)`, `invalidate(target)`,
+  `clear()`. Property: `cached_targets`. Construct with
+  `CredentialsCache(loader, product_label="vrops")` — the label is used
+  in error messages so operators reading audit logs can attribute
+  failures to a specific connector.
+- **`SessionLoginError`** — typed `RuntimeError` subclass raised by
+  `vcf_session_login` on non-2xx response, transport error, or
+  structurally-invalid 2xx (empty token).
+- **`vcf_session_login(client, path, *, username, password, target_name,
+  payload_builder, token_extractor, request_headers)`** — POSTs
+  credentials to *path*, returns the extracted session token, or raises
+  `SessionLoginError` naming the target. The 401-retry-once loop around
+  *downstream* calls stays in the consuming connector — only the login
+  round-trip is shared.
+
+## Control flow
+
+### A vROps / Fleet consumer (HTTP Basic on every request)
+
+1. Consumer constructs `CredentialsCache(loader, product_label="vrops")`
+   in `__init__`.
+2. `auth_headers(target, raw_jwt)` checks
+   `is_acceptable_auth_model(target.auth_model)` → raises
+   `NotImplementedError` if rejected.
+3. `auth_headers` calls `await self._creds.get(target)` → returns
+   `{"username": ..., "password": ...}` from the cache (loading on
+   first use).
+4. `auth_headers` returns
+   `{"Authorization": basic_auth_header(creds["username"], creds["password"])}`.
+
+### A vRLI consumer (session-login + 401 retry loop)
+
+1. Consumer constructs `CredentialsCache(loader, product_label="vrli")`
+   **and** a per-target `_session_tokens: dict[str, str]` cache.
+2. `auth_headers(target, raw_jwt)` checks the auth-model gate.
+3. `auth_headers` returns the cached session token under the product's
+   token header name; on cache miss, calls a `_session_token(target)`
+   helper that calls `vcf_session_login(...)` with the vRLI
+   payload-builder (`{"username", "password", "provider": "Local"}`) and
+   the `sessionId` header extractor.
+4. The connector's own `_get_with_session_retry(target, path)` wraps
+   the inherited GET: on 401 from the downstream call, it invalidates
+   the cached session token and re-tries once. A second 401 raises.
+   This loop lives in the consumer because the downstream path differs
+   per connector.
+
+## Dependencies
+
+- **`httpx`** (>=0.27, 0.28.1 resolved) — the `AsyncClient` + `Response`
+  + `HTTPStatusError` API.
+- **`structlog`** — `vcf_credentials_loaded` and `vcf_session_established`
+  events, both carrying `target` and `host`.
+- **`meho_backplane.connectors.schemas.AuthModel`** — the boundary enum
+  the gate predicate accepts.
+
+## Known issues
+
+- The default `load_credentials_from_vault` is a stub (`NotImplementedError`)
+  pending Goal #214's operator-context per-target Vault credential read.
+  Same shape as Harbor's and NSX's default loaders — they all flip to
+  the live read in a single follow-up commit once #214 lands.
+- The `vcf_session_login` helper does not retry transient network errors
+  at this layer. The consumer's tenacity retry decorator on
+  `HttpConnector._request_json` covers downstream calls; the session-login
+  POST goes through `client.post` directly so failures surface cleanly.
+  If a future product needs retries on the login round-trip itself, the
+  helper grows an optional `retries=` parameter rather than a global
+  decorator (different consumers have different idempotency expectations).
+
+## References
+
+- Task: https://github.com/evoila/meho/issues/841
+- Parent Initiative: https://github.com/evoila/meho/issues/369
+- Parent Goal: https://github.com/evoila/meho/issues/214
+- Recorded-fixture refresh: `docs/cross-repo/vcf-fixture-refresh.md`.
+- Lift sources:
+  `backend/src/meho_backplane/connectors/harbor/connector.py`
+  (`_basic_auth_header`, `_is_acceptable_auth_model`, `_load_credentials`),
+  `backend/src/meho_backplane/connectors/nsx/connector.py`
+  (`_session_token`, session-create POST).

--- a/docs/cross-repo/vcf-fixture-refresh.md
+++ b/docs/cross-repo/vcf-fixture-refresh.md
@@ -1,0 +1,153 @@
+# VCF management-plane fixture refresh recipe
+
+The four VCF management-plane connectors — vROps (#829), vRLI (#830), Fleet
+(#831), Automation (#832) — have no public CI simulator. Their E2E tests
+(#837 / #838 / #839 / #840) replay HTTP responses recorded against a live
+appliance via the refresh tool at `backend/tests/fixtures/vcf/refresh.py`.
+
+This recipe documents how an operator re-captures fixtures when:
+
+- a vendor API changes (response shape drift across appliance versions),
+- a new endpoint is added to a connector's op set,
+- a flaky fixture needs re-recording against a stable lab appliance.
+
+The Automation connector skips this tool entirely — its dual-plane auth
+shape is bespoke and its fixtures live in #840 alongside the connector.
+
+## Prerequisites
+
+- A reachable lab appliance for the target product (vROps / vRLI / Fleet)
+  with a service-account that has read access to the endpoints the recipe
+  records.
+- The appliance hostname and port (default `443`).
+- The repo dev env installed (`uv sync --locked --all-groups` in
+  `backend/`).
+- The service-account password available in an environment variable so it
+  doesn't land in shell history.
+
+## Run
+
+From the repo root:
+
+```bash
+export VCF_PASSWORD='...'  # use a vault read, never the literal in shell history
+uv run --directory backend python tests/fixtures/vcf/refresh.py \
+    --connector vcf-operations \
+    --target vrops-lab \
+    --host vrops-lab.example.com \
+    --username svc-meho \
+    --password "$VCF_PASSWORD" \
+    --insecure          # only on lab appliances with self-signed certs
+```
+
+The supported `--connector` values are `vcf-operations`, `vcf-logs`,
+`vcf-fleet`. Each one has its own recipe (a tuple of endpoint calls + an
+optional session-login path) inside `refresh.py`.
+
+The tool:
+
+1. Connects to `https://<host>:<port>` (TLS verification on by default;
+   pass `--insecure` only against a lab appliance with a self-signed cert).
+2. Establishes a session if any call in the recipe requires it (vRLI hits
+   `POST /api/v2/sessions` with the `Local` provider; the helper extracts
+   the `sessionId` response header).
+3. Hits each recipe endpoint, capturing the HTTP method, path, status,
+   response headers, and JSON body.
+4. **Redacts** secret material — by default `Authorization`,
+   `Set-Cookie`, `sessionId`, `X-XSRF-TOKEN`, `Cookie` headers and
+   `password`, `session_token`, `sessionId`, `token`, `access_token`,
+   `refresh_token` JSON keys. Add more via `--redact-header NAME` /
+   `--redact-json-key KEY`.
+5. Writes each fixture to
+   `backend/tests/fixtures/vcf/<connector>/<fixture-name>.json`.
+
+## Safety guards
+
+- **Refuses to overwrite an existing fixture** unless `--force` is passed.
+  Stale fixtures from a prior appliance version silently masking drift is
+  one of the bigger anti-patterns in recorded-fixture suites — opt-in
+  overwrite makes the operator confirm.
+- **`--dry-run`** records nothing — prints the would-be writes so the
+  operator can eyeball the recipe before touching disk.
+- **Refuses TLS verification skip by default**. Pass `--insecure`
+  explicitly when targeting a lab appliance with a self-signed cert.
+
+## Inspecting a fixture before committing
+
+```bash
+jq . backend/tests/fixtures/vcf/vcf-operations/versions-current.json
+```
+
+Verify there are no leftover secrets. A correctly-redacted snapshot looks
+like:
+
+```json
+{
+  "fixture_name": "versions-current",
+  "request_method": "GET",
+  "request_path": "/suite-api/api/versions/current",
+  "response_status": 200,
+  "response_headers": {
+    "content-type": "application/json",
+    "set-cookie": "<redacted>"
+  },
+  "response_body": {
+    "releaseName": "VMware Cloud Foundation Operations 9.0",
+    "version": "9.0.0",
+    "buildNumber": "12345678"
+  },
+  "recorded_at": "2026-05-21T10:00:00+00:00"
+}
+```
+
+If a secret slips through (e.g. a vendor-specific header the default
+denylist doesn't cover), add a `--redact-header` / `--redact-json-key`
+entry, re-record with `--force`, and **submit a follow-up PR amending the
+default lists** in `refresh.py` so the next operator doesn't have to
+remember.
+
+## Adding a new endpoint to a recipe
+
+Recipes live in `backend/tests/fixtures/vcf/refresh.py` as `ConnectorRecipe`
+constants. To add a new endpoint:
+
+1. Append a `FixtureCall(fixture_name="...", method="GET", path="...", auth="basic")`
+   to the connector's `calls` tuple.
+2. Re-run the refresh tool with `--force` (the existing fixtures are
+   overwritten as a set — pre-existing snapshots from prior runs are
+   replaced atomically).
+3. Commit both the recipe change and the new fixture JSON.
+
+## Compatibility check
+
+Before committing refreshed fixtures, run the E2E test suite against the
+new snapshots:
+
+```bash
+uv run --directory backend pytest -n auto backend/tests/test_connectors_vcf_*_e2e.py
+```
+
+A connector that breaks under the new fixture set is the signal that the
+vendor API shape changed — fix the connector (or roll the fixture back if
+the appliance version isn't yet supported).
+
+## Credential caveats
+
+- Service accounts used for fixture refresh should be **read-only**. The
+  recipes only issue `GET` / `POST /sessions`; no destructive verbs.
+- Never commit a fixture with a real session token or password — the
+  default redaction list covers the well-known fields, but a vendor-specific
+  field may slip through. Always `jq .` over the committed JSON before
+  pushing.
+- The lab appliance the fixtures are recorded against should be on a
+  stable supported version. Bleeding-edge releases trade fixture stability
+  for vendor feature coverage and aren't worth re-recording weekly.
+
+## References
+
+- Task: https://github.com/evoila/meho/issues/841 (this tool).
+- E2E consumers: vROps #837, vRLI #838, Fleet #839 (Automation #840 has
+  its own dual-plane fixtures, separate path).
+- Sibling pattern: `docs/cross-repo/nsx-onboarding.md` and
+  `docs/cross-repo/sddc-manager-onboarding.md` cover the equivalent
+  refresh story for the G3.5 connectors.


### PR DESCRIPTION
## Summary

- Ship `backend/src/meho_backplane/connectors/_shared/vcf_auth.py` — the
  common subset of auth scaffolding the three VCF management-plane
  skeleton connectors (vROps #829, vRLI #830, Fleet #831) will import:
  Basic-auth header, auth-model gate, Vault-credentials-loader protocol +
  per-target `CredentialsCache`, and a flexible `vcf_session_login`
  helper. Each helper is a verbatim lift from the existing inlined copies
  in Harbor / NSX — those keep their copies (migrating them is
  opportunistic later refactor only per #369's cross-cutting note). VCF
  Automation (#832) is intentionally NOT a consumer (dual-plane bespoke
  auth stays in that connector).
- Ship `backend/tests/fixtures/vcf/refresh.py` + `docs/cross-repo/vcf-fixture-refresh.md`
  — the recorded-fixture refresh tool the four E2E tasks
  (#837/#838/#839/#840) replay against. Redacts well-known secret headers
  / JSON keys by default; refuses to overwrite existing fixtures without
  `--force`; `--dry-run` mode for the operator-eyeball pass before
  touching disk.

## Test plan

- [x] `ruff check` — clean on the three new source paths.
- [x] `ruff format --check` — clean (formatter applied to the two test
  files automatically).
- [x] `mypy src/meho_backplane/connectors/_shared/ tests/fixtures/vcf/refresh.py`
  — `Success: no issues found in 3 source files`.
- [x] `pytest -n auto backend/tests/test_connectors_vcf_shared_auth.py`
  — 33 passed.
- [x] Sibling connector unit tests (`harbor`, `nsx`, `sddc_manager` auth)
  — 66 passed, no regressions.
- [x] `uv run python backend/tests/fixtures/vcf/refresh.py --help` —
  CLI parses + prints usage cleanly.
- [x] Acceptance criterion 1 — `vcf_auth.py` exists with the four
  helpers; unit tests cover the Basic header value, auth-model
  accept/reject (enum + string + None + per_user / impersonation /
  unknown / empty / 0 / False), Vault loader missing-username +
  missing-password → `RuntimeError` naming target, session-login →
  token cached + 401 → re-login-once → retry-once → success /
  second-401 → `SessionLoginError`.
- [x] Acceptance criterion 2 — refresh script exists and runs (CLI
  smoke); `docs/cross-repo/vcf-fixture-refresh.md` documents the recipe
  + credential / safety caveats.
- [x] Acceptance criterion 3 — ruff + mypy clean on
  `connectors/_shared/`; pytest passes.
- [x] Acceptance criterion 4 — public API surface is set; vROps / vRLI
  / Fleet skeletons can import the helpers (verified once those land,
  they carry `Depends-on: #841`).

## Out of scope

- Migrating Harbor / NSX / SDDC Manager to the shared helper — those
  shipped with their own inlined copies; per #369's cross-cutting note,
  opportunistic later refactor only.
- VCF Automation's dual-plane auth — bespoke, stays in #832.
- The connector classes / ingestion / CLI — the per-connector tasks
  (#829 / #830 / #831 / #832).

## Notes for reviewers

- The `vcf_session_login` helper covers the login round-trip only. The
  `401 → re-login → retry-once` loop around *downstream* calls is
  intentionally not factored — it lives in the consuming connector
  because the downstream paths differ per connector (vRLI's headline op
  hits `/api/v2/events/query`; vROps's hits `/suite-api/api/resources`;
  etc.). The shared module would have to be parameterised over the
  downstream call shape, defeating the point.
- The `CredentialsCache` composes by attribute rather than inheritance.
  Each consumer keeps a flat layout and the cache is one of several
  collaborating helpers — a mixin would force a single Protocol or a
  generic over `T`, neither of which the three concrete consumers can
  satisfy uniformly.
- `load_credentials_from_vault` is a deliberate `NotImplementedError`
  stub pending Goal #214's operator-context per-target Vault read —
  same shape as Harbor's and NSX's default loaders. The three new
  connectors will need to inject a stub loader at construction time
  for unit tests + production wiring until #214 lands.

Closes #841


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared VCF authentication helpers: basic auth, session login flow, and per-target credential caching.
  * CLI tool to record and produce VCF management-plane HTTP fixtures for replay/testing.

* **Documentation**
  * Guides for the shared VCF auth helpers and the fixture refresh workflow.

* **Tests**
  * Added comprehensive unit tests covering auth helpers, credential caching, and session login behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-22)

Addressed review findings from the iter-1 `/auto-review-pr` (REQUEST_CHANGES,
posted at https://github.com/evoila/meho/pull/884#pullrequestreview-… ):

- **B1** `1b8481b` — `CredentialsCache.invalidate` and `.clear` are now
  coroutines acquiring `self._lock` before mutating `self._cache`; the
  previous sync methods bypassed the lock and could race an in-flight
  `await get(t)`. Two unit tests updated to `await` the methods;
  `docs/codebase/connectors-vcf-auth-shared.md` updated to drop the
  "synchronous" claim.
- **B2** `1b8481b` — `refresh.py:_record_one` now raises before
  serialising the response when `resp.status_code >= 400`; `main()`'s
  existing outer `except Exception` returns exit code 1. Prevents
  poisoning the recorded-fixture set with vendor error payloads.
- **m1** `1b8481b` — dropped the dead `captured["json"]` assignment in
  `test_vcf_session_login_uses_default_payload_when_none_provided`.
- **m2** `1b8481b` — hoisted the two inline `import json` statements to
  the module-level import block.

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 2 -->
