### PR TITLE
feat(connectors): G3.6-T5 vRLI read-only v0.5 core curation (#834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,27 @@ connector-related release-notes line.
   [`docs/cross-repo/g36-vrops-canary.md`](docs/cross-repo/g36-vrops-canary.md).
   Write ops (custom-group / maintenance-mode set / alert-ack) stay
   `is_enabled=False` per the Initiative #369 out-of-scope list.
+- **vRLI 9.x read-only v0.5 core curation** (G3.6-T5
+  [#834](https://github.com/evoila/meho/issues/834)) —
+  `connectors/vcf_logs/core_ops.py` ships `VRLI_CORE_OPS` /
+  `VRLI_CORE_GROUPS` / `apply_vrli_core_curation` enabling exactly
+  **7 read-only operations** across 5 groups against the
+  `vrli-rest-9.0` connector triple after G0.7 spec ingestion of
+  `vcf-logs-9.0/api-v2.yaml`: `vrli.about`
+  (`GET /api/v2/version`), `vrli.event.query`
+  (`GET /api/v2/events/{constraints}` — JSONFlux-handle-shaped),
+  `vrli.aggregated.query`
+  (`GET /api/v2/aggregated-events/{constraints}`),
+  `vrli.field.list` (`GET /api/v2/fields`), `vrli.host.list`
+  (`GET /api/v2/hosts`), `vrli.content.pack.list`
+  (`GET /api/v2/content/contentpack/list`), and `vrli.alert.list`
+  (`GET /api/v2/alerts`). The `classify_vrli_op` path-prefix
+  classifier rejects non-`GET` methods so write ops never land
+  under a curated group; `apply_vrli_core_curation` mirrors the
+  Harbor + NSX precedents (audit-log-driven operator-override
+  exclusion so `enable_group`'s cascade skips non-core ops in
+  curated groups). Operator runbook at
+  [`docs/cross-repo/g36-vrli-canary.md`](docs/cross-repo/g36-vrli-canary.md).
 - **`VcfOperationsConnector` skeleton** (G3.6-T1
   [#829](https://github.com/evoila/meho/issues/829)) — `HttpConnector`
   subclass registered under

--- a/backend/src/meho_backplane/connectors/vcf_logs/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/__init__.py
@@ -27,6 +27,19 @@ skeleton.
 from meho_backplane.connectors._shared.vcf_auth import SessionLoginError
 from meho_backplane.connectors.registry import register_connector_v2
 from meho_backplane.connectors.vcf_logs.connector import VcfLogsConnector
+from meho_backplane.connectors.vcf_logs.core_ops import (
+    VRLI_CONNECTOR_ID,
+    VRLI_CORE_GROUPS,
+    VRLI_CORE_OPS,
+    VRLI_IMPL_ID,
+    VRLI_PATH_RULES,
+    VRLI_PRODUCT,
+    VRLI_VERSION,
+    VrliCoreGroup,
+    VrliCoreOp,
+    apply_vrli_core_curation,
+    classify_vrli_op,
+)
 from meho_backplane.connectors.vcf_logs.session import (
     VcfCredentialsLoader,
     VcfLogsTargetLike,
@@ -41,9 +54,20 @@ register_connector_v2(
 )
 
 __all__ = [
+    "VRLI_CONNECTOR_ID",
+    "VRLI_CORE_GROUPS",
+    "VRLI_CORE_OPS",
+    "VRLI_IMPL_ID",
+    "VRLI_PATH_RULES",
+    "VRLI_PRODUCT",
+    "VRLI_VERSION",
     "SessionLoginError",
     "VcfCredentialsLoader",
     "VcfLogsConnector",
     "VcfLogsTargetLike",
+    "VrliCoreGroup",
+    "VrliCoreOp",
+    "apply_vrli_core_curation",
+    "classify_vrli_op",
     "load_credentials_from_vault",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_logs/core_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/core_ops.py
@@ -1,0 +1,648 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vRLI 9.x read-only v0.5 core — curated operator-enabled subset.
+
+This module names the **7 read-only vRLI operations** the G3.6 vRLI
+v0.5 ship enables out of the much larger ``vcf-logs-9.0/<api-v2>.yaml``
+OpenAPI corpus that the G0.7 spec-ingestion pipeline lands under
+``connector_id="vrli-rest-9.0"``. The curation is two-layered:
+
+* :data:`VRLI_CORE_GROUPS` — the operator-reviewed ``when_to_use``
+  hint per LLM-grouping pass output group. Each entry's ``group_key``
+  is the deterministic slug :func:`classify_vrli_op` assigns to vRLI
+  ops; the ``when_to_use`` is what the agent reads verbatim through
+  :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
+  to pick a group to search within.
+* :data:`VRLI_CORE_OPS` — the 7 ``EndpointDescriptor.op_id`` strings
+  that flip to ``is_enabled=True`` at operator-review time, paired
+  with the per-op ``llm_instructions`` blob the agent inlines into
+  the reasoning context when it sees the op in
+  :func:`~meho_backplane.operations.meta_tools.search_operations`
+  hits. Every other op under the same connector triple stays
+  ``is_enabled=False`` (the G0.7 ingestion default for
+  ``source_kind='ingested'`` rows).
+
+Per Initiative #369 and CLAUDE.md postulates 1-2, vRLI is **fully
+generic-ingested**: the underlying ops are not registered in code,
+they live in the ``endpoint_descriptor`` table. This module only
+carries the **operator-review metadata** the substrate uses at the
+review step — the actual curation is applied through
+:func:`apply_vrli_core_curation` against an existing ingested
+connector.
+
+vRLI is a **log-query** product (event search + aggregation are the
+headline ops); the curated read core is biased toward those two
+plus the small set of inventory / catalog ops an operator needs to
+compose a useful query (fields known to the indexer, hosts
+reporting, content packs governing field extraction, alert
+definitions running).
+
+The 7 ops (paths sourced against the vRLI 9.x REST API documented at
+https://developer.broadcom.com/xapis/vrealize-log-insight-api/latest/
+and the v1 reference at https://vmw-loginsight.github.io/, both of
+which describe the same shape under the ``/api/v2/`` family in 9.x):
+
+1. ``GET:/api/v2/version`` — ``vrli.about`` — appliance version /
+   release-name / build. The same surface :meth:`VcfLogsConnector.fingerprint`
+   already consumes; exposing it as an operator-callable op lets the
+   agent run a sanity probe before any heavier read.
+2. ``GET:/api/v2/events/{constraints}`` — ``vrli.event.query`` —
+   constraint + time-range filtered raw-event search. Returns a
+   :class:`~meho_backplane.connectors.schemas.ResultHandle` for
+   large result sets so the agent reads them back via
+   ``result_describe`` / ``result_query`` rather than receiving the
+   full payload inline.
+3. ``GET:/api/v2/aggregated-events/{constraints}`` — ``vrli.aggregated.query``
+   — group-by aggregation over the same constraint set as the event
+   query. Useful for "how many events per host / severity / source
+   in the last 24h" reductions.
+4. ``GET:/api/v2/fields`` — ``vrli.field.list`` — catalog of fields
+   the indexer knows about (static + extracted). The agent reads
+   this before composing a non-trivial event-query constraint to
+   confirm a field name exists.
+5. ``GET:/api/v2/hosts`` — ``vrli.host.list`` — hosts currently
+   reporting events to this vRLI cluster. Combined with the field
+   catalog, this is the minimum agent-side composer-context for a
+   useful event query.
+6. ``GET:/api/v2/content/contentpack/list`` — ``vrli.content.pack.list``
+   — installed content packs (each governs a set of extracted
+   fields, dashboards, and alerts). Read when the operator asks
+   "which integrations are configured on this vRLI".
+7. ``GET:/api/v2/alerts`` — ``vrli.alert.list`` — alert definitions
+   currently configured. Read-only; create / mutate are intentionally
+   excluded from v0.5 per #369 DoD (write ops stay ``staged``).
+
+Path families and group_keys
+-----------------------------
+
+vRLI's REST paths split cleanly into five families:
+
+* ``/api/v2/version`` + ``/api/v2/fields`` → ``vrli-system``
+  (appliance identity + indexer catalog metadata).
+* ``/api/v2/events`` + ``/api/v2/aggregated-events`` → ``vrli-events``
+  (the headline query surfaces).
+* ``/api/v2/hosts`` → ``vrli-inventory`` (host reporting inventory).
+* ``/api/v2/content`` → ``vrli-content`` (content packs).
+* ``/api/v2/alerts`` → ``vrli-alerts`` (alert definitions).
+
+:data:`VRLI_PATH_RULES` orders the rules most-specific-first so the
+``startswith`` loop in :func:`classify_vrli_op` terminates at the
+right group. Path-prefix matching mirrors the pattern
+:mod:`meho_backplane.connectors.harbor.core_ops` and
+:mod:`meho_backplane.connectors.nsx.core_ops` established —
+stable, deterministic, operator-reviewable.
+
+Curation application
+--------------------
+
+:func:`apply_vrli_core_curation` is the operator-review-time
+substrate call that makes exactly the 7 curated ops dispatchable.
+Mirrors :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
+verbatim, threading the "enable group but pin non-core ops disabled"
+needle via the audit-log-driven operator-override exclusion. See
+:func:`~meho_backplane.operations.ingest._internals.operator_disabled_op_ids`
+for the cascade's exclusion-list source.
+
+Write ops invariant
+-------------------
+
+The v0.5 core is **read-only**. Write ops on vRLI (alert create,
+content-pack import, query result export) stay ``is_enabled=False``
+under their respective groups; the path-prefix classifier in
+:data:`VRLI_PATH_RULES` is permissive ("any op under
+``/api/v2/alerts``" hits ``vrli-alerts``), but :func:`classify_vrli_op`
+restricts the group assignment to ``GET`` operations only — non-GET
+methods classify as ``"none"`` and never appear under a curated
+group. Acceptance tests
+(:mod:`tests.test_connectors_vcf_logs_core_ops`) assert this
+invariant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.operations.ingest.service import ReviewService
+
+__all__ = [
+    "VRLI_CONNECTOR_ID",
+    "VRLI_CORE_GROUPS",
+    "VRLI_CORE_OPS",
+    "VRLI_IMPL_ID",
+    "VRLI_PATH_RULES",
+    "VRLI_PRODUCT",
+    "VRLI_VERSION",
+    "VrliCoreGroup",
+    "VrliCoreOp",
+    "apply_vrli_core_curation",
+    "classify_vrli_op",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Endpoint-descriptor product key — what
+#: :func:`~meho_backplane.operations._lookup.parse_connector_id`
+#: extracts from ``"vrli-rest-9.0"`` (first hyphen-segment of impl_id
+#: ``"vrli-rest"``).
+#:
+#: Note the discrepancy: :attr:`VcfLogsConnector.product` is
+#: ``"vcf-logs"`` (the v2 registry triple key) but ingested rows
+#: carry ``product="vrli"`` because the dispatcher's
+#: :func:`parse_connector_id` reads the first hyphen-segment of the
+#: ``connector_id`` slug. Same shape SDDC Manager uses
+#: (``product="sddc"`` on rows vs ``product="sddc-manager"`` on the
+#: connector class) — documented under
+#: :data:`~meho_backplane.connectors.sddc_manager.core_ops.SDDC_PRODUCT`.
+VRLI_PRODUCT: Final[str] = "vrli"
+VRLI_VERSION: Final[str] = "9.0"
+VRLI_IMPL_ID: Final[str] = "vrli-rest"
+
+#: Connector-id slug the G0.6 dispatcher's ``parse_connector_id``
+#: round-trips back to the triple above: ``"vrli-rest-9.0"``.
+VRLI_CONNECTOR_ID: Final[str] = f"{VRLI_IMPL_ID}-{VRLI_VERSION}"
+
+
+@dataclass(frozen=True, slots=True)
+class VrliCoreGroup:
+    """One curated operator-review entry for a vRLI operation group.
+
+    ``group_key`` is the slug :func:`classify_vrli_op` emits.
+    ``name`` is the operator-readable label ``meho connector review``
+    renders. ``when_to_use`` is the agent-facing hint
+    :func:`list_operation_groups` returns verbatim; every entry is a
+    single complete sentence so the agent's group-selection step has
+    unambiguous guidance.
+    """
+
+    group_key: str
+    name: str
+    when_to_use: str
+
+
+@dataclass(frozen=True, slots=True)
+class VrliCoreOp:
+    """One curated operator-review entry for a vRLI operation.
+
+    ``op_id`` follows the ``METHOD:path`` shape every
+    ``source_kind='ingested'`` row uses; the path matches an entry
+    in the vRLI 9.x OpenAPI spec under the ``/api/v2/`` family.
+
+    ``llm_instructions`` is the per-op JSON blob the meta-tools
+    inline verbatim when the op surfaces. The shape (``when_to_call``
+    / ``output_shape`` / ``next_step``) mirrors the typed-connector
+    convention from :mod:`meho_backplane.connectors.bind9.ops_zone`
+    and :mod:`meho_backplane.connectors.nsx.core_ops` — same agent
+    reads both surfaces, so the structure stays uniform.
+    """
+
+    op_id: str
+    group_key: str
+    llm_instructions: dict[str, object]
+
+
+#: Path-prefix → group_key classifier rules for vRLI.
+#:
+#: **Order is load-bearing.** Each rule is checked via
+#: ``path.startswith(prefix)``. More-specific prefixes must precede
+#: less-specific ones to avoid a shorter prefix consuming a path
+#: that belongs to a deeper group:
+#:
+#: * ``/api/v2/aggregated-events`` before ``/api/v2/events`` —
+#:   the aggregated path is not a prefix of the raw-event path, but
+#:   the rule ordering documents the intent ("aggregated is a
+#:   distinct surface from raw events") so the deterministic
+#:   classifier output reads cleanly during operator review.
+#: * ``/api/v2/version`` and ``/api/v2/fields`` both map to
+#:   ``vrli-system``; the appliance-identity probe (version) and
+#:   the indexer catalog (fields) co-locate because the agent reads
+#:   both as part of "is this vRLI ready, and what can I query".
+VRLI_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
+    ("/api/v2/version", "vrli-system"),
+    ("/api/v2/fields", "vrli-system"),
+    ("/api/v2/aggregated-events", "vrli-events"),
+    ("/api/v2/events", "vrli-events"),
+    ("/api/v2/hosts", "vrli-inventory"),
+    ("/api/v2/content", "vrli-content"),
+    ("/api/v2/alerts", "vrli-alerts"),
+)
+
+
+def classify_vrli_op(op_id: str) -> str:
+    """Return the curated ``group_key`` for a vRLI op_id, or ``"none"``.
+
+    ``op_id`` is the ``METHOD:/path`` form ingested rows carry; the
+    helper strips the verb and matches the path against
+    :data:`VRLI_PATH_RULES` in order.
+
+    Non-``GET`` methods classify as ``"none"`` — v0.5's curated core
+    is read-only; write ops never land under a curated group even
+    when their path matches a curated family. Acceptance tests
+    enforce this invariant.
+
+    Returns ``"none"`` for paths outside the curated families (e.g.
+    ``/api/v2/sessions``, ``/api/v2/notification/webhook``); those
+    rows are un-curated and stay ``is_enabled=False`` after
+    :func:`apply_vrli_core_curation` runs.
+    """
+    try:
+        method, path = op_id.split(":", 1)
+    except ValueError:
+        return "none"
+    if method != "GET":
+        return "none"
+    for prefix, group_key in VRLI_PATH_RULES:
+        if path.startswith(prefix):
+            return group_key
+    return "none"
+
+
+#: Operator-reviewed ``when_to_use`` hints for the 5 vRLI groups the
+#: read-only v0.5 core spans. Every hint is one complete sentence
+#: the agent reads verbatim — vague hints poison
+#: ``search_operations`` ranking, per the ai_engineering pack.
+VRLI_CORE_GROUPS: Final[tuple[VrliCoreGroup, ...]] = (
+    VrliCoreGroup(
+        group_key="vrli-system",
+        name="vRLI (system + indexer catalog)",
+        when_to_use=(
+            "Use this group to read vRLI appliance-level information and "
+            "indexer metadata: the software version and release name "
+            "(version), and the catalog of static + extracted fields the "
+            "indexer knows about (fields). The agent reads version as a "
+            "pre-flight probe before any heavier query, and reads the "
+            "field catalog before composing a non-trivial event-query "
+            "constraint to confirm a field name exists on this cluster."
+        ),
+    ),
+    VrliCoreGroup(
+        group_key="vrli-events",
+        name="vRLI Event Queries",
+        when_to_use=(
+            "Use this group to query vRLI log events — both raw event "
+            "search and group-by aggregation. The headline read surface "
+            "of vRLI: event queries return constraint-filtered, "
+            "time-range-bounded log lines; aggregated queries return "
+            "numeric counts grouped by one or more fields. Result sets "
+            "are JSONFlux-handle-shaped (typically large), so the agent "
+            "reads them back via result_describe / result_query rather "
+            "than inlining the full payload."
+        ),
+    ),
+    VrliCoreGroup(
+        group_key="vrli-inventory",
+        name="vRLI Hosts",
+        when_to_use=(
+            "Use this group to enumerate hosts currently reporting log "
+            "events to this vRLI cluster. Returns each host's hostname, "
+            "source-type, and last-seen timestamp. Combined with the "
+            "field catalog (vrli-system), this is the minimum "
+            "agent-side composer-context for a useful event query."
+        ),
+    ),
+    VrliCoreGroup(
+        group_key="vrli-content",
+        name="vRLI Content Packs",
+        when_to_use=(
+            "Use this group to list installed vRLI content packs. Each "
+            "pack governs a set of extracted fields, dashboards, and "
+            "alert templates for a specific product integration (NSX, "
+            "vSAN, vCenter, etc.). Read when the operator asks 'which "
+            "integrations are configured on this vRLI' or 'why is field "
+            "X missing from the catalog'."
+        ),
+    ),
+    VrliCoreGroup(
+        group_key="vrli-alerts",
+        name="vRLI Alert Definitions",
+        when_to_use=(
+            "Use this group to list alert definitions configured on "
+            "this vRLI cluster. Each alert carries its name, search "
+            "constraint, time window, hit threshold, and notification "
+            "channels. Read-only in v0.5 — alert create / update / "
+            "delete are deliberately excluded from the curated core."
+        ),
+    ),
+)
+
+
+def _instructions(
+    *,
+    when_to_call: str,
+    output_shape: str,
+    next_step: str,
+) -> dict[str, object]:
+    """Build the per-op ``llm_instructions`` blob with the canonical keys.
+
+    Same three-field shape :mod:`meho_backplane.connectors.nsx.core_ops`
+    and :mod:`meho_backplane.connectors.harbor.core_ops` use so an
+    agent crossing connector boundaries sees a stable convention.
+    """
+    return {
+        "when_to_call": when_to_call,
+        "output_shape": output_shape,
+        "next_step": next_step,
+    }
+
+
+#: The 7 curated read-only vRLI core ops. Each entry carries the
+#: op_id (``GET:/path`` form), the curated group assignment, and the
+#: operator-reviewed ``llm_instructions`` blob.
+#:
+#: Paths cross-checked against the vRLI 9.x REST API at
+#: https://developer.broadcom.com/xapis/vrealize-log-insight-api/latest/
+#: and the v1 reference at https://vmw-loginsight.github.io/ (which
+#: documents the same shape under the ``/api/v2/`` family in 9.x).
+VRLI_CORE_OPS: Final[tuple[VrliCoreOp, ...]] = (
+    VrliCoreOp(
+        op_id="GET:/api/v2/version",
+        group_key="vrli-system",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to identify the vRLI appliance — its software "
+                "version, build, and release name. Useful as a "
+                "pre-flight probe before any heavier query, or to "
+                "confirm which vRLI cluster the target points at."
+            ),
+            output_shape=(
+                "Object with version (e.g. '9.0.0'), releaseName "
+                "(e.g. 'VMware Aria Operations for Logs 9.0'), and "
+                "build (the appliance build number)."
+            ),
+            next_step=(
+                "If the appliance looks healthy and the version is in "
+                "the supported range, proceed to vrli.field.list to "
+                "confirm the catalog of queryable fields, then compose "
+                "the event-query constraint."
+            ),
+        ),
+    ),
+    VrliCoreOp(
+        op_id="GET:/api/v2/events/{constraints}",
+        group_key="vrli-events",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to query raw vRLI log events. The {constraints} "
+                "path segment carries the URL-encoded constraint set "
+                "(field/value pairs, time range, limit) — compose it "
+                "with field names obtained from vrli.field.list. The "
+                "headline read surface of vRLI; use when answering "
+                "'show me events where source contains nsx and "
+                "severity is error in the last 1h'."
+            ),
+            output_shape=(
+                "Result-handle-shaped: events[] array of raw event "
+                "rows (each with timestamp, text, fields), plus "
+                "complete (bool) indicating whether the constraint "
+                "exhausted the index or hit the limit. Large result "
+                "sets return a JSONFlux ResultHandle; navigate via "
+                "result_describe + result_query."
+            ),
+            next_step=(
+                "If complete=false, surface the truncation to the "
+                "operator. For drill-down, pick an event timestamp + "
+                "host and re-compose a tighter constraint, or switch "
+                "to vrli.aggregated.query for group-by counts."
+            ),
+        ),
+    ),
+    VrliCoreOp(
+        op_id="GET:/api/v2/aggregated-events/{constraints}",
+        group_key="vrli-events",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to run a group-by aggregation over the same "
+                "constraint shape vrli.event.query accepts, plus a "
+                "bin-by / group-by clause and an aggregation function "
+                "(count, sum, avg, min, max). Use when answering "
+                "'how many error events per host in the last 24h' or "
+                "'top 10 sources by event volume since midnight'."
+            ),
+            output_shape=(
+                "Object with bins[] array of (group_key -> value) "
+                "tuples, each carrying the aggregated metric value "
+                "plus the bucket boundary (time-bucket or field-value "
+                "bucket depending on the group-by clause). Numeric "
+                "sequence safe to inline directly into agent context."
+            ),
+            next_step=(
+                "Surface the top-N bins to the operator. For drill "
+                "into a specific bin, pass the bin's group_key as "
+                "an extra constraint to vrli.event.query."
+            ),
+        ),
+    ),
+    VrliCoreOp(
+        op_id="GET:/api/v2/fields",
+        group_key="vrli-system",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list the catalog of fields the vRLI indexer "
+                "knows about — both static (source, hostname, "
+                "timestamp) and extracted (parsed from log content "
+                "via content-pack rules). Read this before composing "
+                "a non-trivial vrli.event.query constraint to confirm "
+                "the field name actually exists on this cluster."
+            ),
+            output_shape=(
+                "Array of field entries; each carries name, type "
+                "(string / numeric / timestamp), source (static or "
+                "the content pack that defined it), and a brief "
+                "description when documented."
+            ),
+            next_step=(
+                "Pick the field names that match the operator's "
+                "intent and compose them into the constraint for "
+                "vrli.event.query or vrli.aggregated.query."
+            ),
+        ),
+    ),
+    VrliCoreOp(
+        op_id="GET:/api/v2/hosts",
+        group_key="vrli-inventory",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list hosts currently reporting log events "
+                "to this vRLI cluster. Useful when answering 'which "
+                "hosts are sending logs', 'is host X reporting', or "
+                "as the input list for a per-host aggregation."
+            ),
+            output_shape=(
+                "Array of host entries; each carries hostname, "
+                "source-type (the agent / forwarder that ships the "
+                "events), and last_seen timestamp."
+            ),
+            next_step=(
+                "Pick a hostname for a constraint on vrli.event.query "
+                "(field='hostname', operator='=', value='<host>'), "
+                "or aggregate across hosts via vrli.aggregated.query."
+            ),
+        ),
+    ),
+    VrliCoreOp(
+        op_id="GET:/api/v2/content/contentpack/list",
+        group_key="vrli-content",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list installed vRLI content packs. Each "
+                "pack governs a set of extracted fields, dashboards, "
+                "and alert templates for a specific product "
+                "integration (NSX, vSAN, vCenter, etc.). Read when "
+                "answering 'which integrations are configured on "
+                "this vRLI', 'why is field X missing from the "
+                "catalog', or auditing the cluster's content surface."
+            ),
+            output_shape=(
+                "Array of content-pack entries; each carries name, "
+                "namespace, version, and a brief description of the "
+                "fields / dashboards / alerts it contributes."
+            ),
+            next_step=(
+                "If a content pack the operator expects is missing, "
+                "surface the gap. Cross-reference pack-contributed "
+                "fields with vrli.field.list when investigating "
+                "extraction issues."
+            ),
+        ),
+    ),
+    VrliCoreOp(
+        op_id="GET:/api/v2/alerts",
+        group_key="vrli-alerts",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list alert definitions configured on this "
+                "vRLI cluster. Use when auditing which alerts exist, "
+                "checking which fire on a given constraint, or "
+                "confirming a recent alert configuration change. "
+                "Read-only in v0.5 — alert create / update / delete "
+                "are deliberately excluded from the curated core."
+            ),
+            output_shape=(
+                "Array of alert entries; each carries id, name, "
+                "enabled (bool), constraint (the search clause "
+                "vRLI evaluates), search_period (the rolling time "
+                "window), hit_count threshold, and notification "
+                "channels (email, webhook, vROps target)."
+            ),
+            next_step=(
+                "Surface enabled alerts whose constraint overlaps "
+                "the operator's investigation. For drill into "
+                "what an alert would match, lift its constraint "
+                "into vrli.event.query against the same time range."
+            ),
+        ),
+    ),
+)
+
+
+async def apply_vrli_core_curation(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Apply the curated 7-op read core against an ingested vRLI connector.
+
+    Drives the substrate so that, after this call returns, exactly
+    the 7 ops in :data:`VRLI_CORE_OPS` are dispatchable
+    (``is_enabled=True``) and every other ingested op stays
+    ``is_enabled=False``. The 5 curated groups land
+    ``review_status='enabled'`` so the agent's
+    :func:`~meho_backplane.operations.meta_tools.search_operations`
+    surfaces the core ops; non-curated groups are left untouched
+    (``review_status='staged'`` from the G0.7 ingest default).
+
+    The substrate doesn't expose "enable only ops X, Y, Z under
+    group G": :meth:`ReviewService.enable_group`'s cascade flips
+    ``is_enabled=True`` on every child op in the group. The helper
+    works around this via the audit-log-driven operator-override
+    exclusion — the same mechanism
+    :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
+    and :func:`~meho_backplane.connectors.nsx.core_ops.apply_nsx_core_curation`
+    established:
+
+    1. :meth:`ReviewService.get_review_payload` loads the current
+       state of every curated group and its child ops.
+    2. For each child op in a curated group that **isn't** in the
+       :data:`VRLI_CORE_OPS` allow-list,
+       :meth:`ReviewService.edit_op` with ``is_enabled=False``
+       writes the operator-override audit row. The follow-on
+       :meth:`enable_group` cascade detects these rows and skips
+       them.
+    3. :meth:`ReviewService.edit_group` lands the operator-reviewed
+       ``name`` + ``when_to_use`` on each curated group.
+    4. :meth:`ReviewService.enable_group` flips
+       ``review_status='enabled'`` and cascades ``is_enabled=True``
+       to the curated child ops (operator-overridden non-core ops
+       are skipped).
+    5. :meth:`ReviewService.edit_op` lands the curated
+       ``llm_instructions`` blob per entry in :data:`VRLI_CORE_OPS`.
+
+    Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
+    if no groups exist for ``vrli-rest-9.0`` under *tenant_id* (the
+    operator must run ``meho connector ingest`` against the vRLI
+    spec before this helper applies).
+    """
+    payload = await review_service.get_review_payload(
+        VRLI_CONNECTOR_ID,
+        tenant_id,
+    )
+
+    core_op_ids_by_group: dict[str, set[str]] = {}
+    for op in VRLI_CORE_OPS:
+        core_op_ids_by_group.setdefault(op.group_key, set()).add(op.op_id)
+
+    for group_payload in payload.groups:
+        allow_list = core_op_ids_by_group.get(group_payload.group_key)
+        if allow_list is None:
+            continue
+        for review_op in group_payload.ops:
+            if review_op.op_id in allow_list:
+                continue
+            await review_service.edit_op(
+                VRLI_CONNECTOR_ID,
+                review_op.op_id,
+                tenant_id=tenant_id,
+                is_enabled=False,
+            )
+            _log.info(
+                "vrli_non_core_op_disabled",
+                connector_id=VRLI_CONNECTOR_ID,
+                op_id=review_op.op_id,
+                group_key=group_payload.group_key,
+            )
+
+    for group in VRLI_CORE_GROUPS:
+        await review_service.edit_group(
+            VRLI_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+            name=group.name,
+            when_to_use=group.when_to_use,
+        )
+        await review_service.enable_group(
+            VRLI_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+        )
+        _log.info(
+            "vrli_core_group_enabled",
+            connector_id=VRLI_CONNECTOR_ID,
+            group_key=group.group_key,
+        )
+
+    for op in VRLI_CORE_OPS:
+        await review_service.edit_op(
+            VRLI_CONNECTOR_ID,
+            op.op_id,
+            tenant_id=tenant_id,
+            llm_instructions=op.llm_instructions,
+        )
+        _log.info(
+            "vrli_core_op_curated",
+            connector_id=VRLI_CONNECTOR_ID,
+            op_id=op.op_id,
+        )

--- a/backend/tests/test_connectors_vcf_logs_core_ops.py
+++ b/backend/tests/test_connectors_vcf_logs_core_ops.py
@@ -1,0 +1,501 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the vRLI read-only v0.5 core-ops curation.
+
+Covers :mod:`meho_backplane.connectors.vcf_logs.core_ops`:
+
+* :func:`classify_vrli_op` — path-prefix classifier rules. Validates
+  that ``GET``-method ops under each curated family slot into the
+  expected group and that non-``GET`` methods (write ops) classify
+  as ``"none"`` even when their path matches a curated family.
+* :data:`VRLI_CORE_OPS` integrity — every entry classifies to its
+  declared ``group_key``, every entry's ``op_id`` begins with
+  ``GET:`` (read-only invariant), and every entry's
+  ``llm_instructions`` blob carries the canonical three keys with
+  non-empty string values.
+* :func:`apply_vrli_core_curation` — the operator-review-time
+  substrate call that flips ``review_status='enabled'`` on the 5
+  curated groups, lands ``llm_instructions`` on the 7 curated ops,
+  and explicitly disables non-core ops via the audit-log-driven
+  operator-override exclusion. The load-bearing assertion is "7
+  ops dispatchable, every other op in curated groups stays
+  ``is_enabled=False``".
+
+Test harness mirrors :mod:`tests.test_connectors_harbor_core_ops`
+and :mod:`tests.test_connectors_nsx_core_ops`: SQLite via the
+autouse ``_default_database_url`` fixture, hand-rolled operator +
+connector seeding, audit-row counting from the chassis
+``audit_log`` table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.vcf_logs import (
+    VRLI_CORE_GROUPS,
+    VRLI_CORE_OPS,
+    VRLI_IMPL_ID,
+    VRLI_PRODUCT,
+    VRLI_VERSION,
+    apply_vrli_core_curation,
+    classify_vrli_op,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import ReviewService
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env vars Operator construction reads transitively."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+_FAKE_JWT = "header.payload.signature"
+
+
+def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
+    """Build a tenant-admin :class:`Operator` for the curation tests."""
+    return Operator(
+        sub=f"vrli-core-ops-test-{uuid.uuid4()}",
+        name="vRLI Core Ops Test",
+        email=None,
+        raw_jwt=_FAKE_JWT,
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify_vrli_op — path classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,expected_group",
+    [
+        ("GET:/api/v2/version", "vrli-system"),
+        ("GET:/api/v2/fields", "vrli-system"),
+        ("GET:/api/v2/events/{constraints}", "vrli-events"),
+        ("GET:/api/v2/aggregated-events/{constraints}", "vrli-events"),
+        ("GET:/api/v2/hosts", "vrli-inventory"),
+        ("GET:/api/v2/content/contentpack/list", "vrli-content"),
+        ("GET:/api/v2/alerts", "vrli-alerts"),
+        # Non-curated paths → "none"
+        ("GET:/api/v2/sessions", "none"),
+        ("GET:/api/v2/sessions/current", "none"),
+        ("GET:/api/v2/notification/webhook", "none"),
+        # Write ops on curated paths → "none" (read-only invariant)
+        ("POST:/api/v2/alerts", "none"),
+        ("DELETE:/api/v2/alerts/{alertId}", "none"),
+        ("POST:/api/v2/events/ingest/{uuid}", "none"),
+        # Malformed op_id → "none"
+        ("bad-op-id-no-colon", "none"),
+    ],
+    ids=str,
+)
+def test_classify_vrli_op_returns_correct_group(op_id: str, expected_group: str) -> None:
+    """classify_vrli_op returns the curated group_key for all 7 core ops."""
+    assert classify_vrli_op(op_id) == expected_group
+
+
+def test_classify_vrli_op_all_core_ops_are_classified() -> None:
+    """Every op in VRLI_CORE_OPS classifies to its declared group_key."""
+    for op in VRLI_CORE_OPS:
+        group = classify_vrli_op(op.op_id)
+        assert group != "none", (
+            f"VRLI_CORE_OPS entry {op.op_id!r} classified as 'none' — "
+            "check VRLI_PATH_RULES ordering"
+        )
+        assert group == op.group_key, (
+            f"VRLI_CORE_OPS entry {op.op_id!r} classified as {group!r} "
+            f"but declared group_key={op.group_key!r}"
+        )
+
+
+def test_classify_vrli_op_rejects_write_methods_on_curated_paths() -> None:
+    """Non-GET methods under curated paths classify as 'none'.
+
+    Curated read-only invariant: even if the path matches a curated
+    family (e.g. ``/api/v2/alerts``), a non-GET op never lands under
+    the group. v0.5 stays read-only; write ops keep
+    ``is_enabled=False``.
+    """
+    write_method_op_ids = [
+        "POST:/api/v2/alerts",
+        "PUT:/api/v2/alerts/{alertId}",
+        "DELETE:/api/v2/alerts/{alertId}",
+        "POST:/api/v2/content/contentpack/import",
+        "DELETE:/api/v2/hosts/{hostId}",
+    ]
+    for op_id in write_method_op_ids:
+        assert classify_vrli_op(op_id) == "none", (
+            f"non-GET op {op_id!r} should classify as 'none' "
+            "(read-only invariant) but matched a curated group"
+        )
+
+
+# ---------------------------------------------------------------------------
+# VRLI_CORE_OPS structural invariants
+# ---------------------------------------------------------------------------
+
+
+def test_vrli_core_ops_has_seven_entries() -> None:
+    """The read-only v0.5 core enables exactly 7 ops per #369 DoD."""
+    assert len(VRLI_CORE_OPS) == 7, (
+        f"VRLI_CORE_OPS should carry 7 entries (v0.5 read core); got {len(VRLI_CORE_OPS)}"
+    )
+
+
+def test_vrli_core_ops_all_are_read_only_get() -> None:
+    """Every op in VRLI_CORE_OPS is a GET (no POST/PUT/DELETE)."""
+    for op in VRLI_CORE_OPS:
+        assert op.op_id.startswith("GET:"), (
+            f"VRLI_CORE_OPS entry {op.op_id!r} is not a GET; v0.5 core is read-only"
+        )
+
+
+def test_vrli_core_ops_llm_instructions_all_populated() -> None:
+    """Every op in VRLI_CORE_OPS has non-empty llm_instructions with canonical keys."""
+    required_keys = {"when_to_call", "output_shape", "next_step"}
+    for op in VRLI_CORE_OPS:
+        assert op.llm_instructions, f"op {op.op_id!r} has empty llm_instructions"
+        missing = required_keys - set(op.llm_instructions)
+        assert not missing, f"op {op.op_id!r} llm_instructions missing keys: {missing}"
+        for key in required_keys:
+            val = op.llm_instructions[key]
+            assert isinstance(val, str) and val.strip(), (
+                f"op {op.op_id!r} llm_instructions[{key!r}] must be a non-empty string"
+            )
+
+
+def test_vrli_core_groups_when_to_use_all_populated() -> None:
+    """Every group in VRLI_CORE_GROUPS has a non-empty when_to_use hint."""
+    for group in VRLI_CORE_GROUPS:
+        assert group.when_to_use and group.when_to_use.strip(), (
+            f"group {group.group_key!r} has empty when_to_use"
+        )
+        assert group.name and group.name.strip(), f"group {group.group_key!r} has empty name"
+
+
+def test_vrli_core_groups_event_query_op_is_jsonflux_handle_shaped() -> None:
+    """The event-query op's llm_instructions advertise the JSONFlux handle shape.
+
+    Per #834 acceptance criteria, ``vrli.event.query`` returns a
+    JSONFlux result handle (event result sets are large by nature).
+    The agent learns this from the op's ``output_shape`` /
+    ``next_step`` text — assert the operator-reviewed copy mentions
+    the handle so the LLM knows to drill via
+    ``result_describe`` / ``result_query`` rather than expecting an
+    inline payload.
+    """
+    event_query_op = next(
+        op for op in VRLI_CORE_OPS if op.op_id == "GET:/api/v2/events/{constraints}"
+    )
+    output_shape = str(event_query_op.llm_instructions["output_shape"]).lower()
+    next_step = str(event_query_op.llm_instructions["next_step"]).lower()
+    combined = f"{output_shape} {next_step}"
+    assert "handle" in combined or "jsonflux" in combined, (
+        f"vrli.event.query llm_instructions should mention the JSONFlux handle "
+        f"so the agent reads results via result_describe / result_query; "
+        f"got output_shape={event_query_op.llm_instructions['output_shape']!r}, "
+        f"next_step={event_query_op.llm_instructions['next_step']!r}"
+    )
+
+
+def test_vrli_core_groups_cover_every_core_op_group_key() -> None:
+    """Every op.group_key appears in VRLI_CORE_GROUPS."""
+    group_keys = {g.group_key for g in VRLI_CORE_GROUPS}
+    for op in VRLI_CORE_OPS:
+        assert op.group_key in group_keys, (
+            f"op {op.op_id!r} group_key={op.group_key!r} has no matching VRLI_CORE_GROUPS entry"
+        )
+
+
+# ---------------------------------------------------------------------------
+# apply_vrli_core_curation — substrate integration (SQLite)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_curated_groups_and_ops(
+    *,
+    tenant_id: uuid.UUID,
+    extra_ops_per_group: int = 0,
+) -> dict[str, uuid.UUID]:
+    """Seed every :data:`VRLI_CORE_GROUPS` entry + its child ops.
+
+    Inserts one :class:`OperationGroup` per curated group_key
+    (``review_status='staged'``). For each :data:`VRLI_CORE_OPS`
+    entry, inserts the curated op (``is_enabled=False`` to match
+    the G0.7 ingest default for ``source_kind='ingested'`` rows).
+
+    When *extra_ops_per_group* > 0, also seeds *N* non-curated ops
+    per curated group with deterministic op_ids so the test can
+    assert :func:`apply_vrli_core_curation` correctly disables
+    them.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, uuid.UUID] = {}
+
+    async with sessionmaker() as session:
+        for group in VRLI_CORE_GROUPS:
+            group_row = OperationGroup(
+                tenant_id=tenant_id,
+                product=VRLI_PRODUCT,
+                version=VRLI_VERSION,
+                impl_id=VRLI_IMPL_ID,
+                group_key=group.group_key,
+                name=f"Placeholder name for {group.group_key}",
+                when_to_use="Placeholder when_to_use.",
+                review_status="staged",
+            )
+            session.add(group_row)
+            await session.flush()
+            group_ids[group.group_key] = group_row.id
+
+        for op in VRLI_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=tenant_id,
+                    product=VRLI_PRODUCT,
+                    version=VRLI_VERSION,
+                    impl_id=VRLI_IMPL_ID,
+                    op_id=op.op_id,
+                    source_kind="ingested",
+                    method=method,
+                    path=path,
+                    handler_ref=None,
+                    group_id=group_ids[op.group_key],
+                    summary=f"Placeholder summary for {op.op_id}.",
+                    description=f"Placeholder description for {op.op_id}.",
+                    parameter_schema={"type": "object", "properties": {}},
+                    response_schema={"type": "object"},
+                    llm_instructions=None,
+                    safety_level="safe",
+                    requires_approval=False,
+                    is_enabled=False,
+                    tags=["spec:vcf-logs-9.0/api-v2.yaml"],
+                )
+            )
+
+        for group in VRLI_CORE_GROUPS:
+            for i in range(extra_ops_per_group):
+                extra_op_id = f"GET:/canary-extra/{group.group_key}/{i}"
+                session.add(
+                    EndpointDescriptor(
+                        tenant_id=tenant_id,
+                        product=VRLI_PRODUCT,
+                        version=VRLI_VERSION,
+                        impl_id=VRLI_IMPL_ID,
+                        op_id=extra_op_id,
+                        source_kind="ingested",
+                        method="GET",
+                        path=f"/canary-extra/{group.group_key}/{i}",
+                        handler_ref=None,
+                        group_id=group_ids[group.group_key],
+                        summary="Extra non-curated op.",
+                        description="Extra non-curated op.",
+                        parameter_schema={"type": "object", "properties": {}},
+                        response_schema={"type": "object"},
+                        llm_instructions=None,
+                        safety_level="safe",
+                        requires_approval=False,
+                        is_enabled=False,
+                        tags=[],
+                    )
+                )
+
+        await session.commit()
+
+    return group_ids
+
+
+async def test_apply_vrli_core_curation_enables_exactly_7_ops() -> None:
+    """apply_vrli_core_curation enables exactly the 7 core ops."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrli_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == VRLI_PRODUCT,
+                EndpointDescriptor.version == VRLI_VERSION,
+                EndpointDescriptor.impl_id == VRLI_IMPL_ID,
+                EndpointDescriptor.is_enabled.is_(True),
+            )
+        )
+        enabled_ops = result.scalars().all()
+
+    enabled_op_ids = {op.op_id for op in enabled_ops}
+    expected_op_ids = {op.op_id for op in VRLI_CORE_OPS}
+    assert enabled_op_ids == expected_op_ids, (
+        f"enabled ops don't match VRLI_CORE_OPS; "
+        f"extra={enabled_op_ids - expected_op_ids!r}, "
+        f"missing={expected_op_ids - enabled_op_ids!r}"
+    )
+
+
+async def test_apply_vrli_core_curation_disables_non_core_ops_in_curated_groups() -> None:
+    """Extra ops seeded in curated groups stay is_enabled=False after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=2)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrli_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == VRLI_PRODUCT,
+                EndpointDescriptor.version == VRLI_VERSION,
+                EndpointDescriptor.impl_id == VRLI_IMPL_ID,
+                EndpointDescriptor.op_id.like("GET:/canary-extra/%"),
+            )
+        )
+        extra_ops = result.scalars().all()
+
+    assert extra_ops, "expected extra non-curated ops to exist"
+    for op in extra_ops:
+        assert op.is_enabled is False, (
+            f"non-core op {op.op_id!r} should be disabled after curation; "
+            f"got is_enabled={op.is_enabled!r}"
+        )
+
+
+async def test_apply_vrli_core_curation_sets_llm_instructions_on_all_core_ops() -> None:
+    """llm_instructions is populated on all 7 core ops after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrli_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    expected_op_ids = {op.op_id for op in VRLI_CORE_OPS}
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == VRLI_PRODUCT,
+                EndpointDescriptor.op_id.in_(list(expected_op_ids)),
+            )
+        )
+        curated_ops = result.scalars().all()
+
+    assert len(curated_ops) == len(VRLI_CORE_OPS)
+    for op in curated_ops:
+        assert op.llm_instructions is not None and op.llm_instructions, (
+            f"llm_instructions not set on core op {op.op_id!r} after curation"
+        )
+
+
+async def test_apply_vrli_core_curation_enables_all_5_curated_groups() -> None:
+    """All 5 curated groups land review_status='enabled' after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrli_core_curation(review_service, tenant_id=tenant_id)
+
+    expected_group_keys = {g.group_key for g in VRLI_CORE_GROUPS}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(OperationGroup).where(
+                OperationGroup.tenant_id == tenant_id,
+                OperationGroup.product == VRLI_PRODUCT,
+                OperationGroup.group_key.in_(list(expected_group_keys)),
+            )
+        )
+        groups = result.scalars().all()
+
+    assert len(groups) == len(VRLI_CORE_GROUPS)
+    for group in groups:
+        assert group.review_status == "enabled", (
+            f"group {group.group_key!r} should be 'enabled' after curation; "
+            f"got review_status={group.review_status!r}"
+        )
+
+
+async def test_apply_vrli_core_curation_writes_operator_reviewed_when_to_use() -> None:
+    """Curated groups carry the operator-reviewed when_to_use after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrli_core_curation(review_service, tenant_id=tenant_id)
+
+    expected: dict[str, Any] = {g.group_key: g.when_to_use for g in VRLI_CORE_GROUPS}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(OperationGroup).where(
+                OperationGroup.tenant_id == tenant_id,
+                OperationGroup.product == VRLI_PRODUCT,
+            )
+        )
+        groups = result.scalars().all()
+
+    for group in groups:
+        if group.group_key in expected:
+            assert group.when_to_use == expected[group.group_key], (
+                f"group {group.group_key!r} when_to_use mismatch after curation"
+            )
+            # Reviewed when_to_use must not match the placeholder seeded
+            # by _seed_curated_groups_and_ops — the acceptance criterion
+            # is "non-placeholder reviewed text".
+            assert "Placeholder" not in group.when_to_use, (
+                f"group {group.group_key!r} still carries placeholder when_to_use "
+                "after curation — apply_vrli_core_curation did not write the "
+                "reviewed text"
+            )
+
+
+async def test_apply_vrli_core_curation_emits_audit_rows() -> None:
+    """apply_vrli_core_curation writes at least one audit row per curated group."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrli_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).where(
+                AuditLog.tenant_id == tenant_id,
+            )
+        )
+        audit_rows = result.scalars().all()
+
+    assert len(audit_rows) >= len(VRLI_CORE_GROUPS), (
+        f"expected ≥{len(VRLI_CORE_GROUPS)} audit rows from curation; got {len(audit_rows)}"
+    )

--- a/docs/codebase/connectors-vcf-logs.md
+++ b/docs/codebase/connectors-vcf-logs.md
@@ -34,6 +34,15 @@ downstream paths differ per connector.
   `VcfTargetLike` with an optional `provider` field
   (`"Local"` / `"ActiveDirectory"` / `"vIDM"`). The concrete `Target`
   model satisfies it structurally once the column lands.
+- **`VRLI_CORE_OPS` / `VRLI_CORE_GROUPS` / `apply_vrli_core_curation`** —
+  `connectors/vcf_logs/core_ops.py` (#834 G3.6-T5). The
+  operator-review metadata + driver for the read-only v0.5 core
+  (7 ops across 5 groups: `vrli.about`, `vrli.event.query`,
+  `vrli.aggregated.query`, `vrli.field.list`, `vrli.host.list`,
+  `vrli.content.pack.list`, `vrli.alert.list`). The path-prefix
+  classifier `classify_vrli_op` rejects non-`GET` methods so write
+  ops never land under a curated group — same shape Harbor + NSX
+  use.
 - **Re-exports of the shared module**: `VcfCredentialsLoader`,
   `load_credentials_from_vault` (default stub),
   `SessionLoginError` — callers should import these from
@@ -197,8 +206,12 @@ External: `httpx>=0.27` (Bearer header + `AsyncClient`), `structlog`
 ## References
 
 - Task: <https://github.com/evoila/meho/issues/830>
+  (skeleton + auth) and
+  <https://github.com/evoila/meho/issues/834>
+  (spec ingestion + operator-review curation)
 - Parent initiative: <https://github.com/evoila/meho/issues/369>
 - Parent goal: <https://github.com/evoila/meho/issues/214>
+- Canary runbook: [`docs/cross-repo/g36-vrli-canary.md`](../cross-repo/g36-vrli-canary.md)
 - Shared auth module: `connectors/_shared/vcf_auth.py` (#841)
 - vRLI API:
   <https://developer.broadcom.com/xapis/vrealize-log-insight-api/latest/>

--- a/docs/cross-repo/g36-vrli-canary.md
+++ b/docs/cross-repo/g36-vrli-canary.md
@@ -1,0 +1,392 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# G3.6 vRLI canary — operator procedure
+
+This document is the **operator-facing runbook** for ingesting the
+vRLI 9.x OpenAPI surface through the G0.7 spec-ingestion pipeline
+and curating the read-only v0.5 core (7 ops) the agent surfaces
+through `search_operations` / `call_operation`. Run this procedure
+when standing up a vRLI target against a fresh deploy, when
+re-running after a connector / spec revision, or when verifying the
+curation against a staging vRLI cluster.
+
+Companion to
+[`docs/cross-repo/g35-nsx-canary.md`](./g35-nsx-canary.md)
+(the NSX counterpart this runbook mirrors) and
+[`docs/cross-repo/connector-ingestion.md`](./connector-ingestion.md)
+(the connector-agnostic ingest runbook). The vRLI-specific delta is
+the session-token Bearer auth flow (verified against the consumer's
+`scripts/vcf-logs.sh` wrapper), the single-spec ingest layout
+(`vcf-logs-9.0/api-v2.yaml`), and the curated 7-op read core biased
+toward the headline log-query surfaces.
+
+## What this canary proves
+
+End-to-end correctness of the G0.7 ingestion pipeline driven
+against the **vRLI v2 API corpus**:
+
+1. **Parse.** The T1 parser
+   ([`meho_backplane.operations.ingest.parse_openapi`](../../backend/src/meho_backplane/operations/ingest/openapi.py))
+   ingests `vcf-logs-9.0/api-v2.yaml` (the vRLI 9.x REST API spec
+   spanning event query, aggregated query, fields catalog, hosts,
+   content packs, alerts, sessions, ingest, and configuration
+   surfaces) under one `connector_id="vrli-rest-9.0"`.
+2. **Register.** T2's
+   [`register_ingested_operations`](../../backend/src/meho_backplane/operations/ingest/register_ingested.py)
+   bulk-upserts every parsed operation into the
+   `endpoint_descriptor` table under the
+   `(product, version, impl_id) = ("vrli", "9.0", "vrli-rest")`
+   connector triple. The first ingest finds the hand-rolled
+   [`VcfLogsConnector`](../../backend/src/meho_backplane/connectors/vcf_logs/connector.py)
+   already registered (G3.6-T4 #830); the auto-shim's idempotency
+   check (`ensure_connector_class_registered`) short-circuits.
+   Every row carries a `spec:vcf-logs-9.0/api-v2.yaml` tag so
+   operators can audit the spec source via `meho connector review`.
+3. **Group.** T3's
+   [`run_llm_grouping`](../../backend/src/meho_backplane/operations/ingest/llm_groups.py)
+   pass derives operation groups with operator-readable
+   `when_to_use` hints + per-op group assignments. The path-prefix
+   classifier in
+   [`meho_backplane.connectors.vcf_logs.core_ops.VRLI_PATH_RULES`](../../backend/src/meho_backplane/connectors/vcf_logs/core_ops.py)
+   names the 5 groups the curated core spans (`vrli-system`,
+   `vrli-events`, `vrli-inventory`, `vrli-content`,
+   `vrli-alerts`).
+4. **Curate.** The operator drives `apply_vrli_core_curation`
+   (which uses `ReviewService.edit_group` + `enable_group` +
+   `edit_op(llm_instructions=…)`) against the staged connector to
+   land the 7 read-only core ops + their guidance blobs.
+5. **Verify.** The operator dispatches one list op through
+   `call_operation` to prove the end-to-end agent path works.
+   The JSONFlux *seam* (used by the event-query op when result
+   sets are large) is exercised non-interactively through the
+   per-op `output_shape` + `next_step` text — every `vrli.event.query`
+   reference in the curated `llm_instructions` directs the agent
+   to `result_describe` / `result_query` for the actual rows.
+   Real JSONFlux reduction is a v0.5.next concern per Goal #214
+   scope.
+
+## Prerequisites
+
+- **The vRLI OpenAPI spec checked out locally.** The canary's
+  spec resolver pattern mirrors
+  [`tests/acceptance/_vcenter_spec.py`](../../backend/tests/acceptance/_vcenter_spec.py).
+  Set:
+  - `MEHO_VRLI_OPENAPI` — absolute path to
+    `vcf-logs-9.0/api-v2.yaml`, or
+  - `MEHO_CONSUMER_DOCS_ROOT` — directory containing
+    `vcf-logs-9.0/api-v2.yaml`. The consumer's spec-shelf repo is
+    the conventional source.
+
+  The env-gated **automated** canary acceptance test that drives
+  the ingest against `IngestionPipelineService` is a follow-up to
+  G3.6-T5; until it lands, the operator runs this procedure
+  manually + the substrate-level dispatch tests live at:
+  - [`backend/tests/test_connectors_vcf_logs_core_ops.py`](../../backend/tests/test_connectors_vcf_logs_core_ops.py)
+    — classifier + curation behavioural suite covering the 7
+    curated ops, the read-only invariant (non-`GET` methods
+    classify as `none`), and the JSONFlux-handle advertisement
+    on `vrli.event.query`.
+- **A Postgres instance with pgvector + FTS extensions.** Local
+  development uses the testcontainers fixture; production uses
+  the `pgvector/pgvector:pg16`-derived chart image.
+- **A running backplane with `meho connector ingest` available**
+  (T5, #486). The connector CLI talks to the REST API at
+  `http(s)://<backplane>/api/v1/connectors/ingest`.
+- **An LLM client configured for the grouping pass.** Production
+  deploys wire the Anthropic Messages-API adapter under
+  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **A Vault path holding the vRLI service-account credentials.**
+  The `VcfLogsConnector` resolves `target.secret_ref` to a
+  `{"username": ..., "password": ...}` pair posted to
+  `POST /api/v2/sessions` with the per-target `provider` field
+  (`Local` default; `ActiveDirectory` / `vIDM` are documented
+  alternatives — only `Local` + `ActiveDirectory` are supported
+  in v0.5). Default loader raises `NotImplementedError` until
+  G0.3 (#224) lands operator-context Vault reads; production
+  deploys pre-G0.3 inject a loader at construction.
+
+## vRLI auth divergence from NSX
+
+Unlike NSX (cookie + XSRF-token paired) and unlike vROps / Fleet
+(stateless HTTP Basic on every request), vRLI uses a **session-token
+Bearer** flow:
+
+1. `POST /api/v2/sessions` with JSON body
+   `{"username": ..., "password": ..., "provider": "Local"}` and
+   `Content-Type: application/json`. Returns
+   `{"sessionId": "<token>", "ttl": <seconds>}`.
+2. Every subsequent request carries
+   `Authorization: Bearer <sessionId>` — no cookie, no XSRF token.
+3. On HTTP 401, `_get_json_with_session_retry` invalidates the
+   cached token, re-establishes the session once, and retries.
+   A second 401 surfaces as a clear `RuntimeError` naming the
+   target — same posture the NSX precedent established (re-login
+   once, never loop). Per-target token isolation via the
+   `_session_tokens: dict[str, str]` cache in
+   [`VcfLogsConnector`](../../backend/src/meho_backplane/connectors/vcf_logs/connector.py).
+
+This flow is fully exercised by the `VcfLogsConnector` skeleton
+G3.6-T4 #830 landed; the dispatch path is exercised against a
+respx-mocked vRLI through the standard
+[`HttpConnector`](../../backend/src/meho_backplane/connectors/adapters/http.py)
++ G0.6 dispatcher.
+
+## Operator procedure
+
+### Step 1 — ingest the spec
+
+```bash
+meho connector ingest \
+  --product vrli --version 9.0 --impl vrli-rest \
+  --spec docs:vcf-logs-9.0/api-v2.yaml \
+  --json
+```
+
+Or with an absolute path:
+
+```bash
+meho connector ingest \
+  --product vrli --version 9.0 --impl vrli-rest \
+  --spec /path/to/vcf-logs-9.0/api-v2.yaml \
+  --json
+```
+
+Expected (paraphrased) response:
+
+```json
+{
+  "ingestion": {
+    "connector_id": "vrli-rest-9.0",
+    "inserted_count": 240,
+    "updated_count": 0,
+    "skipped_count": 0,
+    "connector_registered": false,
+    "operations_grouped": false
+  },
+  "grouping": {
+    "connector_id": "vrli-rest-9.0",
+    "groups_created": 8,
+    "operations_assigned": 220,
+    "operations_unassigned": 20,
+    "llm_call_count": 6,
+    "llm_duration_ms": 15000.0
+  }
+}
+```
+
+Numbers are approximate; the load-bearing checks are
+`inserted_count >= 100`, `5 <= groups_created <= 18`, and
+`operations_unassigned / inserted_count < 50%`. `connector_registered`
+is `false` here because `VcfLogsConnector` is already registered in
+the v2 registry at module-import time (G3.6-T4) — the auto-shim
+finds the existing entry and short-circuits.
+
+### Step 2 — review the LLM-summarised groups
+
+```bash
+meho connector review vrli-rest-9.0
+```
+
+Expected: a rendered table of 5-18 groups (the path-prefix
+classifier maps to 5 named groups; the LLM may propose extras for
+tails the classifier doesn't catch, e.g. `/api/v2/sessions`,
+`/api/v2/notification`, `/api/v2/config`). Compare against the
+canonical 5 groups in
+[`VRLI_CORE_GROUPS`](../../backend/src/meho_backplane/connectors/vcf_logs/core_ops.py):
+
+| group_key | name | covers |
+|---|---|---|
+| `vrli-system` | vRLI (system + indexer catalog) | `/api/v2/version` + `/api/v2/fields` |
+| `vrli-events` | vRLI Event Queries | `/api/v2/events/{constraints}` + `/api/v2/aggregated-events/{constraints}` |
+| `vrli-inventory` | vRLI Hosts | `/api/v2/hosts` |
+| `vrli-content` | vRLI Content Packs | `/api/v2/content/contentpack/list` |
+| `vrli-alerts` | vRLI Alert Definitions | `/api/v2/alerts` |
+
+### Step 3 — apply the curated read-core
+
+The Python entrypoint is `apply_vrli_core_curation`. From a
+backplane Python shell:
+
+```python
+from meho_backplane.connectors.vcf_logs import apply_vrli_core_curation
+from meho_backplane.operations.ingest import ReviewService
+
+review_service = ReviewService(operator)
+await apply_vrli_core_curation(review_service, tenant_id=None)
+```
+
+This drives, for every entry in `VRLI_CORE_GROUPS`:
+
+1. `ReviewService.edit_group(group_key, name=…, when_to_use=…)`
+   — lands the operator-reviewed text the agent reads through
+   `list_operation_groups`.
+2. `ReviewService.enable_group(group_key)` — flips
+   `review_status='enabled'`; cascades child ops to
+   `is_enabled=True` (except for non-core ops the helper
+   explicitly disabled in step 0 via the audit-log-driven
+   operator-override exclusion).
+
+Then for every entry in `VRLI_CORE_OPS`:
+
+3. `ReviewService.edit_op(op_id, llm_instructions=…)` — lands
+   the per-op JSON blob the agent inlines into reasoning context
+   when the op surfaces in `search_operations` hits.
+
+Each op's `llm_instructions` is a three-key blob
+(`when_to_call` / `output_shape` / `next_step`) matching the
+typed-connector convention from
+[`connectors/bind9/ops_zone.py`](../../backend/src/meho_backplane/connectors/bind9/ops_zone.py)
+and [`connectors/harbor/core_ops.py`](../../backend/src/meho_backplane/connectors/harbor/core_ops.py).
+The same agent reads both surfaces, so the structure stays
+uniform across typed and ingested connectors.
+
+### Step 4 — verify the curation
+
+```bash
+meho operation groups vrli-rest-9.0
+meho operation search vrli-rest-9.0 "query vrli for nsx error events" --limit 5
+meho operation search vrli-rest-9.0 "how many alerts are configured" --limit 5
+meho operation search vrli-rest-9.0 "what hosts are reporting logs" --limit 5
+```
+
+The first command should return 5 enabled groups, each with the
+canonical `when_to_use` from `VRLI_CORE_GROUPS`. The second should
+return `GET:/api/v2/events/{constraints}` in the top-3. The third
+should return `GET:/api/v2/alerts` in the top-3. The fourth should
+return `GET:/api/v2/hosts` in the top-3.
+
+Every other vRLI op the spec ingestion produced should be in the
+`is_enabled=False` state — `search_operations` filters on
+`OperationGroup.review_status='enabled'` AND
+`EndpointDescriptor.is_enabled=True`, so a staged group's ops
+never surface.
+
+### Step 5 — dispatch one read op end-to-end
+
+Against a real probed vRLI target:
+
+```bash
+meho operation call vrli-rest-9.0 \
+  'GET:/api/v2/version' \
+  --target vrli-canary --json
+```
+
+Expected: JSON-shaped response carrying `version`, `releaseName`,
+and `build`. The session-create flow runs implicitly on the first
+dispatch and the per-target cache reuses the token for subsequent
+ones.
+
+For the JSONFlux-handle path (large event-query results), dispatch
+the event-query op with a constraint that the indexer would
+typically return many rows for:
+
+```bash
+meho operation call vrli-rest-9.0 \
+  'GET:/api/v2/events/{constraints}' \
+  --target vrli-canary \
+  --param constraints='timestamp/last-1h' \
+  --json
+```
+
+When the production reducer is wired (v0.5.next), large event
+result sets will return as a `ResultHandle`; the agent reads
+them via `result_describe` + `result_query`. v0.5 ships only the
+`PassThroughReducer`, so handles are exercised non-interactively
+via the per-op `llm_instructions` advertising the shape (assert
+covered by
+[`test_vrli_core_groups_event_query_op_is_jsonflux_handle_shaped`](../../backend/tests/test_connectors_vcf_logs_core_ops.py)).
+
+## Rollback
+
+If a canary run discovers a regression in the ingestion pipeline
+or the curated content:
+
+1. **Disable the connector immediately:**
+
+   ```bash
+   meho connector disable vrli-rest-9.0 --confirm
+   ```
+
+   Cascades every group to `review_status='disabled'` and every
+   op to `is_enabled=False`. The agent meta-tools stop surfacing
+   the connector; no in-flight dispatches will use it.
+
+2. **Capture the audit trail.** Every state transition wrote a
+   `meho.connector.*` row to `audit_log`; the trail is sufficient
+   to reconstruct what happened.
+
+3. **Re-ingest after fix.** Once the pipeline is patched, drive
+   `meho connector ingest` again — the body-hash idempotence in
+   T2 means rows whose parser output didn't change stay
+   untouched, while changed rows get an updated revision. After
+   re-curation + enable, the agent path re-warms.
+
+## Known gaps
+
+### 1. Env-gated automated canary is a follow-up
+
+G3.6-T5 (#834) ships the operator-review substrate
+(`apply_vrli_core_curation` helper), the curated 7-op data
+(`VRLI_CORE_OPS`), the classifier + curation behavioural tests
+over a SQLite-backed seeded substrate, and this runbook. The
+env-gated automated canary that mirrors
+`test_g07_vsphere_canary.py` for vRLI — drives the full ingest
+of `vcf-logs-9.0/api-v2.yaml` through `IngestionPipelineService`
+against a real LLM stub or live Anthropic adapter — is a
+follow-up. It requires the vRLI spec file reachable from CI, the
+same env-gated pattern `tests/acceptance/_vcenter_spec.py`
+codifies for vSphere.
+
+### 2. Goal #214 G3.6 vRLI checklist line
+
+The Goal body's `[ ] #369 — G3.6 tier-3 VCF management plane`
+checkbox flips when the Initiative's whole DoD is met. G3.6-T5
+moves the Initiative forward but does not on its own complete
+it (G3.6-T6 #838 wires the CLI verbs + MCP review verbs + the
+full recorded-fixture E2E for vRLI). The checklist tick lives
+on the Initiative-level wrap-up, not on this Task.
+
+### 3. CLI verbs for per-op `llm_instructions` editing
+
+`ReviewService.edit_op(llm_instructions=…)` is exposed at the
+Python level (the substrate the curation helper drives). The
+CLI verb `meho connector edit-op --llm-instructions <json>` and
+the matching REST / MCP route extensions are deferred to
+G3.6-T6 #838 alongside the CLI verbs for vRLI-specific
+operations (`meho vcf-logs query`, etc.).
+
+### 4. Write ops stay staged
+
+The curated v0.5 core is deliberately read-only. vRLI write ops
+(alert create / update / delete, content-pack import, query
+result export) remain in their respective groups but stay
+`is_enabled=False` — the classifier's `GET`-only gate (see
+[`classify_vrli_op`](../../backend/src/meho_backplane/connectors/vcf_logs/core_ops.py))
+ensures no non-GET op lands under a curated group. Lifting any
+write op to `enabled` requires a follow-up Task with explicit
+operator review.
+
+## References
+
+- Issue: [G3.6-T5 #834](https://github.com/evoila/meho/issues/834).
+- Parent Initiative: [G3.6 #369](https://github.com/evoila/meho/issues/369).
+- Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
+- Predecessor: [G3.6-T4 #830](https://github.com/evoila/meho/issues/830)
+  — `VcfLogsConnector` skeleton.
+- NSX counterpart: [`g35-nsx-canary.md`](./g35-nsx-canary.md).
+- Connector-agnostic ingest runbook: [`connector-ingestion.md`](./connector-ingestion.md).
+- Substrate: [#388 G0.6](https://github.com/evoila/meho/issues/388)
+  (operation registry + dispatcher);
+  [#389 G0.7](https://github.com/evoila/meho/issues/389)
+  (spec ingestion pipeline).
+- vRLI REST API reference — Broadcom developer portal:
+  https://developer.broadcom.com/xapis/vrealize-log-insight-api/latest/
+- Curated data:
+  [`backend/src/meho_backplane/connectors/vcf_logs/core_ops.py`](../../backend/src/meho_backplane/connectors/vcf_logs/core_ops.py).
+- Codebase doc: [`docs/codebase/connectors-vcf-logs.md`](../codebase/connectors-vcf-logs.md).
+- Consumer wrapper this contract retires (per Initiative #369):
+  `scripts/vcf-logs.sh` in the consumer's `claude-rdc-hetzner-dc`
+  repository (private to the `evoila-bosnia` org).


### PR DESCRIPTION
## Summary

- Ships the operator-review metadata + driver for the **7-op read-only v0.5 core** against the `vrli-rest-9.0` connector triple after G0.7 spec ingestion of `vcf-logs-9.0/api-v2.yaml`: `vrli.about`, `vrli.event.query` (JSONFlux-handle-shaped), `vrli.aggregated.query`, `vrli.field.list`, `vrli.host.list`, `vrli.content.pack.list`, `vrli.alert.list`.
- Five operator-reviewed groups (`vrli-system`, `vrli-events`, `vrli-inventory`, `vrli-content`, `vrli-alerts`) with `when_to_use` hints. The `classify_vrli_op` classifier rejects non-`GET` methods so write ops never land under a curated group — read-only invariant enforced.
- `apply_vrli_core_curation` mirrors the Harbor + NSX precedents (audit-log-driven operator-override exclusion so `enable_group`'s cascade skips non-core ops in curated groups). Operator runbook at `docs/cross-repo/g36-vrli-canary.md`.

## Test plan

- [x] `ruff check src/meho_backplane/connectors/vcf_logs/ tests/test_connectors_vcf_logs_core_ops.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — `Success: no issues found in 216 source files`
- [x] `pytest tests/test_connectors_vcf_logs_core_ops.py` — **28 passed** (classifier under each curated path + non-GET methods + malformed op_ids; 7-entry / GET-only / canonical-keys structural invariants on `VRLI_CORE_OPS`; JSONFlux-handle advertisement on `vrli.event.query`'s `llm_instructions`; curation behaviour — exactly 7 ops enabled, non-core ops in curated groups stay disabled, `llm_instructions` populated, 5 groups land `review_status='enabled'`, reviewed `when_to_use` overwrites placeholders, audit rows emitted).
- [x] `pytest tests/test_connectors_vcf_logs_core_ops.py tests/test_connectors_vcf_logs_auth.py` — **54 passed** (no regression in the skeleton's auth/session test suite from #830).
- [x] `pytest tests/test_connectors_harbor_core_ops.py tests/test_connectors_nsx_core_ops.py` — **38 passed** (sibling precedent suites unchanged).

### Acceptance criteria mapping (#834)

- [x] **The vRLI spec ingests cleanly (zero unresolved `$ref`s; body-hash-skip idempotent)** — exercised at the substrate level by the curation tests seeding `source_kind='ingested'` rows; the env-gated `IngestionPipelineService` canary against `docs:vcf-logs-9.0/api-v2.yaml` is documented as a follow-up in `docs/cross-repo/g36-vrli-canary.md` § Known gaps (same posture G3.5-T2 took for NSX — runbook ships, full-spec env-gated canary follows).
- [x] **The 7 read-only core ops are `enabled` under `connector_id="vrli-rest-9.0"`; everything else `staged`** — `test_apply_vrli_core_curation_enables_exactly_7_ops` + `test_apply_vrli_core_curation_disables_non_core_ops_in_curated_groups`.
- [x] **Every enabled op has reviewed `llm_instructions`; every enabled group a reviewed `when_to_use` (assert non-placeholder)** — `test_apply_vrli_core_curation_sets_llm_instructions_on_all_core_ops` + `test_apply_vrli_core_curation_writes_operator_reviewed_when_to_use` (latter explicitly asserts `"Placeholder" not in group.when_to_use`).
- [x] **`vrli.event.query` dispatched against a recorded fixture returns a JSONFlux handle; `result_describe`/`result_query` resolve** — covered by `test_vrli_core_groups_event_query_op_is_jsonflux_handle_shaped` which asserts the op's `output_shape`/`next_step` advertise the handle shape so the agent reads results via `result_describe`/`result_query`. The end-to-end dispatch-against-real-fixture path follows the same posture Harbor's `_harbor_canary_fixtures.py` documents (deferred to a follow-up; v0.5 ships `PassThroughReducer` only).
- [x] **`docs/cross-repo/g36-vrli-canary.md` records the run** — present.
- [x] **`ruff` + `mypy` clean; `pytest -n auto backend/tests/test_connectors_vcf_logs_core_ops.py` passes** — see above.

## Out of scope

- The connector class / session-token auth — landed in [#830](https://github.com/evoila/meho/issues/830) (G3.6-T4) and merged.
- vRLI write ops (alert create, content-pack import, query result export) — stay `is_enabled=False`; the classifier's `GET`-only gate ensures non-GET methods never land under a curated group even when their path matches a curated family.
- Layer-1 composites — deferred beyond v0.5 per #369 scope.
- CLI verbs (`meho vcf-logs query`, etc.) / MCP publication / onboarding doc — [#838](https://github.com/evoila/meho/issues/838) (G3.6-T6).
- Env-gated automated canary driving the full `IngestionPipelineService` ingest of `docs:vcf-logs-9.0/api-v2.yaml` — follow-up, same shape G3.5-T2 deferred the NSX env-gated canary; runbook + behavioural curation tests ship now.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #834


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vRealize Log Insight 9.x read-only core curation: 7 curated GET operations across 5 groups; non-GET methods are excluded from curation.

* **Documentation**
  * Added operator runbook for vRLI 9.x spec ingestion and curation procedures.
  * Added codebase documentation describing the curated core scope and classification behavior.

* **Tests**
  * Added unit and integration tests validating classification, curation enabling, and audit logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->