### PR TITLE
feat(connectors): G3.6-T1 VcfOperationsConnector skeleton — Basic + auth-source query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,29 @@ connector-related release-notes line.
 
 ### Added
 
+- **`VcfOperationsConnector` skeleton** (G3.6-T1
+  [#829](https://github.com/evoila/meho/issues/829)) — `HttpConnector`
+  subclass registered under
+  `(product="vcf-operations", version="9.0", impl_id="vrops-rest")`.
+  HTTP Basic auth on every request (vROps' `/suite-api/api/*` surface
+  is stateless — no session token); optional `auth-source` query
+  parameter on authenticated requests when `target.auth_source` is set,
+  routing the Basic challenge to a non-local identity domain (vIDM, AD
+  realm name, etc.). Auth-model boundary gate accepts
+  `shared_service_account` / the enum member / `None` (pre-G0.3
+  sentinel) and rejects everything else with `NotImplementedError`
+  naming the target + mode. `fingerprint()` against
+  `GET /suite-api/api/versions/current` lifts `releaseName` →
+  `version`, `buildNumber` → `build`, and `humanlyReadableReleaseName`
+  → `extras` when present; transport / status failures return
+  `reachable=False` with structured `extras["error"]`. `probe()`
+  delegates to `fingerprint()` — vROps has no dedicated `/health`
+  endpoint. Shares the `connectors/_shared/vcf_auth.py` scaffolding
+  ([#841](https://github.com/evoila/meho/issues/841)) for the Basic
+  header, auth-model predicate, credentials cache, and Vault loader
+  stub with the sibling vRLI #830 + Fleet #831 skeletons. Operations
+  ship in G3.6-T2 (#833) via G0.7 spec ingestion against the vROps
+  `/suite-api` OpenAPI spec.
 - **`meho admin keycloak bootstrap-clients` CLI verb** (G0.9.1-T11
   #791). Idempotently provisions the realm-side prerequisites the
   2026-05-21 RDC dogfood proved are the single highest-friction

--- a/backend/src/meho_backplane/connectors/vcf_operations/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/__init__.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.vcf_operations — VcfOperationsConnector package.
+
+Importing this package registers :class:`VcfOperationsConnector` against the
+v2 connector registry under
+``(product="vcf-operations", version="9.0", impl_id="vrops-rest")``.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
+point is deliberately **not** called. The connector advertises an explicit
+``(version="9.0", impl_id="vrops-rest")`` key; the v1 entry would land as
+``("vcf-operations", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s tie-break
+ladder. Same pattern :mod:`meho_backplane.connectors.harbor`,
+:mod:`meho_backplane.connectors.sddc_manager`, :mod:`meho_backplane.connectors.nsx`,
+and :mod:`meho_backplane.connectors.vcf_automation` established.
+
+Once G0.7-T8 (#408) lands its
+:func:`ensure_connector_class_registered` auto-shim in main, the idempotency
+check there will no-op on the
+``(product="vcf-operations", version="9.0", impl_id="vrops-rest")`` triple
+because this module has already registered the hand-rolled class. Until
+then, this module is the only registration path.
+
+Spec-ingested read ops arrive in G3.6-T2 (#833) via G0.7 ingestion of the
+vROps ``/suite-api`` OpenAPI spec. This skeleton ships zero operations —
+the :meth:`~VcfOperationsConnector.execute` shim exists for ABC compatibility
+but ``execute(target, op_id, ...)`` against any ``op_id`` resolves to
+"unknown operation" at the dispatcher layer until spec ingestion populates
+the ``endpoint_descriptor`` table.
+
+Sibling skeletons landing in the same Initiative wave:
+
+* :mod:`meho_backplane.connectors.vcf_logs` — vRLI (#830).
+* :mod:`meho_backplane.connectors.vcf_fleet` — Fleet (#831).
+* :mod:`meho_backplane.connectors.vcf_automation` — Automation (#832, already
+  merged; intentionally **not** a consumer of ``_shared/vcf_auth.py``).
+
+All four share the same registration shape; vROps + vRLI + Fleet share the
+``_shared/vcf_auth.py`` helper module (#841).
+"""
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.vcf_operations.connector import VcfOperationsConnector
+from meho_backplane.connectors.vcf_operations.session import (
+    VcfOperationsCredentialsLoader,
+    VcfOperationsTargetLike,
+    load_credentials_from_vault,
+)
+
+register_connector_v2(
+    product="vcf-operations",
+    version="9.0",
+    impl_id="vrops-rest",
+    cls=VcfOperationsConnector,
+)
+
+__all__ = [
+    "VcfOperationsConnector",
+    "VcfOperationsCredentialsLoader",
+    "VcfOperationsTargetLike",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/vcf_operations/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/connector.py
@@ -1,0 +1,372 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VcfOperationsConnector — hand-rolled HttpConnector subclass for vROps 9.0.
+
+Skeleton-only — auth + fingerprint + probe + the G0.6 dispatch shim.
+Operations arrive in G3.6-T2 (#833) via G0.7 spec ingestion against the vROps
+``/suite-api`` OpenAPI spec into the ``endpoint_descriptor`` table.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.vcf_operations.__init__`. The G0.7 auto-shim's
+idempotency check (in
+:func:`~meho_backplane.operations.ingest.connector_registration.ensure_connector_class_registered`)
+no-ops on subsequent ingests against the same
+``(product="vcf-operations", version="9.0", impl_id="vrops-rest")`` triple.
+
+Auth
+----
+
+vROps' ``/suite-api/api/*`` surface accepts HTTP Basic on every request — no
+session cookie or token is established. The connector caches the raw
+service-account credentials (loaded once per target from Vault via an
+injectable loader) and computes the ``Authorization: Basic`` header on each
+:meth:`auth_headers` call.
+
+Optional ``auth-source`` routing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+vROps can federate identity through multiple sources (the local realm,
+``vIDM``, an Active Directory realm name, etc.). When ``target.auth_source``
+is set, the connector appends ``?auth-source=<value>`` as a query parameter
+on every authenticated request so vROps can route the Basic-auth challenge
+to the named identity domain. When ``target.auth_source`` is ``None`` (the
+default), the query parameter is omitted and vROps falls back to its local
+realm. The value is passed through verbatim.
+
+The auth-source query parameter rides alongside any caller-supplied params
+through an :meth:`_request_json` override that merges the auth-supplied
+mapping into the caller-supplied one. Authenticated requests therefore
+always carry ``?auth-source=...`` when configured, regardless of which
+operation handler issued them; unauthenticated transport (none in the
+skeleton, since :meth:`fingerprint` and :meth:`probe` both go through
+:meth:`_get_json` with Basic auth attached) is unaffected.
+
+Auth model gating
+-----------------
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` (or
+``None`` for pre-G0.3 targets where the column hasn't been populated yet).
+:meth:`auth_headers` rejects any other ``target.auth_model`` value with a
+clear :exc:`NotImplementedError` naming both the target and the requested
+mode. Lifted from
+:func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`
+so all G3.6 skeletons enforce the same gate identically.
+
+No 401-retry-once wrapper
+-------------------------
+
+vROps Basic auth is stateless — there is no session token to refresh and no
+``acquire`` round-trip to re-run on a 401. A 401 from the appliance always
+means "bad credentials" (or a misconfigured auth-source); retrying with the
+same credentials would not help, and retrying with different credentials is
+outside the connector's contract. The shared
+:class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+exposes :meth:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache.invalidate`
+for a future rotation-event admin endpoint to call between the rotation and
+the next dispatch; that path is the right place to drop the cache, not a
+transport-layer retry loop.
+
+Contrast vRLI (#830) and Fleet (#831): vRLI establishes a session and uses
+the shared :func:`~meho_backplane.connectors._shared.vcf_auth.vcf_session_login`
+helper, with the 401-retry-once loop in the consumer connector around its
+downstream calls. vROps doesn't need that — same reason Harbor doesn't.
+
+Fingerprint
+-----------
+
+``GET /suite-api/api/versions/current`` returns ``{"releaseName": "...",
+"buildNumber": ...}`` shaped JSON. The connector lifts ``releaseName`` into
+:attr:`FingerprintResult.version` and ``buildNumber`` into
+:attr:`FingerprintResult.build`. Extras carry ``humanlyReadableReleaseName``
+when the appliance returns it (some 9.0 builds do, some don't) for
+operator-visible audit display.
+
+The version endpoint is unauthenticated on vROps; the connector still sends
+Basic auth on the call because (a) the appliance ignores unsolicited auth
+headers on unauthenticated paths, (b) keeping a single
+``_request_json``-shaped transport path simplifies auditing, and (c) the
+Harbor / SDDC Manager / NSX precedents all do the same. The behaviour is
+identical with or without ``target.auth_source`` set.
+
+Probe
+-----
+
+Delegates to :meth:`fingerprint` — same endpoint, same predicate
+(``reachable=True`` ⇒ ``ok=True``). vROps does not expose a dedicated
+``/health`` endpoint distinct from the version surface; the SDDC Manager
+and NSX precedents established the "probe delegates to fingerprint" shape
+for this case. Harbor's purpose-built ``/api/v2.0/health`` is the
+exception, not the rule.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    CredentialsCache,
+    basic_auth_header,
+    is_acceptable_auth_model,
+)
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.connectors.vcf_operations.session import (
+    VcfOperationsCredentialsLoader,
+    VcfOperationsTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = ["VcfOperationsConnector"]
+
+_log = structlog.get_logger(__name__)
+
+
+class VcfOperationsConnector(HttpConnector):
+    """vROps 9.0 REST connector with HTTP Basic auth (+ optional ``auth-source``).
+
+    Per-target credentials cached in :attr:`_creds` (loaded once via the
+    injectable :class:`VcfOperationsCredentialsLoader`). HTTP Basic auth is
+    sent on every request via ``Authorization: Basic <b64>`` — no session
+    token is established and no 401-driven re-login is needed (see the module
+    docstring's "No 401-retry-once wrapper" section).
+
+    The :attr:`priority` is set to ``1`` so a future ``GenericRestConnector``
+    auto-shim that somehow registers for the same triple loses the registry's
+    tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"vrops-rest-9.0"`` -> (``"vcf-operations"``, ``"9.0"``, ``"vrops-rest"``).
+    product = "vcf-operations"
+    version = "9.0"
+    impl_id = "vrops-rest"
+    supported_version_range = ">=9.0,<10.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: VcfOperationsCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._creds = CredentialsCache(
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault,
+            product_label="vcf-operations",
+        )
+
+    async def auth_headers(
+        self,
+        target: VcfOperationsTargetLike,
+        raw_jwt: str,
+    ) -> dict[str, str]:
+        """Return ``{"Authorization": "Basic ..."}`` for the request.
+
+        Loads credentials from Vault on first call against *target*, caches
+        them (via the shared :class:`CredentialsCache`), and reuses the cached
+        values on subsequent calls. ``raw_jwt`` is accepted for ABC-signature
+        compatibility but unused — :attr:`AuthModel.SHARED_SERVICE_ACCOUNT`
+        authenticates with a Vault-sourced service account, not the operator's
+        OIDC token.
+
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is anything
+        other than ``shared_service_account`` or ``None``. Same predicate as
+        Harbor / NSX / SDDC Manager — all G3.6 skeletons share it via
+        :func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`.
+
+        The ``auth-source`` query parameter is **not** part of this method's
+        return value — query parameters are merged in :meth:`_request_json`
+        via :meth:`_auth_query_params`. Keeping headers and query-params on
+        separate seams matches httpx's own API surface
+        (``client.request(..., headers=..., params=...)``).
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT mode does not forward operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"VcfOperationsConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        creds = await self._creds.get(target)
+        return {"Authorization": basic_auth_header(creds["username"], creds["password"])}
+
+    def _auth_query_params(self, target: VcfOperationsTargetLike) -> dict[str, str]:
+        """Return the auth-source query-parameter mapping for *target*.
+
+        ``{"auth-source": target.auth_source}`` when ``target.auth_source`` is
+        a non-empty string, ``{}`` otherwise. Empty strings are treated as
+        unset — vROps rejects an empty ``?auth-source=`` and the silent-omit
+        behaviour is the friendlier default for an operator with a partially
+        populated target row.
+        """
+        auth_source = getattr(target, "auth_source", None)
+        if not auth_source:
+            return {}
+        return {"auth-source": auth_source}
+
+    async def _request_json(
+        self,
+        target: VcfOperationsTargetLike,
+        method: str,
+        path: str,
+        *,
+        raw_jwt: str,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Merge the auth-source query param into *params* before the base call.
+
+        The base :meth:`HttpConnector._request_json` carries the
+        :mod:`tenacity` retry decorator; overriding it here keeps the
+        decorator intact while threading the connector-specific query-param
+        contribution through every call site (including the indirect ones
+        via :meth:`_get_json`). Caller-supplied params win on key conflict —
+        an operation handler that explicitly sets ``auth-source`` overrides
+        the per-target default; nothing today exercises that path, but the
+        ordering documents the intended precedence.
+        """
+        merged_params = dict(self._auth_query_params(target))
+        if params:
+            merged_params.update(params)
+        # An empty mapping is identical-to-None for httpx's params merge, but
+        # ``None`` keeps tests' ``request.url.params`` assertions clean when
+        # auth-source is unset and no caller params are supplied.
+        final_params = merged_params or None
+        return await super()._request_json(
+            target,
+            method,
+            path,
+            raw_jwt=raw_jwt,
+            params=final_params,
+            json=json,
+        )
+
+    async def fingerprint(self, target: VcfOperationsTargetLike) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /suite-api/api/versions/current``.
+
+        The response payload's ``releaseName`` becomes ``version`` and
+        ``buildNumber`` becomes ``build``. ``extras`` carries
+        ``humanlyReadableReleaseName`` when present (some 9.0 builds emit it).
+
+        On transport or status failure, returns a non-reachable
+        :class:`FingerprintResult` whose ``extras["error"]`` carries the
+        exception class + message — same pattern Harbor / SDDC Manager / NSX
+        established for transport-failure fingerprinting.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            payload = await self._get_json(target, "/suite-api/api/versions/current", raw_jwt="")
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="vcf-operations",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="GET /suite-api/api/versions/current",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        return FingerprintResult(
+            vendor="vmware",
+            product="vcf-operations",
+            version=payload.get("releaseName") or None,
+            build=str(payload["buildNumber"]) if payload.get("buildNumber") is not None else None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="GET /suite-api/api/versions/current",
+            extras={
+                "humanly_readable_release_name": payload.get("humanlyReadableReleaseName"),
+            },
+        )
+
+    async def probe(self, target: VcfOperationsTargetLike) -> ProbeResult:
+        """Reachability check — delegates to :meth:`fingerprint`.
+
+        vROps does not expose a dedicated ``/health`` endpoint distinct from
+        the version surface, so the fingerprint call is the right reachability
+        probe. Reuses the fingerprint's try/except shape: ``reachable=True``
+        ⇒ ``ok=True``; ``reachable=False`` ⇒ ``ok=False`` with the same
+        ``extras["error"]`` string surfaced as the probe's ``reason``.
+
+        Same shape SDDC Manager and NSX use; Harbor is the exception with
+        its purpose-built ``/api/v2.0/health`` endpoint.
+        """
+        probed_at = datetime.now(UTC)
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=probed_at)
+        # ``extras["error"]`` is populated on every unreachable fingerprint
+        # result (see ``fingerprint`` above). Fall back to a generic string
+        # only as defence-in-depth.
+        reason = fp.extras.get("error") if fp.extras else None
+        return ProbeResult(
+            ok=False,
+            reason=str(reason) if reason else "vcf-operations fingerprint failed",
+            probed_at=probed_at,
+        )
+
+    async def execute(
+        self,
+        target: VcfOperationsTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`HarborConnector.execute`'s shape. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI verbs
+        once #837 lands) construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly — they don't
+        reach this method.
+
+        The connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``'s contract:
+        ``"vrops-rest-9.0"`` → (product=``"vcf-operations"``,
+        version=``"9.0"``, impl_id=``"vrops-rest"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:vcf-operations-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached credentials, then tear down the httpx pool.
+
+        No server-side session to revoke — HTTP Basic is stateless. The
+        credential cache is cleared so a post-aclose reuse of the same
+        connector instance (e.g. a test that builds one connector across two
+        contexts) starts clean. Mirrors Harbor's ``aclose`` shape — the
+        shared :class:`CredentialsCache.clear` does the locked-mutation under
+        the hood so concurrent in-flight ``get(t)`` calls can't sneak a stale
+        entry past the clear.
+        """
+        await self._creds.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/vcf_operations/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/session.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential + target shape for the vROps (VCF Operations 9.0) connector.
+
+The hand-rolled
+:class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`
+reads service-account credentials from the target's Vault path and sends them
+as HTTP Basic auth on every request — no session token is established; vROps'
+``/suite-api/api/*`` surface accepts Basic auth on each call.
+
+The credential fetch (Vault path → ``{"username": ..., "password": ...}`` dict)
+is delegated to the shared :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+and :data:`~meho_backplane.connectors._shared.vcf_auth.VcfCredentialsLoader`
+contract — all three G3.6 skeleton connectors (vROps #829, vRLI #830,
+Fleet #831) share the same load-once-per-target cache shape and the same
+``RuntimeError``-naming-target contract for missing keys (#841).
+
+vROps adds one product-specific field on top of the shared target Protocol:
+``auth_source``. When set, the connector appends ``?auth-source=<value>`` as a
+query parameter on authenticated requests so vROps can route the Basic-auth
+challenge to a non-local identity domain (``Local``, ``vIDM``, an Active
+Directory realm name, etc.). When unset (``None``), the connector omits the
+query parameter and vROps routes against its default local realm. The exact
+acceptable values are operator-configured per vROps deployment; the connector
+passes the string through verbatim.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    VcfCredentialsLoader,
+    load_credentials_from_vault,
+)
+
+__all__ = [
+    "VcfOperationsCredentialsLoader",
+    "VcfOperationsTargetLike",
+    "load_credentials_from_vault",
+]
+
+
+VcfOperationsCredentialsLoader = VcfCredentialsLoader
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+Type alias for :data:`~meho_backplane.connectors._shared.vcf_auth.VcfCredentialsLoader`.
+Re-exported under a connector-flavoured name so the public API of the
+:mod:`meho_backplane.connectors.vcf_operations` package reads cohesively
+(``VcfOperationsConnector(credentials_loader=...)``) without exposing the
+shared module name at the boundary.
+"""
+
+
+@runtime_checkable
+class VcfOperationsTargetLike(Protocol):
+    """Minimum target shape :class:`VcfOperationsConnector` reads.
+
+    Structural Protocol — the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` (G0.3 #224) satisfies this unchanged. Extends
+    the shared :class:`~meho_backplane.connectors._shared.vcf_auth.VcfTargetLike`
+    base with one product-specific field:
+
+    * ``auth_source`` — optional vROps auth-source name. When set, the
+      connector appends ``?auth-source=<value>`` to authenticated request
+      URLs. When ``None``, no query parameter is added and vROps uses its
+      default local realm. The accepted values (``Local``, ``vIDM``, an AD
+      realm name, etc.) are operator-configured per vROps deployment; the
+      connector passes the string through verbatim.
+
+    The base shared fields (``name``, ``host``, ``port``, ``secret_ref``,
+    ``auth_model``) are gated and consumed identically to the other G3.6
+    skeletons (see :class:`VcfTargetLike`).
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+    auth_source: str | None

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -316,3 +316,25 @@ def test_vcf_automation_connector_registered_under_v2_triple() -> None:
     key = ("vcf-automation", "9.0", "vcfa-rest")
     assert key in snapshot
     assert snapshot[key] is VcfAutomationConnector
+
+
+def test_vcf_operations_connector_registered_under_v2_triple() -> None:
+    """VcfOperationsConnector package registers under (vcf-operations, 9.0, vrops-rest).
+
+    The autouse _clean_registry fixture clears the registry before this test,
+    so we manually re-register using the class attributes to assert the triple
+    resolves correctly. Same pattern as the SDDC Manager / Harbor /
+    VCF Automation tests above.
+    """
+    from meho_backplane.connectors.vcf_operations import VcfOperationsConnector
+
+    register_connector_v2(
+        product=VcfOperationsConnector.product,
+        version=VcfOperationsConnector.version,
+        impl_id=VcfOperationsConnector.impl_id,
+        cls=VcfOperationsConnector,
+    )
+    snapshot = all_connectors_v2()
+    key = ("vcf-operations", "9.0", "vrops-rest")
+    assert key in snapshot
+    assert snapshot[key] is VcfOperationsConnector

--- a/backend/tests/test_connectors_vcf_operations_auth.py
+++ b/backend/tests/test_connectors_vcf_operations_auth.py
@@ -1,0 +1,525 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`VcfOperationsConnector` (G3.6-T1 #829).
+
+Exercises HTTP Basic auth, the optional ``auth-source`` query parameter,
+per-target credential isolation, the auth_model boundary gate, and the
+fingerprint/probe shapes against mocked vROps ``/suite-api/api/*`` endpoints.
+
+Auth: no session token — HTTP Basic sent on every request. Credentials
+cached per target so Vault is only queried once per target per connector
+instance lifetime. The ``auth-source`` query parameter rides on every
+authenticated request when ``target.auth_source`` is set; absent when unset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+import respx
+
+from meho_backplane.connectors._shared.vcf_auth import VcfTargetLike
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vcf_operations import (
+    VcfOperationsConnector,
+    VcfOperationsTargetLike,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_vcf_operations_registry() -> Iterator[None]:
+    """Re-register VcfOperationsConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that calls
+    :func:`clear_registry` between tests. Re-register before every test in
+    this module and clear after — same pattern
+    :mod:`tests.test_connectors_harbor_auth` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=VcfOperationsConnector.product,
+        version=VcfOperationsConnector.version,
+        impl_id=VcfOperationsConnector.impl_id,
+        cls=VcfOperationsConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies VcfOperationsTargetLike Protocol structurally.
+# Replaced by the real Target model when G0.3 (#224) lands ``auth_source``.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    auth_source: str | None = None
+
+
+_TARGET_A = _StubTarget(
+    name="vrops-a",
+    host="vrops-a.test.invalid",
+    port=443,
+    secret_ref="kv/data/vrops/vrops-a",
+)
+_TARGET_B = _StubTarget(
+    name="vrops-b",
+    host="vrops-b.test.invalid",
+    port=443,
+    secret_ref="kv/data/vrops/vrops-b",
+)
+_TARGET_WITH_AUTH_SOURCE = _StubTarget(
+    name="vrops-ad",
+    host="vrops-ad.test.invalid",
+    port=443,
+    secret_ref="kv/data/vrops/vrops-ad",
+    auth_source="corp-ad",
+)
+
+
+async def _stub_loader(_target: VcfTargetLike) -> dict[str, str]:
+    """Return canned local-account credentials regardless of the target."""
+    return {"username": "admin", "password": "stub-password"}
+
+
+def _make_connector() -> VcfOperationsConnector:
+    return VcfOperationsConnector(credentials_loader=_stub_loader)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_vcf_operations_connector_subclasses_http_connector() -> None:
+    assert issubclass(VcfOperationsConnector, HttpConnector)
+    assert VcfOperationsConnector.product == "vcf-operations"
+    assert VcfOperationsConnector.version == "9.0"
+    assert VcfOperationsConnector.impl_id == "vrops-rest"
+    assert VcfOperationsConnector.supported_version_range == ">=9.0,<10.0"
+    assert VcfOperationsConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("vcf-operations", "9.0", "vrops-rest")
+    assert key in registry
+    assert registry[key] is VcfOperationsConnector
+
+
+def test_default_credentials_loader_raises_until_g03_lands() -> None:
+    from meho_backplane.connectors.vcf_operations.session import (
+        load_credentials_from_vault,
+    )
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"Goal #214"):
+            await load_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# HTTP Basic auth header
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_sends_basic_auth() -> None:
+    """auth_headers() produces Authorization: Basic with stub credentials."""
+    connector = _make_connector()
+    headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "Authorization" in headers
+    assert headers["Authorization"].startswith("Basic ")
+    username, password = _decode_basic_auth(headers["Authorization"])
+    assert username == "admin"
+    assert password == "stub-password"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-invoke the loader."""
+    call_count = 0
+
+    async def _counting_loader(_target: VcfTargetLike) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "admin", "password": "stub-password"}
+
+    connector = VcfOperationsConnector(credentials_loader=_counting_loader)
+    h1 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h2 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert h1 == h2
+    assert call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Per-target isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_credentials_separate() -> None:
+    """Two targets get two distinct credential cache entries; no cross-target leakage."""
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: VcfTargetLike) -> dict[str, str]:
+        call_log.append(target.name)
+        return {"username": f"svc-{target.name}", "password": "pass"}
+
+    connector = VcfOperationsConnector(credentials_loader=_tracking_loader)
+    h_a = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h_b = await connector.auth_headers(_TARGET_B, raw_jwt="")
+
+    username_a, _ = _decode_basic_auth(h_a["Authorization"])
+    username_b, _ = _decode_basic_auth(h_b["Authorization"])
+    assert username_a == "svc-vrops-a"
+    assert username_b == "svc-vrops-b"
+    assert call_log == ["vrops-a", "vrops-b"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential loading failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: VcfTargetLike) -> dict[str, str]:
+        return {"username": "admin"}
+
+    connector = VcfOperationsConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"password") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "vrops-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_username_key_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: VcfTargetLike) -> dict[str, str]:
+        return {"password": "stub-password"}
+
+    connector = VcfOperationsConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"username") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "vrops-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(
+    auth_model: str,
+) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="vrops-per-user",
+        host="vrops.test.invalid",
+        port=443,
+        secret_ref="kv/data/vrops/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="")
+
+    assert "vrops-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="vrops-pre-g03",
+        host="vrops.test.invalid",
+        port=443,
+        secret_ref="kv/data/vrops/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="vrops-enum",
+        host="vrops.test.invalid",
+        port=443,
+        secret_ref="kv/data/vrops/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# auth-source query parameter (vROps-specific)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_source_appended_as_query_param_when_set() -> None:
+    """An authenticated request against a target with auth_source carries ?auth-source=..."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-ad.test.invalid") as mock:
+        route = mock.get("/suite-api/api/versions/current").respond(
+            200,
+            json={"releaseName": "9.0.0", "buildNumber": 12345678},
+        )
+        await connector.fingerprint(_TARGET_WITH_AUTH_SOURCE)
+
+    assert route.called
+    sent_url = route.calls[0].request.url
+    assert sent_url.params.get("auth-source") == "corp-ad"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_source_omitted_from_query_when_unset() -> None:
+    """Targets without auth_source send no auth-source query parameter."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        route = mock.get("/suite-api/api/versions/current").respond(
+            200,
+            json={"releaseName": "9.0.0", "buildNumber": 12345678},
+        )
+        await connector.fingerprint(_TARGET_A)
+
+    assert route.called
+    sent_url = route.calls[0].request.url
+    assert "auth-source" not in sent_url.params
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_source_empty_string_is_treated_as_unset() -> None:
+    """``auth_source=""`` is silent-omitted — vROps rejects ?auth-source= empty values."""
+    target = _StubTarget(
+        name="vrops-empty-source",
+        host="vrops-empty-source.test.invalid",
+        port=443,
+        secret_ref="kv/data/vrops/empty-source",
+        auth_source="",
+    )
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-empty-source.test.invalid") as mock:
+        route = mock.get("/suite-api/api/versions/current").respond(
+            200,
+            json={"releaseName": "9.0.0", "buildNumber": 12345678},
+        )
+        await connector.fingerprint(target)
+
+    assert route.called
+    sent_url = route.calls[0].request.url
+    assert "auth-source" not in sent_url.params
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against mocked GET /suite-api/api/versions/current returns canonical shape."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.get("/suite-api/api/versions/current").respond(
+            200,
+            json={
+                "releaseName": "9.0.0",
+                "buildNumber": 23456789,
+                "humanlyReadableReleaseName": "VMware Aria Operations 9.0",
+            },
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcf-operations"
+    assert fp.version == "9.0.0"
+    assert fp.build == "23456789"
+    assert fp.reachable is True
+    assert fp.probe_method == "GET /suite-api/api/versions/current"
+    assert fp.extras["humanly_readable_release_name"] == "VMware Aria Operations 9.0"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_without_humanly_readable_name() -> None:
+    """A vROps response missing humanlyReadableReleaseName leaves the extras key None."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.get("/suite-api/api/versions/current").respond(
+            200,
+            json={"releaseName": "9.0.0", "buildNumber": 23456789},
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.version == "9.0.0"
+    assert fp.build == "23456789"
+    assert fp.reachable is True
+    assert fp.extras["humanly_readable_release_name"] is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_returns_reachable_false_with_structured_error() -> None:
+    """Transport/status failure returns reachable=False with extras['error']."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.get("/suite-api/api/versions/current").respond(
+            401,
+            json={"error": "unauthorised"},
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "vcf-operations"
+    assert fp.reachable is False
+    assert fp.probe_method == "GET /suite-api/api/versions/current"
+    error = fp.extras["error"]
+    assert "HTTPStatusError" in error or "401" in error
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_on_reachable_target() -> None:
+    """probe() returns ok=True when the version endpoint is reachable (delegates to fingerprint)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.get("/suite-api/api/versions/current").respond(
+            200,
+            json={"releaseName": "9.0.0", "buildNumber": 23456789},
+        )
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_with_reason_on_transport_error() -> None:
+    """probe() returns ok=False + reason on transport/status failure."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        # 401 is non-retryable (4xx) — surfaces immediately on the
+        # fingerprint call which probe() delegates to.
+        mock.get("/suite-api/api/versions/current").respond(401)
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    assert "HTTPStatusError" in result.reason or "401" in result.reason
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_credential_cache_and_pool() -> None:
+    """aclose() clears the in-memory credential cache and tears down the httpx pool."""
+    connector = _make_connector()
+    await connector.auth_headers(_TARGET_A, raw_jwt="")
+    assert "vrops-a" in connector._creds.cached_targets
+    await connector.aclose()
+    assert connector._creds.cached_targets == frozenset()
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_with_no_cached_credentials_is_a_noop() -> None:
+    """A fresh connector with no credentials established closes cleanly."""
+    connector = _make_connector()
+    await connector.aclose()
+    assert connector._clients == {}
+    assert connector._creds.cached_targets == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Protocol satisfaction
+# ---------------------------------------------------------------------------
+
+
+def test_stub_target_satisfies_protocol_at_runtime() -> None:
+    """_StubTarget satisfies the runtime-checkable VcfOperationsTargetLike Protocol.
+
+    Guards against drift between the Protocol shape and the test fixture: a
+    new required field on the Protocol that the stub doesn't carry would fail
+    this check before the rest of the suite produces confusing AttributeErrors.
+    """
+    assert isinstance(_TARGET_A, VcfOperationsTargetLike)
+    assert isinstance(_TARGET_WITH_AUTH_SOURCE, VcfOperationsTargetLike)

--- a/docs/codebase/connectors-vcf-operations.md
+++ b/docs/codebase/connectors-vcf-operations.md
@@ -1,0 +1,241 @@
+# Connector: vcf-operations (VCF Operations / vROps 9.0)
+
+## Overview
+
+The `vcf-operations` connector is the hand-rolled `HttpConnector` subclass
+that dispatches VMware Aria Operations (formerly vRealize Operations Manager;
+"vROps") REST operations under the
+`(product="vcf-operations", version="9.0", impl_id="vrops-rest")` registry
+triple. G3.6-T1 (#829) shipped the skeleton — HTTP Basic auth with an
+optional `auth-source` query parameter, the `auth_model` boundary gate,
+fingerprint, probe, and the G0.6 dispatch shim. G3.6-T2 (#833) will add
+spec ingestion + operator-review curation against the vROps `/suite-api`
+OpenAPI spec; G3.6-T3 (#837) will ship the `meho vcf-operations <op>` CLI
+verb tree + recorded-fixture E2E.
+
+Source: `backend/src/meho_backplane/connectors/vcf_operations/`.
+
+The connector is **single-plane** (one API surface at `/suite-api/api/*`)
+and **stateless** (Basic auth on every request, no session token). This
+is the simplest of the four G3.6 management-plane connectors — vRLI #830
+adds session-token + 401-retry-once, Fleet #831 adds product-specific
+fingerprint path, Automation #832 adds dual-plane auth + vhost routing.
+
+## Key types
+
+- **`VcfOperationsConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="vcf-operations"`, `version="9.0"`,
+  `impl_id="vrops-rest"`, `supported_version_range=">=9.0,<10.0"`,
+  `priority=1`. The priority outranks a future `GenericRestConnector`
+  auto-shim defensively if both somehow register for the same triple.
+- **`VcfOperationsTargetLike`** (`session.py`) — runtime-checkable Protocol
+  capturing the minimum target shape the connector reads: the shared
+  `name` / `host` / `port` / `secret_ref` / `auth_model` quintet plus one
+  vROps-specific field, `auth_source` (optional identity-domain label).
+  Replaced by the concrete `Target` model once `auth_source` lands as a
+  column in `meho_backplane.targets` (G0.3 #224); the model satisfies the
+  Protocol structurally without code edits here.
+- **`VcfOperationsCredentialsLoader`** (`session.py`) — type alias for the
+  shared `VcfCredentialsLoader` callable that resolves a target to
+  `{"username": ..., "password": ...}`. Injectable on connector construction
+  (`VcfOperationsConnector(credentials_loader=...)`) so unit tests,
+  integration tests, and pre-G0.3 production deploys override the default
+  Vault loader.
+- **`load_credentials_from_vault`** (re-exported from
+  `connectors/_shared/vcf_auth.py`) — default loader, stubbed
+  `NotImplementedError` until the live operator-context per-target Vault
+  read lands. The same stub serves vROps / vRLI / Fleet (#841 lifted the
+  helper into `_shared` to centralise the swap-over point).
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()` in
+   `meho_backplane/connectors/registry.py`, which walks every
+   `connectors/<product>/` subpackage in name-sorted order.
+2. Importing `meho_backplane.connectors.vcf_operations` triggers the
+   module-level
+   `register_connector_v2(product="vcf-operations", version="9.0", impl_id="vrops-rest", cls=VcfOperationsConnector)`
+   call.
+3. The registry's v2 table now resolves `("vcf-operations", "9.0",
+   "vrops-rest")` to `VcfOperationsConnector`. The G0.7 auto-shim's
+   idempotency check (in `ensure_connector_class_registered`) no-ops on
+   subsequent ingests against the same triple.
+
+The v1 `register_connector` entry point is deliberately **not** called —
+the v1 entry would land as `("vcf-operations", "", "")` and confuse
+`resolve_connector`'s tie-break ladder. Same pattern Harbor / SDDC Manager
+/ NSX / VCF Automation established.
+
+### Authentication (HTTP Basic, stateless)
+
+vROps' `/suite-api/api/*` surface accepts HTTP Basic on every request — no
+session cookie or token is established. The flow:
+
+1. First call against a target loads credentials via the injected
+   `VcfOperationsCredentialsLoader` and caches them under `target.name` in
+   the shared `CredentialsCache`. Missing-key (`"username"` /
+   `"password"`) returns from the loader surface as `RuntimeError` naming
+   both the target and the missing key.
+2. `auth_headers(target, raw_jwt)` checks `target.auth_model` via the
+   shared `is_acceptable_auth_model` predicate. Anything other than
+   `shared_service_account` / the enum member / `None` (the pre-G0.3
+   sentinel) raises `NotImplementedError` naming both the target and the
+   requested mode.
+3. Returns `{"Authorization": "Basic <b64>"}` computed from the cached
+   credentials.
+
+`raw_jwt` is accepted for ABC-signature compatibility but unused —
+`SHARED_SERVICE_ACCOUNT` mode authenticates with a Vault-sourced service
+account, not the operator's OIDC token.
+
+### Optional `auth-source` query parameter
+
+vROps can federate identity through multiple sources (the local realm,
+`vIDM`, an Active Directory realm name, etc.). When `target.auth_source`
+is set, the connector appends `?auth-source=<value>` as a query parameter
+on every authenticated request through `_request_json`. When unset
+(`None` / `""`), the query parameter is omitted and vROps falls back to
+its local realm. The accepted values (the local realm label, an AD
+realm name, etc.) are operator-configured per vROps deployment; the
+connector passes the string through verbatim.
+
+The `_request_json` override merges caller-supplied params with the
+auth-source contribution; **caller-supplied params win on key conflict**.
+The override sits on top of `HttpConnector._request_json`, preserving its
+tenacity retry decorator (3 retries on idempotent verbs, exponential
+backoff, only on connection errors + 5xx — not on 4xx, including 401).
+
+### No 401-retry-once wrapper
+
+vROps Basic auth is stateless. A 401 always means "bad credentials" (or a
+misconfigured `auth-source`); retrying with the same credentials would
+not help. The shared `CredentialsCache.invalidate(target)` is the right
+seam for a future rotation-event admin endpoint to drop the cache between
+the rotation and the next dispatch — but at the transport layer, no
+retry loop is wired.
+
+This contrasts with vRLI (#830) and Fleet (#831), which establish session
+tokens via the shared `vcf_session_login` helper and add a 401-retry-once
+wrapper in the consumer connector around downstream calls. vROps doesn't
+need that — same reason Harbor doesn't.
+
+### Fingerprint
+
+`GET /suite-api/api/versions/current` returns a JSON payload shaped
+`{"releaseName": "...", "buildNumber": <int>, "humanlyReadableReleaseName"?: "..."}`.
+The connector lifts:
+
+- `releaseName` → `FingerprintResult.version`.
+- `buildNumber` → `FingerprintResult.build` (stringified — the wire-level
+  field is an integer; the result-model field is `str | None`).
+- `humanlyReadableReleaseName` → `extras["humanly_readable_release_name"]`
+  (some 9.0 builds emit it, some don't).
+
+The version endpoint is unauthenticated on vROps; the connector still sends
+Basic auth on the call because (a) the appliance ignores unsolicited auth
+headers on unauthenticated paths, (b) keeping a single `_request_json`
+transport path simplifies auditing, and (c) the Harbor / SDDC Manager /
+NSX precedents all do the same.
+
+On transport or status failure, the result carries `reachable=False` and
+`extras["error"]` set to `f"{type(exc).__name__}: {exc}"` — the same
+pattern Harbor / SDDC Manager / NSX use.
+
+### Probe
+
+`probe(target)` delegates to `fingerprint(target)`. vROps does not expose
+a dedicated `/health` endpoint distinct from the version surface, so the
+fingerprint call is the right reachability probe. `reachable=True` ⇒
+`ok=True`; `reachable=False` ⇒ `ok=False` with `extras["error"]`
+surfaced as the probe's `reason`. Harbor's purpose-built
+`/api/v2.0/health` is the exception, not the rule.
+
+### Dispatch shim
+
+`execute(target, op_id, params)` synthesises a minimal `Operator`
+(nil-UUID tenant_id + `sub="system:vcf-operations-connector-shim"`) and
+delegates to `meho_backplane.operations.dispatch` with
+`connector_id="vrops-rest-9.0"`. Pre-G0.6 chassis routes reach the
+dispatcher through this shim; post-G0.6 callers (the
+`/api/v1/operations/call` route, MCP `call_operation`, and the
+`meho vcf-operations …` CLI verbs added in #837) construct a real
+`Operator` and call `dispatch` themselves.
+
+Until G3.6-T2 (#833) ingests the vROps OpenAPI spec, no operations exist
+in the `endpoint_descriptor` table for the `vrops-rest-9.0` connector_id
+— every `execute(..., op_id, ...)` call resolves to "unknown operation"
+at the dispatcher layer. This is the correct behaviour for a
+registered-but-empty connector at this Task's stage.
+
+### Shutdown
+
+`aclose()` clears the shared `CredentialsCache` under its lock (so a
+post-`aclose` reuse of the same connector instance starts clean) and
+delegates to `HttpConnector.aclose()` which closes every per-target httpx
+client.
+
+## Dependencies
+
+- **httpx 0.28.x** — per-target `AsyncClient` pool inherited from
+  `HttpConnector`; the per-target client carries the base URL
+  (`https://{host}` or `https://{host}:{port}` when port ≠ 443),
+  `Timeout(connect=5, read=30, write=30, pool=5)`, and
+  `follow_redirects=True`. The `_request_json` override threads
+  `auth-source` into the merged params; httpx merges params into the
+  request URL.
+- **tenacity 9.x** — base `HttpConnector._request_json` carries the
+  retry decorator (3 retries / exponential backoff / connection errors +
+  5xx only). The vROps override preserves the decorator by calling
+  `super()._request_json(...)` with the merged params.
+- **pydantic 2.13.x** — `FingerprintResult` / `ProbeResult` /
+  `OperationResult` are frozen models; the connector constructs them by
+  keyword.
+- **structlog 25.x** — credential-load events log through the shared
+  `CredentialsCache`; the connector itself doesn't add structlog calls
+  beyond what the base + cache emit.
+- **respx 0.23.x (test-only)** — the unit-test module mocks every request
+  shape (auth header, auth-source query param both set + unset, missing
+  credentials, fingerprint reachable + unreachable, probe ok / not-ok)
+  without a network call. Recorded-fixture integration tests will land in
+  G3.6-T3 (#837) under `backend/tests/fixtures/vcf/`.
+
+## Known issues
+
+- **Default loader stub** — `load_credentials_from_vault` raises
+  `NotImplementedError` until the operator-context per-target Vault read
+  lands (tracked under Goal #214). The supported workaround is to inject
+  a custom `credentials_loader` on `VcfOperationsConnector` at
+  construction time. Same stub serves vRLI + Fleet via the shared
+  `_shared/vcf_auth.py`.
+- **No 401-retry on credential rotation** — a credential rotation event
+  on the operator side requires explicit cache invalidation via
+  `CredentialsCache.invalidate(target)`. Until the admin endpoint for
+  rotation lands, the workaround is to restart the backplane process
+  (which clears the cache on `aclose`).
+- **No operations yet** — the connector is registered but no
+  `endpoint_descriptor` rows exist; dispatch against any `op_id`
+  resolves to "unknown operation" until G3.6-T2 (#833) ingests the
+  vROps `/suite-api` OpenAPI spec.
+
+## References
+
+- **Task**: <https://github.com/evoila/meho/issues/829>
+- **Parent initiative**: <https://github.com/evoila/meho/issues/369>
+- **Parent goal**: <https://github.com/evoila/meho/issues/214>
+- **Sibling skeletons (same Initiative wave)**:
+  <https://github.com/evoila/meho/issues/830> (vRLI),
+  <https://github.com/evoila/meho/issues/831> (Fleet),
+  <https://github.com/evoila/meho/issues/832> (VCF Automation, merged).
+- **Shared auth scaffolding**: `backend/src/meho_backplane/connectors/_shared/vcf_auth.py`
+  ([#841](https://github.com/evoila/meho/issues/841)).
+- **Co-area connector docs**: [`connectors-harbor.md`](connectors-harbor.md)
+  (closest HTTP-Basic precedent), [`connectors-sddc-manager.md`](connectors-sddc-manager.md),
+  [`connectors-vcf-automation.md`](connectors-vcf-automation.md),
+  [`connectors-vcf-auth-shared.md`](connectors-vcf-auth-shared.md).
+- **vROps Suite API**:
+  <https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/>
+- **Release-readiness rubric**:
+  [`connector-release-readiness.md`](connector-release-readiness.md) — vROps
+  starts at **State 0.5** (class registered, no ops yet).


### PR DESCRIPTION
## Summary

- Register `VcfOperationsConnector` against the v2 registry under
  `(product="vcf-operations", version="9.0", impl_id="vrops-rest")` —
  hand-rolled `HttpConnector` subclass; the second of three G3.6 Wave-2a
  skeleton connectors that depend on the merged shared
  `connectors/_shared/vcf_auth.py` (#841).
- HTTP Basic on every request (vROps' `/suite-api/api/*` is stateless —
  no session token) + optional `auth-source` query parameter routing the
  Basic challenge to a non-local identity domain (vIDM, AD realm, etc.)
  when `target.auth_source` is set. `_request_json` override preserves the
  base tenacity retry decorator while merging the auth-source contribution
  into the request params.
- `fingerprint()` against `GET /suite-api/api/versions/current` lifts
  `releaseName` → `version`, `buildNumber` → `build`,
  `humanlyReadableReleaseName` → `extras`; transport / status failures
  return `reachable=False` with structured `extras["error"]`. `probe()`
  delegates to `fingerprint()` — vROps has no dedicated `/health`
  endpoint distinct from the version surface.
- Skeleton-only: no operations yet. Ops arrive in G3.6-T2 (#833) via
  G0.7 spec ingestion against the vROps `/suite-api` OpenAPI spec; CLI
  verbs + recorded-fixture E2E in G3.6-T3 (#837).

## Test plan

- [x] `ruff check src/meho_backplane/ tests/` — clean.
- [x] `ruff format --check` on new files — clean.
- [x] `mypy src/meho_backplane/` — clean (209 source files).
- [x] `pytest -n auto --dist loadscope tests/test_connectors_vcf_operations_auth.py tests/test_connectors_registry_v2.py tests/test_connectors_harbor_auth.py tests/test_connectors_sddc_manager_auth.py tests/test_connectors_vcf_automation_auth.py` — **127 passed**.
- [x] Broader connector slice
  (`tests/test_connectors_base.py + http_adapter + resolver + the five
  auth/registry files above`) — **192 passed**.
- [x] `code-quality.py --diff` — exit 0.

Acceptance criteria from #829:

- [x] `connectors/vcf_operations/` exists; `register_connector_v2(...)`
      called from `__init__.py`; `test_connectors_registry_v2.py` carries
      `test_vcf_operations_connector_registered_under_v2_triple` asserting
      the `("vcf-operations", "9.0", "vrops-rest")` triple resolves.
- [x] respx unit test covers Basic auth header; `auth-source` query
      appended when set / omitted when unset / treated as unset when
      empty; Vault loader missing-key (`"username"` / `"password"`) →
      `RuntimeError` naming the target; per-target client isolation;
      `auth_model="per_user"` → `NotImplementedError` naming target + mode.
- [x] `fingerprint()` against mocked `GET /suite-api/api/versions/current`
      returns the canonical shape (`vendor="vmware"`,
      `product="vcf-operations"`, version + build extracted, reachable);
      unreachable → `reachable=False` + `extras["error"]`.
- [x] `probe()` returns `ok=True` on reachable target / `ok=False` with
      reason on transport failure.
- [x] `ruff check` + `mypy` clean on the new package; `pytest -n auto`
      passes.

## Out of scope

- vROps ops (alerts / metrics / resources lists) — G3.6-T2 #833 spec
  ingestion.
- CLI verbs / MCP description review / onboarding doc — G3.6-T3 #837.
- The `load_credentials_from_vault` live read remains a deliberate
  stub (shared with vRLI + Fleet via `_shared/vcf_auth.py`) tracked
  under Goal #214.

Sibling Wave-2a tasks landing in parallel: #830 (vRLI skeleton),
#831 (Fleet skeleton). All three import from the same
`_shared/vcf_auth.py` but produce separate connector packages — no
cross-PR conflict expected on the shared module. CHANGELOG conflict
is the only expected merge-time touchpoint and is the orchestrator's
to resolve.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #829


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VMware Aria Operations (vROps) 9.0 connector with HTTP Basic authentication support and optional auth-source routing
  * Includes fingerprinting and reachability probing capabilities

* **Documentation**
  * Added comprehensive connector documentation

* **Tests**
  * Added comprehensive test coverage for authentication and connector registration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->