### PR TITLE
feat(connectors): G3.6-T2 vROps suite-api ingest + 8-op read core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,25 @@ connector-related release-notes line.
 
 ### Added
 
+- **vROps suite-api spec ingestion + curated read-only v0.5 core**
+  (G3.6-T2 [#833](https://github.com/evoila/meho/issues/833)) —
+  enables the `VcfOperationsConnector` (#829) for agent dispatch by
+  ingesting `docs:vcf-operations-9.0/suite-api.yaml` via the G0.7
+  pipeline and curating the 8-op read core that
+  `search_operations` / `call_operation` surface:
+  `vrops.about` · `vrops.resource.list` · `vrops.resource.get` ·
+  `vrops.alert.list` · `vrops.alertdefinition.list` ·
+  `vrops.symptom.list` · `vrops.recommendation.list` ·
+  `vrops.supermetric.list`. Ships the
+  `apply_vrops_core_curation` helper (mirrors NSX / Harbor / SDDC
+  precedents — `edit_op(is_enabled=False)` operator-override per
+  non-core op, then `edit_group` + `enable_group` cascade), the
+  curated 7-group `when_to_use` text + 8-op `llm_instructions`
+  blobs, dispatch-smoke + JSONFlux force-handle acceptance tests
+  over respx-mocked vROps, and the operator runbook at
+  [`docs/cross-repo/g36-vrops-canary.md`](docs/cross-repo/g36-vrops-canary.md).
+  Write ops (custom-group / maintenance-mode set / alert-ack) stay
+  `is_enabled=False` per the Initiative #369 out-of-scope list.
 - **`VcfOperationsConnector` skeleton** (G3.6-T1
   [#829](https://github.com/evoila/meho/issues/829)) — `HttpConnector`
   subclass registered under

--- a/backend/src/meho_backplane/connectors/vcf_operations/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/__init__.py
@@ -43,6 +43,19 @@ All four share the same registration shape; vROps + vRLI + Fleet share the
 
 from meho_backplane.connectors.registry import register_connector_v2
 from meho_backplane.connectors.vcf_operations.connector import VcfOperationsConnector
+from meho_backplane.connectors.vcf_operations.core_ops import (
+    VROPS_CONNECTOR_ID,
+    VROPS_CORE_GROUPS,
+    VROPS_CORE_OPS,
+    VROPS_IMPL_ID,
+    VROPS_PATH_RULES,
+    VROPS_PRODUCT,
+    VROPS_VERSION,
+    VropsCoreGroup,
+    VropsCoreOp,
+    apply_vrops_core_curation,
+    classify_vrops_op,
+)
 from meho_backplane.connectors.vcf_operations.session import (
     VcfOperationsCredentialsLoader,
     VcfOperationsTargetLike,
@@ -57,8 +70,19 @@ register_connector_v2(
 )
 
 __all__ = [
+    "VROPS_CONNECTOR_ID",
+    "VROPS_CORE_GROUPS",
+    "VROPS_CORE_OPS",
+    "VROPS_IMPL_ID",
+    "VROPS_PATH_RULES",
+    "VROPS_PRODUCT",
+    "VROPS_VERSION",
     "VcfOperationsConnector",
     "VcfOperationsCredentialsLoader",
     "VcfOperationsTargetLike",
+    "VropsCoreGroup",
+    "VropsCoreOp",
+    "apply_vrops_core_curation",
+    "classify_vrops_op",
     "load_credentials_from_vault",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_operations/core_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/core_ops.py
@@ -1,0 +1,680 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vROps 9.0 read-only v0.5 core — curated operator-enabled subset.
+
+This module names the **8 read-only vROps operations** the G3.6
+vcf-operations v0.5 ship enables out of the much larger vROps
+``/suite-api`` corpus the G0.7 spec-ingestion pipeline lands under
+``connector_id="vrops-rest-9.0"``. The curation is two-layered:
+
+* :data:`VROPS_CORE_GROUPS` — the operator-reviewed ``when_to_use``
+  hint per LLM-grouping pass output group. Each entry's ``group_key``
+  is the deterministic slug :func:`classify_vrops_op` assigns to vROps
+  ops; the ``when_to_use`` is what the agent reads verbatim through
+  :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
+  to pick a group to search within.
+* :data:`VROPS_CORE_OPS` — the 8 ``EndpointDescriptor.op_id`` strings
+  that flip to ``is_enabled=True`` at operator-review time, paired
+  with the per-op ``llm_instructions`` blob the agent inlines into
+  the reasoning context when it sees the op in
+  :func:`~meho_backplane.operations.meta_tools.search_operations`
+  hits. Every other op under the same connector triple stays
+  ``is_enabled=False`` (the G0.7 ingestion default for
+  ``source_kind='ingested'`` rows).
+
+Per Initiative #369 and CLAUDE.md postulates 1-2, vROps is **fully
+generic-ingested**: the underlying ops are not registered in code,
+they live in the ``endpoint_descriptor`` table. This module only
+carries the **operator-review metadata** the substrate uses at the
+review step — the actual curation is applied through
+:func:`apply_vrops_core_curation` against an existing ingested
+connector.
+
+The 8 ops (paths cross-checked against the Broadcom vROps suite-api
+docs at https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/):
+
+1. ``GET:/suite-api/api/versions/current`` — ``vrops.about`` — appliance
+   version + build (the same surface :meth:`VcfOperationsConnector.fingerprint`
+   already consumes; exposing it as an operator-callable op lets the agent
+   run a sanity probe before any heavier read).
+2. ``GET:/suite-api/api/resources`` — ``vrops.resource.list`` — resource
+   inventory filterable by ``resourceKind``, ``name``, or ``adapterKind``.
+3. ``GET:/suite-api/api/resources/{id}`` — ``vrops.resource.get`` — full
+   detail for one resource by id, including identifiers and credential
+   refs (no secret values).
+4. ``GET:/suite-api/api/alerts`` — ``vrops.alert.list`` — current and
+   historical alerts (filter by ``activeOnly``, ``alertCriticality``).
+5. ``GET:/suite-api/api/alertdefinitions`` — ``vrops.alertdefinition.list``
+   — the configured alert definitions (the policy surface the alert
+   list rolls up against).
+6. ``GET:/suite-api/api/symptoms`` — ``vrops.symptom.list`` — currently
+   firing symptoms; the per-condition signal that rolls up into alerts.
+7. ``GET:/suite-api/api/recommendations`` — ``vrops.recommendation.list``
+   — operator-facing remediation hints attached to alerts / symptoms.
+8. ``GET:/suite-api/api/supermetrics`` — ``vrops.supermetric.list`` —
+   user-defined metric formulae, useful when answering "which metric
+   formula was used to compute X".
+
+Path families and group_keys
+-----------------------------
+
+vROps' suite-api is flat — every path is under ``/suite-api/api/<noun>``
+with no deep hierarchy. :data:`VROPS_PATH_RULES` lists the curated
+prefixes in most-specific-first order so the ``startswith`` loop in
+:func:`classify_vrops_op` terminates at the right group:
+
+* ``/suite-api/api/versions`` → ``vrops-system``.
+* ``/suite-api/api/resources`` → ``vrops-resources``.
+* ``/suite-api/api/alertdefinitions`` → ``vrops-alert-definitions``.
+  (Must precede ``/suite-api/api/alerts`` to avoid the broader prefix
+  consuming it.)
+* ``/suite-api/api/alerts`` → ``vrops-alerts``.
+* ``/suite-api/api/symptoms`` → ``vrops-symptoms``.
+* ``/suite-api/api/recommendations`` → ``vrops-recommendations``.
+* ``/suite-api/api/supermetrics`` → ``vrops-supermetrics``.
+
+The ``alertdefinitions`` rule must precede the ``alerts`` rule because
+``startswith("/suite-api/api/alerts")`` would otherwise eat the
+``/suite-api/api/alertdefinitions`` path. The rule ordering is
+load-bearing; :func:`classify_vrops_op` documents the loop contract.
+
+Curation application
+--------------------
+
+:func:`apply_vrops_core_curation` is the operator-review-time
+substrate call that makes exactly the 8 curated ops dispatchable.
+Mirrors :func:`apply_nsx_core_curation` and
+:func:`apply_harbor_core_curation` verbatim, threading the
+"enable group but pin non-core ops disabled" needle via the
+audit-log-driven operator-override exclusion.
+
+Write-ops are deliberately excluded
+------------------------------------
+
+vROps' write surface (custom-group create / maintenance-mode set /
+alert-acknowledge) stays ``is_enabled=False`` in v0.5 per the
+Initiative #369 out-of-scope list. The curation helper's
+"enable group but pin non-core ops disabled" pattern keeps those
+rows on the connector for future enablement without exposing them
+to the agent until an explicit follow-up Task lands their
+``llm_instructions`` + safety review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.operations.ingest.service import ReviewService
+
+__all__ = [
+    "VROPS_CONNECTOR_ID",
+    "VROPS_CORE_GROUPS",
+    "VROPS_CORE_OPS",
+    "VROPS_IMPL_ID",
+    "VROPS_PATH_RULES",
+    "VROPS_PRODUCT",
+    "VROPS_VERSION",
+    "VropsCoreGroup",
+    "VropsCoreOp",
+    "apply_vrops_core_curation",
+    "classify_vrops_op",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: ``VROPS_PRODUCT`` / ``VROPS_VERSION`` / ``VROPS_IMPL_ID`` note
+#: ---------------------------------------------------------------
+#:
+#: ``VROPS_PRODUCT = "vrops"`` is the value
+#: :func:`~meho_backplane.operations._lookup.parse_connector_id`
+#: extracts from ``VROPS_CONNECTOR_ID = "vrops-rest-9.0"``
+#: (``head.split("-", 1)[0]`` where head is ``"vrops-rest"``).
+#:
+#: Distinct from :attr:`VcfOperationsConnector.product` (``"vcf-operations"``)
+#: — same shape as the SDDC Manager case where
+#: ``SddcManagerConnector.product="sddc-manager"`` but rows carry
+#: ``product="sddc"``. The connector class's product field drives the
+#: v2-registry triple; ``endpoint_descriptor.product`` / ``operation_group.product``
+#: column values are derived from the connector_id via
+#: :func:`parse_connector_id` at ingest + review time, so the curation
+#: helper must reference the parser's derived value here, not the
+#: registry's.
+VROPS_PRODUCT: Final[str] = "vrops"
+VROPS_VERSION: Final[str] = "9.0"
+VROPS_IMPL_ID: Final[str] = "vrops-rest"
+
+#: Connector-id slug the G0.6 dispatcher's ``parse_connector_id``
+#: round-trips back to the triple above: ``"vrops-rest-9.0"``.
+VROPS_CONNECTOR_ID: Final[str] = f"{VROPS_IMPL_ID}-{VROPS_VERSION}"
+
+
+@dataclass(frozen=True, slots=True)
+class VropsCoreGroup:
+    """One curated operator-review entry for a vROps operation group.
+
+    ``group_key`` is the slug :func:`classify_vrops_op` emits.
+    ``name`` is the operator-readable label ``meho connector review``
+    renders. ``when_to_use`` is the agent-facing hint
+    :func:`list_operation_groups` returns verbatim; every entry is a
+    single complete sentence so the agent's group-selection step has
+    unambiguous guidance.
+    """
+
+    group_key: str
+    name: str
+    when_to_use: str
+
+
+@dataclass(frozen=True, slots=True)
+class VropsCoreOp:
+    """One curated operator-review entry for a vROps operation.
+
+    ``op_id`` follows the ``METHOD:path`` shape every
+    ``source_kind='ingested'`` row uses; the path matches an entry
+    in the vROps suite-api OpenAPI spec.
+
+    ``llm_instructions`` is the per-op JSON blob the meta-tools inline
+    verbatim when the op surfaces. The shape (``when_to_call`` /
+    ``output_shape`` / ``next_step``) mirrors the typed-connector
+    convention from :mod:`meho_backplane.connectors.bind9.ops_zone`
+    and :mod:`meho_backplane.connectors.nsx.core_ops` — same agent
+    reads both surfaces, so the structure stays uniform.
+    """
+
+    op_id: str
+    group_key: str
+    llm_instructions: dict[str, object]
+
+
+#: Path-prefix → group_key classifier rules for vROps.
+#:
+#: **Order is load-bearing.** Each rule is checked via
+#: ``path.startswith(prefix)``. More-specific prefixes must precede
+#: less-specific ones to avoid a shorter prefix consuming a path that
+#: belongs to a deeper group:
+#:
+#: * ``/alertdefinitions`` before ``/alerts`` — ``/alerts`` is a prefix
+#:   of ``/alertdefinitions``.
+#:
+#: Every other curated prefix is disjoint from the rest, so the order
+#: between them only documents the operator's mental model.
+VROPS_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
+    ("/suite-api/api/versions", "vrops-system"),
+    ("/suite-api/api/resources", "vrops-resources"),
+    # alertdefinitions must precede alerts — startswith("/suite-api/api/alerts")
+    # would otherwise eat the longer path.
+    ("/suite-api/api/alertdefinitions", "vrops-alert-definitions"),
+    ("/suite-api/api/alerts", "vrops-alerts"),
+    ("/suite-api/api/symptoms", "vrops-symptoms"),
+    ("/suite-api/api/recommendations", "vrops-recommendations"),
+    ("/suite-api/api/supermetrics", "vrops-supermetrics"),
+)
+
+
+def classify_vrops_op(op_id: str) -> str:
+    """Return the curated ``group_key`` for a vROps op_id, or ``"none"``.
+
+    ``op_id`` is the ``METHOD:/path`` form ingested rows carry; the
+    helper strips the verb and matches the path against
+    :data:`VROPS_PATH_RULES` in order.
+
+    Returns ``"none"`` for non-GET methods (vROps' v0.5 read core
+    rejects writes outright) and for paths outside the curated
+    families (e.g. ``/suite-api/api/credentialkinds``,
+    ``/suite-api/api/auth/sources``); those rows are un-curated and
+    stay ``is_enabled=False`` after :func:`apply_vrops_core_curation`
+    runs.
+    """
+    try:
+        method, path = op_id.split(":", 1)
+    except ValueError:
+        return "none"
+    if method != "GET":
+        return "none"
+    for prefix, group_key in VROPS_PATH_RULES:
+        if path.startswith(prefix):
+            return group_key
+    return "none"
+
+
+#: Operator-reviewed ``when_to_use`` hints for the 7 vROps groups
+#: the read-only v0.5 core spans. Every hint is one complete sentence
+#: the agent reads verbatim — vague hints poison
+#: ``search_operations`` ranking, per the ai_engineering pack.
+VROPS_CORE_GROUPS: Final[tuple[VropsCoreGroup, ...]] = (
+    VropsCoreGroup(
+        group_key="vrops-system",
+        name="vROps (system / about)",
+        when_to_use=(
+            "Use this group to read the vROps appliance's own identity — "
+            "release name and build number. The probe surface the agent "
+            "calls before any heavier inventory read, or when confirming "
+            "which vROps instance the target points at."
+        ),
+    ),
+    VropsCoreGroup(
+        group_key="vrops-resources",
+        name="vROps Resources",
+        when_to_use=(
+            "Use this group to list or inspect vROps resources — every "
+            "monitored object across vCenter, ESXi hosts, VMs, datastores, "
+            "and cloud adapters. The primary inventory entry point for "
+            "any vROps workflow; filter by resourceKind, adapterKind, or "
+            "name to narrow large fleets. Drill into one resource by id "
+            "for credential references and full identifiers."
+        ),
+    ),
+    VropsCoreGroup(
+        group_key="vrops-alerts",
+        name="vROps Alerts",
+        when_to_use=(
+            "Use this group to list currently firing or recently resolved "
+            "alerts. Filter by activeOnly to focus on the open set, or by "
+            "alertCriticality for severity-scoped views. Each alert ties "
+            "back to an alert definition via alertDefinitionId and to a "
+            "resource via resourceId."
+        ),
+    ),
+    VropsCoreGroup(
+        group_key="vrops-alert-definitions",
+        name="vROps Alert Definitions",
+        when_to_use=(
+            "Use this group to list the configured alert definitions — "
+            "the policy surface the alert list rolls up against. Each "
+            "definition names the triggering symptom set, the impact "
+            "category, and the attached recommendations. Useful when "
+            "answering 'why did this alert fire' or 'which definition "
+            "owns this signal'."
+        ),
+    ),
+    VropsCoreGroup(
+        group_key="vrops-symptoms",
+        name="vROps Symptoms",
+        when_to_use=(
+            "Use this group to list currently firing symptoms — the "
+            "per-condition signals (metric breach, property change, "
+            "message event) that roll up into alerts. Useful when "
+            "debugging which underlying condition triggered an alert "
+            "or when surveying the raw signal layer beneath the alert "
+            "definitions."
+        ),
+    ),
+    VropsCoreGroup(
+        group_key="vrops-recommendations",
+        name="vROps Recommendations",
+        when_to_use=(
+            "Use this group to list the recommendations vROps surfaces "
+            "alongside its alerts and symptoms — operator-facing "
+            "remediation hints, often parameterised against the "
+            "affected resource. Useful when the agent needs to suggest "
+            "next-step actions for an active alert."
+        ),
+    ),
+    VropsCoreGroup(
+        group_key="vrops-supermetrics",
+        name="vROps Super Metrics",
+        when_to_use=(
+            "Use this group to list user-defined super metrics — derived "
+            "metric formulae built from existing vROps metrics. Useful "
+            "when answering 'which formula computes X' or auditing "
+            "custom metric definitions across the deployment."
+        ),
+    ),
+)
+
+
+def _instructions(
+    *,
+    when_to_call: str,
+    output_shape: str,
+    next_step: str,
+) -> dict[str, object]:
+    """Build the per-op ``llm_instructions`` blob with the canonical keys.
+
+    Same three-field shape :mod:`meho_backplane.connectors.nsx.core_ops`
+    and :mod:`meho_backplane.connectors.harbor.core_ops` use so an
+    agent crossing connector boundaries sees a stable convention.
+    """
+    return {
+        "when_to_call": when_to_call,
+        "output_shape": output_shape,
+        "next_step": next_step,
+    }
+
+
+#: The 8 curated read-only vROps core ops. Each entry carries the
+#: op_id (``GET:/path`` form), the curated group assignment, and the
+#: operator-reviewed ``llm_instructions`` blob.
+#:
+#: Paths cross-checked against the vROps suite-api docs at
+#: https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/.
+VROPS_CORE_OPS: Final[tuple[VropsCoreOp, ...]] = (
+    VropsCoreOp(
+        op_id="GET:/suite-api/api/versions/current",
+        group_key="vrops-system",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read the vROps appliance identity: release name "
+                "and build number. Useful as a pre-flight probe before "
+                "heavier inventory reads, or to confirm which vROps "
+                "instance the target points at. The same endpoint the "
+                "connector's fingerprint surface consumes."
+            ),
+            output_shape=(
+                "Object with releaseName (e.g. '9.0.0.1.23456789'), "
+                "buildNumber (int), and optionally "
+                "humanlyReadableReleaseName when the appliance emits it."
+            ),
+            next_step=(
+                "If the version looks healthy, proceed to "
+                "vrops.resource.list for the inventory entry point, or "
+                "vrops.alert.list for the operational signal surface."
+            ),
+        ),
+    ),
+    VropsCoreOp(
+        op_id="GET:/suite-api/api/resources",
+        group_key="vrops-resources",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list vROps-monitored resources. Accepts "
+                "resourceKind (e.g. 'VirtualMachine', 'HostSystem', "
+                "'Datastore'), adapterKind (e.g. 'VMWARE'), and name "
+                "query parameters to narrow large fleets; supports "
+                "pagination via page + pageSize. Large lists return a "
+                "JSONFlux handle through the shared HandleStore — use "
+                "result_describe + result_query to navigate the full "
+                "set."
+            ),
+            output_shape=(
+                "Object with resourceList[]; each entry carries identifier "
+                "(UUID), resourceKey (name + resourceKindKey + "
+                "adapterKindKey + resourceIdentifiers[]), creationTime, "
+                "resourceStatusStates[] (DATA_RECEIVING / NOT_EXISTING / "
+                "etc.), and credentialInstanceId. Also returns pageInfo "
+                "for pagination and links for HATEOAS navigation."
+            ),
+            next_step=(
+                "Pick a resource by identifier (UUID) for "
+                "vrops.resource.get to read full detail, or cross-reference "
+                "a resource's identifier against vrops.alert.list "
+                "(filter by resourceId) to find alerts firing on it."
+            ),
+        ),
+    ),
+    VropsCoreOp(
+        op_id="GET:/suite-api/api/resources/{id}",
+        group_key="vrops-resources",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read the full detail of one vROps resource by "
+                "its identifier (UUID). Returns the same shape as the "
+                "list entry plus extended adapterKindKey-specific "
+                "identifiers. Requires an id obtained from "
+                "vrops.resource.list."
+            ),
+            output_shape=(
+                "Object with identifier (UUID), resourceKey (full "
+                "key with all resourceIdentifiers), creationTime, "
+                "resourceStatusStates[], credentialInstanceId, "
+                "geoLocation (lat/long when set), and dtEnabled flag."
+            ),
+            next_step=(
+                "Cross-reference the resource's identifier with "
+                "vrops.alert.list (?resourceId=<uuid>) to find "
+                "alerts firing on it, or with vrops.symptom.list to "
+                "see the underlying signal layer."
+            ),
+        ),
+    ),
+    VropsCoreOp(
+        op_id="GET:/suite-api/api/alerts",
+        group_key="vrops-alerts",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list currently firing or recently resolved "
+                "alerts. Accepts activeOnly (bool, default false), "
+                "alertCriticality (CRITICAL / IMMEDIATE / WARNING / "
+                "INFORMATION / UNKNOWN), alertStatus (ACTIVE / CANCELED "
+                "/ SUSPENDED / UPDATED), and resourceId (UUID) query "
+                "parameters. Supports pagination via page + pageSize; "
+                "large alert sets return a JSONFlux handle."
+            ),
+            output_shape=(
+                "Object with alerts[]; each entry carries alertId (UUID), "
+                "alertDefinitionId, alertDefinitionName, alertLevel "
+                "(0..5), alertImpact, resourceId, startTimeUTC, "
+                "cancelTimeUTC, status, and controlState. Also returns "
+                "pageInfo and links."
+            ),
+            next_step=(
+                "Surface the high-criticality alerts to the operator; "
+                "cross-reference alertDefinitionId with "
+                "vrops.alertdefinition.list for policy context, "
+                "resourceId with vrops.resource.get for affected-object "
+                "detail."
+            ),
+        ),
+    ),
+    VropsCoreOp(
+        op_id="GET:/suite-api/api/alertdefinitions",
+        group_key="vrops-alert-definitions",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list configured alert definitions — the "
+                "policy surface alerts roll up against. Accepts id "
+                "(repeatable), adapterKind, resourceKind, and name "
+                "query parameters; supports pagination via page + "
+                "pageSize."
+            ),
+            output_shape=(
+                "Object with alertDefinitions[]; each entry carries id, "
+                "name, description, adapterKindKey, resourceKindKey, "
+                "waitCycles, cancelCycles, type, subType, states[] "
+                "(each with severity, base-symptom-set, "
+                "recommendation-priority-map), and links to attached "
+                "recommendations."
+            ),
+            next_step=(
+                "Pick an alertDefinitionId of interest, then call "
+                "vrops.alert.list to see which alerts currently fire "
+                "under that definition, or vrops.symptom.list to "
+                "inspect the underlying signal layer."
+            ),
+        ),
+    ),
+    VropsCoreOp(
+        op_id="GET:/suite-api/api/symptoms",
+        group_key="vrops-symptoms",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list currently firing symptoms — the per-condition "
+                "signals (metric breach, property change, message event) "
+                "that roll up into alerts. Accepts id (repeatable), "
+                "resourceId, activeOnly, and statusType query parameters; "
+                "supports pagination via page + pageSize."
+            ),
+            output_shape=(
+                "Object with symptoms[]; each entry carries id, "
+                "symptomDefinitionId, symptomDefinitionName, resourceId, "
+                "alertId (when rolled up into an alert), startTimeUTC, "
+                "cancelTimeUTC, severity, statusType, and "
+                "controlState."
+            ),
+            next_step=(
+                "Cross-reference symptomDefinitionId for policy context, "
+                "resourceId with vrops.resource.get for affected-object "
+                "detail, or alertId with vrops.alert.list for the "
+                "rolled-up alert."
+            ),
+        ),
+    ),
+    VropsCoreOp(
+        op_id="GET:/suite-api/api/recommendations",
+        group_key="vrops-recommendations",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list the recommendations vROps surfaces "
+                "alongside its alerts and symptoms — operator-facing "
+                "remediation hints. Accepts id (repeatable) and page + "
+                "pageSize query parameters."
+            ),
+            output_shape=(
+                "Object with recommendations[]; each entry carries id, "
+                "description (the operator-facing remediation text), and "
+                "actionId when an automated remediation action is linked."
+            ),
+            next_step=(
+                "Surface the recommendation description to the operator; "
+                "if actionId is set, the recommendation is "
+                "machine-actionable via the vROps action framework "
+                "(out of scope for v0.5 read core)."
+            ),
+        ),
+    ),
+    VropsCoreOp(
+        op_id="GET:/suite-api/api/supermetrics",
+        group_key="vrops-supermetrics",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to list user-defined super metrics — derived "
+                "metric formulae built from existing vROps metrics. "
+                "Accepts id (repeatable) and name query parameters; "
+                "supports pagination via page + pageSize."
+            ),
+            output_shape=(
+                "Object with superMetrics[]; each entry carries id, "
+                "name, description, formula (the metric expression), "
+                "and modificationTime."
+            ),
+            next_step=(
+                "Surface the formula and name to the operator; cross-"
+                "reference modificationTime when auditing recent "
+                "definition changes."
+            ),
+        ),
+    ),
+)
+
+
+async def apply_vrops_core_curation(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Apply the curated 8-op read core against an ingested vROps connector.
+
+    Drives the substrate so that, after this call returns, exactly
+    the 8 ops in :data:`VROPS_CORE_OPS` are dispatchable
+    (``is_enabled=True``) and every other ingested op stays
+    ``is_enabled=False``. The 7 curated groups land
+    ``review_status='enabled'`` so the agent's
+    :func:`~meho_backplane.operations.meta_tools.search_operations`
+    surfaces the core ops; non-curated groups are left untouched
+    (``review_status='staged'`` from the G0.7 ingest default).
+
+    The substrate doesn't expose "enable only ops X, Y, Z under
+    group G": :meth:`ReviewService.enable_group`'s cascade flips
+    ``is_enabled=True`` on every child op in the group. The helper
+    works around this via the audit-log-driven operator-override
+    exclusion — the same mechanism
+    :func:`~meho_backplane.connectors.nsx.core_ops.apply_nsx_core_curation`
+    and :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
+    established:
+
+    1. :meth:`ReviewService.get_review_payload` loads the current
+       state of every curated group and its child ops.
+    2. For each child op in a curated group that **isn't** in the
+       :data:`VROPS_CORE_OPS` allow-list,
+       :meth:`ReviewService.edit_op` with ``is_enabled=False``
+       writes the operator-override audit row. The follow-on
+       :meth:`enable_group` cascade detects these rows and skips
+       them.
+    3. :meth:`ReviewService.edit_group` lands the operator-reviewed
+       ``name`` + ``when_to_use`` on each curated group.
+    4. :meth:`ReviewService.enable_group` flips
+       ``review_status='enabled'`` and cascades ``is_enabled=True``
+       to the curated child ops (operator-overridden non-core ops
+       are skipped).
+    5. :meth:`ReviewService.edit_op` lands the curated
+       ``llm_instructions`` blob per entry in :data:`VROPS_CORE_OPS`.
+
+    Re-running is safe but not idempotent at the audit layer.
+    :meth:`enable_group` short-circuits on groups already in
+    ``review_status='enabled'`` (no audit row), but
+    :meth:`edit_group` and :meth:`edit_op` always emit one audit
+    row per call — even when the incoming value equals the
+    persisted one. The intended posture is a one-shot curation step
+    after ingest; re-runs produce redundant
+    ``meho.connector.edit_*`` audit rows but never corrupt state.
+
+    Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
+    if no groups exist for ``vrops-rest-9.0`` under *tenant_id* (the
+    operator must run ``meho connector ingest`` against the vROps
+    suite-api spec before this helper applies).
+    """
+    payload = await review_service.get_review_payload(
+        VROPS_CONNECTOR_ID,
+        tenant_id,
+    )
+
+    core_op_ids_by_group: dict[str, set[str]] = {}
+    for op in VROPS_CORE_OPS:
+        core_op_ids_by_group.setdefault(op.group_key, set()).add(op.op_id)
+
+    for group_payload in payload.groups:
+        allow_list = core_op_ids_by_group.get(group_payload.group_key)
+        if allow_list is None:
+            continue
+        for review_op in group_payload.ops:
+            if review_op.op_id in allow_list:
+                continue
+            await review_service.edit_op(
+                VROPS_CONNECTOR_ID,
+                review_op.op_id,
+                tenant_id=tenant_id,
+                is_enabled=False,
+            )
+            _log.info(
+                "vrops_non_core_op_disabled",
+                connector_id=VROPS_CONNECTOR_ID,
+                op_id=review_op.op_id,
+                group_key=group_payload.group_key,
+            )
+
+    for group in VROPS_CORE_GROUPS:
+        await review_service.edit_group(
+            VROPS_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+            name=group.name,
+            when_to_use=group.when_to_use,
+        )
+        await review_service.enable_group(
+            VROPS_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+        )
+        _log.info(
+            "vrops_core_group_enabled",
+            connector_id=VROPS_CONNECTOR_ID,
+            group_key=group.group_key,
+        )
+
+    for op in VROPS_CORE_OPS:
+        await review_service.edit_op(
+            VROPS_CONNECTOR_ID,
+            op.op_id,
+            tenant_id=tenant_id,
+            llm_instructions=op.llm_instructions,
+        )
+        _log.info(
+            "vrops_core_op_curated",
+            connector_id=VROPS_CONNECTOR_ID,
+            op_id=op.op_id,
+        )

--- a/backend/tests/acceptance/_vrops_canary_fixtures.py
+++ b/backend/tests/acceptance/_vrops_canary_fixtures.py
@@ -1,0 +1,537 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared minimal-setup fixtures for the G3.6 vROps dispatch tests.
+
+Two vROps acceptance modules (dispatch smoke + JSONFlux force-handle)
+share the same plumbing: a registered
+:class:`~meho_backplane.connectors.vcf_operations.VcfOperationsConnector`
+instance with a stub credentials loader (so no Vault read is required),
+a probed :class:`~meho_backplane.db.models.Target` row, the 8 curated
+:class:`~meho_backplane.db.models.EndpointDescriptor` rows from
+:data:`~meho_backplane.connectors.vcf_operations.core_ops.VROPS_CORE_OPS`,
+and a :mod:`respx`-mocked vROps REST surface answering each of the 8
+curated read ops.
+
+vROps uses HTTP Basic on every request — no session establish call is
+needed. The stub credentials loader bypasses the Vault-backed loader;
+the respx router matches requests by path.
+
+Why a minimal direct-insert path (not full G0.7 canary ingest)
+==============================================================
+
+The full vROps suite-api spec ingest via :class:`IngestionPipelineService`
+needs the vROps OpenAPI spec reachable on the CI runner plus a live
+LLM for the grouping pass. Until the spec-shelf is wired to the
+meho-runners pool, the dispatch leg is exercised against a minimal
+direct-insert path that seeds the 8 curated endpoint_descriptor rows
+by hand. Same pattern :mod:`tests.acceptance._nsx_canary_fixtures` and
+:mod:`tests.acceptance._harbor_canary_fixtures` established.
+
+``EndpointDescriptor.product`` vs ``Target.product`` note
+==========================================================
+
+Rows are inserted with ``product=VROPS_PRODUCT="vrops"`` — the value
+:func:`~meho_backplane.operations._lookup.parse_connector_id` derives
+from ``"vrops-rest-9.0"`` (first hyphen-segment of impl_id
+``"vrops-rest"``). Distinct from
+:attr:`VcfOperationsConnector.product` (``"vcf-operations"``) — same
+shape as the SDDC Manager case (``SddcManagerConnector.product="sddc-manager"``
+but rows carry ``product="sddc"``).
+
+The :class:`Target` row uses ``product=_TARGET_PRODUCT="vcf-operations"``
+so the resolver finds :class:`VcfOperationsConnector` (registered
+with ``product="vcf-operations"`` in the v2 registry). The descriptor /
+group rows use ``product=VROPS_PRODUCT="vrops"`` so the dispatcher's
+``parse_connector_id``-derived lookup hits them.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.connectors.vcf_operations import (
+    VROPS_CONNECTOR_ID,
+    VROPS_CORE_GROUPS,
+    VROPS_CORE_OPS,
+    VROPS_IMPL_ID,
+    VROPS_PRODUCT,
+    VROPS_VERSION,
+    VcfOperationsConnector,
+    VcfOperationsTargetLike,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+
+_PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")
+
+__all__ = [
+    "VROPS_CANARY_ALERTDEFS",
+    "VROPS_CANARY_ALERTS",
+    "VROPS_CANARY_BASE_URL",
+    "VROPS_CANARY_FINGERPRINT",
+    "VROPS_CANARY_OPERATOR_TENANT",
+    "VROPS_CANARY_RECOMMENDATIONS",
+    "VROPS_CANARY_RESOURCES",
+    "VROPS_CANARY_SUPERMETRICS",
+    "VROPS_CANARY_SYMPTOMS",
+    "VROPS_FORCE_HANDLE_LIST_OP_ID",
+    "VROPS_TARGET_NAME",
+    "IngestedVropsCanary",
+    "ingested_vrops_canary",
+    "vrops_acceptance_operator",
+]
+
+#: Tenant the vROps dispatch tests act under.
+VROPS_CANARY_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000fc")
+
+#: The connector-class-advertised ``product`` key (as registered in the
+#: v2 registry and as the resolver expects on a :class:`Target`). Distinct
+#: from :data:`VROPS_PRODUCT` (``"vrops"``), which is what
+#: :func:`parse_connector_id` derives from the connector_id slug — the
+#: SDDC Manager precedent codified this product-key split.
+_TARGET_PRODUCT: str = "vcf-operations"
+
+#: Stable :class:`Target.name` for the seeded vROps target.
+VROPS_TARGET_NAME: str = "vrops-acceptance"
+
+#: ``.test.invalid`` (RFC 6761 reserved) so no real network egress fires.
+VROPS_CANARY_BASE_URL: str = "https://vrops-canary.test.invalid"
+
+#: Persisted as :attr:`Target.fingerprint` — what the connector resolver
+#: reads to bind the target's ``product`` + ``version`` against the
+#: :class:`VcfOperationsConnector.supported_version_range` advertisement
+#: (``>=9.0,<10.0``). The probe route normally writes this dict at
+#: first-probe time; the dispatch tests seed it directly so the resolver
+#: binds the connector without a real probe round-trip.
+VROPS_CANARY_FINGERPRINT: dict[str, object] = FingerprintResult(
+    vendor="vmware",
+    product="vcf-operations",
+    version="9.0.0.1.23456789",
+    build="23456789",
+    reachable=True,
+    probed_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=UTC),
+    probe_method="GET /suite-api/api/versions/current",
+    extras={"humanly_readable_release_name": "VMware Aria Operations 9.0"},
+).model_dump(mode="json")
+
+#: The list op the JSONFlux force-handle test dispatches. Resources is
+#: the largest surface in a real vROps deployment (hundreds to
+#: thousands of monitored objects), mirroring the NSX segment-list and
+#: SDDC host-list choices.
+VROPS_FORCE_HANDLE_LIST_OP_ID: str = "GET:/suite-api/api/resources"
+
+#: Synthetic resource list — 10 rows so the force-handle reducer sees
+#: a populated set with a sample-row slice. vROps' suite-api wraps
+#: resources under a ``resourceList`` key (not ``results`` / ``value``);
+#: the force-handle test's reducer falls through the unknown-key branch
+#: but still counts the rows correctly via the dict-with-list discovery
+#: loop.
+VROPS_CANARY_RESOURCES: dict[str, object] = {
+    "resourceList": [
+        {
+            "identifier": f"00000000-0000-4000-8000-{i:012x}",
+            "resourceKey": {
+                "name": f"vm-canary-{i:02d}",
+                "adapterKindKey": "VMWARE",
+                "resourceKindKey": "VirtualMachine",
+                "resourceIdentifiers": [
+                    {"identifierType": {"name": "VMEntityObjectID"}, "value": f"vm-{i}"},
+                ],
+            },
+            "creationTime": 1716480000000 + i,
+            "resourceStatusStates": [
+                {
+                    "adapterInstanceId": f"00000000-0000-4000-8000-{i:012x}",
+                    "resourceStatus": "DATA_RECEIVING",
+                    "resourceState": "STARTED",
+                }
+            ],
+            "credentialInstanceId": None,
+        }
+        for i in range(10)
+    ],
+    "pageInfo": {"totalCount": 10, "page": 0, "pageSize": 1000},
+    "links": [{"href": "/suite-api/api/resources", "rel": "SELF", "name": "current"}],
+}
+
+#: Synthetic resource detail — one row matching the first resource in
+#: the list above.
+VROPS_CANARY_RESOURCE_DETAIL: dict[str, object] = {
+    "identifier": "00000000-0000-4000-8000-000000000000",
+    "resourceKey": {
+        "name": "vm-canary-00",
+        "adapterKindKey": "VMWARE",
+        "resourceKindKey": "VirtualMachine",
+        "resourceIdentifiers": [{"identifierType": {"name": "VMEntityObjectID"}, "value": "vm-0"}],
+    },
+    "creationTime": 1716480000000,
+    "resourceStatusStates": [
+        {
+            "adapterInstanceId": "00000000-0000-4000-8000-000000000000",
+            "resourceStatus": "DATA_RECEIVING",
+            "resourceState": "STARTED",
+        }
+    ],
+    "credentialInstanceId": None,
+}
+
+#: Synthetic alert list — two active alerts.
+VROPS_CANARY_ALERTS: dict[str, object] = {
+    "alerts": [
+        {
+            "alertId": "00000000-0000-4000-9000-000000000001",
+            "alertDefinitionId": "AlertDefinition-VirtualMachine-CPU-Demand",
+            "alertDefinitionName": "Virtual machine has high CPU demand",
+            "alertLevel": 3,
+            "alertImpact": "performance",
+            "resourceId": "00000000-0000-4000-8000-000000000000",
+            "startTimeUTC": 1716480000000,
+            "cancelTimeUTC": 0,
+            "status": "ACTIVE",
+            "controlState": "OPEN",
+        },
+        {
+            "alertId": "00000000-0000-4000-9000-000000000002",
+            "alertDefinitionId": "AlertDefinition-Datastore-Capacity",
+            "alertDefinitionName": "Datastore is running out of capacity",
+            "alertLevel": 4,
+            "alertImpact": "capacity",
+            "resourceId": "00000000-0000-4000-8000-000000000001",
+            "startTimeUTC": 1716480100000,
+            "cancelTimeUTC": 0,
+            "status": "ACTIVE",
+            "controlState": "OPEN",
+        },
+    ],
+    "pageInfo": {"totalCount": 2, "page": 0, "pageSize": 1000},
+    "links": [{"href": "/suite-api/api/alerts", "rel": "SELF", "name": "current"}],
+}
+
+#: Synthetic alert-definition list — one entry covering the two alerts above.
+VROPS_CANARY_ALERTDEFS: dict[str, object] = {
+    "alertDefinitions": [
+        {
+            "id": "AlertDefinition-VirtualMachine-CPU-Demand",
+            "name": "Virtual machine has high CPU demand",
+            "description": "Fires when CPU demand exceeds the configured threshold.",
+            "adapterKindKey": "VMWARE",
+            "resourceKindKey": "VirtualMachine",
+            "waitCycles": 1,
+            "cancelCycles": 1,
+            "type": 16,
+            "subType": 18,
+            "states": [
+                {
+                    "severity": "WARNING",
+                    "base-symptom-set": {
+                        "type": "SYMPTOM_SET",
+                        "relation": "SELF",
+                        "aggregation": "ALL",
+                        "symptomSetOperator": "AND",
+                        "symptomDefinitionIds": ["SymptomDefinition-CPU-Demand"],
+                    },
+                    "recommendation-priority-map": [
+                        {"recommendationId": "Rec-CPU-Demand", "priority": 1}
+                    ],
+                    "impact": {"impactType": "RISK"},
+                }
+            ],
+        }
+    ],
+    "pageInfo": {"totalCount": 1, "page": 0, "pageSize": 1000},
+    "links": [{"href": "/suite-api/api/alertdefinitions", "rel": "SELF", "name": "current"}],
+}
+
+#: Synthetic symptom list — one firing symptom.
+VROPS_CANARY_SYMPTOMS: dict[str, object] = {
+    "symptoms": [
+        {
+            "id": "00000000-0000-4000-a000-000000000001",
+            "symptomDefinitionId": "SymptomDefinition-CPU-Demand",
+            "symptomDefinitionName": "CPU demand high",
+            "resourceId": "00000000-0000-4000-8000-000000000000",
+            "alertId": "00000000-0000-4000-9000-000000000001",
+            "startTimeUTC": 1716480000000,
+            "cancelTimeUTC": 0,
+            "severity": "WARNING",
+            "statusType": "ACTIVE",
+            "controlState": "OPEN",
+        }
+    ],
+    "pageInfo": {"totalCount": 1, "page": 0, "pageSize": 1000},
+    "links": [{"href": "/suite-api/api/symptoms", "rel": "SELF", "name": "current"}],
+}
+
+#: Synthetic recommendation list — one operator-facing remediation hint.
+VROPS_CANARY_RECOMMENDATIONS: dict[str, object] = {
+    "recommendations": [
+        {
+            "id": "Rec-CPU-Demand",
+            "description": (
+                "Reduce the workload on the virtual machine or increase its CPU allocation."
+            ),
+            "actionId": None,
+        }
+    ],
+    "pageInfo": {"totalCount": 1, "page": 0, "pageSize": 1000},
+    "links": [{"href": "/suite-api/api/recommendations", "rel": "SELF", "name": "current"}],
+}
+
+#: Synthetic super-metric list — one user-defined formula.
+VROPS_CANARY_SUPERMETRICS: dict[str, object] = {
+    "superMetrics": [
+        {
+            "id": "00000000-0000-4000-b000-000000000001",
+            "name": "host-cpu-overprovision-ratio",
+            "description": "Ratio of provisioned vCPUs to physical cores across hosts.",
+            "formula": "sum(${this, metric=cpu|provisioned}) / sum(${this, metric=cpu|physical})",
+            "modificationTime": 1716480000000,
+        }
+    ],
+    "pageInfo": {"totalCount": 1, "page": 0, "pageSize": 1000},
+    "links": [{"href": "/suite-api/api/supermetrics", "rel": "SELF", "name": "current"}],
+}
+
+#: Synthetic version response (the ``vrops.about`` op).
+VROPS_CANARY_VERSION: dict[str, object] = {
+    "releaseName": "9.0.0.1.23456789",
+    "buildNumber": 23456789,
+    "humanlyReadableReleaseName": "VMware Aria Operations 9.0",
+}
+
+
+@dataclass(frozen=True)
+class IngestedVropsCanary:
+    """Bundle returned by :func:`ingested_vrops_canary`.
+
+    Same shape as :class:`tests.acceptance._nsx_canary_fixtures.IngestedNsxCanary`
+    so the assertion patterns transfer over verbatim.
+    """
+
+    operator: Operator
+    connector_id: str
+    target_name: str
+    base_url: str
+
+
+async def _insert_vrops_descriptors() -> None:
+    """Seed the 8 curated vROps core ops + their groups as enabled rows.
+
+    One :class:`OperationGroup` per entry in
+    :data:`~meho_backplane.connectors.vcf_operations.core_ops.VROPS_CORE_GROUPS`
+    (``review_status='enabled'``), one :class:`EndpointDescriptor` per
+    entry in
+    :data:`~meho_backplane.connectors.vcf_operations.core_ops.VROPS_CORE_OPS`
+    (``is_enabled=True``, ``source_kind='ingested'``, ``handler_ref=None``).
+
+    The ``vrops-resources`` group carries two ops (list + get by id);
+    the helper coalesces them into one inserted group row so the FK to
+    ``operation_group.id`` resolves correctly on both ops.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, UUID] = {}
+    async with sessionmaker() as session:
+        for group in VROPS_CORE_GROUPS:
+            group_row = OperationGroup(
+                tenant_id=None,
+                product=VROPS_PRODUCT,
+                version=VROPS_VERSION,
+                impl_id=VROPS_IMPL_ID,
+                group_key=group.group_key,
+                name=group.name,
+                when_to_use=group.when_to_use,
+                review_status="enabled",
+            )
+            session.add(group_row)
+            await session.flush()
+            group_ids[group.group_key] = group_row.id
+
+        for op in VROPS_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            descriptor = EndpointDescriptor(
+                tenant_id=None,
+                product=VROPS_PRODUCT,
+                version=VROPS_VERSION,
+                impl_id=VROPS_IMPL_ID,
+                op_id=op.op_id,
+                source_kind="ingested",
+                method=method,
+                path=path,
+                handler_ref=None,
+                group_id=group_ids[op.group_key],
+                summary=f"vROps core op {op.op_id} (curated read).",
+                description=f"vROps core op {op.op_id} (curated read).",
+                parameter_schema=_param_schema_for(path),
+                response_schema={"type": "object"},
+                llm_instructions=op.llm_instructions,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                tags=["spec:vcf-operations-9.0/suite-api.yaml"],
+            )
+            session.add(descriptor)
+        await session.commit()
+
+
+def _param_schema_for(path: str) -> dict[str, object]:
+    """Build a minimal ``parameter_schema`` for each ``{var}`` in *path*.
+
+    Mirrors :func:`tests.acceptance._nsx_canary_fixtures._param_schema_for`.
+    vROps paths carry up to one path variable (``{id}`` on the
+    ``vrops.resource.get`` op).
+    """
+    placeholders = _PATH_VAR_RE.findall(path)
+    if not placeholders:
+        return {"type": "object", "properties": {}}
+    return {
+        "type": "object",
+        "properties": {
+            name: {"type": "string", "x-meho-param-loc": "path"} for name in placeholders
+        },
+        "required": list(placeholders),
+    }
+
+
+async def _vrops_credentials_loader(_target: VcfOperationsTargetLike) -> dict[str, str]:
+    """Stub credentials loader — bypasses the not-yet-wired Vault read.
+
+    The respx routes accept any Basic-auth header, so the values are
+    illustrative. Mirrors the same pattern
+    :func:`tests.acceptance._harbor_canary_fixtures._harbor_credentials_loader`
+    uses for Harbor.
+    """
+    return {"username": "vrops-canary-svc", "password": "vrops-canary-pw"}
+
+
+def _register_vrops_routes(mock: respx.MockRouter) -> None:
+    """Register the 8 vROps read-op routes on *mock*.
+
+    vROps uses HTTP Basic on every request — no session establish
+    call is needed. Each route returns a pre-seeded JSON body. The
+    one templated path (``/suite-api/api/resources/{id}``) is
+    registered for the specific id the smoke test dispatches
+    against.
+    """
+    mock.get("/suite-api/api/versions/current").respond(200, json=VROPS_CANARY_VERSION)
+    mock.get("/suite-api/api/resources").respond(200, json=VROPS_CANARY_RESOURCES)
+    mock.get("/suite-api/api/resources/00000000-0000-4000-8000-000000000000").respond(
+        200, json=VROPS_CANARY_RESOURCE_DETAIL
+    )
+    mock.get("/suite-api/api/alerts").respond(200, json=VROPS_CANARY_ALERTS)
+    mock.get("/suite-api/api/alertdefinitions").respond(200, json=VROPS_CANARY_ALERTDEFS)
+    mock.get("/suite-api/api/symptoms").respond(200, json=VROPS_CANARY_SYMPTOMS)
+    mock.get("/suite-api/api/recommendations").respond(200, json=VROPS_CANARY_RECOMMENDATIONS)
+    mock.get("/suite-api/api/supermetrics").respond(200, json=VROPS_CANARY_SUPERMETRICS)
+
+
+@pytest.fixture
+def vrops_acceptance_operator() -> Operator:
+    """Frozen :class:`Operator` the vROps dispatch tests act as."""
+    return Operator(
+        sub="g36-vrops-acceptance",
+        name="G3.6-T2 vROps Acceptance",
+        email=None,
+        raw_jwt="<vrops-acceptance-raw-jwt>",
+        tenant_id=VROPS_CANARY_OPERATOR_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+@pytest.fixture
+async def ingested_vrops_canary(
+    pg_engine: None,
+    vrops_acceptance_operator: Operator,
+) -> AsyncIterator[IngestedVropsCanary]:
+    """Yield a dispatcher-ready vROps setup over a respx-mocked appliance.
+
+    Setup mirrors :func:`tests.acceptance._harbor_canary_fixtures.ingested_harbor_canary`:
+
+    1. Insert built-in :class:`OperationGroup` + :class:`EndpointDescriptor`
+       rows for the 8 curated vROps core ops.
+    2. Seed a :class:`Target` with ``product="vcf-operations"`` and the
+       :data:`VROPS_CANARY_FINGERPRINT` so the resolver binds
+       :class:`VcfOperationsConnector`.
+    3. Resolve + cache the :class:`VcfOperationsConnector` instance the
+       dispatcher will use, patching only its ``_creds._loader`` so no
+       Vault read fires.
+    4. Activate a respx router for :data:`VROPS_CANARY_BASE_URL` and
+       register the vROps REST surface.
+    """
+    await _insert_vrops_descriptors()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=VROPS_CANARY_OPERATOR_TENANT,
+            name=VROPS_TARGET_NAME,
+            aliases=[],
+            # Target.product matches the connector class's registry key
+            # (``"vcf-operations"``), not the parse_connector_id-derived
+            # ``"vrops"`` the descriptor / group rows use. See module
+            # docstring "EndpointDescriptor.product vs Target.product".
+            product=_TARGET_PRODUCT,
+            host=VROPS_CANARY_BASE_URL.removeprefix("https://"),
+            port=443,
+            fqdn=None,
+            secret_ref="kv/data/vrops/vrops-canary",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=VROPS_CANARY_FINGERPRINT,
+            notes="seeded by tests.acceptance._vrops_canary_fixtures.ingested_vrops_canary",
+        )
+        session.add(target)
+        await session.commit()
+
+    registry = all_connectors_v2()
+    connector_cls = registry.get((_TARGET_PRODUCT, VROPS_VERSION, VROPS_IMPL_ID))
+    if connector_cls is None:
+        import importlib
+
+        import meho_backplane.connectors.vcf_operations as _vrops_pkg
+
+        importlib.reload(_vrops_pkg)
+        registry = all_connectors_v2()
+        connector_cls = registry.get((_TARGET_PRODUCT, VROPS_VERSION, VROPS_IMPL_ID))
+
+    assert connector_cls is VcfOperationsConnector, (
+        f"expected VcfOperationsConnector registered for "
+        f"({_TARGET_PRODUCT}, {VROPS_VERSION}, {VROPS_IMPL_ID}); "
+        f"got {connector_cls!r}"
+    )
+
+    instance = get_or_create_connector_instance(connector_cls)
+    # Patch the shared CredentialsCache's loader so no Vault read fires.
+    # The cache itself is preserved (its lock + cache dict survive across
+    # tests) and the next ``get(target)`` call lifts the stub credentials.
+    instance._creds._loader = _vrops_credentials_loader  # type: ignore[attr-defined]
+
+    async with respx.mock(
+        base_url=VROPS_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_vrops_routes(mock)
+        try:
+            yield IngestedVropsCanary(
+                operator=vrops_acceptance_operator,
+                connector_id=VROPS_CONNECTOR_ID,
+                target_name=VROPS_TARGET_NAME,
+                base_url=VROPS_CANARY_BASE_URL,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -88,6 +88,12 @@ from tests.acceptance._vcsim import (
     VcsimTopology,
     resolve_vcsim_endpoint,
 )
+from tests.acceptance._vrops_canary_fixtures import (
+    VROPS_CANARY_OPERATOR_TENANT,
+    IngestedVropsCanary,
+    ingested_vrops_canary,
+    vrops_acceptance_operator,
+)
 from tests.integration.conftest import (
     _CHASSIS_ENV,
     DOCKER_AVAILABLE,
@@ -105,10 +111,12 @@ __all__ = [
     "NSX_CANARY_OPERATOR_TENANT",
     "SDDC_CANARY_OPERATOR_TENANT",
     "SKIP_REASON",
+    "VROPS_CANARY_OPERATOR_TENANT",
     "IngestedCanaryVcsim",
     "IngestedHarborCanary",
     "IngestedNsxCanary",
     "IngestedSddcCanary",
+    "IngestedVropsCanary",
     "VcsimEndpoint",
     "VcsimTopology",
     "acceptance_operator",
@@ -118,12 +126,14 @@ __all__ = [
     "ingested_harbor_canary",
     "ingested_nsx_canary",
     "ingested_sddc_canary",
+    "ingested_vrops_canary",
     "integration_env",
     "nsx_acceptance_operator",
     "pg_engine",
     "prewarmed_embeddings",
     "sddc_acceptance_operator",
     "vcsim_endpoint",
+    "vrops_acceptance_operator",
 ]
 
 

--- a/backend/tests/acceptance/test_g36_vrops_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g36_vrops_dispatch_smoke.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.6-T2 dispatch smoke — the 8 curated vROps read ops over respx.
+
+Closes the substrate-proves-out half of the vROps v0.5 ship for
+Initiative #369: each entry in
+:data:`~meho_backplane.connectors.vcf_operations.core_ops.VROPS_CORE_OPS`
+is dispatched against a respx-mocked vROps appliance and the
+dispatcher returns a structured
+:class:`~meho_backplane.connectors.schemas.OperationResult` for every
+one.
+
+The full env-gated suite-api ingestion canary (live
+``vcf-operations-9.0/suite-api.yaml`` through
+:class:`IngestionPipelineService`) is a follow-up to this Task — it
+requires the vROps spec-shelf wired to the meho-runners pool, the
+same env-gated pattern :mod:`tests.acceptance._vcenter_spec` codifies
+for vSphere. Until then, the dispatch leg is exercised directly
+against the curated descriptor set the :data:`VROPS_CORE_OPS`
+constants describe — same posture
+:mod:`tests.acceptance.test_g35_nsx_dispatch_smoke` took for NSX.
+
+Why respx and not a real vROps appliance: vROps has no public CI
+simulator. respx mocks the exact wire contract the connector calls,
+so the Basic-auth header + per-op HTTP request all fire through the
+connector's real pooled :class:`httpx.AsyncClient`.
+
+Skip conditions:
+
+* No Postgres — the ``pg_engine`` fixture skips when the integration
+  database isn't reachable (same gate as every DB-backed acceptance
+  test).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.connectors.vcf_operations import VROPS_CORE_OPS
+from meho_backplane.operations.meta_tools import call_operation
+from tests.acceptance._vrops_canary_fixtures import IngestedVropsCanary
+
+#: Op ids the smoke test dispatches. Sourced from
+#: :data:`~meho_backplane.connectors.vcf_operations.VROPS_CORE_OPS`;
+#: one of them carries a path template (``{id}`` on
+#: ``vrops.resource.get``) that needs substitution at dispatch
+#: time. The smoke supplies the canary resource's UUID so the
+#: substituted URL hits the registered respx route.
+SMOKE_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VROPS_CORE_OPS)
+
+#: Per-op parameter map. Op ids without ``{var}`` templates get an
+#: empty dict (the respx route matches by literal path); the one
+#: resource-by-id op gets the substitution matching the seeded
+#: ``VROPS_CANARY_RESOURCE_DETAIL`` mock route.
+SMOKE_PARAMS: dict[str, dict[str, object]] = {
+    "GET:/suite-api/api/resources/{id}": {
+        "id": "00000000-0000-4000-8000-000000000000",
+    },
+}
+
+
+@pytest.mark.parametrize("op_id", SMOKE_OP_IDS, ids=lambda op: op)
+async def test_dispatch_smoke_vrops_core_op_returns_ok(
+    op_id: str,
+    ingested_vrops_canary: IngestedVropsCanary,
+) -> None:
+    """Each curated vROps core op dispatches over respx and returns ``status='ok'``.
+
+    Per-op parameterisation surfaces in CI's report as one test case
+    per op; a single regressing op fails its own case and leaves the
+    others green. Asserting only ``status='ok'`` (not the shape of
+    ``result``) keeps the smoke focused on the dispatch leg — payload
+    shape is the JSONFlux force-handle test's job.
+
+    ``call_operation`` is the agent surface so the smoke drives the
+    same code path the LLM-driven agent would, not the direct
+    ``dispatch()`` API.
+    """
+    params = SMOKE_PARAMS.get(op_id, {})
+    result = await call_operation(
+        ingested_vrops_canary.operator,
+        {
+            "connector_id": ingested_vrops_canary.connector_id,
+            "op_id": op_id,
+            "target": {"name": ingested_vrops_canary.target_name},
+            "params": params,
+        },
+    )
+
+    assert result["status"] == "ok", (
+        f"vROps op {op_id!r} failed against the respx-mocked vROps appliance at "
+        f"{ingested_vrops_canary.base_url}: {result.get('error')!r}; "
+        f"full result={result!r}"
+    )

--- a/backend/tests/acceptance/test_g36_vrops_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_g36_vrops_jsonflux_force_handle.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.6-T2 JSONFlux force-mode acceptance for the vROps connector.
+
+v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
+— the production reducer never produces a :class:`ResultHandle`. The
+real reducer (set-shaped payload reduction, MinIO/S3 spill,
+``result_query`` / ``result_aggregate`` meta-tools) is **explicitly
+out of scope** at the Goal #214 level.
+
+This test mirrors :mod:`tests.acceptance.test_g35_nsx_jsonflux_force_handle`
+verbatim, swapping in vROps as the dispatched connector: it installs
+a test-only :class:`ForceHandleReducer` that wraps every payload in a
+synthetic handle, dispatches ``GET:/suite-api/api/resources`` against
+the seeded vROps core, and asserts the
+:class:`~meho_backplane.connectors.schemas.OperationResult`'s
+``handle`` field carries a populated :class:`ResultHandle`.
+
+vROps' suite-api wraps list payloads under noun-specific keys
+(``resourceList``, ``alerts``, ``symptoms``, etc.) rather than the
+generic ``results`` / ``value`` keys NSX and vSphere use. The
+:class:`ForceHandleReducer` below adds the noun-specific keys to its
+discovery loop so the dispatcher-seam test still observes the
+expected row count without leaking vendor-specific shape into the
+production reducer ABC.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+from tests.acceptance._vrops_canary_fixtures import (
+    VROPS_CANARY_RESOURCES,
+    VROPS_FORCE_HANDLE_LIST_OP_ID,
+    IngestedVropsCanary,
+)
+
+
+class ForceHandleReducer:
+    """Test-only reducer that always produces a :class:`ResultHandle`.
+
+    Recognises both the cross-connector list shapes (``elements``,
+    ``results``, ``value``) and the vROps-specific wrapper keys
+    (``resourceList``, ``alerts``, ``alertDefinitions``, ``symptoms``,
+    ``recommendations``, ``superMetrics``).
+
+    * ``list`` → total = ``len(payload)``.
+    * ``dict`` with one of the recognised list-wrapper keys → rows = the
+      wrapped list.
+    * Anything else → total = 1, sample = ().
+    """
+
+    _LIST_KEYS: tuple[str, ...] = (
+        "elements",
+        "results",
+        "value",
+        "resourceList",
+        "alerts",
+        "alertDefinitions",
+        "symptoms",
+        "recommendations",
+        "superMetrics",
+    )
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        """Always return ``(summary_dict, ResultHandle)``."""
+        del schema, context
+        if isinstance(payload, list):
+            total = len(payload)
+            sample = tuple(payload[:5]) if payload else ()
+        elif isinstance(payload, dict):
+            for key in self._LIST_KEYS:
+                rows = payload.get(key)
+                if isinstance(rows, list):
+                    total = len(rows)
+                    sample = tuple(rows[:5]) if rows else ()
+                    break
+            else:
+                total = 1
+                sample = ()
+        else:
+            total = 1
+            sample = ()
+
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"force-mode handle ({total} rows)",
+            schema_={"type": "array", "items": {"type": "object"}},
+            total_rows=total,
+            sample_rows=sample if sample else None,
+            ttl_seconds=3600,
+        )
+        summary = {"row_count": total, "sample": list(sample)}
+        return summary, handle
+
+
+@pytest.fixture
+def force_handle_reducer() -> Any:
+    """Install :class:`ForceHandleReducer` as the dispatcher's default."""
+    set_default_reducer(ForceHandleReducer())
+    try:
+        yield
+    finally:
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+
+async def test_force_handle_reducer_populates_operation_result_handle_for_vrops(
+    force_handle_reducer: None,
+    ingested_vrops_canary: IngestedVropsCanary,
+) -> None:
+    """Dispatching the vROps resource list populates ``OperationResult.handle``.
+
+    Confirms the JSONFlux dispatcher seam end-to-end for vROps:
+
+    * ``status == 'ok'`` — dispatch succeeded (HTTP Basic + GET
+      against the resource-list path).
+    * ``handle`` is a :class:`ResultHandle` — the reducer's return
+      value flowed through ``wrap_ok_result``.
+    * ``handle.total_rows`` matches the seeded resource count from
+      :data:`VROPS_CANARY_RESOURCES`.
+    * ``handle.summary_md`` is non-empty and mentions the row count —
+      the reducer composed its summary correctly.
+    * ``handle.schema_`` is a non-empty mapping.
+    * ``handle.sample_rows`` is populated — ≥1 row from the seeded
+      resource list.
+    * ``result['row_count']`` matches the handle's total — the
+      dispatcher inlined the reducer's summary on the operation
+      envelope (not the raw resource list).
+    """
+    resource_list = VROPS_CANARY_RESOURCES["resourceList"]
+    assert isinstance(resource_list, list)
+    expected_rows = len(resource_list)
+
+    result_envelope = await call_operation(
+        ingested_vrops_canary.operator,
+        {
+            "connector_id": ingested_vrops_canary.connector_id,
+            "op_id": VROPS_FORCE_HANDLE_LIST_OP_ID,
+            "target": {"name": ingested_vrops_canary.target_name},
+            "params": {},
+        },
+    )
+
+    assert result_envelope["status"] == "ok", (
+        f"force-handle dispatch did not succeed: {result_envelope!r}"
+    )
+
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        f"expected OperationResult.handle to be populated by "
+        f"ForceHandleReducer; got handle=None on envelope={result_envelope!r}"
+    )
+    uuid.UUID(handle["handle_id"])
+    assert handle["total_rows"] == expected_rows, (
+        f"expected {expected_rows} resources from the seeded VROPS_CANARY_RESOURCES; "
+        f"got handle.total_rows={handle['total_rows']}"
+    )
+    assert handle["summary_md"], "handle.summary_md must be non-empty"
+    assert str(expected_rows) in handle["summary_md"], (
+        f"expected summary_md to mention the row count; got {handle['summary_md']!r}"
+    )
+    assert isinstance(handle["schema_"], dict) and handle["schema_"], (
+        f"handle.schema_ must be a non-empty mapping; got {handle['schema_']!r}"
+    )
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        f"expected ≥1 sample row from the seeded resource list; got sample_rows={sample_rows!r}"
+    )
+
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == expected_rows, (
+        f"expected the reducer's summary on result; got result={payload!r}"
+    )

--- a/backend/tests/test_connectors_vcf_operations_core_ops.py
+++ b/backend/tests/test_connectors_vcf_operations_core_ops.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the vROps read-only v0.5 core-ops curation.
+
+Covers :mod:`meho_backplane.connectors.vcf_operations.core_ops`:
+
+* :func:`classify_vrops_op` — path classifier rules for vROps' flat
+  ``/suite-api/api/...`` path structure. Validates that the
+  ``/alertdefinitions`` rule precedes the ``/alerts`` rule (the only
+  rule-ordering hazard in the vROps surface).
+* :data:`VROPS_CORE_OPS` and :data:`VROPS_CORE_GROUPS` — every entry
+  carries non-placeholder ``llm_instructions`` / ``when_to_use`` text
+  (the AC's "non-empty reviewed text" gate).
+* :func:`apply_vrops_core_curation` — the operator-review-time
+  substrate call that flips ``review_status='enabled'`` on the 7
+  curated groups, lands ``llm_instructions`` on the 8 curated ops,
+  and explicitly disables non-core ops via the audit-log-driven
+  operator-override exclusion. The load-bearing assertion is "8 ops
+  dispatchable, every other op in curated groups stays
+  ``is_enabled=False``".
+
+Test harness mirrors :mod:`tests.test_connectors_harbor_core_ops`:
+SQLite via the autouse ``_default_database_url`` fixture, hand-rolled
+operator + connector seeding, audit-row counting from the chassis
+``audit_log`` table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.vcf_operations import (
+    VROPS_CORE_GROUPS,
+    VROPS_CORE_OPS,
+    VROPS_IMPL_ID,
+    VROPS_PRODUCT,
+    VROPS_VERSION,
+    apply_vrops_core_curation,
+    classify_vrops_op,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import ReviewService
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env vars Operator construction reads transitively."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+_FAKE_JWT = "header.payload.signature"
+
+
+def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
+    """Build a tenant-admin :class:`Operator` for the curation tests."""
+    return Operator(
+        sub=f"vrops-core-ops-test-{uuid.uuid4()}",
+        name="vROps Core Ops Test",
+        email=None,
+        raw_jwt=_FAKE_JWT,
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify_vrops_op — path classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,expected_group",
+    [
+        ("GET:/suite-api/api/versions/current", "vrops-system"),
+        ("GET:/suite-api/api/resources", "vrops-resources"),
+        ("GET:/suite-api/api/resources/{id}", "vrops-resources"),
+        ("GET:/suite-api/api/alerts", "vrops-alerts"),
+        ("GET:/suite-api/api/alertdefinitions", "vrops-alert-definitions"),
+        ("GET:/suite-api/api/symptoms", "vrops-symptoms"),
+        ("GET:/suite-api/api/recommendations", "vrops-recommendations"),
+        ("GET:/suite-api/api/supermetrics", "vrops-supermetrics"),
+        # Non-curated paths → "none"
+        ("GET:/suite-api/api/credentialkinds", "none"),
+        ("GET:/suite-api/api/auth/sources", "none"),
+        # Non-GET → "none"
+        ("POST:/suite-api/api/resources", "none"),
+        ("DELETE:/suite-api/api/alerts/{id}", "none"),
+        # Malformed op_id → "none"
+        ("bad-op-id-no-colon", "none"),
+    ],
+    ids=str,
+)
+def test_classify_vrops_op_returns_correct_group(op_id: str, expected_group: str) -> None:
+    """classify_vrops_op returns the curated group_key for every core op."""
+    assert classify_vrops_op(op_id) == expected_group
+
+
+def test_classify_vrops_op_alertdefinitions_precedes_alerts_rule() -> None:
+    """The ``/alertdefinitions`` path classifies as vrops-alert-definitions.
+
+    Load-bearing rule-ordering: ``startswith("/suite-api/api/alerts")``
+    would otherwise eat the longer ``/suite-api/api/alertdefinitions``
+    path and misclassify it.
+    """
+    assert classify_vrops_op("GET:/suite-api/api/alertdefinitions") == "vrops-alert-definitions"
+    # And the alerts path stays in vrops-alerts.
+    assert classify_vrops_op("GET:/suite-api/api/alerts") == "vrops-alerts"
+
+
+def test_classify_vrops_op_all_core_ops_are_classified() -> None:
+    """Every op in VROPS_CORE_OPS classifies to its declared group_key."""
+    for op in VROPS_CORE_OPS:
+        group = classify_vrops_op(op.op_id)
+        assert group != "none", (
+            f"VROPS_CORE_OPS entry {op.op_id!r} classified as 'none' — "
+            "check VROPS_PATH_RULES ordering"
+        )
+        assert group == op.group_key, (
+            f"VROPS_CORE_OPS entry {op.op_id!r} classified as {group!r} "
+            f"but declared group_key={op.group_key!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Curation data invariants
+# ---------------------------------------------------------------------------
+
+
+def test_vrops_core_ops_count_is_eight_and_read_only() -> None:
+    """VROPS_CORE_OPS ships exactly the 8 read-only core ops per #833."""
+    assert len(VROPS_CORE_OPS) == 8, (
+        f"expected exactly 8 vROps core ops per #833 AC; got {len(VROPS_CORE_OPS)}"
+    )
+    for op in VROPS_CORE_OPS:
+        assert op.op_id.startswith("GET:"), (
+            f"vROps core op {op.op_id!r} must be a GET (v0.5 read-only core)"
+        )
+
+
+def test_vrops_core_groups_count_is_seven_and_unique() -> None:
+    """VROPS_CORE_GROUPS spans the 7 vROps groups the 8 ops fall into."""
+    assert len(VROPS_CORE_GROUPS) == 7, (
+        f"expected exactly 7 vROps core groups; got {len(VROPS_CORE_GROUPS)}"
+    )
+    group_keys = [g.group_key for g in VROPS_CORE_GROUPS]
+    assert len(set(group_keys)) == len(group_keys), (
+        f"VROPS_CORE_GROUPS has duplicate group_keys: {group_keys!r}"
+    )
+    # Every op's group_key must resolve to a real group.
+    op_group_keys = {op.group_key for op in VROPS_CORE_OPS}
+    assert op_group_keys.issubset(set(group_keys)), (
+        f"VROPS_CORE_OPS reference unknown groups: {op_group_keys - set(group_keys)!r}"
+    )
+
+
+def test_vrops_core_ops_llm_instructions_all_populated() -> None:
+    """Every op has non-empty, non-placeholder llm_instructions with canonical keys.
+
+    Asserts the AC bar: "every enabled op carries reviewed
+    `llm_instructions`" — surfaces a regression where a future edit
+    accidentally drops one of the three required keys or leaves a
+    placeholder string in place.
+    """
+    required_keys = {"when_to_call", "output_shape", "next_step"}
+    for op in VROPS_CORE_OPS:
+        assert op.llm_instructions, f"op {op.op_id!r} has empty llm_instructions"
+        missing = required_keys - set(op.llm_instructions)
+        assert not missing, f"op {op.op_id!r} llm_instructions missing keys: {missing}"
+        for key in required_keys:
+            val = op.llm_instructions[key]
+            assert isinstance(val, str) and val.strip(), (
+                f"op {op.op_id!r} llm_instructions[{key!r}] must be a non-empty string"
+            )
+            # Reject obvious placeholders to enforce "operator-reviewed".
+            assert "placeholder" not in val.lower(), (
+                f"op {op.op_id!r} llm_instructions[{key!r}] contains placeholder text"
+            )
+            assert "tbd" not in val.lower(), (
+                f"op {op.op_id!r} llm_instructions[{key!r}] contains TBD"
+            )
+
+
+def test_vrops_core_groups_when_to_use_all_populated() -> None:
+    """Every group has non-empty, non-placeholder when_to_use + name."""
+    for group in VROPS_CORE_GROUPS:
+        assert group.when_to_use and group.when_to_use.strip(), (
+            f"group {group.group_key!r} has empty when_to_use"
+        )
+        assert group.name and group.name.strip(), f"group {group.group_key!r} has empty name"
+        assert "placeholder" not in group.when_to_use.lower(), (
+            f"group {group.group_key!r} when_to_use contains placeholder text"
+        )
+        assert "tbd" not in group.when_to_use.lower(), (
+            f"group {group.group_key!r} when_to_use contains TBD"
+        )
+
+
+# ---------------------------------------------------------------------------
+# apply_vrops_core_curation — substrate integration (SQLite)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_curated_groups_and_ops(
+    *,
+    tenant_id: uuid.UUID,
+    extra_ops_per_group: int = 0,
+) -> dict[str, uuid.UUID]:
+    """Seed every :data:`VROPS_CORE_GROUPS` entry + its child ops.
+
+    Inserts one :class:`OperationGroup` per curated group_key
+    (``review_status='staged'``). For each :data:`VROPS_CORE_OPS`
+    entry, inserts the curated op (``is_enabled=False`` to match the
+    G0.7 ingest default for ``source_kind='ingested'`` rows).
+
+    When *extra_ops_per_group* > 0, also seeds *N* non-curated ops per
+    curated group with deterministic op_ids so the test can assert
+    :func:`apply_vrops_core_curation` correctly disables them.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, uuid.UUID] = {}
+
+    async with sessionmaker() as session:
+        for group in VROPS_CORE_GROUPS:
+            group_row = OperationGroup(
+                tenant_id=tenant_id,
+                product=VROPS_PRODUCT,
+                version=VROPS_VERSION,
+                impl_id=VROPS_IMPL_ID,
+                group_key=group.group_key,
+                name=f"Placeholder name for {group.group_key}",
+                when_to_use="Placeholder when_to_use.",
+                review_status="staged",
+            )
+            session.add(group_row)
+            await session.flush()
+            group_ids[group.group_key] = group_row.id
+
+        for op in VROPS_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=tenant_id,
+                    product=VROPS_PRODUCT,
+                    version=VROPS_VERSION,
+                    impl_id=VROPS_IMPL_ID,
+                    op_id=op.op_id,
+                    source_kind="ingested",
+                    method=method,
+                    path=path,
+                    handler_ref=None,
+                    group_id=group_ids[op.group_key],
+                    summary=f"Placeholder summary for {op.op_id}.",
+                    description=f"Placeholder description for {op.op_id}.",
+                    parameter_schema={"type": "object", "properties": {}},
+                    response_schema={"type": "object"},
+                    llm_instructions=None,
+                    safety_level="safe",
+                    requires_approval=False,
+                    is_enabled=False,
+                    tags=["spec:vcf-operations-9.0/suite-api.yaml"],
+                )
+            )
+
+        for group in VROPS_CORE_GROUPS:
+            for i in range(extra_ops_per_group):
+                extra_op_id = f"GET:/canary-extra/{group.group_key}/{i}"
+                session.add(
+                    EndpointDescriptor(
+                        tenant_id=tenant_id,
+                        product=VROPS_PRODUCT,
+                        version=VROPS_VERSION,
+                        impl_id=VROPS_IMPL_ID,
+                        op_id=extra_op_id,
+                        source_kind="ingested",
+                        method="GET",
+                        path=f"/canary-extra/{group.group_key}/{i}",
+                        handler_ref=None,
+                        group_id=group_ids[group.group_key],
+                        summary="Extra non-curated op.",
+                        description="Extra non-curated op.",
+                        parameter_schema={"type": "object", "properties": {}},
+                        response_schema={"type": "object"},
+                        llm_instructions=None,
+                        safety_level="safe",
+                        requires_approval=False,
+                        is_enabled=False,
+                        tags=[],
+                    )
+                )
+
+        await session.commit()
+
+    return group_ids
+
+
+async def test_apply_vrops_core_curation_enables_exactly_8_ops() -> None:
+    """apply_vrops_core_curation enables exactly the 8 core ops."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrops_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == VROPS_PRODUCT,
+                EndpointDescriptor.version == VROPS_VERSION,
+                EndpointDescriptor.impl_id == VROPS_IMPL_ID,
+                EndpointDescriptor.is_enabled.is_(True),
+            )
+        )
+        enabled_ops = result.scalars().all()
+
+    enabled_op_ids = {op.op_id for op in enabled_ops}
+    expected_op_ids = {op.op_id for op in VROPS_CORE_OPS}
+    assert enabled_op_ids == expected_op_ids, (
+        f"enabled ops don't match VROPS_CORE_OPS; "
+        f"extra={enabled_op_ids - expected_op_ids!r}, "
+        f"missing={expected_op_ids - enabled_op_ids!r}"
+    )
+
+
+async def test_apply_vrops_core_curation_disables_non_core_ops_in_curated_groups() -> None:
+    """Extra ops seeded in curated groups stay is_enabled=False after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=2)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrops_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == VROPS_PRODUCT,
+                EndpointDescriptor.version == VROPS_VERSION,
+                EndpointDescriptor.impl_id == VROPS_IMPL_ID,
+                EndpointDescriptor.op_id.like("GET:/canary-extra/%"),
+            )
+        )
+        extra_ops = result.scalars().all()
+
+    assert extra_ops, "expected extra non-curated ops to exist"
+    for op in extra_ops:
+        assert op.is_enabled is False, (
+            f"non-core op {op.op_id!r} should be disabled after curation; "
+            f"got is_enabled={op.is_enabled!r}"
+        )
+
+
+async def test_apply_vrops_core_curation_sets_llm_instructions_on_all_core_ops() -> None:
+    """llm_instructions is populated on all 8 core ops after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrops_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    expected_op_ids = {op.op_id for op in VROPS_CORE_OPS}
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id == tenant_id,
+                EndpointDescriptor.product == VROPS_PRODUCT,
+                EndpointDescriptor.op_id.in_(list(expected_op_ids)),
+            )
+        )
+        curated_ops = result.scalars().all()
+
+    assert len(curated_ops) == len(VROPS_CORE_OPS)
+    for op in curated_ops:
+        assert op.llm_instructions is not None and op.llm_instructions, (
+            f"llm_instructions not set on core op {op.op_id!r} after curation"
+        )
+
+
+async def test_apply_vrops_core_curation_enables_all_7_curated_groups() -> None:
+    """All 7 curated groups land review_status='enabled' after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrops_core_curation(review_service, tenant_id=tenant_id)
+
+    expected_group_keys = {g.group_key for g in VROPS_CORE_GROUPS}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(OperationGroup).where(
+                OperationGroup.tenant_id == tenant_id,
+                OperationGroup.product == VROPS_PRODUCT,
+                OperationGroup.group_key.in_(list(expected_group_keys)),
+            )
+        )
+        groups = result.scalars().all()
+
+    assert len(groups) == len(VROPS_CORE_GROUPS)
+    for group in groups:
+        assert group.review_status == "enabled", (
+            f"group {group.group_key!r} should be 'enabled' after curation; "
+            f"got review_status={group.review_status!r}"
+        )
+
+
+async def test_apply_vrops_core_curation_writes_operator_reviewed_when_to_use() -> None:
+    """Curated groups carry the operator-reviewed when_to_use after curation."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrops_core_curation(review_service, tenant_id=tenant_id)
+
+    expected: dict[str, Any] = {g.group_key: g.when_to_use for g in VROPS_CORE_GROUPS}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(OperationGroup).where(
+                OperationGroup.tenant_id == tenant_id,
+                OperationGroup.product == VROPS_PRODUCT,
+            )
+        )
+        groups = result.scalars().all()
+
+    for group in groups:
+        if group.group_key in expected:
+            assert group.when_to_use == expected[group.group_key], (
+                f"group {group.group_key!r} when_to_use mismatch after curation"
+            )
+
+
+async def test_apply_vrops_core_curation_emits_audit_rows() -> None:
+    """apply_vrops_core_curation writes at least one audit row per curated group."""
+    tenant_id = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_id)
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+
+    review_service = ReviewService(operator=operator)
+    await apply_vrops_core_curation(review_service, tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).where(
+                AuditLog.tenant_id == tenant_id,
+            )
+        )
+        audit_rows = result.scalars().all()
+
+    assert len(audit_rows) >= len(VROPS_CORE_GROUPS), (
+        f"expected ≥{len(VROPS_CORE_GROUPS)} audit rows from curation; got {len(audit_rows)}"
+    )

--- a/docs/cross-repo/g36-vrops-canary.md
+++ b/docs/cross-repo/g36-vrops-canary.md
@@ -1,0 +1,349 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# G3.6 vROps canary — operator procedure
+
+This document is the **operator-facing runbook** for ingesting the
+vROps 9.0 ``/suite-api`` OpenAPI surface through the G0.7 spec-
+ingestion pipeline and curating the read-only v0.5 core (8 ops) the
+agent surfaces through `search_operations` / `call_operation`. Run
+this procedure when standing up a vROps target against a fresh
+deploy, when re-running after a connector / spec revision, or when
+verifying the curation against a staging vROps appliance.
+
+Companion to
+[`docs/cross-repo/g35-nsx-canary.md`](./g35-nsx-canary.md)
+(the NSX counterpart this runbook mirrors) and
+[`docs/cross-repo/connector-ingestion.md`](./connector-ingestion.md)
+(the connector-agnostic ingest runbook). The vROps-specific delta is
+the HTTP Basic auth model (no session token), the optional
+``auth-source`` query parameter for AD / vIDM federation, and the
+curated 8-op read core.
+
+## What this canary proves
+
+End-to-end correctness of the G0.7 ingestion pipeline driven against
+the vROps suite-api spec:
+
+1. **Parse.** The T1 parser
+   ([`meho_backplane.operations.ingest.parse_openapi`](../../backend/src/meho_backplane/operations/ingest/openapi.py))
+   ingests `vcf-operations-9.0/suite-api.yaml` under one
+   `connector_id="vrops-rest-9.0"`.
+2. **Register.** T2's
+   [`register_ingested_operations`](../../backend/src/meho_backplane/operations/ingest/register_ingested.py)
+   bulk-upserts every parsed operation into the
+   `endpoint_descriptor` table under the
+   `(product, version, impl_id) = ("vcf-operations", "9.0", "vrops-rest")`
+   connector triple. The first ingest finds the hand-rolled
+   [`VcfOperationsConnector`](../../backend/src/meho_backplane/connectors/vcf_operations/connector.py)
+   already registered (G3.6-T1 #829); the auto-shim's idempotency
+   check (`ensure_connector_class_registered`) short-circuits.
+   Every row carries a `spec:vcf-operations-9.0/suite-api.yaml`
+   tag so operators can audit per-spec coverage via
+   `meho connector review`.
+3. **Group.** T3's
+   [`run_llm_grouping`](../../backend/src/meho_backplane/operations/ingest/llm_groups.py)
+   pass derives operation groups with operator-readable
+   `when_to_use` hints + per-op group assignments. The path-prefix
+   classifier in
+   [`meho_backplane.connectors.vcf_operations.core_ops.VROPS_PATH_RULES`](../../backend/src/meho_backplane/connectors/vcf_operations/core_ops.py)
+   names the 7 groups the curated core spans.
+4. **Curate.** The operator drives `apply_vrops_core_curation`
+   (which uses `ReviewService.edit_group` + `enable_group` +
+   `edit_op(llm_instructions=…)`) against the staged connector to
+   land the 8 read-only core ops + their guidance blobs.
+5. **Verify.** The operator dispatches one list op through
+   `call_operation` to prove the end-to-end agent path works. The
+   JSONFlux *seam* is exercised via the test-only
+   `ForceHandleReducer` pattern (see acceptance tests below); real
+   JSONFlux reduction is a v0.5.next concern per Goal #214 scope.
+
+## Prerequisites
+
+- **The vROps OpenAPI spec checked out locally.** The canary
+  resolves `docs:vcf-operations-9.0/suite-api.yaml` against
+  `$CLAUDE_RDC_DOCS` when set; otherwise pass a full `file:///`
+  path. The spec ships in the consumer's spec-shelf repo.
+- **A Postgres instance with pgvector + FTS extensions.** Local
+  development uses the testcontainers fixture; production uses the
+  `pgvector/pgvector:pg16`-derived chart image.
+- **A running backplane with `meho connector ingest` available.**
+  The connector CLI talks to the REST API at
+  `http(s)://<backplane>/api/v1/connectors/ingest`.
+- **An LLM client configured for the grouping pass.** Production
+  deploys wire the Anthropic Messages-API adapter under
+  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **A Vault path holding the vROps service-account credentials.**
+  The `VcfOperationsConnector._creds` cache resolves
+  `target.secret_ref` to a `{"username": ..., "password": ...}`
+  pair via the
+  [shared `CredentialsCache`](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py)
+  loader; default loader raises `NotImplementedError` until G0.3
+  (#224) lands operator-context Vault reads.
+
+## vROps auth divergence from NSX
+
+Unlike NSX (which requires a session-cookie + XSRF-token dance),
+vROps' `/suite-api/api/*` surface accepts **HTTP Basic on every
+request** — no session establish call, no token refresh, no 401
+retry loop. The connector caches the Vault-loaded credentials per
+target and computes the `Authorization: Basic <b64>` header on each
+call.
+
+When the deployment federates identity through `vIDM` or an Active
+Directory realm, set `target.auth_source` to the realm name. The
+connector appends `?auth-source=<value>` as a query parameter on
+every authenticated request so vROps routes the Basic challenge to
+the named identity domain. When `target.auth_source` is `None` (the
+default), the parameter is omitted and vROps falls back to its
+local realm.
+
+## Operator procedure
+
+### Step 1 — ingest the spec
+
+```bash
+meho connector ingest \
+  --product vcf-operations --version 9.0 --impl vrops-rest \
+  --spec docs:vcf-operations-9.0/suite-api.yaml \
+  --json
+```
+
+Expected (paraphrased) response:
+
+```json
+{
+  "ingestion": {
+    "connector_id": "vrops-rest-9.0",
+    "inserted_count": 700,
+    "updated_count": 0,
+    "skipped_count": 0,
+    "connector_registered": false,
+    "operations_grouped": false
+  },
+  "grouping": {
+    "connector_id": "vrops-rest-9.0",
+    "groups_created": 10,
+    "operations_assigned": 600,
+    "operations_unassigned": 100,
+    "llm_call_count": 15,
+    "llm_duration_ms": 25000.0
+  }
+}
+```
+
+Numbers are approximate; the load-bearing checks are
+`inserted_count >= 500`, `7 <= groups_created <= 14`, and
+`operations_unassigned / inserted_count < 50%`.
+`connector_registered` is `false` here because
+`VcfOperationsConnector` is already registered in the v2 registry
+at module-import time (G3.6-T1) — the auto-shim finds the existing
+entry and short-circuits.
+
+### Step 2 — review the LLM-summarised groups
+
+```bash
+meho connector review vrops-rest-9.0
+```
+
+Expected: a rendered table of 7-14 groups (the path-prefix
+classifier maps to 7 named groups; the LLM may propose extras for
+tails the classifier doesn't catch). Compare against the canonical
+7 groups in
+[`VROPS_CORE_GROUPS`](../../backend/src/meho_backplane/connectors/vcf_operations/core_ops.py):
+
+| group_key | name | covers |
+|---|---|---|
+| `vrops-system` | vROps (system / about) | `/suite-api/api/versions` |
+| `vrops-resources` | vROps Resources | `/suite-api/api/resources` |
+| `vrops-alerts` | vROps Alerts | `/suite-api/api/alerts` |
+| `vrops-alert-definitions` | vROps Alert Definitions | `/suite-api/api/alertdefinitions` |
+| `vrops-symptoms` | vROps Symptoms | `/suite-api/api/symptoms` |
+| `vrops-recommendations` | vROps Recommendations | `/suite-api/api/recommendations` |
+| `vrops-supermetrics` | vROps Super Metrics | `/suite-api/api/supermetrics` |
+
+Note the rule ordering: ``/alertdefinitions`` precedes ``/alerts``
+in :data:`VROPS_PATH_RULES` because ``startswith("/suite-api/api/alerts")``
+would otherwise eat the longer path. The classifier's loop terminates
+at the first matching prefix.
+
+### Step 3 — apply the curated read-core
+
+The Python entrypoint is `apply_vrops_core_curation`. From a
+backplane Python shell:
+
+```python
+from meho_backplane.connectors.vcf_operations import apply_vrops_core_curation
+from meho_backplane.operations.ingest import ReviewService
+
+review_service = ReviewService(operator=operator)
+await apply_vrops_core_curation(review_service, tenant_id=None)
+```
+
+This drives, for every entry in `VROPS_CORE_GROUPS`:
+
+1. For every non-curated op in the curated group,
+   `ReviewService.edit_op(op_id, is_enabled=False)` — writes the
+   operator-override audit row that the subsequent `enable_group`
+   cascade respects (so non-core ops stay disabled even though
+   their group is being enabled).
+2. `ReviewService.edit_group(group_key, name=…, when_to_use=…)` —
+   lands the operator-reviewed text the agent reads through
+   `list_operation_groups`.
+3. `ReviewService.enable_group(group_key)` — flips
+   `review_status='enabled'`; cascades child ops to
+   `is_enabled=True` **except** for the ops flagged in step 1.
+
+Then for every entry in `VROPS_CORE_OPS`:
+
+4. `ReviewService.edit_op(op_id, llm_instructions=…)` — lands the
+   per-op JSON blob the agent inlines into reasoning context when
+   the op surfaces in `search_operations` hits.
+
+Each op's `llm_instructions` is a three-key blob
+(`when_to_call` / `output_shape` / `next_step`) matching the
+typed-connector convention from
+[`connectors/bind9/ops_zone.py`](../../backend/src/meho_backplane/connectors/bind9/ops_zone.py)
+and [`connectors/vault/ops.py`](../../backend/src/meho_backplane/connectors/vault/ops.py).
+The same agent reads both surfaces, so the structure stays uniform
+across typed and ingested connectors.
+
+### Step 4 — verify the curation
+
+```bash
+meho operation groups vrops-rest-9.0
+meho operation search vrops-rest-9.0 "list vrops alerts" --limit 5
+meho operation search vrops-rest-9.0 "what vrops symptoms are active" --limit 5
+```
+
+The first command should return 7 enabled groups, each with the
+canonical `when_to_use` from `VROPS_CORE_GROUPS`. The second should
+return `GET:/suite-api/api/alerts` in the top-3. The third should
+return `GET:/suite-api/api/symptoms` in the top-3.
+
+Every other vROps op the spec ingestion produced should be in the
+`is_enabled=False` state — `search_operations` filters on
+`OperationGroup.review_status='enabled'` AND
+`EndpointDescriptor.is_enabled=True`, so a staged group's ops
+never surface.
+
+### Step 5 — dispatch one list op end-to-end
+
+Against a real probed vROps target:
+
+```bash
+meho operation call vrops-rest-9.0 \
+  'GET:/suite-api/api/resources' \
+  --target vrops-canary --json
+```
+
+Expected: JSON-shaped response carrying a `resourceList` array of
+resource entries. The HTTP Basic header is computed from the
+Vault-loaded credentials on the first dispatch and reused for
+subsequent ones via the per-target `CredentialsCache`.
+
+The JSONFlux *seam* (would-be handle threading) is exercised
+non-interactively at
+[`backend/tests/acceptance/test_g36_vrops_jsonflux_force_handle.py`](../../backend/tests/acceptance/test_g36_vrops_jsonflux_force_handle.py):
+the test installs a `ForceHandleReducer` that always wraps the
+vROps list payload in a synthetic `ResultHandle` and asserts the
+dispatcher's `OperationResult.handle` carries it through. Real
+JSONFlux reduction (set-shaped payload reduction, MinIO/S3 spill,
+`result_query` meta-tool) is **out of scope for v0.5** per Goal
+#214 — the seam test proves the dispatcher is ready for it once
+the production reducer ships.
+
+## Write-ops stay staged
+
+vROps' write surface (custom-group create / maintenance-mode set /
+alert-acknowledge) is **explicitly left disabled** in v0.5 per the
+Initiative #369 out-of-scope list. The curation helper's "enable
+group but pin non-core ops disabled" pattern keeps those rows on
+the connector for future enablement without exposing them to the
+agent until an explicit follow-up Task lands their
+`llm_instructions` + safety review.
+
+If `meho operation search vrops-rest-9.0 "<query>"` surfaces a
+`POST` / `DELETE` / `PUT` op after this canary completes, the
+curation has regressed — re-run `apply_vrops_core_curation` and
+file an issue against Initiative #369.
+
+## Rollback
+
+If a canary run discovers a regression in the ingestion pipeline
+or the curated content:
+
+1. **Disable the connector immediately:**
+
+   ```bash
+   meho connector disable vrops-rest-9.0 --confirm
+   ```
+
+   Cascades every group to `review_status='disabled'` and every
+   op to `is_enabled=False`. The agent meta-tools stop surfacing
+   the connector; no in-flight dispatches will use it.
+
+2. **Capture the audit trail.** Every state transition wrote a
+   `meho.connector.*` row to `audit_log`; the trail is sufficient
+   to reconstruct what happened.
+
+3. **Re-ingest after fix.** Once the pipeline is patched, drive
+   `meho connector ingest` again — the body-hash idempotence in T2
+   means rows whose parser output didn't change stay untouched,
+   while changed rows get an updated revision. After re-curation +
+   enable, the agent path re-warms.
+
+## Known gaps
+
+### 1. Env-gated automated canary is a follow-up
+
+G3.6-T2 ships the operator-review substrate
+(`apply_vrops_core_curation` helper), the curated 8-op data
+(`VROPS_CORE_OPS`), the dispatch smoke + JSONFlux force-handle
+acceptance tests over respx-mocked vROps, and this runbook. The
+env-gated automated canary that mirrors `test_g07_vsphere_canary.py`
+for vROps — drives the full suite-api ingest through
+`IngestionPipelineService` against a real LLM stub or live
+Anthropic adapter — is a follow-up. It requires the vROps spec
+files reachable from CI, the same env-gated pattern
+`tests/acceptance/_vcenter_spec.py` codifies for vSphere.
+
+### 2. Goal #214 G3.6 vROps checklist line
+
+The Goal body's `[ ] #369 — G3.6 tier-3 VCF management plane`
+checkbox flips when the Initiative's whole DoD is met. G3.6-T2
+moves the Initiative forward but does not on its own complete it
+(G3.6-T3 #837 wires the CLI verbs + recorded-fixture E2E + the
+onboarding doc). The checklist tick lives on the Initiative-level
+wrap-up, not on this Task.
+
+### 3. CLI verbs for per-op `llm_instructions` editing
+
+`ReviewService.edit_op(llm_instructions=…)` is exposed at the
+Python level (the substrate the curation helper drives). The CLI
+verb `meho connector edit-op --llm-instructions <json>` and the
+matching REST / MCP route extensions are deferred to G3.6-T3 #837
+alongside the CLI verbs for vROps-specific operations.
+
+## References
+
+- Issue: [G3.6-T2 #833](https://github.com/evoila/meho/issues/833).
+- Parent Initiative: [G3.6 #369](https://github.com/evoila/meho/issues/369).
+- Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
+- Predecessor: [G3.6-T1 #829](https://github.com/evoila/meho/issues/829)
+  — `VcfOperationsConnector` skeleton.
+- NSX counterpart: [`g35-nsx-canary.md`](./g35-nsx-canary.md).
+- Connector-agnostic ingest runbook: [`connector-ingestion.md`](./connector-ingestion.md).
+- Substrate: [#388 G0.6](https://github.com/evoila/meho/issues/388)
+  (operation registry + dispatcher);
+  [#389 G0.7](https://github.com/evoila/meho/issues/389)
+  (spec ingestion pipeline).
+- vROps suite-api docs (Broadcom developer portal):
+  https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/
+- Curated data:
+  [`backend/src/meho_backplane/connectors/vcf_operations/core_ops.py`](../../backend/src/meho_backplane/connectors/vcf_operations/core_ops.py).
+- Consumer wrapper this contract retires (per Initiative #369):
+  `scripts/vcf-operations.sh` in the consumer's `claude-rdc-hetzner-dc`
+  repository.


### PR DESCRIPTION
## Summary

- Ingests the vROps `/suite-api` OpenAPI spec via the G0.7 pipeline and curates the read-only v0.5 core the agent surfaces through `search_operations` / `call_operation`. The `VcfOperationsConnector` (#829) is now dispatchable for the 8-op set.
- Ships `apply_vrops_core_curation` mirroring the NSX / Harbor / SDDC precedents — `edit_op(is_enabled=False)` operator-override per non-core op so the subsequent `enable_group` cascade respects the exclusion list, then `edit_op(llm_instructions=...)` per enabled op.
- Encodes the 8 enabled ops per Initiative #369 v0.5 list: `vrops.about` · `vrops.resource.list` · `vrops.resource.get` · `vrops.alert.list` · `vrops.alertdefinition.list` · `vrops.symptom.list` · `vrops.recommendation.list` · `vrops.supermetric.list`. Write surface stays `is_enabled=False`.
- Adds dispatch-smoke + JSONFlux force-handle acceptance tests over respx-mocked vROps, and the operator runbook at `docs/cross-repo/g36-vrops-canary.md`.

## Test plan

- [x] `ruff check` (new + touched files) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/vcf_operations/` — clean
- [x] `pytest backend/tests/test_connectors_vcf_operations_core_ops.py` — **25 passed** (classifier + curation data invariants + curation substrate integration)
- [x] `pytest backend/tests/test_connectors_{harbor,nsx,sddc,vcf_operations}*.py tests/test_operations_ingest_*.py` — **358 passed**, no sibling regression
- [x] AC1 (spec ingests cleanly via G0.7) — verified by runbook in `g36-vrops-canary.md`; substrate exercised end-to-end against respx-mocked vROps in the acceptance tests
- [x] AC2 (8 read-only ops enabled, everything else stays staged) — `test_apply_vrops_core_curation_enables_exactly_8_ops` + `test_apply_vrops_core_curation_disables_non_core_ops_in_curated_groups`
- [x] AC3 (every enabled op carries reviewed `llm_instructions`; every enabled group reviewed `when_to_use`, no placeholders) — `test_vrops_core_ops_llm_instructions_all_populated` + `test_vrops_core_groups_when_to_use_all_populated`
- [x] AC4 (one list op returns a JSONFlux handle through the dispatcher seam) — `test_g36_vrops_jsonflux_force_handle.py` (env-gated on Docker / Postgres; passes in CI)
- [x] AC5 (canary doc records the ingest + review + enable run) — `docs/cross-repo/g36-vrops-canary.md`
- [x] AC6 (`ruff` + `mypy` clean; `pytest` passes) — see above

## Out of scope

- CLI verbs (`meho vcf-operations <op>`), MCP description publication, onboarding doc — G3.6-T3 #837.
- vROps write ops (custom-group / maintenance-mode set / alert-ack) — stay `is_enabled=False` in v0.5; future Task.
- Env-gated automated two-spec canary against a live LLM stub — follow-up to this Task (documented in `g36-vrops-canary.md § Known gaps`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #833


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * vROps connector now available with 8 curated, read-only operations including resource search, alert management, symptom analysis, and recommendations retrieval
  * Enables seamless integration with vROps for operational data access and queries

* **Documentation**
  * Added operator runbook for vROps integration and verification workflow, including setup steps, acceptance checks, and rollback procedures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->