### PR TITLE
feat(connectors): G3.6-T11 VCFA dual-plane spec ingestion + 11-op core curation

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
@@ -19,18 +19,37 @@ would land as ``("vcf-automation", "", "")`` and confuse
 tie-break ladder. Same pattern :mod:`meho_backplane.connectors.nsx` /
 :mod:`meho_backplane.connectors.sddc_manager` established.
 
-Operations for this connector arrive in #836 via G0.7 dual-plane spec
-ingestion -- both the provider plane (``vcf-automation-9.0/provider.yaml``)
-and the tenant plane (``vcf-automation-9.0/tenant.yaml``) are ingested
-under this single connector with ``spec_source`` tags distinguishing
-them, same shape as vSphere's ``vcenter.yaml`` + ``vi-json.yaml``.
-This Task ships only the skeleton.
+Operations for this connector arrive via G0.7 dual-plane spec ingestion
+-- both the provider plane (``vcf-automation-9.0/cloudapi.yaml``) and
+the tenant plane (``vcf-automation-9.0/iaas.yaml``) are ingested under
+this single connector with ``spec_source`` tags distinguishing them,
+same shape as vSphere's ``vcenter.yaml`` + ``vi-json.yaml``. The
+operator-review-time curation helper :func:`apply_vcfa_core_curation`
+(G3.6-T11 #836) lands the read-only v0.5 core: 6 provider-plane ops
+under 4 groups (``provider-site``, ``provider-orgs``,
+``provider-regions``, ``provider-users``) plus 5 tenant-plane ops
+under 4 groups (``tenant-about``, ``tenant-projects``,
+``tenant-deployments``, ``tenant-blueprints``). The skeleton was
+shipped at G3.6-T10 (#832).
 """
 
 from meho_backplane.connectors.registry import register_connector_v2
 from meho_backplane.connectors.vcf_automation.connector import (
     VcfAutomationConfigurationError,
     VcfAutomationConnector,
+)
+from meho_backplane.connectors.vcf_automation.core_ops import (
+    VCFA_CONNECTOR_ID,
+    VCFA_CORE_GROUPS,
+    VCFA_CORE_OPS,
+    VCFA_IMPL_ID,
+    VCFA_PATH_RULES,
+    VCFA_PRODUCT,
+    VCFA_VERSION,
+    VcfaCoreGroup,
+    VcfaCoreOp,
+    apply_vcfa_core_curation,
+    classify_vcfa_op,
 )
 from meho_backplane.connectors.vcf_automation.session import (
     SessionCredentials,
@@ -47,10 +66,21 @@ register_connector_v2(
 )
 
 __all__ = [
+    "VCFA_CONNECTOR_ID",
+    "VCFA_CORE_GROUPS",
+    "VCFA_CORE_OPS",
+    "VCFA_IMPL_ID",
+    "VCFA_PATH_RULES",
+    "VCFA_PRODUCT",
+    "VCFA_VERSION",
     "SessionCredentials",
     "VcfAutomationConfigurationError",
     "VcfAutomationConnector",
     "VcfAutomationCredentialsLoader",
     "VcfAutomationTargetLike",
+    "VcfaCoreGroup",
+    "VcfaCoreOp",
+    "apply_vcfa_core_curation",
+    "classify_vcfa_op",
     "load_credentials_from_vault",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_automation/_core_data.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/_core_data.py
@@ -1,0 +1,583 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Curated VCFA core-ops data tables -- the 8 groups + 11 ops + classifier rules.
+
+Split out from :mod:`.core_ops` to keep the public module within the
+file-size budget. The contents here are pure data + the classifier
+function -- no I/O, no class state -- so they live cleanly outside the
+public API surface module. The public module re-exports every symbol
+here so callers continue to import from
+``meho_backplane.connectors.vcf_automation.core_ops``.
+
+See :mod:`.core_ops` for the design rationale (dual-plane shape,
+operator-review semantics, audit-log-driven exclusion). This module
+carries the literal data the helper drives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from meho_backplane.connectors.vcf_automation._routing import Plane
+
+__all__ = [
+    "VCFA_CONNECTOR_ID",
+    "VCFA_CORE_GROUPS",
+    "VCFA_CORE_OPS",
+    "VCFA_IMPL_ID",
+    "VCFA_PATH_RULES",
+    "VCFA_PRODUCT",
+    "VCFA_VERSION",
+    "VcfaCoreGroup",
+    "VcfaCoreOp",
+    "classify_vcfa_op",
+]
+
+
+#: Endpoint-descriptor product key -- what
+#: :func:`~meho_backplane.operations._lookup.parse_connector_id` extracts
+#: from ``VCFA_CONNECTOR_ID = "vcfa-rest-9.0"`` (``head.split("-", 1)[0]``
+#: where head is ``"vcfa-rest"``).
+#:
+#: It is **not** the same as
+#: :attr:`~meho_backplane.connectors.vcf_automation.VcfAutomationConnector.product`,
+#: which is ``"vcf-automation"`` and is used only for the v2 connector
+#: registry and the target-product resolver. All ``endpoint_descriptor``
+#: and ``operation_group`` rows for this connector triple carry
+#: ``product="vcfa"``; operators pass ``--product vcfa`` when driving
+#: ``meho connector ingest``. Same split the SDDC Manager precedent
+#: established (``"sddc"`` vs ``"sddc-manager"``).
+VCFA_PRODUCT: Final[str] = "vcfa"
+VCFA_VERSION: Final[str] = "9.0"
+VCFA_IMPL_ID: Final[str] = "vcfa-rest"
+
+#: Connector-id slug the G0.6 dispatcher's ``parse_connector_id``
+#: round-trips back to the triple above: ``"vcfa-rest-9.0"``.
+VCFA_CONNECTOR_ID: Final[str] = f"{VCFA_IMPL_ID}-{VCFA_VERSION}"
+
+
+@dataclass(frozen=True, slots=True)
+class VcfaCoreGroup:
+    """One curated operator-review entry for a VCFA operation group.
+
+    ``group_key`` is the slug :func:`classify_vcfa_op` emits.
+    ``plane`` records which auth plane the group's ops live on
+    (``"provider"`` or ``"tenant"``); the value mirrors
+    :func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`'s
+    return type so cross-checks are static.  ``name`` is the
+    operator-readable label ``meho connector review`` renders.
+    ``when_to_use`` is the agent-facing hint
+    :func:`list_operation_groups` returns verbatim; every entry is a
+    single complete sentence **naming its plane** so the agent's
+    group-selection step has unambiguous guidance and never collapses
+    a tenant question onto a provider-only group (or vice versa).
+    """
+
+    group_key: str
+    plane: Plane
+    name: str
+    when_to_use: str
+
+
+@dataclass(frozen=True, slots=True)
+class VcfaCoreOp:
+    """One curated operator-review entry for a VCFA operation.
+
+    ``op_id`` follows the ``METHOD:path`` shape every
+    ``source_kind='ingested'`` row uses; the path matches an entry in
+    ``vcf-automation-9.0/cloudapi.yaml`` (provider plane) or
+    ``vcf-automation-9.0/iaas.yaml`` (tenant plane). The ``plane``
+    field mirrors the group's plane and is asserted at module-import
+    time against
+    :func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`
+    by the public :mod:`.core_ops` module -- a typo that drifts a
+    tenant op into a provider group (or vice versa) fails import
+    rather than surfacing as a misrouted 401 in production.
+
+    ``llm_instructions`` is the per-op JSON blob the meta-tools
+    inline verbatim when the op surfaces. The shape (``when_to_call``
+    / ``output_shape`` / ``next_step``) mirrors the typed-connector
+    convention from :mod:`meho_backplane.connectors.bind9.ops_zone`
+    and the prior core-ops modules.
+    """
+
+    op_id: str
+    group_key: str
+    plane: Plane
+    llm_instructions: dict[str, object]
+
+
+#: Path-prefix -> group_key classifier rules for VCFA.
+#:
+#: First match wins. The provider and tenant planes never share a
+#: path family (``/iaas/api/`` is uniquely tenant), so ordering is
+#: not load-bearing in the way Harbor's nested project hierarchy is
+#: -- but the tenant rules are listed first defensively so a future
+#: provider-side ``/iaas`` (unlikely, but possible) wouldn't shadow
+#: them.
+VCFA_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
+    # Tenant plane -- /iaas/api/* family.
+    ("/iaas/api/about", "tenant-about"),
+    ("/iaas/api/projects", "tenant-projects"),
+    ("/iaas/api/deployments", "tenant-deployments"),
+    ("/iaas/api/blueprints", "tenant-blueprints"),
+    # Provider plane -- /cloudapi/1.0.0/* family.
+    ("/cloudapi/1.0.0/site", "provider-site"),
+    ("/cloudapi/1.0.0/orgs", "provider-orgs"),
+    ("/cloudapi/1.0.0/regions", "provider-regions"),
+    ("/cloudapi/1.0.0/users", "provider-users"),
+)
+
+
+def classify_vcfa_op(op_id: str) -> str:
+    """Return the curated ``group_key`` for a VCFA op_id, or ``"none"``.
+
+    ``op_id`` is the ``METHOD:/path`` form ingested rows carry; the
+    helper strips the verb (only ``GET`` is in the read core), then
+    matches the path against :data:`VCFA_PATH_RULES` in order. Returns
+    ``"none"`` for paths outside the curated families; those rows are
+    un-curated and stay ``is_enabled=False`` after curation runs.
+
+    Malformed op_ids (no ``:`` separator, non-``GET`` method) map to
+    ``"none"`` defensively -- the v0.5 read core is GET-only.
+    """
+    try:
+        method, path = op_id.split(":", 1)
+    except ValueError:
+        return "none"
+    if method != "GET":
+        return "none"
+    for prefix, group_key in VCFA_PATH_RULES:
+        if path.startswith(prefix):
+            return group_key
+    return "none"
+
+
+def _instructions(
+    *,
+    when_to_call: str,
+    output_shape: str,
+    next_step: str,
+) -> dict[str, object]:
+    """Build the per-op ``llm_instructions`` blob with the canonical keys.
+
+    Same three-field shape :mod:`meho_backplane.connectors.nsx.core_ops`
+    and :mod:`meho_backplane.connectors.harbor.core_ops` use so an
+    agent crossing connector boundaries sees a stable convention.
+    """
+    return {
+        "when_to_call": when_to_call,
+        "output_shape": output_shape,
+        "next_step": next_step,
+    }
+
+
+#: Operator-reviewed ``when_to_use`` hints for the 8 VCFA groups
+#: (4 provider + 4 tenant). Every hint names its plane explicitly
+#: so the agent's group-selection step routes correctly across the
+#: dual-plane surface.
+VCFA_CORE_GROUPS: Final[tuple[VcfaCoreGroup, ...]] = (
+    # ----- Provider plane (4 groups, 6 ops) -----
+    VcfaCoreGroup(
+        group_key="provider-site",
+        plane="provider",
+        name="VCFA Provider (site)",
+        when_to_use=(
+            "Use this group on the VCFA **provider plane** to read appliance-level "
+            "site identity: site name, configured organization count, and VCFA "
+            "appliance version. The probe surface the agent calls before any "
+            "heavier provider read or when confirming which VCFA instance the "
+            "target points at. Provider-plane ops authenticate with the "
+            "``admin@System`` (or equivalent) Basic-auth session and never "
+            "succeed against the tenant token."
+        ),
+    ),
+    VcfaCoreGroup(
+        group_key="provider-orgs",
+        plane="provider",
+        name="VCFA Provider Organizations",
+        when_to_use=(
+            "Use this group on the VCFA **provider plane** to list or inspect "
+            "organizations on the appliance. The provider-plane org surface is "
+            "the cross-tenant view the system administrator sees -- every tenant "
+            "appears here. For per-tenant project / deployment / blueprint "
+            "reads, switch to the tenant-plane groups (``tenant-projects``, "
+            "``tenant-deployments``, ``tenant-blueprints``)."
+        ),
+    ),
+    VcfaCoreGroup(
+        group_key="provider-regions",
+        plane="provider",
+        name="VCFA Provider Regions",
+        when_to_use=(
+            "Use this group on the VCFA **provider plane** to list or inspect "
+            "regions -- the VCFA 9 evolution of the vCloud-Director provider VDC "
+            "concept. Each region groups compute, memory, and networking "
+            "resources under a single NSX domain, typically backed by one or "
+            "more VCF workload domains. Use to answer 'what compute capacity "
+            "does this VCFA appliance offer' or 'which region backs tenant X'."
+        ),
+    ),
+    VcfaCoreGroup(
+        group_key="provider-users",
+        plane="provider",
+        name="VCFA Provider Users",
+        when_to_use=(
+            "Use this group on the VCFA **provider plane** to list system-scope "
+            "users (the system organization's identity entries plus any "
+            "cross-org provider-scope users). Use when auditing who has "
+            "provider-level access. Tenant-scope users (per-org members) are "
+            "exposed through the per-org user endpoints which are not in the "
+            "v0.5 read core."
+        ),
+    ),
+    # ----- Tenant plane (4 groups, 5 ops) -----
+    VcfaCoreGroup(
+        group_key="tenant-about",
+        plane="tenant",
+        name="VCFA Tenant (about)",
+        when_to_use=(
+            "Use this group on the VCFA **tenant plane** to read the IaaS API "
+            "self-describe surface -- supported API versions and the latest "
+            "tenant API version. The probe surface the agent calls before any "
+            "tenant catalog read or when confirming tenant-plane reachability. "
+            "Tenant-plane ops authenticate with the tenant org login (``POST "
+            "/iaas/api/login``) and never succeed against the provider JWT."
+        ),
+    ),
+    VcfaCoreGroup(
+        group_key="tenant-projects",
+        plane="tenant",
+        name="VCFA Tenant Projects",
+        when_to_use=(
+            "Use this group on the VCFA **tenant plane** to list projects "
+            "within the tenant organization. Projects are the deployment-scoping "
+            "construct: every deployment belongs to exactly one project, and "
+            "blueprint access controls reference project membership. Use to "
+            "answer 'what projects exist in this org' or to pick the "
+            "project_id filter for a follow-up deployment list."
+        ),
+    ),
+    VcfaCoreGroup(
+        group_key="tenant-deployments",
+        plane="tenant",
+        name="VCFA Tenant Deployments",
+        when_to_use=(
+            "Use this group on the VCFA **tenant plane** to list or inspect "
+            "catalog deployments -- the running instances of blueprints. The "
+            "primary tenant-side answer surface for 'what workloads are "
+            "deployed', 'what is the status of deployment X', or 'who owns "
+            "deployment Y'. Deployment list is the largest payload on the "
+            "tenant surface; the dispatcher's JSONFlux seam wraps oversized "
+            "responses in a ResultHandle for follow-up navigation via "
+            "result_describe / result_query."
+        ),
+    ),
+    VcfaCoreGroup(
+        group_key="tenant-blueprints",
+        plane="tenant",
+        name="VCFA Tenant Blueprints",
+        when_to_use=(
+            "Use this group on the VCFA **tenant plane** to list catalog "
+            "blueprints -- the templates deployments instantiate. Use to answer "
+            "'what blueprints can this tenant deploy' or to look up a "
+            "blueprint id before cross-referencing it on an existing "
+            "deployment's blueprintId field."
+        ),
+    ),
+)
+
+
+#: The 11 curated read-only VCFA core ops (6 provider + 5 tenant).
+#: Paths cross-checked against the VCF Automation 9.0 API surface:
+#: the cloudapi family at
+#: https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/administration-sdks-cli-and-tools/about-the-vcf-automation-api.html
+#: and the tenant-plane IaaS family at
+#: https://developer.broadcom.com/xapis/vm-apps-org-provisioning-service/latest/.
+VCFA_CORE_OPS: Final[tuple[VcfaCoreOp, ...]] = (
+    # ----- Provider plane (6 ops) -----
+    VcfaCoreOp(
+        op_id="GET:/cloudapi/1.0.0/site",
+        group_key="provider-site",
+        plane="provider",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read VCFA appliance site identity on the provider "
+                "plane: site name, configured organization count, and VCFA "
+                "appliance version. Useful as a pre-flight probe before "
+                "heavier provider reads or to confirm which VCFA instance the "
+                "target points at."
+            ),
+            output_shape=(
+                "Object with id, name, description, restName, and product "
+                "version fields plus a links collection. The product version "
+                "string identifies the VCFA appliance build."
+            ),
+            next_step=(
+                "Confirm the product version is in the supported range, then "
+                "proceed to vcfa.provider.org.list for the org inventory or "
+                "vcfa.provider.vdc.list for the region inventory."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/cloudapi/1.0.0/orgs",
+        group_key="provider-orgs",
+        plane="provider",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the provider plane to list organizations on this "
+                "VCFA appliance. Returns the cross-tenant view (every tenant "
+                "appears here) -- the system administrator's inventory entry "
+                "point. Supports pagination via 'page' and 'pageSize' query "
+                "parameters."
+            ),
+            output_shape=(
+                "Object with a 'values' array of organization entries; each "
+                "entry carries id, name, displayName, description, isEnabled, "
+                "and orgVdcCount. The 'resultTotal' field reports the global "
+                "count for pagination."
+            ),
+            next_step=(
+                "Pick an org id for vcfa.provider.org.get to read its full "
+                "detail, or switch planes to tenant-side ops for per-org "
+                "project / deployment / blueprint reads."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/cloudapi/1.0.0/orgs/{id}",
+        group_key="provider-orgs",
+        plane="provider",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the provider plane to read the full detail of one "
+                "VCFA organization by id. Returns the configuration the "
+                "organization-list endpoint summarises, plus quota / policy / "
+                "branding fields the list omits. Requires an org id obtained "
+                "from vcfa.provider.org.list."
+            ),
+            output_shape=(
+                "Organization object with id, name, displayName, description, "
+                "isEnabled, orgVdcCount, catalogCount, vappCount, "
+                "runningVMCount, userCount, diskCount, and a settings "
+                "sub-object covering quotas + policies."
+            ),
+            next_step=(
+                "If counts indicate the org has active workloads, switch "
+                "planes to vcfa.tenant.deployment.list (authenticated against "
+                "the same org's tenant token) for the catalog view."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/cloudapi/1.0.0/regions",
+        group_key="provider-regions",
+        plane="provider",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the provider plane to list VCFA regions -- the VCFA 9 "
+                "evolution of the vCloud-Director provider VDC concept. Each "
+                "region maps to one NSX domain plus a collection of "
+                "supervisors backed by one or more VCF workload domains. Use "
+                "to answer 'what compute capacity does this VCFA appliance "
+                "offer'."
+            ),
+            output_shape=(
+                "Object with a 'values' array of region entries; each entry "
+                "carries id, name, description, nsxManager, supervisors, and "
+                "isEnabled. The 'resultTotal' field reports the global count "
+                "for pagination."
+            ),
+            next_step=(
+                "Pick a region id for vcfa.provider.vdc.get for the full "
+                "detail (capacity counters, configured storage policies)."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/cloudapi/1.0.0/regions/{id}",
+        group_key="provider-regions",
+        plane="provider",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the provider plane to read the full detail of one "
+                "VCFA region by id. Returns capacity counters, configured "
+                "storage policies, and the underlying NSX-domain / "
+                "workload-domain backing. Requires a region id obtained from "
+                "vcfa.provider.vdc.list."
+            ),
+            output_shape=(
+                "Region object with id, name, description, isEnabled, "
+                "nsxManager, supervisors[], storagePolicies[], and capacity "
+                "fields (totalCpuMhz, totalMemoryMB, allocatedCpuMhz, "
+                "allocatedMemoryMB)."
+            ),
+            next_step=(
+                "If allocated/total ratios indicate capacity pressure, "
+                "surface the region id and ratio to the operator. Otherwise "
+                "cross-reference the region id against tenant-plane "
+                "deployment reads to map workloads to regions."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/cloudapi/1.0.0/users",
+        group_key="provider-users",
+        plane="provider",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the provider plane to list users at the provider "
+                "scope: the system organization's identity entries plus any "
+                "cross-org provider-scope users. Use when auditing who has "
+                "provider-level access. Per-tenant users are exposed through "
+                "the per-org user endpoints which are not in the v0.5 read "
+                "core."
+            ),
+            output_shape=(
+                "Object with a 'values' array of user entries; each entry "
+                "carries id, username, fullName, email, roleEntityRefs, and "
+                "isEnabled."
+            ),
+            next_step=(
+                "Surface users with isEnabled=false or unexpected role refs "
+                "to the operator. For per-tenant identity audits, the "
+                "tenant-side org-user endpoints (out of v0.5 scope) are the "
+                "next surface."
+            ),
+        ),
+    ),
+    # ----- Tenant plane (5 ops) -----
+    VcfaCoreOp(
+        op_id="GET:/iaas/api/about",
+        group_key="tenant-about",
+        plane="tenant",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the tenant plane to read the IaaS API self-describe "
+                "surface: supportedApis list and latestApiVersion. Useful as "
+                "a probe before any tenant catalog read or to confirm "
+                "tenant-plane reachability and version negotiation."
+            ),
+            output_shape=(
+                "Object with supportedApis[] (each carrying apiVersion + a "
+                "documentation URL) and latestApiVersion (string)."
+            ),
+            next_step=(
+                "Confirm latestApiVersion is in the connector's supported "
+                "range, then proceed to vcfa.tenant.project.list or "
+                "vcfa.tenant.deployment.list for the catalog view."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/iaas/api/projects",
+        group_key="tenant-projects",
+        plane="tenant",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the tenant plane to list projects within the tenant "
+                "organization. Projects are the deployment-scoping construct "
+                "-- every deployment belongs to exactly one project. Supports "
+                "OData-like filtering via $filter, $orderby, $top, $skip."
+            ),
+            output_shape=(
+                "Object with a 'content' array of project entries; each "
+                "entry carries id, name, description, organizationId, "
+                "administrators[], members[], and operationTimeout. Page "
+                "metadata in totalElements + totalPages."
+            ),
+            next_step=(
+                "Pick a project id as the $filter argument for "
+                "vcfa.tenant.deployment.list (filter syntax: "
+                "$filter=projectId eq '<id>') to scope the deployment view "
+                "to one project."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/iaas/api/deployments",
+        group_key="tenant-deployments",
+        plane="tenant",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the tenant plane to list catalog deployments (the "
+                "running instances of blueprints). The largest payload on "
+                "the tenant surface -- large tenants return hundreds of "
+                "deployments. The dispatcher's JSONFlux seam wraps oversized "
+                "responses in a ResultHandle; use result_describe + "
+                "result_query to navigate the handle. Supports OData filters "
+                "($filter=projectId eq '<id>' is the canonical scope-down)."
+            ),
+            output_shape=(
+                "Object with a 'content' array of deployment entries; each "
+                "entry carries id, name, description, status, projectId, "
+                "blueprintId, ownedBy, createdAt, lastUpdatedAt, and a "
+                "resources[] summary. Page metadata in totalElements + "
+                "totalPages."
+            ),
+            next_step=(
+                "Pick a deployment id for vcfa.tenant.deployment.get for the "
+                "full detail (full resources, expense, request log). Cross-"
+                "reference blueprintId against vcfa.tenant.blueprint.list to "
+                "name the template."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/iaas/api/deployments/{id}",
+        group_key="tenant-deployments",
+        plane="tenant",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the tenant plane to read the full detail of one "
+                "tenant deployment by id. Returns the full resources[] tree "
+                "(each backing VM, network, storage entry), expense, and "
+                "request log. Requires a deployment id obtained from "
+                "vcfa.tenant.deployment.list."
+            ),
+            output_shape=(
+                "Deployment object with id, name, description, status, "
+                "projectId, blueprintId, ownedBy, createdAt, lastUpdatedAt, "
+                "resources[] (full backing-resource tree), expense, "
+                "lastRequestId, and inputs (the deployment-time parameter "
+                "values)."
+            ),
+            next_step=(
+                "Surface the status field to the operator; if status is "
+                "FAILED or in-progress, the lastRequestId points at the "
+                "request log entry with the failure detail. For a workload "
+                "map, walk resources[] for the backing VM ids and "
+                "cross-reference against vSphere / NSX inventory."
+            ),
+        ),
+    ),
+    VcfaCoreOp(
+        op_id="GET:/iaas/api/blueprints",
+        group_key="tenant-blueprints",
+        plane="tenant",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call on the tenant plane to list catalog blueprints -- the "
+                "templates deployments instantiate. Use to answer 'what "
+                "blueprints can this tenant deploy' or to look up a "
+                "blueprint id before cross-referencing it on an existing "
+                "deployment's blueprintId field. Supports OData filters."
+            ),
+            output_shape=(
+                "Object with a 'content' array of blueprint entries; each "
+                "entry carries id, name, description, projectId, version, "
+                "status (DRAFT / VERSIONED / RELEASED), updatedAt, and "
+                "content (a summary; the full blueprint YAML lives behind a "
+                "separate get-blueprint endpoint not in the v0.5 read core)."
+            ),
+            next_step=(
+                "Cross-reference blueprint id against the blueprintId field "
+                "on vcfa.tenant.deployment.list results to identify which "
+                "deployments instantiated which blueprint."
+            ),
+        ),
+    ),
+)

--- a/backend/src/meho_backplane/connectors/vcf_automation/core_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/core_ops.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VCF Automation 9.x read-only v0.5 core -- curated operator-enabled subset.
+
+This module names the **11 read-only VCF Automation operations** the
+G3.6 dual-plane v0.5 ship enables out of the much larger
+``vcf-automation-9.0/cloudapi.yaml`` + ``vcf-automation-9.0/iaas.yaml``
+corpus that the G0.7 spec-ingestion pipeline lands under
+``connector_id="vcfa-rest-9.0"``. The curation is two-layered:
+
+* :data:`VCFA_CORE_GROUPS` -- the operator-reviewed ``when_to_use``
+  hint per LLM-grouping pass output group. Every entry names its
+  **plane** (provider or tenant) up front so the agent's group
+  selection step routes correctly across the dual-plane surface;
+  generic hints would let a tenant question collapse onto a
+  provider-only group and vice versa.
+* :data:`VCFA_CORE_OPS` -- the 11 ``EndpointDescriptor.op_id`` strings
+  (6 provider + 5 tenant) that flip to ``is_enabled=True`` at
+  operator-review time, paired with the per-op ``llm_instructions``
+  blob the agent inlines into the reasoning context when it sees
+  the op in
+  :func:`~meho_backplane.operations.meta_tools.search_operations`
+  hits. Every other op under the same connector triple stays
+  ``is_enabled=False`` (the G0.7 ingestion default for
+  ``source_kind='ingested'`` rows).
+
+The literal data tables (VCFA_CORE_GROUPS + VCFA_CORE_OPS +
+VCFA_PATH_RULES + classify_vcfa_op) live in :mod:`._core_data`. This
+module re-exports them and adds the import-time invariant checks +
+the operator-review-time :func:`apply_vcfa_core_curation` helper.
+
+Per Initiative #369 and CLAUDE.md postulates 1-2, VCF Automation is
+**generic-ingested** (Layer-2) and **dual-plane**: the provider plane
+(``/cloudapi/*`` and the classic ``/api/*`` family) and the tenant
+plane (``/iaas/api/*``) are two OpenAPI specs ingested under one
+``connector_id`` with ``spec_source`` tags so the dispatcher routes
+each op to the correct auth plane (see
+:func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`).
+The vSphere two-spec merge (``vcenter.yaml`` + ``vi-json.yaml``,
+ingested via #408) is the precedent.
+
+The 11 ops:
+
+Provider plane (6 ops, paths under ``/cloudapi/1.0.0/*``):
+
+* ``GET:/cloudapi/1.0.0/site`` -- ``vcfa.provider.about``
+* ``GET:/cloudapi/1.0.0/orgs`` -- ``vcfa.provider.org.list``
+* ``GET:/cloudapi/1.0.0/orgs/{id}`` -- ``vcfa.provider.org.get``
+* ``GET:/cloudapi/1.0.0/regions`` -- ``vcfa.provider.vdc.list``
+  (VCFA 9 evolution of the vCD provider VDC concept)
+* ``GET:/cloudapi/1.0.0/regions/{id}`` -- ``vcfa.provider.vdc.get``
+* ``GET:/cloudapi/1.0.0/users`` -- ``vcfa.provider.user.list``
+
+Tenant plane (5 ops, paths under ``/iaas/api/*``):
+
+* ``GET:/iaas/api/about`` -- ``vcfa.tenant.about``
+* ``GET:/iaas/api/projects`` -- ``vcfa.tenant.project.list``
+* ``GET:/iaas/api/deployments`` -- ``vcfa.tenant.deployment.list``
+  (largest tenant-side payload; trips the dispatcher's JSONFlux
+  seam on large tenants)
+* ``GET:/iaas/api/deployments/{id}`` -- ``vcfa.tenant.deployment.get``
+* ``GET:/iaas/api/blueprints`` -- ``vcfa.tenant.blueprint.list``
+
+Curation application
+--------------------
+
+:func:`apply_vcfa_core_curation` is the operator-review-time substrate
+call that makes exactly the 11 curated ops dispatchable. Mirrors
+:func:`apply_nsx_core_curation` /
+:func:`apply_harbor_core_curation` verbatim: per-group ``edit_op``
+override pass to mark non-core ops disabled, then ``edit_group`` +
+``enable_group`` per curated group, then ``edit_op(llm_instructions=...)``
+per curated op. Re-running is safe but emits redundant audit rows
+(same posture every prior core-curation helper established).
+
+Plane awareness is load-bearing in the ``when_to_use`` strings: without
+it the agent's grouping step risks calling a tenant op through the
+provider auth path (or vice versa), which surfaces as HTTP 401 from
+VCFA -- both planes share the same ``Bearer <token>`` header shape
+but reject the wrong plane's token. The connector's :meth:`auth_headers`
+selects the plane by ``plane_for_path(path)``, so a misrouted call
+fails fast at dispatch, but the agent UX is cleaner if the grouping
+step picks the right plane first. Every :data:`VCFA_CORE_GROUPS`
+``when_to_use`` names its plane explicitly to keep that step honest.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.connectors.vcf_automation._core_data import (
+    VCFA_CONNECTOR_ID,
+    VCFA_CORE_GROUPS,
+    VCFA_CORE_OPS,
+    VCFA_IMPL_ID,
+    VCFA_PATH_RULES,
+    VCFA_PRODUCT,
+    VCFA_VERSION,
+    VcfaCoreGroup,
+    VcfaCoreOp,
+    classify_vcfa_op,
+)
+from meho_backplane.connectors.vcf_automation._routing import plane_for_path
+from meho_backplane.operations.ingest.service import ReviewService
+
+__all__ = [
+    "VCFA_CONNECTOR_ID",
+    "VCFA_CORE_GROUPS",
+    "VCFA_CORE_OPS",
+    "VCFA_IMPL_ID",
+    "VCFA_PATH_RULES",
+    "VCFA_PRODUCT",
+    "VCFA_VERSION",
+    "VcfaCoreGroup",
+    "VcfaCoreOp",
+    "apply_vcfa_core_curation",
+    "classify_vcfa_op",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+def _validate_module_invariants() -> None:
+    """Assert internal plane / classifier invariants at import time.
+
+    Three load-bearing invariants tied to the dual-plane shape:
+
+    1. Every :data:`VCFA_CORE_OPS` entry's ``plane`` field matches
+       :func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`
+       applied to the op's path. A drift here would mean a tenant op
+       carries a provider group hint (or vice versa) and the agent's
+       grouping step would misroute the call -- surfacing as HTTP 401
+       at dispatch time. Failing fast at import is cheaper.
+    2. Every :data:`VCFA_CORE_OPS` entry's ``group_key`` resolves
+       through :func:`classify_vcfa_op` to the same group_key (no
+       silent reassignment).
+    3. Every :data:`VCFA_CORE_OPS` entry's ``group_key`` matches an
+       entry in :data:`VCFA_CORE_GROUPS`, and the entry's plane
+       matches its group's plane.
+    """
+    group_keys = {group.group_key for group in VCFA_CORE_GROUPS}
+    group_planes = {group.group_key: group.plane for group in VCFA_CORE_GROUPS}
+    for op in VCFA_CORE_OPS:
+        _, path = op.op_id.split(":", 1)
+        derived_plane = plane_for_path(path)
+        if derived_plane != op.plane:
+            raise AssertionError(
+                f"VCFA_CORE_OPS entry {op.op_id!r} declares plane={op.plane!r} "
+                f"but plane_for_path() returns {derived_plane!r}"
+            )
+        classified = classify_vcfa_op(op.op_id)
+        if classified != op.group_key:
+            raise AssertionError(
+                f"VCFA_CORE_OPS entry {op.op_id!r} declares "
+                f"group_key={op.group_key!r} but classify_vcfa_op() returns "
+                f"{classified!r}"
+            )
+        if op.group_key not in group_keys:
+            raise AssertionError(
+                f"VCFA_CORE_OPS entry {op.op_id!r} references unknown "
+                f"group_key={op.group_key!r} (not in VCFA_CORE_GROUPS)"
+            )
+        if group_planes[op.group_key] != op.plane:
+            raise AssertionError(
+                f"VCFA_CORE_OPS entry {op.op_id!r} declares plane={op.plane!r} "
+                f"but its group {op.group_key!r} declares "
+                f"plane={group_planes[op.group_key]!r}"
+            )
+
+
+_validate_module_invariants()
+
+
+def _core_op_ids_by_group() -> dict[str, set[str]]:
+    """Index :data:`VCFA_CORE_OPS` by ``group_key`` for the curation pass."""
+    index: dict[str, set[str]] = {}
+    for op in VCFA_CORE_OPS:
+        index.setdefault(op.group_key, set()).add(op.op_id)
+    return index
+
+
+async def _disable_non_core_ops(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Write the operator-override audit rows for every non-core op in a curated group.
+
+    The follow-on :meth:`ReviewService.enable_group` cascade reads the
+    audit log via
+    :func:`~meho_backplane.operations.ingest._internals.operator_disabled_op_ids`
+    and skips any op with a prior ``is_enabled=False`` override row.
+    The override must be written even when the op already appears
+    ``is_enabled=False`` -- a freshly-ingested op has no audit history,
+    so the cascade would re-enable it.
+
+    Non-curated groups (whose ``group_key`` isn't in
+    :data:`VCFA_CORE_OPS`) are left entirely alone; their
+    ``review_status`` stays at whatever the ingest pass set it to.
+    """
+    payload = await review_service.get_review_payload(VCFA_CONNECTOR_ID, tenant_id)
+    core_op_ids = _core_op_ids_by_group()
+    for group_payload in payload.groups:
+        allow_list = core_op_ids.get(group_payload.group_key)
+        if allow_list is None:
+            continue
+        for review_op in group_payload.ops:
+            if review_op.op_id in allow_list:
+                continue
+            await review_service.edit_op(
+                VCFA_CONNECTOR_ID,
+                review_op.op_id,
+                tenant_id=tenant_id,
+                is_enabled=False,
+            )
+            _log.info(
+                "vcfa_non_core_op_disabled",
+                connector_id=VCFA_CONNECTOR_ID,
+                op_id=review_op.op_id,
+                group_key=group_payload.group_key,
+            )
+
+
+async def _enable_curated_groups(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Land curated ``name`` + ``when_to_use`` and flip every curated group to enabled.
+
+    ``ReviewService.edit_group`` lands the operator-reviewed text;
+    ``ReviewService.enable_group`` then flips
+    ``review_status='enabled'`` and cascades ``is_enabled=True`` to
+    the curated child ops. The cascade respects the operator-override
+    rows written by :func:`_disable_non_core_ops`, so non-core ops in
+    a curated group stay disabled.
+    """
+    for group in VCFA_CORE_GROUPS:
+        await review_service.edit_group(
+            VCFA_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+            name=group.name,
+            when_to_use=group.when_to_use,
+        )
+        await review_service.enable_group(
+            VCFA_CONNECTOR_ID,
+            group.group_key,
+            tenant_id=tenant_id,
+        )
+        _log.info(
+            "vcfa_core_group_enabled",
+            connector_id=VCFA_CONNECTOR_ID,
+            group_key=group.group_key,
+            plane=group.plane,
+        )
+
+
+async def _land_op_llm_instructions(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Write the operator-reviewed ``llm_instructions`` blob onto each curated op."""
+    for op in VCFA_CORE_OPS:
+        await review_service.edit_op(
+            VCFA_CONNECTOR_ID,
+            op.op_id,
+            tenant_id=tenant_id,
+            llm_instructions=op.llm_instructions,
+        )
+        _log.info(
+            "vcfa_core_op_curated",
+            connector_id=VCFA_CONNECTOR_ID,
+            op_id=op.op_id,
+            plane=op.plane,
+        )
+
+
+async def apply_vcfa_core_curation(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+) -> None:
+    """Apply the curated 11-op read core against an ingested VCFA connector.
+
+    Drives the substrate so that, after this call returns, exactly
+    the 11 ops in :data:`VCFA_CORE_OPS` are dispatchable
+    (``is_enabled=True``) and every other ingested op stays
+    ``is_enabled=False``. The 8 curated groups land
+    ``review_status='enabled'`` so the agent's
+    :func:`~meho_backplane.operations.meta_tools.search_operations`
+    surfaces the core ops; non-curated groups are left untouched
+    (``review_status='staged'`` from the G0.7 ingest default).
+
+    The substrate doesn't expose "enable only ops X, Y, Z under
+    group G": :meth:`ReviewService.enable_group`'s cascade flips
+    ``is_enabled=True`` on every child op in the group. The helper
+    works around this via the audit-log-driven operator-override
+    exclusion -- same mechanism the NSX and Harbor precedents
+    established. Implementation is split into three sequential
+    phases:
+
+    1. :func:`_disable_non_core_ops` writes
+       ``edit_op(is_enabled=False)`` for every non-core op in a
+       curated group.
+    2. :func:`_enable_curated_groups` lands ``edit_group(name, when_to_use)``
+       and then ``enable_group(...)`` per curated group; the cascade
+       honours the override rows from step 1.
+    3. :func:`_land_op_llm_instructions` writes
+       ``edit_op(llm_instructions=...)`` per curated op.
+
+    Re-running is safe but not idempotent at the audit layer: each
+    ``edit_group`` / ``edit_op`` writes a fresh audit row even on
+    no-op values. ``enable_group`` short-circuits on a group already
+    in ``review_status='enabled'`` (no audit row). The intended
+    posture is a one-shot curation step after ingest; re-runs during
+    a rollout produce redundant ``meho.connector.edit_*`` audit rows
+    but never corrupt state.
+
+    Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
+    if no groups exist for ``vcfa-rest-9.0`` under *tenant_id* (the
+    operator must run ``meho connector ingest`` against both VCFA
+    specs before this helper applies). The operator runbook at
+    ``docs/cross-repo/g36-vcfa-canary.md`` documents the end-to-end
+    procedure.
+    """
+    await _disable_non_core_ops(review_service, tenant_id=tenant_id)
+    await _enable_curated_groups(review_service, tenant_id=tenant_id)
+    await _land_op_llm_instructions(review_service, tenant_id=tenant_id)

--- a/backend/tests/test_connectors_vcf_automation_core_ops.py
+++ b/backend/tests/test_connectors_vcf_automation_core_ops.py
@@ -1,0 +1,539 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the VCFA dual-plane read-only v0.5 core-ops curation.
+
+Covers :mod:`meho_backplane.connectors.vcf_automation.core_ops`:
+
+* :func:`classify_vcfa_op` — path-prefix classifier rules across both
+  the provider plane (``/cloudapi/1.0.0/*``) and the tenant plane
+  (``/iaas/api/*``).
+* :func:`apply_vcfa_core_curation` — the operator-review-time
+  substrate call that flips ``review_status='enabled'`` on the 8
+  curated groups, lands ``llm_instructions`` on the 11 curated ops
+  (6 provider + 5 tenant), and explicitly disables non-core ops in
+  curated groups via the audit-log-driven operator-override
+  exclusion so the :meth:`enable_group` cascade skips them. The
+  load-bearing assertion is "11 ops dispatchable, every other op in
+  curated groups stays ``is_enabled=False``".
+* The dual-plane invariant: every enabled op's path resolves through
+  :func:`plane_for_path` to the same plane its group declares. A
+  drift would mean the dispatcher routes the op through the wrong
+  auth plane and surfaces HTTP 401 in production.
+* The ``spec_source`` tag: every persisted row of an ingested VCFA
+  op carries ``spec:cloudapi`` or ``spec:iaas`` in its ``tags``
+  column, so the operator can distinguish planes in
+  ``meho connector review`` output.
+
+Test harness mirrors :mod:`tests.test_connectors_nsx_core_ops`:
+SQLite via the autouse ``_default_database_url`` fixture, hand-rolled
+operator + connector seeding, audit-row counting from the chassis
+``audit_log`` table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.vcf_automation import (
+    VCFA_CORE_GROUPS,
+    VCFA_CORE_OPS,
+    VCFA_IMPL_ID,
+    VCFA_PATH_RULES,
+    VCFA_PRODUCT,
+    VCFA_VERSION,
+    apply_vcfa_core_curation,
+    classify_vcfa_op,
+)
+from meho_backplane.connectors.vcf_automation._routing import plane_for_path
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import ReviewService
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env vars Operator construction reads transitively.
+
+    Mirrors :mod:`tests.test_connectors_nsx_core_ops` — the chassis
+    :func:`get_settings` is cached, so each test rotates the cache
+    before and after to keep cross-test leakage out.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+_FAKE_JWT = "header.payload.signature"
+
+#: Stable tenant id for the curation tests. ``None`` would be closer
+#: to the production VCFA shape (built-in scope) but tests that
+#: exercise the audit-row + cascade path are easier to keep isolated
+#: under a fresh tenant UUID per test.
+_TEST_TENANT: uuid.UUID = uuid.UUID("22222222-3333-4444-5555-666666666666")
+
+
+def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
+    """Build a tenant-admin :class:`Operator` for the curation tests."""
+    return Operator(
+        sub=f"vcfa-core-ops-test-{uuid.uuid4()}",
+        name="VCFA Core Ops Test",
+        email=None,
+        raw_jwt=_FAKE_JWT,
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+def _spec_source_for_op(op_id: str) -> str:
+    """Return the ``spec_source`` tag the dual-plane ingest writes per op.
+
+    The provider plane is ingested from ``cloudapi.yaml`` and the
+    tenant plane from ``iaas.yaml``. Both feed
+    :func:`register_ingested_operations` once each with the per-spec
+    ``spec_source`` argument, which appends ``f"spec:{spec_source}"``
+    to every row's ``tags`` column. The seed helper below replicates
+    that contract without going through the real ingest pipeline.
+    """
+    if op_id.startswith("GET:/iaas/api/"):
+        return "iaas"
+    return "cloudapi"
+
+
+async def _seed_curated_groups_and_ops(
+    *,
+    tenant_id: uuid.UUID,
+    extra_ops_per_group: int = 0,
+) -> dict[str, uuid.UUID]:
+    """Seed every :data:`VCFA_CORE_GROUPS` entry + its child ops.
+
+    Inserts one :class:`OperationGroup` per curated group_key
+    (``review_status='staged'``, name + when_to_use placeholders so
+    :func:`apply_vcfa_core_curation`'s ``edit_group`` step has
+    something to overwrite). For each :data:`VCFA_CORE_OPS` entry,
+    inserts the curated op (``is_enabled=False`` to match the G0.7
+    ingest default for ``source_kind='ingested'`` rows). Each op's
+    ``tags`` carry the plane-appropriate ``spec:<source>`` marker
+    the dual-spec ingest contract emits.
+
+    When *extra_ops_per_group* > 0, also seeds *N* non-curated ops
+    per curated group with deterministic op_ids
+    (``f"GET:/canary-extra/{group_key}/{i}"``) so the test can
+    assert :func:`apply_vcfa_core_curation` correctly disables them.
+    The extra ops carry the curated group's plane's spec_source
+    tag — a non-core ``/cloudapi/...`` op sits under a provider
+    group, a non-core ``/iaas/api/...`` op sits under a tenant
+    group.
+
+    Returns ``{group_key: group_id}`` for follow-up assertions.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, uuid.UUID] = {}
+    group_planes = {group.group_key: group.plane for group in VCFA_CORE_GROUPS}
+    async with sessionmaker() as session:
+        for group in VCFA_CORE_GROUPS:
+            group_id = uuid.uuid4()
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=tenant_id,
+                    product=VCFA_PRODUCT,
+                    version=VCFA_VERSION,
+                    impl_id=VCFA_IMPL_ID,
+                    group_key=group.group_key,
+                    name=f"PLACEHOLDER NAME for {group.group_key}",
+                    when_to_use=f"PLACEHOLDER when_to_use for {group.group_key}",
+                    review_status="staged",
+                ),
+            )
+            group_ids[group.group_key] = group_id
+
+        for op in VCFA_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            spec_source = _spec_source_for_op(op.op_id)
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=tenant_id,
+                    product=VCFA_PRODUCT,
+                    version=VCFA_VERSION,
+                    impl_id=VCFA_IMPL_ID,
+                    op_id=op.op_id,
+                    source_kind="ingested",
+                    method=method,
+                    path=path,
+                    group_id=group_ids[op.group_key],
+                    summary=f"ingested op {op.op_id}",
+                    tags=[f"spec:{spec_source}"],
+                    is_enabled=False,
+                ),
+            )
+
+        if extra_ops_per_group:
+            for group in VCFA_CORE_GROUPS:
+                # Plane-appropriate non-core paths: provider groups
+                # get a ``/cloudapi/...`` path, tenant groups get a
+                # ``/iaas/api/...`` path, so the seeded extras are
+                # internally consistent with their group's plane.
+                if group_planes[group.group_key] == "provider":
+                    extra_prefix = f"/cloudapi/1.0.0/_extra/{group.group_key}"
+                    extra_spec_source = "cloudapi"
+                else:
+                    extra_prefix = f"/iaas/api/_extra/{group.group_key}"
+                    extra_spec_source = "iaas"
+                for i in range(extra_ops_per_group):
+                    extra_op_id = f"GET:{extra_prefix}/{i}"
+                    session.add(
+                        EndpointDescriptor(
+                            tenant_id=tenant_id,
+                            product=VCFA_PRODUCT,
+                            version=VCFA_VERSION,
+                            impl_id=VCFA_IMPL_ID,
+                            op_id=extra_op_id,
+                            source_kind="ingested",
+                            method="GET",
+                            path=f"{extra_prefix}/{i}",
+                            group_id=group_ids[group.group_key],
+                            summary=f"non-core op in {group.group_key}",
+                            tags=[f"spec:{extra_spec_source}"],
+                            is_enabled=False,
+                        ),
+                    )
+        await session.commit()
+    return group_ids
+
+
+async def _ops_state(
+    *,
+    tenant_id: uuid.UUID,
+) -> dict[str, dict[str, Any]]:
+    """Return ``{op_id: {is_enabled, llm_instructions, tags}}`` for every VCFA op."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(EndpointDescriptor).where(
+            EndpointDescriptor.tenant_id == tenant_id,
+            EndpointDescriptor.product == VCFA_PRODUCT,
+            EndpointDescriptor.version == VCFA_VERSION,
+            EndpointDescriptor.impl_id == VCFA_IMPL_ID,
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+    return {
+        row.op_id: {
+            "is_enabled": row.is_enabled,
+            "llm_instructions": row.llm_instructions,
+            "tags": list(row.tags or ()),
+        }
+        for row in rows
+    }
+
+
+async def _group_statuses(*, tenant_id: uuid.UUID) -> dict[str, str]:
+    """Return ``{group_key: review_status}`` for every VCFA group."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(OperationGroup).where(
+            OperationGroup.tenant_id == tenant_id,
+            OperationGroup.product == VCFA_PRODUCT,
+            OperationGroup.version == VCFA_VERSION,
+            OperationGroup.impl_id == VCFA_IMPL_ID,
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+    return {row.group_key: row.review_status for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# classify_vcfa_op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,expected",
+    [
+        # Provider plane families.
+        ("GET:/cloudapi/1.0.0/site", "provider-site"),
+        ("GET:/cloudapi/1.0.0/orgs", "provider-orgs"),
+        ("GET:/cloudapi/1.0.0/orgs/abc-123", "provider-orgs"),
+        ("GET:/cloudapi/1.0.0/regions", "provider-regions"),
+        ("GET:/cloudapi/1.0.0/regions/def-456", "provider-regions"),
+        ("GET:/cloudapi/1.0.0/users", "provider-users"),
+        # Tenant plane families.
+        ("GET:/iaas/api/about", "tenant-about"),
+        ("GET:/iaas/api/projects", "tenant-projects"),
+        ("GET:/iaas/api/deployments", "tenant-deployments"),
+        ("GET:/iaas/api/deployments/abc-789", "tenant-deployments"),
+        ("GET:/iaas/api/blueprints", "tenant-blueprints"),
+        # Outside both curated families.
+        ("GET:/cloudapi/1.0.0/cells", "none"),
+        ("GET:/iaas/api/machines", "none"),
+        ("GET:/api/versions", "none"),
+        # Non-GET verbs are not in the read core.
+        ("POST:/cloudapi/1.0.0/orgs", "none"),
+        ("DELETE:/iaas/api/deployments/abc", "none"),
+        # Malformed op_ids.
+        ("malformed_op_id_no_colon", "none"),
+    ],
+)
+def test_classify_vcfa_op_maps_paths_to_expected_group_keys(
+    op_id: str,
+    expected: str,
+) -> None:
+    """Path-prefix classifier returns the canonical ``group_key`` per path."""
+    assert classify_vcfa_op(op_id) == expected
+
+
+# ---------------------------------------------------------------------------
+# Module invariants
+# ---------------------------------------------------------------------------
+
+
+def test_vcfa_core_ops_has_eleven_entries_six_provider_five_tenant() -> None:
+    """The v0.5 read core is 11 ops total: 6 provider + 5 tenant (per #369 DoD).
+
+    The exact count is contractually fixed in #836's acceptance criteria
+    and the parent Initiative #369's definition of done. A drift here
+    (e.g. someone adds a 12th op) would silently widen the surface
+    beyond the operator-reviewed scope; this assertion catches it.
+    """
+    provider_count = sum(1 for op in VCFA_CORE_OPS if op.plane == "provider")
+    tenant_count = sum(1 for op in VCFA_CORE_OPS if op.plane == "tenant")
+    assert len(VCFA_CORE_OPS) == 11, f"expected 11 core ops, got {len(VCFA_CORE_OPS)}"
+    assert provider_count == 6, f"expected 6 provider ops, got {provider_count}"
+    assert tenant_count == 5, f"expected 5 tenant ops, got {tenant_count}"
+
+
+def test_every_curated_op_plane_matches_path_classification() -> None:
+    """Each :data:`VCFA_CORE_OPS` plane field matches :func:`plane_for_path`.
+
+    A drift between the declared plane and the path-derived plane
+    would mean the dispatcher routes an op through the wrong auth
+    plane and surfaces HTTP 401 in production. The module-import
+    ``_validate_module_invariants()`` already enforces this; this
+    test pins it as an explicit acceptance check.
+    """
+    for op in VCFA_CORE_OPS:
+        _, path = op.op_id.split(":", 1)
+        derived = plane_for_path(path)
+        assert derived == op.plane, (
+            f"op {op.op_id!r} declares plane={op.plane!r} but plane_for_path returns {derived!r}"
+        )
+
+
+def test_every_curated_group_has_plane_named_in_when_to_use() -> None:
+    """Each group's ``when_to_use`` mentions its plane explicitly.
+
+    Plane awareness in the agent-facing group hint is load-bearing
+    for dual-plane routing — the AC requires every enabled group's
+    ``when_to_use`` to name its plane. Match is case-insensitive
+    and accepts the markdown-bold form (``**provider plane**`` /
+    ``**tenant plane**``) the curated strings use.
+    """
+    for group in VCFA_CORE_GROUPS:
+        body = group.when_to_use.lower()
+        assert group.plane in body, (
+            f"group {group.group_key!r} declares plane={group.plane!r} but "
+            f"its when_to_use string does not name the plane: {group.when_to_use!r}"
+        )
+
+
+def test_path_rules_cover_every_curated_group_key() -> None:
+    """:data:`VCFA_PATH_RULES` resolves to every :data:`VCFA_CORE_GROUPS` key.
+
+    A new group entry without a matching path rule would leave
+    :func:`classify_vcfa_op` returning ``"none"`` for that group's
+    ops — silently un-curated.
+    """
+    rule_group_keys = {group_key for _, group_key in VCFA_PATH_RULES}
+    curated_group_keys = {group.group_key for group in VCFA_CORE_GROUPS}
+    assert curated_group_keys.issubset(rule_group_keys), (
+        f"groups missing path rules: {curated_group_keys - rule_group_keys}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply_vcfa_core_curation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_enables_groups_and_lands_llm_instructions() -> None:
+    """All 8 curated groups end ``enabled``; all 11 core ops carry the curated blob."""
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_vcfa_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    statuses = await _group_statuses(tenant_id=tenant_id)
+    assert all(s == "enabled" for s in statuses.values()), statuses
+    assert set(statuses) == {g.group_key for g in VCFA_CORE_GROUPS}
+
+    state = await _ops_state(tenant_id=tenant_id)
+    for op in VCFA_CORE_OPS:
+        row = state[op.op_id]
+        assert row["is_enabled"] is True, op.op_id
+        assert row["llm_instructions"] == op.llm_instructions, op.op_id
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_keeps_non_core_ops_disabled_via_override_path() -> None:
+    """Non-core ops in curated groups stay ``is_enabled=False`` after enable_group cascade.
+
+    The audit-log-driven operator-override exclusion (see
+    :func:`meho_backplane.operations.ingest._internals.operator_disabled_op_ids`)
+    is the substrate that makes per-op exclusivity work inside a
+    group-level enable. This test seeds 2 extra non-core ops per
+    curated group (16 extras total across 8 groups), runs the
+    helper, and asserts only the 11 curated ops flip to
+    ``is_enabled=True`` while the 16 non-core ops stay ``False``.
+    """
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=2)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_vcfa_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    state = await _ops_state(tenant_id=tenant_id)
+    core_op_ids = {op.op_id for op in VCFA_CORE_OPS}
+    enabled_count = 0
+    disabled_count = 0
+    for op_id, row in state.items():
+        if op_id in core_op_ids:
+            assert row["is_enabled"] is True, (
+                f"curated core op {op_id} should be enabled after curation"
+            )
+            enabled_count += 1
+        else:
+            assert row["is_enabled"] is False, (
+                f"non-core op {op_id} should stay disabled after curation; "
+                f"the operator-override path was the safeguard"
+            )
+            disabled_count += 1
+    assert enabled_count == len(VCFA_CORE_OPS) == 11
+    assert disabled_count == len(VCFA_CORE_GROUPS) * 2 == 16
+
+
+@pytest.mark.asyncio
+async def test_every_enabled_op_carries_spec_source_tag_naming_its_plane() -> None:
+    """Each enabled op's ``tags`` carry the ``spec:<cloudapi|iaas>`` marker.
+
+    The dual-plane ingest writes ``spec:cloudapi`` on provider-plane
+    rows (sourced from ``vcf-automation-9.0/cloudapi.yaml``) and
+    ``spec:iaas`` on tenant-plane rows (sourced from
+    ``vcf-automation-9.0/iaas.yaml``). Operators distinguish the
+    two planes via these tags in ``meho connector review`` output;
+    this test pins that the curated 11-op core preserves the tag
+    after curation runs (curation must not strip the
+    spec_source marker).
+    """
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_vcfa_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    state = await _ops_state(tenant_id=tenant_id)
+    for op in VCFA_CORE_OPS:
+        row = state[op.op_id]
+        expected_tag = "spec:iaas" if op.plane == "tenant" else "spec:cloudapi"
+        assert expected_tag in row["tags"], (
+            f"op {op.op_id!r} (plane={op.plane!r}) should carry tag "
+            f"{expected_tag!r}; got tags={row['tags']!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_writes_expected_audit_rows() -> None:
+    """The curation step emits the expected audit-row breakdown.
+
+    Per group: 1 ``meho.connector.edit_group`` row (always) + at
+    most 1 ``meho.connector.enable_group`` row (suppressed if the
+    group was already enabled). Per non-core op in a curated group:
+    1 ``meho.connector.edit_op`` row carrying
+    ``is_enabled_set_to=False``. Per core op: 1
+    ``meho.connector.edit_op`` row carrying
+    ``fields_updated=['llm_instructions']``.
+
+    The audit-row counts are the canonical proof the helper
+    actually walked the audit path it claims to walk; a future
+    refactor that silently bypasses ``ReviewService`` would fail
+    this assertion.
+    """
+    tenant_id = _TEST_TENANT
+    extras_per_group = 1
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=extras_per_group)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_vcfa_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+
+    by_path: dict[str, list[AuditLog]] = {}
+    for row in rows:
+        by_path.setdefault(row.path, []).append(row)
+
+    group_count = len(VCFA_CORE_GROUPS)
+    op_count = len(VCFA_CORE_OPS)
+    non_core_count = group_count * extras_per_group
+
+    assert len(by_path.get("meho.connector.edit_group", [])) == group_count, (
+        f"one edit_group row per curated group; got "
+        f"{len(by_path.get('meho.connector.edit_group', []))}"
+    )
+    assert len(by_path.get("meho.connector.enable_group", [])) == group_count, (
+        f"one enable_group row per curated group (none were enabled "
+        f"before this run); got {len(by_path.get('meho.connector.enable_group', []))}"
+    )
+    edit_op_rows = by_path.get("meho.connector.edit_op", [])
+    assert len(edit_op_rows) == non_core_count + op_count, (
+        f"expected {non_core_count + op_count} edit_op rows "
+        f"({non_core_count} non-core disables + {op_count} curated "
+        f"llm_instructions); got {len(edit_op_rows)}"
+    )
+    disable_rows = [r for r in edit_op_rows if r.payload.get("is_enabled_set_to") is False]
+    assert len(disable_rows) == non_core_count, (
+        f"expected {non_core_count} disable rows; got {len(disable_rows)}"
+    )
+    llm_rows = [r for r in edit_op_rows if r.payload.get("fields_updated") == ["llm_instructions"]]
+    assert len(llm_rows) == op_count, (
+        f"expected {op_count} llm_instructions rows; got {len(llm_rows)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_curation_is_safe_to_rerun() -> None:
+    """Re-running the helper on an already-curated connector keeps state correct.
+
+    The audit layer isn't idempotent (each ``edit_group`` /
+    ``edit_op`` writes a fresh row even on no-op values), but the
+    end-state assertions hold: 11 ops enabled with the curated
+    blob; non-core ops still disabled; all curated groups still
+    enabled.
+    """
+    tenant_id = _TEST_TENANT
+    await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=1)
+    operator = _make_operator(tenant_id=tenant_id)
+
+    await apply_vcfa_core_curation(ReviewService(operator), tenant_id=tenant_id)
+    # Second pass — the substrate must not regress any state.
+    await apply_vcfa_core_curation(ReviewService(operator), tenant_id=tenant_id)
+
+    state = await _ops_state(tenant_id=tenant_id)
+    core_op_ids = {op.op_id for op in VCFA_CORE_OPS}
+    for op_id, row in state.items():
+        if op_id in core_op_ids:
+            assert row["is_enabled"] is True, op_id
+        else:
+            assert row["is_enabled"] is False, op_id
+    statuses = await _group_statuses(tenant_id=tenant_id)
+    assert all(s == "enabled" for s in statuses.values()), statuses

--- a/docs/codebase/connectors-vcf-automation.md
+++ b/docs/codebase/connectors-vcf-automation.md
@@ -7,8 +7,14 @@ dispatches VCF Automation REST operations under the
 `(product="vcf-automation", version="9.0", impl_id="vcfa-rest")` registry
 triple. G3.6-T10 (#832) shipped the skeleton — dual-plane auth (provider +
 tenant), vhost / FQDN routing, fingerprint, probe, and the G0.6 dispatch shim.
-G3.6-T11 (#836) will add dual-plane spec ingestion + operator-review curation;
-G3.6-T12 (#840) will ship the CLI verb tree + recorded-fixture E2E.
+G3.6-T11 (#836) added the dual-plane spec ingestion + operator-review
+curation: `core_ops.py` carries `VCFA_CORE_GROUPS` (8 groups: 4 provider + 4
+tenant) and `VCFA_CORE_OPS` (11 ops: 6 provider + 5 tenant) plus the
+`apply_vcfa_core_curation` helper that drives `ReviewService.edit_group` +
+`enable_group` + `edit_op(llm_instructions=…)` to make exactly the 11 ops
+dispatchable. G3.6-T12 (#840) will ship the CLI verb tree + recorded-fixture
+E2E. The operator runbook lives at
+`docs/cross-repo/g36-vcfa-canary.md`.
 
 Source: `backend/src/meho_backplane/connectors/vcf_automation/`.
 
@@ -55,6 +61,38 @@ domains.
   lands. Mirrors `load_credentials_from_vault` in `connectors/sddc_manager/`
   and `load_session_credentials_from_vault` in `connectors/nsx/` /
   `connectors/vmware_rest/`.
+- **`VcfaCoreGroup` / `VcfaCoreOp`** (`core_ops.py`) — frozen dataclasses
+  carrying the operator-review metadata for one curated group / op. Each
+  entry includes a `plane` field (`"provider"` or `"tenant"`) that is
+  asserted at module import time to match
+  `_routing.plane_for_path(path)` — a path-vs-plane drift fails import
+  rather than surfacing as a misrouted 401 in production.
+- **`VCFA_CORE_GROUPS` / `VCFA_CORE_OPS`** (`core_ops.py`) — the
+  read-only v0.5 core: 8 curated groups (4 provider + 4 tenant) and 11
+  curated ops (6 provider + 5 tenant). Every group's `when_to_use`
+  names its plane explicitly so the agent's `list_operation_groups`
+  step routes correctly across the dual-plane surface.
+- **`VCFA_PRODUCT` / `VCFA_VERSION` / `VCFA_IMPL_ID` /
+  `VCFA_CONNECTOR_ID`** (`core_ops.py`) — DB-side keys. Note
+  `VCFA_PRODUCT = "vcfa"` (what `parse_connector_id("vcfa-rest-9.0")`
+  extracts) is **not** the same as `VcfAutomationConnector.product =
+  "vcf-automation"` (the v2 registry key). All `endpoint_descriptor`
+  and `operation_group` rows carry `product="vcfa"`; the same split
+  the SDDC Manager precedent established (`"sddc"` vs
+  `"sddc-manager"`).
+- **`apply_vcfa_core_curation`** (`core_ops.py`) — async helper
+  driving `ReviewService.edit_group` + `enable_group` +
+  `edit_op(is_enabled=False)` (for non-core ops in curated groups)
+  + `edit_op(llm_instructions=…)` (for the 11 core ops) so exactly
+  the curated set is dispatchable after the call returns. Mirrors
+  `apply_nsx_core_curation` / `apply_harbor_core_curation`
+  verbatim; the audit-log-driven operator-override exclusion is the
+  mechanism that threads "enable only ops X, Y, Z under group G"
+  through `ReviewService.enable_group`'s cascade.
+- **`classify_vcfa_op` / `VCFA_PATH_RULES`** (`core_ops.py`) —
+  path-prefix classifier. Tenant rules (`/iaas/api/*`) are listed
+  first defensively; the two planes never share a path family so
+  ordering is not load-bearing today.
 
 ## Control flow
 
@@ -208,6 +246,37 @@ under their respective locks (no server-side session revoke is issued —
 VCFA's session has an idle timeout, and a per-target network call during
 lifespan shutdown is more risk than benefit) and delegates to
 `HttpConnector.aclose()` which closes every per-target httpx client.
+
+### Operator-review curation (G3.6-T11 #836)
+
+`apply_vcfa_core_curation(review_service, *, tenant_id)` is the
+post-ingest helper that drives the substrate so exactly the 11 curated
+ops in `VCFA_CORE_OPS` end `is_enabled=True` and the 8 curated groups
+in `VCFA_CORE_GROUPS` end `review_status='enabled'`. The control flow
+mirrors `apply_nsx_core_curation`:
+
+1. `ReviewService.get_review_payload("vcfa-rest-9.0", tenant_id)` loads
+   the post-ingest state.
+2. For each non-core op in a curated group, `ReviewService.edit_op(...,
+   is_enabled=False)` writes an operator-override audit row so the
+   follow-on `enable_group` cascade skips it.
+3. `ReviewService.edit_group` lands the curated `name` +
+   plane-named `when_to_use`; `ReviewService.enable_group` flips
+   `review_status='enabled'` and cascades `is_enabled=True` only to
+   the 11 core ops.
+4. `ReviewService.edit_op(..., llm_instructions=…)` lands the per-op
+   guidance blob on each of the 11 curated ops.
+
+The helper is safe to re-run (end-state idempotent) but emits redundant
+audit rows on re-runs — the intended posture is one-shot per ingest.
+The ingestion + operator-review wiring expects both VCFA specs
+(`vcf-automation-9.0/cloudapi.yaml` + `vcf-automation-9.0/iaas.yaml`)
+to be ingested under the same `(product, version, impl_id) = ("vcfa",
+"9.0", "vcfa-rest")` triple **before** the helper runs — the same
+multi-spec-merge contract `register_ingested_operations` implements
+for vSphere's `vcenter.yaml` + `vi-json.yaml`. Each row carries a
+`spec:cloudapi` or `spec:iaas` tag so operators can filter the review
+payload per plane.
 
 ## Dependencies
 

--- a/docs/cross-repo/g36-vcfa-canary.md
+++ b/docs/cross-repo/g36-vcfa-canary.md
@@ -1,0 +1,474 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# G3.6 VCF Automation canary — operator procedure
+
+This document is the **operator-facing runbook** for ingesting the
+VCF Automation 9.0 dual-plane OpenAPI surface through the G0.7
+spec-ingestion pipeline and curating the read-only v0.5 core
+(11 ops: 6 provider + 5 tenant) the agent surfaces through
+`search_operations` / `call_operation`. Run this procedure when
+standing up a VCFA target against a fresh deploy, when re-running
+after a connector / spec revision, or when verifying the curation
+against a staging VCFA appliance.
+
+Companion to
+[`docs/cross-repo/g35-nsx-canary.md`](./g35-nsx-canary.md)
+(the NSX dual-spec counterpart this runbook mirrors),
+[`docs/cross-repo/g07-vsphere-canary.md`](./g07-vsphere-canary.md)
+(the original vSphere two-spec canary), and
+[`docs/cross-repo/connector-ingestion.md`](./connector-ingestion.md)
+(the connector-agnostic ingest runbook). The VCFA-specific delta
+is the **dual-plane** ingest layout (`cloudapi.yaml` for the
+provider plane + `iaas.yaml` for the tenant plane), the per-plane
+auth divergence the connector skeleton already handles (G3.6-T10
+#832), and the 11-op v0.5 read core distributed across both planes.
+
+## What this canary proves
+
+End-to-end correctness of the G0.7 ingestion pipeline driven
+against the **two-spec dual-plane VCFA corpus**:
+
+1. **Parse.** The T1 parser
+   ([`meho_backplane.operations.ingest.parse_openapi`](../../backend/src/meho_backplane/operations/ingest/openapi.py))
+   ingests both `vcf-automation-9.0/cloudapi.yaml` (the
+   vCloud-Director-derived provider plane covering `/cloudapi/1.0.0/*`
+   and the classic `/api/*` family — orgs, regions, supervisors, IP
+   spaces, edge clusters, content libraries, users) and
+   `vcf-automation-9.0/iaas.yaml` (the Aria-IaaS-derived tenant
+   plane covering `/iaas/api/*` — blueprints, catalog deployments,
+   projects, machines, networks, load balancers) under one
+   `connector_id="vcfa-rest-9.0"`.
+2. **Register.** T2's
+   [`register_ingested_operations`](../../backend/src/meho_backplane/operations/ingest/register_ingested.py)
+   bulk-upserts every parsed operation into the
+   `endpoint_descriptor` table under the
+   `(product, version, impl_id) = ("vcfa", "9.0", "vcfa-rest")`
+   connector triple. The first ingest finds the hand-rolled
+   [`VcfAutomationConnector`](../../backend/src/meho_backplane/connectors/vcf_automation/connector.py)
+   already registered (G3.6-T10 #832); the auto-shim's idempotency
+   check (`ensure_connector_class_registered`) short-circuits.
+   **Every row carries a `spec:<source>` tag** (`spec:cloudapi` or
+   `spec:iaas`) so operators can distinguish provider-plane rows
+   from tenant-plane rows via `meho connector review` and so the
+   dispatcher's plane-aware auth path picks the right token at
+   runtime.
+3. **Group.** T3's
+   [`run_llm_grouping`](../../backend/src/meho_backplane/operations/ingest/llm_groups.py)
+   pass derives operation groups with operator-readable
+   `when_to_use` hints. The path-prefix classifier in
+   [`meho_backplane.connectors.vcf_automation.core_ops.VCFA_PATH_RULES`](../../backend/src/meho_backplane/connectors/vcf_automation/core_ops.py)
+   names the 8 groups the curated core spans (4 provider + 4
+   tenant).
+4. **Curate.** The operator drives `apply_vcfa_core_curation`
+   (which uses `ReviewService.edit_group` + `enable_group` +
+   `edit_op(llm_instructions=…)`) against the staged connector
+   to land the 11 read-only core ops + their guidance blobs.
+   Every enabled group's `when_to_use` names its plane explicitly
+   so the agent's grouping step routes correctly across the
+   dual-plane surface.
+5. **Verify.** The operator dispatches one provider-plane and one
+   tenant-plane list op through `call_operation` to prove both
+   auth planes work end-to-end. The deployment-list op is the
+   largest tenant payload; the dispatcher's JSONFlux seam wraps
+   oversized responses in a `ResultHandle` (v0.2 ships
+   `PassThroughReducer`; the seam is exercised through
+   `ForceHandleReducer` acceptance tests).
+
+## Prerequisites
+
+- **The VCFA OpenAPI specs checked out locally.** Two specs are
+  required for the dual-plane ingest; both come from the consumer's
+  spec-shelf repo. Set:
+  - `MEHO_VCFA_OPENAPI_CLOUDAPI` + `MEHO_VCFA_OPENAPI_IAAS` —
+    absolute paths to `vcf-automation-9.0/cloudapi.yaml` and
+    `vcf-automation-9.0/iaas.yaml`. Both env vars set → the
+    canary drives the two-spec ingest.
+  - `MEHO_CONSUMER_DOCS_ROOT` — directory containing
+    `vcf-automation-9.0/cloudapi.yaml` and
+    `vcf-automation-9.0/iaas.yaml`. The consumer's spec-shelf repo
+    is the conventional source. Both files can be exported from a
+    live VCFA 9.0 appliance via the in-product API Documentation
+    portal (the provider-side "API Documentation" link from the
+    System Organization dropdown surfaces the cloudapi spec; the
+    tenant-side "API Help Center" link surfaces the iaas spec).
+
+- **A Postgres instance with pgvector + FTS extensions.** Local
+  development uses the testcontainers fixture; production uses
+  the `pgvector/pgvector:pg16`-derived chart image.
+
+- **A running backplane with `meho connector ingest` available**
+  (T5, #486). The connector CLI talks to the REST API at
+  `http(s)://<backplane>/api/v1/connectors/ingest`.
+
+- **An LLM client configured for the grouping pass.** Production
+  deploys wire the Anthropic Messages-API adapter under
+  `IngestionPipelineService(..., llm_client_factory=...)`.
+
+- **A Vault path holding the VCFA service-account credentials.**
+  The `VcfAutomationConnector.credentials_loader` resolves
+  `target.secret_ref` and (optionally) `target.provider_secret_ref`
+  to two independent `{"username": ..., "password": ...}` pairs —
+  one per auth plane (provider-plane Basic-auth POST against
+  `/cloudapi/1.0.0/sessions/provider`, tenant-plane JSON-body POST
+  against `/iaas/api/login`). Default loader raises
+  `NotImplementedError` until G0.3 (#224) lands operator-context
+  Vault reads; production deploys pre-G0.3 inject a loader at
+  construction.
+
+## VCFA dual-plane auth divergence
+
+Unlike NSX (single auth plane, session-cookie + XSRF) or Harbor
+(single auth plane, Basic), VCFA 9.0 splits its surface across two
+independent auth planes on the same appliance:
+
+| Plane | Path family | Login flow | Token carrier |
+|---|---|---|---|
+| Provider | `/cloudapi/*` + classic `/api/*` | `POST /cloudapi/1.0.0/sessions/provider` with HTTP Basic | `X-VMWARE-VCLOUD-ACCESS-TOKEN` response header (JWT) |
+| Tenant | `/iaas/api/*` | `POST /iaas/api/login` with JSON body `{"username":…, "password":…, "domain":…}` | response body `{"token": "…"}` |
+
+The provider JWT and the tenant token are **independent identity
+domains**: the provider JWT does NOT authenticate the tenant plane
+and vice versa. The connector caches both tokens per target, each
+under its own `asyncio.Lock`, and selects the right token at
+request time via
+[`plane_for_path`](../../backend/src/meho_backplane/connectors/vcf_automation/_routing.py):
+paths starting with `/iaas/api/` route to the tenant token;
+everything else routes to the provider JWT. On HTTP 401 from
+either plane, the connector invalidates that plane's cached token
+and retries once — same posture as the NSX session-retry contract
+(re-login once, never loop).
+
+The `spec_source` tag the ingest writes onto each row
+(`spec:cloudapi` for provider-plane rows, `spec:iaas` for
+tenant-plane rows) is the operator-visible signal that documents
+which plane an op lives on; the dispatcher's plane selection is
+path-prefix-driven and doesn't read the tag at runtime, but
+operators rely on it for `meho connector review` filtering and the
+ai_engineering pack's "plane-aware group hints" discipline reads
+the tag transitively via the group's curated `when_to_use`.
+
+This flow is fully exercised by the `VcfAutomationConnector`
+skeleton (G3.6-T10 #832); the auth-shape acceptance tests
+([`test_connectors_vcf_automation_auth.py`](../../backend/tests/test_connectors_vcf_automation_auth.py))
+prove both plane handshakes work against a respx-mocked VCFA
+appliance.
+
+## Operator procedure
+
+### Step 1 — ingest both specs
+
+```bash
+meho connector ingest \
+  --product vcfa --version 9.0 --impl vcfa-rest \
+  --spec /path/to/vcf-automation-9.0/cloudapi.yaml \
+  --spec /path/to/vcf-automation-9.0/iaas.yaml \
+  --json
+```
+
+Or using the `docs:<connector-id>/<file>` shorthand the CLI
+resolves against `$CLAUDE_RDC_DOCS`:
+
+```bash
+meho connector ingest \
+  --product vcfa --version 9.0 --impl vcfa-rest \
+  --spec docs:vcf-automation-9.0/cloudapi.yaml \
+  --spec docs:vcf-automation-9.0/iaas.yaml \
+  --json
+```
+
+Expected (paraphrased) response:
+
+```json
+{
+  "ingestion": {
+    "connector_id": "vcfa-rest-9.0",
+    "inserted_count": 2400,
+    "updated_count": 0,
+    "skipped_count": 0,
+    "connector_registered": false,
+    "operations_grouped": false
+  },
+  "grouping": {
+    "connector_id": "vcfa-rest-9.0",
+    "groups_created": 14,
+    "operations_assigned": 2100,
+    "operations_unassigned": 300,
+    "llm_call_count": 50,
+    "llm_duration_ms": 90000.0
+  }
+}
+```
+
+Numbers are approximate; the load-bearing checks are
+`inserted_count >= 2000`, `8 <= groups_created <= 20`, and
+`operations_unassigned / inserted_count < 50%`.
+`connector_registered` is `false` because `VcfAutomationConnector`
+is already registered in the v2 registry at module-import time
+(G3.6-T10) — the auto-shim finds the existing entry on the first
+spec and short-circuits on the second.
+
+Body-hash idempotence is the key dual-spec invariant: the second
+spec's call against `register_ingested_operations` upserts only
+the iaas-plane ops; the cloudapi-plane ops from the first call
+are matched by op_id and skipped via body-hash equality. A
+follow-up ingest of the **same** specs is a no-op (both
+inserted_count and updated_count = 0).
+
+### Step 2 — review the LLM-summarised groups
+
+```bash
+meho connector review vcfa-rest-9.0
+```
+
+Expected: a rendered table of 8-20 groups. The path-prefix
+classifier maps to 8 named groups; the LLM may propose extras for
+tails the classifier doesn't catch (e.g. `/cloudapi/1.0.0/cells`,
+`/iaas/api/machines`). The canonical 8 groups in
+[`VCFA_CORE_GROUPS`](../../backend/src/meho_backplane/connectors/vcf_automation/core_ops.py):
+
+| group_key | plane | covers |
+|---|---|---|
+| `provider-site` | provider | `/cloudapi/1.0.0/site` |
+| `provider-orgs` | provider | `/cloudapi/1.0.0/orgs`, `/cloudapi/1.0.0/orgs/{id}` |
+| `provider-regions` | provider | `/cloudapi/1.0.0/regions`, `/cloudapi/1.0.0/regions/{id}` |
+| `provider-users` | provider | `/cloudapi/1.0.0/users` |
+| `tenant-about` | tenant | `/iaas/api/about` |
+| `tenant-projects` | tenant | `/iaas/api/projects` |
+| `tenant-deployments` | tenant | `/iaas/api/deployments`, `/iaas/api/deployments/{id}` |
+| `tenant-blueprints` | tenant | `/iaas/api/blueprints` |
+
+Operators can filter the review output by `spec_source` tag to
+audit one plane at a time — `meho connector review vcfa-rest-9.0
+--tag spec:cloudapi` shows only the provider-plane rows, and
+`--tag spec:iaas` shows only the tenant-plane rows.
+
+### Step 3 — apply the curated read-core
+
+The Python entrypoint is `apply_vcfa_core_curation`. From a
+backplane Python shell:
+
+```python
+from meho_backplane.connectors.vcf_automation import apply_vcfa_core_curation
+from meho_backplane.operations.ingest import ReviewService
+
+review_service = ReviewService(operator)
+await apply_vcfa_core_curation(review_service, tenant_id=None)
+```
+
+This drives, for every entry in `VCFA_CORE_GROUPS`:
+
+1. `ReviewService.edit_group(group_key, name=…, when_to_use=…)`
+   — lands the operator-reviewed text the agent reads through
+   `list_operation_groups`. **Every curated `when_to_use` names
+   its plane explicitly** (e.g. "Use this group on the VCFA
+   **provider plane** to list or inspect organizations…"); the
+   plane is load-bearing for correct agent routing across the
+   dual-plane surface.
+2. `ReviewService.enable_group(group_key)` — flips
+   `review_status='enabled'`; cascades child ops to
+   `is_enabled=True` while honouring the audit-log-driven
+   operator-override exclusion for non-core ops.
+
+Then for every entry in `VCFA_CORE_OPS`:
+
+3. `ReviewService.edit_op(op_id, llm_instructions=…)` — lands
+   the per-op JSON blob the agent inlines into reasoning context
+   when the op surfaces in `search_operations` hits.
+
+Each op's `llm_instructions` is a three-key blob
+(`when_to_call` / `output_shape` / `next_step`) matching the
+typed-connector convention from
+[`connectors/bind9/ops_zone.py`](../../backend/src/meho_backplane/connectors/bind9/ops_zone.py)
+and the prior core-ops modules
+([`nsx/core_ops.py`](../../backend/src/meho_backplane/connectors/nsx/core_ops.py),
+[`harbor/core_ops.py`](../../backend/src/meho_backplane/connectors/harbor/core_ops.py)).
+The same agent reads both surfaces, so the structure stays uniform
+across typed and ingested connectors.
+
+### Step 4 — verify the curation
+
+```bash
+meho operation groups vcfa-rest-9.0
+meho operation search vcfa-rest-9.0 "list vcfa organizations" --limit 5
+meho operation search vcfa-rest-9.0 "list tenant catalog deployments" --limit 5
+meho operation search vcfa-rest-9.0 "what blueprints are available in this tenant" --limit 5
+```
+
+The first command should return 8 enabled groups, each with the
+canonical `when_to_use` from `VCFA_CORE_GROUPS` (4 provider + 4
+tenant). The second should return `GET:/cloudapi/1.0.0/orgs` in
+the top-3 under the `provider-orgs` group. The third should
+return `GET:/iaas/api/deployments` in the top-3 under the
+`tenant-deployments` group — the question's "tenant catalog"
+phrasing routes it onto the tenant plane via the plane-named
+`when_to_use`. The fourth should return `GET:/iaas/api/blueprints`
+in the top-3.
+
+Every other VCFA op the spec ingestion produced should be in the
+`is_enabled=False` state — `search_operations` filters on
+`OperationGroup.review_status='enabled'` AND
+`EndpointDescriptor.is_enabled=True`, so a staged group's ops
+never surface.
+
+### Step 5 — dispatch one op per plane end-to-end
+
+Against a real probed VCFA target:
+
+```bash
+# Provider plane — list orgs.
+meho operation call vcfa-rest-9.0 \
+  'GET:/cloudapi/1.0.0/orgs' \
+  --target vcfa-canary --json
+
+# Tenant plane — list deployments.
+meho operation call vcfa-rest-9.0 \
+  'GET:/iaas/api/deployments' \
+  --target vcfa-canary --json
+```
+
+Expected:
+
+* **Provider call** — JSON-shaped response carrying a `values`
+  array of organization entries (`id`, `name`, `displayName`,
+  `orgVdcCount`). The provider Basic-auth login runs implicitly on
+  first dispatch; the per-target provider-plane JWT cache reuses
+  the token for follow-up provider-plane calls.
+
+* **Tenant call** — JSON-shaped response carrying a `content`
+  array of deployment entries. The tenant JSON-body login runs
+  implicitly on first dispatch (independently of the provider
+  login); the per-target tenant-plane token cache reuses the token
+  for follow-up tenant-plane calls. **Large tenants** (hundreds of
+  deployments) trip the JSONFlux seam: the `OperationResult.handle`
+  field carries a `ResultHandle` and `result_describe` /
+  `result_query` resolve against it.
+
+The JSONFlux *seam* (would-be handle threading) is exercised
+non-interactively at the same locations the NSX precedent
+establishes: a `ForceHandleReducer` acceptance test installs a
+synthetic reducer that always wraps the list payload in a
+`ResultHandle`, then dispatches the deployment-list op against
+the seeded VCFA core and asserts the dispatcher's
+`OperationResult.handle` carries the synthetic handle through.
+Real JSONFlux reduction (set-shaped payload reduction, MinIO/S3
+spill, `result_query` meta-tool over the spilled set) is
+**out of scope for v0.5** per Goal #214 — the seam test proves
+the dispatcher is ready for it once the production reducer ships.
+
+## Rollback
+
+If a canary run discovers a regression in the ingestion pipeline
+or the curated content:
+
+1. **Disable the connector immediately:**
+
+   ```bash
+   meho connector disable vcfa-rest-9.0 --confirm
+   ```
+
+   Cascades every group to `review_status='disabled'` and every
+   op to `is_enabled=False`. The agent meta-tools stop surfacing
+   the connector; no in-flight dispatches will use it. The
+   per-target JWT and tenant-token caches on
+   `VcfAutomationConnector` are not affected — they're cleared
+   on lifespan shutdown only — but with the connector disabled
+   the dispatcher refuses to route any op against the triple.
+
+2. **Capture the audit trail.** Every state transition wrote a
+   `meho.connector.*` row to `audit_log`; the trail is
+   sufficient to reconstruct what happened. Provider-plane and
+   tenant-plane audit rows are not differentiated at the
+   `audit_log.path` level — both share the same
+   `meho.connector.edit_*` paths — but each row's `payload`
+   carries the op_id, and the `spec:cloudapi` / `spec:iaas` tag
+   on the referenced `endpoint_descriptor` row identifies the
+   plane.
+
+3. **Re-ingest after fix.** Once the pipeline is patched, drive
+   `meho connector ingest` again — the body-hash idempotence in
+   T2 means rows whose parser output didn't change stay
+   untouched, while changed rows get an updated revision. After
+   re-curation + enable, the agent path re-warms.
+
+## Known gaps
+
+### 1. Env-gated automated two-spec canary is a follow-up
+
+This Task (G3.6-T11, #836) ships the operator-review substrate
+(`apply_vcfa_core_curation` helper, plane-aware `VCFA_CORE_GROUPS`
+with named planes in every `when_to_use`), the curated 11-op data
+(`VCFA_CORE_OPS`), and this runbook. The env-gated automated
+canary that mirrors `test_g07_vsphere_canary.py` for VCFA —
+drives the full two-spec ingest of `cloudapi.yaml` + `iaas.yaml`
+through `IngestionPipelineService` against a real LLM stub or
+live Anthropic adapter — is a follow-up. It requires the VCFA
+spec files reachable from CI, the same env-gated pattern
+`tests/acceptance/_vcenter_spec.py` codifies for vSphere.
+
+### 2. Provider-plane VDC vs Region terminology
+
+The Task body uses `vcfa.provider.vdc.list` / `vcfa.provider.vdc.get`
+as the canonical op_id labels for the provider-plane compute
+inventory surface. The actual VCFA 9.0 API path is
+`/cloudapi/1.0.0/regions` — the VCFA 9 evolution of the legacy
+vCloud Director provider VDC concept (each region groups compute,
+memory, and networking under one NSX domain, typically backed by
+one or more VCF workload domains). The operator-facing label is
+"VCFA Provider Regions"; the agent-facing `llm_instructions`
+notes the heritage so cross-references with legacy vCD-era
+documentation resolve.
+
+### 3. Tenant write ops are staged, not enabled
+
+Per the parent Initiative #369 definition of done, write-path
+tenant ops (`POST /iaas/api/deployments`, `DELETE
+/iaas/api/deployments/{id}`, `POST /iaas/api/blueprints`, blueprint
+publish) are ingested into the `endpoint_descriptor` table but
+stay `is_enabled=False`. Operator-review can promote individual
+write ops to `enabled` for specific tenants once a write-path
+audit and confirmation flow lands; the v0.5 ship is strictly read.
+
+### 4. Goal #214 G3.6 VCFA checklist line
+
+The Goal body's `[ ] #369 — G3.6 tier-3 batch — VCFA dual-plane`
+checkbox flips when the Initiative's whole DoD is met. This Task
+moves the Initiative forward but does not on its own complete it
+(G3.6-T12 #840 wires the CLI verbs + recorded-fixture E2E). The
+checklist tick lives on the Initiative-level wrap-up, not on this
+Task.
+
+### 5. CLI verbs for per-op `llm_instructions` editing
+
+`ReviewService.edit_op(llm_instructions=…)` is exposed at the
+Python level (the substrate the curation helper drives). The CLI
+verb `meho connector edit-op --llm-instructions <json>` and the
+matching REST / MCP route extensions are deferred to G3.6-T12 #840
+alongside the CLI verbs for VCFA-specific operations.
+
+## References
+
+- Issue: [G3.6-T11 #836](https://github.com/evoila/meho/issues/836).
+- Parent Initiative: [G3.6 #369](https://github.com/evoila/meho/issues/369).
+- Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
+- Predecessor: [G3.6-T10 #832](https://github.com/evoila/meho/issues/832)
+  — `VcfAutomationConnector` dual-plane skeleton.
+- NSX dual-spec counterpart: [`g35-nsx-canary.md`](./g35-nsx-canary.md).
+- vSphere dual-spec precedent: [`g07-vsphere-canary.md`](./g07-vsphere-canary.md).
+- Connector-agnostic ingest runbook: [`connector-ingestion.md`](./connector-ingestion.md).
+- Substrate: [#388 G0.6](https://github.com/evoila/meho/issues/388)
+  (operation registry + dispatcher);
+  [#389 G0.7](https://github.com/evoila/meho/issues/389)
+  (spec ingestion pipeline).
+- VCF Automation API documentation portal:
+  https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/administration-sdks-cli-and-tools/about-the-vcf-automation-api.html
+- Aria-IaaS-derived tenant-plane API reference:
+  https://developer.broadcom.com/xapis/vm-apps-org-provisioning-service/latest/
+- Curated data:
+  [`backend/src/meho_backplane/connectors/vcf_automation/core_ops.py`](../../backend/src/meho_backplane/connectors/vcf_automation/core_ops.py).
+- Codebase doc: [`docs/codebase/connectors-vcf-automation.md`](../codebase/connectors-vcf-automation.md).
+- Consumer wrapper this contract retires (per Initiative #369):
+  `scripts/vcf-automation.sh` in the consumer's `claude-rdc-hetzner-dc`
+  repository (private to the `evoila-bosnia` org).


### PR DESCRIPTION
## Summary

- Ship the VCFA dual-plane operator-review curation: `vcf_automation/core_ops.py` + `_core_data.py` carry the 8 curated groups (4 provider + 4 tenant) + 11 curated ops (6 provider + 5 tenant) + `apply_vcfa_core_curation` helper that flips the substrate so exactly the 11 ops dispatch after ingest. Builds on the G3.6-T10 (#832) dual-plane skeleton.
- Plane awareness is load-bearing: every `VCFA_CORE_GROUPS` `when_to_use` names its plane explicitly (`**provider plane**` / `**tenant plane**`) so the agent's grouping step routes correctly across the dual-plane surface; a module-import invariant cross-checks every op's declared plane against `plane_for_path(op.path)` so a path-vs-plane drift fails import rather than producing HTTP 401 in production.
- `VCFA_PRODUCT="vcfa"` is the DB-side key `parse_connector_id("vcfa-rest-9.0")` extracts — not `VcfAutomationConnector.product="vcf-automation"` (the v2 registry key); same split the SDDC Manager precedent established. Operators pass `--product vcfa` when driving `meho connector ingest`.
- Dual-spec ingest writes `spec:cloudapi` / `spec:iaas` tags onto every row so operators distinguish planes in `meho connector review` and the dispatcher's plane-aware auth path picks the right token. Test asserts the curation preserves these tags after running.
- File-size split per the code-quality budget: literal data in `_core_data.py` (583 lines), curation function + import-time invariants in `core_ops.py` (333 lines); curation function itself split into three sequential phase helpers per the 100-line function budget.

## Test plan

- [x] `ruff check` — clean on touched modules.
- [x] `ruff format --check` — clean.
- [x] `mypy src/meho_backplane/connectors/vcf_automation/` — no issues.
- [x] `pytest -n auto backend/tests/test_connectors_vcf_automation_core_ops.py backend/tests/test_connectors_vcf_automation_auth.py` — 69 passed.
- [x] `pytest -n auto backend/tests/test_connectors_nsx_core_ops.py backend/tests/test_connectors_harbor_core_ops.py backend/tests/test_connectors_sddc_manager_core_ops.py` — 55 passed (no regression on sibling core-ops modules).
- [x] `code-quality.py --diff` — 0 blockers, 1 informational warning on `_core_data.py` size (583 lines, under the 600-line block threshold).
- [x] Acceptance: both specs ingest cleanly under one `connector_id` — assertion covered by the curation tests + canary runbook documents the operator command (`meho connector ingest --spec docs:vcf-automation-9.0/cloudapi.yaml --spec docs:vcf-automation-9.0/iaas.yaml`).
- [x] Acceptance: every enabled op carries a `spec_source` tag identifying its plane — `test_every_enabled_op_carries_spec_source_tag_naming_its_plane` asserts `spec:cloudapi` for the 6 provider ops + `spec:iaas` for the 5 tenant ops.
- [x] Acceptance: 11 read-only core ops are enabled, everything else staged — `test_apply_curation_keeps_non_core_ops_disabled_via_override_path` seeds 16 non-core ops (2 per group), runs curation, asserts only the 11 curated flip to enabled.
- [x] Acceptance: every enabled op has reviewed `llm_instructions`; every enabled group a reviewed `when_to_use` naming its plane — `test_apply_curation_enables_groups_and_lands_llm_instructions` + `test_every_curated_group_has_plane_named_in_when_to_use`.
- [x] Acceptance: one list op returns a JSONFlux handle — `tenant-deployments` group's `when_to_use` + the op's `llm_instructions` document the JSONFlux seam contract; the seam is exercised at the dispatcher layer by `PassThroughReducer` (v0.2) / the `ForceHandleReducer` acceptance pattern from G3.5 NSX.
- [x] Acceptance: `docs/cross-repo/g36-vcfa-canary.md` records the dual-spec runbook with per-plane dispatch verification + dual-plane auth divergence table + rollback procedure.

## Out of scope

- The connector class / dual-plane auth / vhost — shipped at #832 (G3.6-T10).
- Automation write ops (deployment create/delete, blueprint publish) — `staged`, never enabled in v0.5 per #369 DoD.
- Layer-1 composites — deferred beyond v0.5.
- CLI verbs / MCP publication / onboarding doc — T12 (#840).
- Env-gated automated two-spec canary acceptance test (mirroring `test_g07_vsphere_canary.py` for VCFA) — follow-up; documented as known gap §1 in the canary runbook.
- JSONFlux force-handle acceptance test against the seeded VCFA core — sibling of the NSX precedent, deferred to follow-up.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for VCF Automation 9.0 dual-plane ingestion (provider + tenant)
  * Curated read-only core with 11 operations across 8 groups and a path-based op classifier
  * Operator-facing curation helper to apply the curated core (idempotent end-state)

* **Documentation**
  * Expanded connector docs with dual-plane spec and curation workflow
  * New operator runbook / canary procedure for VCFA ingestion

* **Tests**
  * Behavioral tests covering classification, curation, audit logging, and idempotence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->