### PR TITLE
feat(connectors): G3.6-T10 VcfAutomationConnector skeleton — dual-plane auth + vhost routing

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vcf_automation -- VcfAutomationConnector package.
+
+Importing this package registers :class:`VcfAutomationConnector` against
+the v2 connector registry under
+``(product="vcf-automation", version="9.0", impl_id="vcfa-rest")``. The
+chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+which walks every ``connectors/<product>/`` subpackage at startup, so
+the registration lands before any dispatch can occur.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector`
+entry point is deliberately **not** called. The connector advertises an
+explicit ``(version="9.0", impl_id="vcfa-rest")`` key; the v1 entry
+would land as ``("vcf-automation", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s
+tie-break ladder. Same pattern :mod:`meho_backplane.connectors.nsx` /
+:mod:`meho_backplane.connectors.sddc_manager` established.
+
+Operations for this connector arrive in #836 via G0.7 dual-plane spec
+ingestion -- both the provider plane (``vcf-automation-9.0/provider.yaml``)
+and the tenant plane (``vcf-automation-9.0/tenant.yaml``) are ingested
+under this single connector with ``spec_source`` tags distinguishing
+them, same shape as vSphere's ``vcenter.yaml`` + ``vi-json.yaml``.
+This Task ships only the skeleton.
+"""
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vcf_automation.connector import (
+    VcfAutomationConfigurationError,
+    VcfAutomationConnector,
+)
+from meho_backplane.connectors.vcf_automation.session import (
+    SessionCredentials,
+    VcfAutomationCredentialsLoader,
+    VcfAutomationTargetLike,
+    load_credentials_from_vault,
+)
+
+register_connector_v2(
+    product="vcf-automation",
+    version="9.0",
+    impl_id="vcfa-rest",
+    cls=VcfAutomationConnector,
+)
+
+__all__ = [
+    "SessionCredentials",
+    "VcfAutomationConfigurationError",
+    "VcfAutomationConnector",
+    "VcfAutomationCredentialsLoader",
+    "VcfAutomationTargetLike",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/vcf_automation/_auth.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/_auth.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-plane session-establish helpers for the VCF Automation connector.
+
+Split out from :mod:`.connector` to keep that module within the
+file-size budget. The helpers here take the per-target httpx client +
+the resolved credentials and return the freshly-minted token; cache
+ownership and lock discipline stay in the connector class so the
+per-plane mutual-exclusion contract is co-located with the cache it
+protects.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors.vcf_automation._routing import (
+    PROVIDER_CLOUDAPI_ACCEPT,
+    PROVIDER_SESSION_PATH,
+    PROVIDER_TOKEN_HEADER,
+    TENANT_ACCEPT,
+    TENANT_SESSION_PATH,
+)
+from meho_backplane.connectors.vcf_automation.session import (
+    VcfAutomationCredentialsLoader,
+    VcfAutomationTargetLike,
+)
+
+__all__ = [
+    "load_credentials_with_override",
+    "tenant_login",
+    "vcfa_provider_login",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+async def load_credentials_with_override(
+    loader: VcfAutomationCredentialsLoader,
+    target: VcfAutomationTargetLike,
+    secret_ref: str | None,
+) -> dict[str, str]:
+    """Invoke *loader* against *target* (optionally with override *secret_ref*).
+
+    When *secret_ref* matches ``target.secret_ref`` (or is ``None``)
+    the target passes through unchanged. When it differs, the loader
+    receives a :class:`SimpleNamespace` proxy that mirrors the target's
+    attributes with ``secret_ref`` rewritten to the override -- this
+    lets the provider plane resolve a distinct Vault path
+    (``provider_secret_ref``) when the provider-plane password differs
+    from the SSO/tenant secret.
+    """
+    if secret_ref is None or secret_ref == target.secret_ref:
+        return await loader(target)
+    proxy = SimpleNamespace(
+        name=target.name,
+        host=target.host,
+        port=getattr(target, "port", None),
+        secret_ref=secret_ref,
+        auth_model=getattr(target, "auth_model", None),
+        fqdn=getattr(target, "fqdn", None),
+        domain=getattr(target, "domain", None),
+        provider_username=getattr(target, "provider_username", None),
+        provider_secret_ref=getattr(target, "provider_secret_ref", None),
+    )
+    return await loader(proxy)
+
+
+def _require_username_password(
+    creds: dict[str, str], target_name: str, plane: str
+) -> tuple[str, str]:
+    """Extract ``username`` + ``password`` from *creds*, raising on missing keys."""
+    try:
+        return creds["username"], creds["password"]
+    except KeyError as exc:
+        raise RuntimeError(
+            f"vcf-automation {plane} credentials loader for target "
+            f"{target_name!r} returned a dict missing required key "
+            f"{exc.args[0]!r}; need {{'username': str, 'password': str}}"
+        ) from exc
+
+
+def _compose_provider_basic_user(
+    creds_username: str,
+    provider_username: str | None,
+    domain: str | None,
+) -> str:
+    """Return the verbatim ``provider_username`` when set, otherwise the legacy form.
+
+    The legacy fallback is ``f"{creds_username}@{domain or 'System'}"`` --
+    the consumer wrapper carries this for targets that haven't migrated
+    to the explicit ``provider_username`` field yet.
+    """
+    if provider_username:
+        return provider_username
+    return f"{creds_username}@{domain or 'System'}"
+
+
+async def vcfa_provider_login(
+    client: httpx.AsyncClient,
+    creds: dict[str, str],
+    target: VcfAutomationTargetLike,
+) -> str:
+    """POST the provider session-create endpoint and return the JWT.
+
+    Issues ``POST /cloudapi/1.0.0/sessions/provider`` with HTTP Basic
+    auth and ``Accept: application/json;version=9.0.0``. A 2xx response
+    carries ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` as a response header --
+    the JWT is returned to the caller (which then writes the cache
+    under the per-plane lock). Absence of the header on a 2xx response
+    raises :exc:`RuntimeError` rather than caching an empty token.
+    """
+    username, password = _require_username_password(creds, target.name, "provider")
+    provider_username = getattr(target, "provider_username", None)
+    domain = getattr(target, "domain", None)
+    basic_user = _compose_provider_basic_user(username, provider_username, domain)
+    try:
+        resp = await client.post(
+            PROVIDER_SESSION_PATH,
+            auth=(basic_user, password),
+            headers={"Accept": PROVIDER_CLOUDAPI_ACCEPT},
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise RuntimeError(
+            f"vcf-automation provider session establish failed for target "
+            f"{target.name!r}: POST {PROVIDER_SESSION_PATH} returned "
+            f"HTTP {exc.response.status_code}"
+        ) from exc
+    jwt: str | None = resp.headers.get(PROVIDER_TOKEN_HEADER)
+    if not jwt:
+        raise RuntimeError(
+            f"vcf-automation provider session establish for target "
+            f"{target.name!r}: POST {PROVIDER_SESSION_PATH} returned "
+            f"2xx with no {PROVIDER_TOKEN_HEADER} response header"
+        )
+    _log.info(
+        "vcf_automation_provider_session_established",
+        target=target.name,
+        host=target.host,
+    )
+    return jwt
+
+
+async def tenant_login(
+    client: httpx.AsyncClient,
+    creds: dict[str, str],
+    target: VcfAutomationTargetLike,
+) -> str:
+    """POST the tenant login endpoint and return the bearer token.
+
+    Issues ``POST /iaas/api/login`` with JSON body
+    ``{"username": ..., "password": ...}`` plus an optional ``domain``
+    field when ``target.domain`` is set. The response body is
+    ``{"token": "..."}``. Missing / empty ``token`` field on a 2xx
+    response raises :exc:`RuntimeError`.
+    """
+    username, password = _require_username_password(creds, target.name, "tenant")
+    body: dict[str, str] = {"username": username, "password": password}
+    domain = getattr(target, "domain", None)
+    if domain:
+        body["domain"] = domain
+    try:
+        resp = await client.post(
+            TENANT_SESSION_PATH,
+            json=body,
+            headers={"Accept": TENANT_ACCEPT, "Content-Type": TENANT_ACCEPT},
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise RuntimeError(
+            f"vcf-automation tenant session establish failed for target "
+            f"{target.name!r}: POST {TENANT_SESSION_PATH} returned "
+            f"HTTP {exc.response.status_code}"
+        ) from exc
+    payload: Any = resp.json()
+    raw_token = payload.get("token") if isinstance(payload, dict) else None
+    if not isinstance(raw_token, str) or not raw_token:
+        raise RuntimeError(
+            f"vcf-automation tenant session establish for target "
+            f"{target.name!r}: POST {TENANT_SESSION_PATH} returned "
+            "2xx with no 'token' field in the response body"
+        )
+    _log.info(
+        "vcf_automation_tenant_session_established",
+        target=target.name,
+        host=target.host,
+    )
+    return raw_token

--- a/backend/src/meho_backplane/connectors/vcf_automation/_routing.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/_routing.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Plane classification, vhost validation, and protocol constants.
+
+Split out from :mod:`.connector` to keep that module within the
+file-size budget. The contents here are pure helpers + module
+constants -- no class state, no I/O -- so they live cleanly outside
+the connector class. Verified against ``scripts/vcf-automation.sh``
+(2026-05-21 snapshot, line references inline below).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any, Literal
+
+from meho_backplane.connectors.schemas import AuthModel
+
+__all__ = [
+    "PROVIDER_CLASSIC_API_ACCEPT",
+    "PROVIDER_CLOUDAPI_ACCEPT",
+    "PROVIDER_SESSION_PATH",
+    "PROVIDER_TOKEN_HEADER",
+    "PROVIDER_VERSION_PATH",
+    "TENANT_ACCEPT",
+    "TENANT_SESSION_PATH",
+    "TENANT_VERSION_PATH",
+    "Plane",
+    "VcfAutomationConfigurationError",
+    "compose_base_url",
+    "is_acceptable_auth_model",
+    "plane_for_path",
+    "provider_accept_for_path",
+]
+
+# Per-plane login endpoints. Verified against scripts/vcf-automation.sh
+# (provider login: line 381; tenant login: line 439).
+PROVIDER_SESSION_PATH = "/cloudapi/1.0.0/sessions/provider"
+TENANT_SESSION_PATH = "/iaas/api/login"
+
+# Per-plane unauthenticated version probes. Verified against
+# scripts/vcf-automation.sh (provider: line 252 GET /api/versions XML;
+# tenant: line 309 GET /iaas/api/about JSON). Both self-describe the
+# API surface without exercising the auth flow.
+PROVIDER_VERSION_PATH = "/api/versions"
+TENANT_VERSION_PATH = "/iaas/api/about"
+
+# Provider login response header carrying the JWT (verified against
+# scripts/vcf-automation.sh line 395). HTTP/2 lowercases header names
+# on the wire; httpx's Headers indexing is case-insensitive, so the
+# constant is preserved in the canonical mixed-case form.
+PROVIDER_TOKEN_HEADER = "X-VMWARE-VCLOUD-ACCESS-TOKEN"
+
+# Provider plane Accept media types -- path-family dependent. The
+# split between Tm (/cloudapi/*) and classic vCD (/api/*) is the #517
+# finding in the consumer repo: 40.0 is the highest non-deprecated
+# classic vCD version on VCFA 9.0 (validated 2026-05-17).
+PROVIDER_CLOUDAPI_ACCEPT = "application/json;version=9.0.0"
+PROVIDER_CLASSIC_API_ACCEPT = "application/*+json;version=40.0"
+
+# Tenant plane Accept media type -- plain JSON; no version negotiation.
+TENANT_ACCEPT = "application/json"
+
+Plane = Literal["provider", "tenant"]
+
+
+class VcfAutomationConfigurationError(RuntimeError):
+    """Raised when a target's configuration prevents the connector from running.
+
+    The primary trigger is a target reached by IP with no ``fqdn`` set:
+    VCFA enforces strict vhost routing and would return 404 on every
+    path post-login otherwise (see :class:`.VcfAutomationConnector`
+    docstring section on vhost routing). Subclassing :exc:`RuntimeError`
+    keeps the connector's existing ``except (httpx.HTTPError, OSError,
+    RuntimeError)`` chains catching the case cleanly.
+    """
+
+
+def is_acceptable_auth_model(value: Any) -> bool:
+    """Return ``True`` iff *value* is the SHARED_SERVICE_ACCOUNT mode or unset.
+
+    Accepts the enum member, the equivalent string, and ``None`` (the
+    pre-G0.3 "auth_model column not yet populated" sentinel). Any
+    other value (``"per_user"``, ``"impersonation"``, a typo, an int)
+    is rejected by the caller. Same predicate the NSX / SDDC Manager /
+    vSphere precedents use.
+    """
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+def _is_ip_literal(host: str) -> bool:
+    """Return ``True`` iff *host* parses as an IPv4 or IPv6 literal.
+
+    IPv6 bracket-wrapped forms (``[::1]``) are accepted --
+    :class:`ipaddress.ip_address` rejects them, so one matched pair of
+    brackets is stripped before parsing.
+    """
+    candidate = host
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    try:
+        ipaddress.ip_address(candidate)
+    except ValueError:
+        return False
+    return True
+
+
+def plane_for_path(path: str) -> Plane:
+    """Classify a request path into one of the two auth planes.
+
+    The split is unambiguous: ``/iaas/api/*`` is the tenant plane;
+    everything else (``/cloudapi/*``, ``/api/*``, anything that looks
+    like the vCloud-Director-derived surface) is the provider plane.
+    """
+    if path.startswith("/iaas/api/"):
+        return "tenant"
+    return "provider"
+
+
+def provider_accept_for_path(path: str) -> str:
+    """Return the provider-plane Accept media type for *path*.
+
+    Path-family-dependent per the consumer wrapper (#517 in the
+    consumer repo, line 414-420 of scripts/vcf-automation.sh):
+    classic vCD paths (``/api/*``) need the versioned
+    ``application/*+json;version=40.0`` form; everything else under
+    ``/cloudapi/*`` uses the Tm ``application/json;version=9.0.0``
+    form. The provider Bearer JWT authenticates both surfaces.
+    """
+    if path.startswith("/api/"):
+        return PROVIDER_CLASSIC_API_ACCEPT
+    return PROVIDER_CLOUDAPI_ACCEPT
+
+
+def compose_base_url(target_name: str, host: str, port: int | None, fqdn: str | None) -> str:
+    """Build the per-target base URL honouring vhost routing.
+
+    When *fqdn* is set, the URL host is the FQDN (httpx's request will
+    carry it as the ``Host:`` header, satisfying VCFA's strict vhost
+    match). When *fqdn* is unset and *host* is an IP literal, raise
+    :exc:`VcfAutomationConfigurationError` -- the consumer wrapper
+    documents this as the silent-404 failure mode and we surface it
+    at base-URL construction time. When *host* is itself an FQDN, the
+    URL already carries the right vhost.
+    """
+    scheme = "https"
+    port_suffix = f":{port}" if port and port != 443 else ""
+    if fqdn:
+        return f"{scheme}://{fqdn}{port_suffix}"
+    if _is_ip_literal(host):
+        raise VcfAutomationConfigurationError(
+            f"vcf-automation target {target_name!r} is reached by IP ({host!r}) "
+            "but has no fqdn set. VCFA enforces strict vhost routing and "
+            "returns 404 on every path otherwise. Set target.fqdn (CLI: "
+            "--fqdn; targets.yaml: fqdn:) to the appliance's canonical FQDN."
+        )
+    return f"{scheme}://{host}{port_suffix}"

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -1,0 +1,571 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VcfAutomationConnector -- hand-rolled HttpConnector subclass for VCF Automation 9.x.
+
+Skeleton-only -- dual-plane auth + fingerprint + probe + the G0.6
+dispatch shim + vhost routing. Operations arrive in #836 via G0.7
+spec ingestion against both ``vcf-automation-9.0/provider.yaml`` +
+``vcf-automation-9.0/tenant.yaml`` ingested under one connector with
+``spec_source`` tags distinguishing them -- same dual-source shape as
+vSphere's ``vcenter.yaml`` + ``vi-json.yaml``.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.vcf_automation.__init__`.
+
+Auth divergence: dual-plane on one appliance
+--------------------------------------------
+
+VCFA 9.x exposes two API planes on the same appliance (verified
+against the consumer ``scripts/vcf-automation.sh`` wrapper -- header
+comment + login blocks, 2026-05-21):
+
+* **Provider plane** (vCloud-Director-derived): paths under
+  ``/cloudapi/*`` and the classic ``/api/*`` family. Login is
+  ``POST /cloudapi/1.0.0/sessions/provider`` with **HTTP Basic auth**;
+  the response carries the access token as the
+  ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` response **header** (a JWT). The
+  connector caches that JWT per target and sends
+  ``Authorization: Bearer <jwt>`` on subsequent ``/cloudapi/*`` and
+  ``/api/*`` calls. ``Accept`` is path-family-dependent (#517 in the
+  consumer repo, validated 2026-05-16):
+  ``application/json;version=9.0.0`` for ``/cloudapi/*`` and
+  ``application/*+json;version=40.0`` for the classic ``/api/*``
+  family. The provider Bearer JWT authenticates both surfaces
+  uniformly; only the ``Accept`` differs.
+
+* **Tenant plane** (Aria-IaaS-derived): paths under ``/iaas/api/*``.
+  Login is ``POST /iaas/api/login`` with a **JSON body**
+  (``{"username": ..., "password": ...}`` plus optional ``domain``);
+  the response body is ``{"token": "..."}``. Subsequent ``/iaas/api/*``
+  calls carry ``Authorization: Bearer <token>`` and ``Accept:
+  application/json``. Tokens are bespoke per plane; the provider
+  JWT does NOT authenticate the tenant plane and vice versa.
+
+Both per-plane token caches are keyed on ``target.name`` and
+established lazily on first request that resolves to that plane.
+On HTTP 401 from a downstream call, the relevant plane's cache is
+invalidated and the call retries once -- consumer wrapper posture:
+re-login once on session-expiry, not a retry loop.
+
+Vhost routing
+-------------
+
+VCFA 9.x enforces strict ``Host:`` header matching. When ``target.fqdn``
+is set, the per-target httpx ``AsyncClient`` is built with
+``base_url=https://<fqdn>``; standard DNS resolution targets the FQDN.
+When ``target.fqdn`` is unset and ``target.host`` is an IP literal,
+:func:`._routing.compose_base_url` raises
+:exc:`VcfAutomationConfigurationError` at first session-establish --
+the consumer wrapper documents this as the silent-404 failure mode.
+When ``target.host`` is itself an FQDN, ``fqdn`` is optional -- the
+URL host already carries the right vhost.
+
+Auth model gating
+-----------------
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT`
+(or ``None`` for pre-G0.3 targets). :meth:`auth_headers` rejects any
+other value with a clear :exc:`NotImplementedError` naming both the
+target and the requested mode -- same posture the NSX, SDDC Manager,
+and vSphere precedents established.
+
+Operations
+----------
+
+This module ships zero operations -- the G0.6 dispatch shim
+:meth:`execute` exists for ABC compatibility but operations land in
+the ``endpoint_descriptor`` table via #836's dual-plane spec
+ingestion. Until then, the connector is registered and discoverable
+but ``execute(target, op_id, ...)`` against any ``op_id`` resolves to
+"unknown operation" at the dispatcher layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vcf_automation._auth import (
+    load_credentials_with_override,
+    tenant_login,
+    vcfa_provider_login,
+)
+from meho_backplane.connectors.vcf_automation._routing import (
+    PROVIDER_VERSION_PATH,
+    TENANT_ACCEPT,
+    TENANT_VERSION_PATH,
+    Plane,
+    VcfAutomationConfigurationError,
+    compose_base_url,
+    is_acceptable_auth_model,
+    plane_for_path,
+    provider_accept_for_path,
+)
+from meho_backplane.connectors.vcf_automation.session import (
+    VcfAutomationCredentialsLoader,
+    VcfAutomationTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = ["VcfAutomationConfigurationError", "VcfAutomationConnector"]
+
+_log = structlog.get_logger(__name__)
+
+
+class VcfAutomationConnector(HttpConnector):
+    """VCF Automation 9.x REST connector with dual-plane Bearer-token auth.
+
+    Two independent per-target token caches:
+
+    * :attr:`_provider_tokens` -- ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT
+      values, established by ``POST /cloudapi/1.0.0/sessions/provider``
+      with HTTP Basic.
+    * :attr:`_tenant_tokens` -- ``{"token": "..."}`` body values,
+      established by ``POST /iaas/api/login`` with a JSON body.
+
+    Each plane has its own ``asyncio.Lock`` so concurrent first-use
+    callers serialise per plane and don't double-POST the login
+    endpoint. The :attr:`priority` is set to ``1`` so a future
+    ``GenericRestConnector`` auto-shim that somehow registers for the
+    same triple loses the registry's tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"vcfa-rest-9.0"`` -> (``"vcf-automation"``, ``"9.0"``, ``"vcfa-rest"``).
+    product = "vcf-automation"
+    version = "9.0"
+    impl_id = "vcfa-rest"
+    supported_version_range = ">=9.0,<10.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: VcfAutomationCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        # Per-target, per-plane token caches. Keyed on target.name; same
+        # isolation invariant the NSX precedent established.
+        self._provider_tokens: dict[str, str] = {}
+        self._tenant_tokens: dict[str, str] = {}
+        # One lock per plane -- provider and tenant first-uses are
+        # independent and shouldn't block each other.
+        self._provider_lock = asyncio.Lock()
+        self._tenant_lock = asyncio.Lock()
+        self._credentials_loader: VcfAutomationCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+
+    # ------------------------------------------------------------------
+    # URL composition + vhost routing
+    # ------------------------------------------------------------------
+
+    def _base_url(self, target: VcfAutomationTargetLike) -> str:
+        """Delegate to :func:`._routing.compose_base_url` for vhost handling."""
+        return compose_base_url(
+            target_name=target.name,
+            host=target.host,
+            port=getattr(target, "port", None),
+            fqdn=getattr(target, "fqdn", None),
+        )
+
+    # ------------------------------------------------------------------
+    # auth_headers -- ABC + plane-aware path argument
+    # ------------------------------------------------------------------
+
+    async def auth_headers(
+        self,
+        target: VcfAutomationTargetLike,
+        raw_jwt: str,
+        *,
+        path: str | None = None,
+    ) -> dict[str, str]:
+        """Return plane-specific headers for the request.
+
+        ``path`` is keyword-only and required in practice: ``None`` is
+        rejected because this connector is dual-plane and there is no
+        plane-agnostic auth header set. The plane is selected from the
+        path prefix (``/iaas/api/*`` -> tenant, anything else ->
+        provider), the cached token for that plane is fetched (lazy
+        login on first use), and the response is the canonical Bearer
+        header plus the plane-specific ``Accept`` media type.
+
+        The base ``HttpConnector._request_json`` / ``_post_json``
+        callers don't forward ``path`` -- this connector overrides
+        both transports to thread ``path`` through. A stray path-less
+        call raises :exc:`VcfAutomationConfigurationError` rather than
+        silently picking a plane. ``raw_jwt`` is accepted for
+        ABC-signature compatibility but unused. Raises
+        :exc:`NotImplementedError` for any ``target.auth_model`` other
+        than ``shared_service_account`` / ``None``.
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT does not forward operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"VcfAutomationConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        if path is None:
+            raise VcfAutomationConfigurationError(
+                f"vcf-automation auth_headers requires the request path to "
+                f"select the auth plane (target={target.name!r}). Callers "
+                "must use _request_json / _post_json which forward the path; "
+                "direct auth_headers() calls must pass path= explicitly."
+            )
+        plane = plane_for_path(path)
+        if plane == "provider":
+            token = await self._provider_session_token(target)
+            return {
+                "Authorization": f"Bearer {token}",
+                "Accept": provider_accept_for_path(path),
+            }
+        token = await self._tenant_session_token(target)
+        return {
+            "Authorization": f"Bearer {token}",
+            "Accept": TENANT_ACCEPT,
+        }
+
+    # ------------------------------------------------------------------
+    # Per-plane session establishment
+    # ------------------------------------------------------------------
+
+    async def _provider_session_token(self, target: VcfAutomationTargetLike) -> str:
+        """Return the cached provider-plane JWT, establishing on first use.
+
+        When ``target.provider_secret_ref`` is set, the loader is
+        called with the override path so the provider account can
+        differ from the SSO/tenant account (the ``admin@System`` vs
+        ``svc-meho`` split documented in the consumer wrapper).
+        Otherwise the default ``target.secret_ref`` pair is used for
+        both planes. See :func:`._auth.vcfa_provider_login` for the
+        wire-level POST.
+        """
+        async with self._provider_lock:
+            cached = self._provider_tokens.get(target.name)
+            if cached is not None:
+                return cached
+            override_ref = getattr(target, "provider_secret_ref", None)
+            creds = await load_credentials_with_override(
+                self._credentials_loader, target, override_ref
+            )
+            client = await self._http_client(target)
+            jwt = await vcfa_provider_login(client, creds, target)
+            self._provider_tokens[target.name] = jwt
+            return jwt
+
+    async def _tenant_session_token(self, target: VcfAutomationTargetLike) -> str:
+        """Return the cached tenant-plane token, establishing on first use.
+
+        The tenant plane does NOT honour ``provider_secret_ref`` --
+        it's strictly an SSO-ish account flow against ``target.secret_ref``.
+        See :func:`._auth.tenant_login` for the wire-level POST.
+        """
+        async with self._tenant_lock:
+            cached = self._tenant_tokens.get(target.name)
+            if cached is not None:
+                return cached
+            creds = await load_credentials_with_override(self._credentials_loader, target, None)
+            client = await self._http_client(target)
+            token = await tenant_login(client, creds, target)
+            self._tenant_tokens[target.name] = token
+            return token
+
+    async def _invalidate_plane(self, target: VcfAutomationTargetLike, plane: Plane) -> None:
+        """Drop the cached token for *plane* on *target* under the plane's lock."""
+        lock = self._provider_lock if plane == "provider" else self._tenant_lock
+        cache = self._provider_tokens if plane == "provider" else self._tenant_tokens
+        async with lock:
+            cache.pop(target.name, None)
+
+    # ------------------------------------------------------------------
+    # Transport overrides -- thread path into auth_headers + 401 retry-once
+    # ------------------------------------------------------------------
+
+    async def _request_json(
+        self,
+        target: VcfAutomationTargetLike,
+        method: str,
+        path: str,
+        *,
+        raw_jwt: str,
+        params: Mapping[str, Any] | None = None,
+        json: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Path-aware idempotent JSON request with per-plane 401 retry-once.
+
+        Diverges from :meth:`HttpConnector._request_json` in two ways:
+
+        1. The request path drives plane selection (via
+           :meth:`auth_headers`'s ``path=`` keyword); the base method
+           has no path-aware hook.
+        2. On HTTP 401, the relevant plane's cached token is
+           invalidated and the call retries once with a freshly-minted
+           token. A second 401 raises :exc:`RuntimeError` naming the
+           target -- consumer wrapper posture: re-login once, not a
+           retry loop.
+
+        Connection-error / 5xx retry is intentionally not layered on
+        here; the per-plane 401 dance is the only recovery the
+        connector implements. The base method's ``ValueError`` on
+        non-idempotent verbs is preserved.
+        """
+        method_upper = method.upper()
+        if method_upper not in {"GET", "HEAD", "OPTIONS"}:
+            raise ValueError(
+                f"_request_json only accepts idempotent methods "
+                f"['GET', 'HEAD', 'OPTIONS']; got {method_upper!r}"
+            )
+        return await self._do_request_with_retry(
+            target, method_upper, path, raw_jwt=raw_jwt, params=params, json=json
+        )
+
+    async def _post_json(
+        self,
+        target: VcfAutomationTargetLike,
+        path: str,
+        *,
+        raw_jwt: str,
+        json: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Path-aware non-idempotent JSON POST with per-plane 401 retry-once."""
+        return await self._do_request_with_retry(
+            target, "POST", path, raw_jwt=raw_jwt, params=None, json=json
+        )
+
+    async def _do_request_with_retry(
+        self,
+        target: VcfAutomationTargetLike,
+        method: str,
+        path: str,
+        *,
+        raw_jwt: str,
+        params: Mapping[str, Any] | None,
+        json: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Shared per-plane 401 retry-once dance for _request_json + _post_json.
+
+        Build headers, fire the request; on 401 invalidate the relevant
+        plane's token, refresh headers, retry once. A second 401
+        surfaces as :exc:`RuntimeError`.
+        """
+
+        async def _fire(headers: Mapping[str, str]) -> httpx.Response:
+            client = await self._http_client(target)
+            params_dict = dict(params) if params is not None else None
+            json_dict = dict(json) if json is not None else None
+            return await client.request(
+                method,
+                path,
+                params=params_dict,
+                json=json_dict,
+                headers=dict(headers),
+            )
+
+        plane = plane_for_path(path)
+        headers = await self.auth_headers(target, raw_jwt, path=path)
+        resp = await _fire(headers)
+        if resp.status_code == 401:
+            await self._invalidate_plane(target, plane)
+            headers = await self.auth_headers(target, raw_jwt, path=path)
+            resp = await _fire(headers)
+            if resp.status_code == 401:
+                raise RuntimeError(
+                    f"vcf-automation {plane} session re-login failed for "
+                    f"target {target.name!r}: {method} {path} returned "
+                    "HTTP 401 after refresh"
+                )
+        resp.raise_for_status()
+        payload = resp.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                f"vcf-automation {method} {path} for target {target.name!r} "
+                f"returned a non-object JSON payload of type {type(payload).__name__}"
+            )
+        return payload
+
+    # ------------------------------------------------------------------
+    # fingerprint / probe -- unauthenticated per-plane version endpoints
+    # ------------------------------------------------------------------
+
+    async def fingerprint(self, target: VcfAutomationTargetLike) -> FingerprintResult:
+        """Build the canonical fingerprint from per-plane unauthenticated probes.
+
+        Both unauthenticated probes must succeed for ``reachable=True``
+        -- a failure on either plane surfaces as ``reachable=False``
+        with ``extras["failed_plane"]`` naming the offender and
+        ``extras["error"]`` carrying the exception class + message.
+        Vhost mis-configuration (IP host with no ``fqdn``) is caught
+        at ``_http_client`` construction and reported as the
+        structured failure too. See module docstring for the per-plane
+        probe-endpoint rationale.
+        """
+        probed_at = datetime.now(UTC)
+        probe_method = f"GET {PROVIDER_VERSION_PATH} + GET {TENANT_VERSION_PATH}"
+        try:
+            client = await self._http_client(target)
+        except VcfAutomationConfigurationError as exc:
+            return self._unreachable_fingerprint(probed_at, probe_method, exc, failed_plane=None)
+        provider_resp = await _try_probe(client, PROVIDER_VERSION_PATH)
+        if isinstance(provider_resp, Exception):
+            return self._unreachable_fingerprint(
+                probed_at, probe_method, provider_resp, failed_plane="provider"
+            )
+        tenant_resp = await _try_probe(client, TENANT_VERSION_PATH, accept=TENANT_ACCEPT)
+        if isinstance(tenant_resp, Exception):
+            return self._unreachable_fingerprint(
+                probed_at, probe_method, tenant_resp, failed_plane="tenant"
+            )
+        # The tenant /iaas/api/about response is JSON; the provider
+        # /api/versions response is XML. We carry the tenant version
+        # field (the structured one) into the result.
+        try:
+            tenant_payload = tenant_resp.json()
+        except ValueError:
+            tenant_payload = {}
+        latest_api_version = (
+            tenant_payload.get("latestApiVersion") if isinstance(tenant_payload, dict) else None
+        )
+        supported_apis = (
+            tenant_payload.get("supportedApis") if isinstance(tenant_payload, dict) else None
+        )
+        return FingerprintResult(
+            vendor="vmware",
+            product="vcf-automation",
+            version=latest_api_version,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=probe_method,
+            extras={
+                "planes": ["provider", "tenant"],
+                "provider_versions_status": provider_resp.status_code,
+                "tenant_latest_api_version": latest_api_version,
+                "tenant_supported_apis": supported_apis,
+            },
+        )
+
+    def _unreachable_fingerprint(
+        self,
+        probed_at: datetime,
+        probe_method: str,
+        exc: BaseException,
+        *,
+        failed_plane: str | None,
+    ) -> FingerprintResult:
+        """Build a non-reachable :class:`FingerprintResult` with a structured error."""
+        extras: dict[str, Any] = {"error": f"{type(exc).__name__}: {exc}"}
+        if failed_plane is not None:
+            extras["failed_plane"] = failed_plane
+        return FingerprintResult(
+            vendor="vmware",
+            product="vcf-automation",
+            reachable=False,
+            probed_at=probed_at,
+            probe_method=probe_method,
+            extras=extras,
+        )
+
+    async def probe(self, target: VcfAutomationTargetLike) -> ProbeResult:
+        """Lightweight reachability check -- delegates to :meth:`fingerprint`."""
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    # ------------------------------------------------------------------
+    # G0.6 dispatch shim
+    # ------------------------------------------------------------------
+
+    async def execute(
+        self,
+        target: VcfAutomationTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim -- delegates to the G0.6 dispatcher.
+
+        Same shape as :meth:`NsxConnector.execute` /
+        :meth:`SddcManagerConnector.execute`. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI
+        verbs once #840 lands) construct a real :class:`Operator` and
+        invoke ``dispatch`` themselves.
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:vcfa-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Clear both plane token caches and tear down the httpx pool.
+
+        No DELETE-revoke is issued against either plane -- VCFA's
+        session has an idle timeout, and a per-target network call
+        during lifespan shutdown is more risk than benefit (same
+        posture the NSX precedent established).
+        """
+        async with self._provider_lock:
+            self._provider_tokens.clear()
+        async with self._tenant_lock:
+            self._tenant_tokens.clear()
+        await super().aclose()
+
+
+async def _try_probe(
+    client: httpx.AsyncClient,
+    path: str,
+    accept: str | None = None,
+) -> httpx.Response | Exception:
+    """GET *path* on *client*, returning the response or the captured exception.
+
+    Used by :meth:`VcfAutomationConnector.fingerprint` to probe each
+    plane and produce a structured ``reachable=False`` result on
+    failure rather than letting the exception bubble.
+    """
+    try:
+        headers = {"Accept": accept} if accept else None
+        resp = await client.get(path, headers=headers)
+        resp.raise_for_status()
+    except (httpx.HTTPError, OSError) as exc:
+        return exc
+    return resp

--- a/backend/src/meho_backplane/connectors/vcf_automation/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/session.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading for the vcf-automation connector.
+
+The hand-rolled
+:class:`~meho_backplane.connectors.vcf_automation.connector.VcfAutomationConnector`
+spans two auth planes on the same appliance (vCloud-Director-derived
+*provider* plane + Aria-IaaS-derived *tenant* plane); each plane has its
+own login flow but both ultimately resolve to a single ``{"username": ...,
+"password": ...}`` credential pair sourced from the target's Vault secret.
+A single :class:`VcfAutomationCredentialsLoader` is therefore sufficient
+-- the connector applies the same loaded pair against whichever plane is
+being established. When the provider-plane account differs from the SSO
+account (typical: ``admin@System`` for provider vs ``svc-meho`` for
+tenant) the operator supplies ``target.provider_username`` /
+``target.provider_secret_ref`` and the connector reads them at
+``auth_headers`` time; the loader interface stays single-pair.
+
+The credential fetch (Vault path -> ``{"username": ..., "password": ...}``
+dict) is split out behind a narrow :class:`VcfAutomationCredentialsLoader`
+callable so:
+
+* Production deploys override the default loader at construction time
+  once the operator-context per-target Vault credential read is wired
+  for this connector (tracked under the open
+  `Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_).
+* Unit tests inject their own (mock) loader returning a pre-built dict.
+* Integration tests against a recorded fixture or live VCFA appliance
+  pass a loader that yields the appropriate service-account credentials.
+
+The default loader, :func:`load_credentials_from_vault`, raises
+:exc:`NotImplementedError` until the live read lands -- same posture as
+the NSX / SDDC Manager / vSphere precedents.
+
+The :class:`VcfAutomationTargetLike` Protocol captures the minimum
+target shape the connector reads: ``name`` (per-target token cache key),
+``host`` (the addressable host -- may be an IP), ``port``,
+``secret_ref`` (the Vault path the default loader resolves),
+``auth_model`` (boundary-checked), ``fqdn`` (the vhost the appliance
+expects in the ``Host:`` header -- load-bearing when ``host`` is an
+IP because VCFA returns 404 with empty body before the application
+sees the request otherwise), ``domain`` (optional org / SSO realm
+forwarded on the tenant login body), ``provider_username`` /
+``provider_secret_ref`` (optional provider-plane credential overrides
+for the ``admin@System`` vs ``svc-meho`` split documented in the
+consumer wrapper). The concrete ``Target`` model in
+:mod:`meho_backplane.targets` (G0.3 #224 -- closed) satisfies this
+Protocol structurally; the four optional fields default to ``None``
+so a target that doesn't carry them is still acceptable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "SessionCredentials",
+    "VcfAutomationCredentialsLoader",
+    "VcfAutomationTargetLike",
+    "load_credentials_from_vault",
+]
+
+
+class SessionCredentials(Protocol):
+    """The dict shape :class:`VcfAutomationCredentialsLoader` returns.
+
+    Captured as a Protocol so the type checker can flag a loader that
+    forgets a key. The two values feed both plane logins -- the
+    provider plane sends them as HTTP Basic, the tenant plane as a
+    JSON body field pair -- modulo the optional provider-plane
+    override on ``VcfAutomationTargetLike``.
+    """
+
+    username: str
+    password: str
+
+
+@runtime_checkable
+class VcfAutomationTargetLike(Protocol):
+    """Minimum target shape :class:`VcfAutomationConnector` reads.
+
+    Structural Protocol -- the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` (G0.3 #224 -- closed) satisfies this
+    Protocol unchanged once the four optional fields land in the model.
+    ``auth_model`` is checked at the boundary so a target tagged
+    ``per_user`` or ``impersonation`` raises a clear error rather than
+    silently authenticating as the shared service account.
+
+    ``fqdn`` is the vhost the appliance expects in the ``Host:`` header.
+    VCFA 9.x enforces strict ``Host:`` matching; when ``host`` is an IP
+    and ``fqdn`` is unset, every path returns 404 with empty body before
+    the application sees the request (the consumer wrapper's documented
+    failure mode -- see ``scripts/vcf-automation.sh`` § Vhost routing).
+    The connector raises a clear configuration error at session-establish
+    time rather than emitting a confusing post-login 404 storm.
+
+    ``domain`` is the org name (provider plane) or SSO realm / org
+    (tenant plane). Forwarded verbatim on the tenant login JSON body
+    as the optional ``domain`` field; ignored on the provider plane
+    when ``provider_username`` is set (because that field already
+    carries the ``<user>@System`` form).
+
+    ``provider_username`` is the verbatim Basic-auth user the provider
+    plane needs (typically ``admin@System``); when unset, the connector
+    falls back to ``f"{creds['username']}@{domain or 'System'}"``.
+    ``provider_secret_ref`` is an optional Vault path the loader can
+    resolve to a *different* credential pair when the provider-plane
+    password differs from the SSO secret -- the connector reads the
+    provider plane via the override loader when set, the default loader
+    otherwise.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+    fqdn: str | None
+    domain: str | None
+    provider_username: str | None
+    provider_secret_ref: str | None
+
+
+VcfAutomationCredentialsLoader = Callable[[VcfAutomationTargetLike], Awaitable[dict[str, str]]]
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+The connector's
+:meth:`VcfAutomationConnector._load_credentials` invokes the loader on
+first session-establish per ``(target.name, secret_ref)`` and caches the
+result for the connector instance lifetime. The same loader is invoked
+a second time with ``target.provider_secret_ref`` when that override is
+set, so production deploys can resolve both via a single Vault read
+path. The return type is the looser ``dict[str, str]`` (not
+:class:`SessionCredentials`) because Python :class:`Protocol` instances
+aren't runtime-constructible without a matching class -- production
+code returns a plain dict and the connector reads ``creds["username"]``
+/ ``creds["password"]`` by key.
+"""
+
+
+async def load_credentials_from_vault(
+    target: VcfAutomationTargetLike,
+) -> dict[str, str]:
+    """Default credential loader -- Vault read by ``target.secret_ref``.
+
+    Deliberate stub: the operator-context per-target Vault credential
+    read is not yet wired for the VCF Automation connector. Raising
+    :exc:`NotImplementedError` here keeps the wiring shape stable -- a
+    production caller without an override receives a clear error rather
+    than a silent fallback or a hallucinated credential pair. The
+    supported workaround is to inject a custom ``credentials_loader``
+    on ``VcfAutomationConnector`` at construction time. The live read
+    is tracked under the open Goal #214 (Connector parity).
+
+    Once the read lands, this function becomes the live implementation
+    that reads the ``vcf-automation/<target.name>`` Vault path (or
+    ``target.secret_ref`` directly when set) and returns the parsed
+    ``{"username": ..., "password": ...}`` dict.
+    """
+    raise NotImplementedError(
+        "load_credentials_from_vault is a deliberate stub: the operator-context "
+        "per-target Vault credential read is not yet wired for the VCF Automation "
+        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
+        "Workaround: inject a custom credentials_loader on VcfAutomationConnector. "
+        "Tracked under open Goal #214 (Connector parity): "
+        "https://github.com/evoila/meho/issues/214"
+    )

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -295,3 +295,24 @@ def test_harbor_connector_registered_under_v2_triple() -> None:
     key = ("harbor", "2.x", "harbor-rest")
     assert key in snapshot
     assert snapshot[key] is HarborConnector
+
+
+def test_vcf_automation_connector_registered_under_v2_triple() -> None:
+    """VcfAutomationConnector package registers under (vcf-automation, 9.0, vcfa-rest).
+
+    The autouse _clean_registry fixture clears the registry before this test,
+    so we manually re-register using the class attributes to assert the triple
+    resolves correctly. Same pattern as the SDDC Manager / Harbor tests above.
+    """
+    from meho_backplane.connectors.vcf_automation import VcfAutomationConnector
+
+    register_connector_v2(
+        product=VcfAutomationConnector.product,
+        version=VcfAutomationConnector.version,
+        impl_id=VcfAutomationConnector.impl_id,
+        cls=VcfAutomationConnector,
+    )
+    snapshot = all_connectors_v2()
+    key = ("vcf-automation", "9.0", "vcfa-rest")
+    assert key in snapshot
+    assert snapshot[key] is VcfAutomationConnector

--- a/backend/tests/test_connectors_vcf_automation_auth.py
+++ b/backend/tests/test_connectors_vcf_automation_auth.py
@@ -1,0 +1,887 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`VcfAutomationConnector` dual-plane auth + vhost + fingerprint/probe.
+
+Exercises the load-bearing dual-plane contract:
+
+* Provider plane: ``POST /cloudapi/1.0.0/sessions/provider`` with HTTP
+  Basic; response header ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` is the JWT
+  the connector caches and sends as ``Authorization: Bearer <jwt>`` on
+  subsequent ``/cloudapi/*`` and ``/api/*`` calls.
+* Tenant plane: ``POST /iaas/api/login`` with a JSON body; response
+  body ``{"token": "..."}`` is the token the connector caches and
+  sends as ``Authorization: Bearer <token>`` on subsequent
+  ``/iaas/api/*`` calls.
+* Plane selection by path prefix (``/iaas/api/*`` -> tenant, else
+  provider).
+* Per-plane 401 -> re-login + retry-once (independently per plane).
+* Per-target isolation across both caches.
+* Vhost routing: ``target.fqdn`` set -> base URL uses the FQDN; IP
+  host with no ``fqdn`` -> :exc:`VcfAutomationConfigurationError`.
+* ``auth_model != "shared_service_account"`` -> :exc:`NotImplementedError`.
+
+The contract mirrors :mod:`tests.test_connectors_nsx_auth` and
+:mod:`tests.test_connectors_sddc_manager_auth` with the dual-plane
+divergence: two distinct login flows + two cached tokens per target
++ path-aware plane resolution.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vcf_automation import (
+    VcfAutomationConfigurationError,
+    VcfAutomationConnector,
+    VcfAutomationTargetLike,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_vcfa_registry() -> Iterator[None]:
+    """Re-register VcfAutomationConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that
+    calls :func:`clear_registry` between tests. Re-register before
+    every test in this module and clear after -- same pattern
+    :mod:`tests.test_connectors_nsx_auth` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=VcfAutomationConnector.product,
+        version=VcfAutomationConnector.version,
+        impl_id=VcfAutomationConnector.impl_id,
+        cls=VcfAutomationConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub -- satisfies VcfAutomationTargetLike Protocol structurally.
+# Replaced by the real Target model when fqdn / domain / provider_username /
+# provider_secret_ref columns land in meho_backplane.targets.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    fqdn: str | None = None
+    domain: str | None = None
+    provider_username: str | None = None
+    provider_secret_ref: str | None = None
+
+
+_TARGET_A = _StubTarget(
+    name="vcfa-a",
+    host="vcfa-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/vcfa/vcfa-a",
+)
+_TARGET_B = _StubTarget(
+    name="vcfa-b",
+    host="vcfa-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/vcfa/vcfa-b",
+)
+
+
+async def _stub_loader(_target: VcfAutomationTargetLike) -> dict[str, str]:
+    """Return canned credentials regardless of the target."""
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> VcfAutomationConnector:
+    """Build a connector wired with the stub loader."""
+    return VcfAutomationConnector(credentials_loader=_stub_loader)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_vcfa_connector_subclasses_http_connector() -> None:
+    """Sanity check: the connector inherits from HttpConnector with the right metadata."""
+    assert issubclass(VcfAutomationConnector, HttpConnector)
+    assert VcfAutomationConnector.product == "vcf-automation"
+    assert VcfAutomationConnector.version == "9.0"
+    assert VcfAutomationConnector.impl_id == "vcfa-rest"
+    assert VcfAutomationConnector.supported_version_range == ">=9.0,<10.0"
+    assert VcfAutomationConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    """The package's __init__ calls register_connector_v2 at import time."""
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("vcf-automation", "9.0", "vcfa-rest")
+    assert key in registry
+    assert registry[key] is VcfAutomationConnector
+
+
+def test_default_credentials_loader_raises_until_goal_214() -> None:
+    """The default Vault loader stays unimplemented until Goal #214."""
+    import asyncio
+
+    from meho_backplane.connectors.vcf_automation.session import (
+        load_credentials_from_vault,
+    )
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"Goal #214"):
+            await load_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Vhost routing -- base URL composition
+# ---------------------------------------------------------------------------
+
+
+def test_base_url_uses_fqdn_when_set() -> None:
+    """``target.fqdn`` overrides ``target.host`` in the base URL."""
+    target = _StubTarget(
+        name="vcfa-vhost",
+        host="10.0.0.5",
+        port=443,
+        secret_ref="kv/data/vcfa/vhost",
+        fqdn="vcfa.canonical.invalid",
+    )
+    connector = _make_connector()
+    assert connector._base_url(target) == "https://vcfa.canonical.invalid"
+
+
+def test_base_url_uses_host_when_host_is_fqdn() -> None:
+    """A target reached by FQDN without ``fqdn`` set works -- host already carries the vhost."""
+    connector = _make_connector()
+    assert connector._base_url(_TARGET_A) == "https://vcfa-a.test.invalid"
+
+
+def test_base_url_with_non_default_port_is_appended() -> None:
+    """Non-443 ports are appended to the base URL host."""
+    target = _StubTarget(
+        name="vcfa-port",
+        host="vcfa-port.test.invalid",
+        port=8443,
+        secret_ref="kv/data/vcfa/port",
+    )
+    connector = _make_connector()
+    assert connector._base_url(target) == "https://vcfa-port.test.invalid:8443"
+
+
+@pytest.mark.parametrize("ip_host", ["10.0.0.5", "192.168.1.1", "::1", "[2001:db8::1]"])
+def test_base_url_raises_configuration_error_when_ip_host_has_no_fqdn(ip_host: str) -> None:
+    """An IP-literal host with no ``fqdn`` raises VcfAutomationConfigurationError.
+
+    The consumer wrapper documents this as the silent-404 failure mode
+    (VCFA returns 404 with empty body before the application sees the
+    request when ``Host:`` doesn't match the appliance's expected
+    vhost). The connector surfaces this at base-URL composition time
+    so operators see a clear configuration message rather than a
+    confusing 404 storm.
+    """
+    target = _StubTarget(
+        name="vcfa-ip",
+        host=ip_host,
+        port=443,
+        secret_ref="kv/data/vcfa/ip",
+    )
+    connector = _make_connector()
+    with pytest.raises(VcfAutomationConfigurationError) as exc_info:
+        connector._base_url(target)
+    assert "vcfa-ip" in str(exc_info.value)
+    assert ip_host in str(exc_info.value)
+    assert "fqdn" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Plane selection by path prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_requires_path_argument() -> None:
+    """auth_headers() without path= rejects -- dual-plane has no plane-agnostic header set."""
+    connector = _make_connector()
+    with pytest.raises(VcfAutomationConfigurationError, match=r"path"):
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_plane_path_returns_bearer_with_cloudapi_accept() -> None:
+    """``/cloudapi/*`` path -> provider login + Bearer JWT + version=9.0.0 Accept."""
+    connector = _make_connector()
+    jwt = "provider-jwt-abc-123"
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        login = mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200,
+            headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": jwt},
+        )
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+
+    assert headers == {
+        "Authorization": f"Bearer {jwt}",
+        "Accept": "application/json;version=9.0.0",
+    }
+    # Verify provider login used HTTP Basic with the default
+    # ``<user>@System`` legacy username form (no provider_username,
+    # no domain -> "System" default).
+    request = login.calls[0].request
+    auth_header = request.headers.get("Authorization", "")
+    assert auth_header.startswith("Basic ")
+    basic_user, basic_password = _decode_basic_auth(auth_header)
+    assert basic_user == "svc-meho@System"
+    assert basic_password == "stub-password"
+    # Tenant login must NOT have fired for a provider-plane request.
+    assert connector._tenant_tokens == {}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_plane_api_path_uses_versioned_classic_accept() -> None:
+    """``/api/*`` path -> provider plane but classic vCD Accept (#517)."""
+    connector = _make_connector()
+    jwt = "provider-jwt-xyz"
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": jwt}
+        )
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="", path="/api/admin/extension")
+
+    assert headers == {
+        "Authorization": f"Bearer {jwt}",
+        "Accept": "application/*+json;version=40.0",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tenant_plane_path_returns_bearer_with_plain_accept() -> None:
+    """``/iaas/api/*`` path -> tenant login + Bearer token + Accept: application/json."""
+    connector = _make_connector()
+    token = "tenant-token-456"
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        login = mock.post("/iaas/api/login").respond(200, json={"token": token})
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="", path="/iaas/api/projects")
+
+    assert headers == {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    # Verify tenant login used JSON body with the canonical credential
+    # pair; ``domain`` is omitted when ``target.domain`` is unset.
+    import json as _json
+
+    request = login.calls[0].request
+    assert request.headers.get("content-type", "").startswith("application/json")
+    sent = _json.loads(request.content.decode())
+    assert sent == {"username": "svc-meho", "password": "stub-password"}
+    # Provider login must NOT have fired for a tenant-plane request.
+    assert connector._provider_tokens == {}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tenant_login_forwards_domain_when_target_has_domain() -> None:
+    """``target.domain`` is forwarded on the tenant login JSON body."""
+    target = _StubTarget(
+        name="vcfa-domain",
+        host="vcfa-domain.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcfa/domain",
+        domain="corp.example",
+    )
+    connector = _make_connector()
+    token = "tenant-token-domain"
+
+    async with respx.mock(base_url="https://vcfa-domain.test.invalid") as mock:
+        login = mock.post("/iaas/api/login").respond(200, json={"token": token})
+        await connector.auth_headers(target, raw_jwt="", path="/iaas/api/projects")
+
+    import json as _json
+
+    sent = _json.loads(login.calls[0].request.content.decode())
+    assert sent == {
+        "username": "svc-meho",
+        "password": "stub-password",
+        "domain": "corp.example",
+    }
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Per-plane token caching + isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_token_cached_across_calls_against_same_target() -> None:
+    """Two provider-plane auth_headers calls -> one provider login."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        login = mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        h1 = await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+        h2 = await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/regions")
+
+    assert h1["Authorization"] == h2["Authorization"]
+    assert login.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tenant_token_cached_across_calls_against_same_target() -> None:
+    """Two tenant-plane auth_headers calls -> one tenant login."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        login = mock.post("/iaas/api/login").respond(200, json={"token": "t-tok"})
+        h1 = await connector.auth_headers(_TARGET_A, raw_jwt="", path="/iaas/api/projects")
+        h2 = await connector.auth_headers(_TARGET_A, raw_jwt="", path="/iaas/api/deployments")
+
+    assert h1["Authorization"] == h2["Authorization"]
+    assert login.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_and_tenant_caches_are_independent_per_target() -> None:
+    """Establishing provider then tenant against the same target produces both tokens."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt-1"}
+        )
+        mock.post("/iaas/api/login").respond(200, json={"token": "t-tok-1"})
+        await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+        await connector.auth_headers(_TARGET_A, raw_jwt="", path="/iaas/api/projects")
+
+    assert connector._provider_tokens == {"vcfa-a": "p-jwt-1"}
+    assert connector._tenant_tokens == {"vcfa-a": "t-tok-1"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_both_plane_caches_separate() -> None:
+    """Two targets get two distinct token sets across both planes."""
+    connector = _make_connector()
+
+    async with respx.mock() as mock:
+        mock.post("https://vcfa-a.test.invalid/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-a"}
+        )
+        mock.post("https://vcfa-b.test.invalid/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-b"}
+        )
+        mock.post("https://vcfa-a.test.invalid/iaas/api/login").respond(200, json={"token": "t-a"})
+        mock.post("https://vcfa-b.test.invalid/iaas/api/login").respond(200, json={"token": "t-b"})
+
+        await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+        await connector.auth_headers(_TARGET_B, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+        await connector.auth_headers(_TARGET_A, raw_jwt="", path="/iaas/api/projects")
+        await connector.auth_headers(_TARGET_B, raw_jwt="", path="/iaas/api/projects")
+
+    assert connector._provider_tokens == {"vcfa-a": "p-a", "vcfa-b": "p-b"}
+    assert connector._tenant_tokens == {"vcfa-a": "t-a", "vcfa-b": "t-b"}
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Provider username override (admin@System vs svc-meho)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_username_override_is_used_verbatim() -> None:
+    """``target.provider_username`` overrides the default ``<user>@System`` form."""
+    target = _StubTarget(
+        name="vcfa-prov-user",
+        host="vcfa-prov-user.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcfa/prov-user",
+        provider_username="admin@System",
+    )
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-prov-user.test.invalid") as mock:
+        login = mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        await connector.auth_headers(target, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+
+    auth = login.calls[0].request.headers["Authorization"]
+    user, password = _decode_basic_auth(auth)
+    assert user == "admin@System"
+    assert password == "stub-password"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_secret_ref_override_invokes_loader_for_distinct_provider_pair() -> None:
+    """``target.provider_secret_ref`` -> loader is called twice (provider + tenant secret refs).
+
+    The override path lets operators store distinct provider-plane
+    credentials (e.g. the VCFA-local ``admin@System`` account
+    password) at a different Vault path than the SSO/tenant secret.
+    """
+    target = _StubTarget(
+        name="vcfa-prov-secret",
+        host="vcfa-prov-secret.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcfa/sso",
+        provider_secret_ref="kv/data/vcfa/provider",
+        provider_username="admin@System",
+    )
+
+    seen_secret_refs: list[str] = []
+
+    async def _ref_tracking_loader(t: VcfAutomationTargetLike) -> dict[str, str]:
+        seen_secret_refs.append(t.secret_ref)
+        if t.secret_ref == "kv/data/vcfa/provider":
+            return {"username": "admin", "password": "provider-secret"}
+        return {"username": "svc-meho", "password": "tenant-secret"}
+
+    connector = VcfAutomationConnector(credentials_loader=_ref_tracking_loader)
+
+    async with respx.mock(base_url="https://vcfa-prov-secret.test.invalid") as mock:
+        login = mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        await connector.auth_headers(target, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+
+    # Provider login carried the *provider-only* password.
+    auth = login.calls[0].request.headers["Authorization"]
+    _, password = _decode_basic_auth(auth)
+    assert password == "provider-secret"
+    assert "kv/data/vcfa/provider" in seen_secret_refs
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Failure modes -- login errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_login_401_surfaces_runtime_error_naming_target() -> None:
+    """401 from provider login raises RuntimeError naming the target + status."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(401)
+        with pytest.raises(RuntimeError, match=r"vcfa-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+    assert "401" in str(exc_info.value)
+    assert "provider" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_login_missing_token_header_raises() -> None:
+    """2xx with no X-VMWARE-VCLOUD-ACCESS-TOKEN raises naming the target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(200)
+        with pytest.raises(RuntimeError, match=r"vcfa-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+    assert "X-VMWARE-VCLOUD-ACCESS-TOKEN" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tenant_login_401_surfaces_runtime_error_naming_target() -> None:
+    """401 from tenant login raises RuntimeError naming the target + plane."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/iaas/api/login").respond(401)
+        with pytest.raises(RuntimeError, match=r"vcfa-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="", path="/iaas/api/projects")
+    assert "401" in str(exc_info.value)
+    assert "tenant" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tenant_login_empty_token_field_raises() -> None:
+    """2xx tenant login with no ``token`` field raises naming the target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/iaas/api/login").respond(200, json={"sessionId": "wrong-shape"})
+        with pytest.raises(RuntimeError, match=r"vcfa-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="", path="/iaas/api/projects")
+    assert "token" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_raises_clear_error() -> None:
+    """A loader returning a dict without ``password`` raises naming the target."""
+
+    async def _bad_loader(_t: VcfAutomationTargetLike) -> dict[str, str]:
+        return {"username": "svc-meho"}  # type: ignore[return-value]
+
+    connector = VcfAutomationConnector(credentials_loader=_bad_loader)
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid"):
+        with pytest.raises(RuntimeError, match=r"password"):
+            await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation / unknown modes raise NotImplementedError naming target + mode."""
+    target = _StubTarget(
+        name="vcfa-per-user",
+        host="vcfa.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcfa/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+    assert "vcfa-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """``auth_model=None`` is accepted (pre-G0.3 column-not-yet-populated)."""
+    target = _StubTarget(
+        name="vcfa-pre-g03",
+        host="vcfa.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcfa/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "pre-g03-jwt"}
+        )
+        headers = await connector.auth_headers(target, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+    assert headers["Authorization"] == "Bearer pre-g03-jwt"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
+    """An :class:`AuthModel` enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="vcfa-enum",
+        host="vcfa.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcfa/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "enum-jwt"}
+        )
+        headers = await connector.auth_headers(target, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+    assert headers["Authorization"] == "Bearer enum-jwt"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Per-plane 401 -> re-login + retry-once recovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_plane_401_triggers_relogin_and_retry_once() -> None:
+    """A 401 on a ``/cloudapi/*`` call triggers provider re-login + a single retry."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        login = mock.post("/cloudapi/1.0.0/sessions/provider")
+        login.side_effect = [
+            httpx.Response(200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt-first"}),
+            httpx.Response(200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt-second"}),
+        ]
+        orgs = mock.get("/cloudapi/1.0.0/orgs")
+        orgs.side_effect = [
+            httpx.Response(401),
+            httpx.Response(200, json={"values": [{"name": "System"}]}),
+        ]
+
+        result = await connector._request_json(_TARGET_A, "GET", "/cloudapi/1.0.0/orgs", raw_jwt="")
+
+    assert result == {"values": [{"name": "System"}]}
+    assert login.call_count == 2
+    assert orgs.call_count == 2
+    # Cache holds the refreshed token; tenant cache untouched.
+    assert connector._provider_tokens == {"vcfa-a": "p-jwt-second"}
+    assert connector._tenant_tokens == {}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_plane_401_then_401_after_relogin_raises_runtime_error() -> None:
+    """A repeated 401 (post-relogin) surfaces as RuntimeError naming the target + plane."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        login = mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        orgs = mock.get("/cloudapi/1.0.0/orgs").respond(401)
+
+        with pytest.raises(RuntimeError, match=r"vcfa-a") as exc_info:
+            await connector._request_json(_TARGET_A, "GET", "/cloudapi/1.0.0/orgs", raw_jwt="")
+
+    assert "after refresh" in str(exc_info.value)
+    assert "provider" in str(exc_info.value)
+    assert login.call_count == 2
+    assert orgs.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tenant_plane_401_triggers_independent_relogin_and_retry_once() -> None:
+    """A 401 on ``/iaas/api/*`` re-logs the tenant plane only -- provider cache untouched."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        # Seed a provider token first so we can assert it survives.
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt-stable"}
+        )
+        await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+
+        tenant_login = mock.post("/iaas/api/login")
+        tenant_login.side_effect = [
+            httpx.Response(200, json={"token": "t-first"}),
+            httpx.Response(200, json={"token": "t-second"}),
+        ]
+        projects = mock.get("/iaas/api/projects")
+        projects.side_effect = [
+            httpx.Response(401),
+            httpx.Response(200, json={"content": [{"name": "default"}]}),
+        ]
+
+        result = await connector._request_json(_TARGET_A, "GET", "/iaas/api/projects", raw_jwt="")
+
+    assert result == {"content": [{"name": "default"}]}
+    assert tenant_login.call_count == 2
+    assert projects.call_count == 2
+    # The provider cache survived the tenant-plane re-login.
+    assert connector._provider_tokens == {"vcfa-a": "p-jwt-stable"}
+    assert connector._tenant_tokens == {"vcfa-a": "t-second"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_json_rejects_non_idempotent_method() -> None:
+    """_request_json mirrors the base ABC: non-idempotent verbs raise ValueError."""
+    connector = _make_connector()
+    with pytest.raises(ValueError, match=r"idempotent"):
+        await connector._request_json(_TARGET_A, "POST", "/cloudapi/1.0.0/orgs", raw_jwt="")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() + probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_when_both_planes_reachable() -> None:
+    """Both unauthenticated probes succeed -> reachable=True + canonical extras."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.get("/api/versions").respond(
+            200,
+            content=b"<SupportedVersions><VersionInfo deprecated='false'>"
+            b"<Version>9.0.0</Version></VersionInfo></SupportedVersions>",
+            content_type="application/xml",
+        )
+        mock.get("/iaas/api/about").respond(
+            200,
+            json={
+                "latestApiVersion": "2024-02-20",
+                "supportedApis": ["iaas", "lcm"],
+            },
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcf-automation"
+    assert fp.reachable is True
+    assert fp.version == "2024-02-20"
+    assert fp.probe_method == "GET /api/versions + GET /iaas/api/about"
+    assert fp.extras["planes"] == ["provider", "tenant"]
+    assert fp.extras["provider_versions_status"] == 200
+    assert fp.extras["tenant_supported_apis"] == ["iaas", "lcm"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_provider_failure_returns_reachable_false() -> None:
+    """A 5xx on the provider probe surfaces as reachable=False naming the failed plane."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid", assert_all_called=False) as mock:
+        mock.get("/api/versions").respond(503)
+        mock.get("/iaas/api/about").respond(200, json={"latestApiVersion": "x"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is False
+    assert fp.extras["failed_plane"] == "provider"
+    assert "HTTPStatusError" in fp.extras["error"] or "503" in fp.extras["error"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_tenant_failure_returns_reachable_false() -> None:
+    """A 5xx on the tenant probe surfaces as reachable=False naming the failed plane."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.get("/api/versions").respond(200, content=b"<x/>")
+        mock.get("/iaas/api/about").respond(503)
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is False
+    assert fp.extras["failed_plane"] == "tenant"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_ip_host_without_fqdn_surfaces_configuration_error() -> None:
+    """Vhost mis-config (IP host, no fqdn) -> reachable=False with structured error."""
+    target = _StubTarget(
+        name="vcfa-ip-fp",
+        host="10.0.0.5",
+        port=443,
+        secret_ref="kv/data/vcfa/ip-fp",
+    )
+    connector = _make_connector()
+
+    fp = await connector.fingerprint(target)
+    assert fp.reachable is False
+    error = fp.extras["error"]
+    assert "VcfAutomationConfigurationError" in error
+    assert "fqdn" in error.lower()
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_when_both_planes_reachable() -> None:
+    """probe() returns ok=True when fingerprint succeeds across both planes."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.get("/api/versions").respond(200, content=b"<x/>")
+        mock.get("/iaas/api/about").respond(200, json={"latestApiVersion": "x"})
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_with_reason_when_a_plane_fails() -> None:
+    """probe() returns ok=False + reason on either plane failure."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid", assert_all_called=False) as mock:
+        mock.get("/api/versions").respond(503)
+        mock.get("/iaas/api/about").respond(200, json={})
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose -- clears both plane caches + tears down pool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_both_plane_caches_and_pool() -> None:
+    """aclose() drops both provider+tenant token caches and tears down the httpx pool."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        mock.post("/iaas/api/login").respond(200, json={"token": "t-tok"})
+        await connector.auth_headers(_TARGET_A, raw_jwt="", path="/cloudapi/1.0.0/orgs")
+        await connector.auth_headers(_TARGET_A, raw_jwt="", path="/iaas/api/projects")
+
+    assert connector._provider_tokens == {"vcfa-a": "p-jwt"}
+    assert connector._tenant_tokens == {"vcfa-a": "t-tok"}
+    await connector.aclose()
+    assert connector._provider_tokens == {}
+    assert connector._tenant_tokens == {}
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_with_no_cached_sessions_is_a_noop() -> None:
+    """A fresh connector with no sessions established closes cleanly."""
+    connector = _make_connector()
+    await connector.aclose()
+    assert connector._clients == {}
+    assert connector._provider_tokens == {}
+    assert connector._tenant_tokens == {}

--- a/docs/codebase/connectors-vcf-automation.md
+++ b/docs/codebase/connectors-vcf-automation.md
@@ -1,0 +1,286 @@
+# Connector: vcf-automation (VCF Automation 9.0, dual-plane)
+
+## Overview
+
+The `vcf-automation` connector is the hand-rolled `HttpConnector` subclass that
+dispatches VCF Automation REST operations under the
+`(product="vcf-automation", version="9.0", impl_id="vcfa-rest")` registry
+triple. G3.6-T10 (#832) shipped the skeleton — dual-plane auth (provider +
+tenant), vhost / FQDN routing, fingerprint, probe, and the G0.6 dispatch shim.
+G3.6-T11 (#836) will add dual-plane spec ingestion + operator-review curation;
+G3.6-T12 (#840) will ship the CLI verb tree + recorded-fixture E2E.
+
+Source: `backend/src/meho_backplane/connectors/vcf_automation/`.
+
+The connector is **dual-plane**: a single registry triple covers both the
+vCloud-Director-derived provider plane (paths under `/cloudapi/*` and the
+classic `/api/*` family) and the Aria-IaaS-derived tenant plane (paths under
+`/iaas/api/*`). Each plane has its own login flow, its own cached token, and
+its own 401-driven re-login lock. The dual-source shape parallels vSphere's
+`vcenter.yaml` + `vi-json.yaml` (`connectors/vmware_rest/`); the dual-auth
+shape is unique to VCFA because the two API planes are independent identity
+domains.
+
+## Key types
+
+- **`VcfAutomationConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="vcf-automation"`, `version="9.0"`,
+  `impl_id="vcfa-rest"`, `supported_version_range=">=9.0,<10.0"`,
+  `priority=1`. The priority outranks a future `GenericRestConnector`
+  auto-shim defensively if both somehow register for the same triple.
+- **`VcfAutomationConfigurationError`** (`connector.py`) — `RuntimeError`
+  subclass raised when a target's configuration prevents the connector from
+  running (today: IP host with no `fqdn` set). The subclass lets the
+  fingerprint/probe layer keep its existing `except (httpx.HTTPError, OSError,
+  RuntimeError)` clause without a separate exception branch.
+- **`VcfAutomationTargetLike`** (`session.py`) — runtime-checkable Protocol
+  capturing the minimum target shape the connector reads: `name`, `host`,
+  `port`, `secret_ref`, `auth_model`, plus four VCFA-specific fields: `fqdn`
+  (load-bearing vhost override), `domain` (org / SSO realm forwarded on the
+  tenant login body), `provider_username` (verbatim Basic-auth user for the
+  provider plane, typically `admin@System`), `provider_secret_ref` (optional
+  Vault path for a distinct provider-plane password). Replaced by the
+  concrete `Target` model once those columns land in
+  `meho_backplane.targets`; the model satisfies the Protocol structurally
+  without code edits here.
+- **`VcfAutomationCredentialsLoader`** (`session.py`) — async callable type
+  resolving a target to `{"username": ..., "password": ...}`. Injectable on
+  connector construction (`VcfAutomationConnector(credentials_loader=...)`)
+  so unit tests, integration tests, and pre-G0.3 production deploys override
+  the default Vault loader. The same loader is called twice when
+  `target.provider_secret_ref` differs from `target.secret_ref` — once per
+  plane — so a single read path serves both planes.
+- **`load_credentials_from_vault`** (`session.py`) — default loader, stubbed
+  `NotImplementedError` until the live operator-context per-target Vault read
+  lands. Mirrors `load_credentials_from_vault` in `connectors/sddc_manager/`
+  and `load_session_credentials_from_vault` in `connectors/nsx/` /
+  `connectors/vmware_rest/`.
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()` in
+   `meho_backplane/connectors/registry.py`, which walks every
+   `connectors/<product>/` subpackage in name-sorted order.
+2. Importing `meho_backplane.connectors.vcf_automation` triggers the
+   module-level
+   `register_connector_v2(product="vcf-automation", version="9.0", impl_id="vcfa-rest", cls=VcfAutomationConnector)`
+   call.
+3. The registry's v2 table now resolves `("vcf-automation", "9.0",
+   "vcfa-rest")` to `VcfAutomationConnector`. The G0.7 auto-shim's
+   idempotency check (in `ensure_connector_class_registered`) no-ops on
+   subsequent ingests against the same triple.
+
+### Vhost routing (load-bearing)
+
+VCFA 9.x enforces strict `Host:` header matching — the consumer wrapper
+(`scripts/vcf-automation.sh`) uses `curl --resolve fqdn:443:<ip>` to override
+DNS while keeping the FQDN in the request line. In httpx terms, the
+connector's per-target `AsyncClient` is built with
+`base_url=https://<fqdn-or-host>`; the cleanest equivalent of `--resolve` is
+to use the FQDN as the URL host and rely on operator-side DNS resolution.
+
+The decision tree in `VcfAutomationConnector._base_url`:
+
+1. `target.fqdn` is set → base URL host is the FQDN.
+2. `target.fqdn` is unset and `target.host` is an IP literal (IPv4 or IPv6,
+   bracket-wrapped accepted) → raise `VcfAutomationConfigurationError` with
+   a clear message naming the target and pointing operators at the `--fqdn`
+   / `fqdn:` configuration knob. Without this guard every path returns 404
+   with empty body post-login.
+3. `target.fqdn` is unset and `target.host` is itself an FQDN → use
+   `target.host` as the URL host (the right vhost is already on the wire).
+
+`fingerprint()` catches the configuration error and reports a structured
+`reachable=False` with `extras["error"]` rather than bubbling the exception
+to the dispatcher.
+
+### Plane selection by path prefix
+
+`VcfAutomationConnector.auth_headers(target, raw_jwt, *, path=...)` is
+keyword-only on `path` and **requires** the path argument — a `None`
+default raises `VcfAutomationConfigurationError` because this connector has
+no plane-agnostic header set. The base `HttpConnector._request_json` /
+`_post_json` callers don't forward `path`, so the connector overrides both
+transports (`_request_json` / `_post_json`) to thread the path through
+before resolving headers.
+
+Plane classification (`_plane_for_path`):
+
+- `/iaas/api/*` → tenant plane.
+- Everything else (`/cloudapi/*`, `/api/*`) → provider plane.
+
+The provider plane Bearer JWT authenticates both `/cloudapi/*` and the
+classic `/api/*` surface — only the `Accept` media type differs (#517 in
+the consumer repo, validated 2026-05-17):
+
+- `/cloudapi/*` → `Accept: application/json;version=9.0.0`
+- `/api/*` → `Accept: application/*+json;version=40.0`
+
+### Provider-plane session establishment
+
+1. `auth_headers(..., path="/cloudapi/...")` resolves the plane to
+   `"provider"` and calls `_provider_session_token(target)`.
+2. The lock-protected token cache fast-paths a cached JWT.
+3. On cache miss: credentials are loaded. When `target.provider_secret_ref`
+   is set, the loader is invoked with the override path (typical: a separate
+   Vault entry for the VCFA-local `admin@System` password); otherwise the
+   default `target.secret_ref` pair is used for both planes.
+4. The Basic-auth username is `target.provider_username` verbatim when set
+   (typical: `admin@System`), otherwise the legacy fallback
+   `f"{creds['username']}@{target.domain or 'System'}"`.
+5. `POST /cloudapi/1.0.0/sessions/provider` with HTTP Basic and
+   `Accept: application/json;version=9.0.0`. A 2xx response carries
+   `X-VMWARE-VCLOUD-ACCESS-TOKEN` (a JWT) — the connector caches it under
+   `target.name`. Absence of the header on a 2xx response surfaces as a
+   `RuntimeError` rather than caching an empty token.
+6. `auth_headers` returns `{"Authorization": f"Bearer {jwt}", "Accept": <path-aware>}`.
+
+### Tenant-plane session establishment
+
+1. `auth_headers(..., path="/iaas/api/...")` resolves the plane to
+   `"tenant"` and calls `_tenant_session_token(target)`.
+2. The lock-protected token cache fast-paths a cached token.
+3. On cache miss: credentials are loaded from `target.secret_ref` (the
+   tenant plane does NOT honour `provider_secret_ref`).
+4. `POST /iaas/api/login` with JSON body
+   `{"username": ..., "password": ..., "domain"?: ...}` (the `domain` key
+   is added when `target.domain` is set) and
+   `Accept: application/json` + `Content-Type: application/json`.
+5. The response body is `{"token": "..."}` — the token is cached under
+   `target.name`. Missing / empty `token` field on a 2xx response surfaces
+   as `RuntimeError`.
+6. `auth_headers` returns `{"Authorization": f"Bearer {token}", "Accept": "application/json"}`.
+
+### 401 → re-login + retry-once (per plane, independent)
+
+`VcfAutomationConnector._request_json` (idempotent verbs) and
+`_post_json` (POST) share a common `_do_request_with_retry` helper:
+
+1. Build headers via `auth_headers(..., path=path)` (lazy login on first use).
+2. Fire the request through the per-target `AsyncClient`.
+3. On HTTP 401: invalidate the relevant plane's cache via
+   `_invalidate_plane(target, plane)`, refresh headers (re-login on demand),
+   retry once.
+4. A second 401 surfaces as `RuntimeError` naming the target and the plane
+   — consumer wrapper posture: re-login once on session-expiry, not a
+   retry loop. Hammering VCFA's audit log on a misconfigured credential
+   pair is the failure mode this rule guards against.
+5. The per-plane lock means a tenant-plane 401 doesn't block in-flight
+   provider-plane traffic and vice versa.
+
+### Fingerprint + probe
+
+- `fingerprint(target)` issues both unauthenticated version probes in series
+  through the per-target httpx client:
+  - Provider: `GET /api/versions` — returns vCD-API version XML. The
+    connector reads the status only; XML parsing for the "latest
+    non-deprecated" string lives in the consumer wrapper, which the
+    operator-facing CLI fingerprint surfaces. What we record is that the
+    appliance responded 2xx on the canonical provider probe.
+  - Tenant: `GET /iaas/api/about` — returns JSON
+    `{"latestApiVersion": "...", "supportedApis": [...]}`. The connector
+    reads `latestApiVersion` into the result's `version` field.
+- Both probes must succeed for `reachable=True`. A failure on either plane
+  surfaces as `reachable=False` with `extras["failed_plane"]` naming the
+  offender and `extras["error"]` carrying the exception class + message.
+  Vhost mis-configuration (IP host with no `fqdn`) is caught at
+  `_http_client` construction and reported as the structured failure too.
+- `probe(target)` delegates to `fingerprint` — both unauth probes already
+  cover reachability across both planes, so a separate path would add
+  round-trip cost without changing the boolean `ok`.
+
+### Dispatch shim
+
+`execute(target, op_id, params)` synthesises a minimal `Operator`
+(nil-UUID tenant_id + `sub="system:vcfa-rest-connector-shim"`) and delegates
+to `meho_backplane.operations.dispatch` with `connector_id="vcfa-rest-9.0"`.
+Pre-G0.6 chassis routes reach the dispatcher through this shim; post-G0.6
+callers (the `/api/v1/operations/call` route, MCP `call_operation`, and the
+`meho vcf-automation …` CLI verbs added in #840) construct a real `Operator`
+and call `dispatch` themselves.
+
+### Shutdown
+
+`aclose()` clears both `self._provider_tokens` and `self._tenant_tokens`
+under their respective locks (no server-side session revoke is issued —
+VCFA's session has an idle timeout, and a per-target network call during
+lifespan shutdown is more risk than benefit) and delegates to
+`HttpConnector.aclose()` which closes every per-target httpx client.
+
+## Dependencies
+
+- **httpx 0.28.x** — per-target `AsyncClient` pool (inherited from
+  `HttpConnector`); the connector calls `client.request` / `client.post`
+  directly from `_do_request_with_retry` so it can thread plane-specific
+  headers without rerouting through `_request_json`'s tenacity decorator.
+  The connection-error / 5xx retry layer lives on the base method and
+  applies to callers that use the base `_get_json` / `_post_json` paths
+  (the dispatcher always uses the overridden ones here).
+- **tenacity 9.x** — installed dependency; not in direct use on this
+  connector's overrides (the per-plane 401 retry-once is the only retry
+  layer). Inherited use of tenacity persists on the base `_request_json`.
+- **pydantic 2.13.x** — `FingerprintResult` / `ProbeResult` /
+  `OperationResult` are frozen models; the connector constructs them by
+  keyword.
+- **respx 0.23.x (test-only)** — the unit-test module mocks every request
+  shape (both logins + both probes + all four 401-retry scenarios) without
+  a network call.
+- **structlog** — `vcf_automation_provider_session_established` and
+  `vcf_automation_tenant_session_established` info events on first-use
+  login per plane per target; no other emit points in this skeleton.
+
+## Known issues
+
+- Default credentials loader raises `NotImplementedError`. Production
+  callers must inject `credentials_loader=...` on construction until the
+  operator-context per-target Vault credential read is wired for this
+  connector (tracked under open Goal #214). Mirrors the `vmware_rest` /
+  `nsx` / `sddc_manager` precedents.
+- The classic vCD `/api/versions` response is XML; the connector reads
+  status only and does not parse "latest non-deprecated version" out of it.
+  Operators who need that string call the wrapper directly; the curated
+  ingest in #836 will route through the structured `/cloudapi/*` and
+  `/iaas/api/*` paths instead.
+- `--resolve`-style DNS override (consumer-wrapper-only) has no direct
+  httpx equivalent in the connector — operators are expected to make the
+  appliance's FQDN resolvable on the meho-backplane host (typical: split-DNS
+  for the management network) when the target uses the IP-host-plus-FQDN
+  shape. A future enhancement could use httpx's transport-level resolver
+  hook, but the v0.2 posture matches MEHO's standard "operator-owned DNS"
+  assumption.
+
+## References
+
+- Issues: [G3.6-T10 #832](https://github.com/evoila/meho/issues/832)
+  (skeleton — this Task); [G3.6-T11 #836](https://github.com/evoila/meho/issues/836)
+  (dual-plane spec ingestion + read ops); [G3.6-T12 #840](https://github.com/evoila/meho/issues/840)
+  (CLI verbs + E2E + onboarding doc).
+- Parent Initiative: [G3.6 #369](https://github.com/evoila/meho/issues/369).
+- Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
+- Adapter dependency: [G0.2 #223](https://github.com/evoila/meho/issues/223)
+  (`HttpConnector`).
+- Substrate: [G0.6 #388](https://github.com/evoila/meho/issues/388)
+  (v2 registry), [G0.7 #389](https://github.com/evoila/meho/issues/389)
+  (spec ingestion pipeline).
+- Sibling task: [G3.6-T13 #841](https://github.com/evoila/meho/issues/841)
+  — shared `connectors/_shared/vcf_auth.py` for vROps + vRLI + Fleet. The
+  VCF Automation connector intentionally does NOT use this helper because
+  its dual-plane shape doesn't fit the single-pair-of-creds pattern the
+  helper was designed for.
+- Precedent: `connectors/nsx/connector.py` (session-cookie + XSRF +
+  401-retry-once); `connectors/sddc_manager/connector.py` (per-target
+  credential cache, dispatch-shim shape); `connectors/vmware_rest/`
+  (dual-spec ingestion shape — same `spec_source` tagging that #836 will
+  apply to the provider + tenant plane specs);
+  `connectors/adapters/http.py` (`HttpConnector`);
+  `connectors/registry.py:108` (`register_connector_v2`).
+- VCFA API references:
+  https://developer.broadcom.com/xapis/vmware-cloud-foundation-automation-api/latest/
+  (provider/cloudapi);
+  https://developer.broadcom.com/xapis/aria-automation-api/latest/
+  (tenant/iaas).
+- Consumer wrapper this contract mirrors (authoritative):
+  [`scripts/vcf-automation.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-automation.sh)
+  — header comment + login blocks verified 2026-05-21.


### PR DESCRIPTION
## Summary

- Ship the `VcfAutomationConnector` skeleton for VCF Automation 9.0 — dual-plane auth (provider plane: `POST /cloudapi/1.0.0/sessions/provider` → `X-VMWARE-VCLOUD-ACCESS-TOKEN` JWT; tenant plane: `POST /iaas/api/login` → `{"token": ...}`), path-prefix plane selection (`/iaas/api/*` → tenant, else provider), per-plane 401 → re-login + retry-once.
- Honour VCFA's strict vhost routing: `target.fqdn` overrides `target.host` in the base URL; an IP host with no `fqdn` raises `VcfAutomationConfigurationError` at session-establish time instead of producing the consumer-wrapper-documented silent-404 storm.
- Register under the G0.6 v2 triple `(product="vcf-automation", version="9.0", impl_id="vcfa-rest")`; v1 registry left untouched per the NSX/SDDC Manager precedents.
- Both login flows + the access-token header names + the vhost mechanism verified against `scripts/vcf-automation.sh` in the consumer wrapper repo (2026-05-21 snapshot — header comments + login blocks).

## Test plan

- [x] `ruff check` — clean on touched modules (incl. `_routing.py` + `_auth.py`).
- [x] `ruff format --check` — clean.
- [x] `mypy src/` (strict) — 200 source files, no issues.
- [x] `pytest -n auto backend/tests/test_connectors_vcf_automation_auth.py backend/tests/test_connectors_registry_v2.py backend/tests/test_connectors_sddc_manager_auth.py backend/tests/test_connectors_nsx_auth.py backend/tests/test_connectors_harbor_auth.py` — 125 passed.
- [x] Full backend unit suite `pytest -n auto backend/tests/` — 2871 passed, 285 skipped pre-refactor; re-run included after the file-size split.
- [x] `code-quality.py --diff` — 0 blockers, 1 informational warning on `connector.py` size (572 lines, under the 600-line block threshold).
- [x] Acceptance: `register_connector_v2(product="vcf-automation", version="9.0", impl_id="vcfa-rest", cls=...)` in `__init__.py`; `test_vcf_automation_connector_registered_under_v2_triple` in `test_connectors_registry_v2.py` asserts the triple resolves.
- [x] Acceptance: respx unit test covers — provider login → JWT cached + sent on `/cloudapi/*`; tenant login → token cached + sent on `/iaas/api/*`; plane selection by path prefix (incl. `/api/*` → provider classic vCD Accept); independent per-plane 401 → re-login + retry-once; per-target isolation of both token caches; vhost FQDN routed; IP without fqdn → `VcfAutomationConfigurationError`; `auth_model="per_user"`/`"impersonation"`/`"unknown"` → `NotImplementedError`.
- [x] Acceptance: `fingerprint()` against mocked verified per-plane version paths (`GET /api/versions` provider XML + `GET /iaas/api/about` tenant JSON) returns the canonical shape; unreachable → `reachable=False` + `extras["error"]` + `extras["failed_plane"]`.
- [x] Acceptance: `probe()` returns `ok=True` / `ok=False`+reason via fingerprint delegation.
- [x] Acceptance: docstring + `docs/codebase/connectors-vcf-automation.md` document both login flows, both token header names, and the vhost mechanism as verified against `vcf-automation.sh` + the Automation API.

## Out of scope

- Automation ops (provider org/vdc lists; tenant deployment/blueprint lists) — T11 (#836) dual-plane spec ingestion.
- CLI verbs / MCP tool descriptions / onboarding doc — T12 (#840).
- Recorded-fixture E2E — T12 (#840). Recorded-fixture refresh tooling — T13 (#841) sibling.
- Proactive token-refresh beyond the single per-plane 401 retry.
- `connectors/_shared/vcf_auth.py` shared helper — intentionally not used by this connector (per #369 body — the dual-plane shape doesn't fit the single-pair pattern the helper was designed for; documented in `docs/codebase/connectors-vcf-automation.md` references).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #832


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VCF Automation 9.x connector with dual-plane (provider/tenant) authentication support, independent per-target token caching, automatic 401 retry logic with single-retry semantics, and reachability fingerprinting across both planes.

* **Documentation**
  * Added detailed connector architecture and behavior documentation.

* **Tests**
  * Added comprehensive test suite covering authentication flows, plane selection, token caching isolation, and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->