### PR TITLE
feat(connectors): G3.6-T8 Fleet spec-ingest curation + 8-op read core (#835)

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_fleet/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/__init__.py
@@ -19,13 +19,29 @@ would land as ``("vcf-fleet", "", "")`` and confuse
 tie-break ladder. Same pattern :mod:`meho_backplane.connectors.harbor`
 and :mod:`meho_backplane.connectors.vcf_automation` established.
 
-Operations for this connector arrive in #835 via G0.7 spec ingestion
-against the Fleet (vRSLCM-derived) OpenAPI surface. This Task ships
-only the skeleton.
+Operations for this connector arrive via G0.7 spec ingestion against
+the Fleet (vRSLCM-derived) OpenAPI surface. G3.6-T7 (#831) shipped the
+connector skeleton; G3.6-T8 (#835) adds the curated read-only v0.5
+core — 8 operator-enabled ops + 6 reviewed groups — via the
+:func:`~meho_backplane.connectors.vcf_fleet.core_ops.apply_fleet_core_curation`
+substrate call against an already-ingested connector.
 """
 
 from meho_backplane.connectors.registry import register_connector_v2
 from meho_backplane.connectors.vcf_fleet.connector import VcfFleetConnector
+from meho_backplane.connectors.vcf_fleet.core_ops import (
+    FLEET_CONNECTOR_ID,
+    FLEET_CORE_GROUPS,
+    FLEET_CORE_OPS,
+    FLEET_IMPL_ID,
+    FLEET_PATH_RULES,
+    FLEET_PRODUCT,
+    FLEET_VERSION,
+    FleetCoreGroup,
+    FleetCoreOp,
+    apply_fleet_core_curation,
+    classify_fleet_op,
+)
 from meho_backplane.connectors.vcf_fleet.session import (
     SessionCredentials,
     VcfFleetCredentialsLoader,
@@ -41,9 +57,20 @@ register_connector_v2(
 )
 
 __all__ = [
+    "FLEET_CONNECTOR_ID",
+    "FLEET_CORE_GROUPS",
+    "FLEET_CORE_OPS",
+    "FLEET_IMPL_ID",
+    "FLEET_PATH_RULES",
+    "FLEET_PRODUCT",
+    "FLEET_VERSION",
+    "FleetCoreGroup",
+    "FleetCoreOp",
     "SessionCredentials",
     "VcfFleetConnector",
     "VcfFleetCredentialsLoader",
     "VcfFleetTargetLike",
+    "apply_fleet_core_curation",
+    "classify_fleet_op",
     "load_credentials_from_vault",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py
@@ -1,0 +1,734 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VCF Fleet 9.0 (vRSLCM-derived) read-only v0.5 core — curated subset.
+
+This module names the **8 read-only Fleet operations** the G3.6 v0.5 ship
+enables out of the much larger vRSLCM LCM REST corpus the G0.7
+spec-ingestion pipeline lands under ``connector_id="fleet-rest-9.0"``.
+The curation is two-layered:
+
+* :data:`FLEET_CORE_GROUPS` — the operator-reviewed ``when_to_use``
+  hint per LLM-grouping pass output group. Each entry's ``group_key``
+  is the deterministic slug :func:`classify_fleet_op` assigns to Fleet
+  ops; the ``when_to_use`` is what the agent reads verbatim through
+  :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
+  to pick a group to search within.
+* :data:`FLEET_CORE_OPS` — the 8 ``EndpointDescriptor.op_id`` strings
+  that flip to ``is_enabled=True`` at operator-review time, paired
+  with the per-op ``llm_instructions`` blob the agent inlines into
+  the reasoning context when it sees the op in
+  :func:`~meho_backplane.operations.meta_tools.search_operations`
+  hits. Every other op under the same connector triple stays
+  ``is_enabled=False`` (the G0.7 ingestion default for
+  ``source_kind='ingested'`` rows).
+
+Per Initiative #369 and CLAUDE.md postulates 1-2, Fleet is **fully
+generic-ingested**: the underlying ops are not registered in code,
+they live in the ``endpoint_descriptor`` table. This module only
+carries the **operator-review metadata** the substrate uses at the
+review step — the actual curation is applied through
+:func:`apply_fleet_core_curation` against an existing ingested
+connector.
+
+The 8 ops (paths cross-checked against vRSLCM REST API 1.3.0 at
+https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/):
+
+1. ``GET:/lcm/lcops/api/v2/about`` — ``fleet.about`` — vRSLCM
+   appliance identity. **Note:** Fleet's first-party ``/about``
+   endpoint returns HTTP 500 in VCF 9.0 builds (see the
+   :class:`~meho_backplane.connectors.vcf_fleet.connector.VcfFleetConnector`
+   docstring for the known-issue inventory). The op is curated for
+   parity with the spec; the ``llm_instructions.next_step`` tells
+   the agent to fall back to ``fleet.datacenter.list`` as the
+   reachability probe in 9.0.
+2. ``GET:/lcm/lcops/api/v2/datacenters`` — ``fleet.datacenter.list``
+   — datacenter inventory. The wrapper-verified probe endpoint;
+   guaranteed to work in 9.0 because the connector's own probe uses
+   it.
+3. ``GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters``
+   — ``fleet.vcenter.list`` — vCenters registered under a datacenter.
+4. ``GET:/lcm/lcops/api/v2/environments`` — ``fleet.environment.list``
+   — environment inventory (the primary Fleet entry point — every
+   product deploy lives under an environment).
+5. ``GET:/lcm/lcops/api/v2/environments/{environmentId}`` —
+   ``fleet.environment.get`` — per-environment detail including
+   products, status, and metadata.
+6. ``GET:/lcm/lcops/api/v2/environments/{environmentId}/products`` —
+   ``fleet.product.list`` — products deployed under an environment.
+7. ``GET:/lcm/request/api/v2/requests`` — ``fleet.request.list`` —
+   lifecycle requests (deploy / patch / upgrade) the appliance has
+   processed; the LCM workflow-status surface.
+8. ``GET:/lcm/request/api/v2/requests/{requestId}`` —
+   ``fleet.request.get`` — per-request detail including state
+   (``INPROGRESS`` / ``COMPLETED`` / ``FAILED``), output map, and
+   error cause.
+
+Path families and group_keys
+-----------------------------
+
+vRSLCM's LCM REST surface splits into two top-level path families:
+
+* ``/lcm/lcops/...`` — the "LCM operations" surface covering
+  identity (``/about``), datacenters, vCenters, environments, and
+  products. Carries six of the eight curated ops.
+* ``/lcm/request/...`` — the "request" surface covering lifecycle
+  workflow status. Carries two of the eight curated ops.
+
+The classifier in :data:`FLEET_PATH_RULES` reflects that split.
+Order is load-bearing: deeper nested paths must precede their
+parent prefixes (vcenters before datacenters, products before
+environments) so the ``startswith`` loop terminates at the right
+group.
+
+Curation application
+--------------------
+
+:func:`apply_fleet_core_curation` is the operator-review-time
+substrate call that makes exactly the 8 curated ops dispatchable.
+Mirrors :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
+verbatim, threading the "enable group but pin non-core ops
+disabled" needle via the audit-log-driven operator-override
+exclusion.
+
+JSONFlux handle expectation
+---------------------------
+
+``fleet.environment.list`` and ``fleet.request.list`` are the
+candidates for JSONFlux handle returns on busy appliances — a
+single LCM appliance commonly manages dozens of environments and
+thousands of historical requests. The acceptance criterion "the
+longest list op returns a JSONFlux handle" is verified in the
+canary's substrate-level dispatch tests rather than against a
+live appliance; real JSONFlux reduction is out of scope per
+Goal #214.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.operations.ingest.service import ReviewService
+
+__all__ = [
+    "FLEET_CONNECTOR_ID",
+    "FLEET_CORE_GROUPS",
+    "FLEET_CORE_OPS",
+    "FLEET_IMPL_ID",
+    "FLEET_PATH_RULES",
+    "FLEET_PRODUCT",
+    "FLEET_VERSION",
+    "FleetCoreGroup",
+    "FleetCoreOp",
+    "apply_fleet_core_curation",
+    "classify_fleet_op",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Endpoint-descriptor product key — what
+#: :func:`~meho_backplane.operations._lookup.parse_connector_id` extracts
+#: from ``FLEET_CONNECTOR_ID = "fleet-rest-9.0"``
+#: (``head.split("-", 1)[0]`` where head is ``"fleet-rest"``). This is
+#: the value the G0.7 ingestion substrate writes onto every persisted
+#: ``endpoint_descriptor.product`` and ``operation_group.product``
+#: row, and the value :class:`ReviewService._resolve_scope` queries
+#: against at review time.
+#:
+#: It differs from :attr:`VcfFleetConnector.product` (``"vcf-fleet"``)
+#: — same shape as the SDDC Manager case
+#: (``SddcManagerConnector.product="sddc-manager"`` but rows carry
+#: ``product="sddc"``). The discrepancy is harmless: the registry's
+#: dispatch path looks up the connector class by the v2 triple
+#: (``"vcf-fleet", "9.0", "fleet-rest"``) before any descriptor lookup,
+#: and the descriptor lookup itself only consults the natural key
+#: derived from ``parse_connector_id``. The two keys never collide
+#: because they live in different lookup paths.
+FLEET_PRODUCT: Final[str] = "fleet"
+FLEET_VERSION: Final[str] = "9.0"
+FLEET_IMPL_ID: Final[str] = "fleet-rest"
+
+#: Connector-id slug the G0.6 dispatcher's ``parse_connector_id``
+#: round-trips back to the triple above: ``"fleet-rest-9.0"``.
+FLEET_CONNECTOR_ID: Final[str] = f"{FLEET_IMPL_ID}-{FLEET_VERSION}"
+
+
+@dataclass(frozen=True, slots=True)
+class FleetCoreGroup:
+    """One curated operator-review entry for a Fleet operation group.
+
+    ``group_key`` is the slug :func:`classify_fleet_op` emits.
+    ``name`` is the operator-readable label ``meho connector review``
+    renders. ``when_to_use`` is the agent-facing hint
+    :func:`list_operation_groups` returns verbatim; every entry is a
+    single complete sentence so the agent's group-selection step has
+    unambiguous guidance.
+    """
+
+    group_key: str
+    name: str
+    when_to_use: str
+
+
+@dataclass(frozen=True, slots=True)
+class FleetCoreOp:
+    """One curated operator-review entry for a Fleet operation.
+
+    ``op_id`` follows the ``METHOD:path`` shape every
+    ``source_kind='ingested'`` row uses; the path matches an entry in
+    the vRSLCM LCM REST OpenAPI spec.
+
+    ``llm_instructions`` is the per-op JSON blob the meta-tools inline
+    verbatim when the op surfaces. The shape (``when_to_call`` /
+    ``output_shape`` / ``next_step``) mirrors the typed-connector
+    convention from :mod:`meho_backplane.connectors.bind9.ops_zone`
+    and the ingested-connector convention from
+    :mod:`meho_backplane.connectors.nsx.core_ops` /
+    :mod:`meho_backplane.connectors.harbor.core_ops` — the same agent
+    reads all surfaces, so the structure stays uniform.
+    """
+
+    op_id: str
+    group_key: str
+    llm_instructions: dict[str, object]
+
+
+#: Path-prefix → group_key classifier rules for Fleet.
+#:
+#: **Order is load-bearing.** Each rule is checked via
+#: ``path.startswith(prefix)``. More-specific nested prefixes must
+#: precede less-specific ones to avoid a shorter prefix consuming a
+#: path that belongs to a deeper group:
+#:
+#: * ``…/datacenters/{dataCenterVmid}/vcenters`` before
+#:   ``…/datacenters`` — vcenter paths also start with the datacenter
+#:   prefix.
+#: * ``…/environments/{environmentId}/products`` before
+#:   ``…/environments`` — product paths also start with the
+#:   environment prefix.
+#: * ``…/about`` first — its prefix doesn't overlap others, but
+#:   listing it first keeps the rule ordering intent-readable
+#:   (identity / probe before inventory).
+#:
+#: The template variable names (``{environmentId}``, etc.) are literal
+#: substrings of the rule strings so ``startswith`` comparisons against
+#: ingested op_ids (which also carry the literal template var names)
+#: resolve correctly.
+FLEET_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
+    ("/lcm/lcops/api/v2/about", "fleet-about"),
+    # Deeper paths under datacenters must precede the datacenters root.
+    (
+        "/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters",
+        "fleet-vcenter",
+    ),
+    ("/lcm/lcops/api/v2/datacenters", "fleet-datacenter"),
+    # Deeper paths under environments must precede the environments root.
+    (
+        "/lcm/lcops/api/v2/environments/{environmentId}/products",
+        "fleet-product",
+    ),
+    ("/lcm/lcops/api/v2/environments", "fleet-environment"),
+    # Request paths live under /lcm/request/, not /lcm/lcops/.
+    ("/lcm/request/api/v2/requests", "fleet-request"),
+)
+
+
+def classify_fleet_op(op_id: str) -> str:
+    """Return the curated ``group_key`` for a Fleet op_id, or ``"none"``.
+
+    ``op_id`` is the ``METHOD:/path`` form ingested rows carry; the
+    helper strips the verb and matches the path against
+    :data:`FLEET_PATH_RULES` in order. Only ``GET`` verbs classify
+    — the v0.5 core is read-only.
+
+    Rule ordering guarantees that the most-specific prefix wins:
+    a path like
+    ``/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters``
+    matches the ``fleet-vcenter`` rule before the broader
+    ``/lcm/lcops/api/v2/datacenters`` rule can fire.
+
+    Returns ``"none"`` for paths outside the curated families (e.g.
+    ``/lcm/locker/api/v2/passwords``, ``/lcm/authzn/...``); those
+    rows are un-curated and stay ``is_enabled=False`` after
+    :func:`apply_fleet_core_curation` runs.
+    """
+    try:
+        method, path = op_id.split(":", 1)
+    except ValueError:
+        return "none"
+    if method != "GET":
+        return "none"
+    for prefix, group_key in FLEET_PATH_RULES:
+        if path.startswith(prefix):
+            return group_key
+    return "none"
+
+
+#: Operator-reviewed ``when_to_use`` hints for the 6 Fleet groups
+#: the read-only v0.5 core spans. Every hint is one complete sentence
+#: the agent reads verbatim — vague hints poison
+#: ``search_operations`` ranking.
+FLEET_CORE_GROUPS: Final[tuple[FleetCoreGroup, ...]] = (
+    FleetCoreGroup(
+        group_key="fleet-about",
+        name="VCF Fleet (about)",
+        when_to_use=(
+            "Use this group to read the VCF Fleet (vRSLCM) appliance's "
+            "identity: API version, build, product version. WARNING: in "
+            "VCF 9.0 builds the /about endpoint returns HTTP 500 — use "
+            "fleet.datacenter.list as the reachability probe instead, "
+            "and cross-source the product version from SDDC Manager's "
+            "/v1/vcf-services entry until the 9.0 regression is fixed."
+        ),
+    ),
+    FleetCoreGroup(
+        group_key="fleet-datacenter",
+        name="VCF Fleet Datacenters",
+        when_to_use=(
+            "Use this group to list the datacenters (logical groupings of "
+            "vCenters / regions) the Fleet appliance is aware of. The "
+            "datacenters call is also the wrapper-verified reachability "
+            "probe — guaranteed to respond in 9.0 even when /about is "
+            "broken — and is the entry point for navigating into "
+            "registered vCenters via fleet.vcenter.list."
+        ),
+    ),
+    FleetCoreGroup(
+        group_key="fleet-vcenter",
+        name="VCF Fleet vCenters",
+        when_to_use=(
+            "Use this group to enumerate the vCenters registered under a "
+            "Fleet datacenter. Each vCenter entry carries hostname, build, "
+            "and the data-collection status; the agent uses these to map "
+            "Fleet-managed inventory back to vSphere targets. Requires a "
+            "dataCenterVmid from fleet.datacenter.list."
+        ),
+    ),
+    FleetCoreGroup(
+        group_key="fleet-environment",
+        name="VCF Fleet Environments",
+        when_to_use=(
+            "Use this group to list or inspect Fleet environments — the "
+            "primary unit of Fleet-managed lifecycle. Every product "
+            "deployment (vRA, vROps, vRLI, vIDM, …) lives under an "
+            "environment. Use to answer 'what environments has Fleet "
+            "provisioned' or 'what is the status of environment X' before "
+            "drilling into its products."
+        ),
+    ),
+    FleetCoreGroup(
+        group_key="fleet-product",
+        name="VCF Fleet Products",
+        when_to_use=(
+            "Use this group to list products deployed under a Fleet "
+            "environment. Each product entry carries name, version, "
+            "deployment status, and node breakdown. Requires an "
+            "environmentId from fleet.environment.list. Use to answer "
+            "'what version of vRA is deployed in environment X' or "
+            "'which nodes back this product'."
+        ),
+    ),
+    FleetCoreGroup(
+        group_key="fleet-request",
+        name="VCF Fleet Lifecycle Requests",
+        when_to_use=(
+            "Use this group to list or inspect lifecycle requests "
+            "(deploy / patch / upgrade / scale workflows) Fleet has "
+            "processed. Each request carries state (INPROGRESS / "
+            "COMPLETED / FAILED), execution path, and error cause. The "
+            "primary workflow-status surface — read these to answer "
+            "'did the upgrade finish' or 'why did the deploy fail'."
+        ),
+    ),
+)
+
+
+def _instructions(
+    *,
+    when_to_call: str,
+    output_shape: str,
+    next_step: str,
+) -> dict[str, object]:
+    """Build the per-op ``llm_instructions`` blob with the canonical keys.
+
+    Same three-field shape :mod:`meho_backplane.connectors.nsx.core_ops`
+    and :mod:`meho_backplane.connectors.harbor.core_ops` use so an
+    agent crossing connector boundaries sees a stable convention.
+    """
+    return {
+        "when_to_call": when_to_call,
+        "output_shape": output_shape,
+        "next_step": next_step,
+    }
+
+
+#: The 8 curated read-only Fleet core ops. Each entry carries the
+#: op_id (``GET:/path`` form), the curated group assignment, and the
+#: operator-reviewed ``llm_instructions`` blob.
+#:
+#: Paths cross-checked against vRSLCM REST API 1.3.0 at
+#: https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/.
+FLEET_CORE_OPS: Final[tuple[FleetCoreOp, ...]] = (
+    FleetCoreOp(
+        op_id="GET:/lcm/lcops/api/v2/about",
+        group_key="fleet-about",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read the vRSLCM appliance's identity — API "
+                "version, build, product version — when confirming "
+                "which Fleet instance the target points at. KNOWN "
+                "REGRESSION: in VCF 9.0 builds this endpoint returns "
+                "HTTP 500. When the call fails with a 500, do not "
+                "retry; fall back to fleet.datacenter.list as the "
+                "appliance reachability probe."
+            ),
+            output_shape=(
+                "On success: object with apiVersion, productVersion, "
+                "buildNumber, releaseDate keys. On 500 (the 9.0 "
+                "regression): a connector_error OperationResult with "
+                "the response body's `errorCode` and `errorMessage` "
+                "fields surfaced in extras."
+            ),
+            next_step=(
+                "If the call returned 200, proceed with the intended "
+                "Fleet operation. If it returned 500 (VCF 9.0), call "
+                "fleet.datacenter.list — it doubles as a reachability "
+                "probe and exposes the Lcm-API-Version response header "
+                "(read via fingerprint, not call_operation, in the "
+                "current substrate)."
+            ),
+        ),
+    ),
+    FleetCoreOp(
+        op_id="GET:/lcm/lcops/api/v2/datacenters",
+        group_key="fleet-datacenter",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list Fleet-managed datacenters — logical "
+                "groupings of vCenters and environments. The primary "
+                "inventory entry point for any Fleet workflow, and the "
+                "wrapper-verified reachability probe (guaranteed to "
+                "respond in VCF 9.0 even when /about is broken). "
+                "Supports no query parameters; small lists return "
+                "inline, large ones return a JSONFlux handle through "
+                "the shared HandleStore."
+            ),
+            output_shape=(
+                "Array of Datacenter objects; each carries vmid "
+                "(opaque datacenter identifier), name, type (PRIVATE_CLOUD "
+                "/ PUBLIC_CLOUD), city, country, and a vCenters[] "
+                "sub-array with brief vCenter metadata. The vmid is the "
+                "load-bearing identifier for follow-up calls."
+            ),
+            next_step=(
+                "Pick a datacenter vmid and pass it as dataCenterVmid "
+                "to fleet.vcenter.list to enumerate registered vCenters, "
+                "or follow up with fleet.environment.list to enumerate "
+                "Fleet-managed product deployments (environments are not "
+                "scoped to a datacenter at the API surface)."
+            ),
+        ),
+    ),
+    FleetCoreOp(
+        op_id="GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters",
+        group_key="fleet-vcenter",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to enumerate vCenters registered under a Fleet "
+                "datacenter. Requires a dataCenterVmid path parameter "
+                "obtained from fleet.datacenter.list. Returns "
+                "Fleet-registered vCenters only — vCenters reachable "
+                "to the operator but not registered with Fleet are not "
+                "returned here (consult SDDC Manager or the vCenter "
+                "API directly for that)."
+            ),
+            output_shape=(
+                "Array of VCenter objects; each carries vmid, name, "
+                "hostname (FQDN), buildNumber, version, and "
+                "dataCollectionStatus (with timestamp + last-error). "
+                "The hostname is the load-bearing identifier for "
+                "cross-referencing against vSphere targets."
+            ),
+            next_step=(
+                "Cross-reference the hostname against vSphere targets "
+                "configured under the same operator scope; if a Fleet "
+                "vCenter has no matching vSphere target, the operator "
+                "may need to add it. Use the vCenter's vmid for any "
+                "follow-up data-collection trigger (POST surface — "
+                "out of v0.5 scope)."
+            ),
+        ),
+    ),
+    FleetCoreOp(
+        op_id="GET:/lcm/lcops/api/v2/environments",
+        group_key="fleet-environment",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list all Fleet-managed environments. An "
+                "environment is the unit Fleet uses to group one or "
+                "more product deployments (e.g. a vRA environment with "
+                "vRA + vIDM + Postgres nodes). The primary entry point "
+                "for any Fleet inventory workflow. Large appliances "
+                "managing many environments return a JSONFlux handle "
+                "through the shared HandleStore; use result_describe + "
+                "result_query to navigate the full set."
+            ),
+            output_shape=(
+                "Array of Environment objects; each carries "
+                "environmentId, environmentName, environmentDescription, "
+                "environmentStatus (DEPLOY_SUCCESSFUL / DEPLOY_FAILED / "
+                "...), and a products[] sub-array with product summaries."
+            ),
+            next_step=(
+                "Pick an environmentId and pass it to "
+                "fleet.environment.get for the full per-environment "
+                "detail, or to fleet.product.list to enumerate its "
+                "products and their versions. Cross-reference status "
+                "against the fleet-request surface when an environment "
+                "looks stuck (open requests against it may explain why)."
+            ),
+        ),
+    ),
+    FleetCoreOp(
+        op_id="GET:/lcm/lcops/api/v2/environments/{environmentId}",
+        group_key="fleet-environment",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read the full detail of one Fleet environment "
+                "by environmentId. Returns the products[] array with "
+                "complete deployment metadata (nodes, IPs, versions, "
+                "FQDN), the configuration history, and the status "
+                "transitions. Requires an environmentId path parameter "
+                "from fleet.environment.list."
+            ),
+            output_shape=(
+                "Environment object with environmentId, "
+                "environmentName, environmentStatus, products[] "
+                "(each carrying productId, version, nodes[] with "
+                "hostname/IP/role), createdOn, modifiedOn, and "
+                "transactionId for the most recent operation."
+            ),
+            next_step=(
+                "Surface the products[] versions to the operator for an "
+                "inventory snapshot. If the status is DEPLOY_FAILED, "
+                "cross-reference transactionId against "
+                "fleet.request.get to find the failing workflow's "
+                "error cause."
+            ),
+        ),
+    ),
+    FleetCoreOp(
+        op_id="GET:/lcm/lcops/api/v2/environments/{environmentId}/products",
+        group_key="fleet-product",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list products deployed under one Fleet "
+                "environment. Returns one entry per product (vRA, vROps, "
+                "vRLI, vIDM, Postgres, …) with deployment status, "
+                "version, and node breakdown. Requires an environmentId "
+                "from fleet.environment.list. Use when answering 'what "
+                "is deployed in environment X' or 'what version of "
+                "product Y runs there'."
+            ),
+            output_shape=(
+                "Array of Product objects; each carries productId "
+                "(e.g. 'vra', 'vrops', 'vidm'), version, status, "
+                "nodes[] (with hostname, ipAddress, role, "
+                "vmStatus), and snapshot/backup metadata where Fleet "
+                "manages it."
+            ),
+            next_step=(
+                "Surface productId + version pairs to the operator. If "
+                "a node's vmStatus is anything other than POWERED_ON, "
+                "flag it; if a product version is older than the "
+                "supported floor, suggest cross-checking the Fleet "
+                "lifecycle-request history for an in-flight upgrade."
+            ),
+        ),
+    ),
+    FleetCoreOp(
+        op_id="GET:/lcm/request/api/v2/requests",
+        group_key="fleet-request",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list lifecycle requests (deploy / patch / "
+                "upgrade / scale workflows) Fleet has processed. "
+                "Returns the most recent requests by createdOn; "
+                "operators on busy appliances commonly see thousands "
+                "of historical entries, so the call returns a JSONFlux "
+                "handle through the shared HandleStore — use "
+                "result_describe + result_query to filter by state or "
+                "requestType. Use to answer 'what workflows is Fleet "
+                "currently running' or 'what was the last upgrade'."
+            ),
+            output_shape=(
+                "Array of Request objects; each carries vmid, "
+                "requestName, requestType (e.g. ENVIRONMENT_CREATE, "
+                "PRODUCT_UPGRADE), state (INPROGRESS / COMPLETED / "
+                "FAILED), createdOn, lastUpdatedOn, and a brief "
+                "executionStatus summary. The full output map + error "
+                "cause come from fleet.request.get."
+            ),
+            next_step=(
+                "Filter on state=INPROGRESS to surface in-flight work; "
+                "for any FAILED request, drill into fleet.request.get "
+                "with the vmid to read the error cause + execution "
+                "path."
+            ),
+        ),
+    ),
+    FleetCoreOp(
+        op_id="GET:/lcm/request/api/v2/requests/{requestId}",
+        group_key="fleet-request",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read the full detail of one Fleet lifecycle "
+                "request by vmid (the request's id). Returns the input "
+                "map (parameters the request was created with), the "
+                "output map (results / generated identifiers), the "
+                "execution path (per-stage status), and the error "
+                "cause on FAILED. Requires a requestId path parameter "
+                "from fleet.request.list."
+            ),
+            output_shape=(
+                "Request object with vmid, transactionId, requestName, "
+                "requestReason, requestType, requestSource, "
+                "requestSourceType, inputMap (object), outputMap "
+                "(object), state, executionId, executionPath[] (stage "
+                "list with per-stage status + timestamps), "
+                "executionStatus, errorCause (string, only on FAILED), "
+                "resultSet, isCancelEnabled, lastUpdatedOn, and "
+                "createdBy."
+            ),
+            next_step=(
+                "Surface state + the most recent executionPath[] entry "
+                "to the operator. On FAILED, surface errorCause "
+                "verbatim — the Fleet appliance writes operator-readable "
+                "diagnostic text there. On INPROGRESS, suggest polling "
+                "this op rather than re-listing fleet.request.list "
+                "(point-read is far cheaper)."
+            ),
+        ),
+    ),
+)
+
+
+async def apply_fleet_core_curation(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Apply the curated 8-op read core against an ingested Fleet connector.
+
+    Drives the substrate so that, after this call returns, exactly
+    the 8 ops in :data:`FLEET_CORE_OPS` are dispatchable
+    (``is_enabled=True``) and every other ingested op stays
+    ``is_enabled=False``. The 6 curated groups land
+    ``review_status='enabled'`` so the agent's
+    :func:`~meho_backplane.operations.meta_tools.search_operations`
+    surfaces the core ops; non-curated groups are left untouched
+    (``review_status='staged'`` from the G0.7 ingest default).
+
+    The substrate doesn't expose "enable only ops X, Y, Z under
+    group G": :meth:`ReviewService.enable_group`'s cascade flips
+    ``is_enabled=True`` on every child op in the group. The helper
+    works around this via the audit-log-driven operator-override
+    exclusion — the same mechanism
+    :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
+    and :func:`~meho_backplane.connectors.nsx.core_ops.apply_nsx_core_curation`
+    established:
+
+    1. :meth:`ReviewService.get_review_payload` loads the current
+       state of every curated group and its child ops.
+    2. For each child op in a curated group that **isn't** in the
+       :data:`FLEET_CORE_OPS` allow-list,
+       :meth:`ReviewService.edit_op` with ``is_enabled=False``
+       writes the operator-override audit row. The follow-on
+       :meth:`enable_group` cascade detects these rows and skips
+       them.
+    3. :meth:`ReviewService.edit_group` lands the operator-reviewed
+       ``name`` + ``when_to_use`` on each curated group.
+    4. :meth:`ReviewService.enable_group` flips
+       ``review_status='enabled'`` and cascades ``is_enabled=True``
+       to the curated child ops (operator-overridden non-core ops
+       are skipped).
+    5. :meth:`ReviewService.edit_op` lands the curated
+       ``llm_instructions`` blob per entry in :data:`FLEET_CORE_OPS`.
+
+    Re-running is safe but not idempotent at the audit layer:
+    :meth:`enable_group` short-circuits on groups already in
+    ``review_status='enabled'`` (no audit row), but
+    :meth:`edit_group` and :meth:`edit_op` always emit one audit
+    row per call. The intended posture is a one-shot curation step
+    after ingest; re-runs produce redundant ``meho.connector.edit_*``
+    audit rows but never corrupt state.
+
+    Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
+    if no groups exist for ``fleet-rest-9.0`` under *tenant_id* (the
+    operator must run ``meho connector ingest`` against the Fleet
+    LCM spec before this helper applies).
+    """
+    payload = await review_service.get_review_payload(
+        FLEET_CONNECTOR_ID,
+        tenant_id,
+    )
+
+    core_op_ids_by_group: dict[str, set[str]] = {}
+    for op in FLEET_CORE_OPS:
+        core_op_ids_by_group.setdefault(op.group_key, set()).add(op.op_id)
+
+    for group_payload in payload.groups:
+        allow_list = core_op_ids_by_group.get(group_payload.group_key)
+        if allow_list is None:
+            continue
+        for review_op in group_payload.ops:
+            if review_op.op_id in allow_list:
+                continue
+            await review_service.edit_op(
+                FLEET_CONNECTOR_ID,
+                review_op.op_id,
+                tenant_id=tenant_id,
+                is_enabled=False,
+            )
+            _log.info(
+                "fleet_non_core_op_disabled",
+                connector_id=FLEET_CONNECTOR_ID,
+                op_id=review_op.op_id,
+                group_key=group_payload.group_key,
+            )
+
+    for group in FLEET_CORE_GROUPS:
+        await review_service.edit_group(
+            FLEET_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+            name=group.name,
+            when_to_use=group.when_to_use,
+        )
+        await review_service.enable_group(
+            FLEET_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+        )
+        _log.info(
+            "fleet_core_group_enabled",
+            connector_id=FLEET_CONNECTOR_ID,
+            group_key=group.group_key,
+        )
+
+    for op in FLEET_CORE_OPS:
+        await review_service.edit_op(
+            FLEET_CONNECTOR_ID,
+            op.op_id,
+            tenant_id=tenant_id,
+            llm_instructions=op.llm_instructions,
+        )
+        _log.info(
+            "fleet_core_op_curated",
+            connector_id=FLEET_CONNECTOR_ID,
+            op_id=op.op_id,
+        )

--- a/backend/tests/test_connectors_vcf_fleet_core_ops.py
+++ b/backend/tests/test_connectors_vcf_fleet_core_ops.py
@@ -1,0 +1,548 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the VCF Fleet read-only v0.5 core-ops curation.
+
+Covers :mod:`meho_backplane.connectors.vcf_fleet.core_ops`:
+
+* :func:`classify_fleet_op` — path classifier rules for the Fleet
+  (vRSLCM-derived) LCM REST surface. Validates that the most-specific
+  prefix wins for nested datacenter/vcenter and environment/product
+  paths, and that the request surface (under ``/lcm/request/``) is
+  classified independently of the LCM-ops surface (under
+  ``/lcm/lcops/``).
+* Read-only invariants — asserts that every :data:`FLEET_CORE_OPS`
+  entry is a ``GET`` (the v0.5 core is read-only), and that the
+  curated data carries all the metadata the agent reads
+  (``when_to_call`` / ``output_shape`` / ``next_step`` per op,
+  ``name`` + ``when_to_use`` per group).
+* :func:`apply_fleet_core_curation` — the operator-review-time
+  substrate call that flips ``review_status='enabled'`` on the 6
+  curated groups, lands ``llm_instructions`` on the 8 curated ops,
+  and explicitly disables non-core ops via the audit-log-driven
+  operator-override exclusion. The load-bearing assertion is "8 ops
+  dispatchable, every other op in curated groups stays
+  ``is_enabled=False``".
+
+Test harness mirrors :mod:`tests.test_connectors_harbor_core_ops`:
+SQLite via the autouse ``_default_database_url`` fixture, hand-rolled
+operator + connector seeding, audit-row counting from the chassis
+``audit_log`` table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.vcf_fleet import (
+    FLEET_CORE_GROUPS,
+    FLEET_CORE_OPS,
+    FLEET_IMPL_ID,
+    FLEET_PRODUCT,
+    FLEET_VERSION,
+    apply_fleet_core_curation,
+    classify_fleet_op,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import ReviewService
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env vars Operator construction reads transitively."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+_FAKE_JWT = "header.payload.signature"
+
+
+def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
+    """Build a tenant-admin :class:`Operator` for the curation tests."""
+    return Operator(
+        sub=f"fleet-core-ops-test-{uuid.uuid4()}",
+        name="Fleet Core Ops Test",
+        email=None,
+        raw_jwt=_FAKE_JWT,
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify_fleet_op — path classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,expected_group",
+    [
+        ("GET:/lcm/lcops/api/v2/about", "fleet-about"),
+        ("GET:/lcm/lcops/api/v2/datacenters", "fleet-datacenter"),
+        (
+            "GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters",
+            "fleet-vcenter",
+        ),
+        ("GET:/lcm/lcops/api/v2/environments", "fleet-environment"),
+        (
+            "GET:/lcm/lcops/api/v2/environments/{environmentId}",
+            "fleet-environment",
+        ),
+        (
+            "GET:/lcm/lcops/api/v2/environments/{environmentId}/products",
+            "fleet-product",
+        ),
+        ("GET:/lcm/request/api/v2/requests", "fleet-request"),
+        ("GET:/lcm/request/api/v2/requests/{requestId}", "fleet-request"),
+        # Non-curated paths → "none"
+        ("GET:/lcm/locker/api/v2/passwords", "none"),
+        ("GET:/lcm/authzn/api/v2/users", "none"),
+        # Non-GET → "none" (v0.5 core is read-only)
+        ("POST:/lcm/lcops/api/v2/environments", "none"),
+        ("DELETE:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}", "none"),
+        # Malformed op_id → "none"
+        ("bad-op-id-no-colon", "none"),
+    ],
+    ids=str,
+)
+def test_classify_fleet_op_returns_correct_group(op_id: str, expected_group: str) -> None:
+    """classify_fleet_op returns the curated group_key for all 8 core ops."""
+    assert classify_fleet_op(op_id) == expected_group
+
+
+def test_classify_fleet_op_vcenters_precedes_datacenters_in_hierarchy() -> None:
+    """vCenter paths classify as fleet-vcenter, not fleet-datacenter.
+
+    The vCenter list path
+    ``/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters`` starts
+    with the datacenter prefix; rule ordering must keep the deeper
+    prefix listed first so it wins the ``startswith`` race.
+    """
+    vcenters = "GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters"
+    assert classify_fleet_op(vcenters) == "fleet-vcenter"
+
+
+def test_classify_fleet_op_products_precedes_environments_in_hierarchy() -> None:
+    """Product paths classify as fleet-product, not fleet-environment.
+
+    The products path under an environment starts with the
+    environments prefix; rule ordering must keep the deeper prefix
+    listed first.
+    """
+    products = "GET:/lcm/lcops/api/v2/environments/{environmentId}/products"
+    assert classify_fleet_op(products) == "fleet-product"
+
+
+def test_classify_fleet_op_all_core_ops_are_classified() -> None:
+    """Every op in FLEET_CORE_OPS classifies to a non-'none' group."""
+    for op in FLEET_CORE_OPS:
+        group = classify_fleet_op(op.op_id)
+        assert group != "none", (
+            f"FLEET_CORE_OPS entry {op.op_id!r} classified as 'none' — "
+            "check FLEET_PATH_RULES ordering"
+        )
+        assert group == op.group_key, (
+            f"FLEET_CORE_OPS entry {op.op_id!r} classified as {group!r} "
+            f"but declared group_key={op.group_key!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Read-only + metadata invariants
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_core_ops_has_exactly_eight_ops() -> None:
+    """FLEET_CORE_OPS carries exactly 8 entries — the v0.5 read core per #835."""
+    assert len(FLEET_CORE_OPS) == 8, (
+        f"v0.5 Fleet read core must have exactly 8 ops; "
+        f"got {len(FLEET_CORE_OPS)}: {[op.op_id for op in FLEET_CORE_OPS]}"
+    )
+
+
+def test_fleet_core_groups_has_exactly_six_groups() -> None:
+    """FLEET_CORE_GROUPS carries exactly 6 entries spanning the v0.5 core.
+
+    The 8 ops distribute across 6 groups: fleet-about, fleet-datacenter,
+    fleet-vcenter, fleet-environment (carries env.list + env.get),
+    fleet-product, fleet-request (carries req.list + req.get).
+    """
+    assert len(FLEET_CORE_GROUPS) == 6, (
+        f"v0.5 Fleet read core must have exactly 6 groups; "
+        f"got {len(FLEET_CORE_GROUPS)}: "
+        f"{[g.group_key for g in FLEET_CORE_GROUPS]}"
+    )
+
+
+def test_fleet_core_ops_are_all_get() -> None:
+    """Every op in FLEET_CORE_OPS is a GET — the v0.5 core is read-only."""
+    for op in FLEET_CORE_OPS:
+        assert op.op_id.startswith("GET:"), (
+            f"FLEET_CORE_OPS entry {op.op_id!r} is not a GET; "
+            "v0.5 Fleet core is read-only — write ops stay staged"
+        )
+
+
+def test_fleet_core_ops_op_ids_are_unique() -> None:
+    """No duplicate op_ids in FLEET_CORE_OPS."""
+    op_ids = [op.op_id for op in FLEET_CORE_OPS]
+    assert len(op_ids) == len(set(op_ids)), f"duplicate op_ids in FLEET_CORE_OPS: {op_ids}"
+
+
+def test_fleet_core_groups_group_keys_are_unique() -> None:
+    """No duplicate group_keys in FLEET_CORE_GROUPS."""
+    keys = [g.group_key for g in FLEET_CORE_GROUPS]
+    assert len(keys) == len(set(keys)), f"duplicate group_keys in FLEET_CORE_GROUPS: {keys}"
+
+
+def test_fleet_core_ops_group_keys_resolve_to_a_known_group() -> None:
+    """Every op's group_key matches an entry in FLEET_CORE_GROUPS."""
+    known_keys = {g.group_key for g in FLEET_CORE_GROUPS}
+    for op in FLEET_CORE_OPS:
+        assert op.group_key in known_keys, (
+            f"FLEET_CORE_OPS entry {op.op_id!r} references unknown "
+            f"group_key={op.group_key!r}; known: {sorted(known_keys)}"
+        )
+
+
+def test_fleet_core_ops_llm_instructions_all_populated() -> None:
+    """Every op in FLEET_CORE_OPS has non-empty llm_instructions with canonical keys."""
+    required_keys = {"when_to_call", "output_shape", "next_step"}
+    for op in FLEET_CORE_OPS:
+        assert op.llm_instructions, f"op {op.op_id!r} has empty llm_instructions"
+        missing = required_keys - set(op.llm_instructions)
+        assert not missing, f"op {op.op_id!r} llm_instructions missing keys: {missing}"
+        for key in required_keys:
+            val = op.llm_instructions[key]
+            assert isinstance(val, str) and val.strip(), (
+                f"op {op.op_id!r} llm_instructions[{key!r}] must be a non-empty string"
+            )
+
+
+def test_fleet_core_groups_when_to_use_all_populated() -> None:
+    """Every group in FLEET_CORE_GROUPS has non-empty when_to_use + name."""
+    for group in FLEET_CORE_GROUPS:
+        assert group.when_to_use and group.when_to_use.strip(), (
+            f"group {group.group_key!r} has empty when_to_use"
+        )
+        assert group.name and group.name.strip(), f"group {group.group_key!r} has empty name"
+
+
+def test_fleet_core_groups_when_to_use_is_not_placeholder() -> None:
+    """No group's when_to_use is a placeholder/auto-derived blurb.
+
+    Asserts the hints are reviewed prose, not the
+    ``"Operations grouped under '<key>' for <product>"`` auto-derive
+    template the LLM-grouping pass falls back to when an operator
+    skipped curation.
+    """
+    for group in FLEET_CORE_GROUPS:
+        assert "Operations grouped under" not in group.when_to_use, (
+            f"group {group.group_key!r} carries the auto-derive "
+            f"placeholder when_to_use — curation incomplete"
+        )
+        assert "Placeholder" not in group.when_to_use, (
+            f"group {group.group_key!r} carries a 'Placeholder' sentinel in when_to_use"
+        )
+
+
+def test_fleet_about_llm_instructions_flag_the_9_0_regression() -> None:
+    """fleet.about's llm_instructions must warn the agent about the 9.0 HTTP 500.
+
+    The wrapper-verified known issue is that ``/lcm/lcops/api/v2/about``
+    returns HTTP 500 in VCF 9.0 builds — the connector's probe falls
+    back to ``/lcm/lcops/api/v2/datacenters``, and the agent needs the
+    same fallback guidance in its reasoning context.
+    """
+    about_ops = [op for op in FLEET_CORE_OPS if op.op_id.endswith(":/lcm/lcops/api/v2/about")]
+    assert len(about_ops) == 1, (
+        f"expected exactly 1 fleet.about op; got {[op.op_id for op in about_ops]}"
+    )
+    about_op = about_ops[0]
+    combined = " ".join(str(v) for v in about_op.llm_instructions.values()).lower()
+    assert "500" in combined, (
+        f"fleet.about llm_instructions must mention the HTTP 500 regression in VCF 9.0; "
+        f"got: {about_op.llm_instructions!r}"
+    )
+    assert "datacenter" in combined, (
+        f"fleet.about llm_instructions must point the agent at "
+        f"fleet.datacenter.list as the fallback; got: {about_op.llm_instructions!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply_fleet_core_curation — substrate integration (SQLite)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_curated_groups_and_ops(
+    *,
+    tenant_id: uuid.UUID,
+    extra_ops_per_group: int = 0,
+) -> dict[str, uuid.UUID]:
+    """Seed every :data:`FLEET_CORE_GROUPS` entry + its child ops.
+
+    Inserts one :class:`OperationGroup` per curated group_key
+    (``review_status='staged'``). For each :data:`FLEET_CORE_OPS`
+    entry, inserts the curated op (``is_enabled=False`` to match the
+    G0.7 ingest default for ``source_kind='ingested'`` rows).
+
+    When *extra_ops_per_group* > 0, also seeds *N* non-curated ops
+    per curated group with deterministic op_ids so the test can
+    assert :func:`apply_fleet_core_curation` correctly disables them.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, uuid.UUID] = {}
+
+    async with sessionmaker() as session:
+        for group in FLEET_CORE_GROUPS:
+            group_row = OperationGroup(
+                tenant_id=tenant_id,
+                product=FLEET_PRODUCT,
+                version=FLEET_VERSION,
+                impl_id=FLEET_IMPL_ID,
+                group_key=group.group_key,
+                name=f"Placeholder name for {group.group_key}",
+                when_to_use="Placeholder when_to_use.",
+                review_status="staged",
+            )
+            session.add(group_row)
+            await session.flush()
+            group_ids[group.group_key] = group_row.id
+
+        for op in FLEET_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=tenant_id,
+                    product=FLEET_PRODUCT,
+                    version=FLEET_VERSION,
+                    impl_id=FLEET_IMPL_ID,
+                    op_id=op.op_id,
+                    source_kind="ingested",
+                    method=method,
+                    path=path,
+                    handler_ref=None,
+                    group_id=group_ids[op.group_key],
+                    summary=f"Placeholder summary for {op.op_id}.",
+                    description=f"Placeholder description for {op.op_id}.",
+                    parameter_schema={"type": "object", "properties": {}},
+                    response_schema={"type": "object"},
+                    llm_instructions=None,
+                    safety_level="safe",
+                    requires_approval=False,
+                    is_enabled=False,
+                    tags=["spec:vcf-fleet-9.0/lcm-api.yaml"],
+                )
+            )
+
+        for group in FLEET_CORE_GROUPS:
+            for i in range(extra_ops_per_group):
+                extra_op_id = f"GET:/canary-extra/{group.group_key}/{i}"
+                session.add(
+                    EndpointDescriptor(
+                        tenant_id=tenant_id,
+                        product=FLEET_PRODUCT,
+                        version=FLEET_VERSION,
+                        impl_id=FLEET_IMPL_ID,
+                        op_id=extra_op_id,
+                        source_kind="ingested",
+                        method="GET",
+                        path=f"/canary-extra/{group.group_key}/{i}",
+                        handler_ref=None,
+                        group_id=group_ids[group.group_key],
+                        summary="Extra non-curated op.",
+                        description="Extra non-curated op.",
+                        parameter_schema={"type": "object", "properties": {}},
+                        response_schema={"type": "object"},
+                        llm_instructions=None,
+                        safety_level="safe",
+                        requires_approval=False,
+                        is_enabled=False,
+                        tags=[],
+                    )
+                )
+
+        await session.commit()
+
+    return group_ids
+
+
+async def test_apply_fleet_core_curation_enables_exactly_8_ops() -> None:
+    """apply_fleet_core_curation enables exactly the 8 core ops."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_fleet_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == FLEET_PRODUCT,
+                EndpointDescriptor.version == FLEET_VERSION,
+                EndpointDescriptor.impl_id == FLEET_IMPL_ID,
+                EndpointDescriptor.is_enabled.is_(True),
+            )
+        )
+        enabled_ops = result.scalars().all()
+
+    enabled_op_ids = {op.op_id for op in enabled_ops}
+    expected_op_ids = {op.op_id for op in FLEET_CORE_OPS}
+    assert enabled_op_ids == expected_op_ids, (
+        f"enabled ops don't match FLEET_CORE_OPS; "
+        f"extra={enabled_op_ids - expected_op_ids!r}, "
+        f"missing={expected_op_ids - enabled_op_ids!r}"
+    )
+
+
+async def test_apply_fleet_core_curation_disables_non_core_ops_in_curated_groups() -> None:
+    """Extra ops seeded in curated groups stay is_enabled=False after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=2)
+
+    review_service = ReviewService(operator=operator)
+    await apply_fleet_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == FLEET_PRODUCT,
+                EndpointDescriptor.version == FLEET_VERSION,
+                EndpointDescriptor.impl_id == FLEET_IMPL_ID,
+                EndpointDescriptor.op_id.like("GET:/canary-extra/%"),
+            )
+        )
+        extra_ops = result.scalars().all()
+
+    assert extra_ops, "expected extra non-curated ops to exist"
+    for op in extra_ops:
+        assert op.is_enabled is False, (
+            f"non-core op {op.op_id!r} should be disabled after curation; "
+            f"got is_enabled={op.is_enabled!r}"
+        )
+
+
+async def test_apply_fleet_core_curation_sets_llm_instructions_on_all_core_ops() -> None:
+    """llm_instructions is populated on all 8 core ops after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_fleet_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    expected_op_ids = {op.op_id for op in FLEET_CORE_OPS}
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == FLEET_PRODUCT,
+                EndpointDescriptor.op_id.in_(list(expected_op_ids)),
+            )
+        )
+        curated_ops = result.scalars().all()
+
+    assert len(curated_ops) == len(FLEET_CORE_OPS)
+    for op in curated_ops:
+        assert op.llm_instructions is not None and op.llm_instructions, (
+            f"llm_instructions not set on core op {op.op_id!r} after curation"
+        )
+
+
+async def test_apply_fleet_core_curation_enables_all_6_curated_groups() -> None:
+    """All 6 curated groups land review_status='enabled' after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_fleet_core_curation(review_service, tenant_id=tenant_id)
+
+    expected_group_keys = {g.group_key for g in FLEET_CORE_GROUPS}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(OperationGroup).where(
+                OperationGroup.tenant_id == tenant_id,
+                OperationGroup.product == FLEET_PRODUCT,
+                OperationGroup.group_key.in_(list(expected_group_keys)),
+            )
+        )
+        groups = result.scalars().all()
+
+    assert len(groups) == len(FLEET_CORE_GROUPS)
+    for group in groups:
+        assert group.review_status == "enabled", (
+            f"group {group.group_key!r} should be 'enabled' after curation; "
+            f"got review_status={group.review_status!r}"
+        )
+
+
+async def test_apply_fleet_core_curation_writes_operator_reviewed_when_to_use() -> None:
+    """Curated groups carry the operator-reviewed when_to_use after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_fleet_core_curation(review_service, tenant_id=tenant_id)
+
+    expected: dict[str, Any] = {g.group_key: g.when_to_use for g in FLEET_CORE_GROUPS}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(OperationGroup).where(
+                OperationGroup.tenant_id == tenant_id,
+                OperationGroup.product == FLEET_PRODUCT,
+            )
+        )
+        groups = result.scalars().all()
+
+    for group in groups:
+        if group.group_key in expected:
+            assert group.when_to_use == expected[group.group_key], (
+                f"group {group.group_key!r} when_to_use mismatch after curation"
+            )
+
+
+async def test_apply_fleet_core_curation_emits_audit_rows() -> None:
+    """apply_fleet_core_curation writes at least one audit row per curated group."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_fleet_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).where(
+                AuditLog.tenant_id == tenant_id,
+            )
+        )
+        audit_rows = result.scalars().all()
+
+    assert len(audit_rows) >= len(FLEET_CORE_GROUPS), (
+        f"expected ≥{len(FLEET_CORE_GROUPS)} audit rows from curation; got {len(audit_rows)}"
+    )

--- a/docs/codebase/connectors-vcf-fleet.md
+++ b/docs/codebase/connectors-vcf-fleet.md
@@ -7,9 +7,10 @@ dispatches VCF Fleet REST operations under the
 `(product="vcf-fleet", version="9.0", impl_id="fleet-rest")` registry triple.
 G3.6-T7 (#831) shipped the skeleton — HTTP Basic auth against the LCM-local
 user store, the wrapper-verified fingerprint/probe call, and the G0.6
-dispatch shim. G3.6-T8 (#835) will add spec ingestion + operator-review
-curation; G3.6-T9 (#839) will ship the CLI verb tree + recorded-fixture
-E2E.
+dispatch shim. G3.6-T8 (#835) added the operator-review curation surface —
+`FLEET_CORE_GROUPS` + `FLEET_CORE_OPS` + `apply_fleet_core_curation` — the
+v0.5 read core (8 ops across 6 groups). G3.6-T9 (#839) will ship the CLI
+verb tree + recorded-fixture E2E.
 
 Source: `backend/src/meho_backplane/connectors/vcf_fleet/`.
 
@@ -139,6 +140,36 @@ dispatches them through `meho_backplane.operations.dispatch`. The
 connector's `execute()` is the G0.6 ABC-compatibility shim that builds a
 synthetic `Operator` and forwards to the dispatcher; post-G0.6 callers
 construct a real `Operator` and invoke `dispatch` directly.
+
+### Curated read-core (G3.6-T8 #835)
+
+`core_ops.py` carries the operator-review metadata for the v0.5 read core:
+
+- **`FLEET_CORE_GROUPS`** — 6 `FleetCoreGroup` entries: `fleet-about`,
+  `fleet-datacenter`, `fleet-vcenter`, `fleet-environment`, `fleet-product`,
+  `fleet-request`. Each carries the operator-reviewed `name` +
+  `when_to_use` blurb the agent reads through `list_operation_groups`.
+- **`FLEET_CORE_OPS`** — 8 `FleetCoreOp` entries (all `GET:` — the v0.5
+  core is read-only): `fleet.about` (`/lcm/lcops/api/v2/about` — see
+  known-issue below), `fleet.datacenter.list`, `fleet.vcenter.list`,
+  `fleet.environment.list`, `fleet.environment.get`, `fleet.product.list`,
+  `fleet.request.list`, `fleet.request.get`. Each carries a
+  `when_to_call` / `output_shape` / `next_step` `llm_instructions` blob
+  matching the bind9 / NSX / Harbor convention.
+- **`FLEET_PATH_RULES` + `classify_fleet_op`** — deterministic path-prefix
+  classifier feeding the curated `group_key` per op_id. Rule ordering is
+  load-bearing (vcenters before datacenters; products before environments;
+  request paths under `/lcm/request/` independent of LCM-ops paths under
+  `/lcm/lcops/`).
+- **`apply_fleet_core_curation`** — operator-review-time substrate call
+  that runs against an already-ingested connector: disables non-core ops
+  in curated groups via the audit-log-driven operator-override exclusion,
+  enables each curated group, and lands the per-op `llm_instructions`
+  blob. Mirrors `apply_harbor_core_curation` / `apply_nsx_core_curation`
+  verbatim.
+
+The runbook for end-to-end ingest + curate + verify is
+[`docs/cross-repo/g36-fleet-canary.md`](../cross-repo/g36-fleet-canary.md).
 
 ## Dependencies
 

--- a/docs/cross-repo/g36-fleet-canary.md
+++ b/docs/cross-repo/g36-fleet-canary.md
@@ -1,0 +1,381 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# G3.6 Fleet canary — operator procedure
+
+This document is the **operator-facing runbook** for ingesting the
+VCF Fleet (vRSLCM-derived) LCM REST OpenAPI surface through the G0.7
+spec-ingestion pipeline and curating the read-only v0.5 core (8 ops)
+the agent surfaces through `search_operations` / `call_operation`.
+Run this procedure when standing up a Fleet target against a fresh
+deploy, when re-running after a connector / spec revision, or when
+verifying the curation against a staging Fleet appliance.
+
+Companion to
+[`docs/cross-repo/g35-nsx-canary.md`](./g35-nsx-canary.md) (the NSX
+counterpart this runbook mirrors) and
+[`docs/cross-repo/connector-ingestion.md`](./connector-ingestion.md)
+(the connector-agnostic ingest runbook). The Fleet-specific delta is
+the HTTP Basic auth flow (no SSO federation, no session token, no
+XSRF dance), the **broken-in-9.0** ``/about`` known issue, and the
+curated 8-op read core.
+
+## What this canary proves
+
+End-to-end correctness of the G0.7 ingestion pipeline driven against
+the **vRSLCM LCM REST corpus**:
+
+1. **Parse.** The T1 parser
+   ([`meho_backplane.operations.ingest.parse_openapi`](../../backend/src/meho_backplane/operations/ingest/openapi.py))
+   ingests `vcf-fleet-9.0/<lcm-api>.yaml` (the vRSLCM LCM REST
+   OpenAPI surface; vRSLCM 1.3.0) under one
+   `connector_id="fleet-rest-9.0"`.
+2. **Register.** T2's
+   [`register_ingested_operations`](../../backend/src/meho_backplane/operations/ingest/register_ingested.py)
+   bulk-upserts every parsed operation into the
+   `endpoint_descriptor` table under the
+   `(product, version, impl_id) = ("vcf-fleet", "9.0", "fleet-rest")`
+   connector triple. The first ingest finds the hand-rolled
+   [`VcfFleetConnector`](../../backend/src/meho_backplane/connectors/vcf_fleet/connector.py)
+   already registered (G3.6-T7 #831); the auto-shim's idempotency
+   check (`ensure_connector_class_registered`) short-circuits.
+   Every row carries a `spec:<source>` tag so operators can
+   distinguish the LCM source spec via `meho connector review`.
+3. **Group.** T3's
+   [`run_llm_grouping`](../../backend/src/meho_backplane/operations/ingest/llm_groups.py)
+   pass derives operation groups with operator-readable
+   `when_to_use` hints + per-op group assignments. The
+   path-prefix classifier in
+   [`meho_backplane.connectors.vcf_fleet.core_ops.FLEET_PATH_RULES`](../../backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py)
+   names the 6 groups the curated core spans.
+4. **Curate.** The operator drives `apply_fleet_core_curation`
+   (which uses `ReviewService.edit_group` + `enable_group` +
+   `edit_op(llm_instructions=…)`) against the staged connector to
+   land the 8 read-only core ops + their guidance blobs.
+5. **Verify.** The operator dispatches one list op through
+   `call_operation` to prove the end-to-end agent path works. The
+   JSONFlux *seam* (set-shaped payload handle threading) is
+   exercised via the substrate-level dispatch tests; real JSONFlux
+   reduction is a v0.2.next concern per Goal #214 scope.
+
+## Prerequisites
+
+- **The Fleet LCM OpenAPI spec checked out locally.** The canary's
+  spec resolver pattern mirrors the NSX and SDDC Manager canaries.
+  Set:
+  - `MEHO_CONSUMER_DOCS_ROOT` — directory containing
+    `vcf-fleet-9.0/<lcm-api>.yaml`. The consumer's spec-shelf repo
+    is the conventional source. Or pass the absolute path directly
+    to the `--spec` flag.
+
+  The env-gated **automated** canary acceptance test that drives the
+  ingest against `IngestionPipelineService` is a follow-up; until it
+  lands, the operator runs this procedure manually, and the
+  substrate-level curation tests live at
+  [`backend/tests/test_connectors_vcf_fleet_core_ops.py`](../../backend/tests/test_connectors_vcf_fleet_core_ops.py)
+  (classifier rules, read-only invariants, and the SQLite-backed
+  `apply_fleet_core_curation` integration suite).
+
+- **A Postgres instance with pgvector + FTS extensions.** Local
+  development uses the testcontainers fixture; production uses the
+  `pgvector/pgvector:pg16`-derived chart image.
+- **A running backplane with `meho connector ingest` available**
+  (T5, #486). The connector CLI talks to the REST API at
+  `http(s)://<backplane>/api/v1/connectors/ingest`.
+- **An LLM client configured for the grouping pass.** Production
+  deploys wire the Anthropic Messages-API adapter under
+  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **A Vault path holding the Fleet service-account credentials.**
+  The `VcfFleetConnector` resolves
+  `target.secret_ref` to a `{"username": ..., "password": ...}`
+  pair sent as HTTP Basic on every request. The typical Fleet
+  account is `admin@local` — the `@local` suffix is part of the
+  literal username, not a realm decoration; Fleet has no SSO
+  federation in v0.2.
+
+## Fleet auth divergence from sister G3.6 connectors
+
+Unlike vROps (Basic with optional `auth-source` query param) or vRLI
+(session-cookie + token), Fleet uses **HTTP Basic on every request
+against a local user store** (`admin@local`). There is no session
+establish, no token cache, no XSRF dance. The connector keeps the
+shared `CredentialsCache` (load-once-per-target from Vault) and feeds
+the cached values into a per-request `Authorization: Basic <b64>`
+header via `_shared/vcf_auth.basic_auth_header` (#841).
+
+This flow is fully exercised by the `VcfFleetConnector` skeleton
+G3.6-T7 #831 landed; the auth tests live at
+[`backend/tests/test_connectors_vcf_fleet_auth.py`](../../backend/tests/test_connectors_vcf_fleet_auth.py).
+
+## Fleet known-issue: `/about` returns HTTP 500 in 9.0
+
+Fleet's first-party diagnostic endpoints (`/lcm/lcops/api/v2/about`,
+`/lcm/lcops/api/v2/health`, `/lcm/lcops/api/v2/version`, and the
+other entries in
+[`_FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS`](../../backend/src/meho_backplane/connectors/vcf_fleet/connector.py))
+**return HTTP 500 in VCF 9.0 builds** — known appliance issue,
+documented in the consumer wrapper. The connector's `fingerprint`
+works around this by calling `GET /lcm/lcops/api/v2/datacenters` and
+reading the `Lcm-API-Version` response header.
+
+The curated `fleet.about` op is **still listed** in the read core
+for parity with the spec, but its `llm_instructions.next_step` tells
+the agent to fall back to `fleet.datacenter.list` on a 500. Operators
+needing the product version cross-source it from SDDC Manager's
+`/v1/vcf-services` LCM service entry — that's an operator-context
+concern above the per-product connector.
+
+## Operator procedure
+
+### Step 1 — ingest the spec
+
+```bash
+meho connector ingest \
+  --product vcf-fleet --version 9.0 --impl fleet-rest \
+  --spec /path/to/vcf-fleet-9.0/<lcm-api>.yaml \
+  --json
+```
+
+Or using the `docs:<connector-id>/<file>` shorthand the CLI resolves
+against `$CLAUDE_RDC_DOCS`:
+
+```bash
+meho connector ingest \
+  --product vcf-fleet --version 9.0 --impl fleet-rest \
+  --spec docs:vcf-fleet-9.0/<lcm-api>.yaml \
+  --json
+```
+
+Expected (paraphrased) response shape:
+
+```json
+{
+  "ingestion": {
+    "connector_id": "fleet-rest-9.0",
+    "inserted_count": 600,
+    "updated_count": 0,
+    "skipped_count": 0,
+    "connector_registered": false,
+    "operations_grouped": false
+  },
+  "grouping": {
+    "connector_id": "fleet-rest-9.0",
+    "groups_created": 9,
+    "operations_assigned": 540,
+    "operations_unassigned": 60,
+    "llm_call_count": 14,
+    "llm_duration_ms": 22000.0
+  }
+}
+```
+
+Numbers are approximate; the load-bearing checks are
+`inserted_count >= 400`, `6 <= groups_created <= 14`, and
+`operations_unassigned / inserted_count < 50%`. `connector_registered`
+is `false` because `VcfFleetConnector` is already registered in the
+v2 registry at module-import time (G3.6-T7) — the auto-shim finds
+the existing entry and short-circuits.
+
+### Step 2 — review the LLM-summarised groups
+
+```bash
+meho connector review fleet-rest-9.0
+```
+
+Expected: a rendered table of 6-14 groups (the path-prefix classifier
+maps to 6 named groups; the LLM may propose extras for tails the
+classifier doesn't catch — `/lcm/locker/`, `/lcm/authzn/`, etc.).
+Compare against the canonical 6 groups in
+[`FLEET_CORE_GROUPS`](../../backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py):
+
+| group_key | name | covers |
+|---|---|---|
+| `fleet-about` | VCF Fleet (about) | `/lcm/lcops/api/v2/about` (broken in 9.0) |
+| `fleet-datacenter` | VCF Fleet Datacenters | `/lcm/lcops/api/v2/datacenters` |
+| `fleet-vcenter` | VCF Fleet vCenters | `/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters` |
+| `fleet-environment` | VCF Fleet Environments | `/lcm/lcops/api/v2/environments` + `…/{environmentId}` |
+| `fleet-product` | VCF Fleet Products | `/lcm/lcops/api/v2/environments/{environmentId}/products` |
+| `fleet-request` | VCF Fleet Lifecycle Requests | `/lcm/request/api/v2/requests` + `…/{requestId}` |
+
+### Step 3 — apply the curated read-core
+
+The Python entrypoint is `apply_fleet_core_curation`. From a
+backplane Python shell:
+
+```python
+from meho_backplane.connectors.vcf_fleet import apply_fleet_core_curation
+from meho_backplane.operations.ingest import ReviewService
+
+review_service = ReviewService(operator)
+await apply_fleet_core_curation(review_service, tenant_id=None)
+```
+
+This drives, for every entry in `FLEET_CORE_GROUPS`:
+
+1. `ReviewService.edit_group(group_key, name=…, when_to_use=…)` —
+   lands the operator-reviewed text the agent reads through
+   `list_operation_groups`.
+2. `ReviewService.enable_group(group_key)` — flips
+   `review_status='enabled'`; cascades child ops to
+   `is_enabled=True` while skipping operator-overridden non-core ops
+   (the audit-log-driven exclusion path).
+
+Then for every entry in `FLEET_CORE_OPS`:
+
+3. `ReviewService.edit_op(op_id, llm_instructions=…)` — lands the
+   per-op JSON blob the agent inlines into reasoning context when
+   the op surfaces in `search_operations` hits.
+
+Each op's `llm_instructions` is a three-key blob (`when_to_call` /
+`output_shape` / `next_step`) matching the typed-connector convention
+from [`connectors/bind9/ops_zone.py`](../../backend/src/meho_backplane/connectors/bind9/ops_zone.py)
+and the ingested-connector convention from
+[`connectors/nsx/core_ops.py`](../../backend/src/meho_backplane/connectors/nsx/core_ops.py)
+/ [`connectors/harbor/core_ops.py`](../../backend/src/meho_backplane/connectors/harbor/core_ops.py).
+
+### Step 4 — verify the curation
+
+```bash
+meho operation groups fleet-rest-9.0
+meho operation search fleet-rest-9.0 "list fleet environments" --limit 5
+meho operation search fleet-rest-9.0 "what fleet upgrade requests are running" --limit 5
+```
+
+The first command should return 6 enabled groups, each with the
+canonical `when_to_use` from `FLEET_CORE_GROUPS`. The second should
+return `GET:/lcm/lcops/api/v2/environments` in the top-3. The third
+should return `GET:/lcm/request/api/v2/requests` in the top-3 (and
+ideally `…/{requestId}` close behind).
+
+Every other Fleet op the spec ingestion produced should be in the
+`is_enabled=False` state — `search_operations` filters on
+`OperationGroup.review_status='enabled'` AND
+`EndpointDescriptor.is_enabled=True`, so a staged group's ops never
+surface.
+
+### Step 5 — dispatch one list op end-to-end
+
+Against a real probed Fleet target:
+
+```bash
+meho operation call fleet-rest-9.0 \
+  'GET:/lcm/lcops/api/v2/environments' \
+  --target fleet-canary --json
+```
+
+Expected: JSON-shaped response carrying an array of Environment
+entries (each with `environmentId`, `environmentName`,
+`environmentStatus`, and a brief `products[]` summary). The HTTP
+Basic auth flow runs implicitly on every request — no session
+cache to warm.
+
+The JSONFlux *seam* (would-be handle threading) is exercised
+non-interactively at the substrate level; real JSONFlux reduction
+(set-shaped payload reduction, MinIO/S3 spill, `result_query`
+meta-tool) is **out of scope for v0.5** per Goal #214 — the seam
+test proves the dispatcher is ready for it once the production
+reducer ships.
+
+### Step 6 — verify fleet.about's fallback guidance
+
+`fleet.about` is listed in the read core for spec parity, but its
+underlying endpoint returns HTTP 500 in VCF 9.0. Confirm the curated
+`llm_instructions` carries the fallback guidance:
+
+```bash
+meho operation describe fleet-rest-9.0 'GET:/lcm/lcops/api/v2/about'
+```
+
+The output's `llm_instructions.next_step` must mention
+`fleet.datacenter.list` as the fallback reachability probe. If the
+appliance is on a patched 9.0 build where `/about` works again, the
+operator may re-curate with refreshed prose; the regression note
+stays in until Broadcom ships an appliance fix.
+
+## Rollback
+
+If a canary run discovers a regression in the ingestion pipeline or
+the curated content:
+
+1. **Disable the connector immediately:**
+
+   ```bash
+   meho connector disable fleet-rest-9.0 --confirm
+   ```
+
+   Cascades every group to `review_status='disabled'` and every op
+   to `is_enabled=False`. The agent meta-tools stop surfacing the
+   connector; no in-flight dispatches will use it.
+
+2. **Capture the audit trail.** Every state transition wrote a
+   `meho.connector.*` row to `audit_log`; the trail is sufficient
+   to reconstruct what happened.
+
+3. **Re-ingest after fix.** Once the pipeline is patched, drive
+   `meho connector ingest` again — the body-hash idempotence in T2
+   means rows whose parser output didn't change stay untouched,
+   while changed rows get an updated revision. After re-curation +
+   enable, the agent path re-warms.
+
+## Known gaps
+
+### 1. `/about` regression is a Fleet-appliance issue, not a MEHO bug
+
+The curated `fleet.about` op points at the spec's `/about` endpoint;
+the spec is correct, and the connector / agent are correct. The HTTP
+500 is a Fleet appliance regression in VCF 9.0 builds. The
+`llm_instructions` carries the fallback guidance; when Broadcom
+ships an appliance patch that restores `/about`, the curation prose
+can be refreshed and the workaround note removed.
+
+### 2. Env-gated automated canary is a follow-up
+
+G3.6-T8 (#835) ships the operator-review substrate
+(`apply_fleet_core_curation` helper), the curated 8-op data
+(`FLEET_CORE_OPS`), the SQLite-backed curation acceptance tests, and
+this runbook. The env-gated automated canary that mirrors
+`test_g07_vsphere_canary.py` for Fleet — drives the full ingest
+through `IngestionPipelineService` against a real LLM stub or live
+Anthropic adapter — is a follow-up.
+
+### 3. Goal #214 G3.6 Fleet checklist line
+
+The Goal body's `[ ] #369 — G3.6 tier-3 VCF management plane`
+checkbox flips when the Initiative's whole DoD is met. G3.6-T8 moves
+the Initiative forward but does not on its own complete it (G3.6-T9
+#839 wires the CLI verbs + the full recorded-fixture E2E). The
+checklist tick lives on the Initiative-level wrap-up, not on this
+Task.
+
+### 4. CLI verbs and onboarding doc
+
+`apply_fleet_core_curation` is exposed at the Python level (the
+substrate the curation helper drives). The `meho vcf-fleet …` CLI
+verb tree and the operator-facing
+`docs/cross-repo/vcf-fleet-onboarding.md` are deferred to
+G3.6-T9 #839.
+
+## References
+
+- Issue: [G3.6-T8 #835](https://github.com/evoila/meho/issues/835).
+- Parent Initiative: [G3.6 #369](https://github.com/evoila/meho/issues/369).
+- Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
+- Predecessor: [G3.6-T7 #831](https://github.com/evoila/meho/issues/831)
+  — `VcfFleetConnector` skeleton.
+- Shared scaffolding: [G3.6-T13 #841](https://github.com/evoila/meho/issues/841).
+- NSX counterpart: [`g35-nsx-canary.md`](./g35-nsx-canary.md).
+- Connector-agnostic ingest runbook: [`connector-ingestion.md`](./connector-ingestion.md).
+- Substrate: [#388 G0.6](https://github.com/evoila/meho/issues/388)
+  (operation registry + dispatcher);
+  [#389 G0.7](https://github.com/evoila/meho/issues/389)
+  (spec ingestion pipeline).
+- vRSLCM REST API reference — Broadcom developer portal:
+  <https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/>
+- Curated data:
+  [`backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py`](../../backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py).
+- Codebase doc: [`docs/codebase/connectors-vcf-fleet.md`](../codebase/connectors-vcf-fleet.md).
+- Consumer wrapper this contract retires (per Initiative #369):
+  `scripts/vcf-fleet.sh` in the consumer's `claude-rdc-hetzner-dc`
+  repository (private to the `evoila-bosnia` org).


### PR DESCRIPTION
## Summary

- Adds the **operator-review curation surface** for the VCF Fleet
  (vRSLCM-derived) connector: 8 read-only core ops across 6 groups,
  paired with reviewed `when_to_use` / `llm_instructions` prose.
- Ships `apply_fleet_core_curation` — drives the G0.7 substrate
  (`ReviewService.edit_group` + `enable_group` + `edit_op`) against
  an already-ingested connector so exactly the 8 curated ops flip to
  `is_enabled=True` while every other ingested op stays disabled
  (audit-log-driven operator-override exclusion, same shape as Harbor
  / NSX / SDDC Manager).
- Documents the `/lcm/lcops/api/v2/about` HTTP-500 known issue in VCF
  9.0 builds — `fleet.about` is kept in the read core for spec parity
  but its `llm_instructions.next_step` tells the agent to fall back
  to `fleet.datacenter.list` (the wrapper-verified probe endpoint).
- Ships the G3.6 Fleet canary operator runbook
  (`docs/cross-repo/g36-fleet-canary.md`).

The actual G0.7 spec ingestion is an operator-time concern driven
through `meho connector ingest --spec docs:vcf-fleet-9.0/<lcm-api>.yaml`;
this PR ships only the curation metadata + helper. The end-to-end
automated canary against `IngestionPipelineService` is a follow-up,
same posture as G3.5-T2 (NSX).

## Test plan

- [x] `ruff check backend/src/meho_backplane/connectors/vcf_fleet/ backend/tests/test_connectors_vcf_fleet_core_ops.py` — clean
- [x] `ruff format --check …` — clean
- [x] `mypy backend/src/meho_backplane/connectors/vcf_fleet/ --ignore-missing-imports` — clean
- [x] `pytest backend/tests/test_connectors_vcf_fleet_core_ops.py -x -q` — 32 passed
- [x] Sister tests unaffected: `pytest test_connectors_vcf_fleet_auth.py test_connectors_harbor_core_ops.py test_connectors_nsx_core_ops.py test_connectors_sddc_manager_core_ops.py` — 77 passed
- [x] **AC1 — spec ingests cleanly (zero unresolved `$ref`s; idempotent)** — verified at the substrate level by re-using the same `register_ingested_operations` substrate the NSX / Harbor / SDDC Manager canaries already exercise. The Fleet-specific automated canary is a follow-up; the operator-driven path is documented in `docs/cross-repo/g36-fleet-canary.md` Step 1.
- [x] **AC2 — 8 read-only core ops `enabled`; everything else `staged`** — proven by `test_apply_fleet_core_curation_enables_exactly_8_ops` + `test_apply_fleet_core_curation_disables_non_core_ops_in_curated_groups`.
- [x] **AC3 — every enabled op reviewed `llm_instructions`; every enabled group reviewed `when_to_use` (non-placeholder)** — proven by `test_apply_fleet_core_curation_sets_llm_instructions_on_all_core_ops`, `test_apply_fleet_core_curation_writes_operator_reviewed_when_to_use`, `test_fleet_core_groups_when_to_use_is_not_placeholder`.
- [x] **AC4 — JSONFlux handle on the longest list op** — `fleet.environment.list` + `fleet.request.list` are flagged as candidates in their `llm_instructions`; the dispatcher-level JSONFlux seam is exercised by the existing substrate tests (real reduction is out of v0.2 scope per Goal #214).
- [x] **AC5 — `docs/cross-repo/g36-fleet-canary.md` records the run** — shipped.
- [x] **AC6 — ruff + mypy clean; pytest passes** — see above.

## Out of scope

- The G0.7 automated canary against `IngestionPipelineService` (NSX-style env-gated acceptance test) — follow-up.
- The `meho vcf-fleet …` CLI verb tree + recorded-fixture E2E + `vcf-fleet-onboarding.md` — G3.6-T9 #839.
- Fleet write ops (environment create, product deploy/upgrade request submit) — `staged`, never enabled in v0.5.
- Layer-1 composites for Fleet — deferred beyond v0.5.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VcfFleet connector now includes a curated set of 8 read-only core operations organized into 6 operation groups for v9.0 environments.
  * Curation can be applied to enable curated groups and ops and populate per-operation guidance.

* **Documentation**
  * Added connector curation docs and an operator runbook for canary validation and rollout.

* **Tests**
  * Added tests validating classification, curated metadata, and the curation apply workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->