### PR TITLE
feat(connectors): G3.6-T7 VcfFleetConnector skeleton — HTTP Basic (admin@local) + wrapper-verified probe (#831)

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_fleet/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vcf_fleet — VcfFleetConnector package.
+
+Importing this package registers :class:`VcfFleetConnector` against the
+v2 connector registry under
+``(product="vcf-fleet", version="9.0", impl_id="fleet-rest")``. The
+chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+which walks every ``connectors/<product>/`` subpackage at startup, so
+the registration lands before any dispatch can occur.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector`
+entry point is deliberately **not** called. The connector advertises an
+explicit ``(version="9.0", impl_id="fleet-rest")`` key; the v1 entry
+would land as ``("vcf-fleet", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s
+tie-break ladder. Same pattern :mod:`meho_backplane.connectors.harbor`
+and :mod:`meho_backplane.connectors.vcf_automation` established.
+
+Operations for this connector arrive in #835 via G0.7 spec ingestion
+against the Fleet (vRSLCM-derived) OpenAPI surface. This Task ships
+only the skeleton.
+"""
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vcf_fleet.connector import VcfFleetConnector
+from meho_backplane.connectors.vcf_fleet.session import (
+    SessionCredentials,
+    VcfFleetCredentialsLoader,
+    VcfFleetTargetLike,
+    load_credentials_from_vault,
+)
+
+register_connector_v2(
+    product="vcf-fleet",
+    version="9.0",
+    impl_id="fleet-rest",
+    cls=VcfFleetConnector,
+)
+
+__all__ = [
+    "SessionCredentials",
+    "VcfFleetConnector",
+    "VcfFleetCredentialsLoader",
+    "VcfFleetTargetLike",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/vcf_fleet/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/connector.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VcfFleetConnector — hand-rolled HttpConnector subclass for VCF Fleet 9.0.
+
+Skeleton-only — auth + fingerprint + probe + the G0.6 dispatch shim.
+Operations arrive in #835 via G0.7 spec ingestion against the Fleet
+(vRSLCM-derived) OpenAPI surface. Until then the connector is registered
+and discoverable but ``execute(target, op_id, ...)`` against any
+``op_id`` resolves to "unknown operation" at the dispatcher layer.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.vcf_fleet.__init__`.
+
+Auth
+----
+
+VCF Fleet (vRSLCM-derived lifecycle manager, rebranded under VCF 9) uses
+**HTTP Basic** against its **own LCM-local user store** — typically the
+``admin@local`` account. There is **no SSO federation**. The stored
+username is sent verbatim in the ``Authorization: Basic`` header; no
+realm suffix is appended.
+
+Verified against the consumer wrapper ``scripts/vcf-fleet.sh`` (header
+comment, 2026-05-21): *"HTTP Basic against Fleet's own LCM-local user
+store (typical username `admin@local`). Fleet does NOT federate with
+vCenter SSO out of the box."* and the curl invocation
+``curl -u "${FLEET_USERNAME}:${FLEET_PASSWORD}" ...`` — no realm
+decoration, the wrapper sends ``admin@local:<password>`` literally.
+
+The connector caches the loaded credentials per ``target.name`` via the
+shared :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+(load-once-per-target with the missing-key → :exc:`RuntimeError`
+contract); :meth:`auth_headers` reuses the cached dict on subsequent
+calls. No session token is established — Basic is sent per request.
+
+Auth model gating
+-----------------
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT`
+(or ``None`` for pre-G0.3 targets where the column hasn't been populated
+yet). :meth:`auth_headers` rejects any other ``target.auth_model`` value
+with a clear :exc:`NotImplementedError` naming both the target and the
+requested mode — same posture the Harbor / NSX / SDDC Manager
+precedents established and the shared module's
+:func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`
+gate enforces.
+
+Fingerprint
+-----------
+
+Fleet's first-party diagnostic endpoints (``/lcm/lcops/api/v2/about``,
+``/health``, ``/version``, ``/system-details``, ``/lcm/common/api/about``,
+``/lcm/locker/api/v2/about``) **return HTTP 500 in VCF 9.0 builds** —
+known issue, not a credential problem. The consumer wrapper
+``scripts/vcf-fleet.sh`` documents this explicitly in its probe block
+and works around it by hitting ``/lcm/lcops/api/v2/datacenters`` with
+HTTP Basic auth and reading the ``Lcm-API-Version`` response header for
+the LCM API version. The product version itself is **not** exposed by
+any working Fleet endpoint in 9.0 — operators cross-source it from
+SDDC Manager's ``/v1/vcf-services`` (LCM service entry) when needed.
+
+The connector follows the wrapper's verified path:
+
+* ``probe_method`` = ``GET /lcm/lcops/api/v2/datacenters with HTTP
+  Basic; read Lcm-API-Version response header``.
+* ``version`` → the ``Lcm-API-Version`` header value (e.g. ``"8.0"``)
+  when present, ``None`` otherwise (the connector does **not**
+  cross-source the product version from SDDC Manager — that's an
+  operator-context concern out of scope for the per-product skeleton).
+* ``build`` → ``None`` (Fleet does not expose a build string via any
+  working endpoint in 9.0).
+* ``extras`` carries ``lcm_api_version`` (mirroring the wrapper's
+  ``probe`` JSON shape — kept distinct from ``version`` so a future
+  switch to a working product-version source doesn't break field
+  semantics), ``datacenter_count`` (length of the response array),
+  ``product_lineage`` = ``"vmware-vrealize-suite-lifecycle-manager"``,
+  and ``diagnostic_endpoints_broken`` listing the 9.0-broken paths so
+  the next operator probing this product sees the known-issue list
+  inline.
+
+On transport or status failure (including the 401 / 500 cases) the
+connector returns a non-reachable :class:`FingerprintResult` whose
+``extras["error"]`` carries the exception class + message — same
+pattern Harbor / NSX / SDDC Manager / VCF Automation use.
+
+Probe
+-----
+
+:meth:`probe` delegates to :meth:`fingerprint`. Fleet does not expose a
+dedicated health endpoint that works in 9.0 (the four-broken-diagnostic
+matrix above); the datacenters call is the single reachability surface
+that proves both transport and auth, so reusing the fingerprint result
+is the right shape.
+
+Operations
+----------
+
+This module ships zero operations — the G0.6 dispatch shim
+:meth:`execute` exists for ABC compatibility but operations land in the
+``endpoint_descriptor`` table via #835's spec ingestion. Until then,
+the connector is registered and discoverable but
+``execute(target, op_id, ...)`` against any ``op_id`` resolves to
+"unknown operation" at the dispatcher layer — which is the correct
+behaviour for a registered-but-empty connector at this Task's stage.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    CredentialsCache,
+    basic_auth_header,
+    is_acceptable_auth_model,
+)
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vcf_fleet.session import (
+    VcfFleetCredentialsLoader,
+    VcfFleetTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = ["VcfFleetConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Fleet's first-party diagnostic endpoints all return HTTP 500 in 9.0
+# builds (verified against the consumer wrapper scripts/vcf-fleet.sh
+# probe-block error hint, 2026-05-21). Carried in the FingerprintResult
+# extras so the next operator probing this product sees the
+# known-issue inventory inline rather than rediscovering it.
+_FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS: tuple[str, ...] = (
+    "/lcm/lcops/api/v2/about",
+    "/lcm/lcops/api/v2/health",
+    "/lcm/lcops/api/v2/version",
+    "/lcm/lcops/api/v2/system-details",
+    "/lcm/common/api/about",
+    "/lcm/locker/api/v2/about",
+)
+
+# Wrapper-verified probe path: Fleet's diagnostic endpoints (about /
+# health / version / system-details) return HTTP 500 in VCF 9.0;
+# /lcm/lcops/api/v2/datacenters is the only reachability surface the
+# wrapper found that proves both transport and HTTP Basic auth.
+_FLEET_PROBE_PATH = "/lcm/lcops/api/v2/datacenters"
+_FLEET_PROBE_METHOD = (
+    "GET /lcm/lcops/api/v2/datacenters with HTTP Basic; read Lcm-API-Version response header"
+)
+_FLEET_LCM_API_VERSION_HEADER = "Lcm-API-Version"
+
+
+class VcfFleetConnector(HttpConnector):
+    """VCF Fleet 9.0 REST connector with HTTP Basic auth.
+
+    Per-target credentials cached in :attr:`_creds` via the shared
+    :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+    helper (loaded once via the injectable :class:`VcfFleetCredentialsLoader`).
+    HTTP Basic auth is sent on every request via
+    ``Authorization: Basic <base64>`` — no session token is established
+    and no 401-driven re-login is needed (Fleet's local user store
+    accepts the same Basic header per request, same shape as Harbor).
+
+    The :attr:`priority` is set to ``1`` so a future
+    ``GenericRestConnector`` auto-shim that somehow registers for the
+    same triple loses the registry's tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"fleet-rest-9.0"`` -> (``"vcf-fleet"``, ``"9.0"``, ``"fleet-rest"``).
+    product = "vcf-fleet"
+    version = "9.0"
+    impl_id = "fleet-rest"
+    supported_version_range = ">=9.0,<10.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: VcfFleetCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        loader: VcfFleetCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+        self._creds: CredentialsCache = CredentialsCache(loader, product_label="vcf-fleet")
+
+    async def auth_headers(self, target: VcfFleetTargetLike, raw_jwt: str) -> dict[str, str]:
+        """Return ``{"Authorization": "Basic ..."}`` for the request.
+
+        Loads credentials from Vault on first call against *target* via
+        the shared :class:`CredentialsCache` and reuses the cached
+        values on subsequent calls. ``raw_jwt`` is accepted for
+        ABC-signature compatibility but unused —
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
+        Vault-sourced service account, not the operator's OIDC token.
+
+        The Basic auth username is sent verbatim from the Vault-loaded
+        credentials — no SSO-realm suffix is appended. The typical
+        Fleet account is ``admin@local`` (literal — the ``@local``
+        suffix is part of the stored username, not a realm
+        decoration); production deploys store the username verbatim
+        under the target's ``secret_ref``.
+
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is
+        anything other than ``shared_service_account`` or ``None``.
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT does not forward operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"VcfFleetConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        creds = await self._creds.get(target)
+        return {"Authorization": basic_auth_header(creds["username"], creds["password"])}
+
+    async def fingerprint(self, target: VcfFleetTargetLike) -> FingerprintResult:
+        """Canonical fingerprint built from the wrapper-verified probe call.
+
+        Fleet's first-party diagnostic endpoints return HTTP 500 in 9.0
+        (see module docstring); the consumer wrapper
+        ``scripts/vcf-fleet.sh`` works around this by calling
+        ``GET /lcm/lcops/api/v2/datacenters`` with HTTP Basic auth and
+        reading the ``Lcm-API-Version`` response header for the LCM
+        API version. The connector follows that contract verbatim.
+
+        Carries the wrapper's ``extras`` shape: ``lcm_api_version``,
+        ``datacenter_count``, ``product_lineage``, and the
+        ``diagnostic_endpoints_broken`` known-issue inventory. The
+        product version itself is **not** surfaced here — Fleet does
+        not expose it via any working endpoint in 9.0, and the
+        wrapper's note ("cross-source from SDDC Manager
+        ``/v1/vcf-services``") is an operator-context concern that
+        belongs above the connector layer.
+
+        On transport or status failure (401 / 500 / connection
+        error), returns a non-reachable :class:`FingerprintResult`
+        whose ``extras["error"]`` carries the exception class +
+        message — same pattern Harbor / NSX / SDDC Manager / VCF
+        Automation use.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            client = await self._http_client(target)
+            headers = await self.auth_headers(target, raw_jwt="")
+            resp = await client.get(
+                _FLEET_PROBE_PATH,
+                headers={"Accept": "application/json", **headers},
+            )
+            resp.raise_for_status()
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="vcf-fleet",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=_FLEET_PROBE_METHOD,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        lcm_api_version = resp.headers.get(_FLEET_LCM_API_VERSION_HEADER) or None
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = None
+        datacenter_count = len(payload) if isinstance(payload, list) else None
+        return FingerprintResult(
+            vendor="vmware",
+            product="vcf-fleet",
+            # Carry the LCM API version into `version` as the only
+            # version string Fleet exposes via a working endpoint in
+            # 9.0; the product version itself stays None (operators
+            # cross-source from SDDC Manager when needed).
+            version=lcm_api_version,
+            build=None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=_FLEET_PROBE_METHOD,
+            extras={
+                "lcm_api_version": lcm_api_version,
+                "datacenter_count": datacenter_count,
+                "product_lineage": "vmware-vrealize-suite-lifecycle-manager",
+                "diagnostic_endpoints_broken": list(_FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS),
+            },
+        )
+
+    async def probe(self, target: VcfFleetTargetLike) -> ProbeResult:
+        """Lightweight reachability check — delegates to :meth:`fingerprint`.
+
+        Fleet does not expose a working dedicated health endpoint in
+        VCF 9.0 builds (see :meth:`fingerprint` for the broken-diagnostic
+        matrix); the datacenters call is the only surface that proves
+        both transport and HTTP Basic auth, so reusing the fingerprint
+        result keeps probe + fingerprint pinned to one round-trip.
+        Same delegation shape as the SDDC Manager / NSX / VCF Automation
+        precedents.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: VcfFleetTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`VcfAutomationConnector.execute` /
+        :meth:`HarborConnector.execute`. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI
+        verbs once #839 lands) construct a real :class:`Operator` and
+        call :func:`meho_backplane.operations.dispatch` directly —
+        they don't reach this method.
+
+        The connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``'s contract:
+        ``"fleet-rest-9.0"`` → (product=``"vcf-fleet"``,
+        version=``"9.0"``, impl_id=``"fleet-rest"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:fleet-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached credentials, then tear down the httpx pool.
+
+        No server-side session to revoke — HTTP Basic is stateless.
+        The credential cache is cleared so a post-aclose reuse of the
+        same connector instance starts clean.
+        """
+        await self._creds.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/vcf_fleet/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/session.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading + target shape for the vcf-fleet connector.
+
+The hand-rolled
+:class:`~meho_backplane.connectors.vcf_fleet.connector.VcfFleetConnector`
+authenticates with HTTP Basic against Fleet's **local LCM user store** —
+typically the ``admin@local`` account. There is no SSO federation; the
+stored username is sent verbatim in the Basic auth header (consumer
+wrapper ``scripts/vcf-fleet.sh`` header, 2026-05-21: *"HTTP Basic against
+Fleet's own LCM-local user store (typical username `admin@local`). Fleet
+does NOT federate with vCenter SSO out of the box."*).
+
+The connector reuses the shared scaffolding in
+:mod:`meho_backplane.connectors._shared.vcf_auth` (#841):
+
+* :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+  for the load-once-per-target ``{"username": str, "password": str}``
+  dict with the missing-key → :exc:`RuntimeError` contract.
+* :func:`~meho_backplane.connectors._shared.vcf_auth.basic_auth_header`
+  for the ``Authorization: Basic`` header value.
+* :func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`
+  for the ``shared_service_account`` / ``None`` gate.
+
+The :class:`VcfFleetTargetLike` Protocol captures the minimum target
+shape the connector reads: ``name`` (per-target credential cache key),
+``host`` / ``port`` (forwarded to :meth:`HttpConnector._base_url`),
+``secret_ref`` (the Vault path the loader resolves), and ``auth_model``
+(checked at the boundary). No ``sso_realm`` field — Fleet's Basic auth
+header carries ``username:password`` directly with no realm suffix
+(verified against ``scripts/vcf-fleet.sh`` — the wrapper passes
+``-u "${FLEET_USERNAME}:${FLEET_PASSWORD}"`` with no additional
+realm/domain decoration).
+
+The default loader, :func:`load_credentials_from_vault`, raises
+:exc:`NotImplementedError` until the operator-context Vault read lands.
+Production deploys and tests override the loader on construction (same
+posture as the Harbor / NSX / SDDC Manager / VCF Automation precedents
+— all four currently raise the same shape under open Goal #214).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "SessionCredentials",
+    "VcfFleetCredentialsLoader",
+    "VcfFleetTargetLike",
+    "load_credentials_from_vault",
+]
+
+
+class SessionCredentials(Protocol):
+    """The dict shape :class:`VcfFleetCredentialsLoader` returns.
+
+    Captured as a Protocol so the type checker can flag a loader that
+    forgets a key. The two values map to the Basic-auth components the
+    connector sends on every Fleet API request — no session token is
+    established (HTTP Basic per request, same shape as the Harbor
+    precedent).
+    """
+
+    username: str
+    password: str
+
+
+@runtime_checkable
+class VcfFleetTargetLike(Protocol):
+    """Minimum target shape :class:`VcfFleetConnector` reads.
+
+    Structural Protocol — the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` (G0.3 #224 — closed) satisfies this
+    Protocol unchanged. ``auth_model`` is checked at the boundary so a
+    target tagged ``per_user`` or ``impersonation`` raises a clear error
+    rather than silently authenticating as the shared service account.
+
+    ``secret_ref`` is the Vault path the loader resolves to a
+    :class:`SessionCredentials`-shaped dict. ``port`` is optional —
+    Fleet defaults to 443 and :meth:`HttpConnector._base_url` already
+    handles the ``port is None or 443`` case correctly.
+
+    No ``sso_realm`` field — Fleet's local user store accepts
+    ``admin@local`` as the literal Basic-auth username; no realm suffix
+    is appended by the connector.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+
+
+VcfFleetCredentialsLoader = Callable[[VcfFleetTargetLike], Awaitable[dict[str, str]]]
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+The connector's
+:class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+invokes the loader on first ``auth_headers`` call per target and caches
+the resulting dict under ``target.name``. The return type is the looser
+``dict[str, str]`` (not :class:`SessionCredentials`) because Python
+:class:`Protocol` instances aren't runtime-constructible without a
+matching class — production code returns a plain dict and the connector
+reads ``creds["username"]`` / ``creds["password"]`` by key.
+"""
+
+
+async def load_credentials_from_vault(
+    target: VcfFleetTargetLike,
+) -> dict[str, str]:
+    """Default credential loader — Vault read by ``target.secret_ref``.
+
+    Deliberate stub: the operator-context per-target Vault credential
+    read is not yet wired for the VCF Fleet connector. Raising
+    :exc:`NotImplementedError` here keeps the wiring shape stable — a
+    production caller without an override receives a clear error rather
+    than a silent fallback or a hallucinated credential pair. The
+    supported workaround is to inject a custom ``credentials_loader``
+    on ``VcfFleetConnector`` at construction time. The live read is
+    tracked under the open Goal #214 (Connector parity).
+
+    Once the read lands, this function becomes the live implementation
+    that reads the ``vcf-fleet/<target.name>`` Vault path (or
+    ``target.secret_ref`` directly when set) and returns the parsed
+    ``{"username": ..., "password": ...}`` dict.
+    """
+    raise NotImplementedError(
+        "load_credentials_from_vault is a deliberate stub: the operator-context "
+        "per-target Vault credential read is not yet wired for the VCF Fleet "
+        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
+        "Workaround: inject a custom credentials_loader on VcfFleetConnector. "
+        "Tracked under open Goal #214 (Connector parity): "
+        "https://github.com/evoila/meho/issues/214"
+    )

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -360,3 +360,25 @@ def test_vcf_logs_connector_registered_under_v2_triple() -> None:
     key = ("vcf-logs", "9.0", "vrli-rest")
     assert key in snapshot
     assert snapshot[key] is VcfLogsConnector
+
+
+def test_vcf_fleet_connector_registered_under_v2_triple() -> None:
+    """VcfFleetConnector package registers under (vcf-fleet, 9.0, fleet-rest).
+
+    The autouse _clean_registry fixture clears the registry before this test,
+    so we manually re-register using the class attributes to assert the triple
+    resolves correctly. Same pattern as the SDDC Manager / Harbor /
+    VCF Automation tests above.
+    """
+    from meho_backplane.connectors.vcf_fleet import VcfFleetConnector
+
+    register_connector_v2(
+        product=VcfFleetConnector.product,
+        version=VcfFleetConnector.version,
+        impl_id=VcfFleetConnector.impl_id,
+        cls=VcfFleetConnector,
+    )
+    snapshot = all_connectors_v2()
+    key = ("vcf-fleet", "9.0", "fleet-rest")
+    assert key in snapshot
+    assert snapshot[key] is VcfFleetConnector

--- a/backend/tests/test_connectors_vcf_fleet_auth.py
+++ b/backend/tests/test_connectors_vcf_fleet_auth.py
@@ -1,0 +1,515 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`VcfFleetConnector` auth + fingerprint/probe (G3.6-T7 #831).
+
+Exercises HTTP Basic auth against Fleet's LCM-local user store (typical
+``admin@local``; no SSO federation), per-target credential isolation,
+the auth_model boundary gate, and the fingerprint/probe shapes against
+the wrapper-verified probe call.
+
+The fingerprint path mirrors the consumer wrapper
+``scripts/vcf-fleet.sh``: ``GET /lcm/lcops/api/v2/datacenters`` with
+HTTP Basic auth, reading the ``Lcm-API-Version`` response header for
+the LCM API version. Fleet's first-party diagnostic endpoints
+(``/about``, ``/health``, ``/version``, ``/system-details``) return
+HTTP 500 in VCF 9.0 builds — the wrapper documents this and the
+connector follows the wrapper's workaround verbatim.
+
+Test layout mirrors :mod:`tests.test_connectors_harbor_auth` (HTTP
+Basic + Vault-loader-via-injectable + fingerprint/probe shape) and the
+fixture-clean pattern :mod:`tests.test_connectors_vcf_automation_auth`
+established.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vcf_fleet import (
+    VcfFleetConnector,
+    VcfFleetTargetLike,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_vcf_fleet_registry() -> Iterator[None]:
+    """Re-register VcfFleetConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that
+    calls :func:`clear_registry` between tests. Re-register before
+    every test in this module and clear after — same pattern
+    :mod:`tests.test_connectors_harbor_auth` /
+    :mod:`tests.test_connectors_vcf_automation_auth` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=VcfFleetConnector.product,
+        version=VcfFleetConnector.version,
+        impl_id=VcfFleetConnector.impl_id,
+        cls=VcfFleetConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies VcfFleetTargetLike Protocol structurally.
+# Replaced by the real Target model when G0.3 (#224) is fully wired in.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET_A = _StubTarget(
+    name="vcf-fleet-a",
+    host="vcf-fleet-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/vcf-fleet/vcf-fleet-a",
+)
+_TARGET_B = _StubTarget(
+    name="vcf-fleet-b",
+    host="vcf-fleet-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/vcf-fleet/vcf-fleet-b",
+)
+
+
+async def _stub_loader(_target: VcfFleetTargetLike) -> dict[str, str]:
+    """Return canned ``admin@local`` credentials regardless of the target."""
+    return {"username": "admin@local", "password": "stub-password"}
+
+
+def _make_connector() -> VcfFleetConnector:
+    """Build a connector wired with the stub loader."""
+    return VcfFleetConnector(credentials_loader=_stub_loader)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_vcf_fleet_connector_subclasses_http_connector() -> None:
+    """Sanity check: the connector inherits from HttpConnector with the right metadata."""
+    assert issubclass(VcfFleetConnector, HttpConnector)
+    assert VcfFleetConnector.product == "vcf-fleet"
+    assert VcfFleetConnector.version == "9.0"
+    assert VcfFleetConnector.impl_id == "fleet-rest"
+    assert VcfFleetConnector.supported_version_range == ">=9.0,<10.0"
+    assert VcfFleetConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    """The package's __init__ calls register_connector_v2 at import time."""
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("vcf-fleet", "9.0", "fleet-rest")
+    assert key in registry
+    assert registry[key] is VcfFleetConnector
+
+
+def test_default_credentials_loader_raises_until_goal_214() -> None:
+    """The default Vault loader stays unimplemented until Goal #214."""
+    import asyncio
+
+    from meho_backplane.connectors.vcf_fleet.session import (
+        load_credentials_from_vault,
+    )
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"Goal #214"):
+            await load_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# HTTP Basic auth — admin@local form
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_sends_basic_auth_for_admin_at_local() -> None:
+    """auth_headers() produces Authorization: Basic with the literal admin@local username."""
+    connector = _make_connector()
+    headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "Authorization" in headers
+    assert headers["Authorization"].startswith("Basic ")
+    username, password = _decode_basic_auth(headers["Authorization"])
+    # admin@local is sent verbatim — the @local suffix is part of the
+    # username, not a realm decoration. Fleet does NOT federate SSO.
+    assert username == "admin@local"
+    assert password == "stub-password"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential caching — load once per target
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-invoke the loader."""
+    call_count = 0
+
+    async def _counting_loader(_target: VcfFleetTargetLike) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "admin@local", "password": "stub-password"}
+
+    connector = VcfFleetConnector(credentials_loader=_counting_loader)
+    h1 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h2 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert h1 == h2
+    assert call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Per-target isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_credentials_separate() -> None:
+    """Two targets get two distinct credential cache entries; no cross-target leakage."""
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: VcfFleetTargetLike) -> dict[str, str]:
+        call_log.append(target.name)
+        return {"username": f"svc-{target.name}", "password": "pass"}
+
+    connector = VcfFleetConnector(credentials_loader=_tracking_loader)
+    h_a = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h_b = await connector.auth_headers(_TARGET_B, raw_jwt="")
+
+    username_a, _ = _decode_basic_auth(h_a["Authorization"])
+    username_b, _ = _decode_basic_auth(h_b["Authorization"])
+    assert username_a == "svc-vcf-fleet-a"
+    assert username_b == "svc-vcf-fleet-b"
+    assert call_log == ["vcf-fleet-a", "vcf-fleet-b"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential loading failure modes — missing-key contract from CredentialsCache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
+    """Loader returning a dict missing 'password' raises RuntimeError naming the target."""
+
+    async def _bad_loader(_target: VcfFleetTargetLike) -> dict[str, str]:
+        return {"username": "admin@local"}  # type: ignore[return-value]
+
+    connector = VcfFleetConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"password") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "vcf-fleet-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_username_key_raises_runtime_error_naming_target() -> None:
+    """Loader returning a dict missing 'username' raises RuntimeError naming the target."""
+
+    async def _bad_loader(_target: VcfFleetTargetLike) -> dict[str, str]:
+        return {"password": "stub-password"}  # type: ignore[return-value]
+
+    connector = VcfFleetConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"username") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "vcf-fleet-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="vcf-fleet-per-user",
+        host="vcf-fleet.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcf-fleet/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="")
+
+    assert "vcf-fleet-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="vcf-fleet-pre-g03",
+        host="vcf-fleet.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcf-fleet/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="vcf-fleet-enum",
+        host="vcf-fleet.test.invalid",
+        port=443,
+        secret_ref="kv/data/vcf-fleet/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() — wrapper-verified probe call against the datacenters surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against mocked datacenters returns the canonical shape with extras."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcf-fleet-a.test.invalid") as mock:
+        mock.get("/lcm/lcops/api/v2/datacenters").respond(
+            200,
+            json=[
+                {"datacenterName": "dc-01", "vmid": "abc"},
+                {"datacenterName": "dc-02", "vmid": "def"},
+            ],
+            headers={"Lcm-API-Version": "8.0"},
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcf-fleet"
+    # Fleet exposes no product version via a working endpoint in 9.0;
+    # the connector carries the LCM API version in `version` as the
+    # only version string the wrapper-verified probe surfaces.
+    assert fp.version == "8.0"
+    assert fp.build is None
+    assert fp.reachable is True
+    assert "/lcm/lcops/api/v2/datacenters" in fp.probe_method
+    assert "Lcm-API-Version" in fp.probe_method
+    assert fp.extras["lcm_api_version"] == "8.0"
+    assert fp.extras["datacenter_count"] == 2
+    assert fp.extras["product_lineage"] == "vmware-vrealize-suite-lifecycle-manager"
+    # The known-broken-diagnostic inventory ships with every fingerprint
+    # so the next operator probing this product sees it inline.
+    broken = fp.extras["diagnostic_endpoints_broken"]
+    assert "/lcm/lcops/api/v2/about" in broken
+    assert "/lcm/lcops/api/v2/health" in broken
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_without_lcm_api_version_header_leaves_version_none() -> None:
+    """A response without the Lcm-API-Version header leaves version=None."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcf-fleet-a.test.invalid") as mock:
+        mock.get("/lcm/lcops/api/v2/datacenters").respond(200, json=[])
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.version is None
+    assert fp.reachable is True
+    assert fp.extras["lcm_api_version"] is None
+    assert fp.extras["datacenter_count"] == 0
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_sends_basic_auth_header_to_datacenters() -> None:
+    """The fingerprint call carries the Authorization: Basic header (admin@local)."""
+    connector = _make_connector()
+    captured: list[httpx.Request] = []
+
+    async with respx.mock(base_url="https://vcf-fleet-a.test.invalid") as mock:
+        route = mock.get("/lcm/lcops/api/v2/datacenters").respond(
+            200,
+            json=[],
+            headers={"Lcm-API-Version": "8.0"},
+        )
+        await connector.fingerprint(_TARGET_A)
+        captured.extend(call.request for call in route.calls)
+
+    assert len(captured) == 1
+    auth_header = captured[0].headers.get("Authorization", "")
+    username, password = _decode_basic_auth(auth_header)
+    assert username == "admin@local"
+    assert password == "stub-password"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_500_returns_reachable_false() -> None:
+    """A 500 from the datacenters call surfaces as reachable=False + structured error.
+
+    This is the wrapper-documented Fleet failure mode (the appliance's
+    bootstrap not finished); the connector treats it the same way it
+    treats any other transport/status failure.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcf-fleet-a.test.invalid") as mock:
+        mock.get("/lcm/lcops/api/v2/datacenters").respond(500, json={"error": "bootstrap"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcf-fleet"
+    assert fp.reachable is False
+    error = fp.extras["error"]
+    assert "HTTPStatusError" in error or "500" in error
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_401_returns_reachable_false() -> None:
+    """A 401 from the datacenters call (wrong creds) surfaces as reachable=False."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcf-fleet-a.test.invalid") as mock:
+        mock.get("/lcm/lcops/api/v2/datacenters").respond(
+            401, json={"errors": [{"code": "UNAUTHORIZED"}]}
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is False
+    error = fp.extras["error"]
+    assert "HTTPStatusError" in error or "401" in error
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_connection_error_returns_reachable_false() -> None:
+    """A transport-level connection error surfaces as reachable=False + structured error."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcf-fleet-a.test.invalid") as mock:
+        mock.get("/lcm/lcops/api/v2/datacenters").mock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is False
+    assert "ConnectError" in fp.extras["error"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# probe() — delegates to fingerprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_ok_when_fingerprint_reachable() -> None:
+    """probe() returns ok=True when fingerprint reports reachable."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcf-fleet-a.test.invalid") as mock:
+        mock.get("/lcm/lcops/api/v2/datacenters").respond(
+            200, json=[], headers={"Lcm-API-Version": "8.0"}
+        )
+        probe = await connector.probe(_TARGET_A)
+
+    assert probe.ok is True
+    assert probe.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_not_ok_when_fingerprint_unreachable() -> None:
+    """probe() returns ok=False + reason from fingerprint's error extras."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcf-fleet-a.test.invalid") as mock:
+        mock.get("/lcm/lcops/api/v2/datacenters").respond(500, json={"error": "bootstrap"})
+        probe = await connector.probe(_TARGET_A)
+
+    assert probe.ok is False
+    assert probe.reason is not None
+    assert "HTTPStatusError" in probe.reason or "500" in probe.reason
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose — credential cache is cleared
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_credential_cache() -> None:
+    """aclose() empties the shared credential cache so a reuse re-fetches."""
+    call_count = 0
+
+    async def _counting_loader(_target: VcfFleetTargetLike) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "admin@local", "password": "stub-password"}
+
+    connector = VcfFleetConnector(credentials_loader=_counting_loader)
+    await connector.auth_headers(_TARGET_A, raw_jwt="")
+    assert call_count == 1
+    await connector.aclose()
+    await connector.auth_headers(_TARGET_A, raw_jwt="")
+    assert call_count == 2
+    await connector.aclose()

--- a/docs/codebase/connectors-vcf-fleet.md
+++ b/docs/codebase/connectors-vcf-fleet.md
@@ -1,0 +1,182 @@
+# Connector: vcf-fleet (VCF Fleet 9.0, vRSLCM-derived)
+
+## Overview
+
+The `vcf-fleet` connector is the hand-rolled `HttpConnector` subclass that
+dispatches VCF Fleet REST operations under the
+`(product="vcf-fleet", version="9.0", impl_id="fleet-rest")` registry triple.
+G3.6-T7 (#831) shipped the skeleton — HTTP Basic auth against the LCM-local
+user store, the wrapper-verified fingerprint/probe call, and the G0.6
+dispatch shim. G3.6-T8 (#835) will add spec ingestion + operator-review
+curation; G3.6-T9 (#839) will ship the CLI verb tree + recorded-fixture
+E2E.
+
+Source: `backend/src/meho_backplane/connectors/vcf_fleet/`.
+
+VCF Fleet is the rebrand of vRealize Suite Lifecycle Manager (vRSLCM) under
+the VCF 9 umbrella; the appliance still identifies as vRSLCM in its internal
+config and every response carries an `Lcm-API-Version` header.
+
+## Key types
+
+- **`VcfFleetConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="vcf-fleet"`, `version="9.0"`,
+  `impl_id="fleet-rest"`, `supported_version_range=">=9.0,<10.0"`,
+  `priority=1`. The priority outranks a future `GenericRestConnector`
+  auto-shim defensively if both somehow register for the same triple.
+- **`VcfFleetTargetLike`** (`session.py`) — runtime-checkable Protocol
+  capturing the minimum target shape the connector reads: `name`, `host`,
+  `port`, `secret_ref`, `auth_model`. No `sso_realm` field — Fleet does
+  NOT federate with SSO, so the Basic auth header carries
+  `username:password` directly. Replaced by the concrete `Target` model in
+  `meho_backplane.targets` (#224) structurally; no code edits here when
+  the model lands.
+- **`VcfFleetCredentialsLoader`** (`session.py`) — async callable type
+  resolving a target to `{"username": ..., "password": ...}`. Injectable
+  on connector construction (`VcfFleetConnector(credentials_loader=...)`)
+  so unit tests, integration tests, and pre-G0.3 production deploys
+  override the default Vault loader.
+- **`load_credentials_from_vault`** (`session.py`) — default loader,
+  stubbed `NotImplementedError` until the live operator-context per-target
+  Vault read lands. Mirrors `load_credentials_from_vault` in
+  `connectors/harbor/` and `connectors/vcf_automation/` — all stubs flip
+  to live implementations together under Goal #214.
+
+The connector reuses three helpers from
+`meho_backplane.connectors._shared.vcf_auth` (the #841 cross-cutting
+module landed in G3.6-T13):
+
+- `basic_auth_header(username, password)` — produces the
+  `Authorization: Basic <b64>` value.
+- `is_acceptable_auth_model(value)` — gates the SHARED_SERVICE_ACCOUNT
+  enum / string / `None` triple.
+- `CredentialsCache(loader, product_label=...)` — load-once-per-target
+  `{"username": str, "password": str}` cache with the missing-key →
+  `RuntimeError` contract and a serialised `clear()` for `aclose`.
+
+Sister G3.6 connectors `vcf_operations` (#829) and `vcf_logs` (#830) will
+import the same helpers; `vcf_automation` (#832 / merged) deliberately
+does not — its dual-plane auth shape is bespoke.
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()` in
+   `meho_backplane/connectors/registry.py`, which walks every
+   `connectors/<product>/` subpackage in name-sorted order.
+2. Importing `meho_backplane.connectors.vcf_fleet` triggers the
+   module-level
+   `register_connector_v2(product="vcf-fleet", version="9.0", impl_id="fleet-rest", cls=VcfFleetConnector)`
+   call.
+3. The registry's v2 table now resolves `("vcf-fleet", "9.0",
+   "fleet-rest")` to `VcfFleetConnector`. The G0.7 auto-shim's
+   idempotency check no-ops on subsequent ingests against the same
+   triple.
+
+### Auth
+
+1. The chassis dispatcher calls `auth_headers(target, raw_jwt="")`
+   before issuing the request.
+2. `auth_headers` rejects any `target.auth_model` other than
+   `shared_service_account` / `None` via the shared
+   `is_acceptable_auth_model` predicate, raising `NotImplementedError`
+   naming the target and requested mode.
+3. The shared `CredentialsCache.get(target)` invokes the injected loader
+   on first call per target. The loader returns
+   `{"username": "admin@local", "password": "..."}`; missing keys
+   raise `RuntimeError` naming both the target and the missing key.
+4. The cached dict is fed to `basic_auth_header(username, password)` and
+   returned as `{"Authorization": "Basic <b64>"}`.
+
+The Fleet account is typically `admin@local` — the `@local` suffix is
+part of the literal username, not a realm decoration. Fleet does **not**
+federate with vCenter SSO out of the box (consumer wrapper header,
+verified 2026-05-21: a `vsphere.local` service account was rejected with
+HTTP 401 "Bad credentials" during the discovery journey).
+
+### Fingerprint / probe (wrapper-verified)
+
+Fleet's first-party diagnostic endpoints all return HTTP 500 in VCF 9.0
+builds — known appliance issue:
+
+- `/lcm/lcops/api/v2/about`
+- `/lcm/lcops/api/v2/health`
+- `/lcm/lcops/api/v2/version`
+- `/lcm/lcops/api/v2/system-details`
+- `/lcm/common/api/about`
+- `/lcm/locker/api/v2/about`
+
+The consumer wrapper `scripts/vcf-fleet.sh` documents this explicitly and
+works around it by calling `GET /lcm/lcops/api/v2/datacenters` with HTTP
+Basic auth and reading the `Lcm-API-Version` response header for the LCM
+API version. The connector follows the wrapper's contract verbatim:
+
+- `probe_method` = `"GET /lcm/lcops/api/v2/datacenters with HTTP Basic; read Lcm-API-Version response header"`.
+- `version` ← the `Lcm-API-Version` header value (e.g. `"8.0"`) when
+  present, `None` otherwise.
+- `build` ← `None` (no working endpoint exposes a build string in 9.0).
+- `extras` ← `{lcm_api_version, datacenter_count, product_lineage,
+  diagnostic_endpoints_broken}`.
+
+The product version itself is **not** surfaced by any working endpoint in
+9.0. Operators cross-source it from SDDC Manager's `/v1/vcf-services`
+(LCM service entry) — that's an operator-context concern above the
+per-product connector and out of scope for this skeleton.
+
+`probe()` delegates to `fingerprint()`: Fleet has no working dedicated
+health endpoint, and the datacenters call already proves both transport
+and HTTP Basic auth, so reusing one round-trip is the right shape (same
+delegation pattern as `vcf_automation`, `sddc_manager`, `nsx`).
+
+### Dispatch
+
+Operations are **generic-ingested** (#835) under the same dispatcher path
+the other tier-3 VCF connectors use: G0.7 ingests the Fleet OpenAPI spec
+into `endpoint_descriptor`, the operator reviews and enables the curated
+op_ids, and `POST /api/v1/operations/call` (or MCP `call_operation`)
+dispatches them through `meho_backplane.operations.dispatch`. The
+connector's `execute()` is the G0.6 ABC-compatibility shim that builds a
+synthetic `Operator` and forwards to the dispatcher; post-G0.6 callers
+construct a real `Operator` and invoke `dispatch` directly.
+
+## Dependencies
+
+- `meho_backplane.connectors.adapters.http.HttpConnector` — base class
+  carrying the pooled `httpx.AsyncClient` per target, retry-on-idempotent
+  transport, and base-URL composition.
+- `meho_backplane.connectors._shared.vcf_auth` — `basic_auth_header`,
+  `is_acceptable_auth_model`, `CredentialsCache`. Shipped in #841 / merged
+  into main 2026-05-22.
+- `meho_backplane.connectors.schemas` — `AuthModel`, `FingerprintResult`,
+  `ProbeResult`, `OperationResult`.
+- `httpx>=0.27` (0.28.1 resolved), `pydantic>=2.13.4`, `respx>=0.21`
+  (test-only). No new runtime deps introduced by this Task.
+
+## Known issues
+
+- **Product version unreachable in 9.0.** None of Fleet's `/about` /
+  `/version` / `/health` / `/system-details` endpoints work in 9.0. The
+  connector surfaces only the `Lcm-API-Version` header value (the
+  underlying vRSLCM API version, typically `"8.0"`) — not the marketing
+  product version. Operators needing the product version cross-source it
+  from SDDC Manager's `/v1/vcf-services` LCM service entry.
+- **`auth_model="per_user"` / `"impersonation"` rejected.** v0.2 locks
+  the connector to `shared_service_account` / `None`. Once the per-user
+  identity model lands, the gate moves to the shared module and every
+  consumer (including this connector) flips together.
+- **Default Vault loader is a stub.** Until Goal #214 (Connector parity)
+  wires the operator-context per-target Vault read, production deploys
+  must inject a custom `credentials_loader` on construction.
+
+## References
+
+- Task: <https://github.com/evoila/meho/issues/831>
+- Parent initiative: <https://github.com/evoila/meho/issues/369>
+- Parent goal: <https://github.com/evoila/meho/issues/214>
+- Shared scaffolding (G3.6-T13): <https://github.com/evoila/meho/issues/841>
+- Sibling skeletons: vROps #829, vRLI #830, VCFA #832 (merged).
+- Consumer wrapper (authoritative contract):
+  <https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-fleet.sh>
+- VCF Fleet / vRSLCM API:
+  <https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager-api/latest/>


### PR DESCRIPTION
## Summary

- Ship the **VCF Fleet 9.0 connector skeleton** — HTTP Basic auth against the
  LCM-local user store (typical `admin@local`; no SSO federation), the
  wrapper-verified `GET /lcm/lcops/api/v2/datacenters` fingerprint/probe call,
  and the G0.6 dispatch shim. Registered against the v2 triple
  `(product="vcf-fleet", version="9.0", impl_id="fleet-rest")`.
- Reuses the shared scaffolding from
  `connectors/_shared/vcf_auth.py` (G3.6-T13 / #841) —
  `basic_auth_header`, `is_acceptable_auth_model`, `CredentialsCache` —
  so the three Basic-auth-style G3.6 connectors share one source of
  truth.
- Probe path uses the wrapper's verified workaround: Fleet's first-party
  `/about` / `/health` / `/version` / `/system-details` endpoints all return
  HTTP 500 in VCF 9.0 builds; the connector calls
  `GET /lcm/lcops/api/v2/datacenters` with HTTP Basic and reads
  `Lcm-API-Version` from the response headers, exactly as
  `scripts/vcf-fleet.sh` does. The fingerprint extras carry
  `lcm_api_version`, `datacenter_count`, `product_lineage`, and a
  `diagnostic_endpoints_broken` known-issue inventory so the next
  operator probing Fleet sees the limitation inline.
- Adds `docs/codebase/connectors-vcf-fleet.md` and a registry-triple
  assertion in `tests/test_connectors_registry_v2.py`.

## Test plan

- [x] `ruff check` on `backend/src/meho_backplane/connectors/`, new
      test file, and registry test — clean.
- [x] `ruff format --check` on the new package + tests — clean.
- [x] `mypy backend/src/meho_backplane/connectors/vcf_fleet/
      --ignore-missing-imports` — clean (3 source files).
- [x] `pytest tests/test_connectors_vcf_fleet_auth.py` — 22 passed
      (HTTP Basic + caching + isolation + missing-key contract +
      auth-model gating + fingerprint canonical/error shapes +
      probe delegation + aclose cache-clear).
- [x] `pytest tests/test_connectors_registry_v2.py
      ::test_vcf_fleet_connector_registered_under_v2_triple` — passes
      when the suite runs in order (same convention the existing
      Harbor / VCF Automation / SDDC Manager registration assertions
      use; the `_clean_registry` autouse fixture relies on prior
      tests re-importing the connector modules between runs).
- [x] Acceptance criterion: registry-v2 triple `("vcf-fleet", "9.0",
      "fleet-rest")` resolves — covered by both the new registry test
      and the in-file `test_importing_package_registers_against_v2_registry`.
- [x] Acceptance criterion: respx test covers Basic-auth header,
      Vault-loader missing key → `RuntimeError` naming target,
      per-target isolation, `auth_model="per_user"` →
      `NotImplementedError` — all four exercised across multiple
      tests in `test_connectors_vcf_fleet_auth.py`.
- [x] Acceptance criterion: `fingerprint()` against the
      wrapper-verified probe path returns the canonical shape;
      unreachable → `reachable=False` + `extras["error"]` — covered
      by `test_fingerprint_canonical_shape_on_reachable_target` +
      the 500 / 401 / ConnectError unreachable tests.
- [x] Acceptance criterion: `probe()` returns `ok=True` /
      `ok=False`+reason — `test_probe_ok_when_fingerprint_reachable`
      + `test_probe_not_ok_when_fingerprint_unreachable`.
- [x] Acceptance criterion: probe path documented in the connector
      docstring as verified against `vcf-fleet.sh` + the Fleet API
      — see the module-level `Fingerprint` section in `connector.py`
      and `docs/codebase/connectors-vcf-fleet.md`.

## Out of scope

- Fleet ops (datacenter / environment / request / locker / bundle
  lists) — G3.6-T8 (#835) spec ingestion.
- CLI verb tree + recorded-fixture E2E — G3.6-T9 (#839).
- Sibling G3.6 skeletons: vROps #829, vRLI #830, VCFA #832 (merged).
- Cross-sourcing the Fleet product version from SDDC Manager's
  `/v1/vcf-services` LCM service entry — operator-context concern
  above the per-product connector.

### Adjacent finding (pre-existing on origin/main, not caused by this PR)

`tests/test_connectors_registry_v2.py::test_sddc_manager_connector_registered_under_v2_triple`
already fails in isolation runs on `origin/main` (commit `b2fba58`,
post-#841) due to the `_clean_registry` autouse fixture racing module
re-import. The same flakiness affects the existing Harbor and VCF
Automation parallel tests — the new VCF Fleet test added in this PR
follows the same pattern and is no worse. Reproducible on a pristine
`origin/main` checkout; out of scope here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #831


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VMware Cloud Foundation (VCF) Fleet 9.0 connector support
  * HTTP Basic authentication for Fleet targets
  * Built-in connectivity verification (fingerprint) and health probe
  * Per-target credential caching with lifecycle teardown
* **Documentation**
  * New connector docs, including known broken Fleet diagnostic endpoints and credentials-loader guidance
* **Tests**
  * End-to-end tests covering auth, fingerprint/probe, caching, and registry registration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->