### PR TITLE
feat(connectors): G3.6-T4 VcfLogsConnector skeleton with session-token auth + 401 retry-once

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_logs/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vcf_logs -- VcfLogsConnector package.
+
+Importing this package registers :class:`VcfLogsConnector` against the
+v2 connector registry under
+``(product="vcf-logs", version="9.0", impl_id="vrli-rest")``. The
+chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+which walks every ``connectors/<product>/`` subpackage at startup, so
+the registration lands before any dispatch can occur.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector`
+entry point is deliberately **not** called. The connector advertises an
+explicit ``(version="9.0", impl_id="vrli-rest")`` key; the v1 entry
+would land as ``("vcf-logs", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s
+tie-break ladder. Same pattern :mod:`meho_backplane.connectors.nsx` /
+:mod:`meho_backplane.connectors.vcf_automation` established.
+
+Operations for this connector arrive in #834 via G0.7 spec ingestion
+against ``vcf-logs-9.0/openapi.yaml``. This Task ships only the
+skeleton.
+"""
+
+from meho_backplane.connectors._shared.vcf_auth import SessionLoginError
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vcf_logs.connector import VcfLogsConnector
+from meho_backplane.connectors.vcf_logs.session import (
+    VcfCredentialsLoader,
+    VcfLogsTargetLike,
+    load_credentials_from_vault,
+)
+
+register_connector_v2(
+    product="vcf-logs",
+    version="9.0",
+    impl_id="vrli-rest",
+    cls=VcfLogsConnector,
+)
+
+__all__ = [
+    "SessionLoginError",
+    "VcfCredentialsLoader",
+    "VcfLogsConnector",
+    "VcfLogsTargetLike",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/vcf_logs/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/connector.py
@@ -1,0 +1,509 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VcfLogsConnector -- HttpConnector subclass for VCF Operations for Logs (vRLI) 9.x.
+
+Skeleton-only -- session-token auth + fingerprint + probe + the G0.6
+dispatch shim. Operations arrive in #834 via G0.7 spec ingestion against
+``vcf-logs-9.0/openapi.yaml``.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.vcf_logs.__init__` under
+``(product="vcf-logs", version="9.0", impl_id="vrli-rest")``.
+
+Auth contract -- verified against the consumer wrapper
+``scripts/vcf-logs.sh`` (2026-05-21 snapshot) and the vRLI 9.x REST API
+documentation. The wrapper is the authoritative contract for the field
+shapes the appliance actually accepts:
+
+* Login endpoint: ``POST /api/v2/sessions`` -- ``vcf-logs.sh`` lines
+  103-121 + 192-208 (probe path).
+* Request body: JSON
+  ``{"username": ..., "password": ..., "provider": "Local"}`` with
+  ``Content-Type: application/json`` -- ``vcf-logs.sh`` lines 124-130.
+  The provider field defaults to ``"Local"`` (``vcf-logs.sh`` line 95);
+  ``"ActiveDirectory"`` and ``"vIDM"`` are the documented alternatives,
+  but only ``Local`` + ``ActiveDirectory`` are supported in v0.2
+  (per #369).
+* Response body: ``{"sessionId": "<token>", "ttl": <seconds>}`` --
+  ``vcf-logs.sh`` lines 142-147 extracts ``.sessionId``.
+* Downstream auth header: ``Authorization: Bearer <sessionId>`` --
+  ``vcf-logs.sh`` lines 257-261 (op invocations) + lines 210-213 (probe
+  GET /api/v2/version).
+* Version endpoint: ``GET /api/v2/version`` -- documented unauthenticated
+  per the issue body; the wrapper sends Bearer defensively but the
+  appliance accepts the call without it.
+
+References
+----------
+
+* Issue: https://github.com/evoila/meho/issues/830
+* Wrapper: https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-logs.sh
+* vRLI API: https://developer.broadcom.com/xapis/vrealize-log-insight-api/latest/
+
+Auth model gating
+-----------------
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT`
+(or ``None`` for pre-G0.3 targets). :meth:`auth_headers` rejects any
+other value with a clear :exc:`NotImplementedError` naming both the
+target and the requested mode -- same posture the NSX, SDDC Manager,
+and VCF Automation precedents established.
+
+401 retry-once contract
+-----------------------
+
+On HTTP 401 from a downstream call, :meth:`_get_json_with_session_retry`
+invalidates the cached session token, re-establishes via
+``POST /api/v2/sessions``, and retries the original call **once**. A
+second 401 raises :exc:`RuntimeError` naming the target -- the wrapper's
+posture: re-login once on session-expiry, not a retry loop. Same shape
+the NSX precedent established.
+
+Session lifecycle
+-----------------
+
+vRLI's session has a documented TTL (default 30 days but operator-tunable
+via ``/api/v2/sessions/`` config); the connector does NOT proactively
+refresh. The 401-retry layer above re-establishes on demand.
+:meth:`aclose` clears the in-memory token + credentials caches and tears
+down the httpx pool but does NOT issue a DELETE-revoke -- same posture
+NSX takes (revoke-on-close is v0.2.next).
+
+Operations
+----------
+
+This module ships zero operations -- the G0.6 dispatch shim
+:meth:`execute` exists for ABC compatibility but operations land in
+the ``endpoint_descriptor`` table via #834's spec ingestion. Until
+then, the connector is registered and discoverable but
+``execute(target, op_id, ...)`` against any ``op_id`` will resolve to
+"unknown operation" at the dispatcher layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    CredentialsCache,
+    SessionLoginError,
+    is_acceptable_auth_model,
+    vcf_session_login,
+)
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vcf_logs.session import (
+    VcfCredentialsLoader,
+    VcfLogsTargetLike,
+    load_credentials_from_vault,
+)
+
+# Re-export ``SessionLoginError`` so callers that catch the helper's
+# structured failure don't have to reach into the shared module.
+__all__ = ["SessionLoginError", "VcfLogsConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# vRLI session-establish endpoint. POST with JSON body
+# ``{username, password, provider}``; success returns 200 with a JSON
+# body carrying ``sessionId`` + ``ttl``. Per the consumer wrapper at
+# https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-logs.sh
+_SESSION_CREATE_PATH = "/api/v2/sessions"
+
+# Unauthenticated version endpoint for fingerprint + probe. Returns JSON
+# ``{version, releaseName}`` where ``version`` is e.g.
+# ``"9.0.0.0.21761695"`` (dot-separated). The wrapper splits the value
+# at dots and reports ``parts[0:3]`` as the public version + ``parts[4]``
+# as the build; we mirror that shape in :class:`FingerprintResult`.
+_VERSION_PATH = "/api/v2/version"
+
+# Default vRLI identity-source name. Matches the wrapper's
+# ``PROVIDER="Local"`` default; ``ActiveDirectory`` / ``vIDM`` are
+# permitted alternatives a target may declare via
+# :attr:`VcfLogsTargetLike.provider`.
+_DEFAULT_PROVIDER = "Local"
+
+
+def _vrli_payload_builder(
+    provider: str,
+) -> Callable[[str, str], dict[str, Any]]:
+    """Return a payload-builder closure binding *provider* into the body.
+
+    The shared :func:`vcf_session_login` helper's
+    :data:`SessionPayloadBuilder` is ``(username, password) -> dict``;
+    vRLI also needs ``provider``, so we close over the per-target value
+    at call time. Lifting this to a module helper keeps the
+    :meth:`_session_token` body uncluttered.
+    """
+
+    def _build(username: str, password: str) -> dict[str, Any]:
+        return {
+            "username": username,
+            "password": password,
+            "provider": provider,
+        }
+
+    return _build
+
+
+def _parse_vrli_version(version_full: Any) -> tuple[str | None, str | None, str | None]:
+    """Render a vRLI ``version`` string as ``(public, build, patch)``.
+
+    vRLI reports ``version`` as a dot-separated tuple such as
+    ``"9.0.0.0.21761695"``. The wrapper at ``vcf-logs.sh`` lines
+    226-251 renders ``parts[0:3]`` as the public version and
+    ``parts[4]`` as the build, with ``parts[3]`` exposed as the patch
+    component. Mirror that contract so ``meho connector fingerprint``
+    stays byte-compatible with ``vcf-logs.sh --probe``.
+
+    Returns ``(None, None, None)`` if *version_full* is not a non-empty
+    string -- the appliance returning a malformed response shouldn't
+    crash the fingerprint round-trip.
+    """
+    if not isinstance(version_full, str) or not version_full:
+        return None, None, None
+    parts = version_full.split(".")
+    version = ".".join(parts[0:3]) if len(parts) >= 3 else version_full
+    patch = parts[3] if len(parts) > 3 else None
+    build = parts[4] if len(parts) > 4 else None
+    return version, build, patch
+
+
+def _extract_session_id(resp: httpx.Response) -> str | None:
+    """Pull ``sessionId`` out of the vRLI session-create response body.
+
+    The session-create POST returns ``{"sessionId": "<token>",
+    "ttl": <seconds>}``; the wrapper at ``vcf-logs.sh`` line 142 extracts
+    ``.sessionId`` via ``jq`` and aborts when the field is empty or
+    ``null``. The shared :func:`vcf_session_login` helper treats a
+    ``None``-or-empty return from this extractor as
+    :exc:`SessionLoginError`, so this function never has to raise
+    itself -- it returns ``None`` for the missing / null / empty case
+    and lets the helper produce the consistent target-named error.
+    """
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("sessionId")
+    if not isinstance(value, str) or not value:
+        return None
+    return value
+
+
+class VcfLogsConnector(HttpConnector):
+    """vRLI 9.x REST connector with session-token Bearer auth.
+
+    Per-target session token cached in :attr:`_session_tokens`;
+    per-target credentials cached in :attr:`_credentials` (the shared
+    :class:`CredentialsCache` instance). The :attr:`priority` is set to
+    ``1`` so a future ``GenericRestConnector`` auto-shim that somehow
+    registers for the same triple loses the registry's tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"vrli-rest-9.0"`` -> (``"vcf-logs"``, ``"9.0"``, ``"vrli-rest"``).
+    product = "vcf-logs"
+    version = "9.0"
+    impl_id = "vrli-rest"
+    supported_version_range = ">=9.0,<10.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: VcfCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._session_tokens: dict[str, str] = {}
+        self._session_lock = asyncio.Lock()
+        self._credentials = CredentialsCache(
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault,
+            product_label="vrli",
+        )
+
+    async def auth_headers(self, target: VcfLogsTargetLike, raw_jwt: str) -> dict[str, str]:
+        """Return ``{"Authorization": "Bearer <session_id>"}`` for the request.
+
+        Lazily establishes the session on first call against *target*;
+        subsequent calls reuse the cached token. ``raw_jwt`` is accepted
+        for ABC-signature compatibility but unused --
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
+        Vault-sourced service account, not the operator's OIDC token.
+
+        Raises :exc:`NotImplementedError` (with ``target.name`` and the
+        requested mode in the message) if ``target.auth_model`` is
+        anything other than ``shared_service_account`` or ``None``.
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT does not forward operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"VcfLogsConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        token = await self._session_token(target)
+        return {"Authorization": f"Bearer {token}"}
+
+    async def _session_token(self, target: VcfLogsTargetLike) -> str:
+        """Return the cached session token for *target*, establishing on first use.
+
+        The lock serialises concurrent first-use callers for one target;
+        the cache fast-path means subsequent callers are bounded only by
+        the lock acquisition itself. The slow
+        ``POST /api/v2/sessions`` call runs under the lock so two
+        concurrent first-use callers against the same target don't both
+        pay the round-trip cost.
+
+        Credentials are sourced from the shared :class:`CredentialsCache`
+        which raises :exc:`RuntimeError` naming the target if the loader
+        returns a dict missing ``"username"`` or ``"password"``. The
+        login round-trip itself delegates to the shared
+        :func:`vcf_session_login` helper, which wraps non-2xx responses
+        in :exc:`SessionLoginError` and chains the underlying
+        :exc:`httpx.HTTPStatusError`. Caller catches both as
+        :exc:`RuntimeError` (``SessionLoginError`` is a
+        ``RuntimeError`` subclass) for parity with the NSX precedent's
+        error shape.
+        """
+        async with self._session_lock:
+            cached = self._session_tokens.get(target.name)
+            if cached is not None:
+                return cached
+            creds = await self._credentials.get(target)
+            provider = getattr(target, "provider", None) or _DEFAULT_PROVIDER
+            client = await self._http_client(target)
+            token = await vcf_session_login(
+                client,
+                _SESSION_CREATE_PATH,
+                username=creds["username"],
+                password=creds["password"],
+                target_name=target.name,
+                payload_builder=_vrli_payload_builder(provider),
+                token_extractor=_extract_session_id,
+                request_headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+            )
+            self._session_tokens[target.name] = token
+            _log.info(
+                "vrli_session_established",
+                target=target.name,
+                host=target.host,
+                provider=provider,
+            )
+            return token
+
+    async def _invalidate_session(self, target: VcfLogsTargetLike) -> None:
+        """Drop the cached session token for *target*.
+
+        Called by :meth:`_get_json_with_session_retry` on 401 from a
+        downstream call so the subsequent :meth:`_session_token`
+        re-issues ``POST /api/v2/sessions`` from a clean state. Holds
+        the lock so a concurrent re-establish doesn't race with the
+        invalidation. Credentials cache is left intact -- the 401 means
+        the *session token* expired, not that the credentials are
+        wrong.
+        """
+        async with self._session_lock:
+            self._session_tokens.pop(target.name, None)
+
+    async def _get_json_with_session_retry(
+        self,
+        target: VcfLogsTargetLike,
+        path: str,
+        *,
+        raw_jwt: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """GET *path* with single 401 -> re-login -> retry-once recovery.
+
+        Wraps the inherited :meth:`HttpConnector._get_json` (which
+        carries tenacity's connection-error + 5xx retry decorator);
+        invokes it via ``super()._get_json`` is unnecessary -- this
+        method just calls ``_get_json`` directly and the retry policy
+        on the base method runs transparently.
+
+        On 401 from the inherited call, invalidates the cached session
+        token and re-tries once. A second 401 raises
+        :exc:`RuntimeError` naming the target -- the wrapper's posture:
+        re-login once on session-expiry, not a retry loop. Same shape
+        the NSX precedent established.
+        """
+        try:
+            return await self._get_json(target, path, raw_jwt=raw_jwt, params=params)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 401:
+                raise
+            await self._invalidate_session(target)
+        try:
+            return await self._get_json(target, path, raw_jwt=raw_jwt, params=params)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 401:
+                raise RuntimeError(
+                    f"vrli session re-login failed for target {target.name!r}: "
+                    f"GET {path} returned HTTP 401 after refresh"
+                ) from exc
+            raise
+
+    async def fingerprint(self, target: VcfLogsTargetLike) -> FingerprintResult:
+        """Canonical fingerprint built from unauthenticated ``GET /api/v2/version``.
+
+        The version endpoint is unauthenticated -- the wrapper's probe
+        mode auths first defensively but the appliance accepts the
+        call without a session token. The connector goes the cleaner
+        route: an unauthenticated client request against
+        ``/api/v2/version``, so a vRLI with valid TLS but broken
+        credentials still produces a reachable fingerprint reporting
+        the version + build. This is the same posture vSphere /
+        Automation take for their unauthenticated version probes.
+
+        Failure shape mirrors NSX: ``reachable=False`` with
+        ``extras["error"]`` carrying ``"<ExcType>: <message>"`` so the
+        operator's first ``meho connector fingerprint`` against an
+        unreachable vRLI gets a structured response rather than a
+        stack trace.
+        """
+        probed_at = datetime.now(UTC)
+        probe_method = f"GET {_VERSION_PATH}"
+        try:
+            client = await self._http_client(target)
+            resp = await client.get(
+                _VERSION_PATH,
+                headers={"Accept": "application/json"},
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except (httpx.HTTPError, OSError, ValueError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="vcf-logs",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=probe_method,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        version_full = payload.get("version") if isinstance(payload, dict) else None
+        release_name = payload.get("releaseName") if isinstance(payload, dict) else None
+        version, build, patch = _parse_vrli_version(version_full)
+        return FingerprintResult(
+            vendor="vmware",
+            product="vcf-logs",
+            version=version,
+            build=build,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=probe_method,
+            extras={
+                "release_name": release_name,
+                "version_full": version_full,
+                "patch": patch,
+            },
+        )
+
+    async def probe(self, target: VcfLogsTargetLike) -> ProbeResult:
+        """Lightweight reachability + auth-challenge check.
+
+        Delegates to :meth:`fingerprint` rather than running a
+        separate probe path. Same posture the NSX / VCF Automation
+        precedents established: one unauthenticated round-trip covers
+        both reachability and (transitively) "the appliance is
+        responding on /api/v2", which is enough for the boolean
+        ``ok``. Probe-time auth-challenge is intentionally not run --
+        a target whose creds are wrong still has reachable=true on
+        the version endpoint, and that's the right answer for "is the
+        appliance up".
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: VcfLogsTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim -- delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`NsxConnector.execute` /
+        :meth:`VcfAutomationConnector.execute`'s shape: the connector's
+        ABC :meth:`Connector.execute` predates the G0.6 operator-aware
+        dispatch path, so this shim exists for pre-G0.6 callers.
+        Post-G0.6 callers (``/api/v1/operations/call``, MCP
+        ``call_operation``, the CLI verbs once #838 lands) construct a
+        real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly.
+
+        The shim synthesises a minimal :class:`Operator` carrying a
+        nil-UUID tenant_id + a fixed system sentinel ``sub``; the
+        connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``'s contract:
+        ``"vrli-rest-9.0"`` -> (product=``"vcf-logs"``,
+        version=``"9.0"``, impl_id=``"vrli-rest"``).
+        """
+        # Lazy import -- meho_backplane.operations.dispatch transitively
+        # imports the connector registry which imports this module at
+        # package import time; deferring keeps that initialisation
+        # order stable.
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:vrli-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached session tokens + credentials, then tear down the httpx pool.
+
+        No DELETE-revoke is issued -- vRLI's session has a documented
+        idle timeout, and a per-target network call during lifespan
+        shutdown is more risk than benefit (same posture the NSX
+        precedent established). Token cache is cleared so a
+        post-aclose reuse of the same connector instance (e.g. a test
+        that builds one connector across two contexts) starts clean;
+        credentials cache is cleared so secrets don't outlive the
+        connector instance.
+        """
+        async with self._session_lock:
+            self._session_tokens.clear()
+        await self._credentials.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/vcf_logs/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/session.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Target shape + credentials loader wiring for the vcf_logs connector.
+
+The :class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector`
+trades operator-context Vault reads to a session token via vRLI's
+``POST /api/v2/sessions`` endpoint (JSON body
+``{username, password, provider}`` → ``{sessionId, ttl}`` in response, then
+``Authorization: Bearer <sessionId>`` on subsequent calls). The credential
+fetch (Vault path → service-account ``{"username": ..., "password": ...}``
+dict) is split out behind the cross-connector
+:data:`~meho_backplane.connectors._shared.vcf_auth.VcfCredentialsLoader`
+callable so:
+
+* Production deploys override the default loader at construction time once
+  the operator-context per-target Vault credential read lands for the VCF
+  management-plane connectors.
+* Unit tests inject their own (stub) loader returning a pre-built dict.
+* Integration tests against a recorded-fixture or live vRLI target pass a
+  loader that yields the appropriate service-account credentials.
+
+The default loader, :func:`load_credentials_from_vault`, raises
+:exc:`NotImplementedError` until the Vault read path lands — same posture
+the NSX precedent established, and the shared module's default loader
+already implements verbatim.
+
+The :class:`VcfLogsTargetLike` Protocol extends the cross-connector
+:class:`~meho_backplane.connectors._shared.vcf_auth.VcfTargetLike` shape
+with an optional ``provider`` field naming the vRLI identity-source
+(``"Local"`` / ``"ActiveDirectory"`` / ``"vIDM"``). The wrapper defaults
+to ``"Local"`` when the field is unset; the connector mirrors that
+default. Once the concrete ``Target`` model in
+:mod:`meho_backplane.targets` adds the column, the model satisfies the
+Protocol structurally.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    VcfCredentialsLoader,
+    load_credentials_from_vault,
+)
+
+__all__ = [
+    "VcfCredentialsLoader",
+    "VcfLogsTargetLike",
+    "load_credentials_from_vault",
+]
+
+
+@runtime_checkable
+class VcfLogsTargetLike(Protocol):
+    """Minimum target shape :class:`VcfLogsConnector` reads.
+
+    Extends the cross-connector
+    :class:`~meho_backplane.connectors._shared.vcf_auth.VcfTargetLike`
+    Protocol with an optional ``provider`` field that names the vRLI
+    identity-source for the session-login POST. Structural Protocol -- the
+    concrete ``Target`` model in :mod:`meho_backplane.targets` satisfies
+    this Protocol unchanged once the ``provider`` column lands; until
+    then, callers can pass a stub dataclass.
+
+    Fields:
+
+    * ``name`` -- per-target cache key (credentials + session token).
+    * ``host`` / ``port`` -- forwarded to
+      :meth:`HttpConnector._base_url`.
+    * ``secret_ref`` -- Vault path the loader resolves to a
+      ``{"username": str, "password": str}`` dict.
+    * ``auth_model`` -- checked at the boundary by
+      :func:`is_acceptable_auth_model`; only
+      ``"shared_service_account"`` / ``None`` accepted in v0.2.
+    * ``provider`` -- optional vRLI identity-source name
+      (``"Local"`` / ``"ActiveDirectory"`` / ``"vIDM"``). When unset
+      or empty the connector defaults to ``"Local"``, matching the
+      wrapper's posture.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+    provider: str | None

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -338,3 +338,25 @@ def test_vcf_operations_connector_registered_under_v2_triple() -> None:
     key = ("vcf-operations", "9.0", "vrops-rest")
     assert key in snapshot
     assert snapshot[key] is VcfOperationsConnector
+
+
+def test_vcf_logs_connector_registered_under_v2_triple() -> None:
+    """VcfLogsConnector package registers under (vcf-logs, 9.0, vrli-rest).
+
+    The autouse _clean_registry fixture clears the registry before this test,
+    so we manually re-register using the class attributes to assert the triple
+    resolves correctly. Same pattern as the SDDC Manager / Harbor /
+    VCF Automation tests above.
+    """
+    from meho_backplane.connectors.vcf_logs import VcfLogsConnector
+
+    register_connector_v2(
+        product=VcfLogsConnector.product,
+        version=VcfLogsConnector.version,
+        impl_id=VcfLogsConnector.impl_id,
+        cls=VcfLogsConnector,
+    )
+    snapshot = all_connectors_v2()
+    key = ("vcf-logs", "9.0", "vrli-rest")
+    assert key in snapshot
+    assert snapshot[key] is VcfLogsConnector

--- a/backend/tests/test_connectors_vcf_logs_auth.py
+++ b/backend/tests/test_connectors_vcf_logs_auth.py
@@ -1,0 +1,670 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`VcfLogsConnector` session-auth + fingerprint/probe (G3.6-T4 #830).
+
+Exercises the load-bearing vRLI auth contract verified against the
+consumer wrapper ``scripts/vcf-logs.sh`` (2026-05-21 snapshot):
+
+* ``POST /api/v2/sessions`` with JSON body
+  ``{username, password, provider}`` -- ``provider`` defaults to
+  ``"Local"`` when the target leaves it unset.
+* Response body ``{"sessionId": "<token>", "ttl": <seconds>}`` --
+  ``sessionId`` is extracted and cached per target.
+* Downstream auth header: ``Authorization: Bearer <session_id>``.
+* On HTTP 401 from a downstream call, the cached session is dropped
+  and a single re-login + retry-once dance follows; a second 401
+  surfaces as :exc:`RuntimeError` naming the target.
+* Per-target token isolation (two targets get two distinct caches).
+* Credentials cache: a loader returning a dict missing ``"password"``
+  surfaces a clear :exc:`RuntimeError` naming the target.
+* ``auth_model != "shared_service_account"`` (or ``None``) raises
+  :exc:`NotImplementedError`.
+* ``fingerprint()`` against an unauthenticated ``GET /api/v2/version``
+  reports the parsed version + build + release name; transport failure
+  yields ``reachable=False`` with ``extras["error"]``.
+
+The contract mirrors :mod:`tests.test_connectors_nsx_auth` with vRLI
+divergence: JSON body (not form), provider field, sessionId in body
+(not Set-Cookie/X-XSRF-TOKEN), Bearer header.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.connectors._shared.vcf_auth import VcfTargetLike
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vcf_logs import (
+    VcfLogsConnector,
+    VcfLogsTargetLike,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_vrli_registry() -> Iterator[None]:
+    """Re-register VcfLogsConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that
+    calls :func:`clear_registry` between tests. Re-register before
+    every test in this module and clear after -- same pattern
+    :mod:`tests.test_connectors_nsx_auth` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=VcfLogsConnector.product,
+        version=VcfLogsConnector.version,
+        impl_id=VcfLogsConnector.impl_id,
+        cls=VcfLogsConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub -- satisfies VcfLogsTargetLike Protocol structurally.
+# Replaced by the real Target model when the provider column lands.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    provider: str | None = None
+
+
+_TARGET_A = _StubTarget(
+    name="vrli-a",
+    host="vrli-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/vrli/vrli-a",
+)
+_TARGET_B = _StubTarget(
+    name="vrli-b",
+    host="vrli-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/vrli/vrli-b",
+)
+
+
+async def _stub_loader(_target: VcfTargetLike) -> dict[str, str]:
+    """Return canned credentials regardless of the target."""
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> VcfLogsConnector:
+    """Build a connector wired with the stub loader."""
+    return VcfLogsConnector(credentials_loader=_stub_loader)
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_vrli_connector_subclasses_http_connector() -> None:
+    """Sanity check: the connector inherits from HttpConnector with the right metadata."""
+    assert issubclass(VcfLogsConnector, HttpConnector)
+    assert VcfLogsConnector.product == "vcf-logs"
+    assert VcfLogsConnector.version == "9.0"
+    assert VcfLogsConnector.impl_id == "vrli-rest"
+    assert VcfLogsConnector.supported_version_range == ">=9.0,<10.0"
+    # Outranks a future GenericRestConnector auto-shim defensively.
+    assert VcfLogsConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    """The package's __init__ calls register_connector_v2 at import time."""
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("vcf-logs", "9.0", "vrli-rest")
+    assert key in registry
+    assert registry[key] is VcfLogsConnector
+
+
+def test_default_credentials_loader_raises_until_vault_lands() -> None:
+    """The default Vault loader stays unimplemented until operator-context Vault wiring lands."""
+    import asyncio
+
+    from meho_backplane.connectors.vcf_logs.session import (
+        load_credentials_from_vault,
+    )
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"not yet wired"):
+            await load_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Session establishment -- happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_establishes_session_with_json_body_and_default_provider() -> None:
+    """First auth_headers call POSTs JSON creds + provider="Local" to /api/v2/sessions.
+
+    Asserts the load-bearing auth contract: JSON body (NOT form, NOT
+    HTTP Basic) with ``username``, ``password``, and ``provider``
+    fields; ``provider`` defaults to ``"Local"`` per the wrapper's
+    posture when the target leaves it unset. Bearer header lands in
+    the response.
+    """
+    connector = _make_connector()
+    session_id = "vrli-token-abc-123"
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        session_route = mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": session_id, "ttl": 1800}
+        )
+        headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert session_route.called and session_route.call_count == 1
+    assert headers == {"Authorization": f"Bearer {session_id}"}
+
+    request = session_route.calls[0].request
+    assert request.headers.get("content-type", "").startswith("application/json")
+    sent = request.read()
+    import json
+
+    body = json.loads(sent.decode())
+    assert body == {
+        "username": "svc-meho",
+        "password": "stub-password",
+        "provider": "Local",
+    }
+    # The login POST itself must NOT carry a stale Authorization header.
+    assert "authorization" not in {k.lower() for k in request.headers}
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_uses_target_provider_when_set() -> None:
+    """target.provider="ActiveDirectory" lands in the login POST body."""
+    connector = _make_connector()
+    target = _StubTarget(
+        name="vrli-ad",
+        host="vrli-ad.test.invalid",
+        port=443,
+        secret_ref="kv/data/vrli/vrli-ad",
+        provider="ActiveDirectory",
+    )
+
+    async with respx.mock(base_url="https://vrli-ad.test.invalid") as mock:
+        session_route = mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": "ad-token", "ttl": 1800}
+        )
+        await connector.auth_headers(target, raw_jwt="")
+
+    request = session_route.calls[0].request
+    import json
+
+    body = json.loads(request.read().decode())
+    assert body["provider"] == "ActiveDirectory"
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_session_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-POST /api/v2/sessions."""
+    connector = _make_connector()
+    session_id = "vrli-cached-456"
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        session_route = mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": session_id, "ttl": 1800}
+        )
+        h1 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+        h2 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert h1 == h2 == {"Authorization": f"Bearer {session_id}"}
+    # The load-bearing assertion -- exactly one POST /api/v2/sessions
+    # for two auth header calls.
+    assert session_route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_session_tokens_separate() -> None:
+    """Two targets get two distinct cached tokens; no cross-target leakage."""
+    connector = _make_connector()
+
+    async with respx.mock() as mock:
+        route_a = mock.post("https://vrli-a.test.invalid/api/v2/sessions").respond(
+            200, json={"sessionId": "token-a", "ttl": 1800}
+        )
+        route_b = mock.post("https://vrli-b.test.invalid/api/v2/sessions").respond(
+            200, json={"sessionId": "token-b", "ttl": 1800}
+        )
+
+        h_a = await connector.auth_headers(_TARGET_A, raw_jwt="")
+        h_b = await connector.auth_headers(_TARGET_B, raw_jwt="")
+
+    assert route_a.called and route_b.called
+    assert h_a == {"Authorization": "Bearer token-a"}
+    assert h_b == {"Authorization": "Bearer token-b"}
+    assert connector._session_tokens == {
+        "vrli-a": "token-a",
+        "vrli-b": "token-b",
+    }
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Session establishment -- failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_create_401_surfaces_session_login_error_naming_target() -> None:
+    """401 from POST /api/v2/sessions raises SessionLoginError naming the target."""
+    from meho_backplane.connectors.vcf_logs import SessionLoginError
+
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(401, json={"errorMessage": "invalid_credentials"})
+        with pytest.raises(SessionLoginError, match=r"vrli-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "401" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_create_missing_session_id_in_body_raises() -> None:
+    """A 2xx response without sessionId raises naming the target.
+
+    A misbehaving proxy can 200 with an empty body or with the wrong
+    field name; the connector fails loudly via SessionLoginError rather
+    than caching an empty token that would silently 401 every
+    subsequent call.
+    """
+    from meho_backplane.connectors.vcf_logs import SessionLoginError
+
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        # Body without sessionId -- failure case.
+        mock.post("/api/v2/sessions").respond(200, json={"ttl": 1800})
+        with pytest.raises(SessionLoginError, match=r"vrli-a"):
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_create_empty_session_id_raises() -> None:
+    """A 2xx response with an empty-string sessionId raises naming the target."""
+    from meho_backplane.connectors.vcf_logs import SessionLoginError
+
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"sessionId": "", "ttl": 1800})
+        with pytest.raises(SessionLoginError, match=r"vrli-a"):
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_clear_error_naming_target() -> None:
+    """A loader returning a dict without 'password' surfaces a clear message.
+
+    Exercises the CredentialsCache "missing-key -> RuntimeError naming
+    target" contract -- a typo in a production loader otherwise
+    surfaces as a confusing KeyError deep inside the connector.
+    """
+
+    async def _bad_loader(_target: VcfTargetLike) -> dict[str, str]:
+        return {"username": "svc-meho"}
+
+    connector = VcfLogsConnector(credentials_loader=_bad_loader)
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid"):
+        with pytest.raises(RuntimeError, match=r"vrli-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "password" in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="vrli-per-user",
+        host="vrli.test.invalid",
+        port=443,
+        secret_ref="kv/data/vrli/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="")
+
+    assert "vrli-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="vrli-pre-g03",
+        host="vrli.test.invalid",
+        port=443,
+        secret_ref="kv/data/vrli/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"sessionId": "pre-g03-token", "ttl": 1800})
+        headers = await connector.auth_headers(target, raw_jwt="")
+
+    assert headers == {"Authorization": "Bearer pre-g03-token"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_value_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="vrli-enum",
+        host="vrli.test.invalid",
+        port=443,
+        secret_ref="kv/data/vrli/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"sessionId": "enum-token", "ttl": 1800})
+        headers = await connector.auth_headers(target, raw_jwt="")
+
+    assert headers == {"Authorization": "Bearer enum-token"}
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# 401 -> re-login -> retry-once recovery (downstream call)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_downstream_401_triggers_relogin_and_retry_once() -> None:
+    """A 401 on a downstream GET triggers session invalidation + re-login + a single retry.
+
+    Exercises the issue's "on HTTP 401 from a downstream call, re-login
+    once then retry once" contract. The session-create route fires
+    twice (initial + post-401); the downstream route fires twice (401
+    then 200).
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        session_route = mock.post("/api/v2/sessions")
+        session_route.side_effect = [
+            httpx.Response(200, json={"sessionId": "token-first", "ttl": 1800}),
+            httpx.Response(200, json={"sessionId": "token-second", "ttl": 1800}),
+        ]
+        events_route = mock.get("/api/v2/events")
+        events_route.side_effect = [
+            httpx.Response(401),
+            httpx.Response(200, json={"events": [{"id": "ev-1"}]}),
+        ]
+
+        result = await connector._get_json_with_session_retry(
+            _TARGET_A, "/api/v2/events", raw_jwt=""
+        )
+
+    assert result == {"events": [{"id": "ev-1"}]}
+    # Re-login fired exactly once -- two POSTs total.
+    assert session_route.call_count == 2
+    # Downstream GET fired twice -- the original 401 + the post-relogin retry.
+    assert events_route.call_count == 2
+    # The post-relogin token replaced the stale one.
+    assert connector._session_tokens == {"vrli-a": "token-second"}
+    # Both downstream GETs carried Bearer headers (first the stale
+    # token, second the refreshed one).
+    requests = events_route.calls
+    assert requests[0].request.headers.get("authorization") == "Bearer token-first"
+    assert requests[1].request.headers.get("authorization") == "Bearer token-second"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_downstream_401_then_still_401_after_relogin_raises_runtime_error() -> None:
+    """If the post-relogin retry also 401s, RuntimeError naming the target is raised.
+
+    Single retry, not a loop -- a configured credential pair that
+    consistently 401s should fail fast rather than hammering vRLI's
+    audit log.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        session_route = mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": "any-token", "ttl": 1800}
+        )
+        events_route = mock.get("/api/v2/events").respond(401)
+
+        with pytest.raises(RuntimeError, match=r"vrli-a") as exc_info:
+            await connector._get_json_with_session_retry(_TARGET_A, "/api/v2/events", raw_jwt="")
+
+    assert "401" in str(exc_info.value)
+    assert "after refresh" in str(exc_info.value)
+    # Exactly one re-login attempt + two GETs (no further retries).
+    assert session_route.call_count == 2
+    assert events_route.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_downstream_non_401_status_error_propagates_untouched() -> None:
+    """A 500 (or any non-401 status) on a downstream call does NOT trigger relogin.
+
+    Re-establishing the session on a 5xx would mask transient backend
+    failures behind a credential-rotation that solves nothing; the
+    relogin branch is keyed strictly on 401.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        session_route = mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": "any-token", "ttl": 1800}
+        )
+        # 502 will exhaust the base ``_request_json`` tenacity budget
+        # (3 retries on 5xx) before raising; assert "exactly one POST"
+        # below to guarantee we never triggered a relogin.
+        mock.get("/api/v2/events").respond(502)
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await connector._get_json_with_session_retry(_TARGET_A, "/api/v2/events", raw_jwt="")
+
+    assert exc_info.value.response.status_code == 502
+    # One session-create call (initial); no re-login fired.
+    assert session_route.call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() + probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against a respx-mocked GET /api/v2/version returns the canonical shape.
+
+    Mirrors the wrapper's ``--probe`` output shape: the ``version``
+    field is the dot-separated value parts[0:3], ``build`` is
+    parts[4], ``extras["patch"]`` is parts[3], and the full string
+    lands in ``extras["version_full"]``. The endpoint is hit
+    unauthenticated -- no session-create POST is expected.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid", assert_all_called=False) as mock:
+        version_route = mock.get("/api/v2/version").respond(
+            200,
+            json={
+                "version": "9.0.0.0.21761695",
+                "releaseName": "VMware Aria Operations for Logs 9.0",
+            },
+        )
+        # Defensive: if the connector unexpectedly tries to auth, we
+        # want a loud failure, not a successful 200 -- assert_all_called
+        # is disabled so this unused route doesn't make the test green
+        # the wrong way.
+        session_route = mock.post("/api/v2/sessions").respond(500)
+
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcf-logs"
+    assert fp.version == "9.0.0"
+    assert fp.build == "21761695"
+    assert fp.reachable is True
+    assert fp.probe_method == "GET /api/v2/version"
+    assert fp.extras["release_name"] == "VMware Aria Operations for Logs 9.0"
+    assert fp.extras["version_full"] == "9.0.0.0.21761695"
+    assert fp.extras["patch"] == "0"
+    # Probe is unauthenticated -- session-create was never called.
+    assert version_route.called
+    assert not session_route.called
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_returns_reachable_false_with_error() -> None:
+    """Transport/status failure returns reachable=False with structured extras."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        # 500 on the version endpoint -- the HTTPStatusError surfaces
+        # as a structured reachable=False rather than propagating up.
+        mock.get("/api/v2/version").respond(500, json={"error": "internal"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcf-logs"
+    assert fp.reachable is False
+    assert fp.probe_method == "GET /api/v2/version"
+    # Structured error: ``"<ExcType>: <message>"``.
+    error = fp.extras["error"]
+    assert "HTTPStatusError" in error
+    assert "500" in error
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_when_reachable() -> None:
+    """probe() returns ok=True on a reachable target (delegates to fingerprint)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.get("/api/v2/version").respond(
+            200,
+            json={"version": "9.0.0.0.21761695", "releaseName": "Logs"},
+        )
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_with_reason_when_unreachable() -> None:
+    """probe() returns ok=False + reason on an unreachable target."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.get("/api/v2/version").respond(500, json={"error": "internal"})
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    assert "500" in result.reason
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose -- token + credentials cache clear + pool tear-down
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_session_token_cache_and_credentials_and_pool() -> None:
+    """aclose() clears in-memory session + credentials caches and tears down the httpx pool."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"sessionId": "token", "ttl": 1800})
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert connector._session_tokens == {"vrli-a": "token"}
+    # Credentials cache should also be populated after the first call.
+    assert "vrli-a" in connector._credentials.cached_targets
+    await connector.aclose()
+    assert connector._session_tokens == {}
+    assert connector._credentials.cached_targets == frozenset()
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_with_no_cached_sessions_is_a_noop() -> None:
+    """A fresh connector with no sessions established closes cleanly."""
+    connector = _make_connector()
+    await connector.aclose()
+    assert connector._clients == {}
+    assert connector._session_tokens == {}
+
+
+# ---------------------------------------------------------------------------
+# Protocol satisfaction
+# ---------------------------------------------------------------------------
+
+
+def test_stub_target_satisfies_vcf_logs_target_like_protocol() -> None:
+    """The runtime-checkable Protocol accepts the stub target.
+
+    Sanity-checks that ``_StubTarget`` (which mirrors the shape the
+    concrete Target model will expose once the ``provider`` column
+    lands) satisfies :class:`VcfLogsTargetLike` structurally -- no
+    explicit inheritance required.
+    """
+    assert isinstance(_TARGET_A, VcfLogsTargetLike)

--- a/docs/codebase/connectors-vcf-logs.md
+++ b/docs/codebase/connectors-vcf-logs.md
@@ -1,0 +1,210 @@
+# VCF Operations for Logs (vRLI) connector
+
+## Overview
+
+`backend/src/meho_backplane/connectors/vcf_logs/` ships
+`VcfLogsConnector`, an `HttpConnector` subclass that authenticates
+against vRLI 9.x with a **session-token Bearer** flow. The package
+registers itself under the v2 connector registry triple
+`(product="vcf-logs", version="9.0", impl_id="vrli-rest")` at import
+time; the chassis lifespan's `_eager_import_connectors` discovers it
+during startup.
+
+This is one of the four VCF management-plane connectors landing under
+Initiative #369 (G3.6). The wave is generic-ingested via G0.7 — this
+Task ships only the **skeleton** (auth + fingerprint + probe + the
+G0.6 dispatch shim). Operations arrive in #834 via spec ingestion of
+`vcf-logs-9.0/openapi.yaml`.
+
+The connector imports its auth scaffolding from the shared
+`connectors/_shared/vcf_auth.py` module (#841 G3.6-T13) — vRLI is the
+session-token consumer of that shared module's `vcf_session_login`
+helper. The 401-retry-once loop wraps downstream calls and lives in
+this connector module (not in the shared helper) because the
+downstream paths differ per connector.
+
+## Key types
+
+- **`VcfLogsConnector(HttpConnector)`** —
+  `connectors/vcf_logs/connector.py`. Hand-rolled session-token
+  connector with per-target token cache + Vault-sourced
+  service-account credentials + 401-driven re-login + retry-once.
+- **`VcfLogsTargetLike`** — `connectors/vcf_logs/session.py`.
+  Runtime-checkable Protocol extending the cross-connector
+  `VcfTargetLike` with an optional `provider` field
+  (`"Local"` / `"ActiveDirectory"` / `"vIDM"`). The concrete `Target`
+  model satisfies it structurally once the column lands.
+- **Re-exports of the shared module**: `VcfCredentialsLoader`,
+  `load_credentials_from_vault` (default stub),
+  `SessionLoginError` — callers should import these from
+  `meho_backplane.connectors.vcf_logs` rather than reaching into
+  `_shared`.
+
+## Auth contract
+
+**Verified against the consumer wrapper `scripts/vcf-logs.sh`
+(2026-05-21 snapshot)** in `evoila-bosnia/claude-rdc-hetzner-dc` and
+the vRLI 9.x REST API documentation. The wrapper is the authoritative
+contract for the field shapes the appliance actually accepts.
+
+### Login round-trip
+
+```http
+POST /api/v2/sessions
+Content-Type: application/json
+Accept: application/json
+
+{"username": "<svc-account>", "password": "<…>", "provider": "Local"}
+```
+
+- `provider` field defaults to `"Local"` when the target leaves it
+  unset (`vcf-logs.sh` line 95). `"ActiveDirectory"` and `"vIDM"` are
+  the documented alternatives; v0.2 supports `Local` + `AD` only.
+- Response body shape: `{"sessionId": "<token>", "ttl": <seconds>}`
+  (`vcf-logs.sh` line 142 extracts `.sessionId`).
+
+### Downstream calls
+
+```http
+GET /api/v2/<path>
+Authorization: Bearer <sessionId>
+Content-Type: application/json
+Accept: application/json
+```
+
+The connector caches the `sessionId` per `target.name` in
+`_session_tokens`; subsequent `auth_headers()` calls reuse the cached
+value without a fresh login.
+
+### 401 retry-once
+
+`_get_json_with_session_retry()` wraps `HttpConnector._get_json` and
+handles the session-expiry case:
+
+1. Issue the GET with the cached Bearer header.
+2. On HTTP 401 → invalidate the cached `sessionId` (credentials cache
+   untouched — the 401 means the session expired, not that the creds
+   are wrong) and re-login.
+3. Retry the GET once with the fresh token.
+4. If the retry also 401s → raise `RuntimeError` naming the target.
+
+This is the same posture the NSX precedent established (re-login once,
+not a retry loop) — a misconfigured credential pair fails fast instead
+of hammering vRLI's audit log.
+
+### Fingerprint + probe
+
+`fingerprint()` issues an **unauthenticated** `GET /api/v2/version`.
+The wrapper's probe mode auths first defensively, but the appliance
+accepts the version call without a session — the connector takes the
+cleaner unauthenticated path so a vRLI with valid TLS but broken
+credentials still reports a reachable fingerprint.
+
+Response shape (mirroring the wrapper's probe output):
+
+```json
+{
+  "version": "9.0.0",
+  "build": "21761695",
+  "vendor": "vmware",
+  "product": "vcf-logs",
+  "extras": {
+    "release_name": "VMware Aria Operations for Logs 9.0",
+    "version_full": "9.0.0.0.21761695",
+    "patch": "0"
+  }
+}
+```
+
+The version-string parsing matches `vcf-logs.sh` lines 226-251: the
+appliance reports `version` as a dot-separated tuple
+(e.g. `"9.0.0.0.21761695"`); `parts[0:3]` is the public version,
+`parts[3]` is the patch, `parts[4]` is the build.
+
+`probe()` delegates to `fingerprint()` and returns
+`ProbeResult(ok=True)` when reachable, otherwise
+`ProbeResult(ok=False, reason=<error>)`.
+
+## Auth model gating
+
+`auth_headers()` rejects any `auth_model` other than
+`shared_service_account` (or `None` for pre-G0.3
+column-not-yet-populated targets) with `NotImplementedError` naming
+both the target and the requested mode. Per-user and impersonation
+modes are deferred to v0.2.next — same posture vSphere / NSX / VCF
+Automation take.
+
+## Control flow
+
+```text
+caller wants to issue an authenticated GET:
+  ├─ _get_json_with_session_retry(target, path, raw_jwt)
+  │    ├─ _get_json(target, path)
+  │    │    └─ HttpConnector._request_json (retry on 5xx / conn err)
+  │    │         ├─ auth_headers(target, raw_jwt)
+  │    │         │    └─ _session_token(target)
+  │    │         │         ├─ _credentials.get(target)
+  │    │         │         │    └─ user-injected or Vault loader
+  │    │         │         └─ vcf_session_login(...)
+  │    │         │              └─ POST /api/v2/sessions
+  │    │         └─ client.request("GET", path, ...)
+  │    │              └─ on 200 → return resp.json()
+  │    │              └─ on 401 → raise HTTPStatusError
+  │    └─ on HTTPStatusError(401):
+  │         ├─ _invalidate_session(target)       # drop cached sessionId
+  │         └─ retry _get_json(...) once
+  │              └─ on 401 again → RuntimeError "after refresh"
+```
+
+The credentials cache (`_credentials`, a shared `CredentialsCache`
+keyed on `target.name`) is touched once per target lifetime; the
+session-token cache (`_session_tokens`) is touched once per
+target-session lifetime (initial login + any 401-driven re-login).
+Both caches are flushed on `aclose()`.
+
+## Dependencies
+
+- `connectors/_shared/vcf_auth.py` (#841 G3.6-T13) — provides
+  `CredentialsCache`, `vcf_session_login`, `is_acceptable_auth_model`,
+  `SessionLoginError`, the default `load_credentials_from_vault` stub.
+- `connectors/adapters/http.py` — `HttpConnector` base with the
+  per-target httpx client pool, tenacity retry decorator on
+  `_request_json`, and `aclose()` plumbing.
+- `connectors/registry.py` — `register_connector_v2` for the
+  module-import-time registration.
+- `connectors/schemas.py` — `AuthModel`, `FingerprintResult`,
+  `ProbeResult`, `OperationResult`.
+
+External: `httpx>=0.27` (Bearer header + `AsyncClient`), `structlog`
+(observability), `respx>=0.21` (test mocks only).
+
+## Known issues
+
+- The default credentials loader
+  (`_shared.vcf_auth.load_credentials_from_vault`) is a stub that
+  raises `NotImplementedError`; production deploys must inject a
+  custom loader on connector construction until the operator-context
+  Vault read path is wired for the VCF management-plane connectors
+  (tracked under Goal #214).
+- No proactive token refresh. vRLI's session has a documented TTL
+  (default 30 days but operator-tunable); the connector relies on the
+  401-retry layer to handle expiry. Acceptable in v0.2; revisit if
+  operator-side cache TTLs drop below the round-trip timing.
+- No DELETE-revoke on `aclose()` — a per-target network call during
+  lifespan shutdown is more risk than benefit (same posture NSX
+  takes). Revoke-on-close is v0.2.next.
+
+## References
+
+- Task: <https://github.com/evoila/meho/issues/830>
+- Parent initiative: <https://github.com/evoila/meho/issues/369>
+- Parent goal: <https://github.com/evoila/meho/issues/214>
+- Shared auth module: `connectors/_shared/vcf_auth.py` (#841)
+- vRLI API:
+  <https://developer.broadcom.com/xapis/vrealize-log-insight-api/latest/>
+- Consumer wrapper:
+  <https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-logs.sh>
+- Sibling skeleton precedent: NSX (`connectors/nsx/`) for the
+  session-token + 401 retry-once pattern; VCF Automation
+  (`connectors/vcf_automation/`) for the most recent VCF management-
+  plane skeleton.


### PR DESCRIPTION
## Summary

- `connectors/vcf_logs/` — `VcfLogsConnector(HttpConnector)` for vRLI 9.x; **skeleton only** (auth + fingerprint + probe + G0.6 dispatch shim). Operations land in #834 via G0.7 spec ingestion.
- Registered against the v2 registry under `(product="vcf-logs", version="9.0", impl_id="vrli-rest")`; v1 `register_connector` deliberately not called (same posture NSX / VCF Automation established).
- Auth: session-token Bearer. `POST /api/v2/sessions` with JSON `{username, password, provider}` (provider defaults to `"Local"`) → `{sessionId, ttl}` cached per target → `Authorization: Bearer <sessionId>` on downstream calls. On HTTP 401, invalidate + re-login + retry once; second 401 raises `RuntimeError` naming the target.
- Imports the shared `connectors/_shared/vcf_auth.py` helpers from #841: `CredentialsCache` (async API), `vcf_session_login`, `is_acceptable_auth_model`, `SessionLoginError`. The 401-retry-once loop lives in this connector (matches #841's documented split — loop wrapper belongs where downstream paths live).
- Verified the wire contract against the consumer wrapper `scripts/vcf-logs.sh` (2026-05-21 snapshot) — JSON body shape, `sessionId` extraction, Bearer header, default `Local` provider, `/api/v2/version` unauthenticated probe.

## Test plan

- [x] `ruff check` — clean (vcf_logs + tests + registry test)
- [x] `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean (3 source files, 209 in full backend)
- [x] `pytest -n auto backend/tests/test_connectors_vcf_logs_auth.py backend/tests/test_connectors_registry_v2.py` — 40 passed (the 3 SDDC/Harbor/VCFA failures when run in this narrow set are pre-existing on `main`: cold-import ordering; they pass when other connector tests load first — verified by running with `tests/test_connectors_nsx_auth.py tests/test_connectors_harbor_auth.py tests/test_connectors_sddc_manager_auth.py tests/test_connectors_vcf_automation_auth.py tests/test_connectors_vcf_logs_auth.py`, all 152 pass).
- [x] Full backend connector test suite (`tests/test_connectors_*.py`) — 988 passed.
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers, 1 warning (`connector.py` 510 lines, well under 600 block threshold).

### Acceptance criteria coverage

- [x] `connectors/vcf_logs/` exists; `register_connector_v2(product="vcf-logs", version="9.0", impl_id="vrli-rest", cls=VcfLogsConnector)` in `__init__.py`; `test_connectors_registry_v2.py::test_vcf_logs_connector_registered_under_v2_triple` asserts the triple resolves.
- [x] respx unit tests cover: login success + token cached + Bearer header sent; session reuse (no second login); 401 → re-login + retry-once → success; 401 → re-login → still 401 → `RuntimeError` naming target; per-target token isolation; Vault loader missing `"password"` key → `RuntimeError` naming target; `auth_model="per_user"` → `NotImplementedError`.
- [x] `fingerprint()` against mocked `GET /api/v2/version` returns the canonical shape (`version="9.0.0"`, `build="21761695"`, `extras` with `release_name` / `version_full` / `patch`); unreachable → `reachable=False` + `extras["error"]`.
- [x] `probe()` returns `ok=True` on reachable, `ok=False` + `reason` on unreachable.
- [x] Connector docstring documents the login path + token header + `provider` field as verified against `vcf-logs.sh` lines 103-121, 142-147, 192-208, 257-261 + the vRLI API doc.

## Out of scope

- vRLI ops (event/query/aggregation lists) — #834 (G3.6-T5 spec ingestion).
- CLI verbs / MCP review / onboarding doc — #838 (G3.6-T6).
- Write ops — deferred beyond v0.5 per the Initiative.
- Proactive token refresh — same posture NSX takes; the 401 retry-once layer handles expiry.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for vRLI 9.x logs connector with session-based authentication, per-target token caching, and automatic token refresh on auth failures.
  * Connector is discoverable/registered for use by the system.
  * Added fingerprint/probe health checks for reachability and version reporting.

* **Tests**
  * Added comprehensive tests for auth flows, token caching/isolation, retry behavior, fingerprint/probe, and lifecycle teardown.

* **Documentation**
  * Added operational docs covering auth, retries, fingerprinting, and connector usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->