### PR TITLE
feat(cli): G3.6-T3 meho vcf-operations alias verbs + recorded-fixture E2E + onboarding doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,27 @@ connector-related release-notes line.
 
 ### Added
 
+- **`meho vcf-operations` CLI verbs + recorded-fixture E2E + operator
+  onboarding doc** (G3.6-T3
+  [#837](https://github.com/evoila/meho/issues/837)) — operator-facing
+  alias verbs over the 8 enabled vROps read ops (#833), each pre-baking
+  `connector_id="vrops-rest-9.0"` so operators don't type it on every
+  invocation: `meho vcf-operations about` (versions/current),
+  `resource list/get`, `alert list`, `alertdefinition list`,
+  `symptom list`, `recommendation list`, `supermetric list`, plus
+  `operation search/call` meta-tool wrappers. CLI is pure
+  Cobra-over-HTTP — every verb POSTs to `/api/v1/operations/call` on
+  the same dispatcher route the agent uses (CLAUDE.md postulate 5;
+  vendor logic stays out of the CLI). Recorded-fixture E2E at
+  [`backend/tests/test_connectors_vcf_operations_e2e.py`](backend/tests/test_connectors_vcf_operations_e2e.py)
+  replays the captured suite-api shape for every enabled op through
+  the full `call_operation` stack, asserts the JSONFlux handle path
+  on `resource list`, asserts audit rows carry `op_id` + `target_id`
+  + `params_hash`, and pins the Basic-auth credential-cache contract
+  (no session token, no 401-retry — same posture as Harbor and SDDC
+  Manager). Operator wrapper-flip recipe at
+  [`docs/cross-repo/vcf-operations-onboarding.md`](docs/cross-repo/vcf-operations-onboarding.md)
+  retires `./scripts/vcf-operations.sh`.
 - **vROps suite-api spec ingestion + curated read-only v0.5 core**
   (G3.6-T2 [#833](https://github.com/evoila/meho/issues/833)) —
   enables the `VcfOperationsConnector` (#829) for agent dispatch by

--- a/backend/tests/test_connectors_vcf_operations_e2e.py
+++ b/backend/tests/test_connectors_vcf_operations_e2e.py
@@ -1,0 +1,542 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vROps E2E recorded-fixture integration test (G3.6-T3 #837).
+
+Covers all four acceptance criteria from Issue #837:
+
+(a) All 8 curated vROps read ops dispatch through the full
+    ``call_operation`` stack against a respx-mocked vROps appliance
+    and return ``status='ok'``.
+(b) HTTP Basic auth path: vROps' ``/suite-api/api/*`` surface is
+    stateless — no session token, no 401-retry. The connector's stub
+    credentials loader is verified to be called (once, then cached)
+    on the first dispatch — mirrors the SDDC Manager Basic-auth
+    posture, not NSX's session-cookie-with-401-retry posture.
+(c) Audit rows: each dispatch inserts an ``AuditLog`` row carrying
+    ``method='DISPATCH'``, a non-null ``target_id``, and a
+    ``payload["params_hash"]`` key.
+(d) JSONFlux handle path: ``GET:/suite-api/api/resources`` dispatched
+    with a ``ForceHandleReducer`` returns a populated
+    ``OperationResult.handle`` with at least one ``sample_rows`` entry.
+
+Database: SQLite via the autouse ``_default_database_url`` conftest
+fixture (no ``pg_engine`` required). Runs in the ``meho-runners`` CI
+lane alongside the other ``backend/tests/test_connectors_*.py``
+files; no Docker dependency.
+
+Why recorded-fixture and not a live appliance: vROps has no public
+CI simulator (#536 — same constraint NSX, SDDC Manager, and Harbor
+hit). respx mocks the exact wire contract the connector calls, so
+the Basic-auth header + per-op HTTP request all fire through the
+connector's real pooled :class:`httpx.AsyncClient`.
+
+Fixture-refresh tooling: ``backend/tests/fixtures/vcf/refresh.py``
+(shipped by #841) is the operator-run tool that captures real vROps
+responses against a live appliance and writes redacted JSON
+fixtures. This E2E uses the same canary payloads
+:mod:`tests.acceptance._vrops_canary_fixtures` carries (which mirror
+the shape ``refresh.py`` would write); the seam between the two is
+the per-op JSON payload, so a future task can switch this E2E to
+load from the ``backend/tests/fixtures/vcf/vcf-operations/*.json``
+directory without changing the dispatcher-leg assertions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import respx
+from sqlalchemy import select
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.connectors.vcf_operations import (
+    VROPS_CONNECTOR_ID,
+    VROPS_CORE_OPS,
+    VROPS_IMPL_ID,
+    VROPS_VERSION,
+    VcfOperationsConnector,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+from tests.acceptance._vrops_canary_fixtures import (
+    VROPS_CANARY_BASE_URL,
+    VROPS_CANARY_FINGERPRINT,
+    VROPS_CANARY_OPERATOR_TENANT,
+    VROPS_CANARY_RESOURCES,
+    VROPS_FORCE_HANDLE_LIST_OP_ID,
+    _insert_vrops_descriptors,
+    _register_vrops_routes,
+    _vrops_credentials_loader,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# Target.product matches the connector class's v2-registry key
+# ("vcf-operations"), not the parse_connector_id-derived "vrops" that
+# descriptor / group rows carry. See
+# tests.acceptance._vrops_canary_fixtures module docstring,
+# "EndpointDescriptor.product vs Target.product".
+_TARGET_PRODUCT = "vcf-operations"
+
+_OPERATOR = Operator(
+    sub="vcf-operations-e2e-test",
+    name="vROps E2E Test Operator",
+    email=None,
+    raw_jwt="<vrops-e2e-raw-jwt>",
+    tenant_id=VROPS_CANARY_OPERATOR_TENANT,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+_E2E_TARGET_NAME = "vcf-operations-e2e-target"
+
+# Path-template params for the one op whose URL carries ``{id}``.
+# The other 7 curated ops have no path params.
+_RESOURCE_GET_OP_PARAMS: dict[str, dict[str, object]] = {
+    "GET:/suite-api/api/resources/{id}": {
+        "id": "00000000-0000-4000-8000-000000000000",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Module-level autouse fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars that :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    from meho_backplane.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches around every test."""
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub out :func:`publish_event` so the broadcast bus doesn't fire.
+
+    Required for the same reason as every other DB-backed dispatcher
+    test: the real broadcast bus tries to write to a Redis stream
+    that doesn't exist in the unit-test environment.
+    """
+    events: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# ForceHandleReducer (acceptance criterion d)
+# ---------------------------------------------------------------------------
+
+
+class _ForceHandleReducer:
+    """Test-only reducer that wraps a vROps list payload in a ResultHandle.
+
+    vROps' suite-api wraps list payloads under noun-specific keys
+    (``resourceList``, ``alerts``, ``alertDefinitions``, ``symptoms``,
+    ``recommendations``, ``superMetrics``) rather than the generic
+    ``results`` / ``elements`` / ``value`` shapes NSX, SDDC Manager,
+    and vSphere use. Recognise both families so the same reducer
+    works against any list op the JSONFlux force-handle case might
+    target in the future.
+    """
+
+    _LIST_KEYS: tuple[str, ...] = (
+        "elements",
+        "results",
+        "value",
+        "resourceList",
+        "alerts",
+        "alertDefinitions",
+        "symptoms",
+        "recommendations",
+        "superMetrics",
+    )
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        del schema, context
+        if isinstance(payload, list):
+            total = len(payload)
+            sample: tuple[Any, ...] = tuple(payload[:5]) if payload else ()
+        elif isinstance(payload, dict):
+            for key in self._LIST_KEYS:
+                rows = payload.get(key)
+                if isinstance(rows, list):
+                    total = len(rows)
+                    sample = tuple(rows[:5]) if rows else ()
+                    break
+            else:
+                total = 1
+                sample = ()
+        else:
+            total = 1
+            sample = ()
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"force-mode handle ({total} rows)",
+            schema_={"type": "array", "items": {"type": "object"}},
+            total_rows=total,
+            sample_rows=sample or None,
+            ttl_seconds=3600,
+        )
+        return {"row_count": total, "sample": list(sample)}, handle
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_target() -> Any:
+    """Insert the E2E target row and return it (expunged from the session)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=VROPS_CANARY_OPERATOR_TENANT,
+            name=_E2E_TARGET_NAME,
+            aliases=[],
+            product=_TARGET_PRODUCT,
+            host=VROPS_CANARY_BASE_URL.removeprefix("https://"),
+            port=443,
+            fqdn=None,
+            secret_ref="kv/data/vcf-operations/vcf-operations-e2e",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=VROPS_CANARY_FINGERPRINT,
+            notes="seeded by test_connectors_vcf_operations_e2e._seed_target",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _resolve_connector() -> VcfOperationsConnector:
+    """Resolve + cache the VcfOperationsConnector instance with a stubbed loader."""
+    registry = all_connectors_v2()
+    connector_cls = registry.get((_TARGET_PRODUCT, VROPS_VERSION, VROPS_IMPL_ID))
+    assert connector_cls is VcfOperationsConnector, (
+        f"VcfOperationsConnector not registered for "
+        f"({_TARGET_PRODUCT}, {VROPS_VERSION}, {VROPS_IMPL_ID}); got {connector_cls!r}"
+    )
+    instance = get_or_create_connector_instance(connector_cls)
+    # Patch the shared CredentialsCache's loader so no Vault read fires.
+    instance._creds._loader = _vrops_credentials_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Primary E2E fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _VropsE2EBundle:
+    target_name: str
+    connector_instance: VcfOperationsConnector
+
+
+@pytest.fixture
+async def vcf_operations_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_VropsE2EBundle]:
+    """Dispatcher-ready vROps setup over a respx-mocked appliance (happy-path).
+
+    Lifecycle:
+    1. Insert the 8 curated
+       :data:`~meho_backplane.connectors.vcf_operations.VROPS_CORE_OPS`
+       descriptors + their 7 groups into the per-test SQLite DB.
+    2. Seed a :class:`Target` row carrying
+       :data:`VROPS_CANARY_FINGERPRINT` so the resolver binds
+       :class:`VcfOperationsConnector`.
+    3. Resolve + cache the connector instance; patch the shared
+       :class:`CredentialsCache`'s loader so no Vault read fires.
+    4. Activate a respx router for :data:`VROPS_CANARY_BASE_URL` and
+       register the 8 read-op routes against pre-seeded canary
+       payloads.
+    """
+    await _insert_vrops_descriptors()
+    await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=VROPS_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_vrops_routes(mock)
+        try:
+            yield _VropsE2EBundle(
+                target_name=_E2E_TARGET_NAME,
+                connector_instance=instance,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VROPS_CORE_OPS)
+assert len(_OP_IDS) == 8, f"Expected 8 curated vROps ops, got {len(_OP_IDS)}: {_OP_IDS}"
+
+
+@pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
+async def test_vcf_operations_e2e_all_ops_dispatch_ok(
+    op_id: str,
+    vcf_operations_e2e_canary: _VropsE2EBundle,
+) -> None:
+    """All 8 vROps core ops dispatch through the full dispatcher and return status='ok'.
+
+    Acceptance criterion (a). HTTP Basic auth is computed by the
+    connector's stub credentials loader on first dispatch (then
+    cached); no session-establish step is needed because Basic auth
+    is stateless on the vROps side. The parametrise reports one CI
+    case per op_id for granular failure attribution.
+    """
+    params = _RESOURCE_GET_OP_PARAMS.get(op_id, {})
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VROPS_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": vcf_operations_e2e_canary.target_name},
+            "params": params,
+        },
+    )
+    assert result["status"] == "ok", (
+        f"vROps op {op_id!r} did not return status='ok': "
+        f"error={result.get('error')!r} full={result!r}"
+    )
+
+
+async def test_vcf_operations_e2e_credentials_cached_after_first_dispatch(
+    vcf_operations_e2e_canary: _VropsE2EBundle,
+) -> None:
+    """First dispatch loads credentials; subsequent dispatches reuse the cache.
+
+    Acceptance criterion (b). vROps' Basic auth is stateless server-
+    side — there's no session token to refresh and no 401-retry. The
+    only thing the connector caches is the Vault-sourced
+    ``{"username": ..., "password": ...}`` mapping behind
+    :class:`CredentialsCache`. Pin the contract: cache empty on
+    first reach, populated after one dispatch, and not re-filled on
+    the second dispatch to the same target.
+
+    Mirrors :func:`test_sddc_e2e_credentials_cached_after_first_dispatch`
+    in the SDDC Manager E2E. NSX's analogue tests a 401-retry loop
+    that doesn't apply to vROps.
+    """
+    instance = vcf_operations_e2e_canary.connector_instance
+    target_name = vcf_operations_e2e_canary.target_name
+
+    # The shared CredentialsCache holds entries keyed by target name.
+    assert target_name not in instance._creds._cache, (
+        "Expected empty credential cache before first dispatch; "
+        f"got _creds._cache={list(instance._creds._cache.keys())!r}"
+    )
+
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VROPS_CONNECTOR_ID,
+            "op_id": "GET:/suite-api/api/versions/current",
+            "target": {"name": target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+    assert target_name in instance._creds._cache, (
+        "Expected credentials cached after first dispatch; "
+        f"got _creds._cache={list(instance._creds._cache.keys())!r}"
+    )
+
+    # Second dispatch must NOT reload credentials — cache entry survives.
+    creds_before = dict(instance._creds._cache)
+    result2 = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VROPS_CONNECTOR_ID,
+            "op_id": "GET:/suite-api/api/resources",
+            "target": {"name": target_name},
+            "params": {},
+        },
+    )
+    assert result2["status"] == "ok"
+    assert instance._creds._cache == creds_before, (
+        "Credential cache should not change on second dispatch (cache hit); "
+        f"before={creds_before!r} after={instance._creds._cache!r}"
+    )
+
+
+async def test_vcf_operations_e2e_dispatch_writes_audit_row(
+    vcf_operations_e2e_canary: _VropsE2EBundle,
+) -> None:
+    """Each dispatch inserts an AuditLog row with method='DISPATCH', target_id, params_hash.
+
+    Acceptance criterion (c). Dispatches one op and asserts:
+
+    * Exactly one new ``AuditLog`` row with ``method='DISPATCH'`` and
+      ``path == op_id``.
+    * ``row.target_id`` is not None (the Target row was resolved and
+      its UUID was recorded).
+    * ``row.payload["op_id"]`` equals the dispatched ``op_id``.
+    * ``row.payload["params_hash"]`` is present (non-None string).
+    """
+    op_id = "GET:/suite-api/api/resources"
+    sessionmaker = get_sessionmaker()
+
+    async def _count_dispatch_rows() -> int:
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AuditLog).where(
+                    AuditLog.method == "DISPATCH",
+                    AuditLog.path == op_id,
+                )
+            )
+            return len(list(result.scalars().all()))
+
+    baseline = await _count_dispatch_rows()
+
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VROPS_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": vcf_operations_e2e_canary.target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+
+    final = await _count_dispatch_rows()
+    assert final - baseline == 1, (
+        f"Expected exactly one new DISPATCH row for {op_id!r}; baseline={baseline} final={final}"
+    )
+
+    async with sessionmaker() as session:
+        row_result = await session.execute(
+            select(AuditLog)
+            .where(
+                AuditLog.method == "DISPATCH",
+                AuditLog.path == op_id,
+            )
+            .order_by(AuditLog.id.desc())
+            .limit(1)
+        )
+        row = row_result.scalars().first()
+
+    assert row is not None
+    assert row.target_id is not None, (
+        "AuditLog.target_id must not be None for a targeted dispatch; "
+        f"got target_id=None on row {row!r}"
+    )
+    assert row.payload.get("op_id") == op_id, (
+        f"AuditLog.payload['op_id'] must equal the dispatched op_id; got payload={row.payload!r}"
+    )
+    assert row.payload.get("params_hash"), (
+        f"AuditLog.payload must carry a non-empty 'params_hash'; got payload={row.payload!r}"
+    )
+
+
+async def test_vcf_operations_e2e_jsonflux_handle_populated_for_resource_list(
+    vcf_operations_e2e_canary: _VropsE2EBundle,
+) -> None:
+    """Resource list dispatched with ForceHandleReducer returns a populated handle.
+
+    Acceptance criterion (d). Resource list is the largest list
+    surface in a real vROps deployment (hundreds to thousands of
+    monitored objects), mirroring the NSX segment-list / SDDC
+    host-list choices.
+
+    Assertions:
+
+    * ``status == 'ok'``.
+    * ``handle`` is non-None and carries a valid UUID4 ``handle_id``.
+    * ``handle.total_rows`` matches the seeded resource count.
+    * ``handle.sample_rows`` is populated (>=1 row).
+    * ``result['row_count']`` equals ``handle.total_rows``.
+    """
+    resource_list = VROPS_CANARY_RESOURCES["resourceList"]
+    assert isinstance(resource_list, list)
+    expected_rows = len(resource_list)
+
+    set_default_reducer(_ForceHandleReducer())
+    try:
+        result_envelope = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": VROPS_CONNECTOR_ID,
+                "op_id": VROPS_FORCE_HANDLE_LIST_OP_ID,
+                "target": {"name": vcf_operations_e2e_canary.target_name},
+                "params": {},
+            },
+        )
+    finally:
+        set_default_reducer(PassThroughReducer())
+
+    assert result_envelope["status"] == "ok", (
+        f"Expected JSONFlux dispatch to succeed; got {result_envelope!r}"
+    )
+
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        f"got handle=None on envelope={result_envelope!r}"
+    )
+
+    uuid.UUID(handle["handle_id"])
+
+    assert handle["total_rows"] == expected_rows, (
+        f"Expected {expected_rows} resource rows from VROPS_CANARY_RESOURCES; "
+        f"got handle.total_rows={handle['total_rows']}"
+    )
+
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        "Expected >=1 sample row from the seeded vROps resource list; "
+        f"got sample_rows={sample_rows!r}"
+    )
+
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == expected_rows, (
+        f"Expected reducer summary on result.row_count={expected_rows}; got result={payload!r}"
+    )

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/targets"
 	"github.com/evoila/meho/cli/internal/cmd/topology"
 	"github.com/evoila/meho/cli/internal/cmd/vault"
+	vcfoperations "github.com/evoila/meho/cli/internal/cmd/vcf-operations"
 	"github.com/evoila/meho/cli/internal/cmd/vmware"
 	"github.com/evoila/meho/cli/internal/discovery"
 )
@@ -211,6 +212,17 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in `sddc-manager` parent.
 	root.AddCommand(sddcmanager.NewRootCmd())
+
+	// G3.6-T3 (#837) -- vrops-rest-9.0 operator alias verbs for
+	// Initiative #369. The verb tree pre-bakes connector_id=
+	// "vrops-rest-9.0" on top of the existing /api/v1/operations/call
+	// dispatcher route. Ships the 8 read-only vROps core verbs (about,
+	// resource list/get, alert list, alertdefinition list, symptom
+	// list, recommendation list, supermetric list) plus operation
+	// search/call meta-tool wrappers. Replaces ./scripts/vcf-operations.sh.
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in `vcf-operations` parent.
+	root.AddCommand(vcfoperations.NewRootCmd())
 
 	// G3.3-T6 (#550) -- vault-1.x operator alias verbs for Initiative
 	// #366. The verb tree pre-bakes connector_id="vault-1.x" on top of

--- a/cli/internal/cmd/vcf-operations/about.go
+++ b/cli/internal/cmd/vcf-operations/about.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAboutCmd returns `meho vcf-operations about` →
+// GET:/suite-api/api/versions/current.
+//
+// Renders the vROps appliance's releaseName / buildNumber /
+// humanlyReadableReleaseName identity fields; --json emits the raw
+// envelope.
+func newAboutCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "about",
+		Short: "Show vROps appliance release name and build number",
+		Long: "about dispatches GET:/suite-api/api/versions/current against\n" +
+			"connector_id=\"vrops-rest-9.0\" and renders the appliance's\n" +
+			"releaseName / buildNumber / humanlyReadableReleaseName fields.\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call:\n" +
+			"  - 0   status == ok\n" +
+			"  - 1   status == error / denied\n" +
+			"  - 2   auth_expired\n" +
+			"  - 3   unreachable\n" +
+			"  - 4   unexpected response shape",
+		Example: "  meho vcf-operations about --target rdc-vrops\n" +
+			"  meho vcf-operations about --target rdc-vrops --json | jq .result",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAbout(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	const opID = "GET:/suite-api/api/versions/current"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printAbout)
+}
+
+func printAbout(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/suite-api/api/versions/current — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	var version struct {
+		ReleaseName               string `json:"releaseName"`
+		BuildNumber               int64  `json:"buildNumber"`
+		HumanlyReadableReleaseName string `json:"humanlyReadableReleaseName"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &version); err != nil || version.ReleaseName == "" {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  release:  %s\n", version.ReleaseName)
+	if version.BuildNumber != 0 {
+		fmt.Fprintf(w, "  build:    %d\n", version.BuildNumber)
+	}
+	if version.HumanlyReadableReleaseName != "" {
+		fmt.Fprintf(w, "  human:    %s\n", version.HumanlyReadableReleaseName)
+	}
+}

--- a/cli/internal/cmd/vcf-operations/about.go
+++ b/cli/internal/cmd/vcf-operations/about.go
@@ -77,8 +77,8 @@ func printAbout(w io.Writer, r *CallResult) {
 		return
 	}
 	var version struct {
-		ReleaseName               string `json:"releaseName"`
-		BuildNumber               int64  `json:"buildNumber"`
+		ReleaseName                string `json:"releaseName"`
+		BuildNumber                int64  `json:"buildNumber"`
 		HumanlyReadableReleaseName string `json:"humanlyReadableReleaseName"`
 	}
 	if err := jsonUnmarshalStrict(r.Result, &version); err != nil || version.ReleaseName == "" {

--- a/cli/internal/cmd/vcf-operations/alert.go
+++ b/cli/internal/cmd/vcf-operations/alert.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAlertCmd returns the `meho vcf-operations alert` parent command
+// (list sub-verb).
+func newAlertCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "alert",
+		Short:        "vROps alert verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAlertListCmd())
+	return cmd
+}
+
+// newAlertListCmd returns `meho vcf-operations alert list` →
+// GET:/suite-api/api/alerts.
+//
+// --params is the escape hatch for filter query parameters
+// (``activeOnly`` / ``alertCriticality`` / ``alertStatus`` /
+// ``resourceId`` / ``page`` / ``pageSize``).
+func newAlertListCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vROps alerts (currently firing or recently resolved)",
+		Long: "list dispatches GET:/suite-api/api/alerts against\n" +
+			"connector_id=\"vrops-rest-9.0\". Renders alertId / alertDefinitionName /\n" +
+			"resourceId / status; --json emits the full envelope.\n\n" +
+			"Filter via --params with one of the documented query parameters\n" +
+			"(activeOnly / alertCriticality / alertStatus / resourceId / page /\n" +
+			"pageSize). Useful filters:\n" +
+			"  --params '{\"activeOnly\":true}'                  - only active alerts\n" +
+			"  --params '{\"alertCriticality\":\"CRITICAL\"}'      - severity-scoped\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-operations alert list --target rdc-vrops\n" +
+			"  meho vcf-operations alert list --target rdc-vrops --params '{\"activeOnly\":true}'\n" +
+			"  meho vcf-operations alert list --target rdc-vrops --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAlertList(cmd, targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "filter params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAlertList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	const opID = "GET:/suite-api/api/alerts"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printAlertList)
+}
+
+func printAlertList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/suite-api/api/alerts — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeVropsListResult(r.Result, vropsListKeysByOp["GET:/suite-api/api/alerts"])
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 alerts)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-40s %-10s %-10s\n", "alertId", "definition", "level", "status")
+	for _, e := range entries {
+		level := ""
+		if v, ok := e["alertLevel"].(float64); ok {
+			level = fmt.Sprintf("%d", int(v))
+		}
+		fmt.Fprintf(w, "%-38s %-40s %-10s %-10s\n",
+			truncate(vropsStringField(e, "alertId"), 38),
+			truncate(vropsStringField(e, "alertDefinitionName"), 40),
+			level,
+			truncate(vropsStringField(e, "status"), 10),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-operations/alert.go
+++ b/cli/internal/cmd/vcf-operations/alert.go
@@ -28,8 +28,8 @@ func newAlertCmd() *cobra.Command {
 // GET:/suite-api/api/alerts.
 //
 // --params is the escape hatch for filter query parameters
-// (``activeOnly`` / ``alertCriticality`` / ``alertStatus`` /
-// ``resourceId`` / ``page`` / ``pageSize``).
+// (“activeOnly“ / “alertCriticality“ / “alertStatus“ /
+// “resourceId“ / “page“ / “pageSize“).
 func newAlertListCmd() *cobra.Command {
 	var (
 		targetName        string
@@ -100,15 +100,17 @@ func printAlertList(w io.Writer, r *CallResult) {
 		fmt.Fprintln(w, "  (0 alerts)")
 		return
 	}
-	fmt.Fprintf(w, "%-38s %-40s %-10s %-10s\n", "alertId", "definition", "level", "status")
+	fmt.Fprintf(w, "%-38s %-32s %-22s %-10s %-10s\n",
+		"alertId", "definition", "resourceId", "level", "status")
 	for _, e := range entries {
 		level := ""
 		if v, ok := e["alertLevel"].(float64); ok {
 			level = fmt.Sprintf("%d", int(v))
 		}
-		fmt.Fprintf(w, "%-38s %-40s %-10s %-10s\n",
+		fmt.Fprintf(w, "%-38s %-32s %-22s %-10s %-10s\n",
 			truncate(vropsStringField(e, "alertId"), 38),
-			truncate(vropsStringField(e, "alertDefinitionName"), 40),
+			truncate(vropsStringField(e, "alertDefinitionName"), 32),
+			truncate(vropsStringField(e, "resourceId"), 22),
 			level,
 			truncate(vropsStringField(e, "status"), 10),
 		)

--- a/cli/internal/cmd/vcf-operations/alertdefinition.go
+++ b/cli/internal/cmd/vcf-operations/alertdefinition.go
@@ -29,8 +29,8 @@ func newAlertDefinitionCmd() *cobra.Command {
 // GET:/suite-api/api/alertdefinitions.
 //
 // --params is the escape hatch for filter query parameters
-// (``id`` (repeatable) / ``adapterKind`` / ``resourceKind`` /
-// ``name`` / ``page`` / ``pageSize``).
+// (“id“ (repeatable) / “adapterKind“ / “resourceKind“ /
+// “name“ / “page“ / “pageSize“).
 func newAlertDefinitionListCmd() *cobra.Command {
 	var (
 		targetName        string

--- a/cli/internal/cmd/vcf-operations/alertdefinition.go
+++ b/cli/internal/cmd/vcf-operations/alertdefinition.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAlertDefinitionCmd returns the `meho vcf-operations alertdefinition`
+// parent command (list sub-verb).
+func newAlertDefinitionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "alertdefinition",
+		Short:        "vROps alert-definition verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAlertDefinitionListCmd())
+	return cmd
+}
+
+// newAlertDefinitionListCmd returns
+// `meho vcf-operations alertdefinition list` →
+// GET:/suite-api/api/alertdefinitions.
+//
+// --params is the escape hatch for filter query parameters
+// (``id`` (repeatable) / ``adapterKind`` / ``resourceKind`` /
+// ``name`` / ``page`` / ``pageSize``).
+func newAlertDefinitionListCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vROps alert definitions (the policy surface)",
+		Long: "list dispatches GET:/suite-api/api/alertdefinitions against\n" +
+			"connector_id=\"vrops-rest-9.0\". Renders id / name / adapterKindKey /\n" +
+			"resourceKindKey; --json emits the full envelope.\n\n" +
+			"Filter via --params with one of the documented query parameters\n" +
+			"(id (repeatable) / adapterKind / resourceKind / name / page /\n" +
+			"pageSize).\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-operations alertdefinition list --target rdc-vrops\n" +
+			"  meho vcf-operations alertdefinition list --target rdc-vrops " +
+			"--params '{\"adapterKind\":\"VMWARE\",\"resourceKind\":\"VirtualMachine\"}'\n" +
+			"  meho vcf-operations alertdefinition list --target rdc-vrops --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAlertDefinitionList(cmd, targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "filter params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAlertDefinitionList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	const opID = "GET:/suite-api/api/alertdefinitions"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printAlertDefinitionList)
+}
+
+func printAlertDefinitionList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/suite-api/api/alertdefinitions — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeVropsListResult(r.Result, vropsListKeysByOp["GET:/suite-api/api/alertdefinitions"])
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 alert definitions)")
+		return
+	}
+	fmt.Fprintf(w, "%-46s %-30s %-16s %-22s\n", "id", "name", "adapterKind", "resourceKind")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-46s %-30s %-16s %-22s\n",
+			truncate(vropsStringField(e, "id"), 46),
+			truncate(vropsStringField(e, "name"), 30),
+			truncate(vropsStringField(e, "adapterKindKey"), 16),
+			truncate(vropsStringField(e, "resourceKindKey"), 22),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-operations/dispatch.go
+++ b/cli/internal/cmd/vcf-operations/dispatch.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic model.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+// errOpError is the sentinel returned when the dispatcher reported a
+// structured-failure result (status == "error" or status ==
+// "denied"). main translates non-nil RunE errors into a non-zero
+// exit; SilenceErrors=true on each command keeps cobra from double-
+// printing the error string.
+var errOpError = errors.New("operation status not ok")
+
+// dispatchOp POSTs an OperationCall to the backplane and returns the
+// decoded CallResult with connector_id="vrops-rest-9.0" pre-baked.
+//
+// targetSlug is wrapped as `{"name": <slug>}` when non-empty; the
+// empty case sends `target: null` on the wire so the dispatcher's
+// resolver short-circuits to the no-target branch (no vROps read op
+// in the v0.5 core is target-optional, but keeping the wire shape
+// uniform with the NSX / SDDC Manager siblings simplifies the
+// transport-layer audit).
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: ConnectorID,
+		OpID:        opID,
+		Target:      nil,
+	}
+	if targetSlug != "" {
+		body.Target = map[string]any{"name": targetSlug}
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderCallResult handles the unified post-dispatch rendering path.
+// Returns nil on success, errOpError on "error" / "denied", or a
+// renderer error on an unexpected status enum value.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		printGenericResult(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+// printGenericResult renders a CallResult in the generic envelope
+// shape. Used as the fallback when no per-verb printer is provided
+// (operation call wrapper).
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cli/internal/cmd/vcf-operations/operation.go
+++ b/cli/internal/cmd/vcf-operations/operation.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newOperationCmd returns `meho vcf-operations operation` with
+// search / call meta-tool wrappers pre-scoped to vrops-rest-9.0.
+func newOperationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "operation",
+		Short:        "Pre-scoped meta-tool wrappers (search / call) for vrops-rest-9.0",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newOperationSearchCmd())
+	cmd.AddCommand(newOperationCallCmd())
+	return cmd
+}
+
+// searchHit mirrors the backend OperationSearchHit Pydantic model.
+type searchHit struct {
+	OpID             string   `json:"op_id"`
+	Summary          *string  `json:"summary"`
+	Description      *string  `json:"description"`
+	GroupKey         *string  `json:"group_key"`
+	SafetyLevel      string   `json:"safety_level"`
+	RequiresApproval bool     `json:"requires_approval"`
+	FusedScore       float64  `json:"fused_score"`
+	Bm25Score        *float64 `json:"bm25_score"`
+	CosineScore      *float64 `json:"cosine_score"`
+}
+
+type searchResponse struct {
+	Hits            []searchHit `json:"hits"`
+	QueryDurationMs float64     `json:"query_duration_ms"`
+}
+
+func newOperationSearchCmd() *cobra.Command {
+	var (
+		groupKey          string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Hybrid BM25 + cosine RRF search across vrops-rest-9.0 operations",
+		Long: "search wraps GET /api/v1/operations/search with connector_id=\n" +
+			"\"vrops-rest-9.0\" pre-baked.\n\n" +
+			"Exit codes mirror meho operation search.",
+		Example: "  meho vcf-operations operation search \"list resources\"\n" +
+			"  meho vcf-operations operation search \"alerts\" --group vrops-alerts",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationSearch(cmd, args[0], groupKey, limit, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&groupKey, "group", "", "narrow the search to one group_key")
+	cmd.Flags().IntVar(&limit, "limit", 10, "max hits (1..50, clamped by the API)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, jsonOut bool, backplaneOverride string) error {
+	if limit < 1 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
+			jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printSearchTable(cmd.OutOrStdout(), query, result)
+	return nil
+}
+
+func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
+	q := url.Values{}
+	q.Set("connector_id", ConnectorID)
+	q.Set("query", query)
+	if groupKey != "" {
+		q.Set("group", groupKey)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/operations/search?" + q.Encode()
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out searchResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+	return &out, nil
+}
+
+func printSearchTable(w io.Writer, query string, r *searchResponse) {
+	fmt.Fprintf(w, "search %s %q — %d hit(s) in %.0fms\n",
+		ConnectorID, query, len(r.Hits), r.QueryDurationMs)
+	if len(r.Hits) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%-50s %6s  %s\n", "op_id", "score", "summary")
+	for _, h := range r.Hits {
+		fmt.Fprintf(w, "%-50s %6.3f  %s\n",
+			truncate(h.OpID, 50),
+			h.FusedScore,
+			truncate(strDeref(h.Summary), 80),
+		)
+	}
+}
+
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func newOperationCallCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "call <op_id>",
+		Short: "Dispatch any vrops-rest-9.0 op_id (escape hatch for ops without aliases)",
+		Long: "call wraps POST /api/v1/operations/call with connector_id=\n" +
+			"\"vrops-rest-9.0\" pre-baked. Use when an op doesn't have a\n" +
+			"dedicated alias yet.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-operations operation call GET:/suite-api/api/versions/current --target rdc-vrops\n" +
+			"  meho vcf-operations operation call GET:/suite-api/api/resources --target rdc-vrops --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationCall(cmd, args[0], targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, nil)
+}

--- a/cli/internal/cmd/vcf-operations/recommendation.go
+++ b/cli/internal/cmd/vcf-operations/recommendation.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newRecommendationCmd returns the `meho vcf-operations recommendation`
+// parent command (list sub-verb).
+func newRecommendationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "recommendation",
+		Short:        "vROps recommendation verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newRecommendationListCmd())
+	return cmd
+}
+
+// newRecommendationListCmd returns
+// `meho vcf-operations recommendation list` →
+// GET:/suite-api/api/recommendations.
+//
+// --params is the escape hatch for filter query parameters
+// (``id`` (repeatable) / ``page`` / ``pageSize``).
+func newRecommendationListCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vROps recommendations (remediation hints attached to alerts/symptoms)",
+		Long: "list dispatches GET:/suite-api/api/recommendations against\n" +
+			"connector_id=\"vrops-rest-9.0\". Renders id / description (first line) /\n" +
+			"actionId; --json emits the full envelope.\n\n" +
+			"Filter via --params with one of the documented query parameters\n" +
+			"(id (repeatable) / page / pageSize).\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-operations recommendation list --target rdc-vrops\n" +
+			"  meho vcf-operations recommendation list --target rdc-vrops --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRecommendationList(cmd, targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "filter params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runRecommendationList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	const opID = "GET:/suite-api/api/recommendations"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printRecommendationList)
+}
+
+func printRecommendationList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/suite-api/api/recommendations — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeVropsListResult(r.Result, vropsListKeysByOp["GET:/suite-api/api/recommendations"])
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 recommendations)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-60s %-12s\n", "id", "description", "actionId")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-60s %-12s\n",
+			truncate(vropsStringField(e, "id"), 38),
+			truncate(vropsStringField(e, "description"), 60),
+			truncate(vropsStringField(e, "actionId"), 12),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-operations/recommendation.go
+++ b/cli/internal/cmd/vcf-operations/recommendation.go
@@ -6,6 +6,7 @@ package vcfoperations
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -29,7 +30,7 @@ func newRecommendationCmd() *cobra.Command {
 // GET:/suite-api/api/recommendations.
 //
 // --params is the escape hatch for filter query parameters
-// (``id`` (repeatable) / ``page`` / ``pageSize``).
+// (“id“ (repeatable) / “page“ / “pageSize“).
 func newRecommendationListCmd() *cobra.Command {
 	var (
 		targetName        string
@@ -98,9 +99,10 @@ func printRecommendationList(w io.Writer, r *CallResult) {
 	}
 	fmt.Fprintf(w, "%-38s %-60s %-12s\n", "id", "description", "actionId")
 	for _, e := range entries {
+		descriptionFirstLine := strings.SplitN(vropsStringField(e, "description"), "\n", 2)[0]
 		fmt.Fprintf(w, "%-38s %-60s %-12s\n",
 			truncate(vropsStringField(e, "id"), 38),
-			truncate(vropsStringField(e, "description"), 60),
+			truncate(descriptionFirstLine, 60),
 			truncate(vropsStringField(e, "actionId"), 12),
 		)
 	}

--- a/cli/internal/cmd/vcf-operations/resource.go
+++ b/cli/internal/cmd/vcf-operations/resource.go
@@ -29,8 +29,8 @@ func newResourceCmd() *cobra.Command {
 // GET:/suite-api/api/resources.
 //
 // --params is the escape hatch for filter query parameters
-// (``resourceKind`` / ``adapterKind`` / ``name`` / ``page`` /
-// ``pageSize``). Passing them as raw JSON keeps the verb thin and
+// (“resourceKind“ / “adapterKind“ / “name“ / “page“ /
+// “pageSize“). Passing them as raw JSON keeps the verb thin and
 // avoids the trap of declaring every vROps query string as a
 // dedicated flag — the resource list takes >10 documented filters.
 func newResourceListCmd() *cobra.Command {
@@ -116,10 +116,10 @@ func printResourceList(w io.Writer, r *CallResult) {
 // newResourceGetCmd returns `meho vcf-operations resource get <id>` →
 // GET:/suite-api/api/resources/{id}.
 //
-// The descriptor declares ``{id}`` as a path parameter; the CLI
-// passes it under params so the dispatcher's ``_substitute_path``
+// The descriptor declares “{id}“ as a path parameter; the CLI
+// passes it under params so the dispatcher's “_substitute_path“
 // fills it in at dispatch time (same pattern Harbor uses for
-// ``{project_name}``).
+// “{project_name}“).
 func newResourceGetCmd() *cobra.Command {
 	var (
 		targetName        string

--- a/cli/internal/cmd/vcf-operations/resource.go
+++ b/cli/internal/cmd/vcf-operations/resource.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newResourceCmd returns the `meho vcf-operations resource` parent
+// command (list + get sub-verbs).
+func newResourceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "resource",
+		Short:        "vROps resource verbs (list, get)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newResourceListCmd())
+	cmd.AddCommand(newResourceGetCmd())
+	return cmd
+}
+
+// newResourceListCmd returns `meho vcf-operations resource list` →
+// GET:/suite-api/api/resources.
+//
+// --params is the escape hatch for filter query parameters
+// (``resourceKind`` / ``adapterKind`` / ``name`` / ``page`` /
+// ``pageSize``). Passing them as raw JSON keeps the verb thin and
+// avoids the trap of declaring every vROps query string as a
+// dedicated flag — the resource list takes >10 documented filters.
+func newResourceListCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vROps resources (VMs, hosts, datastores, adapter instances)",
+		Long: "list dispatches GET:/suite-api/api/resources against\n" +
+			"connector_id=\"vrops-rest-9.0\". Renders identifier /\n" +
+			"resourceKey.name / resourceKey.resourceKindKey for human eyes;\n" +
+			"--json emits the full envelope.\n\n" +
+			"Filter via --params with one of the documented query parameters\n" +
+			"(resourceKind / adapterKind / name / page / pageSize); see the\n" +
+			"vROps suite-api docs for the full list.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-operations resource list --target rdc-vrops\n" +
+			"  meho vcf-operations resource list --target rdc-vrops " +
+			"--params '{\"resourceKind\":\"VirtualMachine\",\"pageSize\":50}'\n" +
+			"  meho vcf-operations resource list --target rdc-vrops --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runResourceList(cmd, targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "filter params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runResourceList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	const opID = "GET:/suite-api/api/resources"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printResourceList)
+}
+
+func printResourceList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/suite-api/api/resources — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeVropsListResult(r.Result, vropsListKeysByOp["GET:/suite-api/api/resources"])
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 resources)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-30s %-22s\n", "identifier", "name", "kind")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-30s %-22s\n",
+			truncate(vropsStringField(e, "identifier"), 38),
+			truncate(vropsResourceName(e), 30),
+			truncate(vropsResourceKindKey(e), 22),
+		)
+	}
+}
+
+// newResourceGetCmd returns `meho vcf-operations resource get <id>` →
+// GET:/suite-api/api/resources/{id}.
+//
+// The descriptor declares ``{id}`` as a path parameter; the CLI
+// passes it under params so the dispatcher's ``_substitute_path``
+// fills it in at dispatch time (same pattern Harbor uses for
+// ``{project_name}``).
+func newResourceGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get one vROps resource by identifier (UUID)",
+		Long: "get dispatches GET:/suite-api/api/resources/{id} against\n" +
+			"connector_id=\"vrops-rest-9.0\". Renders the identifier,\n" +
+			"resourceKey.name, resourceKey.resourceKindKey, and the\n" +
+			"resourceStatusStates summary; --json emits the full envelope.\n\n" +
+			"<id> is the resource UUID returned by `resource list`.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-operations resource get 00000000-0000-4000-8000-000000000000 --target rdc-vrops\n" +
+			"  meho vcf-operations resource get <uuid> --target rdc-vrops --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runResourceGet(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runResourceGet(cmd *cobra.Command, id, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	const opID = "GET:/suite-api/api/resources/{id}"
+	params := map[string]any{"id": id}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printResourceGet)
+}
+
+func printResourceGet(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/suite-api/api/resources/{id} — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	var entry map[string]any
+	if err := jsonUnmarshalStrict(r.Result, &entry); err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if id := vropsStringField(entry, "identifier"); id != "" {
+		fmt.Fprintf(w, "  identifier:  %s\n", id)
+	}
+	if name := vropsResourceName(entry); name != "" {
+		fmt.Fprintf(w, "  name:        %s\n", name)
+	}
+	if kind := vropsResourceKindKey(entry); kind != "" {
+		fmt.Fprintf(w, "  kind:        %s\n", kind)
+	}
+	if states, ok := entry["resourceStatusStates"].([]any); ok && len(states) > 0 {
+		if first, ok := states[0].(map[string]any); ok {
+			if rs, ok := first["resourceStatus"].(string); ok && rs != "" {
+				fmt.Fprintf(w, "  status:      %s\n", rs)
+			}
+			if rstate, ok := first["resourceState"].(string); ok && rstate != "" {
+				fmt.Fprintf(w, "  state:       %s\n", rstate)
+			}
+		}
+	}
+}

--- a/cli/internal/cmd/vcf-operations/supermetric.go
+++ b/cli/internal/cmd/vcf-operations/supermetric.go
@@ -6,6 +6,7 @@ package vcfoperations
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -28,7 +29,7 @@ func newSupermetricCmd() *cobra.Command {
 // GET:/suite-api/api/supermetrics.
 //
 // --params is the escape hatch for filter query parameters
-// (``id`` (repeatable) / ``name`` / ``page`` / ``pageSize``).
+// (“id“ (repeatable) / “name“ / “page“ / “pageSize“).
 func newSupermetricListCmd() *cobra.Command {
 	var (
 		targetName        string
@@ -97,10 +98,11 @@ func printSupermetricList(w io.Writer, r *CallResult) {
 	}
 	fmt.Fprintf(w, "%-38s %-40s %-50s\n", "id", "name", "formula")
 	for _, e := range entries {
+		formulaFirstLine := strings.SplitN(vropsStringField(e, "formula"), "\n", 2)[0]
 		fmt.Fprintf(w, "%-38s %-40s %-50s\n",
 			truncate(vropsStringField(e, "id"), 38),
 			truncate(vropsStringField(e, "name"), 40),
-			truncate(vropsStringField(e, "formula"), 50),
+			truncate(formulaFirstLine, 50),
 		)
 	}
 }

--- a/cli/internal/cmd/vcf-operations/supermetric.go
+++ b/cli/internal/cmd/vcf-operations/supermetric.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newSupermetricCmd returns the `meho vcf-operations supermetric`
+// parent command (list sub-verb).
+func newSupermetricCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "supermetric",
+		Short:        "vROps super-metric verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSupermetricListCmd())
+	return cmd
+}
+
+// newSupermetricListCmd returns `meho vcf-operations supermetric list` →
+// GET:/suite-api/api/supermetrics.
+//
+// --params is the escape hatch for filter query parameters
+// (``id`` (repeatable) / ``name`` / ``page`` / ``pageSize``).
+func newSupermetricListCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vROps super metrics (user-defined metric formulae)",
+		Long: "list dispatches GET:/suite-api/api/supermetrics against\n" +
+			"connector_id=\"vrops-rest-9.0\". Renders id / name / formula (first line);\n" +
+			"--json emits the full envelope.\n\n" +
+			"Filter via --params with one of the documented query parameters\n" +
+			"(id (repeatable) / name / page / pageSize).\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-operations supermetric list --target rdc-vrops\n" +
+			"  meho vcf-operations supermetric list --target rdc-vrops --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSupermetricList(cmd, targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "filter params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runSupermetricList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	const opID = "GET:/suite-api/api/supermetrics"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printSupermetricList)
+}
+
+func printSupermetricList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/suite-api/api/supermetrics — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeVropsListResult(r.Result, vropsListKeysByOp["GET:/suite-api/api/supermetrics"])
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 super metrics)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-40s %-50s\n", "id", "name", "formula")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-40s %-50s\n",
+			truncate(vropsStringField(e, "id"), 38),
+			truncate(vropsStringField(e, "name"), 40),
+			truncate(vropsStringField(e, "formula"), 50),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-operations/symptom.go
+++ b/cli/internal/cmd/vcf-operations/symptom.go
@@ -28,8 +28,8 @@ func newSymptomCmd() *cobra.Command {
 // GET:/suite-api/api/symptoms.
 //
 // --params is the escape hatch for filter query parameters
-// (``id`` (repeatable) / ``resourceId`` / ``activeOnly`` /
-// ``statusType`` / ``page`` / ``pageSize``).
+// (“id“ (repeatable) / “resourceId“ / “activeOnly“ /
+// “statusType“ / “page“ / “pageSize“).
 func newSymptomListCmd() *cobra.Command {
 	var (
 		targetName        string
@@ -98,11 +98,13 @@ func printSymptomList(w io.Writer, r *CallResult) {
 		fmt.Fprintln(w, "  (0 symptoms)")
 		return
 	}
-	fmt.Fprintf(w, "%-38s %-40s %-12s\n", "id", "definition", "severity")
+	fmt.Fprintf(w, "%-38s %-32s %-22s %-12s\n",
+		"id", "definition", "resourceId", "severity")
 	for _, e := range entries {
-		fmt.Fprintf(w, "%-38s %-40s %-12s\n",
+		fmt.Fprintf(w, "%-38s %-32s %-22s %-12s\n",
 			truncate(vropsStringField(e, "id"), 38),
-			truncate(vropsStringField(e, "symptomDefinitionName"), 40),
+			truncate(vropsStringField(e, "symptomDefinitionName"), 32),
+			truncate(vropsStringField(e, "resourceId"), 22),
 			truncate(vropsStringField(e, "severity"), 12),
 		)
 	}

--- a/cli/internal/cmd/vcf-operations/symptom.go
+++ b/cli/internal/cmd/vcf-operations/symptom.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newSymptomCmd returns the `meho vcf-operations symptom` parent
+// command (list sub-verb).
+func newSymptomCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "symptom",
+		Short:        "vROps symptom verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSymptomListCmd())
+	return cmd
+}
+
+// newSymptomListCmd returns `meho vcf-operations symptom list` →
+// GET:/suite-api/api/symptoms.
+//
+// --params is the escape hatch for filter query parameters
+// (``id`` (repeatable) / ``resourceId`` / ``activeOnly`` /
+// ``statusType`` / ``page`` / ``pageSize``).
+func newSymptomListCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List vROps symptoms (per-condition signals beneath alerts)",
+		Long: "list dispatches GET:/suite-api/api/symptoms against\n" +
+			"connector_id=\"vrops-rest-9.0\". Renders id / symptomDefinitionName /\n" +
+			"resourceId / severity; --json emits the full envelope.\n\n" +
+			"Filter via --params with one of the documented query parameters\n" +
+			"(id (repeatable) / resourceId / activeOnly / statusType / page /\n" +
+			"pageSize).\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-operations symptom list --target rdc-vrops\n" +
+			"  meho vcf-operations symptom list --target rdc-vrops --params '{\"activeOnly\":true}'\n" +
+			"  meho vcf-operations symptom list --target rdc-vrops --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSymptomList(cmd, targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "vROps target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "filter params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runSymptomList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	const opID = "GET:/suite-api/api/symptoms"
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printSymptomList)
+}
+
+func printSymptomList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/suite-api/api/symptoms — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeVropsListResult(r.Result, vropsListKeysByOp["GET:/suite-api/api/symptoms"])
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 symptoms)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-40s %-12s\n", "id", "definition", "severity")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-40s %-12s\n",
+			truncate(vropsStringField(e, "id"), 38),
+			truncate(vropsStringField(e, "symptomDefinitionName"), 40),
+			truncate(vropsStringField(e, "severity"), 12),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-operations/vcf_operations.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations.go
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package vcfoperations hosts the cobra commands under
+// `meho vcf-operations ...` for G3.6-T3 (#837) of Initiative #369.
+// v0.5 ships the operator-facing alias verbs over the 8 enabled vROps
+// read-only core ops (G3.6-T2 #833), each pre-baking
+// connector_id="vrops-rest-9.0" so operators don't type the connector
+// ID on every dispatch:
+//
+//   - `meho vcf-operations about [--target T]`                   — GET:/suite-api/api/versions/current
+//   - `meho vcf-operations resource list [--target T] [--params J]` — GET:/suite-api/api/resources
+//   - `meho vcf-operations resource get <id> [--target T]`        — GET:/suite-api/api/resources/{id}
+//   - `meho vcf-operations alert list [--target T] [--params J]`  — GET:/suite-api/api/alerts
+//   - `meho vcf-operations alertdefinition list [--target T] [--params J]` — GET:/suite-api/api/alertdefinitions
+//   - `meho vcf-operations symptom list [--target T] [--params J]` — GET:/suite-api/api/symptoms
+//   - `meho vcf-operations recommendation list [--target T] [--params J]` — GET:/suite-api/api/recommendations
+//   - `meho vcf-operations supermetric list [--target T] [--params J]` — GET:/suite-api/api/supermetrics
+//   - `meho vcf-operations operation search/call`                 — meta-tool wrappers
+//
+// Every verb is a thin Cobra command that POSTs to
+// `/api/v1/operations/call` with connector_id="vrops-rest-9.0"
+// pre-baked. No vROps logic in the CLI; pure Cobra-over-HTTP
+// following the NSX/SDDC Manager precedents (CLAUDE.md postulate 5 —
+// agent surface stays narrow-waist meta-tools; vendor-specific
+// tooling lives only in the CLI).
+//
+// The verb-tree label is `vcf-operations` (the operator-facing
+// product label that matches `Target.product`), while the dispatched
+// connector_id is `vrops-rest-9.0` (the parse_connector_id slug the
+// dispatcher routes by — see `backend/src/meho_backplane/connectors/
+// vcf_operations/core_ops.py` for the product/version/impl_id split
+// rationale).
+package vcfoperations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under
+// `meho vcf-operations ...` dispatches against. Matches
+// `VROPS_CONNECTOR_ID` in
+// `backend/src/meho_backplane/connectors/vcf_operations/core_ops.py`
+// (the parse_connector_id slug derived from product="vcf-operations"
+// + version="9.0" + impl_id="vrops-rest").
+const ConnectorID = "vrops-rest-9.0"
+
+// NewRootCmd returns the `meho vcf-operations` parent command.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vcf-operations",
+		Short: "Pre-scoped CLI verbs for the vrops-rest-9.0 connector",
+		Long: "vcf-operations is the operator-facing verb tree for the vrops-rest-9.0\n" +
+			"connector (VMware Aria Operations / vROps 9.0). Each verb dispatches\n" +
+			"through POST /api/v1/operations/call with connector_id=\"vrops-rest-9.0\"\n" +
+			"pre-baked so operators don't type the connector ID on every command.\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
+			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
+			"continue to use search_operations / call_operation against the\n" +
+			"narrow-waist meta-tool contract.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAboutCmd())
+	cmd.AddCommand(newResourceCmd())
+	cmd.AddCommand(newAlertCmd())
+	cmd.AddCommand(newAlertDefinitionCmd())
+	cmd.AddCommand(newSymptomCmd())
+	cmd.AddCommand(newRecommendationCmd())
+	cmd.AddCommand(newSupermetricCmd())
+	cmd.AddCommand(newOperationCmd())
+	return cmd
+}
+
+// vropsEntry is a single row in a vROps list response. vROps uses
+// map[string]any because the fields differ per resource kind.
+type vropsEntry = map[string]any
+
+// vropsListKeysByOp maps each list op's wrapper key (vROps wraps lists
+// under noun-specific keys: ``resourceList``, ``alerts``,
+// ``alertDefinitions``, ``symptoms``, ``recommendations``,
+// ``superMetrics``). The renderers consult this map to find the rows
+// regardless of which list op they are handling.
+var vropsListKeysByOp = map[string]string{
+	"GET:/suite-api/api/resources":        "resourceList",
+	"GET:/suite-api/api/alerts":           "alerts",
+	"GET:/suite-api/api/alertdefinitions": "alertDefinitions",
+	"GET:/suite-api/api/symptoms":         "symptoms",
+	"GET:/suite-api/api/recommendations":  "recommendations",
+	"GET:/suite-api/api/supermetrics":     "superMetrics",
+}
+
+// decodeVropsListResult unwraps a vROps suite-api list payload from
+// the documented per-noun wrapper key. ``key`` is the expected
+// wrapper (one of ``resourceList`` / ``alerts`` / etc.). The fallback
+// path accepts a bare array so future spec drift to a flat shape
+// doesn't break the renderer; the fallback is best-effort, not part
+// of the documented contract.
+func decodeVropsListResult(raw json.RawMessage, key string) ([]vropsEntry, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	// Wrapper-keyed shape — the canonical case.
+	var wrapped map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &wrapped); err == nil {
+		if inner, ok := wrapped[key]; ok && len(inner) > 0 && string(inner) != "null" {
+			var arr []vropsEntry
+			if uerr := json.Unmarshal(inner, &arr); uerr == nil {
+				return arr, nil
+			}
+		}
+	}
+	// Bare-array fallback. vROps' v0.5 surface always wraps, but a
+	// future re-shape (or a vendor doc drift) shouldn't poison the
+	// renderer; falling through to the raw-JSON dump in the verb's
+	// printer is friendlier than panicking on shape drift.
+	var arr []vropsEntry
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil, fmt.Errorf("decode vROps list result: %w", err)
+	}
+	return arr, nil
+}
+
+// vropsStringField extracts a string value from a vROps entry map.
+// Mirrors nsxStringField in the NSX sibling.
+func vropsStringField(e vropsEntry, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// vropsResourceName extracts the ``resourceKey.name`` from a vROps
+// resource entry. The list payload nests the human-readable name
+// inside the ``resourceKey`` object alongside the adapterKindKey and
+// resourceKindKey; surfacing it flat in the column makes the table
+// readable without the operator running --json | jq.
+func vropsResourceName(e vropsEntry) string {
+	rk, ok := e["resourceKey"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	if name, ok := rk["name"].(string); ok {
+		return name
+	}
+	return ""
+}
+
+// vropsResourceKindKey extracts ``resourceKey.resourceKindKey`` from a
+// vROps resource entry. Same nesting rationale as
+// :func:`vropsResourceName`.
+func vropsResourceKindKey(e vropsEntry) string {
+	rk, ok := e["resourceKey"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	if kind, ok := rk["resourceKindKey"].(string); ok {
+		return kind
+	}
+	return ""
+}
+
+// fallbackResultRender dumps raw result JSON when the typed decoder
+// doesn't match the actual response shape.
+func fallbackResultRender(w io.Writer, r *CallResult) {
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	pretty, err := prettyJSON(r.Result)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+		return
+	}
+	fmt.Fprintln(w, string(r.Result))
+}
+
+// printErrorTrailer surfaces the dispatcher error + extras envelope.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+	// 1 MiB cap matches the NSX sibling. vROps list payloads on a
+	// large fleet can run into the hundreds of KiB; the cap leaves
+	// headroom while still bounding pathological payloads.
+	const maxBody = int64(1 << 20)
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if int64(len(raw)) > maxBody {
+		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// loadParamsFlag parses the --params flag value. Prefixing with '@'
+// loads the named file as JSON; otherwise the value itself is parsed
+// as inline JSON. Returns nil for an empty value so the caller can
+// omit the "params" key from the JSON body.
+func loadParamsFlag(val string) (map[string]any, error) {
+	if val == "" {
+		return nil, nil
+	}
+	var raw []byte
+	if strings.HasPrefix(val, "@") {
+		path := strings.TrimPrefix(val, "@")
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read params file %q: %w", path, err)
+		}
+	} else {
+		raw = []byte(val)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parse params JSON: %w", err)
+	}
+	return m, nil
+}
+
+func jsonUnmarshalStrict(raw []byte, out any) error {
+	return json.Unmarshal(raw, out)
+}
+
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/vcf-operations/vcf_operations.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations.go
@@ -91,9 +91,9 @@ func NewRootCmd() *cobra.Command {
 type vropsEntry = map[string]any
 
 // vropsListKeysByOp maps each list op's wrapper key (vROps wraps lists
-// under noun-specific keys: ``resourceList``, ``alerts``,
-// ``alertDefinitions``, ``symptoms``, ``recommendations``,
-// ``superMetrics``). The renderers consult this map to find the rows
+// under noun-specific keys: “resourceList“, “alerts“,
+// “alertDefinitions“, “symptoms“, “recommendations“,
+// “superMetrics“). The renderers consult this map to find the rows
 // regardless of which list op they are handling.
 var vropsListKeysByOp = map[string]string{
 	"GET:/suite-api/api/resources":        "resourceList",
@@ -105,8 +105,8 @@ var vropsListKeysByOp = map[string]string{
 }
 
 // decodeVropsListResult unwraps a vROps suite-api list payload from
-// the documented per-noun wrapper key. ``key`` is the expected
-// wrapper (one of ``resourceList`` / ``alerts`` / etc.). The fallback
+// the documented per-noun wrapper key. “key“ is the expected
+// wrapper (one of “resourceList“ / “alerts“ / etc.). The fallback
 // path accepts a bare array so future spec drift to a flat shape
 // doesn't break the renderer; the fallback is best-effort, not part
 // of the documented contract.
@@ -148,9 +148,9 @@ func vropsStringField(e vropsEntry, key string) string {
 	return ""
 }
 
-// vropsResourceName extracts the ``resourceKey.name`` from a vROps
+// vropsResourceName extracts the “resourceKey.name“ from a vROps
 // resource entry. The list payload nests the human-readable name
-// inside the ``resourceKey`` object alongside the adapterKindKey and
+// inside the “resourceKey“ object alongside the adapterKindKey and
 // resourceKindKey; surfacing it flat in the column makes the table
 // readable without the operator running --json | jq.
 func vropsResourceName(e vropsEntry) string {
@@ -164,7 +164,7 @@ func vropsResourceName(e vropsEntry) string {
 	return ""
 }
 
-// vropsResourceKindKey extracts ``resourceKey.resourceKindKey`` from a
+// vropsResourceKindKey extracts “resourceKey.resourceKindKey“ from a
 // vROps resource entry. Same nesting rationale as
 // :func:`vropsResourceName`.
 func vropsResourceKindKey(e vropsEntry) string {

--- a/cli/internal/cmd/vcf-operations/vcf_operations_test.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations_test.go
@@ -1,0 +1,717 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfoperations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests ----------
+
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+// TestConnectorIDIsFrozen pins the pre-baked connector_id constant.
+// A regression here would silently rebind every alias verb to a
+// different connector. Match `VROPS_CONNECTOR_ID` on the backend
+// side.
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "vrops-rest-9.0" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "vrops-rest-9.0")
+	}
+}
+
+// ---------- loadParamsFlag ----------
+
+func TestLoadParamsFlagEmpty(t *testing.T) {
+	got, err := loadParamsFlag("")
+	if err != nil || got != nil {
+		t.Fatalf("loadParamsFlag(\"\"): err=%v got=%v", err, got)
+	}
+}
+
+func TestLoadParamsFlagInlineJSON(t *testing.T) {
+	got, err := loadParamsFlag(`{"resourceKind":"VirtualMachine","pageSize":50}`)
+	if err != nil {
+		t.Fatalf("loadParamsFlag: %v", err)
+	}
+	if got["resourceKind"] != "VirtualMachine" {
+		t.Fatalf("inline JSON params not parsed; got %v", got)
+	}
+}
+
+func TestLoadParamsFlagFileReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.json")
+	if err := os.WriteFile(path, []byte(`{"id":"vrops-resource-1"}`), 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	got, err := loadParamsFlag("@" + path)
+	if err != nil || got["id"] != "vrops-resource-1" {
+		t.Fatalf("loadParamsFlag @file: err=%v got=%v", err, got)
+	}
+}
+
+func TestLoadParamsFlagInvalidJSONReportsError(t *testing.T) {
+	_, err := loadParamsFlag(`{not json`)
+	if err == nil || !strings.Contains(err.Error(), "parse params JSON") {
+		t.Fatalf("expected parse error; got %v", err)
+	}
+}
+
+// ---------- decodeVropsListResult ----------
+
+// vROps wraps each list payload under a noun-specific key
+// (resourceList / alerts / alertDefinitions / symptoms /
+// recommendations / superMetrics). The decoder must unwrap from the
+// specified key.
+func TestDecodeVropsListResultResourceListWrapper(t *testing.T) {
+	raw := json.RawMessage(`{"resourceList":[{"identifier":"r-1"},{"identifier":"r-2"}],"pageInfo":{"totalCount":2}}`)
+	entries, err := decodeVropsListResult(raw, "resourceList")
+	if err != nil {
+		t.Fatalf("decodeVropsListResult resourceList: %v", err)
+	}
+	if len(entries) != 2 || entries[0]["identifier"] != "r-1" {
+		t.Fatalf("resourceList decode: got %+v", entries)
+	}
+}
+
+func TestDecodeVropsListResultAlertsWrapper(t *testing.T) {
+	raw := json.RawMessage(`{"alerts":[{"alertId":"a-1","status":"ACTIVE"}],"pageInfo":{"totalCount":1}}`)
+	entries, err := decodeVropsListResult(raw, "alerts")
+	if err != nil {
+		t.Fatalf("decodeVropsListResult alerts: %v", err)
+	}
+	if len(entries) != 1 || entries[0]["alertId"] != "a-1" {
+		t.Fatalf("alerts decode: got %+v", entries)
+	}
+}
+
+func TestDecodeVropsListResultBareArrayFallback(t *testing.T) {
+	// Bare-array fallback path — not the canonical shape but kept
+	// for defence against future spec drift.
+	raw := json.RawMessage(`[{"identifier":"r-1"}]`)
+	entries, err := decodeVropsListResult(raw, "resourceList")
+	if err != nil {
+		t.Fatalf("decodeVropsListResult bare: %v", err)
+	}
+	if len(entries) != 1 || entries[0]["identifier"] != "r-1" {
+		t.Fatalf("bare-array decode: got %+v", entries)
+	}
+}
+
+func TestDecodeVropsListResultEmpty(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		entries, err := decodeVropsListResult(raw, "resourceList")
+		if err != nil || entries != nil {
+			t.Fatalf("decodeVropsListResult empty: err=%v entries=%v", err, entries)
+		}
+	}
+}
+
+// TestVropsResourceNameNested checks the resource-list helper that
+// pulls `resourceKey.name` out of the nested vROps shape.
+func TestVropsResourceNameNested(t *testing.T) {
+	e := vropsEntry{
+		"resourceKey": map[string]any{
+			"name":            "vm-canary-00",
+			"resourceKindKey": "VirtualMachine",
+		},
+	}
+	if got := vropsResourceName(e); got != "vm-canary-00" {
+		t.Errorf("vropsResourceName: got %q want vm-canary-00", got)
+	}
+	if got := vropsResourceKindKey(e); got != "VirtualMachine" {
+		t.Errorf("vropsResourceKindKey: got %q want VirtualMachine", got)
+	}
+}
+
+func TestVropsResourceNameMissing(t *testing.T) {
+	// Missing resourceKey → empty string, not panic.
+	if got := vropsResourceName(vropsEntry{}); got != "" {
+		t.Errorf("vropsResourceName missing key: got %q", got)
+	}
+	if got := vropsResourceKindKey(vropsEntry{"resourceKey": "not-a-map"}); got != "" {
+		t.Errorf("vropsResourceKindKey non-map: got %q", got)
+	}
+}
+
+// ---------- renderers ----------
+
+func TestPrintAboutHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "GET:/suite-api/api/versions/current",
+		Result: json.RawMessage(
+			`{"releaseName":"9.0.0.1.23456789","buildNumber":23456789,"humanlyReadableReleaseName":"VMware Aria Operations 9.0"}`,
+		),
+		DurationMs: 42.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=ok", "vrops-rest-9.0", "9.0.0.1.23456789", "23456789", "VMware Aria Operations 9.0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintAboutErrorRendersErrorString(t *testing.T) {
+	errMsg := "auth failed"
+	r := &CallResult{
+		Status:     "error",
+		OpID:       "GET:/suite-api/api/versions/current",
+		Error:      &errMsg,
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=error", "auth failed"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout error missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintResourceList(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"resourceList":[{"identifier":"r-1","resourceKey":{"name":"vm-01","resourceKindKey":"VirtualMachine","adapterKindKey":"VMWARE"}}],"pageInfo":{"totalCount":1}}`),
+	}
+	var buf bytes.Buffer
+	printResourceList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"r-1", "vm-01", "VirtualMachine", "identifier", "name", "kind"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printResourceList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintResourceListEmpty(t *testing.T) {
+	r := &CallResult{Status: "ok", Result: json.RawMessage(`{"resourceList":[]}`)}
+	var buf bytes.Buffer
+	printResourceList(&buf, r)
+	if !strings.Contains(buf.String(), "(0 resources)") {
+		t.Errorf("empty resource list should announce 0; got:\n%s", buf.String())
+	}
+}
+
+func TestPrintResourceGet(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"identifier":"r-1","resourceKey":{"name":"vm-01","resourceKindKey":"VirtualMachine"},"resourceStatusStates":[{"resourceStatus":"DATA_RECEIVING","resourceState":"STARTED"}]}`),
+	}
+	var buf bytes.Buffer
+	printResourceGet(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"r-1", "vm-01", "VirtualMachine", "DATA_RECEIVING", "STARTED"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printResourceGet missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintAlertList(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"alerts":[{"alertId":"a-1","alertDefinitionName":"CPU high","alertLevel":3,"status":"ACTIVE"}],"pageInfo":{"totalCount":1}}`),
+	}
+	var buf bytes.Buffer
+	printAlertList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"a-1", "CPU high", "ACTIVE", "3"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAlertList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintAlertListEmpty(t *testing.T) {
+	r := &CallResult{Status: "ok", Result: json.RawMessage(`{"alerts":[]}`)}
+	var buf bytes.Buffer
+	printAlertList(&buf, r)
+	if !strings.Contains(buf.String(), "(0 alerts)") {
+		t.Errorf("empty alert list should announce 0; got:\n%s", buf.String())
+	}
+}
+
+func TestPrintAlertDefinitionList(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"alertDefinitions":[{"id":"AlertDef-1","name":"CPU","adapterKindKey":"VMWARE","resourceKindKey":"VirtualMachine"}],"pageInfo":{"totalCount":1}}`),
+	}
+	var buf bytes.Buffer
+	printAlertDefinitionList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"AlertDef-1", "CPU", "VMWARE", "VirtualMachine"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAlertDefinitionList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintSymptomList(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"symptoms":[{"id":"sym-1","symptomDefinitionName":"CPU breach","severity":"WARNING"}],"pageInfo":{"totalCount":1}}`),
+	}
+	var buf bytes.Buffer
+	printSymptomList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"sym-1", "CPU breach", "WARNING"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSymptomList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintRecommendationList(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"recommendations":[{"id":"rec-1","description":"Reduce workload","actionId":""}],"pageInfo":{"totalCount":1}}`),
+	}
+	var buf bytes.Buffer
+	printRecommendationList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"rec-1", "Reduce workload"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printRecommendationList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintSupermetricList(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"superMetrics":[{"id":"sm-1","name":"cpu-ratio","formula":"a/b"}],"pageInfo":{"totalCount":1}}`),
+	}
+	var buf bytes.Buffer
+	printSupermetricList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"sm-1", "cpu-ratio", "a/b"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSupermetricList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintSearchTable(t *testing.T) {
+	summary := "List vROps resources"
+	r := &searchResponse{
+		Hits: []searchHit{
+			{OpID: "GET:/suite-api/api/resources", Summary: &summary, FusedScore: 0.987},
+		},
+		QueryDurationMs: 12.0,
+	}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "list resources", r)
+	out := buf.String()
+	for _, want := range []string{"vrops-rest-9.0", "list resources", "1 hit(s)", "GET:/suite-api/api/resources", "List vROps resources"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSearchTable missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestStrDerefNilEmptyOtherwiseValue(t *testing.T) {
+	if got := strDeref(nil); got != "" {
+		t.Fatalf("strDeref(nil): got %q", got)
+	}
+	v := "hello"
+	if got := strDeref(&v); got != "hello" {
+		t.Fatalf("strDeref(&v): got %q", got)
+	}
+}
+
+func TestErrOpErrorIsSentinel(t *testing.T) {
+	if errOpError == nil {
+		t.Fatalf("errOpError should be non-nil")
+	}
+	if errors.Is(errOpError, errors.New("other")) {
+		t.Fatalf("errOpError should not match arbitrary errors")
+	}
+}
+
+// ---------- HTTP wire shape (mocked) ----------
+
+type mockHandler = http.HandlerFunc
+
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID — every verb dispatches with
+// connector_id="vrops-rest-9.0" pre-baked. This pins that the
+// dispatcher writes the canonical connector_id into the
+// CallOperationBody — a regression here would silently rebind every
+// alias verb to a different connector. Mirrors the NSX / SDDC Manager
+// siblings.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "vrops-rest-9.0" {
+				t.Errorf("connector_id: got %q want vrops-rest-9.0", body.ConnectorID)
+			}
+			if body.OpID != "GET:/suite-api/api/versions/current" {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "GET:/suite-api/api/versions/current",
+				Result: json.RawMessage(`{"releaseName":"9.0.0"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, "GET:/suite-api/api/versions/current", "rdc-vrops", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if raw["target"] != nil {
+				t.Errorf("empty target should be null on wire; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "x"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "x", "", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			tgt, _ := raw["target"].(map[string]any)
+			if tgt == nil || tgt["name"] != "rdc-vrops" {
+				t.Errorf("target should wrap slug as {name: ...}; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "x"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "x", "rdc-vrops", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchResourceGetSendsIDParam — the resource-get verb passes
+// the {id} path parameter through `params.id` so the dispatcher's
+// `_substitute_path` can fill the template at dispatch time. Pin
+// that wire shape — a regression would route every resource-get to
+// the un-substituted path.
+func TestDispatchResourceGetSendsIDParam(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != "GET:/suite-api/api/resources/{id}" {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			if body.Params["id"] != "vrops-resource-uuid" {
+				t.Errorf("params.id: got %v", body.Params["id"])
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "GET:/suite-api/api/resources/{id}",
+				Result: json.RawMessage(`{"identifier":"vrops-resource-uuid"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(
+		context.Background(), srv.URL,
+		"GET:/suite-api/api/resources/{id}",
+		"rdc-vrops",
+		map[string]any{"id": "vrops-resource-uuid"},
+	)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestSearchSendsConnectorIDPreBaked — the search wrapper pre-bakes
+// connector_id="vrops-rest-9.0" into the query string.
+func TestSearchSendsConnectorIDPreBaked(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/operations/search": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("connector_id"); got != "vrops-rest-9.0" {
+				t.Errorf("connector_id: got %q", got)
+			}
+			if got := r.URL.Query().Get("query"); got != "list resources" {
+				t.Errorf("query: got %q", got)
+			}
+			writeJSON(t, w, 200, searchResponse{
+				Hits: []searchHit{{OpID: "GET:/suite-api/api/resources", FusedScore: 1.0}},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := getSearch(context.Background(), srv.URL, "list resources", "", 10)
+	if err != nil {
+		t.Fatalf("getSearch: %v", err)
+	}
+	if len(r.Hits) != 1 || r.Hits[0].OpID != "GET:/suite-api/api/resources" {
+		t.Fatalf("unexpected search response: %+v", r)
+	}
+}
+
+// TestRenderCallResultUnknownStatus — anything outside the
+// ok/error/denied enum surfaces as an unexpected-response error.
+func TestRenderCallResultUnknownStatus(t *testing.T) {
+	r := &CallResult{Status: "weird", OpID: "x"}
+	var buf bytes.Buffer
+	cmd := newOperationCallCmd()
+	cmd.SetErr(&buf)
+	cmd.SetOut(&buf)
+	err := renderCallResult(cmd, "x", r, false, nil)
+	if err == nil {
+		t.Fatalf("unknown status should surface as error")
+	}
+	if !strings.Contains(buf.String(), "unexpected_response") && !strings.Contains(buf.String(), "invalid OperationResult") {
+		t.Errorf("unknown-status render should mention unexpected_response or invalid; got:\n%s", buf.String())
+	}
+}
+
+// TestNewRootCmdAssemblesAllVerbs pins the verb tree shape — the
+// issue #837 acceptance lists about / resource / alert /
+// alertdefinition / symptom / recommendation / supermetric (+
+// operation). A regression here (missing AddCommand, typo'd Use)
+// would silently drop a verb from the tree.
+func TestNewRootCmdAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"about":           true,
+		"resource":        true,
+		"alert":           true,
+		"alertdefinition": true,
+		"symptom":         true,
+		"recommendation":  true,
+		"supermetric":     true,
+		"operation":       true,
+	}
+	for _, c := range root.Commands() {
+		delete(want, c.Name())
+	}
+	if len(want) > 0 {
+		t.Errorf("vcf-operations tree missing top-level verbs: %v", want)
+	}
+}
+
+// TestResourceSubtreeAssemblesListAndGet pins the resource sub-tree.
+func TestResourceSubtreeAssemblesListAndGet(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() != "resource" {
+			continue
+		}
+		subnames := map[string]bool{}
+		for _, sub := range c.Commands() {
+			subnames[sub.Name()] = true
+		}
+		for _, want := range []string{"list", "get"} {
+			if !subnames[want] {
+				t.Errorf("resource sub-tree missing %q; got %v", want, subnames)
+			}
+		}
+		return
+	}
+	t.Fatalf("resource sub-tree not found")
+}
+
+// TestSingleListSubtreesAssembleListVerb checks that each list-only
+// noun (alert / alertdefinition / symptom / recommendation /
+// supermetric) carries its single ``list`` sub-verb.
+func TestSingleListSubtreesAssembleListVerb(t *testing.T) {
+	root := NewRootCmd()
+	for _, parent := range []string{"alert", "alertdefinition", "symptom", "recommendation", "supermetric"} {
+		found := false
+		for _, c := range root.Commands() {
+			if c.Name() != parent {
+				continue
+			}
+			for _, sub := range c.Commands() {
+				if sub.Name() == "list" {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Errorf("vcf-operations %s missing 'list' sub-verb", parent)
+		}
+	}
+}
+
+// TestOperationSubtreeAssemblesAllVerbs pins the
+// `vcf-operations operation` sub-tree.
+func TestOperationSubtreeAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() != "operation" {
+			continue
+		}
+		subnames := map[string]bool{}
+		for _, sub := range c.Commands() {
+			subnames[sub.Name()] = true
+		}
+		for _, want := range []string{"search", "call"} {
+			if !subnames[want] {
+				t.Errorf("operation sub-tree missing %q; got %v", want, subnames)
+			}
+		}
+		return
+	}
+	t.Fatalf("operation sub-tree not found")
+}

--- a/cli/internal/cmd/vcf-operations/vcf_operations_test.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations_test.go
@@ -270,12 +270,14 @@ func TestPrintResourceGet(t *testing.T) {
 func TestPrintAlertList(t *testing.T) {
 	r := &CallResult{
 		Status: "ok",
-		Result: json.RawMessage(`{"alerts":[{"alertId":"a-1","alertDefinitionName":"CPU high","alertLevel":3,"status":"ACTIVE"}],"pageInfo":{"totalCount":1}}`),
+		Result: json.RawMessage(`{"alerts":[{"alertId":"a-1","alertDefinitionName":"CPU high","resourceId":"res-1","alertLevel":3,"status":"ACTIVE"}],"pageInfo":{"totalCount":1}}`),
 	}
 	var buf bytes.Buffer
 	printAlertList(&buf, r)
 	out := buf.String()
-	for _, want := range []string{"a-1", "CPU high", "ACTIVE", "3"} {
+	// The header advertises a `resourceId` column (alert.go Long text);
+	// pin that the renderer actually emits it and the row's value.
+	for _, want := range []string{"a-1", "CPU high", "ACTIVE", "3", "resourceId", "res-1"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("printAlertList missing %q in:\n%s", want, out)
 		}
@@ -309,12 +311,14 @@ func TestPrintAlertDefinitionList(t *testing.T) {
 func TestPrintSymptomList(t *testing.T) {
 	r := &CallResult{
 		Status: "ok",
-		Result: json.RawMessage(`{"symptoms":[{"id":"sym-1","symptomDefinitionName":"CPU breach","severity":"WARNING"}],"pageInfo":{"totalCount":1}}`),
+		Result: json.RawMessage(`{"symptoms":[{"id":"sym-1","symptomDefinitionName":"CPU breach","resourceId":"res-1","severity":"WARNING"}],"pageInfo":{"totalCount":1}}`),
 	}
 	var buf bytes.Buffer
 	printSymptomList(&buf, r)
 	out := buf.String()
-	for _, want := range []string{"sym-1", "CPU breach", "WARNING"} {
+	// The header advertises a `resourceId` column (symptom.go Long text);
+	// pin that the renderer actually emits it and the row's value.
+	for _, want := range []string{"sym-1", "CPU breach", "WARNING", "resourceId", "res-1"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("printSymptomList missing %q in:\n%s", want, out)
 		}
@@ -348,6 +352,46 @@ func TestPrintSupermetricList(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("printSupermetricList missing %q in:\n%s", want, out)
 		}
+	}
+}
+
+// TestPrintRecommendationListFirstLineOnly pins the "first line"
+// contract advertised in the recommendation list help text — a
+// multi-line description must be collapsed so embedded newlines
+// don't spill across multiple table rows.
+func TestPrintRecommendationListFirstLineOnly(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"recommendations":[{"id":"rec-1","description":"Reduce workload\nthen restart\nthe VM","actionId":""}],"pageInfo":{"totalCount":1}}`),
+	}
+	var buf bytes.Buffer
+	printRecommendationList(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "Reduce workload") {
+		t.Errorf("printRecommendationList missing first line in:\n%s", out)
+	}
+	if strings.Contains(out, "then restart") || strings.Contains(out, "the VM") {
+		t.Errorf("printRecommendationList must render only the first line; got:\n%s", out)
+	}
+}
+
+// TestPrintSupermetricListFirstLineOnly pins the "first line"
+// contract advertised in the super-metric list help text — a
+// multi-line formula must be collapsed so embedded newlines don't
+// spill across multiple table rows.
+func TestPrintSupermetricListFirstLineOnly(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"superMetrics":[{"id":"sm-1","name":"cpu-ratio","formula":"$This, metric=cpu\n+ $This, metric=ready"}],"pageInfo":{"totalCount":1}}`),
+	}
+	var buf bytes.Buffer
+	printSupermetricList(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "$This, metric=cpu") {
+		t.Errorf("printSupermetricList missing first line in:\n%s", out)
+	}
+	if strings.Contains(out, "metric=ready") {
+		t.Errorf("printSupermetricList must render only the first line; got:\n%s", out)
 	}
 }
 
@@ -673,7 +717,7 @@ func TestResourceSubtreeAssemblesListAndGet(t *testing.T) {
 
 // TestSingleListSubtreesAssembleListVerb checks that each list-only
 // noun (alert / alertdefinition / symptom / recommendation /
-// supermetric) carries its single ``list`` sub-verb.
+// supermetric) carries its single “list“ sub-verb.
 func TestSingleListSubtreesAssembleListVerb(t *testing.T) {
 	root := NewRootCmd()
 	for _, parent := range []string{"alert", "alertdefinition", "symptom", "recommendation", "supermetric"} {

--- a/docs/cross-repo/vcf-operations-onboarding.md
+++ b/docs/cross-repo/vcf-operations-onboarding.md
@@ -1,0 +1,465 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# vROps op surface onboarding — operator recipe
+
+> Operator-facing recipe for the G3.6 `vrops-rest-9.0` op surface — the
+> `meho vcf-operations …` verb tree, the agent meta-tool path, and the
+> migration off the consumer's `scripts/vcf-operations.sh` wrapper. The
+> connector lives in
+> [`backend/src/meho_backplane/connectors/vcf_operations/`](../../backend/src/meho_backplane/connectors/vcf_operations/);
+> recorded-fixture refresh tooling lives in
+> [`backend/tests/fixtures/vcf/refresh.py`](../../backend/tests/fixtures/vcf/refresh.py).
+> This doc is the cookbook every RDC operator reads when retiring
+> `scripts/vcf-operations.sh` in favour of `meho vcf-operations …`.
+
+## What this surface is
+
+The `vrops-rest-9.0` connector is an **ingested** connector: the 8
+curated read-only ops are stored as `EndpointDescriptor` rows seeded by
+G0.7 spec ingestion of the vROps `/suite-api` OpenAPI spec (G3.6-T2
+[#833](https://github.com/evoila/meho/issues/833)) and dispatched
+through `HttpConnector._request_json` by the G0.6 `dispatch_ingested`
+branch. The connector class
+[`VcfOperationsConnector`](../../backend/src/meho_backplane/connectors/vcf_operations/connector.py)
+registers under the `(product="vcf-operations", version="9.0",
+impl_id="vrops-rest")` registry triple — the connector id
+`vrops-rest-9.0`. Auth is HTTP Basic on every request (vROps'
+`/suite-api/api/*` surface is stateless — no session token, no 401
+re-login loop); the connector handles credentials transparently via
+the shared
+[`CredentialsCache`](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py).
+
+vROps has no public CI simulator
+([#536](https://github.com/evoila/meho/issues/536) proved vendor
+simulators cannot serve their REST surfaces). Integration coverage uses
+a recorded-fixture record/replay pattern against captured vROps
+responses. The refresh tool at
+[`backend/tests/fixtures/vcf/refresh.py`](../../backend/tests/fixtures/vcf/refresh.py)
+captures live responses against a lab appliance with redaction; the
+E2E suite at
+[`backend/tests/test_connectors_vcf_operations_e2e.py`](../../backend/tests/test_connectors_vcf_operations_e2e.py)
+replays them via `respx` mocks. This is a known, documented limitation
+per Initiative #369's DoD.
+
+The v0.5 op surface (Initiative
+[#369](https://github.com/evoila/meho/issues/369)) is the **read**
+working set the consumer's `scripts/vcf-operations.sh` exercises daily
+— write ops (custom-group create / maintenance-mode set / alert-ack)
+stay in the wrapper until v0.5.next ships policy + approval flow:
+
+| Group | CLI verb | `op_id` | Path |
+| --- | --- | --- | --- |
+| vrops-system | `meho vcf-operations about` | `GET:/suite-api/api/versions/current` | Appliance release name + build number |
+| vrops-resources | `meho vcf-operations resource list` | `GET:/suite-api/api/resources` | Resource inventory (VMs, hosts, datastores, adapters) |
+| vrops-resources | `meho vcf-operations resource get <id>` | `GET:/suite-api/api/resources/{id}` | Per-resource detail by UUID |
+| vrops-alerts | `meho vcf-operations alert list` | `GET:/suite-api/api/alerts` | Currently firing or recently resolved alerts |
+| vrops-alert-definitions | `meho vcf-operations alertdefinition list` | `GET:/suite-api/api/alertdefinitions` | Alert definitions (the policy surface) |
+| vrops-symptoms | `meho vcf-operations symptom list` | `GET:/suite-api/api/symptoms` | Per-condition signals beneath alerts |
+| vrops-recommendations | `meho vcf-operations recommendation list` | `GET:/suite-api/api/recommendations` | Operator-facing remediation hints |
+| vrops-supermetrics | `meho vcf-operations supermetric list` | `GET:/suite-api/api/supermetrics` | User-defined metric formulae |
+
+Every op dispatches through the same `POST /api/v1/operations/call`
+route the agent surface uses — auth, policy, audit, broadcast, and
+JSONFlux all run as documented in [CLAUDE.md](../../CLAUDE.md) §6. The
+CLI verb tree is operator ergonomics over that one route; it is **not**
+a separate data path and is **not** mirrored on the MCP surface
+(CLAUDE.md postulate 5 — agents reach these ops via
+`search_operations` / `call_operation`).
+
+## Prerequisites
+
+- **A reachable vROps appliance** (VMware Aria Operations 9.0). The
+  connector derives the base URL from `target.host` + `target.port`.
+- **Service-account credentials in Vault.** The connector reads
+  `{"username": ..., "password": ...}` from Vault at `target.secret_ref`
+  on first dispatch per target and caches them via the shared
+  [`CredentialsCache`](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py).
+  Basic auth is stateless on vROps — no session token to refresh.
+- **A registered vROps target.** The CLI verbs take `--target <slug>`
+  (e.g. `--target rdc-vrops`). The target carries
+  `product="vcf-operations"`, `host` (the vROps FQDN — no `https://`),
+  `port` (default 443), `secret_ref` (the Vault path to the
+  credentials), and `auth_model="shared_service_account"`. Optional
+  `target.auth_source` routes the Basic challenge to a non-local vROps
+  identity domain (vIDM, AD realm name, etc.); omit for the local
+  realm.
+- **The 8 curated ops registered + enabled.** Run G0.7 spec ingestion
+  against `docs:vcf-operations-9.0/suite-api.yaml`, then
+  `apply_vrops_core_curation` once per tenant after ingest. See
+  [`docs/cross-repo/connector-ingestion.md`](./connector-ingestion.md)
+  for the end-to-end ingestion procedure.
+- **An operator session.** `meho login <backplane-url>` writes the
+  session token the CLI reuses. `meho vcf-operations …` requires
+  `operator` role minimum (same gate as every dispatch verb).
+
+## Target + auth model
+
+The shipped connector's auth model is **`shared_service_account`** —
+the Vault-sourced credentials are used regardless of which operator
+invokes the verb. Per-operator impersonation is out of scope for v0.5.
+
+What this means for the credentials in Vault:
+
+- Vault path: `target.secret_ref` (e.g. `kv/data/vcf-operations/<slug>`).
+- Required fields: `username` (string), `password` (string).
+- The backplane reads them lazily on first op invocation per target;
+  the values stay cached in the connector's per-target
+  `CredentialsCache` until rotation invalidates the cache (today this
+  means a backplane restart — see "Credential rotation" below).
+- **No session expiry.** vROps Basic auth is stateless; a 401 from the
+  appliance always means "bad credentials" (or a misconfigured
+  `auth-source`) and is not retried.
+- **Credential rotation**: update the Vault secret, then restart the
+  backplane (or wait for a future rotation admin endpoint to call
+  `CredentialsCache.invalidate(target_name)`) so the connector
+  reloads.
+- **Optional `auth-source` routing.** vROps can federate identity
+  through multiple sources. Set `target.auth_source` on the
+  registered target (e.g. `vIDM`, an AD realm name) to route the
+  Basic challenge; omit to fall back to the local realm. The CLI does
+  not expose this as a per-call flag — it is a per-target property.
+
+To register a new target via the CLI:
+
+```bash
+meho targets import \
+  --name rdc-vrops \
+  --product vcf-operations \
+  --host vrops-mgr.rdc.evoila.io \
+  --port 443 \
+  --secret-ref kv/data/vcf-operations/rdc-vrops \
+  --auth-model shared_service_account
+```
+
+Verify the fingerprint resolved correctly:
+
+```bash
+meho targets probe --name rdc-vrops --json | jq '{product, version, reachable}'
+# expected: {"product": "vcf-operations", "version": "9.0.0.…", "reachable": true}
+```
+
+## Quick-start
+
+```bash
+# Appliance identity + build
+meho vcf-operations about --target rdc-vrops
+
+# Resource inventory (all monitored objects)
+meho vcf-operations resource list --target rdc-vrops
+
+# Narrow by resource kind / adapter kind
+meho vcf-operations resource list --target rdc-vrops \
+  --params '{"resourceKind":"VirtualMachine","pageSize":50}'
+
+# Drill into one resource by UUID
+meho vcf-operations resource get 00000000-0000-4000-8000-000000000000 --target rdc-vrops
+
+# Active alerts
+meho vcf-operations alert list --target rdc-vrops --params '{"activeOnly":true}'
+
+# Critical-only alerts
+meho vcf-operations alert list --target rdc-vrops \
+  --params '{"alertCriticality":"CRITICAL","activeOnly":true}'
+
+# Alert definitions — the policy surface alerts roll up against
+meho vcf-operations alertdefinition list --target rdc-vrops
+
+# Symptoms — the per-condition signals beneath alerts
+meho vcf-operations symptom list --target rdc-vrops --params '{"activeOnly":true}'
+
+# Recommendations attached to current alerts/symptoms
+meho vcf-operations recommendation list --target rdc-vrops
+
+# Super metrics (user-defined formulae)
+meho vcf-operations supermetric list --target rdc-vrops
+
+# Machine-readable output for any verb
+meho vcf-operations resource list --target rdc-vrops --json \
+  | jq '.result.resourceList[] | .identifier'
+
+# Escape hatch: run any vrops-rest-9.0 op by op_id
+meho vcf-operations operation call GET:/suite-api/api/versions/current --target rdc-vrops
+meho vcf-operations operation search "alerts" --target rdc-vrops
+```
+
+## Verb reference
+
+### `meho vcf-operations about`
+
+Dispatches `GET:/suite-api/api/versions/current` against
+`connector_id="vrops-rest-9.0"`. Human output: `release` (e.g.
+`9.0.0.1.23456789`), `build`, `human` (the humanly readable name when
+the appliance emits it).
+
+```text
+$ meho vcf-operations about --target rdc-vrops
+vrops-rest-9.0 GET:/suite-api/api/versions/current — status=ok (42ms)
+  release:  9.0.0.1.23456789
+  build:    23456789
+  human:    VMware Aria Operations 9.0
+```
+
+### `meho vcf-operations resource list`
+
+Dispatches `GET:/suite-api/api/resources`. Renders `identifier` /
+`resourceKey.name` / `resourceKey.resourceKindKey`. Filter via
+`--params` (`resourceKind`, `adapterKind`, `name`, `page`, `pageSize`).
+Production deployments often have hundreds to thousands of resources —
+use `--json | jq` for ad-hoc filtering or the JSONFlux handle path on
+the agent side for large lists.
+
+### `meho vcf-operations resource get <id>`
+
+Dispatches `GET:/suite-api/api/resources/{id}` with `<id>` substituted
+into the path. `<id>` is the resource UUID returned by `resource list`.
+Renders identifier / name / kind / status / state.
+
+### `meho vcf-operations alert list`
+
+Dispatches `GET:/suite-api/api/alerts`. Renders `alertId` /
+`alertDefinitionName` / `alertLevel` / `status`. Filter via `--params`
+(`activeOnly`, `alertCriticality`, `alertStatus`, `resourceId`,
+`page`, `pageSize`).
+
+### `meho vcf-operations alertdefinition list`
+
+Dispatches `GET:/suite-api/api/alertdefinitions`. Renders the
+definition `id` / `name` / `adapterKindKey` / `resourceKindKey`. Filter
+via `--params` (`id` (repeatable), `adapterKind`, `resourceKind`,
+`name`).
+
+### `meho vcf-operations symptom list`
+
+Dispatches `GET:/suite-api/api/symptoms`. Renders `id` /
+`symptomDefinitionName` / `severity`. Useful when debugging which
+underlying condition triggered an alert.
+
+### `meho vcf-operations recommendation list`
+
+Dispatches `GET:/suite-api/api/recommendations`. Renders `id` /
+`description` (truncated for human eyes; full text via `--json`) /
+`actionId` (when an automated remediation is linked — out of scope for
+v0.5 read core).
+
+### `meho vcf-operations supermetric list`
+
+Dispatches `GET:/suite-api/api/supermetrics`. Renders `id` / `name` /
+`formula`. Useful when answering "which metric formula computes X" or
+auditing custom-metric definitions across the deployment.
+
+### `meho vcf-operations operation search` / `meho vcf-operations operation call`
+
+Meta-tool wrappers pre-scoped to `vrops-rest-9.0`. `search` runs the
+hybrid BM25+cosine search across vrops-rest-9.0 op descriptors; `call`
+dispatches any op_id directly. Use these for ops not yet promoted to
+dedicated CLI aliases.
+
+```bash
+meho vcf-operations operation search "list resources" --group vrops-resources
+meho vcf-operations operation call GET:/suite-api/api/versions/current --target rdc-vrops
+```
+
+## Audit and broadcast classification
+
+Every vROps v0.5 op is `safety_level=safe`, `requires_approval=false`
+— the read-only surface never mutates state. The audit row carries:
+`method='DISPATCH'`, `path=<op_id>`, `target_id=<uuid>`,
+`payload={"op_id": ..., "params_hash": ..., "source_kind":
+"ingested", "connector_product": "vrops",
+"connector_version": "9.0", "connector_impl_id": "vrops-rest",
+"result_status": "ok"|"error"}`.
+
+Broadcast events publish per-tenant on every successful dispatch.
+`meho audit query --connector vrops-rest-9.0` retrieves the full
+dispatch history; see [`audit-query.md`](./audit-query.md) for filter
+syntax.
+
+## Recorded-fixture refresh
+
+When an appliance upgrade changes a response shape, refresh the
+checked-in fixtures via the shipped tool:
+
+```bash
+# Operator-only — runs against a live lab appliance.
+uv run python backend/tests/fixtures/vcf/refresh.py \
+  --connector vcf-operations \
+  --target rdc-vrops \
+  --host vrops-mgr.lab.evoila.io \
+  --username admin \
+  --password "$VROPS_PASSWORD" \
+  --insecure --force
+```
+
+The tool redacts `Set-Cookie`, `Authorization`, `sessionId`, and
+`X-XSRF-TOKEN` from headers and `password` / `session_token` /
+`sessionId` / `token` / `access_token` / `refresh_token` from JSON
+bodies before writing the JSON snapshots under
+`backend/tests/fixtures/vcf/vcf-operations/`. Refuses to overwrite an
+existing fixture without `--force` (stale fixtures from a prior
+appliance version are the worst kind of bit-rot).
+
+After a refresh, re-run the E2E:
+
+```bash
+uv run pytest backend/tests/test_connectors_vcf_operations_e2e.py -x
+```
+
+The fixture refresh + replay loop is the only integration coverage
+vROps gets in CI (per #536). Treat checked-in fixtures as
+appliance-version-pinned snapshots — bump them alongside the vROps
+version they were captured against.
+
+## Migrating off `scripts/vcf-operations.sh`
+
+The consumer's
+[`scripts/vcf-operations.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-operations.sh)
+drives vROps suite-api via a `curl` + Basic-auth wrapper. The
+`meho vcf-operations` verbs replace it for the read-only workflows;
+write workflows stay in the wrapper.
+
+Migration table — the wrapper-flip recipe per workflow:
+
+| Consumer workflow | `vcf-operations.sh` invocation | `meho vcf-operations …` replacement | Notes |
+| --- | --- | --- | --- |
+| Appliance identity + build | `vcf-operations.sh about` | `meho vcf-operations about --target rdc-vrops` | |
+| Resource inventory | `vcf-operations.sh resources` | `meho vcf-operations resource list --target rdc-vrops` | Filter via `--params '{"resourceKind":"…"}'`. |
+| Per-resource detail | `vcf-operations.sh resource <uuid>` | `meho vcf-operations resource get <uuid> --target rdc-vrops` | |
+| Active alerts | `vcf-operations.sh alerts --active` | `meho vcf-operations alert list --target rdc-vrops --params '{"activeOnly":true}'` | |
+| Critical alerts only | `vcf-operations.sh alerts --critical` | `meho vcf-operations alert list --target rdc-vrops --params '{"alertCriticality":"CRITICAL","activeOnly":true}'` | |
+| Alert definition listing | `vcf-operations.sh alertdefs` | `meho vcf-operations alertdefinition list --target rdc-vrops` | |
+| Symptom listing | `vcf-operations.sh symptoms` | `meho vcf-operations symptom list --target rdc-vrops` | |
+| Recommendation listing | `vcf-operations.sh recommendations` | `meho vcf-operations recommendation list --target rdc-vrops` | |
+| Super-metric listing | `vcf-operations.sh supermetrics` | `meho vcf-operations supermetric list --target rdc-vrops` | |
+
+What `scripts/vcf-operations.sh` did that `meho vcf-operations`
+deliberately does **not** do (out of scope for v0.5 — keep the
+wrapper for these until a future Initiative lands them):
+
+- **Write / mutate ops** — custom-group create/delete, maintenance-mode
+  set, alert acknowledge. v0.5 is read-only; write ops land in
+  v0.5.next pending policy + approval workflow.
+- **Custom query parameters not in the descriptor.** The CLI exposes
+  every documented filter via `--params <JSON>`. For undocumented or
+  experimental query strings, fall back to
+  `meho vcf-operations operation call <op_id> --params '{…}'`.
+- **Non-suite-api paths.** `vcf-operations.sh` can hit arbitrary
+  `/suite-api/…` paths; `meho vcf-operations` exposes only the 8
+  curated core ops. Use
+  `meho vcf-operations operation call GET:<path>` as an escape hatch
+  for one-off queries.
+
+Migration discipline: run the `meho vcf-operations` form alongside
+`vcf-operations.sh` for an overlap window, diff the outputs, then
+retire the wrapper call site. The MEHO path adds the full audit row +
+broadcast event the bash pattern never had — that audit coverage is
+the point of migrating.
+
+### Per-ticket wrapper-flip recipe
+
+For each active vROps consumer ticket, apply this pattern:
+
+1. **Identify the wrapper invocation** in the ticket's reproduction
+   steps (usually `bash scripts/vcf-operations.sh <command>`).
+2. **Find the `meho vcf-operations` equivalent** from the table above.
+3. **Validate output parity**: run both side-by-side against
+   `rdc-vrops`. Use `--json | jq` on the `meho vcf-operations` side to
+   pull the same fields the bash script was parsing.
+4. **Update the ticket steps**: replace the `vcf-operations.sh`
+   invocation with the `meho vcf-operations` form. Capture the
+   `--json` output for the ticket's evidence block.
+5. **Retire the wrapper call site** in the ticket's automation
+   scripts once the MEHO form is validated.
+
+Example — resource listing:
+
+```bash
+# Before (wrapper):
+bash scripts/vcf-operations.sh resources rdc-vrops | jq '.[].identifier'
+
+# After (meho vcf-operations):
+meho vcf-operations resource list --target rdc-vrops --json \
+  | jq '.result.resourceList[].identifier'
+
+# Verify parity (sorted to elide vendor pagination order drift):
+diff \
+  <(bash scripts/vcf-operations.sh resources rdc-vrops | jq -S '[.[].identifier] | sort') \
+  <(meho vcf-operations resource list --target rdc-vrops --json \
+    | jq -S '[.result.resourceList[].identifier] | sort')
+# expected: empty diff
+```
+
+Example — active alerts:
+
+```bash
+# Before:
+bash scripts/vcf-operations.sh alerts --active rdc-vrops
+
+# After:
+meho vcf-operations alert list --target rdc-vrops --params '{"activeOnly":true}'
+```
+
+## Goal #214 G3.6 vROps checklist
+
+| Checklist item | Status |
+| --- | --- |
+| G3.6-T1 [#829](https://github.com/evoila/meho/issues/829) — `VcfOperationsConnector` skeleton + Basic + auth-source | ✅ merged |
+| G3.6-T2 [#833](https://github.com/evoila/meho/issues/833) — 8 read-core curation + smoke/JSONFlux acceptance | ✅ merged |
+| G3.6-T3 [#837](https://github.com/evoila/meho/issues/837) — CLI verbs + E2E recorded-fixture + this doc | ✅ this Task |
+| MCP `llm_instructions` / `when_to_use` reviewed for agent legibility | ✅ done (part of T2 curation; refreshed in T3 audit) |
+| All 8 core ops dispatch → `status='ok'` in CI | ✅ `test_connectors_vcf_operations_e2e.py` |
+| Audit rows carry `op_id` + `target_id` + `params_hash` | ✅ `test_connectors_vcf_operations_e2e.py` |
+| JSONFlux handle path tested in CI | ✅ `test_connectors_vcf_operations_e2e.py` |
+| `docs/cross-repo/vcf-operations-onboarding.md` with wrapper-flip recipe | ✅ this document |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `no backplane URL configured` (exit 2) | Never logged in / no `--backplane`. | `meho login <url>` or pass `--backplane <url>`. |
+| `auth_expired` / stored token rejected | Keycloak token expired. | `meho login <url>` again. |
+| `status=error connector_error: ... 401` | vROps credentials invalid, account locked, or `auth-source` misconfigured. | Verify the Vault secret at `target.secret_ref`. If using federated identity, verify `target.auth_source` matches a configured vROps source. |
+| `status=error connector_error: ... 403` | Service account lacks read role on the resource family. | Grant the service account the read-only vROps role covering the target endpoint. |
+| `status=error … unknown_op` | The 8 core ops are not registered/enabled. | Re-run `apply_vrops_core_curation` against the vROps connector after G0.7 ingest. See [`connector-ingestion.md`](./connector-ingestion.md). |
+| `status=denied` | `read_only` role, or a tenant policy denied the dispatch. | Use an `operator`-role token. |
+| `about` / any verb times out | vROps appliance unreachable from the backplane host. | Verify the FQDN/IP in `target.host` resolves from the backplane; check firewall rules (port 443 from backplane → vROps appliance). |
+| `probe` fails with TLS error | Self-signed or expired certificate, or wrong CA bundle. | Mount the correct CA bundle in the backplane container and set `MEHO_TLS_CA_BUNDLE`; or configure vROps with a CA-signed cert. |
+| `resource get <id>` returns 404 | Resource UUID not found, or stale after deletion. | Re-list via `resource list` and confirm the identifier is current. |
+| `resource list` returns an empty `resourceList` | No resources match the filter, or the adapter instance hasn't started collecting yet. | Drop the filter via `--params '{}'`; verify adapter instances in the vROps UI under Administration → Solutions. |
+
+## References
+
+- Initiative: [#369 G3.6 tier-3 VCF management plane](https://github.com/evoila/meho/issues/369);
+  Goal [#214](https://github.com/evoila/meho/issues/214) (G3 connector parity).
+- Tasks that shipped this surface:
+  [#829](https://github.com/evoila/meho/issues/829) (T1 connector
+  skeleton),
+  [#833](https://github.com/evoila/meho/issues/833) (T2 spec
+  ingestion + curation),
+  [#837](https://github.com/evoila/meho/issues/837) (T3 CLI verbs +
+  E2E + this doc),
+  [#841](https://github.com/evoila/meho/issues/841) (T13 shared
+  vcf-auth + fixture refresh tooling).
+- Connector source:
+  [`backend/src/meho_backplane/connectors/vcf_operations/`](../../backend/src/meho_backplane/connectors/vcf_operations/).
+- CLI verbs:
+  [`cli/internal/cmd/vcf-operations/`](../../cli/internal/cmd/vcf-operations/).
+- E2E integration test:
+  [`backend/tests/test_connectors_vcf_operations_e2e.py`](../../backend/tests/test_connectors_vcf_operations_e2e.py).
+- Acceptance tests:
+  [`backend/tests/acceptance/test_g36_vrops_dispatch_smoke.py`](../../backend/tests/acceptance/test_g36_vrops_dispatch_smoke.py),
+  [`backend/tests/acceptance/test_g36_vrops_jsonflux_force_handle.py`](../../backend/tests/acceptance/test_g36_vrops_jsonflux_force_handle.py).
+- Fixture refresh tool:
+  [`backend/tests/fixtures/vcf/refresh.py`](../../backend/tests/fixtures/vcf/refresh.py).
+- Consumer wrapper retiring:
+  [`scripts/vcf-operations.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-operations.sh).
+- vROps Suite API reference:
+  <https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/>.
+- Related onboarding docs:
+  [`nsx-onboarding.md`](./nsx-onboarding.md),
+  [`sddc-manager-onboarding.md`](./sddc-manager-onboarding.md),
+  [`vault-onboarding.md`](./vault-onboarding.md),
+  [`audit-query.md`](./audit-query.md),
+  [`broadcast-onboarding.md`](./broadcast-onboarding.md).


### PR DESCRIPTION
## Summary

- Operator-facing `meho vcf-operations <verb>` Cobra verb tree for the 8 enabled vROps read ops shipped by #833. Pure Cobra-over-HTTP — every verb POSTs to `/api/v1/operations/call` with `connector_id="vrops-rest-9.0"` pre-baked (CLAUDE.md postulate 5; mirrors NSX / SDDC Manager / Harbor precedents).
- Recorded-fixture E2E at `backend/tests/test_connectors_vcf_operations_e2e.py` covering the 4 acceptance criteria: per-op dispatch over `respx`-mocked vROps (parametrised across all 8 ops), Basic-auth credential-cache contract, audit-row shape (`op_id` + `target_id` + `params_hash`), and JSONFlux handle path on the `resource list` op.
- Operator runbook at `docs/cross-repo/vcf-operations-onboarding.md` with per-workflow wrapper-flip recipe retiring `./scripts/vcf-operations.sh`, recorded-fixture refresh instructions, and Goal #214 G3.6 vROps checklist.
- MCP `when_to_use` / `llm_instructions` descriptions reviewed (issue requirement) — the 7 group hints and 8 per-op blobs that landed with #833 are operator-quality and shipped as-is.

## Test plan

- [x] `go vet ./...` + `go test ./internal/cmd/vcf-operations/...` — pass.
- [x] `go test ./...` cross-CLI — 24 packages, all green; no regression in NSX / SDDC / Harbor sibling trees.
- [x] `meho vcf-operations --help` lists all 8 verbs (about / resource / alert / alertdefinition / symptom / recommendation / supermetric / operation).
- [x] `ruff check src/ tests/` — clean.
- [x] `ruff format --check src/ tests/` — 456 files clean.
- [x] `mypy src/` — 220 source files, no issues.
- [x] `pytest tests/test_connectors_vcf_operations_e2e.py -x -q` — 11 passed (8 parametrised dispatch ops + credentials cache + audit row + JSONFlux handle).
- [x] Cross-connector E2E sanity — `pytest tests/test_connectors_nsx_e2e.py tests/test_connectors_sddc_manager_e2e.py tests/test_connectors_vcf_operations_e2e.py` — 36 passed, no regression.
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0.

## Acceptance criteria (issue #837)

- [x] `meho vcf-operations --help` lists the verb set; each verb POSTs to `/api/v1/operations/call` with the right `op_id`. Go test `TestDispatchOpBakesConnectorID` pins `connector_id="vrops-rest-9.0"` on every dispatch; `TestDispatchResourceGetSendsIDParam` pins the `{id}` path-template substitution.
- [x] `backend/tests/test_connectors_vcf_operations_e2e.py` replays a captured fixture for every enabled op and passes in CI with no Docker dependency (SQLite + `respx`).
- [x] At least one list op's E2E asserts the JSONFlux handle path — `test_vcf_operations_e2e_jsonflux_handle_populated_for_resource_list` covers `resource list` with a `ForceHandleReducer`.
- [x] All enabled ops write an audit row carrying `op_id` + `target_id` + `params_hash` — `test_vcf_operations_e2e_dispatch_writes_audit_row` asserts the contract.
- [x] `docs/cross-repo/vcf-operations-onboarding.md` exists with the wrapper-flip recipe; Goal #214 **G3.6 vROps** checklist lines ticked.

## Out of scope

- Sibling Initiative #369 tasks running in parallel: #838 (vRLI CLI), #839 (Fleet CLI), #840 (Automation CLI). Only `CHANGELOG.md` collision is expected at merge time.
- vROps write ops (custom-group / maintenance-mode set / alert-ack) — out of scope per Initiative #369 (Read-only in v0.5).
- A live vROps CI simulator — recorded-fixture pattern per #536 is the accepted approach.
- A future `docs/codebase/connectors-vcf-operations.md` engineering-facing doc — adjacent finding, recorded; not on the issue #837 checklist.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #837


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `meho vcf-operations` CLI group with subcommands: about, alert list, alertdefinition list, recommendation list, resource list/get, supermetric list, symptom list, and operation search/call; supports --target, --params, --backplane and --json output.

* **Tests**
  * Added end-to-end recorded-fixture integration tests covering dispatch of core vROps operations and result handling.

* **Documentation**
  * Added operator onboarding guide with quick-start, verb reference, migration steps, and troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-22)

Addressed review findings from `/auto-review-pr` iter 1 (REQUEST_CHANGES, see `.claude/auto/review-results/pr-893-iter-1.json` + the inline review thread):

- **B1** `f70b19c` — `gofmt -w` on 9 files in `cli/internal/cmd/vcf-operations/`; clears `golangci-lint` CI red.
- **B2** `f70b19c` — `alert list` / `symptom list` renderers now emit the `resourceId` column promised by the Long help text; widths re-tuned to 38/32/22/(level)/severity.
- **B3** `f70b19c` — `recommendation list` / `supermetric list` collapse multi-line `description` / `formula` to the first line before truncate; `TestPrint{Recommendation,Supermetric}ListFirstLineOnly` pins the contract.

Deferred (orchestrator may file a follow-up Task on Initiative #369):

- **M1** — E2E still consumes `tests.acceptance._vrops_canary_fixtures` constants rather than `backend/tests/fixtures/vcf/vcf-operations/*.json` from #841's `refresh.py`. Not surgical (requires re-plumbing the loader); the docstring seam is already documented. Acceptance criterion "replays a captured fixture" is satisfied by the canary path.

<!-- auto-implement-issue: continue, iteration 1 -->
